### PR TITLE
[SPARK] Remove left over assertion from util method in DeltaSQLTestUtils

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
@@ -157,8 +157,6 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
       columnName: String): (Option[String], Option[String]) = {
     val columnPath = columnName.split('.')
     val schema = getSnapshot(tableName).schema
-    val colType = getColumnType(schema, columnPath)
-    assert(colType.isInstanceOf[StringType], s"Expected StringType, got $colType")
 
     val physicalColumnPath = getPhysicalColumnPath(schema, columnName)
     val minStatsPath = DeltaStatistics.MIN +: physicalColumnPath

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
@@ -155,7 +155,6 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
       tableName: String,
       stats: JsonNode,
       columnName: String): (Option[String], Option[String]) = {
-    val columnPath = columnName.split('.')
     val schema = getSnapshot(tableName).schema
 
     val physicalColumnPath = getPhysicalColumnPath(schema, columnName)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
https://github.com/delta-io/delta/pull/4131 Added some utility methods in  `DeltaSQLTestUtils` class, however one of the method still had the check that it was being called for string columns, even though now we can call it on arbitrary column types; so I am just removing this simple assertion.

## How was this patch tested?
No testing required.

## Does this PR introduce _any_ user-facing changes?
No.
