### PR TITLE
[Spark] Fix exception type for missing nested clustering column

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteringColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteringColumnSuite.scala
@@ -71,4 +71,20 @@ class ClusteringColumnSuite extends ClusteredTableTestUtils with DeltaSQLCommand
           "tableSchema" -> schema.treeString))
     }
   }
+
+  test("ClusteringColumn: throws correct error when nested column not found") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl (a INT, b STRING) USING DELTA")
+      val schema = spark.table("tbl").schema
+      val e = intercept[AnalysisException] {
+        ClusteringColumn(schema, "b.c")
+      }
+      checkError(
+        e,
+        "DELTA_COLUMN_NOT_FOUND_IN_SCHEMA",
+        parameters = Map(
+          "columnName" -> "b.c",
+          "tableSchema" -> schema.treeString))
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [x] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Previously, we'd try casting the data type of the previously-found column into a StructType blindly, even if it was not of a StructType. This was problematic if the cluster by clause contained a column reference that did not exist; we'd return a ClassCastException instead of a column not found exception. This change addresses that.

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

No
