### PR TITLE
Kernel: Add package private SchemaChanges and SchemaUtils#computeDiffById

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
@@ -17,11 +17,13 @@ package io.delta.kernel.internal.util;
 
 import io.delta.kernel.types.StructField;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * SchemaChanges encapsulates a list of added, removed, renamed, or updated fields in a schema
- * change
+ * change. Updated fields include renamed fields, moved fields, type changes, nullability changes,
+ * and metadata attribute changes.
  *
  * <p>ToDo: Possibly track moves/renames independently
  */
@@ -70,16 +72,16 @@ class SchemaChanges {
 
   /* Added Fields */
   public List<StructField> addedFields() {
-    return addedFields;
+    return Collections.unmodifiableList(addedFields);
   }
 
   /* Removed Fields */
   public List<StructField> removedFields() {
-    return removedFields;
+    return Collections.unmodifiableList(removedFields);
   }
 
   /* Updated Fields (e.g. rename, type change) represented as a Tuple<FieldBefore, FieldAfter> */
   public List<Tuple2<StructField, StructField>> updatedFields() {
-    return updatedFields;
+    return Collections.unmodifiableList(updatedFields);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util;
+
+import io.delta.kernel.types.StructField;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * SchemaChanges encapsulates a list of added, removed, renamed, or updated fields in a schema
+ * change
+ *
+ * <p>ToDo: Possibly track moves/renames independently
+ */
+class SchemaChanges {
+  private List<StructField> addedFields;
+  private List<StructField> removedFields;
+  private List<Tuple2<StructField, StructField>> updatedFields;
+
+  private SchemaChanges(
+      List<StructField> addedFields,
+      List<StructField> removedFields,
+      List<Tuple2<StructField, StructField>> updatedFields) {
+    this.addedFields = addedFields;
+    this.removedFields = removedFields;
+    this.updatedFields = updatedFields;
+  }
+
+  static class Builder {
+    private List<StructField> addedFields = new ArrayList<>();
+    private List<StructField> removedFields = new ArrayList<>();
+    private List<Tuple2<StructField, StructField>> updatedFields = new ArrayList<>();
+
+    public Builder withAddedField(StructField addedField) {
+      addedFields.add(addedField);
+      return this;
+    }
+
+    public Builder withRemovedField(StructField removedField) {
+      removedFields.add(removedField);
+      return this;
+    }
+
+    public Builder withUpdatedField(StructField existingField, StructField newField) {
+      updatedFields.add(new Tuple2<>(existingField, newField));
+      return this;
+    }
+
+    public SchemaChanges build() {
+      return new SchemaChanges(addedFields, removedFields, updatedFields);
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /* Added Fields */
+  public List<StructField> addedFields() {
+    return addedFields;
+  }
+
+  /* Removed Fields */
+  public List<StructField> removedFields() {
+    return removedFields;
+  }
+
+  /* Updated Fields (e.g. rename, type change) represented as a Tuple<FieldBefore, FieldAfter> */
+  public List<Tuple2<StructField, StructField>> updatedFields() {
+    return updatedFields;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
@@ -32,8 +32,8 @@ import java.util.List;
  * `renamed_id` 1 update will be produced for the change to struct_col and 1 update will be produced
  * for the change to inner_struct
  *
- * <p>ToDo: Possibly track moves/renames independently, enable capturing re-ordered columns in top level
- * schema
+ * <p>ToDo: Possibly track moves/renames independently, enable capturing re-ordered columns in top
+ * level schema
  */
 class SchemaChanges {
   private List<StructField> addedFields;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -317,26 +317,19 @@ public class SchemaUtils {
       // New field added
       if (existingField == null) {
         schemaDiff.withAddedField(updatedField);
-      } else if (isUpdatedField(existingField, fieldInUpdatedSchema.getValue())) {
-        // Field renamed or changed types
-        schemaDiff.withUpdatedField(existingField, fieldInUpdatedSchema.getValue());
+      } else if (!existingField.equals(updatedField)) {
+        // Field changed name, nullability, metadata or type
+        schemaDiff.withUpdatedField(existingField, updatedField);
       }
     }
 
     for (Map.Entry<Long, StructField> entry : currentFieldIdToField.entrySet()) {
-      StructField fieldInUpdatedSchema = updatedFieldIdToField.get(entry.getKey());
-      if (fieldInUpdatedSchema == null) {
+      if (!updatedFieldIdToField.containsKey(entry.getKey())) {
         schemaDiff.withRemovedField(entry.getValue());
       }
     }
 
     return schemaDiff.build();
-  }
-
-  // Returns if the field has been renamed, if the types are different or if fields have been moved
-  private static boolean isUpdatedField(StructField existingField, StructField updatedField) {
-    return !existingField.getName().equals(updatedField.getName())
-        || !existingField.equals(updatedField);
   }
 
   /** column name by concatenating the column path elements (think of nested) with dots */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -307,6 +307,38 @@ public class SchemaUtils {
     return filtered;
   }
 
+  /* Compute the SchemaChanges using field IDs */
+  static SchemaChanges computeSchemaChangesById(
+      Map<Long, StructField> currentFieldIdToField, Map<Long, StructField> updatedFieldIdToField) {
+    SchemaChanges.Builder schemaDiff = SchemaChanges.builder();
+    for (Map.Entry<Long, StructField> fieldInUpdatedSchema : updatedFieldIdToField.entrySet()) {
+      StructField existingField = currentFieldIdToField.get(fieldInUpdatedSchema.getKey());
+      StructField updatedField = fieldInUpdatedSchema.getValue();
+      // New field added
+      if (existingField == null) {
+        schemaDiff.withAddedField(updatedField);
+      } else if (isUpdatedField(existingField, fieldInUpdatedSchema.getValue())) {
+        // Field renamed or changed types
+        schemaDiff.withUpdatedField(existingField, fieldInUpdatedSchema.getValue());
+      }
+    }
+
+    for (Map.Entry<Long, StructField> entry : currentFieldIdToField.entrySet()) {
+      StructField fieldInUpdatedSchema = updatedFieldIdToField.get(entry.getKey());
+      if (fieldInUpdatedSchema == null) {
+        schemaDiff.withRemovedField(entry.getValue());
+      }
+    }
+
+    return schemaDiff.build();
+  }
+
+  // Returns if the field has been renamed, if the types are different or if fields have been moved
+  private static boolean isUpdatedField(StructField existingField, StructField updatedField) {
+    return !existingField.getName().equals(updatedField.getName())
+        || !existingField.equals(updatedField);
+  }
+
   /** column name by concatenating the column path elements (think of nested) with dots */
   private static String concatWithDot(List<String> columnPath) {
     return columnPath.stream().map(SchemaUtils::escapeDots).collect(Collectors.joining("."));

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -316,105 +316,85 @@ class SchemaUtilsSuite extends AnyFunSuite {
   ///////////////////////////////////////////////////////////////////////////
   test("Compute schema changes with added columns") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      1L -> new StructField("id", IntegerType.INTEGER, true))
 
     val fieldMappingAfter = Map(
       1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      2L -> new StructField("data", StringType.STRING, true))
 
-    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+    val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
     assert(schemaChanges.removedFields().isEmpty)
     assert(schemaChanges.updatedFields().isEmpty)
     assert(schemaChanges.addedFields().size() == 1)
-    assert(schemaChanges.addedFields().get(0) == fieldMappingAfter.get(2))
+    assert(schemaChanges.addedFields().get(0) == fieldMappingAfter(2))
   }
 
   test("Compute schema changes with renamed fields") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      1L -> new StructField("id", IntegerType.INTEGER, true))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField("renamed_id", IntegerType.INTEGER, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      1L -> new StructField("renamed_id", IntegerType.INTEGER, true))
 
-    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+    val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
     assert(schemaChanges.addedFields().isEmpty)
     assert(schemaChanges.removedFields().isEmpty)
     assert(schemaChanges.updatedFields().size() == 1)
     assert(schemaChanges.updatedFields().get(0) ==
-      new Tuple2(fieldMappingBefore.get(1L), fieldMappingAfter.get(1)))
+      new Tuple2(fieldMappingBefore(1), fieldMappingAfter(1)))
   }
 
   test("Compute schema changes with type changed columns") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      1L -> new StructField("id", IntegerType.INTEGER, true))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField("promoted_to_long", LongType.LONG, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      1L -> new StructField("promoted_to_long", LongType.LONG, true))
 
-    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+    val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
     assert(schemaChanges.addedFields().isEmpty)
     assert(schemaChanges.removedFields().isEmpty)
     assert(schemaChanges.updatedFields().size() == 1)
     assert(schemaChanges.updatedFields().get(0) ==
-      new Tuple2(fieldMappingBefore.get(1L), fieldMappingAfter.get(1)))
+      new Tuple2(fieldMappingBefore(1), fieldMappingAfter(1)))
   }
 
   test("Compute schema changes with dropped fields") {
     val fieldMappingBefore = Map(
       1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      2L -> new StructField("data", StringType.STRING, true))
 
     val fieldMappingAfter = Map(
-      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      2L -> new StructField("data", StringType.STRING, true))
 
-    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+    val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
     assert(schemaChanges.addedFields().isEmpty)
     assert(schemaChanges.updatedFields().isEmpty)
     assert(schemaChanges.removedFields().size() == 1)
-    assert(schemaChanges.removedFields().get(0) == fieldMappingBefore.get(1))
+    assert(schemaChanges.removedFields().get(0) == fieldMappingBefore(1))
   }
 
   test("Compute schema changes with nullability change") {
     val fieldMappingBefore = Map(
       1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      2L -> new StructField("data", StringType.STRING, true))
 
     val fieldMappingAfter = Map(
       1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("required_data", StringType.STRING, false)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      2L -> new StructField("required_data", StringType.STRING, false))
 
-    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+    val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
     assert(schemaChanges.addedFields().isEmpty)
     assert(schemaChanges.removedFields().isEmpty)
     assert(schemaChanges.updatedFields().size() == 1)
     assert(schemaChanges.updatedFields().get(0) == new Tuple2(
-      fieldMappingBefore.get(2),
-      fieldMappingAfter.get(2)))
+      fieldMappingBefore(2),
+      fieldMappingAfter(2)))
   }
 
   test("Compute schema changes with moved fields") {
@@ -426,9 +406,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
           .add(new StructField("data", StringType.STRING, true)),
         true),
       2L -> new StructField("id", IntegerType.INTEGER, true),
