### PR TITLE
[Kernel] In txn with no domainMetadata updates, skip loading domainMetadatas from snapshot

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -202,6 +202,13 @@ public class TransactionImpl implements Transaction {
    *     transaction.
    */
   public List<DomainMetadata> getDomainMetadatas() {
+    if (domainMetadatasAdded.isEmpty() && domainMetadatasRemoved.isEmpty()) {
+      // If no domain metadatas are added or removed, return an empty list. This is to avoid
+      // unnecessary loading of the domain metadatas from the snapshot (which is an expensive
+      // operation).
+      return Collections.emptyList();
+    }
+
     // If we have already processed the domain metadatas, then return the list.
     if (domainMetadatas.isPresent()) {
       return domainMetadatas.get();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -202,17 +202,19 @@ public class TransactionImpl implements Transaction {
    *     transaction.
    */
   public List<DomainMetadata> getDomainMetadatas() {
-    if (domainMetadatasAdded.isEmpty() && domainMetadatasRemoved.isEmpty()) {
-      // If no domain metadatas are added or removed, return an empty list. This is to avoid
-      // unnecessary loading of the domain metadatas from the snapshot (which is an expensive
-      // operation).
-      return Collections.emptyList();
-    }
-
     // If we have already processed the domain metadatas, then return the list.
     if (domainMetadatas.isPresent()) {
       return domainMetadatas.get();
     }
+
+    if (domainMetadatasAdded.isEmpty() && domainMetadatasRemoved.isEmpty()) {
+      // If no domain metadatas are added or removed, return an empty list. This is to avoid
+      // unnecessary loading of the domain metadatas from the snapshot (which is an expensive
+      // operation).
+      domainMetadatas = Optional.of(Collections.emptyList());
+      return Collections.emptyList();
+    }
+
     // Add all domain metadatas added in the transaction
     List<DomainMetadata> finalDomainMetadatas = new ArrayList<>(domainMetadatasAdded.values());
 


### PR DESCRIPTION
## Description
Loading domainMetadatas from snapshot is expensive as it involves reading checkpoints and commit files.

## How was this patch tested?
Pending tests