### PR TITLE
[Spark] Improve the API of the run method of PostCommitHook

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1454,7 +1454,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
         throw e
     }
 
-    runPostCommitHooks(version, postCommitSnapshot, actualCommittedActions)
+    runPostCommitHooks(version, postCommitSnapshot, actualCommittedActions.toIterator)
 
     executionObserver.transactionCommitted()
     Some(version)
@@ -2683,7 +2683,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
   protected def runPostCommitHooks(
       version: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit = {
+      committedActions: Iterator[Action]): Unit = {
     assert(committed, "Can't call post commit hooks before committing")
 
     // Keep track of the active txn because hooks may create more txns and overwrite the active one.
@@ -2701,7 +2701,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       hook: PostCommitHook,
       version: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit = {
+      committedActions: Iterator[Action]): Unit = {
     try {
       hook.run(spark, this, version, postCommitSnapshot, committedActions)
     } catch {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -102,7 +102,7 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
       txn: DeltaTransaction,
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
-      actions: Seq[Action]): Unit = {
+      actions: Iterator[Action]): Unit = {
     val conf = spark.sessionState.conf
     val autoCompactTypeOpt = getAutoCompactType(conf, postCommitSnapshot.metadata)
     // Skip Auto Compact if current transaction is not qualified or the table is not qualified

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -30,7 +30,7 @@ object CheckpointHook extends PostCommitHook {
       txn: DeltaTransaction,
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit = {
+      committedActions: Iterator[Action]): Unit = {
     if (!txn.needsCheckpoint) return
 
     // Since the postCommitSnapshot isn't guaranteed to match committedVersion, we have to

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/ChecksumHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/ChecksumHook.scala
@@ -43,7 +43,7 @@ object ChecksumHook extends PostCommitHook with DeltaLogging {
       txn: DeltaTransaction,
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit = {
+      committedActions: Iterator[Action]): Unit = {
     // Only write the checksum if the postCommitSnapshot matches the version that was committed.
     if (postCommitSnapshot.version != committedVersion) return
     logInfo(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/HudiConverterHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/HudiConverterHook.scala
@@ -34,7 +34,7 @@ object HudiConverterHook extends PostCommitHook with DeltaLogging {
       txn: DeltaTransaction,
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit = {
+      committedActions: Iterator[Action]): Unit = {
     // Only convert to Hudi if the snapshot matches the version committed.
     // This is to skip converting the same actions multiple times - they'll be written out
     // by another commit anyways.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
@@ -35,7 +35,7 @@ object IcebergConverterHook extends PostCommitHook with DeltaLogging {
       txn: DeltaTransaction,
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit = {
+      committedActions: Iterator[Action]): Unit = {
     // Only convert to Iceberg if the snapshot matches the version committed.
     // This is to skip converting the same actions multiple times - they'll be written out
     // by another commit anyways.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
@@ -46,7 +46,7 @@ trait PostCommitHook {
     txn: DeltaTransaction,
     committedVersion: Long,
     postCommitSnapshot: Snapshot,
-    committedActions: Seq[Action]): Unit
+    committedActions: Iterator[Action]): Unit
 
   /**
    * Handle any error caused while running the hook. By default, all errors are ignored as

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
@@ -67,7 +67,7 @@ trait UpdateCatalogBase extends PostCommitHook with DeltaLogging {
       txn: DeltaTransaction,
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
-      actions: Seq[Action]): Unit = {
+      actions: Iterator[Action]): Unit = {
     // There's a potential race condition here, where a newer commit has already triggered
     // this to run. That's fine.
     executeOnWrite(spark, postCommitSnapshot)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -923,7 +923,7 @@ trait DeltaErrorsSuiteBase
           override val name: String = "DummyPostCommitHook"
           override def run(
             spark: SparkSession, txn: DeltaTransaction, committedVersion: Long,
-            postCommitSnapshot: Snapshot, committedActions: Seq[Action]): Unit = {}
+            postCommitSnapshot: Snapshot, committedActions: Iterator[Action]): Unit = {}
         }, 0, "msg", null)
       }
       checkErrorMessage(e, Some("DELTA_POST_COMMIT_HOOK_FAILED"), Some("2DKD0"),
@@ -936,7 +936,7 @@ trait DeltaErrorsSuiteBase
           override val name: String = "DummyPostCommitHook"
           override def run(
             spark: SparkSession, txn: DeltaTransaction, committedVersion: Long,
-            postCommitSnapshot: Snapshot, committedActions: Seq[Action]): Unit = {}
+            postCommitSnapshot: Snapshot, committedActions: Iterator[Action]): Unit = {}
         }, 0, null, null)
       }
       checkErrorMessage(e, Some("DELTA_POST_COMMIT_HOOK_FAILED"), Some("2DKD0"),


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Currently, the `PostCommitHook::run` method is taking in a `Seq[Action]`. This means the actions must be materialized in memory before passing to this method, which may cause OOM for commit with a large number of actions. This PR changes the type to be an `Iterator[Action]` instead to allow future optimizations where the Actions are read from file on demand.

This change also prompts a change in `GenerateSymlinkManifest` to make sure that the iterator is only used once. Some test refactoring for `DeltaGenerateSymlinkManifestSuite` is also included

## How was this patch tested?

Existing unit tests

## Does this PR introduce _any_ user-facing changes?

No