### PR TITLE
[Kernel] Validate updated schema compatibility

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -337,9 +337,10 @@ public class SchemaUtils {
 
   /* Compute the SchemaChanges using field IDs */
   static SchemaChanges computeSchemaChangesById(
-      Map<Long, StructField> currentFieldIdToField, Map<Long, StructField> updatedFieldIdToField) {
+      Map<Integer, StructField> currentFieldIdToField,
+      Map<Integer, StructField> updatedFieldIdToField) {
     SchemaChanges.Builder schemaDiff = SchemaChanges.builder();
-    for (Map.Entry<Long, StructField> fieldInUpdatedSchema : updatedFieldIdToField.entrySet()) {
+    for (Map.Entry<Integer, StructField> fieldInUpdatedSchema : updatedFieldIdToField.entrySet()) {
       StructField existingField = currentFieldIdToField.get(fieldInUpdatedSchema.getKey());
       StructField updatedField = fieldInUpdatedSchema.getValue();
       // New field added
@@ -351,7 +352,7 @@ public class SchemaUtils {
       }
     }
 
-    for (Map.Entry<Long, StructField> entry : currentFieldIdToField.entrySet()) {
+    for (Map.Entry<Integer, StructField> entry : currentFieldIdToField.entrySet()) {
       if (!updatedFieldIdToField.containsKey(entry.getKey())) {
         schemaDiff.withRemovedField(entry.getValue());
       }
@@ -401,21 +402,21 @@ public class SchemaUtils {
    * fields
    */
   private static void validateSchemaEvolutionById(StructType currentSchema, StructType newSchema) {
-    Map<Long, StructField> currentFieldsById = fieldsById(currentSchema);
-    Map<Long, StructField> updatedFieldsById = fieldsById(newSchema);
+    Map<Integer, StructField> currentFieldsById = fieldsById(currentSchema);
+    Map<Integer, StructField> updatedFieldsById = fieldsById(newSchema);
     SchemaChanges schemaChanges = computeSchemaChangesById(currentFieldsById, updatedFieldsById);
     validatePhysicalNameConsistency(schemaChanges.updatedFields());
+    // Validates that the updated schema does not contain breaking changes in terms of types and
+    // nullability
     validateUpdatedSchemaCompatibility(schemaChanges);
     // ToDo Potentially validate IcebergCompatV2 nested IDs
   }
 
   /**
-   * Verifies the following
+   * Verifies that no non-nullable fields are added, no existing field nullability is tightened and
+   * no invalid type changes are performed
    *
-   * <ul>
-   *   <li>no non-nullable fields are added
-   *   <li>no tightening of existing fields
-   *   <li>no type changes are performed
+   * <p>ToDo: Prevent moving fields outside of their containing struct
    */
   private static void validateUpdatedSchemaCompatibility(SchemaChanges schemaChanges) {
     for (StructField addedField : schemaChanges.addedFields()) {
@@ -426,15 +427,18 @@ public class SchemaUtils {
     }
 
     for (Tuple2<StructField, StructField> updatedFields : schemaChanges.updatedFields()) {
-      validateNoTypeChange(updatedFields._1, updatedFields._2);
+      // ToDo: See if recursion can be avoided by incorporating map key/value and array element
+      // updates in updatedFields
+      validateFieldCompatibility(updatedFields._1, updatedFields._2);
     }
   }
 
   /**
    * Validate that there was no change in type from existing field from new field, excluding
-   * modified, dropped, or added fields to structs.
+   * modified, dropped, or added fields to structs. Validates that a field's nullability is not
+   * tightened
    */
-  private static void validateNoTypeChange(StructField existingField, StructField newField) {
+  private static void validateFieldCompatibility(StructField existingField, StructField newField) {
     if (existingField.isNullable() && !newField.isNullable()) {
       throw new KernelException(
           String.format(
@@ -442,21 +446,20 @@ public class SchemaUtils {
     }
 
     // Both fields are structs, ensure there's no changes in the individual fields
-    // ToDo: Prevent additions, removals, and type updates to struct fields when the struct is a map
-    // key
+    // ToDo: Prevent additions, removals,
+    //  and type updates to struct fields when the struct is a map key
     if (existingField.getDataType() instanceof StructType
         && newField.getDataType() instanceof StructType) {
       StructType existingStruct = (StructType) existingField.getDataType();
       StructType newStruct = (StructType) newField.getDataType();
-      Map<Integer, StructField> existingStructFieldsById =
+      Map<Integer, StructField> existingNestedFields =
           existingStruct.fields().stream()
               .collect(Collectors.toMap(ColumnMapping::getColumnId, Function.identity()));
 
       for (StructField newNestedField : newStruct.fields()) {
-        StructField existingNestedFields =
-            existingStructFieldsById.get(getColumnId(newNestedField));
-        if (existingNestedFields != null) {
-          validateNoTypeChange(existingNestedFields, newNestedField);
+        StructField existingNestedField = existingNestedFields.get(getColumnId(newNestedField));
+        if (existingNestedField != null) {
+          validateFieldCompatibility(existingNestedField, newNestedField);
         }
       }
     } else if (existingField.getDataType() instanceof MapType
@@ -464,14 +467,15 @@ public class SchemaUtils {
       MapType existingMapType = (MapType) existingField.getDataType();
       MapType newMapType = (MapType) newField.getDataType();
 
-      validateNoTypeChange(existingMapType.getKeyField(), newMapType.getKeyField());
-      validateNoTypeChange(existingMapType.getValueField(), newMapType.getValueField());
+      validateFieldCompatibility(existingMapType.getKeyField(), newMapType.getKeyField());
+      validateFieldCompatibility(existingMapType.getValueField(), newMapType.getValueField());
     } else if (existingField.getDataType() instanceof ArrayType
         && newField.getDataType() instanceof ArrayType) {
       ArrayType existingArrayType = (ArrayType) existingField.getDataType();
       ArrayType newArrayType = (ArrayType) newField.getDataType();
 
-      validateNoTypeChange(existingArrayType.getElementField(), newArrayType.getElementField());
+      validateFieldCompatibility(
+          existingArrayType.getElementField(), newArrayType.getElementField());
     } else if (!existingField.getDataType().equivalent(newField.getDataType())) {
       throw new KernelException(
           String.format(
@@ -480,20 +484,19 @@ public class SchemaUtils {
     }
   }
 
-  /** Returns a map from field ID to the field in the schema */
-  private static Map<Long, StructField> fieldsById(StructType schema) {
+  private static Map<Integer, StructField> fieldsById(StructType schema) {
     List<Tuple2<List<String>, StructField>> columnPathToStructField =
         filterRecursively(
             schema,
             true /* recurseIntoMapOrArrayElements */,
             false /* stopOnFirstMatch */,
             sf -> true);
-    Map<Long, StructField> columnIdToField = new HashMap<>();
+    Map<Integer, StructField> columnIdToField = new HashMap<>();
     for (Tuple2<List<String>, StructField> pathAndField : columnPathToStructField) {
       StructField field = pathAndField._2;
       checkArgument(hasColumnId(field), "Field %s is missing column id", field.getName());
       checkArgument(hasPhysicalName(field), "Field %s is missing physical name", field.getName());
-      long columnId = field.getMetadata().getLong(COLUMN_MAPPING_ID_KEY);
+      int columnId = getColumnId(field);
       checkArgument(
           !columnIdToField.containsKey(columnId),
           "Field %s with id %d already exists",

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -26,7 +26,7 @@ import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.actions.{Format, Metadata}
 import io.delta.kernel.internal.types.DataTypeJsonSerDe
 import io.delta.kernel.internal.util.ColumnMapping.{COLUMN_MAPPING_ID_KEY, COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_NESTED_IDS_KEY, COLUMN_MAPPING_PHYSICAL_NAME_KEY, ColumnMappingMode}
-import io.delta.kernel.internal.util.SchemaUtils.{filterRecursively, validateSchema}
+import io.delta.kernel.internal.util.SchemaUtils.{filterRecursively, validateSchema, validateUpdatedSchema}
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
 import io.delta.kernel.types.{ArrayType, DataType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructField, StructType}
 import io.delta.kernel.types.IntegerType.INTEGER
@@ -325,11 +325,11 @@ class SchemaUtilsSuite extends AnyFunSuite {
   ///////////////////////////////////////////////////////////////////////////
   test("Compute schema changes with added columns") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true))
+      1 -> new StructField("id", IntegerType.INTEGER, true))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("data", StringType.STRING, true))
+      1 -> new StructField("id", IntegerType.INTEGER, true),
+      2 -> new StructField("data", StringType.STRING, true))
 
     val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
@@ -341,10 +341,10 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("Compute schema changes with renamed fields") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true))
+      1 -> new StructField("id", IntegerType.INTEGER, true))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField("renamed_id", IntegerType.INTEGER, true))
+      1 -> new StructField("renamed_id", IntegerType.INTEGER, true))
 
     val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
@@ -357,10 +357,10 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("Compute schema changes with type changed columns") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true))
+      1 -> new StructField("id", IntegerType.INTEGER, true))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField("promoted_to_long", LongType.LONG, true))
+      1 -> new StructField("promoted_to_long", LongType.LONG, true))
 
     val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
@@ -373,11 +373,11 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("Compute schema changes with dropped fields") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("data", StringType.STRING, true))
+      1 -> new StructField("id", IntegerType.INTEGER, true),
+      2 -> new StructField("data", StringType.STRING, true))
 
     val fieldMappingAfter = Map(
-      2L -> new StructField("data", StringType.STRING, true))
+      2 -> new StructField("data", StringType.STRING, true))
 
     val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
@@ -389,12 +389,12 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("Compute schema changes with nullability change") {
     val fieldMappingBefore = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("data", StringType.STRING, true))
+      1 -> new StructField("id", IntegerType.INTEGER, true),
+      2 -> new StructField("data", StringType.STRING, true))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField("id", IntegerType.INTEGER, true),
-      2L -> new StructField("required_data", StringType.STRING, false))
+      1 -> new StructField("id", IntegerType.INTEGER, true),
+      2 -> new StructField("required_data", StringType.STRING, false))
 
     val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
