### PR TITLE
[Spark] Remove listFromOrNone in SnapshotManagement

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -103,31 +103,26 @@ trait SnapshotManagement { self: DeltaLog =>
     isCheckpointFile(path) || isDeltaFile(path)
   }
 
-  /** Returns an iterator containing a list of files found from the provided path */
-  protected def listFromOrNone(startVersion: Long): Option[Iterator[FileStatus]] = {
-    // LIST the directory, starting from the provided lower bound (treat missing dir as empty).
-    // NOTE: "empty/missing" is _NOT_ equivalent to "contains no useful commit files."
-    try {
-      Some(listFrom(startVersion)).filterNot(_.isEmpty)
-    } catch {
-      case _: FileNotFoundException => None
-    }
-  }
-
   /**
    * @return A tuple where the first element is an array of log files (possibly empty, if no
    *         usable log files are found), and the second element is the latest checksum file found
    *         which has a version less than or equal to `versionToLoad`.
    */
-  private def listFromFileSystemInternal(
+  private[delta] def listFromFileSystemInternal(
       startVersion: Long,
       versionToLoad: Option[Long],
       includeMinorCompactions: Boolean
   ): (Option[Array[(FileStatus, FileType.Value, Long)]], Option[FileStatus]) = {
     var latestAvailableChecksumFileStatus = Option.empty[FileStatus]
-    val filesIter = listFromOrNone(startVersion)
+    // LIST the directory, starting from the provided lower bound (treat missing dir as empty).
+    // NOTE: "empty/missing" is _NOT_ equivalent to "contains no useful commit files."
+    val filesOpt = try {
+      Some(listFrom(startVersion)).filterNot(_.isEmpty)
+    } catch {
+      case _: FileNotFoundException => None
+    }
     val files =
-      filesIter.map {
+      filesOpt.map {
       _.flatMap {
         case DeltaFile(f, fileVersion) =>
           Some((f, FileType.DELTA, fileVersion))
@@ -177,7 +172,11 @@ trait SnapshotManagement { self: DeltaLog =>
       includeMinorCompactions: Boolean): (Option[Array[FileStatus]], Option[FileStatus]) = {
     val tableCommitCoordinatorClient = tableCommitCoordinatorClientOpt.getOrElse {
       val (filesOpt, checksumOpt) =
-        listFromFileSystemInternal(startVersion, versionToLoad, includeMinorCompactions)
+        listFromFileSystemInternal(
+          startVersion,
+          versionToLoad,
+          includeMinorCompactions
+        )
       return (filesOpt.map(_.map(_._1)), checksumOpt)
     }
 
@@ -205,7 +204,11 @@ trait SnapshotManagement { self: DeltaLog =>
 
     var maxDeltaVersionSeen = startVersion - 1
     val (initialLogTuplesFromFsListingOpt, initialChecksumOpt) =
-      listFromFileSystemInternal(startVersion, versionToLoad, includeMinorCompactions)
+      listFromFileSystemInternal(
+        startVersion,
+        versionToLoad,
+        includeMinorCompactions
+      )
     // Ideally listFromFileSystemInternal should return lexicographically sorted files and so
     // maxDeltaVersionSeen should be equal to the last delta version. But we are being
     // defensive here and taking max of all the delta fileVersions seen.
@@ -247,7 +250,10 @@ trait SnapshotManagement { self: DeltaLog =>
         recordDeltaEvent(
           this, CoordinatedCommitsUsageLogs.COMMIT_COORDINATOR_ADDITIONAL_LISTING_REQUIRED)
         listFromFileSystemInternal(
-          startVersion = initialMaxDeltaVersionSeen + 1, versionToLoad, includeMinorCompactions)
+          startVersion = initialMaxDeltaVersionSeen + 1,
+          versionToLoad,
+          includeMinorCompactions
+        )
       } else {
         (None, initialChecksumOpt)
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The method `listFromOrNone` only has one call site so removing it and inline its implementation at that call site.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No