### PR TITLE
[Kernel][Defaults] Add `fileSize` as argument to `FileIO.newInputFile` when reading

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
@@ -92,7 +92,7 @@ public class DefaultFileSystemClient implements FileSystemClient {
   }
 
   private ByteArrayInputStream getStream(String filePath, int offset, int size) {
-    InputFile inputFile = this.fileIO.newInputFile(filePath);
+    InputFile inputFile = this.fileIO.newInputFile(filePath, /* fileSize */ -1);
     try (SeekableInputStream stream = inputFile.newStream()) {
       stream.seek(offset);
       byte[] buff = new byte[size];

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -144,7 +144,7 @@ public class DefaultJsonHandler implements JsonHandler {
           currentFile = scanFileIter.next();
           SeekableInputStream stream = null;
           try {
-            stream = fileIO.newInputFile(currentFile.getPath()).newStream();
+            stream = fileIO.newInputFile(currentFile.getPath(), currentFile.getSize()).newStream();
             currentFileReader =
                 new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
           } catch (Exception e) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
@@ -71,8 +71,7 @@ public class DefaultParquetHandler implements ParquetHandler {
           Utils.closeCloseables(currentFileReader);
           currentFileReader = null;
           if (fileIter.hasNext()) {
-            String nextFile = fileIter.next().getPath();
-            currentFileReader = batchReader.read(nextFile, physicalSchema, predicate);
+            currentFileReader = batchReader.read(fileIter.next(), physicalSchema, predicate);
             return hasNext(); // recurse since it's possible the loaded file is empty
           } else {
             return false;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/FileIO.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/FileIO.java
@@ -75,9 +75,11 @@ public interface FileIO {
    * arbitrary position in the file.
    *
    * @param path Fully qualified path to the file.
+   * @param fileSize Size of the file in bytes. If available, it can be used to optimize the read
+   *     otherwise it can be set to -1.
    * @return {@link InputFile} instance.
    */
-  InputFile newInputFile(String path);
+  InputFile newInputFile(String path, long fileSize);
 
   /**
    * Create a {@link OutputFile} to write new file at the given path.

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/FileIO.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/FileIO.java
@@ -75,8 +75,7 @@ public interface FileIO {
    * arbitrary position in the file.
    *
    * @param path Fully qualified path to the file.
-   * @param fileSize Size of the file in bytes. If available, it can be used to optimize the read
-   *     otherwise it can be set to -1.
+   * @param fileSize Size of the file in bytes.
    * @return {@link InputFile} instance.
    */
   InputFile newInputFile(String path, long fileSize);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/InputFile.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/InputFile.java
@@ -22,7 +22,7 @@ public interface InputFile {
   /**
    * Get the size of the file.
    *
-   * @return the size of the file. If not known, this should return -1.
+   * @return the size of the file.
    */
   long length() throws IOException;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/InputFile.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/fileio/InputFile.java
@@ -22,7 +22,7 @@ public interface InputFile {
   /**
    * Get the size of the file.
    *
-   * @return the size of the file.
+   * @return the size of the file. If not known, this should return -1.
    */
   long length() throws IOException;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopFileIO.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopFileIO.java
@@ -79,8 +79,8 @@ public class HadoopFileIO implements FileIO {
   }
 
   @Override
-  public InputFile newInputFile(String path) {
-    return new HadoopInputFile(getFs(path), new Path(path));
+  public InputFile newInputFile(String path, long fileSize) {
+    return new HadoopInputFile(getFs(path), new Path(path), fileSize);
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
@@ -24,15 +24,17 @@ import org.apache.hadoop.fs.Path;
 public class HadoopInputFile implements InputFile {
   private final FileSystem fs;
   private final Path path;
+  private final long fileSize;
 
-  public HadoopInputFile(FileSystem fs, Path path) {
+  public HadoopInputFile(FileSystem fs, Path path, long fileSize) {
     this.fs = fs;
     this.path = path;
+    this.fileSize = fileSize;
   }
 
   @Override
   public long length() throws IOException {
-    return fs.getFileStatus(path).getLen();
+    return fileSize;
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileWriter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileWriter.java
@@ -455,7 +455,9 @@ public class ParquetFileWriter {
                 emptyMap() /* maxValues */,
                 emptyMap() /* nullCounts */);
       } else {
-        stats = readDataFileStatistics(fileIO, resolvedPath, dataSchema, statsColumns);
+        stats =
+            readDataFileStatistics(
+                fileIO.newInputFile(resolvedPath, fileStatus.getSize()), dataSchema, statsColumns);
       }
 
       return new DataFileStatus(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetStatsReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetStatsReader.java
@@ -21,7 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.UnaryOperator.identity;
 import static org.apache.hadoop.shaded.com.google.common.collect.ImmutableMap.toImmutableMap;
 
-import io.delta.kernel.defaults.engine.fileio.FileIO;
+import io.delta.kernel.defaults.engine.fileio.InputFile;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.statistics.DataFileStatistics;
@@ -46,18 +46,17 @@ public class ParquetStatsReader {
   /**
    * Read the statistics for the given Parquet file.
    *
-   * @param parquetFilePath The path to the Parquet file.
-   * @param fileIO The file IO implementation to use for reading the file.
+   * @param kernelInputFile {@link InputFile} representing the Parquet file.
    * @param dataSchema The schema of the Parquet file. Type info is used to decode statistics.
    * @param statsColumns The columns for which statistics should be collected and returned.
    * @return File/column level statistics as {@link DataFileStatistics} instance.
    */
   public static DataFileStatistics readDataFileStatistics(
-      FileIO fileIO, String parquetFilePath, StructType dataSchema, List<Column> statsColumns)
+      InputFile kernelInputFile, StructType dataSchema, List<Column> statsColumns)
       throws IOException {
     // Read the Parquet footer to compute the statistics
     org.apache.parquet.io.InputFile parquetFile =
-        ParquetIOUtils.createParquetInputFile(fileIO.newInputFile(parquetFilePath));
+        ParquetIOUtils.createParquetInputFile(kernelInputFile);
     ParquetMetadata footer =
         ParquetFileReader.readFooter(parquetFile, ParquetMetadataConverter.NO_FILTER);
     ImmutableMultimap.Builder<Column, ColumnChunkMetaData> metadataForColumn =

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
@@ -223,18 +223,18 @@ public class BenchmarkParallelCheckpointReading {
           }
           List<Future<List<ColumnarBatch>>> futures = new ArrayList<>();
           while (fileIter.hasNext()) {
-            String path = fileIter.next().getPath();
-            futures.add(executorService.submit(() -> parquetFileReader(path, physicalSchema)));
+            futures.add(
+                executorService.submit(() -> parquetFileReader(fileIter.next(), physicalSchema)));
           }
           futuresIter = futures.iterator();
         }
       };
     }
 
-    List<ColumnarBatch> parquetFileReader(String filePath, StructType readSchema) {
+    List<ColumnarBatch> parquetFileReader(FileStatus fileStatus, StructType readSchema) {
       ParquetFileReader reader = new ParquetFileReader(fileIO);
       try (CloseableIterator<ColumnarBatch> batchIter =
-          reader.read(filePath, readSchema, Optional.empty())) {
+          reader.read(fileStatus, readSchema, Optional.empty())) {
         List<ColumnarBatch> batches = new ArrayList<>();
         while (batchIter.hasNext()) {
           batches.add(batchIter.next());

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetReaderPredicatePushdownSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetReaderPredicatePushdownSuite.scala
@@ -182,7 +182,8 @@ class ParquetReaderPredicatePushdownSuite extends AnyFunSuite
   }
 
   private def assertConvertedFilterIsEmpty(predicate: Predicate, tablePath: String): Unit = {
-    val parquetFileSchema = parquetFiles(tablePath).map(footer(_)).head.getFileMetaData.getSchema
+    val parquetFileSchema =
+      parquetFiles(tablePath).map(_.getPath).map(footer(_)).head.getFileMetaData.getSchema
 
     assert(
       !ParquetFilterUtils.toParquetFilter(parquetFileSchema, predicate).isPresent,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
@@ -86,7 +86,7 @@ trait ParquetSuiteBase extends TestUtils {
    */
   def verifyFileMetadata(targetDir: String): Unit = {
     parquetFiles(targetDir).foreach { file =>
-      footer(file).getFileMetaData
+      footer(file.getPath).getFileMetaData
         .getKeyValueMetaData.containsKey("io.delta.kernel.default-parquet-writer")
     }
   }
@@ -140,7 +140,7 @@ trait ParquetSuiteBase extends TestUtils {
       targetDir: String,
       deltaSchema: StructType,
       expectNestedFiledIds: Boolean): Unit = {
-    parquetFiles(targetDir).map(footer(_)).foreach {
+    parquetFiles(targetDir).map(_.getPath).map(footer(_)).foreach {
       footer =>
         val parquetSchema = footer.getFileMetaData.getSchema
 
@@ -283,7 +283,6 @@ trait ParquetSuiteBase extends TestUtils {
       readSchema: StructType,
       predicate: Optional[Predicate] = Optional.empty()): Seq[ColumnarBatch] = {
     val parquetFileList = parquetFiles(inputFileOrDir)
-      .map(FileStatus.of(_, 0, 0))
 
     val data = defaultEngine.getParquetHandler.readParquetFiles(
       toCloseableIterator(parquetFileList.asJava.iterator()),
@@ -301,23 +300,21 @@ trait ParquetSuiteBase extends TestUtils {
     var rowCount = 0L
     files.foreach { file =>
       // read parquet file using spark and count.
-      rowCount = rowCount + spark.read.parquet(file).count()
+      rowCount = rowCount + spark.read.parquet(file.getPath).count()
     }
 
     rowCount
   }
 
-  def parquetFiles(fileOrDir: String): Seq[String] = {
-    val fileOrDirPath = Paths.get(fileOrDir)
-    if (Files.isDirectory(fileOrDirPath)) {
-      Files.list(fileOrDirPath)
-        .iterator().asScala
-        .map(_.toString)
-        .filter(path => path.endsWith(".parquet"))
-        .toSeq
-    } else {
-      Seq(fileOrDir)
-    }
+  def parquetFiles(fileOrDir: String): Seq[FileStatus] = {
+    val fileOrDirPath = new Path(fileOrDir)
+    val hadoopFs = new Path(fileOrDir).getFileSystem(configuration)
+    hadoopFs.listStatus(fileOrDirPath)
+      .iterator
+      .filter(_.getPath.toString.endsWith(".parquet"))
+      .map(status =>
+        FileStatus.of(status.getPath.toString, status.getLen, status.getModificationTime))
+      .toSeq
   }
 
   def footer(path: String): ParquetMetadata = {


### PR DESCRIPTION
## Description
Length can be useful when readers want to optimize (for example, in Parquet reader to find the location of metadata and seek there directly rather than making a call to the filesystem to get the size). In Kernel's case we already have the information from Delta Log. Pass the length as new argument to `FileIO.newInputFile`.

## How was this patch tested?
Existing tests.