### PR TITLE
[Spark] Fix metadata cleanup by retaining files required for log reconstruction

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -865,10 +865,10 @@ object DeltaHistoryManager extends DeltaLogging {
             currentFile.getLen, currentFile.isDirectory, currentFile.getReplication,
             currentFile.getBlockSize, lastFile.getModificationTime + 1, currentFile.getPath)
         } else if (FileNames.isCheckpointFile(currentFile)
-          && shouldDeleteFile(currentFile)
+          && shouldDeleteFile(lastFile)
           && (versionGetter(currentFile.getPath) > versionGetter(lastFile.getPath))) {
-          // Need to keep at least one expired checkpoint
-          // Version check is to handle multi-part checkpoint
+          // Version check is to handle multi-part checkpoint.
+          // We don't want to flush part2 only because the part1 is expired
           flushBuffer()
           continueBuffering = false
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -867,10 +867,10 @@ object DeltaHistoryManager extends DeltaLogging {
             currentFile.getLen, currentFile.isDirectory, currentFile.getReplication,
             currentFile.getBlockSize, lastFile.getModificationTime + 1, currentFile.getPath)
           maybeDeleteFiles.append(currentFile)
-        } else if (FileNames.isCheckpointFile(currentFile)) {
-          // Only flush the buffer when find a checkpoint. This is because we don't want to delete
-          // the delta log files unless we have a checkpoint to ensure that non-expired subsequent
-          // delta logs are valid.
+        } else if (FileNames.isCheckpointFile(currentFile) && currentFile.getLen > 0) {
+          // Only flush the buffer when we find a checkpoint. This is because we don't want to
+          // delete the delta log files unless we have a checkpoint to ensure that non-expired
+          // subsequent delta logs are valid.
           val numParts = FileNames.numCheckpointParts(currentFile.getPath)
 
           if (numParts.isEmpty) { // Single-part or V2

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -828,7 +828,7 @@ object DeltaHistoryManager extends DeltaLogging {
      * Files need a time adjustment if their timestamp isn't later than the lastFile.
      */
     private def needsTimeAdjustment(file: FileStatus): Boolean = {
-      versionGetter(lastFile.getPath) < versionGetter(file.getPath) &&
+      isFileVersionGreaterThanLastFileVersion(file) &&
         lastFile.getModificationTime >= file.getModificationTime
     }
 
@@ -864,7 +864,7 @@ object DeltaHistoryManager extends DeltaLogging {
             currentFile.getLen, currentFile.isDirectory, currentFile.getReplication,
             currentFile.getBlockSize, lastFile.getModificationTime + 1, currentFile.getPath)
         } else if (FileNames.isCheckpointFile(currentFile)
-          && (versionGetter(currentFile.getPath) > versionGetter(lastFile.getPath))) {
+          && isFileVersionGreaterThanLastFileVersion(currentFile)) {
           // Only flush the buffer when find a checkpoint. This is because we don't want to delete
           // the delta log files unless we have a checkpoint to ensure that non-expired subsequent
           // delta logs are valid.
@@ -877,6 +877,10 @@ object DeltaHistoryManager extends DeltaLogging {
         maybeDeleteFiles.append(currentFile)
         lastFile = currentFile
       }
+    }
+
+    def isFileVersionGreaterThanLastFileVersion(file: FileStatus): Boolean = {
+      versionGetter(file.getPath) > versionGetter(lastFile.getPath)
     }
 
     override def hasNext: Boolean = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -163,38 +163,12 @@ trait MetadataCleanup extends DeltaLogging {
   private def listExpiredDeltaLogs(fileCutOffTime: Long): Iterator[FileStatus] = {
     val latestCheckpoint = readLastCheckpointFile()
     if (latestCheckpoint.isEmpty) return Iterator.empty
-
-    def listExpiredDeltaLogsInternal(threshold: Long): Iterator[FileStatus] = {
+    val threshold = latestCheckpoint.get.version - 1L
     val files = store.listFrom(listingPrefix(logPath, 0), newDeltaHadoopConf())
       .filter(f => isCheckpointFile(f) || isDeltaFile(f) || isChecksumFile(f))
 
     new BufferingLogDeletionIterator(
       files, fileCutOffTime, threshold, getDeltaFileChecksumOrCheckpointVersion)
-    }
-
-      // Get latest expired checkpoint version
-    val latestExpiredCheckpointVersion = {
-      val cutOffCheckpoint = listExpiredDeltaLogsInternal(latestCheckpoint.get.version - 1)
-        .filter(f => isCheckpointFile(f))
-        .map(FileNames.checkpointVersion)
-        .foldLeft(Option.empty[Long]) { (a, c) => if (a.getOrElse(-1L) < c) { Some(c) } else { a } }
-
-      logInfo("Cut off checkpoint version: " + cutOffCheckpoint)
-
-      recordDeltaEvent(this, "delta.log.cleanup.stats", data = Map(
-        "cutOffCheckpoint" -> cutOffCheckpoint.getOrElse(-1L),
-        "latestCheckpoint" -> latestCheckpoint.get.version))
-
-      if(cutOffCheckpoint.isEmpty) {
-        logInfo("No expired checkpoint file found. Returning empty iterator.")
-        return Iterator.empty
-      } else {
-        // Math.min for sanity check
-        Math.min(cutOffCheckpoint.get, latestCheckpoint.get.version) - 1L
-      }
-    }
-
-    listExpiredDeltaLogsInternal(latestExpiredCheckpointVersion)
   }
 
   protected def checkpointExistsAtCleanupBoundary(deltaLog: DeltaLog, version: Long): Boolean = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -745,31 +745,34 @@ class DeltaRetentionSuite extends QueryTest
 
       // Corner cases.
       testRequireCheckpointProtectionBeforeVersion(
-        createNumCommitsOutsideRetentionPeriod = 2,
-        createNumCommitsWithinRetentionPeriod = 14,
-        createCheckpoints = Set(2),
+        createNumCommitsOutsideRetentionPeriod = 1,
+        createNumCommitsWithinRetentionPeriod = 15,
+        createCheckpoints = Set(1),
         requireCheckpointProtectionBeforeVersion = 0,
-        expectedCommitsAfterCleanup = (2 to 15),
+        expectedCommitsAfterCleanup = (1 to 15),
         // Α checkpoint is automatically created every 10 commits.
-        expectedCheckpointsAfterCleanup = Set(2, 10))
+        expectedCheckpointsAfterCleanup = Set(1, 10))
 
       testRequireCheckpointProtectionBeforeVersion(
-        createNumCommitsOutsideRetentionPeriod = 2,
-        createNumCommitsWithinRetentionPeriod = 14,
-        createCheckpoints = Set(2),
+        createNumCommitsOutsideRetentionPeriod = 1,
+        createNumCommitsWithinRetentionPeriod = 15,
+        createCheckpoints = Set(1),
         requireCheckpointProtectionBeforeVersion = 1,
-        expectedCommitsAfterCleanup = (2 to 15),
+        expectedCommitsAfterCleanup = (1 to 15),
         // Α checkpoint is automatically created every 10 commits.
-        expectedCheckpointsAfterCleanup = Set(2, 10))
+        expectedCheckpointsAfterCleanup = Set(1, 10))
 
+      // v1 can't be deleted because it is the only checkpoint before version 2.
+      // v0 can't be deleted because of the checkpoint protection, v0 and v1 needs
+      // to be deleted together.
       testRequireCheckpointProtectionBeforeVersion(
-        createNumCommitsOutsideRetentionPeriod = 2,
-        createNumCommitsWithinRetentionPeriod = 14,
-        createCheckpoints = Set(2),
+        createNumCommitsOutsideRetentionPeriod = 1,
+        createNumCommitsWithinRetentionPeriod = 15,
+        createCheckpoints = Set(1),
         requireCheckpointProtectionBeforeVersion = 2,
-        expectedCommitsAfterCleanup = (2 to 15),
+        expectedCommitsAfterCleanup = (0 to 15),
         // Α checkpoint is automatically created every 10 commits.
-        expectedCheckpointsAfterCleanup = Set(2, 10))
+        expectedCheckpointsAfterCleanup = Set(1, 10))
 
       testRequireCheckpointProtectionBeforeVersion(
         createNumCommitsOutsideRetentionPeriod = 2,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -627,7 +627,7 @@ class DeltaRetentionSuite extends QueryTest
         val sqlCommand = s"SELECT * FROM " +
           s"table_changes_by_path('${tempDir.getCanonicalPath}', $version, 25)"
         if (version < earliestExpectedChkVersion) {
-          if (coordinatedCommitsEnabledInTests) {
+          if (catalogOwnedDefaultCreationEnabledInTests) {
             intercept[IllegalStateException] {
               spark.sql(sqlCommand).collect()
             }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -645,6 +645,86 @@ class DeltaRetentionSuite extends QueryTest
   }
   }
 
+  test(s"cleanup does not delete the JSON logs if the multi-part checkpoint is incomplete.") {
+    withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_PART_SIZE.key -> "1") {
+    withTempDir { tempDir =>
+      val startTime = getStartTimeForRetentionTest
+      val clock = new ManualClock(startTime)
+      val actualTestStartTime = System.currentTimeMillis()
+      val tableReference = s"delta.`${tempDir.getCanonicalPath()}`"
+      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath), clock)
+      val logPath = new File(log.logPath.toUri)
+
+      // commit 0
+      spark.sql(
+        s"""CREATE TABLE $tableReference (id Int) USING delta
+           | TBLPROPERTIES('delta.enableChangeDataFeed' = true)
+        """.stripMargin)
+      // Set time for commit 0 to ensure that the commits don't need timestamp adjustment.
+      val commit0Time = clock.getTimeMillis()
+      new File(FileNames.unsafeDeltaFile(log.logPath, 0).toUri).setLastModified(commit0Time)
+      new File(FileNames.checksumFile(log.logPath, 0).toUri).setLastModified(commit0Time)
+
+      def commitNewVersion(version: Long): Unit = {
+        spark.sql(s"INSERT INTO $tableReference VALUES (1)")
+
+        val deltaFile = new File(FileNames.unsafeDeltaFile(log.logPath, version).toUri)
+        val time = clock.getTimeMillis() + version * 1000
+        deltaFile.setLastModified(time)
+        val crcFile = new File(FileNames.checksumFile(log.logPath, version).toUri)
+        crcFile.setLastModified(time)
+        val chks = getCheckpointFiles(logPath)
+          .filter(f => FileNames.checkpointVersion(new Path(f.getCanonicalPath)) == version)
+
+        if (version % 10 == 0) {
+          assert(chks.length >= 2) // Multipart checkpoints
+          chks.foreach { chk =>
+              assert(chk.exists())
+              chk.setLastModified(time)
+          }
+        } else { assert(chks.isEmpty) }
+      }
+
+      // Day 0: Add commits 1 to 15 --> creates 1 checkpoint at Day 0 for version 10
+      (1L to 15L).foreach(commitNewVersion)
+
+      // ensure that the checkpoint at version 10 exists
+      val checkpoint10Files = getCheckpointFiles(logPath)
+        .filter(f => FileNames.checkpointVersion(new Path(f.getCanonicalPath)) == 10)
+      assert(checkpoint10Files.length >= 2) // Multipart checkpoints
+      assert(checkpoint10Files.forall(_.exists))
+      val deltaFiles = (0 to 15).map { i =>
+        new File(FileNames.unsafeDeltaFile(log.logPath, i).toUri)
+      }
+      deltaFiles.foreach { f =>
+        assert(f.exists())
+      }
+
+      // Day 35: Add commits 16 to 25 --> creates a checkpoint at Day 35 for version 20
+      clock.setTime(day(startTime, 35))
+      (16L to 25L).foreach(commitNewVersion)
+
+      assert(checkpoint10Files.forall(_.exists))
+      deltaFiles.foreach { f =>
+        assert(f.exists())
+      }
+
+      checkpoint10Files.lastOption.foreach { lastPart =>
+        lastPart.delete() // delete the last part to simulate incomplete checkpoint
+      }
+
+      // auto cleanup is disabled in DeltaRetentionSuiteBase so tests have control when it happens
+      cleanUpExpiredLogs(log)
+
+      // assert that delta logs are not deleted due to missing checkpoint part
+      deltaFiles.foreach { f =>
+        val version = FileNames.deltaVersion(new Path(f.toString()))
+        assert(f.exists, s"version $version should not be deleted")
+      }
+    }
+    }
+  }
+
   test("Metadata cleanup respects requireCheckpointProtectionBeforeVersion") {
     withSQLConf(
         DeltaSQLConf.ALLOW_METADATA_CLEANUP_WHEN_ALL_PROTOCOLS_SUPPORTED.key -> "false",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -627,8 +627,14 @@ class DeltaRetentionSuite extends QueryTest
         val sqlCommand = s"SELECT * FROM " +
           s"table_changes_by_path('${tempDir.getCanonicalPath}', $version, 25)"
         if (version < earliestExpectedChkVersion) {
-          val ex = intercept[org.apache.spark.sql.delta.DeltaFileNotFoundException] {
-            spark.sql(sqlCommand).collect()
+          if (coordinatedCommitsEnabledInTests) {
+            intercept[IllegalStateException] {
+              spark.sql(sqlCommand).collect()
+            }
+          } else {
+            intercept[org.apache.spark.sql.delta.DeltaFileNotFoundException] {
+              spark.sql(sqlCommand).collect()
+            }
           }
         } else {
           spark.sql(sqlCommand).collect()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -675,6 +675,10 @@ class DeltaRetentionSuite extends QueryTest
         val deltaFile = new File(FileNames.unsafeDeltaFile(log.logPath, version).toUri)
         val time = clock.getTimeMillis() + version * 1000
         deltaFile.setLastModified(time)
+        val checkpointFile = new File(FileNames.checkpointFileSingular(log.logPath, version).toUri)
+        if (checkpointFile.exists()) {
+          checkpointFile.setLastModified(time)
+        }
         val crcFile = new File(FileNames.checksumFile(log.logPath, version).toUri)
         crcFile.setLastModified(time)
       }
@@ -763,6 +767,10 @@ class DeltaRetentionSuite extends QueryTest
         val deltaFile = new File(FileNames.unsafeDeltaFile(log.logPath, version).toUri)
         val time = clock.getTimeMillis() + version * 1000
         deltaFile.setLastModified(time)
+        val checkpointFile = new File(FileNames.checkpointFileSingular(log.logPath, version).toUri)
+        if (checkpointFile.exists()) {
+          checkpointFile.setLastModified(time)
+        }
         val crcFile = new File(FileNames.checksumFile(log.logPath, version).toUri)
         crcFile.setLastModified(time)
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -841,20 +841,18 @@ class DeltaRetentionSuite extends QueryTest
       testRequireCheckpointProtectionBeforeVersion(
         createNumCommitsOutsideRetentionPeriod = 8,
         createNumCommitsWithinRetentionPeriod = 8,
-        createCheckpoints = Set(1),
+        createCheckpoints = Set(1, 8),
         requireCheckpointProtectionBeforeVersion = 10,
         expectedCommitsAfterCleanup = (8 to 15),
-        // This is a bit weird. Cleanup should had created a checkpoint at 8.
-        expectedCheckpointsAfterCleanup = Set(10))
+        expectedCheckpointsAfterCleanup = Set(8, 10))
 
       testRequireCheckpointProtectionBeforeVersion(
         createNumCommitsOutsideRetentionPeriod = 8,
         createNumCommitsWithinRetentionPeriod = 8,
-        createCheckpoints = Set(0),
+        createCheckpoints = Set(0, 8),
         requireCheckpointProtectionBeforeVersion = 10,
         expectedCommitsAfterCleanup = (8 to 15),
-        // This is a bit weird. Cleanup should had created a checkpoint at 8.
-        expectedCheckpointsAfterCleanup = Set(10))
+        expectedCheckpointsAfterCleanup = Set(8, 10))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -236,8 +236,8 @@ class DeltaTimeTravelSuite extends QueryTest
    * timestamps come from the input.
    */
   private def createFileStatuses(modTimes: Long*): Iterator[FileStatus] = {
-    modTimes.zipWithIndex.map { case (time, version) =>
-      new FileStatus(10L, false, 1, 10L, time, FileNames.checkpointFileSingular(new Path("/foo"), version))
+    modTimes.zipWithIndex.map { case (time, version) => new FileStatus(
+      10L, false, 1, 10L, time, FileNames.checkpointFileSingular(new Path("/foo"), version))
     }.iterator
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -237,7 +237,7 @@ class DeltaTimeTravelSuite extends QueryTest
    */
   private def createFileStatuses(modTimes: Long*): Iterator[FileStatus] = {
     modTimes.zipWithIndex.map { case (time, version) =>
-      new FileStatus(10L, false, 1, 10L, time, new Path(version.toString))
+      new FileStatus(10L, false, 1, 10L, time, FileNames.checkpointFileSingular(new Path("/foo"), version))
     }.iterator
   }
 
@@ -249,8 +249,8 @@ class DeltaTimeTravelSuite extends QueryTest
   private def testBufferingLogDeletionIterator(
       maxTimestamp: Long,
       maxVersion: Long)(inputTimestamps: Seq[Long], deleted: Seq[Long]): Unit = {
-    val i = new BufferingLogDeletionIterator(
-      createFileStatuses(inputTimestamps: _*), maxTimestamp, maxVersion, _.getName.toLong)
+    val i = new BufferingLogDeletionIterator(createFileStatuses(inputTimestamps: _*),
+      maxTimestamp, maxVersion, FileNames.getFileVersion)
     deleted.foreach { ts =>
       assert(i.hasNext, s"Was supposed to delete $ts, but iterator returned hasNext: false")
       assert(i.next().getModificationTime === ts, "Returned files out of order!")
@@ -264,12 +264,12 @@ class DeltaTimeTravelSuite extends QueryTest
     assert(!i1.hasNext)
 
     testBufferingLogDeletionIterator(maxTimestamp = 100, maxVersion = 100)(
-      inputTimestamps = Seq(10),
+      inputTimestamps = Seq(10, 11),
       deleted = Seq(10)
     )
 
     testBufferingLogDeletionIterator(maxTimestamp = 100, maxVersion = 100)(
-      inputTimestamps = Seq(10, 15, 25),
+      inputTimestamps = Seq(10, 15, 25, 26),
       deleted = Seq(10, 15, 25)
     )
   }
@@ -294,9 +294,9 @@ class DeltaTimeTravelSuite extends QueryTest
       deleted = Seq(5, 10, 11)
     )
 
-    // When it is 12, we can return all
+    // When it is 12, we can return all, except last one
     testBufferingLogDeletionIterator(maxTimestamp = 12, maxVersion = 100)(
-      inputTimestamps = Seq(5, 10, 8, 12),
+      inputTimestamps = Seq(5, 10, 8, 12, 13),
       deleted = Seq(5, 10, 11, 12)
     )
 
@@ -308,7 +308,7 @@ class DeltaTimeTravelSuite extends QueryTest
 
     // When it is 11, we can delete both 10 and 8
     testBufferingLogDeletionIterator(maxTimestamp = 11, maxVersion = 100)(
-      inputTimestamps = Seq(5, 10, 8),
+      inputTimestamps = Seq(5, 10, 8, 12),
       deleted = Seq(5, 10, 11)
     )
   }
@@ -333,9 +333,9 @@ class DeltaTimeTravelSuite extends QueryTest
       deleted = Seq(5, 10, 11)
     )
 
-    // When it is version 3, we can return all
+    // When it is version 3, we can return all, except last one
     testBufferingLogDeletionIterator(maxTimestamp = 100, maxVersion = 3)(
-      inputTimestamps = Seq(5, 10, 8, 12),
+      inputTimestamps = Seq(5, 10, 8, 12, 13),
       deleted = Seq(5, 10, 11, 12)
     )
 
@@ -347,7 +347,7 @@ class DeltaTimeTravelSuite extends QueryTest
 
     // When we can delete up to version 2, we can return up to version 2
     testBufferingLogDeletionIterator(maxTimestamp = 100, maxVersion = 2)(
-      inputTimestamps = Seq(5, 10, 8),
+      inputTimestamps = Seq(5, 10, 8, 12),
       deleted = Seq(5, 10, 11)
     )
   }
