### PR TITLE
chore: remove redundant words

### DIFF
--- a/connectors/flink/src/main/java/io/delta/flink/internal/options/DeltaConnectorConfiguration.java
+++ b/connectors/flink/src/main/java/io/delta/flink/internal/options/DeltaConnectorConfiguration.java
@@ -66,7 +66,7 @@ public class DeltaConnectorConfiguration implements Serializable {
 
     /**
      * This method returns a value for used {@code DeltaSourceOption}. The type of returned value
-     * will be cast to the the same type that was used in {@link DeltaSourceOptions} definition.
+     * will be cast to the same type that was used in {@link DeltaSourceOptions} definition.
      * Using {@code DeltaSourceOption} object as an argument rather than option's string key
      * guaranties type safety.
      *

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -37,7 +37,7 @@ import io.delta.standalone.expressions.Expression;
 
 
 /**
- * Wrap a {@link io.delta.kernel.Snapshot} such that it conforms to the the {@link
+ * Wrap a {@link io.delta.kernel.Snapshot} such that it conforms to the {@link
  * io.delta.standalone.Snapshot} interface.
  *
  * NB: Currently only supports the getMetadata and getVersion methods. All others throw exceptions.

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -140,7 +140,7 @@ case class DeltaFormatSharingSource(
   }
 
   // Latest endOffset of the getBatch call, used to compute startingOffset which will then be used
-  // to compare with the the latest table version on server to decide whether to fetch new data.
+  // to compare with the latest table version on server to decide whether to fetch new data.
   private var latestProcessedEndOffsetOption: Option[DeltaSourceOffset] = None
 
   // Latest table version for the data fetched from the delta sharing server, and stored in the

--- a/spark/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
@@ -91,7 +91,7 @@ class DeltaColumnBuilder private[tables](
    *
    * Specify a expression if the column is always generated as a function of other columns.
    *
-   * @param expr string the the generation expression
+   * @param expr string the generation expression
    * @since 1.0.0
    */
   @Evolving

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -676,7 +676,7 @@ object DeltaHistoryManager extends DeltaLogging {
    * We will return the first available commit if the condition cannot be met. This method works
    * even for boundary commits, and can be best demonstrated through an example:
    * Imagine we have commits 999, 1000, 1001, 1002. t_999 < t_1000 but t_1000 > t_1001 and
-   * t_1001 < t_1002. So at the the boundary, we will need to eventually adjust t_1001. Assume the
+   * t_1001 < t_1002. So at the boundary, we will need to eventually adjust t_1001. Assume the
    * result needs to be t_1001 after the adjustment as t_search < t_1002 and t_search > t_1000.
    * What will happen is that the first fragment will return t_1000, and the second fragment will
    * return t_1001. On the Driver, we will adjust t_1001 = t_1000 + 1 milliseconds, and our linear

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -491,7 +491,7 @@ object TableFeatureProtocolUtils {
   }
 
   /**
-   * Checks if the the given table property key is a Table Protocol property, i.e.,
+   * Checks if the given table property key is a Table Protocol property, i.e.,
    * `delta.minReaderVersion`, `delta.minWriterVersion`, ``delta.ignoreProtocolDefaults``, or
    * anything that starts with `delta.feature.`
    */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -663,7 +663,7 @@ trait DeltaSourceBase extends Source
       // check whether we can use `schema` (the fixed source schema we use in the same run of the
       // query) to read these new files safely.
       val backfilling = version < snapshotAtSourceInit.version
-      // We forbid the case when the the schemaChange is nullable while the read schema is NOT
+      // We forbid the case when the schemaChange is nullable while the read schema is NOT
       // nullable, or in other words, `schema` should not tighten nullability from `schemaChange`,
       // because we don't ever want to read back any nulls when the read schema is non-nullable.
       val shouldForbidTightenNullability = !forceEnableUnsafeReadOnNullabilityChange


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

remove redundant words

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
