### PR TITLE
[Build] Add google maven repo as an option in `spark-submit` tests

### DIFF
--- a/examples/python/using_with_pip.py
+++ b/examples/python/using_with_pip.py
@@ -25,7 +25,11 @@ builder = SparkSession.builder \
     .appName("with-pip") \
     .master("local[*]") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+    .config("spark.jars.repositories", \
+        ("https://maven-central.storage-download.googleapis.com/maven2/,"
+            "https://repo1.maven.org/maven2/")\
+    )
 
 # This is only for testing staged release artifacts. Ignore this completely.
 if os.getenv('EXTRA_MAVEN_REPO'):

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -37,6 +37,9 @@ def test(root_dir, package):
         try:
             cmd = ["spark-submit",
                    "--driver-class-path=%s" % extra_class_path,
+                   "--repositories",
+                   ("https://maven-central.storage-download.googleapis.com/maven2/,"
+                       "https://repo1.maven.org/maven2/"),
                    "--packages", package, test_file]
             print("Running tests in %s\n=============" % test_file)
             print("Command: %s" % str(cmd))


### PR DESCRIPTION
## Description
Add Google maven repo as an option for dependency lookup. Currently it defaults to maven central which has lower rate limits.

## How was this patch tested?
Locally tested, by setting `0.0.0.0		https://repo1.maven.org/maven2/` in `/etc/hosts` (request to maven central fails and should try to use other repos)
