### PR TITLE
[Spark] Plumb CatalogTable through PreparedDeltaFileIndex

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
@@ -59,6 +59,7 @@ class PrepareDeltaSharingScan(override val spark: SparkSession) extends PrepareD
           spark,
           deltaLog,
           deltaLog.dataPath,
+          catalogTableOpt = None,
           preparedScan = deltaScan,
           versionScanned = Some(snapshot.version)
         )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -99,6 +100,7 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       spark,
       fileIndex.deltaLog,
       fileIndex.path,
+      fileIndex.catalogTableOpt,
       preparedScan,
       fileIndex.versionToUse)
   }
@@ -342,6 +344,7 @@ case class PreparedDeltaFileIndex(
     override val spark: SparkSession,
     override val deltaLog: DeltaLog,
     override val path: Path,
+    catalogTableOpt: Option[CatalogTable],
     preparedScan: DeltaScan,
     versionScanned: Option[Long])
   extends TahoeFileIndexWithSnapshotDescriptor(spark, deltaLog, path, preparedScan.scannedSnapshot)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Plumb the CatalogTable through PreparedDeltaFileIndex. This is a continuing effort to support coordinated commits.


## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No