### PR TITLE
[Spark] Fix error when reading empty CDF of generated column

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -178,10 +178,10 @@ object CDCReader extends CDCReaderImpl
       // of the internal DataFrame.
       val outputMap = df.queryExecution.analyzed.output.map(a => a.name -> a).toMap
       val projections =
-        requiredColumns.map(a => Column(a.withExprId(outputMap(a.name).exprId)))
+        requiredColumns.map(a => Column(outputMap(a.name)))
       val filter = Column(
         filters
-          .map(_.transform { case a: Attribute => a.withExprId(outputMap(a.name).exprId) })
+          .map(_.transform { case a: Attribute => outputMap(a.name) })
           .reduceOption(And)
           .getOrElse(Literal.TrueLiteral)
       )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, Inva
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.DateTimeUtils.SECONDS_PER_DAY
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import io.delta.tables.DeltaTableBuilder
 
@@ -40,7 +41,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, stringToDate, stringToTimestamp, toJavaDate, toJavaTimestamp}
 import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.functions.{current_timestamp, lit, struct, typedLit}
+import org.apache.spark.sql.functions.{lit, make_dt_interval, struct, typedLit}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{StreamingQueryException, Trigger}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -1905,6 +1906,12 @@ trait GeneratedColumnSuiteBase
     val tableName1 = "gcEnabledCDCOn"
     val tableName2 = "gcEnabledCDCOff"
     withTable(tableName1, tableName2) {
+      def readCdf(startingVersion: Long): DataFrame = {
+        spark.read.format("delta").option("readChangeData", "true")
+          .option("startingVersion", startingVersion)
+          .table(tableName1)
+          .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      }
 
       createTable(
         tableName1,
@@ -1919,24 +1926,26 @@ trait GeneratedColumnSuiteBase
         )
       )
 
+      checkAnswer(readCdf(startingVersion = 0), Seq())
+
       spark.range(100).repartition(10)
-        .withColumn("timeCol", current_timestamp())
+        .withColumn(
+          "timeCol", lit(sqlTimestamp("1970-01-01 00:00:00")) + make_dt_interval($"id"))
         .write
         .format("delta")
         .mode("append")
         .saveAsTable(tableName1)
 
-      spark.sql(s"DELETE FROM ${tableName1} WHERE id < 3")
+      spark.sql(s"DELETE FROM $tableName1 WHERE id < 3")
 
-      val changeData = spark.read.format("delta").option("readChangeData", "true")
-        .option("startingVersion", "2")
-        .table(tableName1)
-        .select("id", CDCReader.CDC_TYPE_COLUMN_NAME, CDCReader.CDC_COMMIT_VERSION)
-
-      val expected = spark.range(0, 3)
-        .withColumn(CDCReader.CDC_TYPE_COLUMN_NAME, lit("delete"))
-        .withColumn(CDCReader.CDC_COMMIT_VERSION, lit(2))
-      checkAnswer(changeData, expected)
+      checkAnswer(
+        readCdf(startingVersion = 2),
+        Seq(
+          Row(0, sqlTimestamp("1970-01-01 00:00:00"), sqlDate("1970-01-01"), "delete", 2),
+          Row(1, sqlTimestamp("1970-01-02 00:00:00"), sqlDate("1970-01-02"), "delete", 2),
+          Row(2, sqlTimestamp("1970-01-03 00:00:00"), sqlDate("1970-01-03"), "delete", 2)
+        )
+      )
 
       // Now write out the data frame of cdc to another table that has generated columns but not
       // cdc enabled.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes a `PLAN_VALIDATION_FAILED_RULE_EXECUTOR` error that occurs when reading the CDF of a commit range that contains no file actions and when reading a generated column. In this case `DeltaCDFRelation.buildScan` will add a `Project` or `Filter` containing `AttributeReference`s with empty `metadata` on top of a plan where the `metadata`. This will cause `hasUniqueExprIdsForOutput` to trip, but only if the plan does not contain a `Union`, which is only the case when reading the CDF of a commit range without any file actions.

The fix is to substitute the attribute references in the projections and filters entirely, instead of just patching up the expression ids. (I am not sure why I didn't simply do this in the first place.)

## How was this patch tested?

Modified an existing test to reproduce the error.

## Does this PR introduce _any_ user-facing changes?

No
