### PR TITLE
[Kernel] More LogSegment cleanup and refactor

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -59,7 +59,7 @@ public class SnapshotImpl implements Snapshot {
       SnapshotQueryContext snapshotContext) {
     this.logPath = new Path(dataPath, "_delta_log");
     this.dataPath = dataPath;
-    this.version = logSegment.version;
+    this.version = logSegment.getVersion();
     this.logSegment = logSegment;
     this.logReplay = logReplay;
     this.protocol = protocol;
@@ -99,15 +99,15 @@ public class SnapshotImpl implements Snapshot {
     if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       if (!inCommitTimestampOpt.isPresent()) {
         Optional<CommitInfo> commitInfoOpt =
-            CommitInfo.getCommitInfoOpt(engine, logPath, logSegment.version);
+            CommitInfo.getCommitInfoOpt(engine, logPath, logSegment.getVersion());
         inCommitTimestampOpt =
             Optional.of(
                 CommitInfo.getRequiredInCommitTimestamp(
-                    commitInfoOpt, String.valueOf(logSegment.version), dataPath));
+                    commitInfoOpt, String.valueOf(logSegment.getVersion()), dataPath));
       }
       return inCommitTimestampOpt.get();
     } else {
-      return logSegment.lastCommitTimestamp;
+      return logSegment.getLastCommitTimestamp();
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -162,7 +162,7 @@ public class LogReplay {
   }
 
   public long getVersion() {
-    return logSegment.version;
+    return logSegment.getVersion();
   }
 
   /**
@@ -222,12 +222,13 @@ public class LogReplay {
             asList(
                 // Prefer reading hint over CRC, so start listing from hint's version + 1.
                 snapshotHint.map(SnapshotHint::getVersion).orElse(0L) + 1,
-                logSegment.checkpointVersionOpt.orElse(0L),
+                logSegment.getCheckpointVersionOpt().orElse(0L),
                 // Only find the CRC within 100 versions.
                 snapshotVersion - 100,
                 0L));
     Optional<CRCInfo> crcInfoOpt =
-        ChecksumReader.getCRCInfo(engine, logSegment.logPath, snapshotVersion, crcSearchLowerBound);
+        ChecksumReader.getCRCInfo(
+            engine, logSegment.getLogPath(), snapshotVersion, crcSearchLowerBound);
     if (crcInfoOpt.isPresent()) {
       CRCInfo crcInfo = crcInfoOpt.get();
       if (crcInfo.getVersion() == snapshotVersion) {
@@ -321,11 +322,11 @@ public class LogReplay {
 
     if (protocol == null) {
       throw new IllegalStateException(
-          String.format("No protocol found at version %s", logSegment.version));
+          String.format("No protocol found at version %s", logSegment.getVersion()));
     }
 
     throw new IllegalStateException(
-        String.format("No metadata found at version %s", logSegment.version));
+        String.format("No metadata found at version %s", logSegment.getVersion()));
   }
 
   private Optional<Long> loadLatestTransactionVersion(Engine engine, String applicationId) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
@@ -58,6 +58,19 @@ public class LogSegment {
    * Provides information around which files in the transaction log need to be read to create the
    * given version of the log.
    *
+   * <p>This constructor validates and guarantees that:
+   *
+   * <ul>
+   *   <li>All deltas are valid deltas files
+   *   <li>All checkpoints are valid checkpoint files
+   *   <li>All checkpoint files have the same version
+   *   <li>All deltas are contiguous and range from {@link #checkpointVersionOpt} to version
+   *   <li>If no deltas are present then {@link #checkpointVersionOpt} is equal to version
+   * </ul>
+   *
+   * <p>Notably, this constructor does not guarantee that this LogSegment is complete and fully
+   * describes a Snapshot version. You may use the {@link #isComplete()} method to check this.
+   *
    * @param logPath The path to the _delta_log directory
    * @param version The Snapshot version to generate
    * @param deltas The delta commit files (.json) to read
@@ -136,6 +149,8 @@ public class LogSegment {
                       + "of this LogSegment");
             });
       }
+    } else {
+      checkArgument(deltas.isEmpty() && checkpoints.isEmpty(), "Version -1 should have no files");
     }
 
     ////////////////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -88,7 +88,7 @@ public class SnapshotManager {
     final LogSegment logSegment =
         getLogSegmentForVersion(engine, Optional.empty() /* versionToLoad */);
 
