### PR TITLE
[Spark] Move GenerateRowIDs rule to optimizer phase

### DIFF
--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -127,14 +127,14 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
       PostHocResolveUpCast(session)
     }
 
-    extensions.injectPlanNormalizationRule { _ => GenerateRowIDs }
-
     extensions.injectPreCBORule { session =>
       new PrepareDeltaScan(session)
     }
     // Fold constants that may have been introduced by PrepareDeltaScan. This is only useful with
     // Spark 3.5 as later versions apply constant folding after pre-CBO rules.
     extensions.injectPreCBORule { _ => ConstantFolding }
+
+    extensions.injectOptimizerRule { _ => GenerateRowIDs }
 
     // Add skip row column and filter.
     extensions.injectPlannerStrategy(PreprocessTableWithDVsStrategy)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -151,7 +151,7 @@ class DeltaParquetFileFormatSuite extends DeltaParquetFileFormatSuiteBase {
           val deltaParquetFormat = new DeltaParquetFileFormat(
             deltaLog.snapshot.protocol,
             metadata,
-            nullableRowTrackingFields = false,
+            rowTrackingFieldsUpdated = false,
             optimizationsEnabled = false,
             if (enableDVs) Some(tablePath) else None)
 
@@ -257,7 +257,7 @@ class DeltaParquetFileFormatWithPredicatePushdownSuite extends DeltaParquetFileF
       val deltaParquetFormat = new DeltaParquetFileFormat(
         deltaLog.update().protocol,
         metadata,
-        nullableRowTrackingFields = false,
+        rowTrackingFieldsUpdated = false,
         optimizationsEnabled = true,
         Some(tablePath))
 


### PR DESCRIPTION


## Description
The `GenerateRowIDs` rule is used to inject the correct expressions for the `_metadata.row_id` and `_metadata.row_commit_version` fields, that will provide default values when these are not materialized in the data files:
- `_metadata.row_id = coalesce(_metadata.row_id, _metadata.base_row_id + _metadata.row_index)`
- `_metadata.row_commit_version = coalesce(_metadata.row_commit_version, _metadata.default_row_commit_version)`

This rule was initially applied during the normalization phase, which can interfere with plan caching.

Ideally we'd like this rule to be a resolution rule, but this is hard to achieve, mainly due to the updated metadata attribute not being able to use analyzer tricks to plumb metadata through plans anymore. That prevents updating an already analyzed plan to reference new metadata fields, which is exactly what we do when preserving row tracking in DMLs.

Instead we execute this rule during early optimization phase.

Few improvements to the rule to make this work:
- Make the rule idempotent, using `rowTrackingFieldsUpdated` to track whether the rule already update the fields.
- Allow applying rule after unused metadata fields have been pruned. E.p. `base_row_id`, `row_index` and `default_row_commit_version` are required to generate correct values but may not be present if these are not referenced elsewhere in the query and have bee pruned.
- Skip applying the rule if `_metadata.row_id` and `_metadata.row_commit_version` aren't used in the query. 

## How was this patch tested?
Covered by existing row tracking tests and `GenerateRowIDsSuite`

## Does this PR introduce _any_ user-facing changes?
No