### PR TITLE
[Kernel] Add utility to filter for columns in a schema

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -200,7 +200,7 @@ public class SchemaUtils {
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
-  /// Protected methods accessible in tests                                                     ///
+  /// Private methods                                                                           ///
   /////////////////////////////////////////////////////////////////////////////////////////////////
   /**
    * Returns all column names in this schema as a flat list. For example, a schema like:
@@ -216,7 +216,7 @@ public class SchemaUtils {
    *   will get flattened to: "a", "a.1", "a.2", "b", "c", "c.nest", "c.nest.3"
    * </pre>
    */
-  static List<String> flattenNestedFieldNames(StructType schema) {
+  private static List<String> flattenNestedFieldNames(StructType schema) {
     List<Tuple2<List<String>, StructField>> columnPathToStructFields =
         filterRecursively(
             schema,
@@ -230,9 +230,6 @@ public class SchemaUtils {
         .collect(Collectors.toList());
   }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////////
-  /// Private methods                                                                           ///
-  /////////////////////////////////////////////////////////////////////////////////////////////////
   private static List<Tuple2<List<String>, StructField>> recurseIntoComplexTypes(
       DataType type,
       List<String> columnPath,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -16,11 +16,11 @@
 package io.delta.kernel.internal.util
 
 import io.delta.kernel.exceptions.KernelException
-import io.delta.kernel.internal.util.SchemaUtils.{filterRecursively, flattenNestedFieldNames, validateSchema}
+import io.delta.kernel.internal.util.SchemaUtils.{filterRecursively, validateSchema}
 import io.delta.kernel.types.IntegerType.INTEGER
 import io.delta.kernel.types.LongType.LONG
 import io.delta.kernel.types.TimestampType.TIMESTAMP
-import io.delta.kernel.types.{ArrayType, DataType, LongType, MapType, StringType, StructField, StructType, TimestampType}
+import io.delta.kernel.types.{ArrayType, MapType, StringType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.util.Locale


### PR DESCRIPTION
## Description
This utility method can be used to filter for columns with invariants or a certain data type (timestamp_ntz, variant, etc.) to implicitly identify the table features that should be enabled.

## How was this patch tested?
Unit tests.