@@ -408,24 +408,24 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("Compute schema changes with moved fields") {
     val fieldMappingBefore = Map(
-      1L -> new StructField(
+      1 -> new StructField(
         "struct",
         new StructType()
           .add(new StructField("id", IntegerType.INTEGER, true))
           .add(new StructField("data", StringType.STRING, true)),
         true),
-      2L -> new StructField("id", IntegerType.INTEGER, true),
-      3L -> new StructField("data", StringType.STRING, true))
+      2 -> new StructField("id", IntegerType.INTEGER, true),
+      3 -> new StructField("data", StringType.STRING, true))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField(
+      1 -> new StructField(
         "struct",
         new StructType()
           .add(new StructField("data", StringType.STRING, true))
           .add(new StructField("id", IntegerType.INTEGER, true)),
         true),
-      2L -> new StructField("id", IntegerType.INTEGER, true),
-      3L -> new StructField("data", StringType.STRING, true))
+      2 -> new StructField("id", IntegerType.INTEGER, true),
+      3 -> new StructField("data", StringType.STRING, true))
 
     val schemaChanges = schemaChangesHelper(fieldMappingBefore, fieldMappingAfter)
 
@@ -439,7 +439,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("Compute schema changes with field metadata changes") {
     val fieldMappingBefore = Map(
-      1L -> new StructField(
+      1 -> new StructField(
         "id",
         IntegerType.INTEGER,
         true,
@@ -448,7 +448,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
           "metadata_val").build()))
 
     val fieldMappingAfter = Map(
-      1L -> new StructField(
+      1 -> new StructField(
         "id",
         IntegerType.INTEGER,
         true,
@@ -467,14 +467,14 @@ class SchemaUtilsSuite extends AnyFunSuite {
   }
 
   private def schemaChangesHelper(
-      before: Map[Long, StructField],
-      after: Map[Long, StructField]): SchemaChanges = {
+      before: Map[Int, StructField],
+      after: Map[Int, StructField]): SchemaChanges = {
     SchemaUtils.computeSchemaChangesById(
       before.map {
-        case (k, v) => java.lang.Long.valueOf(k) -> v
+        case (k, v) => java.lang.Integer.valueOf(k) -> v
       }.asJava,
       after.map {
-        case (k, v) => java.lang.Long.valueOf(k) -> v
+        case (k, v) => java.lang.Integer.valueOf(k) -> v
       }.asJava)
   }
 
@@ -487,7 +487,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
     val e = intercept[IllegalArgumentException] {
       val tblProperties = Map(COLUMN_MAPPING_MODE_KEY -> "none")
-      SchemaUtils.validateUpdatedSchema(
+      validateUpdatedSchema(
         current,
         updated,
         metadata(current, properties = tblProperties))
@@ -520,11 +520,11 @@ class SchemaUtilsSuite extends AnyFunSuite {
       new StructType().add(
         "array",
         new ArrayType(
-          new StructType().add("id", IntegerType.INTEGER, true, fieldMetadata(4L, "id")),
+          new StructType().add("id", IntegerType.INTEGER, true, fieldMetadata(4, "id")),
           false),
         false,
-        fieldMetadata(2L, "array_field")),
-      fieldMetadata(1L, "top_level_struct"))
+        fieldMetadata(2, "array_field")),
+      fieldMetadata(1, "top_level_struct"))
 
   private val updatedSchemasWithInconsistentPhysicalNames = Table(
     ("schemaBefore", "updatedSchemaWithInconsistentPhysicalNames"),
@@ -561,7 +561,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
         new StructType().add(
           "renamed_id",
           IntegerType.INTEGER,
-          fieldMetadata(4L, "inconsistent_name")),
+          fieldMetadata(4, "inconsistent_name")),
         false))))
 
   test("validateUpdatedSchema fails when physical names are not consistent across ids") {
@@ -677,12 +677,12 @@ class SchemaUtilsSuite extends AnyFunSuite {
         .add(
           "duplicate_id",
           IntegerType.INTEGER,
-          fieldMetadata(4L, "duplicate_id"))))
+          fieldMetadata(4, "duplicate_id"))))
 
   test("validateUpdatedSchema fails with schema with duplicate column ID") {
     forAll(updatedSchemaHasDuplicateColumnId) { (schemaBefore, schemaAfter) =>
       val e = intercept[IllegalArgumentException] {
-        SchemaUtils.validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
+        validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
       }
 
       assert(e.getMessage.matches("Field duplicate_id with id .* already exists"))
@@ -723,27 +723,27 @@ class SchemaUtilsSuite extends AnyFunSuite {
           new StructType().add(
             "array",
             new ArrayType(
-              new StructType().add("renamed_id", IntegerType.INTEGER, fieldMetadata(4L, "id")),
+              new StructType().add("renamed_id", IntegerType.INTEGER, fieldMetadata(4, "id")),
               false),
             false,
-            fieldMetadata(2L, "array_field")),
-          fieldMetadata(1L, "top_level_struct"))))
+            fieldMetadata(2, "array_field")),
+          fieldMetadata(1, "top_level_struct"))))
 
   test("validateUpdatedSchema succeeds with valid ID and physical name") {
     forAll(validUpdatedSchemas) { (schemaBefore, schemaAfter) =>
-      SchemaUtils.validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
+      validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
     }
   }
 
   private val nonNullableFieldAdded = Table(
-    ("schemaBefore", "updatedSchemaWithNoNestedId"),
+    ("schemaBefore", "schemaWithNonNullableFieldAdded"),
     (
       primitiveSchema,
       primitiveSchema.add(
         "required_field",
         IntegerType.INTEGER,
         false,
-        fieldMetadata(3L, "required_field"))),
+        fieldMetadata(3, "required_field"))),
     // Map with struct key where non-nullable field is added to struct
     (
       mapWithStructKey,
@@ -771,8 +771,8 @@ class SchemaUtilsSuite extends AnyFunSuite {
           new StructType().add(
             "renamed_id",
             IntegerType.INTEGER,
-            fieldMetadata(4L, "id"))
-            .add("required_field", IntegerType.INTEGER, false, fieldMetadata(5L, "required_field")),
+            fieldMetadata(4, "id"))
+            .add("required_field", IntegerType.INTEGER, false, fieldMetadata(5, "required_field")),
           false),
         arrayName = "renamed_array")))
 
