### PR TITLE
[KERNEL] CollatedPredicate support

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -39,6 +39,7 @@ public class CollatedPredicate extends Predicate {
         return super.toString();
     }
 
+    /** Supported operators for collation-based comparisons. */
     private static final Set<String> COLLATION_SUPPORTED_OPERATORS =
         Stream.of("<", "<=", ">", ">=", "=", "STARTS_WITH").collect(Collectors.toSet());
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -2,48 +2,47 @@ package io.delta.kernel.expressions;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.types.CollationIdentifier;
-
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Defines collated predicate which is an extension of {@link Predicate} that
- * evaluates to true, false, or null for each input row.
- *
- * <br><br>
+ * Defines collated predicate which is an extension of {@link Predicate} that evaluates to true,
+ * false, or null for each input row. <br>
+ * <br>
  * Examples:
+ *
  * <ol>
- *     <li><code>expr1 = expr2 COLLATE "SPARK.UTF8_LCASE"</code></li>
- *     <br>
- *     <li><code>expr1 <= expr2 COLLATE "ICU.sr_Cyrl_SRB.75.1"</code></li>
- *     <br>
- *     <li><code>expr1 STARTS_WITH expr2 COLLATE "ICU.en_US"</code></li>
+ *   <li><code>expr1 = expr2 COLLATE "SPARK.UTF8_LCASE"</code> <br>
+ *   <li><code>expr1 <= expr2 COLLATE "ICU.sr_Cyrl_SRB.75.1"</code> <br>
+ *   <li><code>expr1 STARTS_WITH expr2 COLLATE "ICU.en_US"</code>
  * </ol>
  */
 @Evolving
 public class CollatedPredicate extends Predicate {
-    private final CollationIdentifier collationIdentifier;
+  private final CollationIdentifier collationIdentifier;
 
-    /** Constructor for a CollatedPredicate expression */
-    public CollatedPredicate(String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
-        super(name, left, right);
-        this.collationIdentifier = collationIdentifier;
+  /** Constructor for a CollatedPredicate expression */
+  public CollatedPredicate(
+      String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
+    super(name, left, right);
+    this.collationIdentifier = collationIdentifier;
+  }
+
+  public CollationIdentifier getCollationIdentifier() {
+    return collationIdentifier;
+  }
+
+  @Override
+  public String toString() {
+    if (COLLATION_SUPPORTED_OPERATORS.contains(name)) {
+      return String.format(
+          "(%s %s %s COLLATE %s)", children.get(0), name, children.get(1), collationIdentifier);
     }
+    return super.toString();
+  }
 
-    public CollationIdentifier getCollationIdentifier() {
-        return collationIdentifier;
-    }
-
-    @Override
-    public String toString() {
-        if (COLLATION_SUPPORTED_OPERATORS.contains(name)) {
-            return String.format("(%s %s %s COLLATE %s)", children.get(0), name, children.get(1), collationIdentifier);
-        }
-        return super.toString();
-    }
-
-    /** Supported operators for collation-based comparisons. */
-    private static final Set<String> COLLATION_SUPPORTED_OPERATORS =
-        Stream.of("<", "<=", ">", ">=", "=", "STARTS_WITH").collect(Collectors.toSet());
+  /** Supported operators for collation-based comparisons. */
+  private static final Set<String> COLLATION_SUPPORTED_OPERATORS =
+      Stream.of("<", "<=", ">", ">=", "=", "STARTS_WITH").collect(Collectors.toSet());
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -14,11 +14,11 @@ import java.util.stream.Stream;
  * <br><br>
  * Examples:
  * <ol>
- *     <li><code>expr1 = expr2 collate "SPARK.UTF8_LCASE"</code></li>
+ *     <li><code>expr1 = expr2 COLLATE "SPARK.UTF8_LCASE"</code></li>
  *     <br>
- *     <li><code>expr1 <= expr2 collate "sr_Cyrl_SRB.75.1"</code></li>
+ *     <li><code>expr1 <= expr2 COLLATE "ICU.sr_Cyrl_SRB.75.1"</code></li>
  *     <br>
- *     <li><code>expr1 STARTS_WITH expr2 collate "ICU.en_US"</code></li>
+ *     <li><code>expr1 STARTS_WITH expr2 COLLATE "ICU.en_US"</code></li>
  * </ol>
  */
 @Evolving
@@ -33,12 +33,12 @@ public class CollatedPredicate extends Predicate {
 
     @Override
     public String toString() {
-        if (BINARY_OPERATORS.contains(name)) {
-            return String.format("(%s %s %s [%s])", children.get(0), name, children.get(1), collationIdentifier);
+        if (COLLATION_SUPPORTED_OPERATORS.contains(name)) {
+            return String.format("(%s %s %s COLLATE %s)", children.get(0), name, children.get(1), collationIdentifier);
         }
         return super.toString();
     }
 
-    private static final Set<String> BINARY_OPERATORS =
-        Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
+    private static final Set<String> COLLATION_SUPPORTED_OPERATORS =
+        Stream.of("<", "<=", ">", ">=", "=", "STARTS_WITH").collect(Collectors.toSet());
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -14,9 +14,11 @@ import java.util.stream.Stream;
  * <br><br>
  * Examples:
  * <ol>
- *     <li><code>expr1 = expr2 using "SPARK.UTF8_LCASE"</code></li>
+ *     <li><code>expr1 = expr2 collate "SPARK.UTF8_LCASE"</code></li>
  *     <br>
- *     <li><code>expr1 <= expr2 using "sr_Cyrl_SRB.75.1"</code></li>
+ *     <li><code>expr1 <= expr2 collate "sr_Cyrl_SRB.75.1"</code></li>
+ *     <br>
+ *     <li><code>expr1 STARTS_WITH expr2 collate "ICU.en_US"</code></li>
  * </ol>
  */
 @Evolving

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -2,7 +2,6 @@ package io.delta.kernel.expressions;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.types.CollationIdentifier;
-
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -2,6 +2,8 @@ package io.delta.kernel.expressions;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.types.CollationIdentifier;
+
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -26,6 +28,7 @@ public class CollatedPredicate extends Predicate {
   public CollatedPredicate(
       String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
     super(name, left, right);
+    Objects.requireNonNull(collationIdentifier, "Collation identifier cannot be null");
     this.collationIdentifier = collationIdentifier;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -31,6 +31,10 @@ public class CollatedPredicate extends Predicate {
         this.collationIdentifier = collationIdentifier;
     }
 
+    public CollationIdentifier getCollationIdentifier() {
+        return collationIdentifier;
+    }
+
     @Override
     public String toString() {
         if (COLLATION_SUPPORTED_OPERATORS.contains(name)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -1,0 +1,42 @@
+package io.delta.kernel.expressions;
+
+import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.types.CollationIdentifier;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Defines collated predicate which is an extension of {@link Predicate} that
+ * evaluates to true, false, or null for each input row.
+ *
+ * <br><br>
+ * Examples:
+ * <ol>
+ *     <li><code>expr1 = expr2 using "SPARK.UTF8_LCASE"</code></li>
+ *     <br>
+ *     <li><code>expr1 <= expr2 using "sr_Cyrl_SRB.75.1"</code></li>
+ * </ol>
+ */
+@Evolving
+public class CollatedPredicate extends Predicate {
+    private final CollationIdentifier collationIdentifier;
+
+    /** Constructor for a CollatedPredicate expression */
+    public CollatedPredicate(String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
+        super(name, left, right);
+        this.collationIdentifier = collationIdentifier;
+    }
+
+    @Override
+    public String toString() {
+        if (BINARY_OPERATORS.contains(name)) {
+            return String.format("(%s %s %s [%s])", children.get(0), name, children.get(1), collationIdentifier);
+        }
+        return super.toString();
+    }
+
+    private static final Set<String> BINARY_OPERATORS =
+        Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/expressions/CollatedPredicateSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/expressions/CollatedPredicateSuite.scala
@@ -21,6 +21,11 @@ class CollatedPredicateSuite extends AnyFunSuite {
         new CollatedPredicate("stARtS_wiTh", new Column("c1"), Literal.ofString("a"),
           CollationIdentifier.fromString("ICU.en_US")),
         "(column(`c1`) STARTS_WITH a COLLATE ICU.EN_US)",
+      ),
+      (
+        new CollatedPredicate("AND", new Column("c1"), Literal.ofString("a"),
+          CollationIdentifier.fromString("ICU.en_US")),
+        "(column(`c1`) AND a)",
       )
     ).foreach {
       case (collatedPredicate, expectedToString) =>

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/expressions/CollatedPredicateSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/expressions/CollatedPredicateSuite.scala
@@ -1,0 +1,30 @@
+package io.delta.kernel.expressions
+
+import io.delta.kernel.types.CollationIdentifier
+import org.scalatest.funsuite.AnyFunSuite
+
+class CollatedPredicateSuite extends AnyFunSuite {
+
+  test("check toString") {
+    Seq(
+      (
+        new CollatedPredicate("<", new Column("c1"), new Column("c2"),
+          CollationIdentifier.fromString("SPARK.UTF8_LCASE")),
+        "(column(`c1`) < column(`c2`) COLLATE SPARK.UTF8_LCASE)",
+      ),
+      (
+        new CollatedPredicate(">=", Literal.ofString("a"), new Column("c1"),
+          CollationIdentifier.fromString("ICU.sr_Cyrl_SRB.75.1")),
+        "(a >= column(`c1`) COLLATE ICU.SR_CYRL_SRB.75.1)",
+      ),
+      (
+        new CollatedPredicate("stARtS_wiTh", new Column("c1"), Literal.ofString("a"),
+          CollationIdentifier.fromString("ICU.en_US")),
+        "(column(`c1`) STARTS_WITH a COLLATE ICU.EN_US)",
+      )
+    ).foreach {
+      case (collatedPredicate, expectedToString) =>
+        assert(collatedPredicate.toString == expectedToString)
+    }
+  }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -350,15 +350,15 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
       // If the collation is not "SPARK.UTF8_BINARY" we throw an exception.
       if (predicate instanceof CollatedPredicate) {
         CollatedPredicate collatedPredicate = (CollatedPredicate) predicate;
-        if (!collatedPredicate.getCollationIdentifier().equals(CollationIdentifier.fromString("SPARK.UTF8_BINARY"))) {
+        if (!(leftResult.outputType instanceof StringType) || !(rightResult.outputType instanceof StringType)) {
+          String msg =
+                  format(
+                          "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
+                          leftResult.outputType, rightResult.outputType);
+          throw unsupportedExpressionException(predicate, msg);
+        } else if (!collatedPredicate.getCollationIdentifier().equals(CollationIdentifier.fromString("SPARK.UTF8_BINARY"))) {
           String msg =
                   format("Unsupported collation identifier: %s. Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
-            throw unsupportedExpressionException(predicate, msg);
-        } else if (!(leftResult.outputType instanceof StringType) || !(rightResult.outputType instanceof StringType)) {
-          String msg =
-              format(
-                  "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
-                  leftResult.outputType, rightResult.outputType);
           throw unsupportedExpressionException(predicate, msg);
         } else {
           return predicate;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -351,15 +351,20 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
       // If the collation is not "SPARK.UTF8_BINARY" we throw an exception.
       if (predicate instanceof CollatedPredicate) {
         CollatedPredicate collatedPredicate = (CollatedPredicate) predicate;
-        if (!(leftResult.outputType instanceof StringType) || !(rightResult.outputType instanceof StringType)) {
+        if (!(leftResult.outputType instanceof StringType)
+            || !(rightResult.outputType instanceof StringType)) {
           String msg =
-                  format(
-                          "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
-                          leftResult.outputType, rightResult.outputType);
+              format(
+                  "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
+                  leftResult.outputType, rightResult.outputType);
           throw unsupportedExpressionException(predicate, msg);
-        } else if (!collatedPredicate.getCollationIdentifier().equals(STRING.getCollationIdentifier())) {
+        } else if (!collatedPredicate
+            .getCollationIdentifier()
+            .equals(STRING.getCollationIdentifier())) {
           String msg =
-                  format("Unsupported collation: \"%s\". Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
+              format(
+                  "Unsupported collation: \"%s\". Default Engine supports just \"SPARK.UTF8_BINARY\" collation.",
+                  collatedPredicate.getCollationIdentifier());
           throw unsupportedExpressionException(predicate, msg);
         } else {
           return predicate;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -350,18 +350,16 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
       // So we just return the predicate as is.
       // If the collation is not "SPARK.UTF8_BINARY" we throw an exception.
       if (predicate instanceof CollatedPredicate) {
+        String msg =
+            format(
+                "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
+                leftResult.outputType, rightResult.outputType);
+        checkIsStringType(leftResult.outputType, predicate, msg);
+        checkIsStringType(rightResult.outputType, predicate, msg);
+
         CollatedPredicate collatedPredicate = (CollatedPredicate) predicate;
-        if (!(leftResult.outputType instanceof StringType)
-            || !(rightResult.outputType instanceof StringType)) {
-          String msg =
-              format(
-                  "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
-                  leftResult.outputType, rightResult.outputType);
-          throw unsupportedExpressionException(predicate, msg);
-        } else if (!collatedPredicate
-            .getCollationIdentifier()
-            .equals(STRING.getCollationIdentifier())) {
-          String msg =
+        if (!collatedPredicate.getCollationIdentifier().equals(STRING.getCollationIdentifier())) {
+          msg =
               format(
                   "Unsupported collation: \"%s\". Default Engine supports just \"SPARK.UTF8_BINARY\" collation.",
                   collatedPredicate.getCollationIdentifier());

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -359,7 +359,7 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
           throw unsupportedExpressionException(predicate, msg);
         } else if (!collatedPredicate.getCollationIdentifier().equals(STRING.getCollationIdentifier())) {
           String msg =
-                  format("Unsupported collation identifier: %s. Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
+                  format("Unsupported collation: \"%s\". Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
           throw unsupportedExpressionException(predicate, msg);
         } else {
           return predicate;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -20,6 +20,7 @@ import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUti
 import static io.delta.kernel.defaults.internal.expressions.ImplicitCastExpression.canCastTo;
 import static io.delta.kernel.internal.util.ExpressionUtils.*;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static io.delta.kernel.types.StringType.STRING;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -295,7 +296,7 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
               substring,
               children.stream().map(e -> e.expression).collect(toList()),
               children.stream().map(e -> e.outputType).collect(toList()));
-      return new ExpressionTransformResult(transformedExpression, StringType.STRING);
+      return new ExpressionTransformResult(transformedExpression, STRING);
     }
 
     @Override
@@ -356,7 +357,7 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                           "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
                           leftResult.outputType, rightResult.outputType);
           throw unsupportedExpressionException(predicate, msg);
-        } else if (!collatedPredicate.getCollationIdentifier().equals(CollationIdentifier.fromString("SPARK.UTF8_BINARY"))) {
+        } else if (!collatedPredicate.getCollationIdentifier().equals(STRING.getCollationIdentifier())) {
           String msg =
                   format("Unsupported collation identifier: %s. Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
           throw unsupportedExpressionException(predicate, msg);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -339,6 +339,19 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
       ExpressionTransformResult rightResult = visit(getRight(predicate));
       Expression left = leftResult.expression;
       Expression right = rightResult.expression;
+      // We have a separate check for CollatedPredicate because it can compare StringTypes with different
+      // collation identifiers. In that case, it means that the types are not equivalent, so we would need to cast one to another.
+      // That is not needed because we fetch those Strings as regular Java Strings in the end and just compare them with the collation specified in CollatedPredicate.
+      if (predicate instanceof CollatedPredicate) {
+        if (leftResult.outputType instanceof StringType && rightResult.outputType instanceof StringType) {
+          return predicate;
+        } else {
+          String msg =
+                  format("CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
+                          leftResult.outputType, rightResult.outputType);
+            throw unsupportedExpressionException(predicate, msg);
+        }
+      }
       if (!leftResult.outputType.equivalent(rightResult.outputType)) {
         if (canCastTo(leftResult.outputType, rightResult.outputType)) {
           left = new ImplicitCastExpression(left, rightResult.outputType);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -339,17 +339,22 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
       ExpressionTransformResult rightResult = visit(getRight(predicate));
       Expression left = leftResult.expression;
       Expression right = rightResult.expression;
-      // We have a separate check for CollatedPredicate because it can compare StringTypes with different
-      // collation identifiers. In that case, it means that the types are not equivalent, so we would need to cast one to another.
-      // That is not needed because we fetch those Strings as regular Java Strings in the end and just compare them with the collation specified in CollatedPredicate.
+      // We have a separate check for CollatedPredicate because it can compare StringTypes with
+      // different collation identifiers.
+      // In that case, it means that the types are not equivalent, so we
+      // would need to cast one to another.
+      // That is not needed because we fetch those Strings as regular Java Strings in the end and
+      // just compare them with the collation specified in CollatedPredicate.
       if (predicate instanceof CollatedPredicate) {
-        if (leftResult.outputType instanceof StringType && rightResult.outputType instanceof StringType) {
+        if (leftResult.outputType instanceof StringType
+            && rightResult.outputType instanceof StringType) {
           return predicate;
         } else {
           String msg =
-                  format("CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
-                          leftResult.outputType, rightResult.outputType);
-            throw unsupportedExpressionException(predicate, msg);
+              format(
+                  "CollatedPredicate should be used to compare strings, but got left type=%s, right type=%s",
+                  leftResult.outputType, rightResult.outputType);
+          throw unsupportedExpressionException(predicate, msg);
         }
       }
       if (!leftResult.outputType.equivalent(rightResult.outputType)) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -414,7 +414,7 @@ class DefaultExpressionUtils {
   }
 
   static void checkIsStringType(DataType dataType, Expression parentExpr, String errorMessage) {
-    if (StringType.STRING.equals(dataType)) {
+    if (dataType instanceof StringType) {
       return;
     }
     throw unsupportedExpressionException(parentExpr, errorMessage);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -103,7 +103,12 @@ abstract class ExpressionVisitor<R> {
       case ">=":
       case "IS NOT DISTINCT FROM":
         if (expression instanceof CollatedPredicate) {
-          return visitComparator(new CollatedPredicate(name, children.get(0), children.get(1), ((CollatedPredicate) expression).getCollationIdentifier()));
+          return visitComparator(
+              new CollatedPredicate(
+                  name,
+                  children.get(0),
+                  children.get(1),
+                  ((CollatedPredicate) expression).getCollationIdentifier()));
         }
         return visitComparator(new Predicate(name, children));
       case "ELEMENT_AT":
@@ -124,7 +129,12 @@ abstract class ExpressionVisitor<R> {
         return visitLike(new Predicate(name, children));
       case "STARTS_WITH":
         if (expression instanceof CollatedPredicate) {
-          return visitStartsWith(new CollatedPredicate(name, children.get(0), children.get(1), ((CollatedPredicate) expression).getCollationIdentifier()));
+          return visitStartsWith(
+              new CollatedPredicate(
+                  name,
+                  children.get(0),
+                  children.get(1),
+                  ((CollatedPredicate) expression).getCollationIdentifier()));
         }
         return visitStartsWith(new Predicate(name, children));
       default:

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -102,6 +102,9 @@ abstract class ExpressionVisitor<R> {
       case ">":
       case ">=":
       case "IS NOT DISTINCT FROM":
+        if (expression instanceof CollatedPredicate) {
+          return visitComparator(new CollatedPredicate(name, children.get(0), children.get(1), ((CollatedPredicate) expression).getCollationIdentifier()));
+        }
         return visitComparator(new Predicate(name, children));
       case "ELEMENT_AT":
         return visitElementAt(expression);
@@ -120,6 +123,9 @@ abstract class ExpressionVisitor<R> {
       case "LIKE":
         return visitLike(new Predicate(name, children));
       case "STARTS_WITH":
+        if (expression instanceof CollatedPredicate) {
+          return visitStartsWith(new CollatedPredicate(name, children.get(0), children.get(1), ((CollatedPredicate) expression).getCollationIdentifier()));
+        }
         return visitStartsWith(new Predicate(name, children));
       default:
         throw new UnsupportedOperationException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
@@ -55,7 +55,7 @@ public class StartsWithExpressionEvaluator {
       CollatedPredicate collatedPredicate = (CollatedPredicate) startsWith;
       if (!collatedPredicate.getCollationIdentifier().equals(STRING.getCollationIdentifier())) {
         String msg =
-                format("Unsupported collation identifier: %s. Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
+                format("Unsupported collation: \"%s\". Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
         throw unsupportedExpressionException(startsWith, msg);
       }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
@@ -55,7 +55,9 @@ public class StartsWithExpressionEvaluator {
       CollatedPredicate collatedPredicate = (CollatedPredicate) startsWith;
       if (!collatedPredicate.getCollationIdentifier().equals(STRING.getCollationIdentifier())) {
         String msg =
-                format("Unsupported collation: \"%s\". Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
+            format(
+                "Unsupported collation: \"%s\". Default Engine supports just \"SPARK.UTF8_BINARY\" collation.",
+                collatedPredicate.getCollationIdentifier());
         throw unsupportedExpressionException(startsWith, msg);
       }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
@@ -49,8 +49,11 @@ public class StartsWithExpressionEvaluator {
         "'STARTS_WITH' expects literal as the second input");
 
     if (startsWith instanceof CollatedPredicate) {
-      return new CollatedPredicate(startsWith.getName(),
-              childrenExpressions.get(0), childrenExpressions.get(1), ((CollatedPredicate) startsWith).getCollationIdentifier());
+      return new CollatedPredicate(
+          startsWith.getName(),
+          childrenExpressions.get(0),
+          childrenExpressions.get(1),
+          ((CollatedPredicate) startsWith).getCollationIdentifier());
     }
     return new Predicate(startsWith.getName(), childrenExpressions);
   }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
@@ -15,7 +15,10 @@
  */
 package io.delta.kernel.defaults.internal.expressions;
 
+import static io.delta.kernel.defaults.internal.DefaultEngineErrors.unsupportedExpressionException;
 import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.*;
+import static io.delta.kernel.types.StringType.STRING;
+import static java.lang.String.format;
 
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.expressions.CollatedPredicate;
@@ -49,6 +52,13 @@ public class StartsWithExpressionEvaluator {
         "'STARTS_WITH' expects literal as the second input");
 
     if (startsWith instanceof CollatedPredicate) {
+      CollatedPredicate collatedPredicate = (CollatedPredicate) startsWith;
+      if (!collatedPredicate.getCollationIdentifier().equals(STRING.getCollationIdentifier())) {
+        String msg =
+                format("Unsupported collation identifier: %s. Default Engine supports just \"SPARK.UTF8_BINARY\" collation.", collatedPredicate.getCollationIdentifier());
+        throw unsupportedExpressionException(startsWith, msg);
+      }
+
       return new CollatedPredicate(
           startsWith.getName(),
           childrenExpressions.get(0),

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
@@ -18,6 +18,7 @@ package io.delta.kernel.defaults.internal.expressions;
 import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.*;
 
 import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.expressions.CollatedPredicate;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.util.Utils;
@@ -46,6 +47,11 @@ public class StartsWithExpressionEvaluator {
         childrenExpressions.get(1),
         startsWith,
         "'STARTS_WITH' expects literal as the second input");
+
+    if (startsWith instanceof CollatedPredicate) {
+      return new CollatedPredicate(startsWith.getName(),
+              childrenExpressions.get(0), childrenExpressions.get(1), ((CollatedPredicate) startsWith).getCollationIdentifier());
+    }
     return new Predicate(startsWith.getName(), childrenExpressions);
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -60,8 +60,13 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
     new Predicate("like", children.asJava)
   }
 
-  protected def startsWith(left: Expression, right: Expression): Predicate = {
-    new Predicate("starts_with", left, right)
+  protected def startsWith(left: Expression, right: Expression,
+                           collationIdentifier: Option[CollationIdentifier] = None): Predicate = {
+    if (collationIdentifier.isDefined && collationIdentifier.get != null) {
+      new CollatedPredicate("starts_with", left, right, collationIdentifier.get)
+    } else {
+      new Predicate("starts_with", left, right)
+    }
   }
 
   protected def comparator(symbol: String, left: Expression, right: Expression): Predicate = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR introduces `CollatedPredicate` as a new type of `Predicate` for comparing strings in collated fashion. The `DefaultEngine` will only support the default collation (SPARK.UTF8_BINARY), meaning `ExpressionHandler` should be implemented for using any other collation.

## How was this patch tested?

Tests added to `CollatedPredicateSuite` and `DefaultExpressionEvaluatorSuite`.
Tests for file pruning will be added in the next PR, as modifying `DataSkippingPredicate` is required.
Currently, `DataSkippingPredicate` is just a regular `Predicate`, but it needs to be updated to also include information about collation.

## Does this PR introduce _any_ user-facing changes?

No.
