### PR TITLE
[Docs] Remove section about converting Delta back to parquet

### DIFF
--- a/docs/source/delta-utility.md
+++ b/docs/source/delta-utility.md
@@ -516,13 +516,6 @@ CONVERT TO DELTA iceberg.`<path-to-table>` NO STATISTICS
 
   - Converting Iceberg merge-on-read tables that have experienced updates, deletions, or merges is not supported.
 
-## Convert a Delta table to a Parquet table
-
-You can easily convert a Delta table back to a Parquet table using the following steps:
-
-1. If you have performed <Delta> operations that can change the data files (for example, `delete` or `merge`), run [vacuum](#delta-vacuum) with retention of 0 hours to delete all data files that do not belong to the latest version of the table.
-#. Delete the `_delta_log` directory in the table directory.
-
 <a id="restore-delta-table"></a>
 
 ## Restore a Delta table to an earlier state


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (docs)

## Description

Remove the section about "easily converting Delta to parquet" from the docs. This section is very misleading as this doesn't work with anything but the most trivial of Delta tables with no parquet-incompatible features enabled. For the majority of modern Delta tables, the only real option to achieve this is via CTAS or equivalent that rewrites the contents as parquet, rather than an in-place conversion.

## How was this patch tested?

n/a

## Does this PR introduce _any_ user-facing changes?

Yes, the docs look different^^
