### PR TITLE
[Spark] Support committing multiple column changes in one txn

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -565,6 +565,23 @@ object DeltaOperations {
 
     override val isInPlaceFileMetadataUpdate: Option[Boolean] = Some(false)
   }
+
+  /** Recorded when columns are changed in bulk. */
+  case class ChangeColumns(columns: Seq[ChangeColumn]) extends Operation("CHANGE COLUMNS") {
+
+    override val parameters: Map[String, Any] = Map(
+      "columns" -> JsonUtils.toJson(
+        columns.map(col =>
+          structFieldToMap(col.columnPath, col.newColumn) ++ col.colPosition.map("position" -> _))
+      )
+    )
+
+    // This operation shouldn't be introducing AddFile actions at all. This check should be trivial.
+    override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
+
+    override val isInPlaceFileMetadataUpdate: Option[Boolean] = Some(false)
+  }
+
   /** Recorded when columns are replaced. */
   case class ReplaceColumns(
       columns: Seq[StructField]) extends Operation("REPLACE COLUMNS") {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
 
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
 import org.apache.spark.sql.delta.ClassicColumnConversions._
-import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
+import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
@@ -2765,6 +2765,9 @@ trait OptimisticTransactionImpl extends DeltaTransaction
 
     op match {
       case change: ChangeColumn if usesDefaults(change.newColumn) =>
+        throwError("WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED",
+          Array("ALTER TABLE"))
+      case changes: ChangeColumns if changes.columns.exists(c => usesDefaults(c.newColumn)) =>
         throwError("WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED",
           Array("ALTER TABLE"))
       case create: CreateTable if create.metadata.schema.fields.exists(usesDefaults) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -720,6 +720,13 @@ case class AlterTableDropColumnsDeltaCommand(
   }
 }
 
+case class DeltaChangeColumnSpec(
+    columnPath: Seq[String],
+    columnName: String,
+    newColumn: StructField,
+    colPosition: Option[ColumnPosition],
+    syncIdentity: Boolean)
+
 /**
  * A command to change the column for a Delta table, support changing the comment of a column and
  * reordering columns.
@@ -733,11 +740,7 @@ case class AlterTableDropColumnsDeltaCommand(
  */
 case class AlterTableChangeColumnDeltaCommand(
     table: DeltaTableV2,
-    columnPath: Seq[String],
-    columnName: String,
-    newColumn: StructField,
-    colPosition: Option[ColumnPosition],
-    syncIdentity: Boolean)
+    columnChanges: Seq[DeltaChangeColumnSpec])
   extends LeafRunnableCommand with AlterDeltaTableCommand with IgnoreCachedData {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
@@ -754,89 +757,107 @@ case class AlterTableChangeColumnDeltaCommand(
         }
       val resolver = sparkSession.sessionState.conf.resolver
 
-      // Verify that the columnName provided actually exists in the schema
-      SchemaUtils.findColumnPosition(columnPath :+ columnName, oldSchema, resolver)
+      columnChanges.foreach(change => {
+        val columnName = change.columnName
+        val columnPath = change.columnPath
+        val newColumn = change.newColumn
+        if (newColumn.name != columnName) {
+          // need to validate the changes if the column is renamed
+          checkDependentExpressions(
+            sparkSession, columnPath :+ columnName, metadata, txn.protocol)
+        }
+        // Verify that the columnName provided actually exists in the schema
+        SchemaUtils.findColumnPosition(columnPath :+ columnName, oldSchema, resolver)
+      })
 
-      val transformedSchema = transformSchema(oldSchema, Some(columnName)) {
-        case (`columnPath`, struct @ StructType(fields), _) =>
-          val oldColumn = struct(columnName)
+      def transformSchemaOnce(prevSchema: StructType, change: DeltaChangeColumnSpec) = {
+        val columnPath = change.columnPath
+        val columnName = change.columnName
+        val newColumn = change.newColumn
+        transformSchema(prevSchema, Some(columnName)) {
+          case (`columnPath`, struct @ StructType(fields), _) =>
+            val oldColumn = struct(columnName)
 
-          // Analyzer already validates the char/varchar type change of ALTER COLUMN in
-          // `CheckAnalysis.checkAlterTableCommand`. We should normalize char/varchar type
-          // to string type first, then apply Delta-specific checks.
-          val oldColumnForVerification = if (bypassCharVarcharToStringFix) {
-            oldColumn
-          } else {
-            CharVarcharUtils.replaceCharVarcharWithStringInSchema(StructType(Seq(oldColumn))).head
-          }
-          verifyColumnChange(sparkSession, oldColumnForVerification, resolver, txn)
-
-          val newField = {
-            if (syncIdentity) {
-              assert(oldColumn == newColumn)
-              val df = txn.snapshot.deltaLog.createDataFrame(txn.snapshot, txn.filterFiles())
-              val allowLoweringHighWaterMarkForSyncIdentity = sparkSession.conf
-                .get(DeltaSQLConf.DELTA_IDENTITY_ALLOW_SYNC_IDENTITY_TO_LOWER_HIGH_WATER_MARK)
-              val field = IdentityColumn.syncIdentity(
-                deltaLog,
-                newColumn,
-                df,
-                allowLoweringHighWaterMarkForSyncIdentity
-              )
-              txn.setSyncIdentity()
-              txn.readWholeTable()
-              field
+            // Analyzer already validates the char/varchar type change of ALTER COLUMN in
+            // `CheckAnalysis.checkAlterTableCommand`. We should normalize char/varchar type
+            // to string type first, then apply Delta-specific checks.
+            val oldColumnForVerification = if (bypassCharVarcharToStringFix) {
+              oldColumn
             } else {
-              // Take the name, comment, nullability and data type from newField
-              // It's crucial to keep the old column's metadata, which may contain column mapping
-              // metadata.
-              var result = newColumn.getComment().map(oldColumn.withComment).getOrElse(oldColumn)
-              // Apply the current default value as well, if any.
-              result = newColumn.getCurrentDefaultValue() match {
-                case Some(newDefaultValue) => result.withCurrentDefaultValue(newDefaultValue)
-                case None => result.clearCurrentDefaultValue()
-              }
-
-              result
-                .copy(
-                  name = newColumn.name,
-                  dataType =
-                    SchemaUtils.changeDataType(oldColumn.dataType, newColumn.dataType, resolver),
-                  nullable = newColumn.nullable)
+              CharVarcharUtils.replaceCharVarcharWithStringInSchema(StructType(Seq(oldColumn))).head
             }
-          }
+            verifyColumnChange(change, sparkSession, oldColumnForVerification, resolver, txn)
 
-          // Replace existing field with new field
-          val newFieldList = fields.map { field =>
-            if (DeltaColumnMapping.getPhysicalName(field) ==
-              DeltaColumnMapping.getPhysicalName(newField)) {
-              newField
-            } else field
-          }
+            val newField = {
+              if (change.syncIdentity) {
+                assert(oldColumn == newColumn)
+                val df = txn.snapshot.deltaLog.createDataFrame(txn.snapshot, txn.filterFiles())
+                val allowLoweringHighWaterMarkForSyncIdentity = sparkSession.conf
+                  .get(DeltaSQLConf.DELTA_IDENTITY_ALLOW_SYNC_IDENTITY_TO_LOWER_HIGH_WATER_MARK)
+                val field = IdentityColumn.syncIdentity(
+                  deltaLog,
+                  newColumn,
+                  df,
+                  allowLoweringHighWaterMarkForSyncIdentity
+                )
+                txn.setSyncIdentity()
+                txn.readWholeTable()
+                field
+              } else {
+                // Take the name, comment, nullability and data type from newField
+                // It's crucial to keep the old column's metadata, which may contain column mapping
+                // metadata.
+                var result = newColumn.getComment().map(oldColumn.withComment).getOrElse(oldColumn)
+                // Apply the current default value as well, if any.
+                result = newColumn.getCurrentDefaultValue() match {
+                  case Some(newDefaultValue) => result.withCurrentDefaultValue(newDefaultValue)
+                  case None => result.clearCurrentDefaultValue()
+                }
 
-          // Reorder new field to correct position if necessary
-          StructType(colPosition.map { position =>
-            reorderFieldList(struct, newFieldList, newField, position, resolver)
-          }.getOrElse(newFieldList.toSeq))
+                result
+                  .copy(
+                    name = newColumn.name,
+                    dataType =
+                      SchemaUtils.changeDataType(oldColumn.dataType, newColumn.dataType, resolver),
+                    nullable = newColumn.nullable)
+              }
+            }
 
-        case (`columnPath`, m: MapType, _) if columnName == "key" =>
-          val originalField = StructField(columnName, m.keyType, nullable = false)
-          verifyMapArrayChange(sparkSession, originalField, resolver, txn)
-          m.copy(keyType = SchemaUtils.changeDataType(m.keyType, newColumn.dataType, resolver))
+            // Replace existing field with new field
+            val newFieldList = fields.map { field =>
+              if (DeltaColumnMapping.getPhysicalName(field) ==
+                DeltaColumnMapping.getPhysicalName(newField)) {
+                newField
+              } else field
+            }
 
-        case (`columnPath`, m: MapType, _) if columnName == "value" =>
-          val originalField = StructField(columnName, m.valueType, nullable = m.valueContainsNull)
-          verifyMapArrayChange(sparkSession, originalField, resolver, txn)
-          m.copy(valueType = SchemaUtils.changeDataType(m.valueType, newColumn.dataType, resolver))
+            // Reorder new field to correct position if necessary
+            StructType(change.colPosition.map { position =>
+              reorderFieldList(columnName, struct, newFieldList, newField, position, resolver)
+            }.getOrElse(newFieldList.toSeq))
 
-        case (`columnPath`, a: ArrayType, _) if columnName == "element" =>
-          val originalField = StructField(columnName, a.elementType, nullable = a.containsNull)
-          verifyMapArrayChange(sparkSession, originalField, resolver, txn)
-          a.copy(elementType =
-            SchemaUtils.changeDataType(a.elementType, newColumn.dataType, resolver))
+          case (`columnPath`, m: MapType, _) if columnName == "key" =>
+            val originalField = StructField(columnName, m.keyType, nullable = false)
+            verifyMapArrayChange(change, sparkSession, originalField, resolver, txn)
+            m.copy(keyType = SchemaUtils.changeDataType(m.keyType, newColumn.dataType, resolver))
 
-        case (_, other @ (_: StructType | _: ArrayType | _: MapType), _) => other
+          case (`columnPath`, m: MapType, _) if columnName == "value" =>
+            val originalField = StructField(columnName, m.valueType, nullable = m.valueContainsNull)
+            verifyMapArrayChange(change, sparkSession, originalField, resolver, txn)
+            m.copy(
+              valueType = SchemaUtils.changeDataType(m.valueType, newColumn.dataType, resolver))
+
+          case (`columnPath`, a: ArrayType, _) if columnName == "element" =>
+            val originalField = StructField(columnName, a.elementType, nullable = a.containsNull)
+            verifyMapArrayChange(change, sparkSession, originalField, resolver, txn)
+            a.copy(elementType =
+              SchemaUtils.changeDataType(a.elementType, newColumn.dataType, resolver))
+
+          case (_, other @ (_: StructType | _: ArrayType | _: MapType), _) => other
+        }
       }
+
+      val transformedSchema = columnChanges.foldLeft(oldSchema)(transformSchemaOnce)
       val newSchema = if (bypassCharVarcharToStringFix) {
         transformedSchema
       } else {
@@ -847,47 +868,70 @@ case class AlterTableChangeColumnDeltaCommand(
         CharVarcharUtils.replaceCharVarcharWithStringInSchema(transformedSchema)
       }
 
-      // update `partitionColumns` if the changed column is a partition column
-      val newPartitionColumns = if (columnPath.isEmpty) {
-        metadata.partitionColumns.map { partCol =>
-          if (partCol == columnName) newColumn.name else partCol
-        }
-      } else metadata.partitionColumns
-
-      val oldColumnPath = columnPath :+ columnName
-      val newColumnPath = columnPath :+ newColumn.name
-      // Rename the column in the delta statistics columns configuration, if present.
-      val newConfiguration = metadata.configuration ++
-        StatisticsCollection.renameDeltaStatsColumn(metadata, oldColumnPath, newColumnPath)
-
       val newSchemaWithTypeWideningMetadata =
         TypeWideningMetadata.addTypeWideningMetadata(
           txn,
           schema = newSchema,
           oldSchema = metadata.schema)
 
-      val newMetadata = metadata.copy(
-        schemaString = newSchemaWithTypeWideningMetadata.json,
-        partitionColumns = newPartitionColumns,
-        configuration = newConfiguration
-      )
+      val metadataWithNewSchema = metadata.copy(
+        schemaString = newSchemaWithTypeWideningMetadata.json)
 
-      if (newColumn.name != columnName) {
-        // need to validate the changes if the column is renamed
-        checkDependentExpressions(
-          sparkSession, columnPath :+ columnName, metadata, txn.protocol)
+      def updateMetadataOnce(prevMetadata: actions.Metadata, change: DeltaChangeColumnSpec) = {
+        val columnPath = change.columnPath
+        val columnName = change.columnName
+        val newColumn = change.newColumn
+        // update `partitionColumns` if the changed column is a partition column
+        val newPartitionColumns = if (columnPath.isEmpty) {
+          metadata.partitionColumns.map { partCol =>
+            if (partCol == columnName) newColumn.name else partCol
+          }
+        } else metadata.partitionColumns
+
+        val oldColumnPath = columnPath :+ columnName
+        val newColumnPath = columnPath :+ newColumn.name
+        // Rename the column in the delta statistics columns configuration, if present.
+        val newConfiguration = metadata.configuration ++
+          StatisticsCollection.renameDeltaStatsColumn(metadata, oldColumnPath, newColumnPath)
+
+        val updatedMetadata = prevMetadata.copy(
+          partitionColumns = newPartitionColumns,
+          configuration = newConfiguration
+        )
+
+        updatedMetadata
       }
+
+      val newMetadata = columnChanges.foldLeft(metadataWithNewSchema)(updateMetadataOnce)
 
 
       txn.updateMetadata(newMetadata)
 
-      if (newColumn.name != columnName) {
-        // record column rename separately
-        txn.commit(Nil, DeltaOperations.RenameColumn(oldColumnPath, newColumnPath))
+      def getDeltaChangeColumnOperation(change: DeltaChangeColumnSpec) =
+        DeltaOperations.ChangeColumn(
+          change.columnPath,
+          change.columnName,
+          change.newColumn,
+          change.colPosition.map(_.toString))
+
+      val operation = if (columnChanges.size == 1) {
+        val change = columnChanges.head
+        val columnName = change.columnName
+        val newColumn = change.newColumn
+        if (newColumn.name != columnName) {
+          val columnPath = change.columnPath
+          val oldColumnPath = columnPath :+ columnName
+          val newColumnPath = columnPath :+ newColumn.name
+          // record column rename separately
+          DeltaOperations.RenameColumn(oldColumnPath, newColumnPath)
+        } else {
+          getDeltaChangeColumnOperation(change)
+        }
       } else {
-        txn.commit(Nil, DeltaOperations.ChangeColumn(
-          columnPath, columnName, newColumn, colPosition.map(_.toString)))
+        val changes = columnChanges.map(getDeltaChangeColumnOperation)
+        DeltaOperations.ChangeColumns(changes)
       }
+      txn.commit(Nil, operation)
 
       Seq.empty[Row]
     }
@@ -896,6 +940,7 @@ case class AlterTableChangeColumnDeltaCommand(
   /**
    * Reorder the given fieldList to place `field` at the given `position` in `fieldList`
    *
+   * @param columnName Name of the column being reordered
    * @param struct The initial StructType with the original field at its original position
    * @param fieldList List of fields with the changed field in the original position
    * @param field The field that is to be added
@@ -903,6 +948,7 @@ case class AlterTableChangeColumnDeltaCommand(
    * @return Returns a new list of fields with the changed field in the new position
    */
   private def reorderFieldList(
+      columnName: String,
       struct: StructType,
       fieldList: Array[StructField],
       field: StructField,
@@ -939,14 +985,18 @@ case class AlterTableChangeColumnDeltaCommand(
    * Note that this requires a full table scan in the case of SET NOT NULL to verify that all
    * existing values are valid.
    *
+   * @param change Information about the column change
    * @param originalField The existing column
    */
   private def verifyColumnChange(
+      change: DeltaChangeColumnSpec,
       spark: SparkSession,
       originalField: StructField,
       resolver: Resolver,
       txn: OptimisticTransaction): Unit = {
-
+    val columnPath = change.columnPath
+    val columnName = change.columnName
+    val newColumn = change.newColumn
     originalField.dataType match {
       case same if same == newColumn.dataType =>
       // just changing comment or position so this is fine
@@ -1009,10 +1059,18 @@ case class AlterTableChangeColumnDeltaCommand(
    * Verify whether replacing the original map key/value or array element with a new data type is a
    * valid operation.
    *
+   * @param change Information about the column change
    * @param originalField the original map key/value or array element to update.
    */
-  private def verifyMapArrayChange(spark: SparkSession, originalField: StructField,
-      resolver: Resolver, txn: OptimisticTransaction): Unit = {
+  private def verifyMapArrayChange(
+      change: DeltaChangeColumnSpec,
+      spark: SparkSession,
+      originalField: StructField,
+      resolver: Resolver,
+      txn: OptimisticTransaction): Unit = {
+    val columnPath = change.columnPath
+    val columnName = change.columnName
+    val newColumn = change.newColumn
     // Map key/value and array element can't have comments.
     if (newColumn.getComment().nonEmpty) {
       throw DeltaErrors.addCommentToMapArrayException(
@@ -1027,7 +1085,7 @@ case class AlterTableChangeColumnDeltaCommand(
         newField = newColumn
       )
     }
-    verifyColumnChange(spark, originalField, resolver, txn)
+    verifyColumnChange(change, spark, originalField, resolver, txn)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The `DeltaCatalog::alterTable` accepts a list of table changes. However, we are currently committing the column changes in separate transactions. This PR does the following refactoring:

+ introduces `DeltaChangeColumnSpec` as arguments to `AlterTableChangeColumnDeltaCommand` so that we can pass multiple changes and commit them in one transaction.
+ updates `DeltaCatalog::alterTable` to collect the column changes into `DeltaChangeColumnSpec`
+ for SYNC IDENITY, `DeltaCatalog::alterTable` previously has a single syncIdentity variable for all table changes to denote whether to run sync identity or not. This PR fixes that and record the sync identity parameter separately for each column.


## How was this patch tested?

Existing unit tests

## Does this PR introduce _any_ user-facing changes?

No