@@ -388,7 +388,7 @@ class DeltaTimeTravelSuite extends QueryTest
     }
 
     testBufferingLogDeletionIterator(maxTimestamp = 12, maxVersion = 100)(
-      inputTimestamps = Seq(5, 10, 8, 9),
+      inputTimestamps = Seq(5, 10, 8, 9, 13),
       deleted = Seq(5, 10, 11, 12)
     )
 
@@ -400,7 +400,7 @@ class DeltaTimeTravelSuite extends QueryTest
     }
 
     testBufferingLogDeletionIterator(maxTimestamp = 100, maxVersion = 3)(
-      inputTimestamps = Seq(5, 10, 8, 9),
+      inputTimestamps = Seq(5, 10, 8, 9, 13),
       deleted = Seq(5, 10, 11, 12)
     )
 
@@ -413,7 +413,7 @@ class DeltaTimeTravelSuite extends QueryTest
 
     // Test the first element causing cascading adjustments
     testBufferingLogDeletionIterator(maxTimestamp = 12, maxVersion = 100)(
-      inputTimestamps = Seq(10, 8, 9),
+      inputTimestamps = Seq(10, 8, 9, 13),
       deleted = Seq(10, 11, 12)
     )
 
@@ -425,7 +425,7 @@ class DeltaTimeTravelSuite extends QueryTest
     }
 
     testBufferingLogDeletionIterator(maxTimestamp = 100, maxVersion = 2)(
-      inputTimestamps = Seq(10, 8, 9),
+      inputTimestamps = Seq(10, 8, 9, 13),
       deleted = Seq(10, 11, 12)
     )
 
@@ -443,7 +443,7 @@ class DeltaTimeTravelSuite extends QueryTest
     }
 
     testBufferingLogDeletionIterator(maxTimestamp = 17, maxVersion = 100)(
-      inputTimestamps = Seq(5, 10, 8, 9, 12, 15, 14, 14), // 5, 10, 11, 12, 13, 15, 16, 17
+      inputTimestamps = Seq(5, 10, 8, 9, 12, 15, 14, 14, 18), // 5, 10, 11, 12, 13, 15, 16, 17, 18
       deleted = Seq(5, 10, 11, 12, 13, 15, 16, 17)
     )
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Delete eligible delta log files only if there's a checkpoint newer than them before the cutoff window.

Resolves #606

Unit tests based on https://github.com/delta-io/delta/pull/2673

## How was this patch tested?
Unit Tests

## Does this PR introduce _any_ user-facing changes?
Yes, tables with low rate of commit/checkpoints will have increased log retention beyond the cutoff window