-      3L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      3L -> new StructField("data", StringType.STRING, true))
 
     val fieldMappingAfter = Map(
       1L -> new StructField(
@@ -438,18 +416,16 @@ class SchemaUtilsSuite extends AnyFunSuite {
           .add(new StructField("id", IntegerType.INTEGER, true)),
         true),
       2L -> new StructField("id", IntegerType.INTEGER, true),
-      3L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+      3L -> new StructField("data", StringType.STRING, true))
 
-    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+    val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
     assert(schemaChanges.addedFields().isEmpty)
     assert(schemaChanges.removedFields().isEmpty)
     assert(schemaChanges.updatedFields().size() == 1)
     assert(schemaChanges.updatedFields().get(0) == new Tuple2(
-      fieldMappingBefore.get(1),
-      fieldMappingAfter.get(1)))
+      fieldMappingBefore(1),
+      fieldMappingAfter(1)))
   }
 
   test("Compute schema changes with field metadata changes") {
@@ -460,9 +436,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
         true,
         FieldMetadata.builder().putString(
           "metadata_col",
-          "metadata_val").build())).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+          "metadata_val").build()))
 
     val fieldMappingAfter = Map(
       1L -> new StructField(
@@ -471,18 +445,28 @@ class SchemaUtilsSuite extends AnyFunSuite {
         true,
         FieldMetadata.builder().putString(
           "metadata_col",
-          "updated_metadata_val").build())).map { case (k, v) =>
-      java.lang.Long.valueOf(k) -> v
-    }.asJava
+          "updated_metadata_val").build()))
 
