### PR TITLE
Uniform: Fix microsecond conversion for timestamp/ntz partition value

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -35,6 +35,7 @@ import shadedForDelta.org.apache.iceberg.{DataFile, DataFiles, FileFormat, Parti
 import shadedForDelta.org.apache.iceberg.Metrics
 import shadedForDelta.org.apache.iceberg.StructLike
 import shadedForDelta.org.apache.iceberg.TableProperties
+import shadedForDelta.org.apache.iceberg.util.DateTimeUtil
 
 // scalastyle:off import.ordering.noEmptyLine
 import shadedForDelta.org.apache.iceberg.catalog.{Namespace, TableIdentifier => IcebergTableIdentifier}
@@ -239,7 +240,8 @@ object IcebergTransactionUtils
       case _: DecimalType => new java.math.BigDecimal(partitionVal)
       case _: BinaryType => ByteBuffer.wrap(partitionVal.getBytes("UTF-8"))
       case _: TimestampNTZType =>
-        java.sql.Timestamp.valueOf(partitionVal).getNanos/1000.asInstanceOf[Long]
+        DateTimeUtil.isoTimestampToMicros(
+          partitionVal.replace(" ", "T"))
       case _: TimestampType =>
         try {
           getMicrosSinceEpoch(partitionVal)
@@ -257,7 +259,8 @@ object IcebergTransactionUtils
   }
 
   private def getMicrosSinceEpoch(instant: String): Long = {
-    Instant.parse(instant).getNano/1000.asInstanceOf[Long]
+    DateTimeUtil.microsFromInstant(
+      Instant.parse(instant))
   }
 
   private def getMetricsForIcebergDataFile(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -64,7 +64,7 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
       "to_date('2016-12-31', 'yyyy-MM-dd')",
       "'asdf'",
       true,
-      "TIMESTAMP_NTZ'2021-12-06 00:00:00'",
+      "TIMESTAMP_NTZ'2021-12-06 05:12:34'",
       "TIMESTAMP'2023-08-18 05:00:00UTC-7'"
     )
 
@@ -88,7 +88,7 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
             s"where ${partitionColumnName}=${partitionColumnsAndValues._2}"
           // Verify against Delta read and Iceberg read
           checkAnswer(spark.sql(verificationQuery), Seq(Row(123)))
-          checkAnswer(createReaderSparkSession.sql(verificationQuery), Seq(Row(123)))
+          assert(read(verificationQuery).sameElements(Seq(Row(123))))
         }
     }
   }
@@ -109,7 +109,7 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
         s"where id=1 and ts=TIMESTAMP'2023-08-18 05:00:00UTC-7'"
       // Verify against Delta read and Iceberg read
       checkAnswer(spark.sql(verificationQuery), Seq(Row(123)))
-      checkAnswer(createReaderSparkSession.sql(verificationQuery), Seq(Row(123)))
+      assert(read(verificationQuery).sameElements(Seq(Row(123))))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here)

## Description

When converting timestamp partition values from Delta to Iceberg, currently we're doing the microsecond conversion incorectly. This leads to every conversion just returning the Unix epoch timestamp.

 In the current approach we're using some utilities from Iceberg, such as DateTimeUtil.microsFromInstant which already have implemented this logic correctly.

 There were unit tests that should've caught this earlier by testing the Iceberg spark session as a reader, but they were passing just because the wrong read method was used. This PR fixes that as well.

## How was this patch tested?

I fixed existing unit tests since they should've caught this. 

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
