### PR TITLE
[Spark] Fix redirect path reconstruction

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -451,7 +451,7 @@ object DeltaTableV2 {
         deltaLog.getInitialCatalogTable
       }
       val tableIdentifier = catalogTableOpt.map(_.identifier.identifier)
-      val newPath = new Path(deltaLog.dataPath.toUri.getPath)
+      val newPath = new Path(deltaLog.dataPath.toUri)
       deltaTable.copy(
         path = newPath, catalogTable = catalogTableOpt, tableIdentifier = tableIdentifier
       )


### PR DESCRIPTION


#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR contains a tiny fix of the redirect path reconstruction. The original getPath method would erase cloud vendor prefix: s3, abfs, etc.

## How was this patch tested?
Existing test case

## Does this PR introduce _any_ user-facing changes?
No.