### PR TITLE
[Kernel] Remove duplicate addConfig entries in TableConfig.java

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -287,9 +287,6 @@ public class TableConfig<T> {
               addConfig(this, TOMBSTONE_RETENTION);
               addConfig(this, CHECKPOINT_INTERVAL);
               addConfig(this, IN_COMMIT_TIMESTAMPS_ENABLED);
-              addConfig(this, TOMBSTONE_RETENTION);
-              addConfig(this, CHECKPOINT_INTERVAL);
-              addConfig(this, IN_COMMIT_TIMESTAMPS_ENABLED);
               addConfig(this, IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION);
               addConfig(this, IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP);
               addConfig(this, COLUMN_MAPPING_MODE);


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Removes duplicate additions to the HashMap for TableConfig

Resolves #4315

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No

Signed-off-by: Micah Kornfield <micah.kornfield@databricks.com>