### PR TITLE
[Kernel] Reorganize metadata updates in TransactionBuilder to clearly delineate what happens when for updates + validation

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -106,8 +106,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
 
   @Override
   public TransactionBuilder withTableProperties(Engine engine, Map<String, String> properties) {
-    Map<String, String> validatedProperties = TableConfig.validateDeltaProperties(properties);
-    this.tableProperties = Optional.of(Collections.unmodifiableMap(validatedProperties));
+    this.tableProperties =
+        Optional.of(Collections.unmodifiableMap(TableConfig.validateDeltaProperties(properties)));
     return this;
   }
 
@@ -245,7 +245,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
    * <ul>
    *   <li>We can write to the current version of the table
    *   <li>Partition columns are not specified for an existing table
-   *   <li>The schema provides is valid (e.g. no duplicate columns, valid names)
+   *   <li>The provided schema is valid (e.g. no duplicate columns, valid names)
    *   <li>Partition columns provided are valid (e.g. they exist, valid data types)
    *   <li>Concurrent txn has not already committed to the table with same txnId
    * </ul>
@@ -300,7 +300,6 @@ public class TransactionBuilderImpl implements TransactionBuilder {
    */
   private void validateMetadataChange(
       Metadata oldMetadata, Metadata newMetadata, boolean isNewTable) {
-    // Validate configuration changes
     ColumnMapping.verifyColumnMappingChange(
         oldMetadata.getConfiguration(), newMetadata.getConfiguration(), isNewTable);
     // TODO In the future block enabling IcebergWriterCompatV1 for existing tables

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -171,8 +171,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     Optional<Protocol> newProtocol = Optional.empty();
 
     /* ------- Update the METADATA with new table properties or schema set in the builder ------- */
-    Map<String, String> newProperties = snapshotMetadata.filterOutUnchangedProperties(
-        tableProperties.orElse(Collections.emptyMap()));
+    Map<String, String> newProperties =
+        snapshotMetadata.filterOutUnchangedProperties(
+            tableProperties.orElse(Collections.emptyMap()));
 
     if (!newProperties.isEmpty()) {
       newMetadata = Optional.of(snapshotMetadata.withMergedConfiguration(newProperties));
@@ -184,7 +185,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     // This is the only place we update the protocol action; takes care of any dependent features
     Optional<Tuple2<Protocol, Set<TableFeature>>> newProtocolAndFeatures =
         TableFeatures.autoUpgradeProtocolBasedOnMetadata(
-            newMetadata.orElse(snapshotMetadata), !domainMetadatasAdded.isEmpty(), snapshotProtocol);
+            newMetadata.orElse(snapshotMetadata),
+            !domainMetadatasAdded.isEmpty(),
+            snapshotProtocol);
     if (newProtocolAndFeatures.isPresent()) {
       logger.info(
           "Automatically enabling table features: {}",
@@ -194,23 +197,23 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       TableFeatures.validateKernelCanWriteToTable(
           newProtocol.orElse(snapshotProtocol),
           newMetadata.orElse(snapshotMetadata),
-          table.getPath(engine)
-      );
+          table.getPath(engine));
     }
 
     /* -------- Update the METADATA with new table properties based on set properties --------- */
-    newMetadata = IcebergCompatV2MetadataValidatorAndUpdater
-        .validateAndUpdateIcebergCompatV2Metadata(isNewTable, newMetadata.orElse(snapshotMetadata),
-            newProtocol.orElse(snapshotProtocol));
+    newMetadata =
+        IcebergCompatV2MetadataValidatorAndUpdater.validateAndUpdateIcebergCompatV2Metadata(
+            isNewTable, newMetadata.orElse(snapshotMetadata), newProtocol.orElse(snapshotProtocol));
 
     /* ---------- Update the METADATA with column mapping info if applicable ------------ */
-    newMetadata = ColumnMapping.updateColumnMappingMetadataIfNeeded(
-        newMetadata.orElse(snapshotMetadata), isNewTable);
+    newMetadata =
+        ColumnMapping.updateColumnMappingMetadataIfNeeded(
+            newMetadata.orElse(snapshotMetadata), isNewTable);
 
     /* ----------------- Validate the metadata change --------------------- */
     // Now that all the config and schema changes have been made validate the old vs new metadata
-    newMetadata.ifPresent(metadata -> validateMetadataChange(snapshotMetadata, metadata,
-        isNewTable));
+    newMetadata.ifPresent(
+        metadata -> validateMetadataChange(snapshotMetadata, metadata, isNewTable));
 
     return new TransactionImpl(
         isNewTable,
@@ -270,9 +273,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         });
   }
 
