### PR TITLE
[Spark] Fix Table Redirect Comment

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
@@ -255,7 +255,6 @@ case class TableRedirectConfiguration(
   private def isNoRedirectApp(spark: SparkSession): Boolean = {
     noRedirectRules.exists { rule =>
       // If rule.appName is empty, then it applied to "spark.app.name"
-      // Todo(LC-6953): The operation name should also be taken into consideration.
       rule.appName.forall(_.equalsIgnoreCase(spark.conf.get("spark.app.name")))
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR removes comments from TableRedirect.scala.

## How was this patch tested?
N.A

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->