-    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+    val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
     assert(schemaChanges.addedFields().isEmpty)
     assert(schemaChanges.removedFields().isEmpty)
     assert(schemaChanges.updatedFields().size() == 1)
     assert(schemaChanges.updatedFields().get(0) == new Tuple2(
-      fieldMappingBefore.get(1),
-      fieldMappingAfter.get(1)))
+      fieldMappingBefore(1),
+      fieldMappingAfter(1)))
+  }
+
+  private def schemaChangesHelper(
+      before: Map[Long, StructField],
+      after: Map[Long, StructField]): SchemaChanges = {
+    SchemaUtils.computeSchemaChangesById(
+      before.map {
+        case (k, v) => java.lang.Long.valueOf(k) -> v
+      }.asJava,
+      after.map {
+        case (k, v) => java.lang.Long.valueOf(k) -> v
+      }.asJava)
   }
 
   ///////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -18,10 +18,11 @@ package io.delta.kernel.internal.util
 import java.util.Locale
 
 import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.util.SchemaUtils.{filterRecursively, validateSchema}
-import io.delta.kernel.types.{ArrayType, MapType, StringType, StructField, StructType}
+import io.delta.kernel.types.{ArrayType, IntegerType, LongType, MapType, StringType, StructField, StructType}
 import io.delta.kernel.types.IntegerType.INTEGER
 import io.delta.kernel.types.LongType.LONG
 import io.delta.kernel.types.TimestampType.TIMESTAMP
@@ -308,6 +309,140 @@ class SchemaUtilsSuite extends AnyFunSuite {
         validateSchema(schema, true /* isColumnMappingEnabled */ )
       }
     }
