### PR TITLE
[Spark] Simplify reference binding in DeltaInvariantChecker

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
@@ -43,13 +43,24 @@ import org.apache.spark.sql.types.StructType
  */
 case class DeltaInvariantChecker(
     child: LogicalPlan,
-    deltaConstraints: Seq[Constraint]) extends UnaryNode {
+    deltaConstraints: Seq[CheckDeltaInvariant]) extends UnaryNode {
   assert(deltaConstraints.nonEmpty)
 
   override def output: Seq[Attribute] = child.output
 
   override protected def withNewChildInternal(newChild: LogicalPlan): DeltaInvariantChecker =
     copy(child = newChild)
+}
+
+object DeltaInvariantChecker {
+  def apply(
+      spark: SparkSession,
+      child: LogicalPlan,
+      constraints: Seq[Constraint]): DeltaInvariantChecker = {
+    val invariantChecks =
+      DeltaInvariantCheckerExec.buildInvariantChecks(child.output, constraints, spark)
+    DeltaInvariantChecker(child, invariantChecks)
+  }
 }
 
 object DeltaInvariantCheckerStrategy extends SparkStrategy {
@@ -66,26 +77,15 @@ object DeltaInvariantCheckerStrategy extends SparkStrategy {
  */
 case class DeltaInvariantCheckerExec(
     child: SparkPlan,
-    constraints: Seq[Constraint]) extends UnaryExecNode {
+    constraints: Seq[CheckDeltaInvariant]) extends UnaryExecNode {
 
   override def output: Seq[Attribute] = child.output
 
   override protected def doExecute(): RDD[InternalRow] = {
     if (constraints.isEmpty) return child.execute()
-    val invariantChecks =
-      DeltaInvariantCheckerExec.buildInvariantChecks(child.output, constraints, session)
-
-    // Resolve current_date()/current_time() expressions.
-    // We resolve currentTime for all invariants together to make sure we use the same timestamp.
-    val invariantsFakePlan = AnalysisHelper.FakeLogicalPlan(invariantChecks, Nil)
-    val newInvariantsPlan = optimizer.ComputeCurrentTime(invariantsFakePlan)
-    val localOutput = child.output
 
     child.execute().mapPartitionsInternal { rows =>
-      val boundRefs = newInvariantsPlan.expressions
-        .asInstanceOf[Seq[CheckDeltaInvariant]]
-        .map(_.withBoundReferences(localOutput))
-      val assertions = UnsafeProjection.create(boundRefs)
+      val assertions = UnsafeProjection.create(constraints, child.output)
       rows.map { row =>
         assertions(row)
         row
@@ -102,6 +102,14 @@ case class DeltaInvariantCheckerExec(
 }
 
 object DeltaInvariantCheckerExec extends DeltaLogging {
+  def apply(
+      spark: SparkSession,
+      child: SparkPlan,
+      constraints: Seq[Constraint]): DeltaInvariantCheckerExec = {
+    val invariantChecks =
+      DeltaInvariantCheckerExec.buildInvariantChecks(child.output, constraints, spark)
+    DeltaInvariantCheckerExec(child, invariantChecks)
+  }
 
   // Specialized optimizer to run necessary rules so that the check expressions can be evaluated.
   object DeltaInvariantCheckerOptimizer
@@ -201,7 +209,7 @@ object DeltaInvariantCheckerExec extends DeltaLogging {
           resolvedExpr
       }
 
-      CheckDeltaInvariant(executableExpr, columnExtractors.toMap, constraint)
+      CheckDeltaInvariant(executableExpr, columnExtractors.toSeq, constraint)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
@@ -88,7 +88,7 @@ case class DeltaInvariantCheckerExec(
     // We resolve currentTime for all invariants together to make sure we use the same timestamp.
     val invariantsFakePlan = AnalysisHelper.FakeLogicalPlan(constraints, Nil)
     val newInvariantsPlan = optimizer.ComputeCurrentTime(invariantsFakePlan)
-    val constraintsWithFixedTime = newInvariantsPlan.expressions
+    val constraintsWithFixedTime = newInvariantsPlan.expressions.toArray
 
     child.execute().mapPartitionsInternal { rows =>
       val assertions = UnsafeProjection.create(constraintsWithFixedTime, child.output)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -433,7 +433,7 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
 
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryExecution.executedPlan,
         partitioningColumns, constraints)
-      val checkInvariants = DeltaInvariantCheckerExec(empty2NullPlan, constraints)
+      val checkInvariants = DeltaInvariantCheckerExec(spark, empty2NullPlan, constraints)
       // No need to plan optimized write if the write command is OPTIMIZE, which aims to produce
       // evenly-balanced data files already.
       val physicalPlan = if (!isOptimize &&


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR simplifies the binding of attribute references in `DeltaInvariantCheckerExec`. Before this PR we had some code to manually bind these references. This PR changes this to make Spark do the binding for us.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
