### PR TITLE
[Spark] Add protocol validation in Metadata cleanup based on CRCs

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
@@ -91,6 +91,7 @@ object DeltaLogFileIndex {
   lazy val COMMIT_FILE_FORMAT = new JsonFileFormat
   lazy val CHECKPOINT_FILE_FORMAT_PARQUET = new ParquetFileFormat
   lazy val CHECKPOINT_FILE_FORMAT_JSON = new JsonFileFormat
+  lazy val CHECKSUM_FILE_FORMAT = new JsonFileFormat
 
   def apply(format: FileFormat, fs: FileSystem, paths: Seq[Path]): DeltaLogFileIndex = {
     DeltaLogFileIndex(format, paths.map(fs.getFileStatus).toArray)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaUDF.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaUDF.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
+import org.apache.spark.sql.delta.actions.{DeletionVectorDescriptor, Protocol}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DeletedRecordCountsHistogram
 
@@ -62,6 +62,9 @@ object DeltaUDF {
   def booleanFromString(s: String => Boolean): UserDefinedFunction =
     createUdfFromTemplateUnsafe(booleanFromStringTemplate, s, udf(s))
 
+  def booleanFromProtocol(f: Protocol => Boolean): UserDefinedFunction =
+    createUdfFromTemplateUnsafe(booleanFromProtocol, f, udf(f))
+
   def booleanFromMap(f: Map[String, String] => Boolean): UserDefinedFunction =
     createUdfFromTemplateUnsafe(booleanFromMapTemplate, f, udf(f))
 
@@ -94,6 +97,9 @@ object DeltaUDF {
 
   private lazy val booleanFromStringTemplate =
     udf((_: String) => false).asInstanceOf[SparkUserDefinedFunction]
+
+  private lazy val booleanFromProtocol =
+    udf((_: Protocol) => true).asInstanceOf[SparkUserDefinedFunction]
 
   private lazy val booleanFromMapTemplate =
     udf((_: Map[String, String]) => true).asInstanceOf[SparkUserDefinedFunction]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.util.{Calendar, TimeZone}
 
+import scala.collection.immutable.NumericRange
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
@@ -25,12 +26,14 @@ import org.apache.spark.sql.delta.TruncationGranularity.{DAY, HOUR, MINUTE, Trun
 import org.apache.spark.sql.delta.actions.{Action, Metadata}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.commons.lang3.time.DateUtils
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 
 import org.apache.spark.internal.MDC
+import org.apache.spark.sql.functions.{col, isnull, lit, not, when}
 
 private[delta] object TruncationGranularity extends Enumeration {
   type TruncationGranularity = Value
@@ -40,6 +43,11 @@ private[delta] object TruncationGranularity extends Enumeration {
 /** Cleans up expired Delta table metadata. */
 trait MetadataCleanup extends DeltaLogging {
   self: DeltaLog =>
+
+  protected type VersionRange = NumericRange.Inclusive[Long]
+
+  protected def versionRange(start: Long, end: Long): VersionRange =
+    NumericRange.inclusive[Long](start = start, end = end, step = 1)
 
   /** Whether to clean up expired log files and checkpoints. */
   def enableExpiredLogCleanup(metadata: Metadata): Boolean =
@@ -163,24 +171,115 @@ trait MetadataCleanup extends DeltaLogging {
       files, fileCutOffTime, threshold, getDeltaFileOrCheckpointVersion)
   }
 
+  protected def checkpointExistsAtCleanupBoundary(deltaLog: DeltaLog, version: Long): Boolean = {
+    if (spark.conf.get(DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED)) {
+      return false
+    }
+
+    val upperBoundVersion = Some(CheckpointInstance(version = version + 1))
+    deltaLog
+      .findLastCompleteCheckpointBefore(upperBoundVersion)
+      .exists(_.version == version)
+  }
+
   /**
    * Validates whether the metadata cleanup adheres to the CheckpointProtectionTableFeature
-   * requirements. Metadata cleanup is only allowed if we can clean up everything before
-   * requireCheckpointProtectionBeforeVersion. The implementation below scans the history
-   * until it finds a commit that satisfies the invariant.
+   * requirements. Metadata cleanup is only allowed if we can cleanup everything before
+   * requireCheckpointProtectionBeforeVersion. If this is not possible, we can still cleanup
+   * if there is already a checkpoint at the cleanup boundary version.
+   *
+   * If none of the invariants above are satisfied, we validate whether we support all
+   * protocols in the commit range we are planning to delete. If we encounter an unsupported
+   * protocol we skip the cleanup.
    */
   private def metadataCleanupAllowed(
       snapshot: Snapshot,
       fileCutOffTime: Long): Boolean = {
+    def expandVersionRange(currentRange: VersionRange, versionToCover: Long): VersionRange =
+      versionRange(currentRange.start.min(versionToCover), currentRange.end.max(versionToCover))
+
     val checkpointProtectionVersion =
       CheckpointProtectionTableFeature.getCheckpointProtectionVersion(snapshot)
     if (checkpointProtectionVersion <= 0) return true
 
-    def versionGreaterOrEqualToThreshold(file: FileStatus): Boolean =
-      getDeltaFileOrCheckpointVersion(file.getPath) >= checkpointProtectionVersion - 1
-
     val expiredDeltaLogs = listExpiredDeltaLogs(fileCutOffTime)
-    expiredDeltaLogs.isEmpty || expiredDeltaLogs.exists(versionGreaterOrEqualToThreshold)
+    if (expiredDeltaLogs.isEmpty) return true
+
+    val deltaLog = snapshot.deltaLog
+    val toCleanVersionRange = expiredDeltaLogs
+      .filter(isDeltaFile)
+      .collect { case DeltaFile(_, version) => version }
+      // Stop early if we cannot cleanup beyond the checkpointProtectionVersion.
+      // We include equality for the CheckpointProtection invariant check below.
+      // Assumes commit versions are continuous.
+      .takeWhile { _ <= checkpointProtectionVersion - 1 }
+      .foldLeft(versionRange(Long.MaxValue, 0L))(expandVersionRange)
+
+    // CheckpointProtectionTableFeature main invariant.
+    if (toCleanVersionRange.end >= checkpointProtectionVersion - 1) return true
+    // If we cannot delete until the checkpoint protection version. Check if a checkpoint already
+    // exists at the cleanup boundary. If it does, it is safe to clean up to the boundary.
+    if (checkpointExistsAtCleanupBoundary(deltaLog, toCleanVersionRange.end + 1L)) return true
+
+    // If the CheckpointProtectionTableFeature invariants do not hold, we must support all
+    // protocols for commits that we are cleaning up. Also, we have to support the first
+    // commit that we retain, because we will be creating a new checkpoint for that commit.
+    allProtocolsSupported(
+      deltaLog,
+      versionRange(toCleanVersionRange.start, toCleanVersionRange.end + 1L))
+  }
+
+  /**
+   * Returns false if there is a non-supported or null protocol in the provided checksums.
+   * Returns true otherwise.
+   */
+  protected[delta] def allProtocolsSupported(
+      deltaLog: DeltaLog,
+      checksumsToValidate: Iterator[FileStatus],
+      versionThatRequiresWriteSupport: Long,
+      expectedChecksumFileCount: Long): Boolean = {
+    if (!spark.conf.get(DeltaSQLConf.ALLOW_METADATA_CLEANUP_WHEN_ALL_PROTOCOLS_SUPPORTED)) {
+      return false
+    }
+
+    val schemaToUse = Action.logSchema(Set("protocol"))
+    val supportedForRead = DeltaUDF.booleanFromProtocol(_.supportedForRead())(col("protocol"))
+    val supportedForWrite = DeltaUDF.booleanFromProtocol(_.supportedForWrite())(col("protocol"))
+    val supportedForReadAndWrite = supportedForRead && supportedForWrite
+    val supported =
+      when(col("version") === lit(versionThatRequiresWriteSupport), supportedForReadAndWrite)
+      .otherwise(supportedForRead)
+
+    val fileIndexOpt =
+      DeltaLogFileIndex(DeltaLogFileIndex.CHECKSUM_FILE_FORMAT, checksumsToValidate.toSeq)
+    val fileIndexSupportedOpt = fileIndexOpt.map { index =>
+      if (index.inputFiles.length != expectedChecksumFileCount) return false
+
+      deltaLog
+        .loadIndex(index, schemaToUse)
+        // If we find any CRC with no protocol definition we need to abort.
+        .filter(isnull(col("protocol")) || not(supported))
+        .take(1)
+        .isEmpty
+    }
+    fileIndexSupportedOpt.getOrElse(true)
+  }
+
+  protected[delta] def allProtocolsSupported(
+      deltaLog: DeltaLog,
+      versionRange: VersionRange): Boolean = {
+    // We only expect back filled commits in the range.
+    val checksumsToValidate = deltaLog
+      .listFrom(versionRange.start)
+      .collect { case ChecksumFile(fileStatus, version) => (fileStatus, version) }
+      .takeWhile { case (_, version) => version <= versionRange.end }
+      .map { case (fileStatus, _) => fileStatus }
+
+    allProtocolsSupported(
+      deltaLog,
+      checksumsToValidate,
+      versionThatRequiresWriteSupport = versionRange.end,
+      expectedChecksumFileCount = versionRange.end - versionRange.start + 1)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -230,8 +230,18 @@ trait MetadataCleanup extends DeltaLogging {
   }
 
   /**
-   * Returns false if there is a non-supported or null protocol in the provided checksums.
-   * Returns true otherwise.
+   * Validates whether the client supports read for all the protocols in the provided checksums
+   * as well as write for `versionThatRequiresWriteSupport`.
+   *
+   * @param deltaLog The log of the delta table.
+   * @param checksumsToValidate An iterator with the checksum files we need to validate. The client
+   *                            needs read support for all the encountered protocols.
+   * @param versionThatRequiresWriteSupport The version the client needs write support. This
+   *                                        is the version we are creating a new checkpoint.
+   * @param expectedChecksumFileCount The expected number of checksum files. If the iterator
+   *                                  contains less files, the function returns false.
+   * @return Returns false if there is a non-supported or null protocol in the provided checksums.
+   *         Returns true otherwise.
    */
   protected[delta] def allProtocolsSupported(
       deltaLog: DeltaLog,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -77,6 +77,11 @@ case class TestUnsupportedReaderWriterFeaturePreDowngradeCommand(table: DeltaTab
   override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = true
 }
 
+case class TestUnsupportedWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = true
+}
+
 case class TestWriterWithHistoryValidationFeaturePreDowngradeCommand(table: DeltaTableV2)
     extends PreDowngradeTableFeatureCommand
     with DeltaLogging {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -407,6 +407,29 @@ trait TableFeatureSupport { this: Protocol =>
       // new protocol
       readerAndWriterFeatureNames.contains(feature.name)
   }
+
+  /** Returns whether this client supports writing in a table with this protocol. */
+  def supportedForWrite(): Boolean = {
+    val supportedWriterVersions = Action.supportedWriterVersionNumbers
+    val supportedWriterFeatures = Action.supportedProtocolVersion().writerFeatureNames
+    val testUnsupportedFeatures: Set[String] = TableFeature.testUnsupportedFeatures
+      .filterNot(_.isReaderWriterFeature)
+      .map(_.name)
+
+    supportedWriterVersions.contains(this.minWriterVersion) &&
+      this.writerFeatureNames.subsetOf(supportedWriterFeatures -- testUnsupportedFeatures)
+  }
+
+  /** Returns whether this client supports reading a table with this protocol. */
+  def supportedForRead(): Boolean = {
+    val supportedReaderVersions = Action.supportedReaderVersionNumbers
+    val supportedReaderFeatures = Action.supportedProtocolVersion().readerFeatureNames
+    val testUnsupportedFeatures: Set[String] = TableFeature.testUnsupportedFeatures
+      .filter(_.isReaderWriterFeature).map(_.name)
+
+    supportedReaderVersions.contains(this.minReaderVersion) &&
+      this.readerFeatureNames.subsetOf(supportedReaderFeatures -- testUnsupportedFeatures)
+  }
 }
 
 object TableFeatureProtocolUtils {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -440,6 +440,25 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val ALLOW_METADATA_CLEANUP_WHEN_ALL_PROTOCOLS_SUPPORTED =
+    buildConf("tableFeatures.allowMetadataCleanupWhenAllProtocolsSupported")
+      .internal()
+      .doc(
+        """Whether to perform protocol validation when the client is unable to clean
+          |up to 'delta.requireCheckpointProtectionBeforeVersion'.""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
+  val ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED =
+    buildConf("tableFeatures.dev.allowMetadataCleanupCheckpointExistenceCheck.disabled")
+      .internal()
+      .doc(
+        """Whether to disable the checkpoint check at the cleanup boundary when performing
+          |the CheckpointProtectionTableFeature validations.
+          |This is only used for testing purposes.'.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val FAST_DROP_FEATURE_ENABLED =
     buildConf("tableFeatures.dev.fastDropFeature.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -508,136 +508,323 @@ class DeltaRetentionSuite extends QueryTest
   }
 
   test("Metadata cleanup respects requireCheckpointProtectionBeforeVersion") {
-    // Commits should be cleaned up to the latest checkpoint.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8),
-      requireCheckpointProtectionBeforeVersion = 2,
-      expectedCommitsAfterCleanup = Range.inclusive(8, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(8, 10))
+    withSQLConf(
+        DeltaSQLConf.ALLOW_METADATA_CLEANUP_WHEN_ALL_PROTOCOLS_SUPPORTED.key -> "false",
+        DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
+      // Commits should be cleaned up to the latest checkpoint.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8),
+        requireCheckpointProtectionBeforeVersion = 2,
+        expectedCommitsAfterCleanup = (8 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(8, 10))
 
-    // Commits should be cleaned up to the latest checkpoint.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8),
-      requireCheckpointProtectionBeforeVersion = 6,
-      expectedCommitsAfterCleanup = Range.inclusive(8, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(8, 10))
+      // Commits should be cleaned up to the latest checkpoint.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8),
+        requireCheckpointProtectionBeforeVersion = 6,
+        expectedCommitsAfterCleanup = (8 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(8, 10))
 
-    // Commits should be cleaned up to the latest checkpoint.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8),
-      requireCheckpointProtectionBeforeVersion = 7,
-      expectedCommitsAfterCleanup = Range.inclusive(8, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(8, 10))
+      // Commits should be cleaned up to the latest checkpoint.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8),
+        requireCheckpointProtectionBeforeVersion = 7,
+        expectedCommitsAfterCleanup = (8 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(8, 10))
 
-    // Commits should be cleaned up to the latest checkpoint.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8),
-      requireCheckpointProtectionBeforeVersion = 8,
-      expectedCommitsAfterCleanup = Range.inclusive(8, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(8, 10))
+      // Commits should be cleaned up to the latest checkpoint.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8),
+        requireCheckpointProtectionBeforeVersion = 8,
+        expectedCommitsAfterCleanup = (8 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(8, 10))
 
-    // Commits should be cleaned up to the checkpoint 10.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 10,
-      createNumCommitsWithinRetentionPeriod = 10,
-      createCheckpoints = Set(6, 8),
-      requireCheckpointProtectionBeforeVersion = 9,
-      expectedCommitsAfterCleanup = Range.inclusive(10, 19).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(10))
+      // Commits should be cleaned up to the checkpoint 10.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 10,
+        createNumCommitsWithinRetentionPeriod = 10,
+        createCheckpoints = Set(6, 8),
+        requireCheckpointProtectionBeforeVersion = 9,
+        expectedCommitsAfterCleanup = (10 to 19),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(10))
 
-    // Checkpoint 8 is within the retention period.
-    // Cleanup should be skipped.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8),
-      requireCheckpointProtectionBeforeVersion = 9,
-      expectedCommitsAfterCleanup = Range.inclusive(0, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(6, 8, 10))
+      // Checkpoint 8 is within the retention period.
+      // Cleanup should be skipped.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8),
+        requireCheckpointProtectionBeforeVersion = 9,
+        expectedCommitsAfterCleanup = (0 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(6, 8, 10))
 
-    // Cleanup should be skipped.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8),
-      requireCheckpointProtectionBeforeVersion = 20,
-      expectedCommitsAfterCleanup = Range.inclusive(0, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(6, 8, 10))
+      // Cleanup should be skipped.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8),
+        requireCheckpointProtectionBeforeVersion = 20,
+        expectedCommitsAfterCleanup = (0 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(6, 8, 10))
 
-    // With multiple checkpoints (8, 12, 14) within the retention period.
-    // None of these should be cleaned up.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8, 12, 14),
-      requireCheckpointProtectionBeforeVersion = 8,
-      expectedCommitsAfterCleanup = Range.inclusive(8, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(8, 10, 12, 14))
+      // With multiple checkpoints (8, 12, 14) within the retention period.
+      // None of these should be cleaned up.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8, 12, 14),
+        requireCheckpointProtectionBeforeVersion = 8,
+        expectedCommitsAfterCleanup = (8 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(8, 10, 12, 14))
 
-    // With multiple checkpoints (8, 12, 14) within the retention period.
-    // requireCheckpointProtectionBeforeVersion = 9 is within the retention period.
-    // Cleanup should be skipped.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 8,
-      createNumCommitsWithinRetentionPeriod = 8,
-      createCheckpoints = Set(6, 8, 12, 14),
-      requireCheckpointProtectionBeforeVersion = 9,
-      expectedCommitsAfterCleanup = Range.inclusive(0, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(6, 8, 10, 12, 14))
+      // With multiple checkpoints (8, 12, 14) within the retention period.
+      // requireCheckpointProtectionBeforeVersion = 9 is within the retention period.
+      // Cleanup should be skipped.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(6, 8, 12, 14),
+        requireCheckpointProtectionBeforeVersion = 9,
+        expectedCommitsAfterCleanup = (0 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(6, 8, 10, 12, 14))
 
-    // Corner cases.
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 2,
-      createNumCommitsWithinRetentionPeriod = 14,
-      createCheckpoints = Set(1),
-      requireCheckpointProtectionBeforeVersion = 0,
-      expectedCommitsAfterCleanup = Range.inclusive(2, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(10))
+      // Corner cases.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 2,
+        createNumCommitsWithinRetentionPeriod = 14,
+        createCheckpoints = Set(1),
+        requireCheckpointProtectionBeforeVersion = 0,
+        expectedCommitsAfterCleanup = (2 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(10))
 
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 2,
-      createNumCommitsWithinRetentionPeriod = 14,
-      createCheckpoints = Set(1),
-      requireCheckpointProtectionBeforeVersion = 1,
-      expectedCommitsAfterCleanup = Range.inclusive(2, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(10))
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 2,
+        createNumCommitsWithinRetentionPeriod = 14,
+        createCheckpoints = Set(1),
+        requireCheckpointProtectionBeforeVersion = 1,
+        expectedCommitsAfterCleanup = (2 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(10))
 
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 2,
-      createNumCommitsWithinRetentionPeriod = 14,
-      createCheckpoints = Set(1),
-      requireCheckpointProtectionBeforeVersion = 2,
-      expectedCommitsAfterCleanup = Range.inclusive(2, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(10))
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 2,
+        createNumCommitsWithinRetentionPeriod = 14,
+        createCheckpoints = Set(1),
+        requireCheckpointProtectionBeforeVersion = 2,
+        expectedCommitsAfterCleanup = (2 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(10))
 
-    testRequireCheckpointProtectionBeforeVersion(
-      createNumCommitsOutsideRetentionPeriod = 2,
-      createNumCommitsWithinRetentionPeriod = 14,
-      createCheckpoints = Set(1),
-      requireCheckpointProtectionBeforeVersion = 3,
-      expectedCommitsAfterCleanup = Range.inclusive(0, 15).toSet,
-      // Α checkpoint is automatically created every 10 commits.
-      expectedCheckpointsAfterCleanup = Set(1, 10))
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 2,
+        createNumCommitsWithinRetentionPeriod = 14,
+        createCheckpoints = Set(1),
+        requireCheckpointProtectionBeforeVersion = 3,
+        expectedCommitsAfterCleanup = (0 to 15),
+        // Α checkpoint is automatically created every 10 commits.
+        expectedCheckpointsAfterCleanup = Set(1, 10))
+    }
+  }
+
+  test("Cleanup is allowed if a checkpoint already exists at the boundary") {
+    withSQLConf(DeltaSQLConf.ALLOW_METADATA_CLEANUP_WHEN_ALL_PROTOCOLS_SUPPORTED.key -> "false") {
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        // Metadata cleanup should attempt to clean before version 8.
+        createCheckpoints = Set(0, 8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        unsupportedFeatureStartVersion = Some(8),
+        expectedCommitsAfterCleanup = (8 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+    }
+  }
+
+  test("Metadata cleanup protocol validation positive tests.") {
+    withSQLConf(
+        DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
+      // In all tests below, we cannot satisfy the version requirement and thus fallback
+      // to protocol validations. We identify we support all features and proceed to
+      // metadata cleanup.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        expectedCommitsAfterCleanup = (8 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      // The protocol contains unsupported feature but at requireCheckpointProtectionBeforeVersion.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        unsupportedFeatureStartVersion = Some(10),
+        expectedCommitsAfterCleanup = (8 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      // The protocol contains unsupported feature but after
+      // requireCheckpointProtectionBeforeVersion.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        unsupportedFeatureStartVersion = Some(11),
+        expectedCommitsAfterCleanup = (8 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      // The protocol contains unsupported feature before requireCheckpointProtectionBeforeVersion
+      // but right after the boundary version where the cleanup ends.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        // Metadata cleanup should attempt to clean before version 8.
+        createCheckpoints = Set(0, 8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        unsupportedFeatureStartVersion = Some(9),
+        expectedCommitsAfterCleanup = (8 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      // Other corner cases.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(1),
+        requireCheckpointProtectionBeforeVersion = 10,
+        expectedCommitsAfterCleanup = (8 to 15),
+        // This is a bit weird. Cleanup should had created a checkpoint at 8.
+        expectedCheckpointsAfterCleanup = Set(10))
+
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(0),
+        requireCheckpointProtectionBeforeVersion = 10,
+        expectedCommitsAfterCleanup = (8 to 15),
+        // This is a bit weird. Cleanup should had created a checkpoint at 8.
+        expectedCheckpointsAfterCleanup = Set(10))
+    }
+  }
+
+  test("Metadata cleanup protocol validation negative tests.") {
+    withSQLConf(
+        DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
+      // In all tests below, we cannot satisfy the version requirement and thus fallback
+      // to protocol validations. We should detect the start version version includes a
+      // non-supported feature and skip the cleanup.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        // Unsupported feature in the first version.
+        unsupportedFeatureStartVersion = Some(0),
+        unsupportedFeatureEndVersion = Some(1),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(0, 8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        // Unsupported feature right before the boundary version where the cleanup ends.
+        unsupportedFeatureStartVersion = Some(7),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(0, 8, 10))
+
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        // Unsupported feature in intermediate versions.
+        unsupportedFeatureStartVersion = Some(4),
+        unsupportedFeatureEndVersion = Some(7),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        // Unsupported feature in dropped at the boundary version.
+        unsupportedFeatureStartVersion = Some(4),
+        unsupportedFeatureEndVersion = Some(8),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      // The protocol contains unsupported feature before requireCheckpointProtectionBeforeVersion
+      // but at the boundary version where the cleanup ends.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        // Metadata cleanup should attempt to clean before version 8.
+        createCheckpoints = Set(0, 8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        unsupportedFeatureStartVersion = Some(8),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(0, 8, 10))
+
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        // Metadata cleanup should attempt to clean before version 8.
+        createCheckpoints = Set(0, 8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        // Make sure we correctly validate the protocol of the checkpoint version.
+        unsupportedFeature = TestUnsupportedWriterFeature,
+        unsupportedFeatureStartVersion = Some(8),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(0, 8, 10))
+    }
+  }
+
+  test("Metadata cleanup protocol validation with incomplete CRCs.") {
+    withSQLConf(
+        DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
+      // We fall back to protocol validations which cannot be completed due to missing
+      // protocol in one of the CRCs.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        incompleteCRCVersion = Some(3),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+
+      // Similar to above but a CRC file is missing.
+      testRequireCheckpointProtectionBeforeVersion(
+        createNumCommitsOutsideRetentionPeriod = 8,
+        createNumCommitsWithinRetentionPeriod = 8,
+        createCheckpoints = Set(8),
+        requireCheckpointProtectionBeforeVersion = 10,
+        missingCRCVersion = Some(3),
+        expectedCommitsAfterCleanup = (0 to 15),
+        expectedCheckpointsAfterCleanup = Set(8, 10))
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

`CheckpointProtectionTableFeature` requires clients to only cleanup metadata if they can clean up to `requireCheckpointProtectionBeforeVersion`. When this this not possible the metadata cleanup operation aborts. `requireCheckpointProtectionBeforeVersion` is updated with the version of the latest protocol downgrade every time a feature is dropped. Because of that, in certain scenarios, metadata cleanup could halt for extended periods of time.

This PR improves this behavior by allowing the client to proceed with metadata cleanup when the invariant above does not hold, as long as, a checkpoint already exists at the cleanup cut off version. If none of the invariants hold, it verifies it supports the protocols of all commits planning to remove (including any new checkpoint creation version).

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added tests in `DeltaRetentionSuite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
