### PR TITLE
[Spark] Remove internal metadata from output of time travel queries

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -623,7 +623,8 @@ class DeltaLog private(
     HadoopFsRelation(
       fileIndex,
       partitionSchema = DeltaTableUtils.removeInternalDeltaMetadata(
-        spark, snapshot.metadata.partitionSchema),
+        spark,
+        DeltaTableUtils.removeInternalWriterMetadata(spark, snapshot.metadata.partitionSchema)),
       // We pass all table columns as `dataSchema` so that Spark will preserve the partition
       // column locations. Otherwise, for any partition columns not in `dataSchema`, Spark would
       // just append them to the end of `dataSchema`.


### PR DESCRIPTION
## Description
We usually strip internal delta metadata (column mapping, generated columns) in schemas returned from e.g. `df.schema`.

One missing case is for partition columns during time-travel, which removes some metadata (column mapping, type widening), but not others (generated columns, identity columns).

Exposing generated column metadata can cause issues as it may then be propagated to other tables during CTAS.

## How was this patch tested?
- Adding test case covering stripping generated column metadata for partition columns in time-travel query.
The test fails without this fix.