-    snapshotContext.setVersion(logSegment.version);
+    snapshotContext.setVersion(logSegment.getVersion());
 
     return createSnapshot(logSegment, engine, snapshotContext);
   }
@@ -246,10 +246,10 @@ public class SnapshotManager {
       LogSegment initSegment, Engine engine, SnapshotQueryContext snapshotContext) {
     final String startingFromStr =
         initSegment
-            .checkpointVersionOpt
+            .getCheckpointVersionOpt()
             .map(v -> format("starting from checkpoint version %s.", v))
             .orElse(".");
-    logger.info("{}: Loading version {} {}", tablePath, initSegment.version, startingFromStr);
+    logger.info("{}: Loading version {} {}", tablePath, initSegment.getVersion(), startingFromStr);
 
     long startTimeMillis = System.currentTimeMillis();
 
@@ -257,7 +257,7 @@ public class SnapshotManager {
         new LogReplay(
             logPath,
             tablePath,
-            initSegment.version,
+            initSegment.getVersion(),
             engine,
             initSegment,
             Optional.ofNullable(latestSnapshotHint.get()),
@@ -281,7 +281,7 @@ public class SnapshotManager {
         "{}: Took {}ms to construct the snapshot (loading protocol and metadata) for {} {}",
         tablePath,
         System.currentTimeMillis() - startTimeMillis,
-        initSegment.version,
+        initSegment.getVersion(),
         startingFromStr);
 
     final SnapshotHint hint =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/FileStatus.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/FileStatus.java
@@ -26,6 +26,26 @@ import java.util.Objects;
  */
 @Evolving
 public class FileStatus {
+
+  //////////////////////////////////
+  // Static variables and methods //
+  //////////////////////////////////
+
+  /**
+   * Create a {@link FileStatus} with the given path, size and modification time.
+   *
+   * @param path Fully qualified file path.
+   * @param size File size in bytes
+   * @param modificationTime Modification time of the file in epoch millis
+   */
+  public static FileStatus of(String path, long size, long modificationTime) {
+    return new FileStatus(path, size, modificationTime);
+  }
+
+  //////////////////////////////////
+  // Member variables and methods //
+  //////////////////////////////////
+
   private final String path;
   private final long size;
   private final long modificationTime;
@@ -64,15 +84,10 @@ public class FileStatus {
     return modificationTime;
   }
 
-  /**
-   * Create a {@link FileStatus} with the given path, size and modification time.
-   *
-   * @param path Fully qualified file path.
-   * @param size File size in bytes
-   * @param modificationTime Modification time of the file in epoch millis
-   */
-  public static FileStatus of(String path, long size, long modificationTime) {
-    return new FileStatus(path, size, modificationTime);
+  @Override
+  public String toString() {
+    return String.format(
+        "FileStatus{path='%s', size=%d, modificationTime=%d}", path, size, modificationTime);
   }
 
   /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -72,25 +72,25 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       expectedCheckpointVersion: Option[Long],
       expectedLastCommitTimestamp: Long): Unit = {
 
-    assert(logSegment.logPath == logPath)
-    assert(logSegment.version == expectedVersion)
+    assert(logSegment.getLogPath == logPath)
+    assert(logSegment.getVersion == expectedVersion)
     assert(expectedDeltas.map(f => (f.getPath, f.getSize, f.getModificationTime)) sameElements
-      logSegment.deltas.asScala.map(f => (f.getPath, f.getSize, f.getModificationTime)))
+      logSegment.getDeltas.asScala.map(f => (f.getPath, f.getSize, f.getModificationTime)))
 
     val expectedCheckpointStatuses = expectedCheckpoints
       .map(f => (f.getPath, f.getSize, f.getModificationTime)).sortBy(_._1)
-    val actualCheckpointStatuses = logSegment.checkpoints.asScala
+    val actualCheckpointStatuses = logSegment.getCheckpoints.asScala
       .map(f => (f.getPath, f.getSize, f.getModificationTime)).sortBy(_._1)
     assert(expectedCheckpointStatuses sameElements actualCheckpointStatuses,
       s"expected:\n$expectedCheckpointStatuses\nactual:\n$actualCheckpointStatuses")
 
     expectedCheckpointVersion match {
       case Some(v) =>
-        assert(logSegment.checkpointVersionOpt.isPresent() &&
-          logSegment.checkpointVersionOpt.get == v)
-      case None => assert(!logSegment.checkpointVersionOpt.isPresent())
+        assert(logSegment.getCheckpointVersionOpt.isPresent() &&
+          logSegment.getCheckpointVersionOpt.get == v)
+      case None => assert(!logSegment.getCheckpointVersionOpt.isPresent())
     }
-    assert(expectedLastCommitTimestamp == logSegment.lastCommitTimestamp)
+    assert(expectedLastCommitTimestamp == logSegment.getLastCommitTimestamp)
   }
 
   /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
@@ -16,102 +16,145 @@
 
 package io.delta.kernel.internal.snapshot
 
-import java.util.Arrays
-import java.util.{Collections, Optional}
+import java.util.Collections
 
-import io.delta.kernel.internal.fs.Path
-import io.delta.kernel.internal.util.FileNames
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.exceptions.InvalidTableException
+import io.delta.kernel.test.MockFileSystemClientUtils
 import io.delta.kernel.utils.FileStatus
 import org.scalatest.funsuite.AnyFunSuite
 
-class LogSegmentSuite extends AnyFunSuite {
-  private val logPath = new Path("/a/_delta_log")
-  private val checkpointFs10 =
-    FileStatus.of(FileNames.checkpointFileSingular(logPath, 10).toString, 1, 1)
-  private val checkpointFs10List = Collections.singletonList(checkpointFs10)
-  private val deltaFs11 = FileStatus.of(FileNames.deltaFile(logPath, 11), 1, 1)
-  private val deltaFs11List = Collections.singletonList(deltaFs11)
-  private val deltaFs12 = FileStatus.of(FileNames.deltaFile(logPath, 12), 1, 1)
-  private val deltaFs12List = Collections.singletonList(deltaFs12)
-  private val deltasFs11To12List = Arrays.asList(deltaFs11, deltaFs12)
+class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
+  private val checkpointFs10List = singularCheckpointFileStatuses(Seq(10)).toList.asJava
+  private val deltaFs11List = deltaFileStatuses(Seq(11)).toList.asJava
+  private val deltaFs12List = deltaFileStatuses(Seq(12)).toList.asJava
+  private val deltasFs11To12List = deltaFileStatuses(Seq(11, 12)).toList.asJava
   private val badJsonsList = Collections.singletonList(
     FileStatus.of(s"${logPath.toString}/gibberish.json", 1, 1))
   private val badCheckpointsList = Collections.singletonList(
     FileStatus.of(s"${logPath.toString}/gibberish.checkpoint.parquet", 1, 1))
 
   test("constructor -- valid case (empty)") {
-    LogSegment.empty(new Path("/a/_delta_log"))
+    LogSegment.empty(logPath)
   }
 
   test("constructor -- valid case (non-empty)") {
-    val logPath = new Path("/a/_delta_log")
     new LogSegment(logPath, 12, deltasFs11To12List, checkpointFs10List, 1)
   }
 
   test("constructor -- null arguments => throw") {
     // logPath is null
     intercept[NullPointerException] {
-      new LogSegment(
-        null, 1, Collections.emptyList(), Collections.emptyList(), -1)
+      new LogSegment(null, 1, Collections.emptyList(), Collections.emptyList(), -1)
     }
     // deltas is null
     intercept[NullPointerException] {
-      new LogSegment(
-        new Path("/a/_delta_log"), 1, null, Collections.emptyList(), -1)
+      new LogSegment(logPath, 1, null, Collections.emptyList(), -1)
     }
     // checkpoints is null
     intercept[NullPointerException] {
-      new LogSegment(
-        new Path("/a/_delta_log"), 1, Collections.emptyList(), null, -1)
+      new LogSegment(logPath, 1, Collections.emptyList(), null, -1)
     }
   }
 
   test("constructor -- all deltas must be actual delta files") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(
-        logPath, 12, badJsonsList, checkpointFs10List, 1)
+      new LogSegment(logPath, 12, badJsonsList, checkpointFs10List, 1)
     }.getMessage
     assert(exMsg === "deltas must all be actual delta (commit) files")
   }
 
   test("constructor -- all checkpoints must be actual checkpoint files") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(
-        logPath, 12, deltasFs11To12List, badCheckpointsList, 1)
+      new LogSegment(logPath, 12, deltasFs11To12List, badCheckpointsList, 1)
     }.getMessage
     assert(exMsg === "checkpoints must all be actual checkpoint files")
   }
 
   test("constructor -- if version >= 0 then both deltas and checkpoints cannot be empty") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(
-        logPath, 12, Collections.emptyList(), Collections.emptyList(), 1)
+      new LogSegment(logPath, 12, Collections.emptyList(), Collections.emptyList(), 1)
     }.getMessage
     assert(exMsg === "No files to read")
   }
 
   test("constructor -- if deltas non-empty then first delta must equal checkpointVersion + 1") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(
-        logPath, 12, deltaFs12List, checkpointFs10List, 1)
+      new LogSegment(logPath, 12, deltaFs12List, checkpointFs10List, 1)
     }.getMessage
     assert(exMsg === "First delta file version must equal checkpointVersion + 1")
   }
 
   test("constructor -- if deltas non-empty then last delta must equal version") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(
-        logPath, 12, deltaFs11List, checkpointFs10List, 1)
+      new LogSegment(logPath, 12, deltaFs11List, checkpointFs10List, 1)
     }.getMessage
     assert(exMsg === "Last delta file version must equal the version of this LogSegment")
   }
 
   test("constructor -- if no deltas then checkpointVersion must equal version") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(
-        logPath, 11, Collections.emptyList(), checkpointFs10List, 1)
+      new LogSegment(logPath, 11, Collections.emptyList(), checkpointFs10List, 1)
     }.getMessage
     assert(exMsg ===
       "If there are no deltas, then checkpointVersion must equal the version of this LogSegment")
