### PR TITLE
[Kernel] Minor cleanup of APIs used for checking read/write supported protocol

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -197,8 +196,7 @@ public class TableImpl implements Table {
               for (int rowId = 0; rowId < protocolVector.getSize(); rowId++) {
                 if (!protocolVector.isNullAt(rowId)) {
                   Protocol protocol = Protocol.fromColumnVector(protocolVector, rowId);
-                  TableFeatures.validateReadSupportedTable(
-                      protocol, getDataPath().toString(), Optional.empty());
+                  TableFeatures.validateReadSupportedTable(protocol, getDataPath().toString());
                 }
               }
               if (shouldDropProtocolColumn) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -158,8 +158,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         protocol = protocol.withNewWriterFeatures(newWriterFeatures);
         List<String> curWriterFeatures = protocol.getWriterFeatures();
         checkArgument(!Objects.equals(oldWriterFeatures, curWriterFeatures));
-        TableFeatures.validateWriteSupportedTable(
-            protocol, metadata, metadata.getSchema(), table.getPath(engine));
+        TableFeatures.validateWriteSupportedTable(protocol, metadata, table.getPath(engine));
       }
     }
 
@@ -184,10 +183,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     String tablePath = table.getPath(engine);
     // Validate the table has no features that Kernel doesn't yet support writing into it.
     TableFeatures.validateWriteSupportedTable(
-        snapshot.getProtocol(),
-        snapshot.getMetadata(),
-        snapshot.getMetadata().getSchema(),
-        tablePath);
+        snapshot.getProtocol(), snapshot.getMetadata(), tablePath);
 
     if (!isNewTable) {
       if (schema.isPresent()) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -66,9 +66,7 @@ public class Checkpointer {
 
     // Check if writing to the given table protocol version/features is supported in Kernel
     validateWriteSupportedTable(
-        snapshot.getProtocol(),
-        snapshot.getMetadata(),
-        snapshot.getDataPath().toString());
+        snapshot.getProtocol(), snapshot.getMetadata(), snapshot.getDataPath().toString());
 
     final Path checkpointPath = FileNames.checkpointFileSingular(logPath, version);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -68,7 +68,6 @@ public class Checkpointer {
     validateWriteSupportedTable(
         snapshot.getProtocol(),
         snapshot.getMetadata(),
-        snapshot.getSchema(),
         snapshot.getDataPath().toString());
 
     final Path checkpointPath = FileNames.checkpointFileSingular(logPath, version);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -286,8 +286,7 @@ public class LogReplay {
 
               if (protocol != null) {
                 // Stop since we have found the latest Protocol and Metadata.
-                TableFeatures.validateReadSupportedTable(
-                    protocol, dataPath.toString(), Optional.of(metadata));
+                TableFeatures.validateReadSupportedTable(protocol, dataPath.toString());
                 return new Tuple2<>(protocol, metadata);
               }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -82,16 +82,6 @@ public class ColumnMapping {
   }
 
   /**
-   * Checks if the given column mapping mode in the given table metadata is supported. Throws on
-   * unsupported modes.
-   *
-   * @param metadata Metadata of the table
-   */
-  public static void throwOnUnsupportedColumnMappingMode(Metadata metadata) {
-    getColumnMappingMode(metadata.getConfiguration());
-  }
-
-  /**
    * Helper method that converts the logical schema (requested by the connector) to physical schema
    * of the data stored in data files based on the table's column mapping mode.
    *


### PR DESCRIPTION
## Description
Currently, we pass optional `Metadata` to `validateReadSupportedTable`, which is just used for checking whether it has supported column mapping mode. We don't need to check that as if an unknown mode is passed, it will anyway fail later on. Also if a new mode is added, it will be part of a new table feature

Also for `validateWriteSupportedTable`, we pass the `schema` and `metadata` separately. Instead just passing the `metadata` (which has the `schema`) should be sufficient.

The implementation of these APIs going to change in the subsequent PRs.

## How was this patch tested?
Existing tests.