### PR TITLE
[Kernel] Add `getReadTableVersion` method to `Transaction`

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -62,7 +62,8 @@ public interface Transaction {
   List<String> getPartitionColumns(Engine engine);
 
   /**
-   * Gets the latest version of the table used as the base of this transaction.
+   * Gets the latest version of the table used as the base of this transaction. This returns -1 when
+   * the table is being created in this transaction.
    *
    * @return The version of the table as of the beginning of this Transaction
    */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -62,6 +62,13 @@ public interface Transaction {
   List<String> getPartitionColumns(Engine engine);
 
   /**
+   * Gets the latest version used as the base of this transaction.
+   *
+   * @return The version of the table as of the beginning of this Transaction
+   */
+  long getVersion();
+
+  /**
    * Get the state of the transaction. The state helps Kernel do the transformations to logical data
    * according to the Delta protocol and table features enabled on the table. The engine should use
    * this at the data writer task to transform the logical data that the engine wants to write to

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -62,11 +62,11 @@ public interface Transaction {
   List<String> getPartitionColumns(Engine engine);
 
   /**
-   * Gets the latest version used as the base of this transaction.
+   * Gets the latest version of the table used as the base of this transaction.
    *
    * @return The version of the table as of the beginning of this Transaction
    */
-  long getCommitBaseVersion();
+  long getReadTableVersion();
 
   /**
    * Get the state of the transaction. The state helps Kernel do the transformations to logical data

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -66,7 +66,7 @@ public interface Transaction {
    *
    * @return The version of the table as of the beginning of this Transaction
    */
-  long getVersion();
+  long getCommitBaseVersion();
 
   /**
    * Get the state of the transaction. The state helps Kernel do the transformations to logical data

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -142,7 +142,7 @@ public class TransactionImpl implements Transaction {
   }
 
   @Override
-  public long getCommitBaseVersion() {
+  public long getReadTableVersion() {
     return readSnapshot.getVersion();
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -143,7 +143,7 @@ public class TransactionImpl implements Transaction {
 
   @Override
   public long getVersion() {
-    return readSnapshot.getVersion()
+    return readSnapshot.getVersion() + 1;
   }
 
   public Optional<SetTransaction> getSetTxnOpt() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -141,6 +141,11 @@ public class TransactionImpl implements Transaction {
     return readSnapshot.getSchema();
   }
 
+  @Override
+  public long getVersion() {
+    return readSnapshot.getVersion()
+  }
+
   public Optional<SetTransaction> getSetTxnOpt() {
     return setTxnOpt;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -142,8 +142,8 @@ public class TransactionImpl implements Transaction {
   }
 
   @Override
-  public long getVersion() {
-    return readSnapshot.getVersion() + 1;
+  public long getCommitBaseVersion() {
+    return readSnapshot.getVersion();
   }
 
   public Optional<SetTransaction> getSetTxnOpt() {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -128,6 +128,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
 
       assert(txn.getSchema(engine) === testSchema)
       assert(txn.getPartitionColumns(engine) === Seq.empty.asJava)
+      assert(txn.getReadTableVersion == -1)
       val txnResult = commitTransaction(txn, engine, emptyIterable())
 
       assert(txnResult.getVersion === 0)
@@ -411,10 +412,10 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       verifyCommitInfo(tblPath, version = 0, partitionCols = Seq.empty, operation = WRITE)
       verifyWrittenContent(tblPath, testSchema, dataBatches1.flatMap(_.toTestRows))
 
-      val commitResult1 = appendData(
-        engine,
-        tblPath,
-        data = Seq(Map.empty[String, Literal] -> dataBatches2))
+      val txn = createTxn(engine, tblPath)
+      assert(txn.getReadTableVersion == 0)
+      val commitResult1 =
+        commitAppendData(engine, txn, data = Seq(Map.empty[String, Literal] -> dataBatches2))
 
       val expAnswer = dataBatches1.flatMap(_.toTestRows) ++ dataBatches2.flatMap(_.toTestRows)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR adds a method to get the version at the base of a transaction. This is useful information to know about a transaction 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