@@ -783,7 +783,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
   }
 
   private val existingFieldNullabilityTightened = Table(
-    ("schemaBefore", "updatedSchemaWithNoNestedId"),
+    ("schemaBefore", "schemaWithFieldNullabilityTightened"),
     (
       primitiveSchema,
       new StructType()
@@ -815,7 +815,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
             "renamed_id",
             IntegerType.INTEGER,
             false,
-            fieldMetadata(4L, "id")),
+            fieldMetadata(4, "id")),
           false),
         arrayName = "renamed_array")))
 
@@ -826,7 +826,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
   }
 
   private val invalidTypeChange = Table(
-    ("schemaBefore", "updatedSchemaWithNoNestedId"),
+    ("schemaBefore", "schemaWithInvalidTypeChange"),
     (
       primitiveSchema,
       new StructType()
@@ -858,7 +858,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
             "renamed_id_as_string",
             StringType.STRING,
             true,
-            fieldMetadata(4L, "id")),
+            fieldMetadata(4, "id")),
           false),
         arrayName = "renamed_array")))
 
@@ -866,6 +866,59 @@ class SchemaUtilsSuite extends AnyFunSuite {
     assertSchemaEvolutionFailure[KernelException](
       invalidTypeChange,
       "Cannot change the type of existing field id from integer to string")
+  }
+
+  private val validateAddedFields = Table(
+    ("schemaBefore", "schemaWithAddedField"),
+    (
+      primitiveSchema,
+      primitiveSchema
+        .add(
+          "data",
+          StringType.STRING,
+          true,
+          fieldMetadata(id = 2, physicalName = "data"))),
+    // Map with struct key where data field is added
+    (
+      mapWithStructKey,
+      mapWithStructKey(
+        new MapType(
+          new StructType()
+            .add(
+              "renamed_id",
+              IntegerType.INTEGER,
+              true,
+              fieldMetadata(id = 2, physicalName = "id"))
+            .add(
+              "data",
+              StringType.STRING,
+              true,
+              fieldMetadata(id = 3, physicalName = "data")),
+          IntegerType.INTEGER,
+          false),
+        fieldMetadata(id = 1, physicalName = "map"))),
+    // Struct of array of struct where inner struct has added string data field
+    (
+      structWithArrayOfStructs,
+      structWithArrayOfStructs(
+        arrayType = new ArrayType(
+          new StructType().add(
+            "renamed_id",
+            IntegerType.INTEGER,
+            true,
+            fieldMetadata(4, "id"))
+            .add(
+              "data",
+              StringType.STRING,
+              true,
+              fieldMetadata(5, "data")),
+          false),
+        arrayName = "renamed_array")))
+
+  test("validateUpdatedSchema succeeds when adding field") {
+    forAll(validateAddedFields) { (schemaBefore, schemaAfter) =>
+      validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
+    }
   }
 
   private def mapWithStructKey(
@@ -901,7 +954,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
           arrayType,
           false,
           arrayMetadata),
