### PR TITLE
Update delta protocol to specify remove file path must byte match add file path

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -553,7 +553,7 @@ The schema of the `remove` action is as follows:
 
 Field Name | Data Type | Description | optional/required
 -|-|-|-
-path| String | A relative path to a file from the root of the table or an absolute path to a file that should be removed from the table. The path is a URI as specified by [RFC 2396 URI Generic Syntax](https://www.ietf.org/rfc/rfc2396.txt), which needs to be decoded to get the data file path. The path must string match the corresponding add action. | required
+path| String | A relative path to a file from the root of the table or an absolute path to a file that should be removed from the table. The path is a URI as specified by [RFC 2396 URI Generic Syntax](https://www.ietf.org/rfc/rfc2396.txt), which needs to be decoded to get the data file path. The path must string match the corresponding `add` action. | required
 deletionTimestamp | Option[Long] | The time the deletion occurred, represented as milliseconds since the epoch | optional
 dataChange | Boolean | When `false` the records in the removed file must be contained in one or more `add` file actions in the same version | required
 extendedFileMetadata | Boolean | When `true` the fields `partitionValues`, `size`, and `tags` are present | optional

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -842,7 +842,7 @@ To achieve the requirements above, related actions from different delta files ne
  - The latest `metaData` action seen wins
  - For `txn` actions, the latest `version` seen for a given `appId` wins
  - For `domainMetadata`, the latest `domainMetadata` seen for a given `domain` wins. The actions with `removed=true` act as tombstones to suppress earlier versions. Snapshot reads do _not_ return removed `domainMetadata` actions.
- - Logical files in a table are identified by their `(path, deletionVector.uniqueId)` primary key. File actions (`add` or `remove`) reference logical files, and a log can contain any number of references to a single file.
+ - Logical files in a table are identified by their `(path, deletionVector.uniqueId)` primary key. File actions (`add` or `remove`) reference logical files, and a log can contain any number of references to a single file. `add` and `remove` are considered the same only if the paths are string equal.
  - To replay the log, scan all file actions and keep only the newest reference for each logical file.
  - `add` actions in the result identify logical files currently present in the table (for queries). `remove` actions in the result identify tombstones of logical files no longer present in the table (for VACUUM).
  - [v2 checkpoint spec](#v2-spec) actions are not allowed in normal commit files, and do not participate in log replay.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -553,7 +553,7 @@ The schema of the `remove` action is as follows:
 
 Field Name | Data Type | Description | optional/required
 -|-|-|-
-path| String | A relative path to a file from the root of the table or an absolute path to a file that should be removed from the table. The path is a URI as specified by [RFC 2396 URI Generic Syntax](https://www.ietf.org/rfc/rfc2396.txt), which needs to be decoded to get the data file path. | required
+path| String | A relative path to a file from the root of the table or an absolute path to a file that should be removed from the table. The path is a URI as specified by [RFC 2396 URI Generic Syntax](https://www.ietf.org/rfc/rfc2396.txt), which needs to be decoded to get the data file path. The path must string match the corresponding add action. | required
 deletionTimestamp | Option[Long] | The time the deletion occurred, represented as milliseconds since the epoch | optional
 dataChange | Boolean | When `false` the records in the removed file must be contained in one or more `add` file actions in the same version | required
 extendedFileMetadata | Boolean | When `true` the fields `partitionValues`, `size`, and `tags` are present | optional


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here)

## Description

Update delta protocol to specify remove file path must string match add file path. The current spec doesn't actually say how to compare the paths from two string actions. An implementation could choose any of the following, with very different outcomes for ambiguous cases:
* Do a raw string comparison. Not reliable because different URI encoding libraries could choose to encode a different subset of "illegal" characters. e.g. abc vs %65bc.
* URI-decode the strings before comparing them. Moderately expensive, but still not reliable, e.g. /path/to/table and /path//to//table refer to the same URI.
* Construct a full URI from the string is the most expensive, and still not reliable, e.g. /path/to/table and /path/to/other/../table are not considered the same URI but some systems still treat them as the same path

In practice, all Delta clients we know of just copy whatever was in add.path as remove.path, so they should anyway compare byte-equal. Many Delta clients already perform raw string comparisons.

Since none of the approaches is reliable, and raw string comparisons are already used in practice, hereby we just update the spec to make that the required behavior.
