### PR TITLE
[Spark] Pass catalog table through TahoeLogFileIndex

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -212,7 +212,7 @@ case class DeltaSharingFileIndex(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): TahoeLogFileIndex = {
     val deltaLog = fetchFilesAndConstructDeltaLog(partitionFilters, dataFilters, None)
-    TahoeLogFileIndex(params.spark, deltaLog)
+    TahoeLogFileIndex(params.spark, deltaLog, catalogTableOpt = None)
   }
 
   override def listFiles(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -582,7 +582,7 @@ class DeltaLog private(
     }
 
     val fileIndex = TahoeLogFileIndex(
-      spark, this, dataPath, snapshotToUse, partitionFilters, isTimeTravelQuery)
+      spark, this, dataPath, snapshotToUse, catalogTableOpt, partitionFilters, isTimeTravelQuery)
     var bucketSpec: Option[BucketSpec] = None
 
     val r = buildHadoopFsRelationWithFileIndex(snapshotToUse, fileIndex, bucketSpec = bucketSpec)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, GenericInternalRow, Literal}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.types.StructType
@@ -244,6 +245,7 @@ case class TahoeLogFileIndex(
     override val deltaLog: DeltaLog,
     override val path: Path,
     snapshotAtAnalysis: SnapshotDescriptor,
+    catalogTableOpt: Option[CatalogTable],
     partitionFilters: Seq[Expression],
     isTimeTravelQuery: Boolean)
   extends TahoeFileIndex(spark, deltaLog, path) {
@@ -253,6 +255,7 @@ case class TahoeLogFileIndex(
     deltaLog: DeltaLog,
     path: Path,
     snapshotAtAnalysis: Snapshot,
+    catalogTableOpt: Option[CatalogTable],
     partitionFilters: Seq[Expression] = Nil,
     isTimeTravelQuery: Boolean = false
   ) = this (
@@ -261,6 +264,7 @@ case class TahoeLogFileIndex(
     path,
     if (isTimeTravelQuery) snapshotAtAnalysis
     else new ShallowSnapshotDescriptor(snapshotAtAnalysis),
+    catalogTableOpt,
     partitionFilters,
     isTimeTravelQuery)
 
@@ -288,7 +292,7 @@ case class TahoeLogFileIndex(
     if (isTimeTravelQuery) {
       snapshotAtAnalysis.asInstanceOf[Snapshot]
     } else {
-      deltaLog.update(stalenessAcceptable = true)
+      deltaLog.update(stalenessAcceptable = true, catalogTableOpt = catalogTableOpt)
     }
   }
 
@@ -366,19 +370,23 @@ case class TahoeLogFileIndex(
 }
 
 object TahoeLogFileIndex {
-  def apply(spark: SparkSession, deltaLog: DeltaLog): TahoeLogFileIndex =
-    new TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.unsafeVolatileSnapshot)
+  def apply(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      catalogTableOpt: Option[CatalogTable]): TahoeLogFileIndex =
+    new TahoeLogFileIndex(
+      spark, deltaLog, deltaLog.dataPath, deltaLog.unsafeVolatileSnapshot, catalogTableOpt)
 
   def apply(
     spark: SparkSession,
     deltaLog: DeltaLog,
     path: Path,
     snapshotAtAnalysis: Snapshot,
+    catalogTableOpt: Option[CatalogTable],
     partitionFilters: Seq[Expression] = Nil,
     isTimeTravelQuery: Boolean = false): TahoeLogFileIndex
   = new TahoeLogFileIndex(
-    spark, deltaLog, path, snapshotAtAnalysis, partitionFilters, isTimeTravelQuery
-  )
+    spark, deltaLog, path, snapshotAtAnalysis, catalogTableOpt, partitionFilters, isTimeTravelQuery)
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.delta.actions.{Action, AddFile, Metadata, Protocol}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
 import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
+import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.hooks.AutoCompact
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import io.delta.storage.commit.{CommitResponse, GetCommitsResponse, UpdatedActions}
@@ -179,6 +180,12 @@ object DeltaTestImplicits {
   implicit class DeltaTableV2TestHelper(deltaTable: DeltaTableV2) {
     /** For backward compatibility with existing unit tests */
     def snapshot: Snapshot = deltaTable.initialSnapshot
+  }
+
+  implicit class TahoeLogFileIndexObjectTestHelper(index: TahoeLogFileIndex.type) {
+    def apply(spark: SparkSession, deltaLog: DeltaLog): TahoeLogFileIndex = {
+      index.apply(spark, deltaLog, catalogTableOpt = None)
+    }
   }
 
   implicit class AutoCompactObjectTestHelper(ac: AutoCompact.type) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`TahoeLogFileIndex` contains `DeltaLog::update` calls but it does not pass in the catalog table yet. This causes the check for catalog table existence unreliable in `DeltaLog::update`. This PR fixes that by adding the catalog table argument to `TahoeLogFileIndex` and pass the catalog table from `DeltaLog::createRelation`

## How was this patch tested?

Run existing unit tests

## Does this PR introduce _any_ user-facing changes?

No
