### PR TITLE
[Spark] Take existing DV size into account in DeletionVectorData size

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2196,6 +2196,15 @@ trait DeltaSQLConfBase {
       .doc("Controls the target file deletion vector file size when packing multiple" +
         "deletion vectors in a single file.")
       .bytesConf(ByteUnit.BYTE)
+      /**
+       * A [[DeletionVectorDescriptor]] stores an offset as a 32-bit integer into the file where the
+       * deletion vector is stored. There is a hard limit of ~2.1GB for this file before the offset
+       * integer overflows. Since we do bin packing with estimates, we set a lower internal
+       * limit to be safe.
+       */
+      .checkValue(_ >= 0, "deletionVectors.packing.targetSize must be non-negative")
+      .checkValue(_ < 3L * 1024L * 1024L * 1024L / 2L,
+         "deletionVectors.packing.targetSize must be less than 1.5GB")
       .createWithDefault(2L * 1024L * 1024L)
 
   val TIGHT_BOUND_COLUMN_ON_FILE_INIT_DISABLED =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -438,8 +438,9 @@ class DeletionVectorsSuite extends QueryTest
           val expectedDVFileCount = targetDVFileSize match {
             // Each AddFile will have its own DV file
             case 2 => numFilesWithDVs
-            // Each DV size is about 34bytes according the latest format.
-            case 200 => numFilesWithDVs / (200 / 34).floor.toInt
+            // Each DV size is about 34bytes according the latest format, plus 4 bytes for
+            // checksum and another 4 bytes for data length.
+            case 200 => (numFilesWithDVs.toDouble / (200 / (34 + 4 + 4)).toDouble).ceil.toInt
             // Expect all DVs in one file
             case 2000000 => 1
             case default =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.storage.dv
+
+import java.io.File
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DeletionVectorFileSizeSuite extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLTestUtils {
+  private def getAddAndRemoveFilesFromCommitVersion(
+      deltaLog: DeltaLog,
+      commitVersion: Long): (Seq[AddFile], Seq[RemoveFile]) = {
+    require(commitVersion <= deltaLog.update().version,
+      "Commit version should be less than or equal to the current version")
+    val changes = deltaLog.getChanges(commitVersion, commitVersion, failOnDataLoss = true)
+    val (changesItrForAddFiles, changesItrForRemoveFiles) = changes.duplicate
+    val addFiles: Seq[AddFile] =
+       changesItrForAddFiles.flatMap(_._2.collect { case a: AddFile => a }).toSeq
+    val removeFiles: Seq[RemoveFile] =
+       changesItrForRemoveFiles.flatMap(_._2.collect { case r: RemoveFile => r }).toSeq
+    (addFiles, removeFiles)
+  }
+
+  private def getDeletionVectorFilePath(
+    dvDescriptor: DeletionVectorDescriptor,
+    tableDataPath: String
+  ): Path = {
+    val path = dvDescriptor.absolutePath(new Path(tableDataPath))
+    path
+  }
+
+  private def getFileSizeInBytes(
+      absoluteFilePath: Path,
+      hadoopConf: org.apache.hadoop.conf.Configuration): Long = {
+    val file = new File(absoluteFilePath.toString)
+    assert(file.exists())
+
+    val fs = absoluteFilePath.getFileSystem(hadoopConf)
+    val fileStatus = fs.getFileStatus(absoluteFilePath)
+    fileStatus.getLen
+  }
+
+  test("Bin Packing should take the size of existing DVs into account") {
+    withTempDir { tempDir =>
+      val source = new File(DeletionVectorsSuite.table1Path)
+      val target = new File(tempDir, "deleteTest")
+
+      // Copy the source table with existing table layout to a temporary directory
+      FileUtils.copyDirectory(source, target)
+
+      val (deltaLog, snapshot) =
+        DeltaLog.forTableWithSnapshot(spark, new Path(target.getAbsolutePath))
+      assert(snapshot.version === 4, "Table should exist")
+      // All existing individual DVs either have 34 or 36 bytes, corresponding 1 or 2 deleted rows.
+      val priorAddFiles = snapshot.allFiles.collect()
+      priorAddFiles.forall(a => a.deletionVector == null
+        || (a.deletionVector.sizeInBytes == 34 || a.deletionVector.sizeInBytes == 36))
+      assert(priorAddFiles.count(_.deletionVector != null) === 8,
+        "8 AddFiles with DVs expected")
+
+      val targetPackingFileSizeInBytes = 110
+      withSQLConf(
+          DeltaSQLConf.DELETION_VECTOR_PACKING_TARGET_SIZE.key ->
+          targetPackingFileSizeInBytes.toString) {
+        // Delete some rows to trigger the creation of new DVs.
+        sql(s"DELETE FROM delta.`${target.getAbsolutePath}` WHERE value IN (255, 303, 707, 1905)")
+        val (addFiles, removeFiles) =
+          getAddAndRemoveFilesFromCommitVersion(deltaLog, deltaLog.update().version)
+        assert(addFiles.size === 3, "Deletion vector added to 3 different AddFiles")
+        assert(addFiles.forall(_.deletionVector != null),
+          "Deletion should have used DVs and not rewrite any files")
+        val removeFilesPaths = removeFiles.map(_.path).toSet
+        assert(priorAddFiles.filter(a => removeFilesPaths.contains(a.path))
+          .count(_.deletionVector != null) === 2, "2 of the AddFiles had existing DVs")
+
+        // Get the file sizes of the DV files added by this commit.
+        val dvFileSizes = addFiles.map(_.deletionVector)
+          .map(dv => getDeletionVectorFilePath(dv, target.getAbsolutePath))
+          .toSet
+          .map(path => getFileSizeInBytes(path, deltaLog.newDeltaHadoopConf()))
+        assert(addFiles.forall(a => a.deletionVector.sizeInBytes <= targetPackingFileSizeInBytes),
+          "the individual DVs can each fit in their own file if needed")
+        assert(dvFileSizes.forall(_ <= targetPackingFileSizeInBytes),
+          "The target file size should be respected when individual DVs fit under the file size")
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 
@@ -32,7 +32,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 class DeletionVectorFileSizeSuite extends QueryTest
     with SharedSparkSession
-    with DeltaSQLTestUtils {
+    with DeltaSQLTestUtils
+    with DeltaSQLCommandTest {
   private def getAddAndRemoveFilesFromCommitVersion(
       deltaLog: DeltaLog,
       commitVersion: Long): (Seq[AddFile], Seq[RemoveFile]) = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/BinPackingIteratorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/BinPackingIteratorSuite.scala
@@ -61,7 +61,7 @@ class BinPackingIteratorSuite extends QueryTest
       // 3rd bin
       TestArbitrarySizing(Int.MaxValue / 2),
       // 4th bin
-      TestArbitrarySizing(Int.MaxValue / 2),
+      TestArbitrarySizing(Int.MaxValue / 2)
     )
     val binPackingIterator = new BinPackingIterator(testInput.iterator, targetSize)
     assert(binPackingIterator.hasNext)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/BinPackingIteratorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/BinPackingIteratorSuite.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import scala.collection.generic.Sizing
+
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+case class IntArrayImplementingSizing(array: Seq[Int]) extends Sizing {
+  override def size: Int = array.size
+}
+
+case class TestArbitrarySizing(size: Int) extends Sizing
+
+class BinPackingIteratorSuite extends QueryTest
+  with SharedSparkSession {
+
+  test("Bin packing works") {
+    val targetSize = 4
+    val testInput = Seq(
+      IntArrayImplementingSizing(Seq(1, 2, 3)),
+      IntArrayImplementingSizing(Seq(1, 2, 3)))
+
+    val binPackingIterator = new BinPackingIterator(testInput.iterator, targetSize)
+
+    assert(binPackingIterator.hasNext)
+    var count = 0
+    for (bin <- binPackingIterator) {
+      assert(bin.size === 1)
+      assert(bin.toSeq === Seq(IntArrayImplementingSizing(Seq(1, 2, 3))))
+      count += 1
+    }
+    assert(count === 2)
+  }
+
+  test("Bin packing can handle overflows to internal size tracking") {
+    val targetSize = Int.MaxValue / 2
+    val testInput = Seq(
+      // 1st bin
+      TestArbitrarySizing(1),
+      TestArbitrarySizing(1),
+      TestArbitrarySizing(2),
+      // 2nd bin
+      TestArbitrarySizing(Int.MaxValue - 14),
+      // 3rd bin
+      TestArbitrarySizing(Int.MaxValue / 2),
+      // 4th bin
+      TestArbitrarySizing(Int.MaxValue / 2),
+    )
+    val binPackingIterator = new BinPackingIterator(testInput.iterator, targetSize)
+    assert(binPackingIterator.hasNext)
+    val firstBin = binPackingIterator.next()
+    assert(firstBin.size === 3)
+    assert(firstBin.toSeq === Seq(
+      TestArbitrarySizing(1),
+      TestArbitrarySizing(1),
+      TestArbitrarySizing(2)))
+    assert(binPackingIterator.hasNext)
+    val secondBin = binPackingIterator.next()
+    assert(secondBin.size === 1)
+    assert(secondBin.toSeq === Seq(TestArbitrarySizing(Int.MaxValue - 14)))
+    assert(binPackingIterator.hasNext)
+    val thirdBin = binPackingIterator.next()
+    assert(thirdBin.size === 1)
+    assert(thirdBin.toSeq === Seq(TestArbitrarySizing(Int.MaxValue / 2)))
+    assert(binPackingIterator.hasNext)
+    val fourthBin = binPackingIterator.next()
+    assert(fourthBin.size === 1)
+    assert(fourthBin.toSeq === Seq(TestArbitrarySizing(Int.MaxValue / 2)))
+    assert(!binPackingIterator.hasNext)
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Currently, it is possible for BinPackingIterator to create Deletion Vector files that are much bigger than the target size specified (default 2MB) because DeletionVectorData.size() only returns the size of the intermediate results and not the combined size with the persisted deletion vector.

In this PR,

* We add the size of the existing persistent DV to the size calculation in DeletionVectorData.
* We add some additional safeguards around the DV target size -- we bound it to [0, 1.5GB].
* If we detect overflow in DeletionVectorData, we will bump the size to Int.Max so that the erroneous item goes into its own bin. If the size is overflowing, it will likely fail later when we try to write the DV since it's oversized.
* We add the fixed cost of adding checksums to every DV to the size of DeletionVectorData to get better estimates.

## How was this patch tested?
New tests that fail without this fix.

## Does this PR introduce _any_ user-facing changes?
No.
