### PR TITLE
[Spark] Added vacuumType to API methods

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -99,7 +99,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(retentionHours: Double): DataFrame = {
-    executeVacuum(table, Some(retentionHours))
+    executeVacuum(table, Some(retentionHours), None)
   }
 
   /**
@@ -107,12 +107,45 @@ class DeltaTable private[tables](
    * maintaining older versions up to the given retention threshold. This method will return an
    * empty DataFrame on successful completion.
    *
-   * note: This will use the default retention period of 7 days.
+   * @param vacuumType Specifies type of VACUUM - FULL or LITE.
+   *                   Defaults to None which is equal to FULL.
+   *                   VACUUM LITE finds only files that are dereferenced in Delta transaction log.
+   *                   VACUUM FULL lists all files in underlying FS and compares against log.
+   * @since 0.3.0
+   */
+  def vacuum(vacuumType: String): DataFrame = {
+    executeVacuum(table, None, Some(vacuumType))
+  }
+
+  /**
+   * Recursively delete files and directories in the table that are not needed by the table for
+   * maintaining older versions up to the given retention threshold. This method will return an
+   * empty DataFrame on successful completion.
+   *
+   * @param retentionHours The retention threshold in hours. Files required by the table for
+   *                       reading versions earlier than this will be preserved and the
+   *                       rest of them will be deleted.
+   * @param vacuumType Specifies type of VACUUM - FULL or LITE.
+   *                   Defaults to None which is equal to FULL.
+   *                   VACUUM LITE finds only files that are dereferenced in Delta transaction log.
+   *                   VACUUM FULL lists all files in underlying FS and compares against log.
+   * @since 0.3.0
+   */
+  def vacuum(retentionHours: Double, vacuumType: String): DataFrame = {
+    executeVacuum(table, Some(retentionHours), Some(vacuumType))
+  }
+
+  /**
+   * Recursively delete files and directories in the table that are not needed by the table for
+   * maintaining older versions up to the given retention threshold. This method will return an
+   * empty DataFrame on successful completion.
+   *
+   * note: This will use VACUUM FULL operation with the default retention period of 7 days.
    *
    * @since 0.3.0
    */
   def vacuum(): DataFrame = {
-    executeVacuum(table, retentionHours = None)
+    executeVacuum(table, None, None)
   }
 
   /**

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -89,7 +89,8 @@ trait DeltaTableOperations extends AnalysisHelper { self: io.delta.tables.DeltaT
 
   protected def executeVacuum(
       table: DeltaTableV2,
-      retentionHours: Option[Double]): DataFrame = withActiveSession(sparkSession) {
+      retentionHours: Option[Double],
+      vacuumType: Option[String]): DataFrame = withActiveSession(sparkSession) {
     val tableId = table.getTableIdentifierIfExists
     val path = Option.when(tableId.isEmpty)(deltaLog.dataPath.toString)
     val vacuum = VacuumTableCommand(
@@ -99,7 +100,7 @@ trait DeltaTableOperations extends AnalysisHelper { self: io.delta.tables.DeltaT
       inventoryQuery = None,
       retentionHours,
       dryRun = false,
-      vacuumType = None,
+      vacuumType,
       deltaLog.options)
     toDataset(sparkSession, vacuum)
     sparkSession.emptyDataFrame


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR changes signatures of `vacuum` method of `DeltaTable` class. This is needed to expose `vacuumType` (`FULL` or `LITE`) to public API
This PR resolves issue #4259 

## How was this patch tested?

No new tests added, not sure if this functionality is testable

## Does this PR introduce _any_ user-facing changes?

Previous behavior: only one overload available for `DeltaTable.vacuum` method - `retentionHours` param
New behavior: `vacuumType` param added to `DeltaTable.vacuum`