-  /**
-   * Validate that the change from oldMetadata to newMetadata is a valid change.
-   */
+  /** Validate that the change from oldMetadata to newMetadata is a valid change. */
   private void validateMetadataChange(
       Metadata oldMetadata, Metadata newMetadata, boolean isNewTable) {
     // Validate configuration changes

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -204,7 +204,10 @@ public class TransactionBuilderImpl implements TransactionBuilder {
           table.getPath(engine));
     }
 
-    /* ----- 3: Update the METADATA with new table properties based on set properties ----- */
+    /* 3: Validate the METADATA and PROTOCOL and possibly update the METADATA for IcebergCompat */
+    // IcebergCompat validates that the current metadata and protocol is compatible (e.g. all the
+    // required TF are present, no incompatible types, etc). It also updates the metadata for new
+    // tables if needed (e.g. enables column mapping)
     // Ex: We enable column mapping mode in the configuration such that our properties now include
     // Map(delta.enableIcebergCompatV2 -> true, delta.columnMapping.mode -> name)
     newMetadata =
@@ -243,7 +246,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
    * Validates the transaction as built given the parameters input by the user. This includes
    *
    * <ul>
-   *   <li>We can write to the current version of the table
+   *   <li>Ensures that the table, as defined by the protocol and metadata of its latest version, is
+   *       writable by Kernel
    *   <li>Partition columns are not specified for an existing table
    *   <li>The provided schema is valid (e.g. no duplicate columns, valid names)
    *   <li>Partition columns provided are valid (e.g. they exist, valid data types)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -210,15 +210,21 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     // tables if needed (e.g. enables column mapping)
     // Ex: We enable column mapping mode in the configuration such that our properties now include
     // Map(delta.enableIcebergCompatV2 -> true, delta.columnMapping.mode -> name)
-    newMetadata =
+    Optional<Metadata> icebergCompatV2Metadata =
         IcebergCompatV2MetadataValidatorAndUpdater.validateAndUpdateIcebergCompatV2Metadata(
             isNewTable, newMetadata.orElse(snapshotMetadata), newProtocol.orElse(snapshotProtocol));
+    if (icebergCompatV2Metadata.isPresent()) {
+      newMetadata = icebergCompatV2Metadata;
+    }
 
     /* ----- 4: Update the METADATA with column mapping info if applicable ----- */
     // We update the column mapping info here after all configuration changes are finished
-    newMetadata =
+    Optional<Metadata> columnMappingMetadata =
         ColumnMapping.updateColumnMappingMetadataIfNeeded(
             newMetadata.orElse(snapshotMetadata), isNewTable);
+    if (columnMappingMetadata.isPresent()) {
+      newMetadata = columnMappingMetadata;
+    }
 
     /* ----- 5: Validate the metadata change ----- */
     // Now that all the config and schema changes have been made validate the old vs new metadata

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -120,7 +120,7 @@ public class Metadata {
                         .collect(Collectors.toList())));
   }
 