+  }
+
+  test("Compute schema changes with added columns") {
+    val fieldMappingBefore = Map(
+      1L -> new StructField("id", IntegerType.INTEGER, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val fieldMappingAfter = Map(
+      1L -> new StructField("id", IntegerType.INTEGER, true),
+      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+
+    assert(schemaChanges.removedFields().isEmpty)
+    assert(schemaChanges.updatedFields().isEmpty)
+    assert(schemaChanges.addedFields().size() == 1)
+    assert(schemaChanges.addedFields().get(0) == fieldMappingAfter.get(2))
+  }
+
+  test("Compute schema changes with renamed fields") {
+    val fieldMappingBefore = Map(
+      1L -> new StructField("id", IntegerType.INTEGER, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val fieldMappingAfter = Map(
+      1L -> new StructField("renamed_id", IntegerType.INTEGER, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+
+    assert(schemaChanges.addedFields().isEmpty)
+    assert(schemaChanges.removedFields().isEmpty)
+    assert(schemaChanges.updatedFields().size() == 1)
+    assert(schemaChanges.updatedFields().get(0) ==
+      new Tuple2(fieldMappingBefore.get(1L), fieldMappingAfter.get(1)))
+  }
+
+  test("Compute schema changes with type changed columns") {
+    val fieldMappingBefore = Map(
+      1L -> new StructField("id", IntegerType.INTEGER, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val fieldMappingAfter = Map(
+      1L -> new StructField("promoted_to_long", LongType.LONG, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+
+    assert(schemaChanges.addedFields().isEmpty)
+    assert(schemaChanges.removedFields().isEmpty)
+    assert(schemaChanges.updatedFields().size() == 1)
+    assert(schemaChanges.updatedFields().get(0) ==
+      new Tuple2(fieldMappingBefore.get(1L), fieldMappingAfter.get(1)))
+  }
+
+  test("Compute schema changes with dropped fields") {
+    val fieldMappingBefore = Map(
+      1L -> new StructField("id", IntegerType.INTEGER, true),
+      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val fieldMappingAfter = Map(
+      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+
+    assert(schemaChanges.addedFields().isEmpty)
+    assert(schemaChanges.updatedFields().isEmpty)
+    assert(schemaChanges.removedFields().size() == 1)
+    assert(schemaChanges.removedFields().get(0) == fieldMappingBefore.get(1))
+  }
+
+  test("Compute schema changes with nullability change") {
+    val fieldMappingBefore = Map(
+      1L -> new StructField("id", IntegerType.INTEGER, true),
+      2L -> new StructField("data", StringType.STRING, true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val fieldMappingAfter = Map(
+      1L -> new StructField("id", IntegerType.INTEGER, true),
+      2L -> new StructField("required_data", StringType.STRING, false)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+
+    assert(schemaChanges.addedFields().isEmpty)
+    assert(schemaChanges.removedFields().isEmpty)
+    assert(schemaChanges.updatedFields().size() == 1)
+    assert(schemaChanges.updatedFields().get(0) == new Tuple2(
+      fieldMappingBefore.get(2),
+      fieldMappingAfter.get(2)))
+  }
+
+  test("Compute schema changes with moved fields") {
+    val fieldMappingBefore = Map(
+      1L -> new StructField(
+        "struct",
+        new StructType()
+          .add(new StructField("id", IntegerType.INTEGER, true))
+          .add(new StructField("data", StringType.STRING, true)),
+        true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val fieldMappingAfter = Map(
+      1L -> new StructField(
+        "struct",
+        new StructType()
+          .add(new StructField("data", StringType.STRING, true))
+          .add(new StructField("id", IntegerType.INTEGER, true)),
+        true)).map { case (k, v) =>
+      java.lang.Long.valueOf(k) -> v
+    }.asJava
+
+    val schemaChanges = SchemaUtils.computeSchemaChangesById(fieldMappingBefore, fieldMappingAfter)
+
+    assert(schemaChanges.addedFields().isEmpty)
+    assert(schemaChanges.removedFields().isEmpty)
+    assert(schemaChanges.updatedFields().size() == 1)
+    assert(schemaChanges.updatedFields().get(0) == new Tuple2(
+      fieldMappingBefore.get(1),
+      fieldMappingAfter.get(1)))
   }
 
   ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X ] Kernel
- [ ] Other (fill in here)

## Description

This change adds an internal SchemaChanges class which will be used to keep track of differences between Schema evolutions, and also adds a computeDiffByID package private method which will be used in future validation. 

This is breaking away some of the changes from https://github.com/delta-io/delta/pull/4196

## How was this patch tested?

Added unit tests

## Does this PR introduce _any_ user-facing changes?

No
