### PR TITLE
Make Redirect Table Features Droppable

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -655,3 +655,45 @@ case class CheckpointProtectionPreDowngradeCommand(table: DeltaTableV2)
     false
   }
 }
+
+case class RedirectWriterOnlyPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand
+    with DeltaLogging {
+  /**
+   * We disable the feature by removing [[DeltaConfigs.REDIRECT_WRITER_ONLY]].
+   *
+   * @return True if the property is removed. False otherwise.
+   */
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
+    // Make sure feature data/metadata exist before proceeding.
+    if (RedirectWriterOnlyFeature.validateRemoval(table.initialSnapshot)) {
+      return false
+    }
+
+    val properties = Seq(DeltaConfigs.REDIRECT_WRITER_ONLY.key)
+    AlterTableUnsetPropertiesDeltaCommand(
+      table, properties, ifExists = false, fromDropFeatureCommand = true).run(spark)
+    true
+  }
+}
+
+case class RedirectReaderWriterPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand
+    with DeltaLogging {
+  /**
+   * We disable the feature by removing [[DeltaConfigs.REDIRECT_READER_WRITER]].
+   *
+   * @return True if the property is removed. False otherwise.
+   */
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
+    // Make sure feature data/metadata exist before proceeding.
+    if (RedirectReaderWriterFeature.validateRemoval(table.initialSnapshot)) {
+      return false
+    }
+
+    val properties = Seq(DeltaConfigs.REDIRECT_READER_WRITER.key)
+    AlterTableUnsetPropertiesDeltaCommand(
+      table, properties, ifExists = false, fromDropFeatureCommand = true).run(spark)
+    true
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -4174,7 +4174,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           spark.sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
           val deltaLog = DeltaLog.forTable(spark, dir)
 
-          val redirectSpec = new PathBasedRedirectSpec("targetPath")
+          val redirectSpec = new PathBasedRedirectSpec("sourcePath", "targetPath")
           tableRedirect.add(
             deltaLog,
             catalogTableOpt = None,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This allows dropping RedirectWriterOnlyFeature and RedirectReaderWriterFeature

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
`DeltaProtocolVersionSuite.scala`


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
