### PR TITLE
[Deprecated][Kernel][Clustering #4] add ClusteringUtils

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -379,7 +379,7 @@ public final class DeltaErrors {
   public static KernelException missingFileStatsForClustering(
       List<Column> columns, DataFileStatus dataFileStatus) {
     return new KernelException(
-        String.format(
+        format(
             "Cannot write to a clustering-enabled table without per-file statistics. "
                 + "Missing statistics for clustering columns: %s. DataFileStatus: %s",
             columns, dataFileStatus));
@@ -388,7 +388,7 @@ public final class DeltaErrors {
   public static KernelException missingColumnStatsForClustering(
       Column column, DataFileStatus dataFileStatus) {
     return new KernelException(
-        String.format(
+        format(
             "Cannot write to a clustering-enabled table without per-column statistics. "
                 + "Missing statistics for clustering column: %s. DataFileStatus: %s",
             column, dataFileStatus));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -376,6 +376,24 @@ public final class DeltaErrors {
             + " but 'domainMetadata' is unsupported");
   }
 
+  public static KernelException missingFileStatsForClustering(
+      List<Column> columns, DataFileStatus dataFileStatus) {
+    return new KernelException(
+        String.format(
+            "Cannot write to a clustering-enabled table without per-file statistics. "
+                + "Missing statistics for clustering columns: %s. DataFileStatus: %s",
+            columns, dataFileStatus));
+  }
+
+  public static KernelException missingColumnStatsForClustering(
+      Column column, DataFileStatus dataFileStatus) {
+    return new KernelException(
+        String.format(
+            "Cannot write to a clustering-enabled table without per-column statistics. "
+                + "Missing statistics for clustering column: %s. DataFileStatus: %s",
+            column, dataFileStatus));
+  }
+
   public static KernelException enablingIcebergWriterCompatV1OnExistingTable(String key) {
     return new KernelException(
         String.format(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -380,8 +380,8 @@ public final class DeltaErrors {
       List<Column> columns, DataFileStatus dataFileStatus) {
     return new KernelException(
         format(
-            "Cannot write to a clustering-enabled table without per-file statistics. "
-                + "Missing statistics for clustering columns: %s. DataFileStatus: %s",
+            "Unable to write the given data file to a clustering-enabled table: "
+                + "Missing per-file statistics for clustering columns [%s]. DataFileStatus: %s",
             columns, dataFileStatus));
   }
 
@@ -389,8 +389,8 @@ public final class DeltaErrors {
       Column column, DataFileStatus dataFileStatus) {
     return new KernelException(
         format(
-            "Cannot write to a clustering-enabled table without per-column statistics. "
-                + "Missing statistics for clustering column: %s. DataFileStatus: %s",
+            "Unable to write the given data file to a clustering-enabled table: "
+                + "Missing per-file statistics for clustering column: %s. DataFileStatus: %s",
             column, dataFileStatus));
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.clustering;
+
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.DeltaErrors;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.DomainMetadata;
+import io.delta.kernel.statistics.DataFileStatistics;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.DataFileStatus;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class ClusteringUtils {
+
+  private ClusteringUtils() {
+    // Empty private constructor to prevent instantiation
+  }
+
+  /**
+   * Get the domain metadata for the clustering columns.
+   *
+   * @param logicalClusteringColumns The logical clustering columns.
+   * @param schema The schema of the table.
+   * @return The domain metadata including the clustering columns.
+   */
+  public static DomainMetadata getClusteringDomainMetadata(
+      List<Column> logicalClusteringColumns, StructType schema) {
+    final ClusteringMetadataDomain clusteringMetadataDomain =
+        new ClusteringMetadataDomain(logicalClusteringColumns, schema);
+    return clusteringMetadataDomain.toDomainMetadata();
+  }
+
+  /**
+   * Extract ClusteringColumns from a given snapshot. Return None if the clustering domain metadata
+   * is missing.
+   *
+   * @param snapshot The snapshot instance
+   */
+  public static Optional<List<Column>> getClusteringColumnsOptional(SnapshotImpl snapshot) {
+    return ClusteringMetadataDomain.fromSnapshot(snapshot)
+        .map(ClusteringMetadataDomain::fetchClusteringColumns);
+  }
+
+  /**
+   * Validates the given {@link DataFileStatus} being added as an {@code add} action to the Delta
+   * Log. Specifically, it ensures that file-level statistics are present and that statistics exist
+   * for all clustering columns.
+   *
+   * @param clusteringColumns The list of clustering columns that require statistics.
+   * @param dataFileStatus The {@link DataFileStatus} to validate.
+   */
+  public static void validateDataFileStatus(
+      List<Column> clusteringColumns, DataFileStatus dataFileStatus) {
+    if (!dataFileStatus.getStatistics().isPresent()) {
+      throw DeltaErrors.missingFileStatsForClustering(clusteringColumns, dataFileStatus);
+    }
+
+    DataFileStatistics dataFileStatistics = dataFileStatus.getStatistics().get();
+
+    Map<Column, Literal> minValues = dataFileStatistics.getMinValues();
+    Map<Column, Literal> maxValues = dataFileStatistics.getMaxValues();
+    Map<Column, Long> nullCounts = dataFileStatistics.getNullCounts();
+
+    for (Column column : clusteringColumns) {
+      if (!minValues.containsKey(column)
+          || !maxValues.containsKey(column)
+          || !nullCounts.containsKey(column)) {
+        throw DeltaErrors.missingColumnStatsForClustering(column, dataFileStatus);
+      }
+    }
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringUtils.java
@@ -33,26 +33,22 @@ public class ClusteringUtils {
   }
 
   /**
-   * Get the domain metadata for the clustering columns.
-   *
-   * @param physicalClusteringColumns The physical clustering columns.
-   * @return The domain metadata including the clustering columns.
+   * Get the domain metadata for the clustering columns. If column mapping is enabled, pass the list
+   * of physical names assigned; otherwise, use the logical column names.
    */
-  public static DomainMetadata getClusteringDomainMetadata(List<Column> physicalClusteringColumns) {
-    final ClusteringMetadataDomain clusteringMetadataDomain =
-        ClusteringMetadataDomain.fromPhysicalColumns(physicalClusteringColumns);
+  public static DomainMetadata getClusteringDomainMetadata(List<Column> clusteringColumns) {
+    ClusteringMetadataDomain clusteringMetadataDomain =
+        ClusteringMetadataDomain.fromClusteringColumns(clusteringColumns);
     return clusteringMetadataDomain.toDomainMetadata();
   }
 
   /**
    * Extract ClusteringColumns from a given snapshot. Return None if the clustering domain metadata
    * is missing.
-   *
-   * @param snapshot The snapshot instance
    */
   public static Optional<List<Column>> getClusteringColumnsOptional(SnapshotImpl snapshot) {
     return ClusteringMetadataDomain.fromSnapshot(snapshot)
-        .map(ClusteringMetadataDomain::getClusteringColumnsAsColumnList);
+        .map(ClusteringMetadataDomain::getClusteringColumns);
   }
 
   /**
@@ -71,7 +67,7 @@ public class ClusteringUtils {
 
     DataFileStatistics dataFileStatistics = dataFileStatus.getStatistics().get();
 
-    Long numRecords = dataFileStatistics.getNumRecords();
+    long numRecords = dataFileStatistics.getNumRecords();
     Map<Column, Literal> minValues = dataFileStatistics.getMinValues();
     Map<Column, Literal> maxValues = dataFileStatistics.getMaxValues();
     Map<Column, Long> nullCounts = dataFileStatistics.getNullCounts();

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/clustering/ClusteringUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/clustering/ClusteringUtilsSuite.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.clustering
+
+import java.util.Optional
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.expressions.{Column, Literal}
+import io.delta.kernel.statistics.DataFileStatistics
+import io.delta.kernel.utils.DataFileStatus
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
+
+class ClusteringUtilsSuite extends AnyFunSuite with Matchers {
+
+  test("validateDataFileStatus: Throws when statistics are missing entirely") {
+    val dataFile = new DataFileStatus("path", 100L, 123456L, Optional.empty())
+    val clusteringCols = List(new Column("a"))
+
+    val ex = intercept[KernelException] {
+      ClusteringUtils.validateDataFileStatus(clusteringCols.asJava, dataFile)
+    }
+
+    assert(ex.getMessage.contains(
+      "Cannot write to a clustering-enabled table without per-file statistics."))
+  }
+
+  test("validateDataFileStatus: Throws when min/max/nullCount is missing for a clustering column") {
+    val stats = new DataFileStatistics(
+      1L,
+      Map.empty[Column, Literal].asJava,
+      Map.empty[Column, Literal].asJava,
+      Map.empty[Column, java.lang.Long].asJava)
+    val dataFile = new DataFileStatus("path", 100L, 123456L, Optional.of(stats))
+    val clusteringCols = List(new Column("a"))
+
+    val ex = intercept[KernelException] {
+      ClusteringUtils.validateDataFileStatus(clusteringCols.asJava, dataFile)
+    }
+
+    assert(ex.getMessage.contains(
+      "Cannot write to a clustering-enabled table without per-column statistics."))
+  }
+
+  test("validateDataFileStatus: Passes when all stats exist for clustering column") {
+    val col = new Column("a")
+    val stats = new DataFileStatistics(
+      100L,
+      Map(col -> Literal.ofInt(1)).asJava,
+      Map(col -> Literal.ofInt(10)).asJava,
+      Map(col -> java.lang.Long.valueOf(0L)).asJava)
+    val dataFile = new DataFileStatus("path", 100L, 123456L, Optional.of(stats))
+    noException should be thrownBy {
+      ClusteringUtils.validateDataFileStatus(List(col).asJava, dataFile)
+    }
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/clustering/ClusteringUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/clustering/ClusteringUtilsSuite.scala
@@ -29,6 +29,14 @@ import org.scalatest.matchers.must.Matchers
 
 class ClusteringUtilsSuite extends AnyFunSuite with Matchers {
 
+  test("getClusteringDomainMetadata: Returns the domain metadata for clustering columns") {
+    val clusteringCols = List(new Column("a"), new Column("b"))
+    val domainMetadata = ClusteringUtils.getClusteringDomainMetadata(clusteringCols.asJava)
+    assert(domainMetadata.getDomain === "delta.clustering")
+    assert(domainMetadata.getConfiguration ===
+      """{"clusteringColumns":[["a"],["b"]]}""")
+  }
+
   test("validateDataFileStatus: Throws when statistics are missing entirely") {
     val dataFile = new DataFileStatus("path", 100L, 123456L, Optional.empty())
     val clusteringCols = List(new Column("a"))
@@ -38,7 +46,8 @@ class ClusteringUtilsSuite extends AnyFunSuite with Matchers {
     }
 
     assert(ex.getMessage.contains(
-      "Cannot write to a clustering-enabled table without per-file statistics."))
+      "Unable to write the given data file to a clustering-enabled table: " +
+        "Missing per-file statistics for clustering columns"))
   }
 
   test("validateDataFileStatus: Throws when min/max/nullCount is missing for a clustering column") {
@@ -55,7 +64,8 @@ class ClusteringUtilsSuite extends AnyFunSuite with Matchers {
     }
 
     assert(ex.getMessage.contains(
-      "Cannot write to a clustering-enabled table without per-column statistics."))
+      "Unable to write the given data file to a clustering-enabled table: " +
+        "Missing per-file statistics for clustering column"))
   }
 
   test("validateDataFileStatus: Throws when min/max is missing and nullCount != numRecords " +
@@ -73,7 +83,8 @@ class ClusteringUtilsSuite extends AnyFunSuite with Matchers {
     }
 
     assert(ex.getMessage.contains(
-      "Cannot write to a clustering-enabled table without per-column statistics."))
+      "Unable to write the given data file to a clustering-enabled table: " +
+        "Missing per-file statistics for clustering column"))
   }
 
   test("validateDataFileStatus: Passes when min/max is missing but nullCount == numRecords " +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Split the main PR https://github.com/delta-io/delta/pull/4265 for faster review

This PR adds the ClusteringUtils which includes a few utils would could be used for clustering feature

- getClusteringDomainMetadata: Generate the domain metadata for the clustering columns.
- getClusteringColumnsOptional: Extract ClusteringColumns from a given snapshot.
- validateDataFileStatus: validate the per-file statistics and per-column statistics for clustering columns

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests, more tests would be added later in integration tests.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