+  }
+
+  test("constructor -- deltas not contiguous") {
+    val deltas = deltaFileStatuses(Seq(11, 13)).toList.asJava
+    val exMsg = intercept[IllegalArgumentException] {
+      new LogSegment(logPath, 13, deltas, checkpointFs10List, 1)
+    }.getMessage
+    assert(exMsg === "Delta versions must be contiguous: [11, 13]")
+  }
+
+  test("isComplete") {
+    {
+      // case 1: checkpoint and deltas => complete
+      val logSegment = new LogSegment(logPath, 12, deltasFs11To12List, checkpointFs10List, 1)
+      assert(logSegment.isComplete)
+    }
+    {
+      // case 2: checkpoint only => complete
+      val logSegment = new LogSegment(logPath, 10, Collections.emptyList(), checkpointFs10List, 1)
+      assert(logSegment.isComplete)
+    }
+    {
+      // case 3: deltas from 0 to N with no checkpoint => complete
+      val deltaFiles = deltaFileStatuses((0L to 17L)).toList.asJava
+      val logSegment = new LogSegment(logPath, 17, deltaFiles, Collections.emptyList(), 1)
+      assert(logSegment.isComplete)
+    }
+    {
+      // case 4: just deltas from 11 to 12 with no checkpoint => incomplete
+      val logSegment = new LogSegment(logPath, 12, deltasFs11To12List, Collections.emptyList(), 1)
+      assert(!logSegment.isComplete)
+    }
+    {
+      // case 5: empty log segment => incomplete
+      assert(!LogSegment.empty(logPath).isComplete)
+    }
+  }
+
+  test("toString") {
+    val logSegment = new LogSegment(logPath, 12, deltasFs11To12List, checkpointFs10List, 1)
+    // scalastyle:off line.size.limit
+    val expectedToString =
+      """LogSegment {
+        |  logPath='/fake/path/to/table/_delta_log',
+        |  version=12,
+        |  deltas=[
+        |    FileStatus{path='/fake/path/to/table/_delta_log/00000000000000000011.json', size=11, modificationTime=110},
+        |    FileStatus{path='/fake/path/to/table/_delta_log/00000000000000000012.json', size=12, modificationTime=120}
+        |  ],
+        |  checkpoints=[
+        |    FileStatus{path='/fake/path/to/table/_delta_log/00000000000000000010.checkpoint.parquet', size=10, modificationTime=100}
+        |  ],
+        |  checkpointVersion=10,
+        |  lastCommitTimestamp=1
+        |}""".stripMargin
+    // scalastyle:on line.size.limit
+    assert(logSegment.toString === expectedToString)
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
@@ -20,7 +20,6 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
-import io.delta.kernel.exceptions.InvalidTableException
 import io.delta.kernel.test.MockFileSystemClientUtils
 import io.delta.kernel.utils.FileStatus
 import org.scalatest.funsuite.AnyFunSuite
@@ -56,6 +55,18 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
     intercept[NullPointerException] {
       new LogSegment(logPath, 1, Collections.emptyList(), null, -1)
     }
+  }
+
+  test("constructor -- non-empty deltas or checkpoints with version -1 => throw") {
+    val exMsg1 = intercept[IllegalArgumentException] {
+      new LogSegment(logPath, -1, deltasFs11To12List, Collections.emptyList(), 1)
+    }.getMessage
+    assert(exMsg1 === "Version -1 should have no files")
+
+    val exMsg2 = intercept[IllegalArgumentException] {
+      new LogSegment(logPath, -1, Collections.emptyList(), checkpointFs10List, 1)
+    }.getMessage
+    assert(exMsg2 === "Version -1 should have no files")
   }
 
   test("constructor -- all deltas must be actual delta files") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
@@ -88,10 +88,10 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils with ExpressionTe
     // interval of 2, this will be the most recent even version.
     val expectedV2CkptToRead =
       ckptVersionExpected.getOrElse(snapshotFromSpark.version - (snapshotFromSpark.version % 2))
-    assert(snapshotImpl.getLogSegment.checkpoints.asScala.map(
+    assert(snapshotImpl.getLogSegment.getCheckpoints.asScala.map(
       f => FileNames.checkpointVersion(new Path(f.getPath)))
       .contains(expectedV2CkptToRead))
-    assert(snapshotImpl.getLogSegment.checkpoints.asScala.map(
+    assert(snapshotImpl.getLogSegment.getCheckpoints.asScala.map(
       f => new CheckpointInstance(f.getPath).format == CheckpointInstance.CheckpointFormat.V2)
       .contains(expectV2CheckpointFormat))
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR does some misc improvements:

- turn public member values in LogSegment to be private; add proper getters
- add better validation
- add isComplete and toString methods
- add toString method in FileStatus

## How was this patch tested?

New UTs

## Does this PR introduce _any_ user-facing changes?

No.
