### PR TITLE
[Kernel][icebergWriterCompatV1 - PR#2] Introduce IcebergWriterCompatV1MetadataValidatorAndUpdater for metadata validation and updates for table feature icebergWriterCompatV1

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -282,10 +282,15 @@ public final class DeltaErrors {
             compatVersion, dataType));
   }
 
-  public static KernelException icebergCompatDeletionVectorsUnsupported(String compatVersion) {
+  public static KernelException icebergCompatIncompatibleTableFeatures(
+      String compatVersion, Set<TableFeature> incompatibleFeatures) {
     throw new KernelException(
         format(
-            "Simultaneous support for %s and deletion vectors is not compatible.", compatVersion));
+            "Table features %s are incompatible with %s.",
+            incompatibleFeatures.stream()
+                .map(TableFeature::featureName)
+                .collect(Collectors.toList()),
+            compatVersion));
   }
 
   public static KernelException icebergCompatRequiredFeatureMissing(
@@ -363,16 +368,6 @@ public final class DeltaErrors {
     return new KernelException(
         "Feature 'rowTracking' is supported and depends on feature 'domainMetadata',"
             + " but 'domainMetadata' is unsupported");
-  }
-
-  public static KernelException icebergWriterCompatV1IncompatibleTableFeatures(
-      Set<TableFeature> incompatibleFeatures) {
-    return new KernelException(
-        String.format(
-            "Cannot enable table features %s on a table with icebergWriterCompatV1",
-            incompatibleFeatures.stream()
-                .map(TableFeature::featureName)
-                .collect(Collectors.toList())));
   }
 
   /* ------------------------ HELPER METHODS ----------------------------- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -19,6 +19,7 @@ import static java.lang.String.format;
 
 import io.delta.kernel.exceptions.*;
 import io.delta.kernel.internal.actions.DomainMetadata;
+import io.delta.kernel.internal.tablefeatures.TableFeature;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.DataFileStatus;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /** Contains methods to create user-facing Delta exceptions. */
 public final class DeltaErrors {
@@ -361,6 +363,16 @@ public final class DeltaErrors {
     return new KernelException(
         "Feature 'rowTracking' is supported and depends on feature 'domainMetadata',"
             + " but 'domainMetadata' is unsupported");
+  }
+
+  public static KernelException icebergWriterCompatV1IncompatibleTableFeatures(
+      Set<TableFeature> incompatibleFeatures) {
+    return new KernelException(
+        String.format(
+            "Cannot enable table features %s on a table with icebergWriterCompatV1",
+            incompatibleFeatures.stream()
+                .map(TableFeature::featureName)
+                .collect(Collectors.toList())));
   }
 
   /* ------------------------ HELPER METHODS ----------------------------- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -294,9 +294,9 @@ public class TableConfig<T> {
               addConfig(this, IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP);
               addConfig(this, COLUMN_MAPPING_MODE);
               addConfig(this, ICEBERG_COMPAT_V2_ENABLED);
+              addConfig(this, ICEBERG_WRITER_COMPAT_V1_ENABLED);
               addConfig(this, COLUMN_MAPPING_MAX_COLUMN_ID);
               addConfig(this, DATA_SKIPPING_NUM_INDEXED_COLS);
-              addConfig(this, ICEBERG_WRITER_COMPAT_V1_ENABLED);
             }
           });
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
@@ -118,7 +118,8 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
       this(property, validator, autoSetValue, (c) -> Optional.empty());
     }
 
-    Optional<Metadata> validateAndUpdate(IcebergCompatInputContext inputContext) {
+    Optional<Metadata> validateAndUpdate(
+        IcebergCompatInputContext inputContext, String compatVersion) {
       Metadata newMetadata = inputContext.newMetadata;
       T newestValue = property.fromMetadata(newMetadata);
       boolean newestValueOkay = validator.test(newestValue);
@@ -137,8 +138,8 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
           throw new KernelException(
               String.format(
                   "The value '%s' for the property '%s' is not compatible with "
-                      + "Iceberg compat requirements",
-                  newestValue, property.getKey()));
+                      + "%s requirements",
+                  newestValue, property.getKey(), compatVersion));
         }
       }
 
@@ -177,7 +178,8 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
         requiredDeltaTableProperties();
     for (IcebergCompatRequiredTablePropertyEnforcer requiredDeltaTableProperty :
         requiredDeltaTableProperties) {
-      Optional<Metadata> updated = requiredDeltaTableProperty.validateAndUpdate(inputContext);
+      Optional<Metadata> updated =
+          requiredDeltaTableProperty.validateAndUpdate(inputContext, compatVersion());
 
       if (updated.isPresent()) {
         inputContext = inputContext.withUpdatedMetadata(updated.get());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
@@ -179,7 +179,7 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
     for (IcebergCompatRequiredTablePropertyEnforcer requiredDeltaTableProperty :
         requiredDeltaTableProperties) {
       Optional<Metadata> updated =
-          requiredDeltaTableProperty.validateAndUpdate(inputContext, compatVersion());
+          requiredDeltaTableProperty.validateAndUpdate(inputContext, compatFeatureName());
 
       if (updated.isPresent()) {
         inputContext = inputContext.withUpdatedMetadata(updated.get());
@@ -202,7 +202,7 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
     for (TableFeature requiredDependencyTableFeature : requiredDependencyTableFeatures()) {
       if (!inputContext.newProtocol.supportsFeature(requiredDependencyTableFeature)) {
         throw DeltaErrors.icebergCompatRequiredFeatureMissing(
-            compatVersion(), requiredDependencyTableFeature.featureName());
+            compatFeatureName(), requiredDependencyTableFeature.featureName());
       }
     }
 
@@ -214,7 +214,7 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
     return metadataUpdated ? Optional.of(inputContext.newMetadata) : Optional.empty();
   }
 
-  abstract String compatVersion();
+  abstract String compatFeatureName();
 
   abstract TableConfig<Boolean> requiredDeltaTableProperty();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -29,6 +29,7 @@ import io.delta.kernel.internal.util.SchemaUtils;
 import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.DataFileStatus;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -61,7 +62,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
     if (!dataFileStatus.getStatistics().isPresent()) {
       // presence of stats means always has a non-null `numRecords`
       throw DeltaErrors.icebergCompatMissingNumRecordsStats(
-          INSTANCE.compatVersion(), dataFileStatus);
+          INSTANCE.compatFeatureName(), dataFileStatus);
     }
   }
 
@@ -86,7 +87,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
                 .getConfiguration()
                 .getOrDefault("delta.enableIcebergCompatV1", "false"))) {
           throw DeltaErrors.icebergCompatIncompatibleVersionEnabled(
-              INSTANCE.compatVersion(), "delta.enableIcebergCompatV1");
+              INSTANCE.compatFeatureName(), "delta.enableIcebergCompatV1");
         }
       };
 
@@ -119,7 +120,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
 
         if (!matches.isEmpty()) {
           throw DeltaErrors.icebergCompatUnsupportedTypeColumns(
-              INSTANCE.compatVersion(),
+              INSTANCE.compatFeatureName(),
               matches.stream().map(tuple -> tuple._2.getDataType()).collect(toList()));
         }
       };
@@ -149,7 +150,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
                             || dataType instanceof TimestampNTZType;
                     if (!validType) {
                       throw DeltaErrors.icebergCompatUnsupportedTypePartitionColumn(
-                          INSTANCE.compatVersion(), dataType);
+                          INSTANCE.compatFeatureName(), dataType);
                     }
                   });
 
@@ -162,7 +163,8 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
   private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_NO_DELETION_VECTORS =
       (inputContext) -> {
         if (inputContext.newProtocol.supportsFeature(DELETION_VECTORS_RW_FEATURE)) {
-          throw DeltaErrors.icebergCompatDeletionVectorsUnsupported(INSTANCE.compatVersion());
+          throw DeltaErrors.icebergCompatIncompatibleTableFeatures(
+              INSTANCE.compatFeatureName(), Collections.singleton(DELETION_VECTORS_RW_FEATURE));
         }
       };
 
@@ -179,7 +181,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
       };
 
   @Override
-  String compatVersion() {
+  String compatFeatureName() {
     return "icebergCompatV2";
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
@@ -145,7 +145,8 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
           Set<TableFeature> incompatibleFeatures =
               inputContext.newProtocol.getImplicitlyAndExplicitlySupportedFeatures();
           incompatibleFeatures.removeAll(ALLOWED_TABLE_FEATURES);
-          throw DeltaErrors.icebergWriterCompatV1IncompatibleTableFeatures(incompatibleFeatures);
+          throw DeltaErrors.icebergCompatIncompatibleTableFeatures(
+              INSTANCE.compatFeatureName(), incompatibleFeatures);
         }
       };
 
@@ -167,7 +168,7 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
 
         if (!matches.isEmpty()) {
           throw DeltaErrors.icebergCompatUnsupportedTypeColumns(
-              INSTANCE.compatVersion(),
+              INSTANCE.compatFeatureName(),
               matches.stream().map(tuple -> tuple._2.getDataType()).collect(toList()));
         }
       };
@@ -182,13 +183,13 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
       // If Kernel starts supporting the feature `invariants` this check will become applicable
       (inputContext) -> {
         if (TableFeatures.hasInvariants(inputContext.newMetadata.getSchema())) {
-          throw DeltaErrors.icebergWriterCompatV1IncompatibleTableFeatures(
-              Collections.singleton(INVARIANTS_W_FEATURE));
+          throw DeltaErrors.icebergCompatIncompatibleTableFeatures(
+              INSTANCE.compatFeatureName(), Collections.singleton(INVARIANTS_W_FEATURE));
         }
       };
 
   @Override
-  String compatVersion() {
+  String compatFeatureName() {
     return "icebergWriterCompatV1";
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
@@ -54,11 +54,11 @@ import java.util.stream.Stream;
  *       table features. This simultaneously ensures that any unsupported features are not present
  *       (e.g. CDF, variant type, etc).
  *   <li>Checks that there are no fields with data type byte or short.
- *   <li>Checks that the table feature `invariants` is not active in the table (i.e. there are
- *   no invariants in the table schema). This is a special case where the incompatible feature
- *   `invariants` is in the allow-list of features since it is included by default in the table
- *   protocol for new tables. Since it is incompatible we must verify that it is inactive in
- *   the table.
+ *   <li>Checks that the table feature `invariants` is not active in the table (i.e. there are no
+ *       invariants in the table schema). This is a special case where the incompatible feature
+ *       `invariants` is in the allow-list of features since it is included by default in the table
+ *       protocol for new tables. Since it is incompatible we must verify that it is inactive in the
+ *       table.
  * </ul>
  *
  * TODO additional enforcements coming in (ie physicalName=fieldId)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.icebergcompat;
+
+import static io.delta.kernel.internal.tablefeatures.TableFeatures.*;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import io.delta.kernel.internal.DeltaErrors;
+import io.delta.kernel.internal.TableConfig;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.tablefeatures.TableFeature;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.SchemaUtils;
+import io.delta.kernel.internal.util.Tuple2;
+import io.delta.kernel.types.*;
+import java.util.*;
+import java.util.stream.Stream;
+
+/**
+ * Performs the validations and updates necessary to support the table feature IcebergWriterCompatV1
+ * when it is enabled by the table property "delta.enableIcebergWriterCompatV1".
+ *
+ * <p>Requires that the following table properties are set to the specified values. If they are set
+ * to an invalid value, throws an exception. If they are not set, enable them if possible.
+ *
+ * <ul>
+ *   <li>Requires ID column mapping mode (cannot be enabled on existing table).
+ *   <li>Requires icebergCompatV2 to be enabled.
+ * </ul>
+ *
+ * <p>Checks that required table features are enabled: icebergCompatWriterV1, icebergCompatV2,
+ * columnMapping
+ *
+ * <p>Checks the following:
+ *
+ * <ul>
+ *   <li>Checks that all table features supported in the table's protocol are in the allow-list of
+ *       table features. This simultaneously ensures that any unsupported features are not present
+ *       (e.g. CDF, variant type, etc).
+ *   <li>Checks that there are no fields with data type byte or short.
+ *   <li>Checks that the table feature `invariants` is not active in the table (i.e. there are
+ *   no invariants in the table schema). This is a special case where the incompatible feature
+ *   `invariants` is in the allow-list of features since it is included by default in the table
+ *   protocol for new tables. Since it is incompatible we must verify that it is inactive in
+ *   the table.
+ * </ul>
+ *
+ * TODO additional enforcements coming in (ie physicalName=fieldId)
+ */
+public class IcebergWriterCompatV1MetadataValidatorAndUpdater
+    extends IcebergCompatMetadataValidatorAndUpdater {
+
+  /**
+   * Validate and update the given Iceberg Writer Compat V1 metadata.
+   *
+   * @param newMetadata Metadata after the current updates
+   * @param newProtocol Protocol after the current updates
+   * @return The updated metadata if the metadata is valid and updated, otherwise empty.
+   * @throws UnsupportedOperationException if the metadata is not compatible with Iceberg Writer V1
+   *     requirements
+   */
+  public static Optional<Metadata> validateAndUpdateIcebergWriterCompatV1Metadata(
+      boolean isCreatingNewTable, Metadata newMetadata, Protocol newProtocol) {
+    return INSTANCE.validateAndUpdateMetadata(
+        new IcebergCompatInputContext(isCreatingNewTable, newMetadata, newProtocol));
+  }
+
+  /// //////////////////////////////////////////////////////////////////////////////
+  /// Define the compatibility and update checks for icebergWriterCompatV1       ///
+  /// //////////////////////////////////////////////////////////////////////////////
+
+  private static final IcebergWriterCompatV1MetadataValidatorAndUpdater INSTANCE =
+      new IcebergWriterCompatV1MetadataValidatorAndUpdater();
+
+  private static final IcebergCompatRequiredTablePropertyEnforcer CM_ID_MODE_ENABLED =
+      new IcebergCompatRequiredTablePropertyEnforcer<>(
+          TableConfig.COLUMN_MAPPING_MODE,
+          (value) -> ColumnMapping.ColumnMappingMode.ID == value,
+          ColumnMapping.ColumnMappingMode.ID.value);
+
+  private static final IcebergCompatRequiredTablePropertyEnforcer ICEBERG_COMPAT_V2_ENABLED =
+      new IcebergCompatRequiredTablePropertyEnforcer<>(
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED,
+          (value) -> value,
+          "true",
+          (inputContext) ->
+              IcebergCompatV2MetadataValidatorAndUpdater.validateAndUpdateIcebergCompatV2Metadata(
+                  inputContext.isCreatingNewTable,
+                  inputContext.newMetadata,
+                  inputContext.newProtocol));
+
+  /**
+   * Current set of allowed table features. This may evolve as the protocol evolves. This includes
+   * `invariants` because it is auto-enabled for tables due to the default writer protocol version =
+   * 2. Below in INVARIANTS_INACTIVE_CHECK we check that there are no invariants in the table
+   * schema.
+   *
+   * <p>Notably, we do NOT include the other legacy table features here (such as CDF) because since
+   * we only support enabling IcebergWriterCompatV1 on *new* tables, if those features are present
+   * in the protocol they must be active (since they were enabled by the metadata). Thus, we know
+   * any protocol with those features we are incompatible with. `invariants` is a special case since
+   * it may be present but inactive even for new tables.
+   */
+  private static Set<TableFeature> ALLOWED_TABLE_FEATURES =
+      Stream.of(
+              INVARIANTS_W_FEATURE,
+              APPEND_ONLY_W_FEATURE,
+              COLUMN_MAPPING_RW_FEATURE,
+              ICEBERG_COMPAT_V2_W_FEATURE,
+              ICEBERG_WRITER_COMPAT_V1,
+              DOMAIN_METADATA_W_FEATURE,
+              VACUUM_PROTOCOL_CHECK_RW_FEATURE,
+              CHECKPOINT_V2_RW_FEATURE,
+              IN_COMMIT_TIMESTAMP_W_FEATURE,
+              // TODO: add clustering once we support it in Kernel
+              TIMESTAMP_NTZ_RW_FEATURE,
+              TYPE_WIDENING_RW_FEATURE,
+              TYPE_WIDENING_PREVIEW_TABLE_FEATURE)
+          .collect(toSet());
+
+  /** Checks that all features supported in the protocol are in {@link #ALLOWED_TABLE_FEATURES} */
+  private static final IcebergCompatCheck UNSUPPORTED_FEATURES_CHECK =
+      (inputContext) -> {
+        // TODO include additional information in inputContext so that we can throw different errors
+        //   for blocking enablement of icebergWriterCompatV1 versus enablement of the incompatible
+        //   feature
+        if (!ALLOWED_TABLE_FEATURES.containsAll(
+            inputContext.newProtocol.getImplicitlyAndExplicitlySupportedFeatures())) {
+          Set<TableFeature> incompatibleFeatures =
+              inputContext.newProtocol.getImplicitlyAndExplicitlySupportedFeatures();
+          incompatibleFeatures.removeAll(ALLOWED_TABLE_FEATURES);
+          throw DeltaErrors.icebergWriterCompatV1IncompatibleTableFeatures(incompatibleFeatures);
+        }
+      };
+
+  /**
+   * Checks that there are no unsupported types in the schema. Data types {@link ByteType} and
+   * {@link ShortType} are unsupported for IcebergWriterCompatV1 tables.
+   */
+  private static final IcebergCompatCheck UNSUPPORTED_TYPES_CHECK =
+      (inputContext) -> {
+        List<Tuple2<List<String>, StructField>> matches =
+            SchemaUtils.filterRecursively(
+                inputContext.newMetadata.getSchema(),
+                /* recurseIntoMapAndArrayTypes= */ true,
+                /* stopOnFirstMatch = */ false,
+                field -> {
+                  DataType dataType = field.getDataType();
+                  return (dataType instanceof ByteType || dataType instanceof ShortType);
+                });
+
+        if (!matches.isEmpty()) {
+          throw DeltaErrors.icebergCompatUnsupportedTypeColumns(
+              INSTANCE.compatVersion(),
+              matches.stream().map(tuple -> tuple._2.getDataType()).collect(toList()));
+        }
+      };
+
+  /**
+   * Checks that the table feature `invariants` is not active in the table, meaning there are no
+   * invariants stored in the table schema.
+   */
+  private static final IcebergCompatCheck INVARIANTS_INACTIVE_CHECK =
+      // Note - since Kernel currently does not support the table feature `invariants` we will not
+      // hit this check for E2E writes since we will fail early due to unsupported write
+      // If Kernel starts supporting the feature `invariants` this check will become applicable
+      (inputContext) -> {
+        if (TableFeatures.hasInvariants(inputContext.newMetadata.getSchema())) {
+          throw DeltaErrors.icebergWriterCompatV1IncompatibleTableFeatures(
+              Collections.singleton(INVARIANTS_W_FEATURE));
+        }
+      };
+
+  @Override
+  String compatVersion() {
+    return "icebergWriterCompatV1";
+  }
+
+  @Override
+  TableConfig<Boolean> requiredDeltaTableProperty() {
+    return TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED;
+  }
+
+  @Override
+  List<IcebergCompatRequiredTablePropertyEnforcer> requiredDeltaTableProperties() {
+    return Stream.of(CM_ID_MODE_ENABLED, ICEBERG_COMPAT_V2_ENABLED).collect(toList());
+  }
+
+  @Override
+  List<TableFeature> requiredDependencyTableFeatures() {
+    return Stream.of(
+            ICEBERG_WRITER_COMPAT_V1, ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE)
+        .collect(toList());
+  }
+
+  @Override
+  List<IcebergCompatCheck> icebergCompatChecks() {
+    return Stream.of(UNSUPPORTED_FEATURES_CHECK, UNSUPPORTED_TYPES_CHECK, INVARIANTS_INACTIVE_CHECK)
+        .collect(toList());
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -562,7 +562,7 @@ public class TableFeatures {
     }
   }
 
-  private static boolean hasInvariants(StructType tableSchema) {
+  public static boolean hasInvariants(StructType tableSchema) {
     return !SchemaUtils.filterRecursively(
             tableSchema,
             // invariants are not allowed in maps or arrays

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -33,7 +33,7 @@ trait IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase extends AnyFunSuite
 
   import IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase._
 
-  /** When testing supported data column types skip any types defined here */
+  /** When testing supported simple column types skip any types defined here */
   def simpleTypesToSkip: Set[DataType]
 
   /** Get a metadata with the given schema and partCols with the desired icebergCompat enabled */
@@ -50,7 +50,7 @@ trait IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase extends AnyFunSuite
       metadata: Metadata,
       protocol: Protocol): Unit
 
-  (SIMPLE_TYPES ++ COMPLEX_TYPES).diff(simpleTypesToSkip).foreach {
+  (SIMPLE_TYPES.diff(simpleTypesToSkip) ++ COMPLEX_TYPES).foreach {
     dataType: DataType =>
       Seq(true, false).foreach { isNewTable =>
         test(s"allowed data column types: $dataType, new table = $isNewTable") {
@@ -74,7 +74,7 @@ trait IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase extends AnyFunSuite
       }
   }
 
-  (UNSUPPORTED_DATA_COLUMN_TYPES).foreach {
+  UNSUPPORTED_DATA_COLUMN_TYPES.foreach {
     dataType: DataType =>
       Seq(true, false).foreach { isNewTable =>
         test(s"disallowed data column types: $dataType, new table = $isNewTable") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -18,8 +18,9 @@ package io.delta.kernel.internal.icebergcompat
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.exceptions.KernelException
-import io.delta.kernel.internal.actions.Protocol
+import io.delta.kernel.internal.actions.{Metadata, Protocol}
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdater.validateAndUpdateIcebergCompatV2Metadata
+import io.delta.kernel.internal.tablefeatures.TableFeature
 import io.delta.kernel.internal.tablefeatures.TableFeatures.{COLUMN_MAPPING_RW_FEATURE, DELETION_VECTORS_RW_FEATURE, ICEBERG_COMPAT_V2_W_FEATURE, TYPE_WIDENING_PREVIEW_TABLE_FEATURE, TYPE_WIDENING_RW_FEATURE}
 import io.delta.kernel.internal.util.ColumnMappingSuiteBase
 import io.delta.kernel.test.VectorTestUtils
@@ -27,47 +28,61 @@ import io.delta.kernel.types._
 
 import org.scalatest.funsuite.AnyFunSuite
 
-class IcebergCompatV2MetadataValidatorAndUpdaterSuite
-    extends AnyFunSuite
+trait IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase extends AnyFunSuite
     with VectorTestUtils with ColumnMappingSuiteBase {
 
-  import IcebergCompatV2MetadataValidatorAndUpdaterSuite._
+  import IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase._
 
-  (SIMPLE_TYPES ++ COMPLEX_TYPES).foreach {
+  /** When testing supported data column types skip any types defined here */
+  def simpleTypesToSkip: Set[DataType]
+
+  /** Get a metadata with the given schema and partCols with the desired icebergCompat enabled */
+  def getCompatEnabledMetadata(
+      schema: StructType,
+      partCols: Seq[String] = Seq.empty): Metadata
+
+  /** Get a protocol with features needed for the desired icebergCompat plus the `tableFeatures` */
+  def getCompatEnabledProtocol(tableFeatures: TableFeature*): Protocol
+
+  /** Run the desired validate and update metadata method that triggers icebergCompatV2 checks */
+  def runValidateAndUpdateIcebergCompatV2Metadata(
+      isNewTable: Boolean,
+      metadata: Metadata,
+      protocol: Protocol): Unit
+
+  (SIMPLE_TYPES ++ COMPLEX_TYPES).diff(simpleTypesToSkip).foreach {
     dataType: DataType =>
       Seq(true, false).foreach { isNewTable =>
         test(s"allowed data column types: $dataType, new table = $isNewTable") {
           val schema = new StructType().add("col", dataType)
-          val metadata = testMetadata(schema).withIcebergCompatV2AndCMEnabled()
-
-          val protocol = testProtocol(ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE)
-          validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+          val metadata = getCompatEnabledMetadata(schema)
+          val protocol = getCompatEnabledProtocol()
+          runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
         }
       }
   }
 
-  SIMPLE_TYPES.foreach {
+  SIMPLE_TYPES.diff(simpleTypesToSkip).foreach {
     dataType: DataType =>
       Seq(true, false).foreach { isNewTable =>
         test(s"allowed partition column types: $dataType, new table = $isNewTable") {
           val schema = new StructType().add("col", dataType)
-          val metadata = testMetadata(schema, partitionCols = Seq("col"))
-            .withIcebergCompatV2AndCMEnabled()
-          val protocol = testProtocol(ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE)
-          validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+          val metadata = getCompatEnabledMetadata(schema, Seq("col"))
+          val protocol = getCompatEnabledProtocol()
+          runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
         }
       }
   }
 
-  UNSUPPORTED_DATA_COLUMN_TYPES.foreach {
+  (UNSUPPORTED_DATA_COLUMN_TYPES).foreach {
     dataType: DataType =>
       Seq(true, false).foreach { isNewTable =>
         test(s"disallowed data column types: $dataType, new table = $isNewTable") {
           val schema = new StructType().add("col", dataType)
-          val metadata = testMetadata(schema).withIcebergCompatV2AndCMEnabled()
-          val protocol = testProtocol(ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE)
+          val metadata = getCompatEnabledMetadata(schema)
+          val protocol = getCompatEnabledProtocol()
           val e = intercept[KernelException] {
-            validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+            runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
           }
           assert(e.getMessage.contains(
             s"icebergCompatV2 does not support the data types: "))
@@ -80,11 +95,10 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
       Seq(true, false).foreach { isNewTable =>
         test(s"disallowed partition column types: $dataType, new table = $isNewTable") {
           val schema = new StructType().add("col", dataType)
-          val metadata = testMetadata(schema, partitionCols = Seq("col"))
-            .withIcebergCompatV2AndCMEnabled()
-          val protocol = testProtocol(ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE)
+          val metadata = getCompatEnabledMetadata(schema, Seq("col"))
+          val protocol = getCompatEnabledProtocol()
           val e = intercept[KernelException] {
-            validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+            runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
           }
           assert(e.getMessage.matches(
             s"icebergCompatV2 does not support the data type .* for a partition column."))
@@ -95,17 +109,76 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
   Seq(true, false).foreach { isNewTable =>
     test(s"can't be enabled on a table with deletion vectors supported, isNewTable $isNewTable") {
       val schema = new StructType().add("col", BooleanType.BOOLEAN)
-      val metadata = testMetadata(schema, Seq.empty).withIcebergCompatV2AndCMEnabled()
-      val protocol = testProtocol(
-        ICEBERG_COMPAT_V2_W_FEATURE,
-        COLUMN_MAPPING_RW_FEATURE,
-        DELETION_VECTORS_RW_FEATURE)
+      val metadata = getCompatEnabledMetadata(schema)
+      val protocol = getCompatEnabledProtocol(DELETION_VECTORS_RW_FEATURE)
       val e = intercept[KernelException] {
-        validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+        runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
       }
       assert(e.getMessage.contains(
         "Simultaneous support for icebergCompatV2 and deletion vectors is not compatible."))
     }
+  }
+
+  Seq(true, false).foreach { isNewTable =>
+    Seq(TYPE_WIDENING_RW_FEATURE, TYPE_WIDENING_PREVIEW_TABLE_FEATURE).foreach {
+      typeWideningFeature =>
+        test(s"can't enable icebergCompatV2 on a table with $typeWideningFeature supported, " +
+          s"isNewTable = $isNewTable") {
+          val schema = new StructType().add("col", BooleanType.BOOLEAN)
+          val metadata = getCompatEnabledMetadata(schema)
+          val protocol = getCompatEnabledProtocol(typeWideningFeature)
+
+          val ex = intercept[KernelException] {
+            runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+          }
+          assert(ex.getMessage.contains(
+            s"Unsupported Delta table feature: table requires feature " +
+              s""""${typeWideningFeature.featureName()}" which is unsupported by this version """ +
+              s"of Delta Kernel."))
+        }
+    }
+  }
+
+  Seq(true, false).foreach { isNewTable =>
+    test(s"can't enable icebergCompatV2 on a table with icebergCompatv1 enabled, " +
+      s"isNewTable = $isNewTable") {
+      val schema = new StructType().add("col", BooleanType.BOOLEAN)
+      val metadata = getCompatEnabledMetadata(schema)
+        .withMergedConfiguration(
+          Map("delta.enableIcebergCompatV1" -> "true").asJava)
+      val protocol = getCompatEnabledProtocol()
+
+      val ex = intercept[KernelException] {
+        runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+      }
+      assert(ex.getMessage.contains(
+        "icebergCompatV2: Only one IcebergCompat version can be enabled. " +
+          "Incompatible version enabled: delta.enableIcebergCompatV1"))
+    }
+  }
+}
+
+class IcebergCompatV2MetadataValidatorAndUpdaterSuite
+    extends IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase {
+
+  override def simpleTypesToSkip: Set[DataType] = Set.empty
+
+  override def getCompatEnabledMetadata(
+      schema: StructType,
+      partCols: Seq[String] = Seq.empty): Metadata = {
+    testMetadata(schema, partCols)
+      .withIcebergCompatV2AndCMEnabled()
+  }
+
+  override def getCompatEnabledProtocol(tableFeatures: TableFeature*): Protocol = {
+    testProtocol(tableFeatures ++ Seq(ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE): _*)
+  }
+
+  override def runValidateAndUpdateIcebergCompatV2Metadata(
+      isNewTable: Boolean,
+      metadata: Metadata,
+      protocol: Protocol): Unit = {
+    validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
   }
 
   Seq(true, false).foreach { isNewTable =>
@@ -140,7 +213,7 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
         }
         assert(e.getMessage.contains(
           "The value 'none' for the property 'delta.columnMapping.mode' is" +
-            " not compatible with Iceberg compat requirements"))
+            " not compatible with icebergCompatV2 requirements"))
       }
     }
   }
@@ -163,56 +236,11 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
       }
     }
   }
-
-  Seq(true, false).foreach { isNewTable =>
-    Seq(TYPE_WIDENING_RW_FEATURE, TYPE_WIDENING_PREVIEW_TABLE_FEATURE).foreach {
-      typeWideningFeature =>
-        test(s"can't enable icebergCompatV2 on a table $typeWideningFeature supported, " +
-          s"isNewTable = $isNewTable") {
-          val schema = new StructType().add("col", BooleanType.BOOLEAN)
-          val metadata = testMetadata(schema).withIcebergCompatV2AndCMEnabled()
-          val protocol = testProtocol(
-            ICEBERG_COMPAT_V2_W_FEATURE,
-            COLUMN_MAPPING_RW_FEATURE,
-            typeWideningFeature)
-
-          val ex = intercept[KernelException] {
-            validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
-          }
-          assert(ex.getMessage.contains(
-            s"Unsupported Delta table feature: table requires feature " +
-              s""""${typeWideningFeature.featureName()}" which """ +
-              "is unsupported by this version of Delta Kernel."))
-        }
-    }
-  }
-
-  Seq(true, false).foreach { isNewTable =>
-    test(s"can't enable icebergCompatV2 on a table with icebergCompatv1 enabled, " +
-      s"isNewTable = $isNewTable") {
-      val schema = new StructType().add("col", BooleanType.BOOLEAN)
-      val metadata = testMetadata(
-        schema,
-        tblProps = Map(
-          "delta.enableIcebergCompatV2" -> "true",
-          "delta.columnMapping.mode" -> "name",
-          "delta.enableIcebergCompatV1" -> "true"))
-
-      val protocol = testProtocol(ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE)
-
-      val ex = intercept[KernelException] {
-        validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
-      }
-      assert(ex.getMessage.contains(
-        "icebergCompatV2: Only one IcebergCompat version can be enabled. " +
-          "Incompatible version enabled: delta.enableIcebergCompatV1"))
-    }
-  }
 }
 
-object IcebergCompatV2MetadataValidatorAndUpdaterSuite {
+object IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase {
   // Allowed simple types as data or partition columns
-  val SIMPLE_TYPES: Seq[DataType] = Seq(
+  val SIMPLE_TYPES: Set[DataType] = Set(
     BooleanType.BOOLEAN,
     ByteType.BYTE,
     ShortType.SHORT,
@@ -228,14 +256,14 @@ object IcebergCompatV2MetadataValidatorAndUpdaterSuite {
     new DecimalType(10, 5))
 
   // Allowed complex types as data columns
-  val COMPLEX_TYPES: Seq[DataType] = Seq(
+  val COMPLEX_TYPES: Set[DataType] = Set(
     new ArrayType(BooleanType.BOOLEAN, true),
     new MapType(IntegerType.INTEGER, LongType.LONG, true),
     new StructType().add("s1", BooleanType.BOOLEAN).add("s2", IntegerType.INTEGER))
 
   // Unsupported data type columns
-  val UNSUPPORTED_DATA_COLUMN_TYPES: Seq[VariantType] = Seq(VariantType.VARIANT)
+  val UNSUPPORTED_DATA_COLUMN_TYPES: Set[VariantType] = Set(VariantType.VARIANT)
 
   // Unsupported partition column types
-  val UNSUPPORTED_PARTITION_COLUMN_TYPES: Seq[DataType] = COMPLEX_TYPES
+  val UNSUPPORTED_PARTITION_COLUMN_TYPES: Set[DataType] = COMPLEX_TYPES
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -115,7 +115,7 @@ trait IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase extends AnyFunSuite
         runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
       }
       assert(e.getMessage.contains(
-        "Simultaneous support for icebergCompatV2 and deletion vectors is not compatible."))
+        "Table features [deletionVectors] are incompatible with icebergCompatV2"))
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -1,0 +1,325 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.icebergcompat
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.internal.TableConfig
+import io.delta.kernel.internal.actions.{Metadata, Protocol}
+import io.delta.kernel.internal.icebergcompat.IcebergWriterCompatV1MetadataValidatorAndUpdater.validateAndUpdateIcebergWriterCompatV1Metadata
+import io.delta.kernel.internal.tablefeatures.TableFeature
+import io.delta.kernel.internal.tablefeatures.TableFeatures.{COLUMN_MAPPING_RW_FEATURE, ICEBERG_COMPAT_V2_W_FEATURE, ICEBERG_WRITER_COMPAT_V1}
+import io.delta.kernel.types.{ByteType, DataType, FieldMetadata, IntegerType, ShortType, StructType}
+
+class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
+    extends IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase {
+
+  val icebergWriterCompatV1EnabledProps = Map(
+    TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.getKey -> "true")
+
+  val icebergCompatV2EnabledProps = Map(
+    TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
+
+  val columnMappingIdModeProps = Map(
+    TableConfig.COLUMN_MAPPING_MODE.getKey -> "id")
+
+  override def simpleTypesToSkip: Set[DataType] = Set(ByteType.BYTE, ShortType.SHORT)
+
+  override def getCompatEnabledMetadata(
+      schema: StructType,
+      partCols: Seq[String] = Seq.empty): Metadata = {
+    testMetadata(schema, partCols)
+      .withMergedConfiguration((
+        icebergWriterCompatV1EnabledProps ++ icebergCompatV2EnabledProps
+          ++ columnMappingIdModeProps).asJava)
+  }
+
+  override def getCompatEnabledProtocol(tableFeatures: TableFeature*): Protocol = {
+    testProtocol(tableFeatures ++
+      Seq(ICEBERG_WRITER_COMPAT_V1, ICEBERG_COMPAT_V2_W_FEATURE, COLUMN_MAPPING_RW_FEATURE): _*)
+  }
+
+  override def runValidateAndUpdateIcebergCompatV2Metadata(
+      isNewTable: Boolean,
+      metadata: Metadata,
+      protocol: Protocol): Unit = {
+    validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+  }
+
+  test("checks are not enforced when table property is not enabled") {
+    // Violate check by including BYTE type column
+    val schema = new StructType().add("col", ByteType.BYTE)
+    val metadata = testMetadata(schema)
+    assert(!TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.fromMetadata(metadata))
+    validateAndUpdateIcebergWriterCompatV1Metadata(
+      true, /* isNewTable */
+      metadata,
+      getCompatEnabledProtocol())
+  }
+
+  /* --- UNSUPPORTED_TYPES_CHECK tests --- */
+
+  Seq(ByteType.BYTE, ShortType.SHORT).foreach { unsupportedType =>
+    Seq(true, false).foreach { isNewTable =>
+      test(s"disallowed data types: $unsupportedType, new table = $isNewTable") {
+        val schema = new StructType().add("col", unsupportedType)
+        val metadata = getCompatEnabledMetadata(schema)
+        val protocol = getCompatEnabledProtocol()
+        val e = intercept[KernelException] {
+          validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+        }
+        assert(e.getMessage.contains(
+          s"icebergWriterCompatV1 does not support the data types: "))
+      }
+    }
+  }
+
+  /* --- CM_ID_MODE_ENABLED tests --- */
+
+  Seq(true, false).foreach { isNewTable =>
+    Seq(true, false).foreach { icebergCompatV2Enabled =>
+      test(s"column mapping mode `id` is auto enabled when icebergWriterCompatV1 is enabled, " +
+        s"isNewTable = $isNewTable, icebergCompatV2Enabled = $icebergCompatV2Enabled") {
+
+        val tblProperties = icebergWriterCompatV1EnabledProps ++
+          (if (icebergCompatV2Enabled) {
+             icebergCompatV2EnabledProps
+           } else {
+             Map()
+           })
+        val metadata = testMetadata(cmTestSchema(), tblProps = tblProperties)
+        val protocol = getCompatEnabledProtocol()
+
+        assert(!metadata.getConfiguration.containsKey("delta.columnMapping.mode"))
+
+        if (isNewTable) {
+          val updatedMetadata =
+            validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+          assert(updatedMetadata.isPresent)
+          assert(updatedMetadata.get().getConfiguration.get("delta.columnMapping.mode") == "id")
+        } else {
+          val e = intercept[KernelException] {
+            validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+          }
+          assert(e.getMessage.contains(
+            "The value 'none' for the property 'delta.columnMapping.mode' is" +
+              " not compatible with icebergWriterCompatV1 requirements"))
+        }
+      }
+    }
+  }
+
+  Seq("name", "none").foreach { cmMode =>
+    Seq(true, false).foreach { isNewTable =>
+      test(s"cannot enable icebergWriterCompatV1 with incompatible column mapping mode " +
+        s"`$cmMode`, isNewTable = $isNewTable") {
+        val tblProperties = icebergWriterCompatV1EnabledProps ++
+          Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> cmMode)
+
+        val metadata = testMetadata(cmTestSchema(), tblProps = tblProperties)
+        val protocol = getCompatEnabledProtocol()
+
+        val e = intercept[KernelException] {
+          validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+        }
+        assert(e.getMessage.contains(
+          s"The value '$cmMode' for the property 'delta.columnMapping.mode' is" +
+            " not compatible with icebergWriterCompatV1 requirements"))
+      }
+    }
+  }
+
+  /* --- ICEBERG_COMPAT_V2_ENABLED tests --- */
+
+  Seq(true, false).foreach { isNewTable =>
+    test(s"icebergCompatV2 is auto enabled when icebergWriterCompatV1 is enabled, " +
+      s"isNewTable = $isNewTable") {
+      val metadata = testMetadata(
+        cmTestSchema(),
+        tblProps = icebergWriterCompatV1EnabledProps ++ columnMappingIdModeProps)
+      val protocol = getCompatEnabledProtocol()
+      assert(!TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(metadata))
+
+      if (isNewTable) {
+        val updatedMetadata =
+          validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+        assert(updatedMetadata.isPresent)
+        assert(TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(updatedMetadata.get))
+      } else {
+        val e = intercept[KernelException] {
+          validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+        }
+        assert(e.getMessage.contains(
+          "The value 'false' for the property 'delta.enableIcebergCompatV2' is" +
+            " not compatible with icebergWriterCompatV1 requirements"))
+      }
+    }
+  }
+
+  Seq(true, false).foreach { isNewTable =>
+    test(s"cannot enable icebergWriterCompatV1 with icebergCompatV2 explicitly disabled, " +
+      s"isNewTable = $isNewTable") {
+      val tblProperties = icebergWriterCompatV1EnabledProps ++ columnMappingIdModeProps ++
+        Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false")
+
+      val metadata = testMetadata(cmTestSchema(), tblProps = tblProperties)
+      val protocol = getCompatEnabledProtocol()
+
+      val e = intercept[KernelException] {
+        validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+      }
+      assert(e.getMessage.contains(
+        "The value 'false' for the property 'delta.enableIcebergCompatV2' is" +
+          " not compatible with icebergWriterCompatV1 requirements"))
+    }
+  }
+
+  /* --- UNSUPPORTED_FEATURES_CHECK tests --- */
+
+  test("all supported features are allowed") {
+    val readerFeatures = Set("columnMapping", "timestampNtz", "v2Checkpoint", "vacuumProtocolCheck")
+    // TODO add clustering here once it's added to Kernel
+    // TODO add typeWidening and typeWidening-preview here once it's no longer blocked
+    //  icebergCompatV2
+    val writerFeatures = Set(
+      "invariants",
+      "appendOnly",
+      "columnMapping",
+      "icebergCompatV2",
+      "icebergWriterCompatV1",
+      "domainMetadata",
+      "vacuumProtocolCheck",
+      "v2Checkpoint",
+      "inCommitTimestamp",
+      // "clustering", add this to this test once we support clustering
+      // "typeWidening", add this to this test once we support typeWidening
+      // "typeWidening-preview", add this to this test once we support typeWidening
+      "timestampNtz")
+    val protocol = new Protocol(3, 7, readerFeatures.asJava, writerFeatures.asJava)
+    val metadata = getCompatEnabledMetadata(cmTestSchema())
+    validateAndUpdateIcebergWriterCompatV1Metadata(true /* isNewTable */, metadata, protocol)
+    validateAndUpdateIcebergWriterCompatV1Metadata(false /* isNewTable */, metadata, protocol)
+  }
+
+  private def checkUnsupportedOrIncompatibleFeature(
+      tableFeature: String,
+      expectedErrorMessageContains: String): Unit = {
+    val protocol = new Protocol(
+      3,
+      7,
+      Set("columnMapping").asJava,
+      Set(
+        "columnMapping",
+        "icebergCompatV2",
+        "icebergWriterCompatV1",
+        tableFeature).asJava)
+    val metadata = getCompatEnabledMetadata(cmTestSchema())
+    Seq(true, false).foreach { isNewTable =>
+      val e = intercept[KernelException] {
+        validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+      }
+      assert(e.getMessage.contains(expectedErrorMessageContains))
+    }
+  }
+
+  Seq("clustering", "typeWidening", "typeWidening-preview").foreach {
+    unsupportedCompatibleFeature =>
+      test(s"cannot enable with compatible UNSUPPORTED feature $unsupportedCompatibleFeature") {
+        // We add this test here so that it will fail when we add Kernel support for these features
+        // When this happens -> add the feature to the test above
+        checkUnsupportedOrIncompatibleFeature(
+          unsupportedCompatibleFeature,
+          "Unsupported Delta table feature: table requires feature " +
+            s""""$unsupportedCompatibleFeature" which is unsupported by this version of """ +
+            "Delta Kernel")
+      }
+  }
+
+  Seq(
+    "changeDataFeed",
+    "checkConstraints",
+    "identityColumns",
+    "generatedColumns",
+    // "defaultColumns", add this to this test once we support defaultColumns
+    "rowTracking",
+    // "collations", add this to this test once we support collations
+    "variantType").foreach { incompatibleFeature =>
+    test(s"cannot enable with incompatible feature $incompatibleFeature") {
+      checkUnsupportedOrIncompatibleFeature(
+        incompatibleFeature,
+        s"Cannot enable table features [$incompatibleFeature] on a " +
+          s"table with icebergWriterCompatV1")
+    }
+  }
+
+  Seq("collations", "defaultColumns").foreach { unsupportedIncompatibleFeature =>
+    test(s"cannot enable with incompatible UNSUPPORTED feature $unsupportedIncompatibleFeature") {
+      // We add this test here so that it will fail when we add Kernel support for these features
+      // When this happens -> add the feature to the test above
+      checkUnsupportedOrIncompatibleFeature(
+        unsupportedIncompatibleFeature,
+        "Unsupported Delta table feature: table requires feature " +
+          s""""$unsupportedIncompatibleFeature" which is unsupported by this version of """ +
+          "Delta Kernel")
+    }
+  }
+
+  /* --- INVARIANTS_INACTIVE_CHECK tests --- */
+  Seq(true, false).foreach { isNewTable =>
+    test(s"cannot enable with invariants active in the schema, isNewTable = $isNewTable") {
+      val schema = new StructType()
+        .add("c1", IntegerType.INTEGER)
+        .add(
+          "c2",
+          IntegerType.INTEGER,
+          FieldMetadata.builder()
+            .putString("delta.invariants", "{\"expression\": { \"expression\": \"x > 3\"} }")
+            .build())
+      val metadata = getCompatEnabledMetadata(schema)
+      val protocol = getCompatEnabledProtocol()
+      val e = intercept[KernelException] {
+        validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+      }
+      assert(e.getMessage.contains(
+        "Cannot enable table features [invariants] on a table with icebergWriterCompatV1"))
+    }
+  }
+
+  /* --- requiredDependencyTableFeatures tests --- */
+  Seq(
+    ("columnMapping", "icebergCompatV2"),
+    ("icebergCompatV2", "columnMapping")).foreach {
+    case (featureToIncludeStr, missingFeatureStr) =>
+      Seq(true, false).foreach { isNewTable =>
+        test(s"protocol is missing required feature $missingFeatureStr, isNewTable = $isNewTable") {
+          val metadata = getCompatEnabledMetadata(cmTestSchema())
+          val readerFeatures: Set[String] = if ("columnMapping" == featureToIncludeStr) {
+            Set("columnMapping")
+          } else Set.empty
+          val writerFeatures = Set("icebergWriterCompatV1", featureToIncludeStr)
+          val protocol = new Protocol(3, 7, readerFeatures.asJava, writerFeatures.asJava)
+          val e = intercept[KernelException] {
+            validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
+          }
+          // Since we run icebergCompatV2 validation as part of ICEBERG_COMPAT_V2_ENABLED.postProcess
+          // we actually hit the missing feature error in the icebergCompatV2 checks first
+          assert(e.getMessage.contains(
+            s"icebergCompatV2: requires the feature '$missingFeatureStr' to be enabled"))
+        }
+      }
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -262,8 +262,8 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
     test(s"cannot enable with incompatible feature $incompatibleFeature") {
       checkUnsupportedOrIncompatibleFeature(
         incompatibleFeature,
-        s"Cannot enable table features [$incompatibleFeature] on a " +
-          s"table with icebergWriterCompatV1")
+        s"Table features [$incompatibleFeature] are incompatible with " +
+          s"icebergWriterCompatV1")
     }
   }
 
@@ -296,7 +296,7 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
         validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
       }
       assert(e.getMessage.contains(
-        "Cannot enable table features [invariants] on a table with icebergWriterCompatV1"))
+        "Table features [invariants] are incompatible with icebergWriterCompatV1"))
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -37,6 +37,7 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
   val columnMappingIdModeProps = Map(
     TableConfig.COLUMN_MAPPING_MODE.getKey -> "id")
 
+  /* icebergWriterCompatV1 restricts additional types allowed by icebergCompatV2 */
   override def simpleTypesToSkip: Set[DataType] = Set(ByteType.BYTE, ShortType.SHORT)
 
   override def getCompatEnabledMetadata(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -211,8 +211,8 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
       "timestampNtz")
     val protocol = new Protocol(3, 7, readerFeatures.asJava, writerFeatures.asJava)
     val metadata = getCompatEnabledMetadata(cmTestSchema())
-    validateAndUpdateIcebergWriterCompatV1Metadata(true /* isNewTable */, metadata, protocol)
-    validateAndUpdateIcebergWriterCompatV1Metadata(false /* isNewTable */, metadata, protocol)
+    validateAndUpdateIcebergWriterCompatV1Metadata(true, metadata, protocol)
+    validateAndUpdateIcebergWriterCompatV1Metadata(false, metadata, protocol)
   }
 
   private def checkUnsupportedOrIncompatibleFeature(
@@ -315,8 +315,9 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
           val e = intercept[KernelException] {
             validateAndUpdateIcebergWriterCompatV1Metadata(isNewTable, metadata, protocol)
           }
-          // Since we run icebergCompatV2 validation as part of ICEBERG_COMPAT_V2_ENABLED.postProcess
-          // we actually hit the missing feature error in the icebergCompatV2 checks first
+          // Since we run icebergCompatV2 validation as part of
+          // ICEBERG_COMPAT_V2_ENABLED.postProcess we actually hit the missing feature error in the
+          // icebergCompatV2 checks first
           assert(e.getMessage.contains(
             s"icebergCompatV2: requires the feature '$missingFeatureStr' to be enabled"))
         }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -28,7 +28,7 @@ import io.delta.kernel.types.{DataType, StructType}
 
 /** This suite tests reading or writing into Delta table that have `icebergCompatV2` enabled. */
 class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMappingSuiteBase {
-  import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdaterSuite._
+  import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase._
 
   (SIMPLE_TYPES ++ COMPLEX_TYPES).foreach {
     dataType: DataType =>

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -132,7 +132,7 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
   test("can't be enabled on a new table with deletion vectors supported") {
     withTempDirAndEngine { (tablePath, engine) =>
       checkError[KernelException](
-        "Simultaneous support for icebergCompatV2 and deletion vectors is not compatible.") {
+        "Table features [deletionVectors] are incompatible with icebergCompatV2") {
         val tblProps = Map(
           TableConfig.DELETION_VECTORS_CREATION_ENABLED.getKey -> "true",
           TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
@@ -150,7 +150,7 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
       createEmptyTable(engine, tablePath, schema = testSchema, tableProperties = tblProps)
 
       checkError[KernelException](
-        "Simultaneous support for icebergCompatV2 and deletion vectors is not compatible.") {
+        "Table features [deletionVectors] are incompatible with icebergCompatV2") {
         val newTblProps = Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
         updateTableMetadata(engine, tablePath, tableProperties = newTblProps)
       }
@@ -163,7 +163,7 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
       createEmptyTable(engine, tablePath, schema = testSchema, tableProperties = tblProps)
 
       checkError[KernelException](
-        "Simultaneous support for icebergCompatV2 and deletion vectors is not compatible.") {
+        "Table features [deletionVectors] are incompatible with icebergCompatV2") {
         val tblProps = Map(TableConfig.DELETION_VECTORS_CREATION_ENABLED.getKey -> "true")
         updateTableMetadata(engine, tablePath, schema = testSchema, tableProperties = tblProps)
       }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -122,7 +122,7 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
 
       checkError[KernelException](
         "The value 'none' for the property 'delta.columnMapping.mode' is not " +
-          "compatible with Iceberg compat requirements") {
+          "compatible with icebergCompatV2 requirements") {
         val newTblProps = Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
         updateTableMetadata(engine, tablePath, tableProperties = newTblProps)
       }
@@ -176,7 +176,7 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
 
       checkError[KernelException](
         "The value 'none' for the property 'delta.columnMapping.mode' is not " +
-          "compatible with Iceberg compat requirements") {
+          "compatible with icebergCompatV2 requirements") {
         val tblProps = Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
         updateTableMetadata(engine, tablePath, testSchema, tableProperties = tblProps)
       }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4291/files) to review incremental changes.
  - [**stack/metadata-validator-and-updater**](https://github.com/delta-io/delta/pull/4291)[[Files changed](https://github.com/delta-io/delta/pull/4291/files)]

---------

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Parent issue https://github.com/delta-io/delta/issues/4289

Introduces `IcebergWriterCompatV1MetadataValidatorAndUpdater` which performs the metadata validation and updates for the writer feature IcebergWriterCompatV1:
```
/**
 * Performs the validations and updates necessary to support the table feature IcebergWriterCompatV1
 * when it is enabled by the table property "delta.enableIcebergWriterCompatV1".
 *
 * <p>Requires that the following table properties are set to the specified values. If they are set
 * to an invalid value, throws an exception. If they are not set, enable them if possible.
 *
 * <ul>
 *   <li>Requires ID column mapping mode (cannot be enabled on existing table).
 *   <li>Requires icebergCompatV2 to be enabled.
 * </ul>
 *
 * <p>Checks that required table features are enabled: icebergCompatWriterV1, icebergCompatV2,
 * columnMapping
 *
 * <p>Checks the following:
 *
 * <ul>
 *   <li>Checks that all table features supported in the table's protocol are in the allow-list of
 *       table features. This simultaneously ensures that any unsupported features are not present
 *       (e.g. CDF, variant type, etc).
 *   <li>Checks that there are no fields with data type byte or short.
 *   <li>Checks that the table feature `invariants` is not active in the table (i.e. there are
 *   no invariants in the table schema). This is a special case where the incompatible feature
 *   `invariants` is in the allow-list of features since it is included by default in the table
 *   protocol for new tables. Since it is incompatible we must verify that it is inactive in
 *   the table.
 * </ul>

```

## How was this patch tested?

Adds unit tests.

Note - we refactor the tests in `IcebergCompatV2MetadataValidatorAndUpdaterSuite` so that we can run them for `icebergCompatV2` and for `icebergWriterCompatV1` since `icebergWriterCompatV1` enables and enforces `icebergCompatV2`.

## Does this PR introduce _any_ user-facing changes?

Yes, after all tasks in https://github.com/delta-io/delta/issues/4289 are complete a new writer feature will be supported.
