### PR TITLE
Uniform: Fix microsecond conversion for timestamp/ntz partition value

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -37,6 +37,7 @@ import shadedForDelta.org.apache.iceberg.StructLike
 import shadedForDelta.org.apache.iceberg.TableProperties
 import shadedForDelta.org.apache.iceberg.catalog.{Namespace, TableIdentifier => IcebergTableIdentifier}
 import shadedForDelta.org.apache.iceberg.hive.HiveCatalog
+import shadedForDelta.org.apache.iceberg.util.DateTimeUtil
 
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier => SparkTableIdentifier}
 import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
@@ -236,7 +237,8 @@ object IcebergTransactionUtils
       case _: DecimalType => new java.math.BigDecimal(partitionVal)
       case _: BinaryType => ByteBuffer.wrap(partitionVal.getBytes("UTF-8"))
       case _: TimestampNTZType =>
-        java.sql.Timestamp.valueOf(partitionVal).getNanos/1000.asInstanceOf[Long]
+        DateTimeUtil.isoTimestampToMicros(
+          partitionVal.replace(" ", "T"))
       case _: TimestampType =>
         try {
           getMicrosSinceEpoch(partitionVal)
@@ -254,7 +256,8 @@ object IcebergTransactionUtils
   }
 
   private def getMicrosSinceEpoch(instant: String): Long = {
-    Instant.parse(instant).getNano/1000.asInstanceOf[Long]
+    DateTimeUtil.microsFromInstant(
+      Instant.parse(instant))
   }
 
   private def getMetricsForIcebergDataFile(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When converting timestamp partition values from Delta to Iceberg, currently we're doing the microsecond conversion incorectly. This leads to every conversion just returning the Unix epoch timestamp.

In the current approach we're using some utilities from Iceberg, such as DateTimeUtil.microsFromInstant which already have implemented this logic correctly.

There were unit tests that should've caught this earlier by testing the Iceberg spark session as a reader, but they were passing just because the wrong read method was used. This PR fixes that as well.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