-  public Metadata withNewConfiguration(Map<String, String> configuration) {
+  public Metadata withMergedConfiguration(Map<String, String> configuration) {
     Map<String, String> newConfiguration = new HashMap<>(getConfiguration());
     newConfiguration.putAll(configuration);
     return new Metadata(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
@@ -114,9 +114,7 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
      *     creation)
      */
     IcebergCompatRequiredTablePropertyEnforcer(
-        TableConfig<T> property,
-        Predicate<T> validator,
-        String autoSetValue) {
+        TableConfig<T> property, Predicate<T> validator, String autoSetValue) {
       this.property = property;
       this.validator = validator;
       this.autoSetValue = autoSetValue;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
@@ -105,6 +105,24 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
       this.postMetadataProcessor = postMetadataProcessor;
     }
 
+    /**
+     * Constructor for RequiredDeltaTableProperty
+     *
+     * @param property DeltaConfig we are checking
+     * @param validator A generic method to validate the given value
+     * @param autoSetValue The value to set if we can auto-set this value (e.g. during table
+     *     creation)
+     */
+    IcebergCompatRequiredTablePropertyEnforcer(
+        TableConfig<T> property,
+        Predicate<T> validator,
+        String autoSetValue) {
+      this.property = property;
+      this.validator = validator;
+      this.autoSetValue = autoSetValue;
+      this.postMetadataProcessor = (c) -> Optional.empty();
+    }
+
     Optional<Metadata> validateAndUpdate(IcebergCompatInputContext inputContext) {
       Metadata newMetadata = inputContext.newMetadata;
       T newestValue = property.fromMetadata(newMetadata);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
@@ -133,7 +133,7 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
           // Covers the case CREATE that did not explicitly specify the required table property.
           // In these cases, we set the property automatically.
           newMetadata =
-              newMetadata.withNewConfiguration(singletonMap(property.getKey(), autoSetValue));
+              newMetadata.withMergedConfiguration(singletonMap(property.getKey(), autoSetValue));
           return Optional.of(newMetadata);
         } else {
           // In all other cases, if the property value is not compatible

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
@@ -115,10 +115,7 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
      */
     IcebergCompatRequiredTablePropertyEnforcer(
         TableConfig<T> property, Predicate<T> validator, String autoSetValue) {
-      this.property = property;
-      this.validator = validator;
-      this.autoSetValue = autoSetValue;
-      this.postMetadataProcessor = (c) -> Optional.empty();
+      this(property, validator, autoSetValue, (c) -> Optional.empty());
     }
 
     Optional<Metadata> validateAndUpdate(IcebergCompatInputContext inputContext) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -80,10 +80,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
       new IcebergCompatRequiredTablePropertyEnforcer<>(
           TableConfig.COLUMN_MAPPING_MODE,
           (value) -> ColumnMappingMode.NAME == value || ColumnMappingMode.ID == value,
-          ColumnMappingMode.NAME.value,
-          (inputContext) ->
-              ColumnMapping.updateColumnMappingMetadataIfNeeded(
-                  inputContext.newMetadata, inputContext.isCreatingNewTable));
+          ColumnMappingMode.NAME.value);
 
   private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_NO_COMPAT_V1_ENABLED =
       (inputContext) -> {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -27,7 +27,6 @@ import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeature;
-import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.kernel.internal.util.SchemaUtils;
 import io.delta.kernel.internal.util.Tuple2;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -328,7 +328,7 @@ public class ColumnMapping {
     return Optional.of(
         metadata
             .withNewSchema(newSchema)
-            .withNewConfiguration(singletonMap(COLUMN_MAPPING_MAX_COLUMN_ID_KEY, maxFieldId)));
+            .withMergedConfiguration(singletonMap(COLUMN_MAPPING_MAX_COLUMN_ID_KEY, maxFieldId)));
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -49,7 +49,7 @@ public class InCommitTimestampUtils {
           TableConfig.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.getKey(),
           Long.toString(inCommitTimestamp));
 
-      Metadata newMetadata = metadata.withNewConfiguration(enablementTrackingProperties);
+      Metadata newMetadata = metadata.withMergedConfiguration(enablementTrackingProperties);
       return Optional.of(newMetadata);
     } else {
       return Optional.empty();

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -134,7 +134,6 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
           validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
         assert(updatedMetadata.isPresent)
         assert(updatedMetadata.get().getConfiguration.get("delta.columnMapping.mode") == "name")
-        verifyCMTestSchemaHasValidColumnMappingInfo(updatedMetadata.get(), isNewTable)
       } else {
         val e = intercept[KernelException] {
           validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
@@ -159,9 +158,8 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
 
         val updatedMetadata =
           validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
-        // Metadata should be updated as we make sure column mapping fields are assigned
-        assert(updatedMetadata.isPresent)
-        verifyCMTestSchemaHasValidColumnMappingInfo(updatedMetadata.get(), isNewTable)
+        // No metadata update is needed since already compatible column mapping mode
+        assert(!updatedMetadata.isPresent)
       }
     }
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
@@ -56,12 +56,12 @@ trait ColumnMappingSuiteBase extends VectorTestUtils {
 
   implicit class MetadataImplicits(metadata: Metadata) {
     def withIcebergCompatV2Enabled: Metadata = {
-      metadata.withNewConfiguration(
+      metadata.withMergedConfiguration(
         Maps.newHashMap(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey, "true"))
     }
 
     def withColumnMappingEnabled(mode: String = "name"): Metadata = {
-      metadata.withNewConfiguration(
+      metadata.withMergedConfiguration(
         Maps.newHashMap(TableConfig.COLUMN_MAPPING_MODE.getKey, mode))
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Reorganizes the order of metadata updates and validation in `TransactionBuilder`. When building the transaction the metadata may be updated many different ways including new user provided properties, new user provided schema, transitive property changes based on enabled confs (e.g. enabling `IcebergCompatV2` enables column mapping). We should be sure to perform any validation AFTER any metadata changes have been made, less we miss something. This PR reorganizes the transformations to do transformations first and then validation.

Examples of how this could go wrong
- Right now we only block changing cmMode none -> id (which not allowed for existing tables) when newProperties are set by the user. However, cmMode confs may change after during the `IcebergCompat` checks. We should perform this validation only AFTER any config changes have been made.
   - Note - currently this invalid change is not possible since we don't automatically enable table properties for iceberg compats, but this could change in the future.
- Example in this PR where we should be using the latest updated metadata to perform validation https://github.com/delta-io/delta/pull/4196/files/70cdbc9067079705e3f68e2b9cbbc16156d19015#r1994099944 but this is not easy given the current set up

## How was this patch tested?

Existing tests suffice.

## Does this PR introduce _any_ user-facing changes?

No.
