### PR TITLE
[Uniform]Add test for restore with name column mapping enabled

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -422,6 +422,7 @@ trait DeltaColumnMappingBase extends DeltaLogging {
     val rawSchema = newMetadata.schema
     var maxId = DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(newMetadata) max
                 findMaxColumnId(rawSchema)
+    maxId = maxId.max(DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(oldMetadata))
     val startId = maxId
     val newSchema =
       SchemaMergingUtils.transformColumns(rawSchema)((path, field, _) => {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -421,8 +421,8 @@ trait DeltaColumnMappingBase extends DeltaLogging {
       isOverwritingSchema: Boolean): Metadata = {
     val rawSchema = newMetadata.schema
     var maxId = DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(newMetadata) max
-                findMaxColumnId(rawSchema)
-    maxId = maxId.max(DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(oldMetadata))
+      DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(oldMetadata) max
+      findMaxColumnId(rawSchema)
     val startId = maxId
     val newSchema =
       SchemaMergingUtils.transformColumns(rawSchema)((path, field, _) => {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -1762,8 +1762,8 @@ class DeltaColumnMappingSuite extends QueryTest
         val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
         assert(log.update().metadata.configuration("delta.columnMapping.maxColumnId") == "2")
         sql(replaceExternalTblCmd)
-        // Configuration after replacing existing table should be like the table has started new.
-        assert(log.update().metadata.configuration("delta.columnMapping.maxColumnId") == "1")
+        // Replace table starts assigning field id from previous maxColumnId.
+        assert(log.update().metadata.configuration("delta.columnMapping.maxColumnId") == "3")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -1768,6 +1768,28 @@ class DeltaColumnMappingSuite extends QueryTest
     }
   }
 
+  test("restore Delta table with name column mapping enabled") {
+    withTempDir { dir =>
+      withTable("t1") {
+        sql(s"""
+               |CREATE OR REPLACE TABLE t1 (a long)
+               |USING DELTA
+               |LOCATION '${dir.getCanonicalPath}'
+               |TBLPROPERTIES('delta.columnMapping.mode'='name')""".stripMargin)
+        // Add column and drop the old one to increment max column ID
+        sql(s"ALTER TABLE t1 ADD COLUMN (b long)")
+        sql(s"ALTER TABLE t1 DROP COLUMN a")
+        sql(s"ALTER TABLE t1 RENAME COLUMN b to a")
+        val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+        assert(log.update().metadata.configuration("delta.columnMapping.maxColumnId") == "2")
+        sql(s"RESTORE TABLE t1 TO VERSION AS OF 0")
+        // Restore should not reduce the max field id,
+        // but it should also not give out new field ids to the restored schema.
+        assert(log.update().metadata.configuration("delta.columnMapping.maxColumnId") == "2")
+      }
+    }
+  }
+
   test("verify internal table properties only if property exists in spec and existing metadata") {
     val withoutMaxColumnId = Map[String, String]("delta.columnMapping.mode" -> "name")
     val maxColumnIdOne = Map[String, String](


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR adds a new test case for restoring table with column mapping enabled.

For src code, it make small refactor with no functional change

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
