### PR TITLE
[Kernel] Fix config passed to the column mapping mode change validation method

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -170,11 +170,14 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         TableConfig.validateDeltaProperties(tableProperties.orElse(Collections.emptyMap()));
     Map<String, String> newProperties = metadata.filterOutUnchangedProperties(validatedProperties);
 
-    ColumnMapping.verifyColumnMappingChange(metadata.getConfiguration(), newProperties, isNewTable);
-
     if (!newProperties.isEmpty()) {
       shouldUpdateMetadata = true;
+      Map<String, String> oldConfiguration = metadata.getConfiguration();
+
       metadata = metadata.withNewConfiguration(newProperties);
+
+      ColumnMapping.verifyColumnMappingChange(
+              oldConfiguration, metadata.getConfiguration() /* new config */, isNewTable);
     }
 
     Optional<Tuple2<Protocol, Set<TableFeature>>> newProtocolAndFeatures =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -177,7 +177,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       metadata = metadata.withNewConfiguration(newProperties);
 
       ColumnMapping.verifyColumnMappingChange(
-              oldConfiguration, metadata.getConfiguration() /* new config */, isNewTable);
+          oldConfiguration, metadata.getConfiguration() /* new config */, isNewTable);
     }
 
     Optional<Tuple2<Protocol, Set<TableFeature>>> newProtocolAndFeatures =


### PR DESCRIPTION
## Description
Currently, the `ColumnMapping.verifyColumnMappingChange` takes just the new properties as the argument for the new configuration. This is incorrect, as the method looks for the CM mode based on the new complete config.

Also missing the test coverage for this. Add a new test.