-        fieldMetadata(1L, "top_level_struct"))
+        fieldMetadata(1, "top_level_struct"))
   }
 
   private def assertSchemaEvolutionFailure[T <: Throwable](
@@ -911,7 +964,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
         Map(ColumnMapping.COLUMN_MAPPING_MODE_KEY -> "id"))(implicit classTag: ClassTag[T]) {
     forAll(evolutionCases) { (schemaBefore, schemaAfter) =>
       val e = intercept[T] {
-        SchemaUtils.validateUpdatedSchema(
+        validateUpdatedSchema(
           schemaBefore,
           schemaAfter,
           metadata(schemaBefore, tableProperties))
@@ -938,9 +991,9 @@ class SchemaUtilsSuite extends AnyFunSuite {
     )
   }
 
-  private def fieldMetadata(id: Long, physicalName: String): FieldMetadata = {
+  private def fieldMetadata(id: Integer, physicalName: String): FieldMetadata = {
     FieldMetadata.builder()
-      .putLong(COLUMN_MAPPING_ID_KEY, id)
+      .putLong(COLUMN_MAPPING_ID_KEY, id.longValue())
       .putString(COLUMN_MAPPING_PHYSICAL_NAME_KEY, physicalName)
       .build()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This change is broken away from #4196 as part of schema evolution support. This change adds validation that the updated schema is compatible with the previous schema. Compatibility includes:
1. making sure no new non-nullable fields are added
2. no existing fields are tightened in nullability and no invalid type changes have occurred. 

Note: For now, "invalid type changes" includes any type change but we can later extend this to support whatever type promotion is desired.

This change also cleans up the following:

1. Removing some duplication in the SchemaUtils validateUpdatedSchema suite
2. Removing usage of Longs for field IDs, they will always be 32 bit integers.

## How was this patch tested?

Added unit tests

## Does this PR introduce _any_ user-facing changes?

No