### PR TITLE
[Kernel] Block typeWidening-preview feature with icebergCompatV2

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -15,10 +15,7 @@
  */
 package io.delta.kernel.internal.icebergcompat;
 
-import static io.delta.kernel.internal.tablefeatures.TableFeatures.COLUMN_MAPPING_RW_FEATURE;
-import static io.delta.kernel.internal.tablefeatures.TableFeatures.DELETION_VECTORS_RW_FEATURE;
-import static io.delta.kernel.internal.tablefeatures.TableFeatures.ICEBERG_COMPAT_V2_W_FEATURE;
-import static io.delta.kernel.internal.tablefeatures.TableFeatures.TYPE_WIDENING_RW_FEATURE;
+import static io.delta.kernel.internal.tablefeatures.TableFeatures.*;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
@@ -175,6 +172,9 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
           // TODO: Currently Kernel has no support for writing with type widening. When it is
           //  supported extend this to allow a whitelist of supported type widening in Iceberg
           throw DeltaErrors.unsupportedTableFeature(TYPE_WIDENING_RW_FEATURE.featureName());
+        } else if (inputContext.newProtocol.supportsFeature(TYPE_WIDENING_PREVIEW_TABLE_FEATURE)) {
+          throw DeltaErrors.unsupportedTableFeature(
+              TYPE_WIDENING_PREVIEW_TABLE_FEATURE.featureName());
         }
       };
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -20,7 +20,7 @@ import scala.collection.JavaConverters._
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.actions.Protocol
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdater.validateAndUpdateIcebergCompatV2Metadata
-import io.delta.kernel.internal.tablefeatures.TableFeatures.{COLUMN_MAPPING_RW_FEATURE, DELETION_VECTORS_RW_FEATURE, ICEBERG_COMPAT_V2_W_FEATURE, TYPE_WIDENING_RW_FEATURE}
+import io.delta.kernel.internal.tablefeatures.TableFeatures.{COLUMN_MAPPING_RW_FEATURE, DELETION_VECTORS_RW_FEATURE, ICEBERG_COMPAT_V2_W_FEATURE, TYPE_WIDENING_PREVIEW_TABLE_FEATURE, TYPE_WIDENING_RW_FEATURE}
 import io.delta.kernel.internal.util.ColumnMappingSuiteBase
 import io.delta.kernel.test.VectorTestUtils
 import io.delta.kernel.types._
@@ -165,21 +165,25 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
   }
 
   Seq(true, false).foreach { isNewTable =>
-    test(s"can't enable icebergCompatV2 on a table with type widening supported, " +
-      s"isNewTable = $isNewTable") {
-      val schema = new StructType().add("col", BooleanType.BOOLEAN)
-      val metadata = testMetadata(schema).withIcebergCompatV2AndCMEnabled()
-      val protocol = testProtocol(
-        ICEBERG_COMPAT_V2_W_FEATURE,
-        COLUMN_MAPPING_RW_FEATURE,
-        TYPE_WIDENING_RW_FEATURE)
+    Seq(TYPE_WIDENING_RW_FEATURE, TYPE_WIDENING_PREVIEW_TABLE_FEATURE).foreach {
+      typeWideningFeature =>
+        test(s"can't enable icebergCompatV2 on a table $typeWideningFeature supported, " +
+          s"isNewTable = $isNewTable") {
+          val schema = new StructType().add("col", BooleanType.BOOLEAN)
+          val metadata = testMetadata(schema).withIcebergCompatV2AndCMEnabled()
+          val protocol = testProtocol(
+            ICEBERG_COMPAT_V2_W_FEATURE,
+            COLUMN_MAPPING_RW_FEATURE,
+            typeWideningFeature)
 
-      val ex = intercept[KernelException] {
-        validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
-      }
-      assert(ex.getMessage.contains(
-        "Unsupported Delta table feature: table requires feature \"typeWidening\" which " +
-          "is unsupported by this version of Delta Kernel."))
+          val ex = intercept[KernelException] {
+            validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+          }
+          assert(ex.getMessage.contains(
+            s"Unsupported Delta table feature: table requires feature " +
+              s""""${typeWideningFeature.featureName()}" which """ +
+              "is unsupported by this version of Delta Kernel."))
+        }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Blocks "typeWidening-preview" feauture with icebergCompatV2.

## How was this patch tested?

Updates unit tests.
