### PR TITLE
[Kernel] Add ability to set table features via configuration properties.

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -319,9 +319,12 @@ public class TableConfig<T> {
       String key = kv.getKey().toLowerCase(Locale.ROOT);
       String value = kv.getValue();
 
-      // TableFeature properties validation is handled separately in TransactionBuilder.
-      if (key.startsWith("delta.")
-          && !key.startsWith(TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX)) {
+      boolean isTableFeatureOverrideKey =
+          key.startsWith(TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX);
+      boolean isTableConfigKey = key.startsWith("delta.");
+      // TableFeature override properties validation is handled separately in TransactionBuilder.
+      boolean shouldValidateProperties = isTableConfigKey && !isTableFeatureOverrideKey;
+      if (shouldValidateProperties) {
         // If it is a delta table property, make sure it is a supported property and editable
         if (!VALID_PROPERTIES.containsKey(key)) {
           throw DeltaErrors.unknownConfigurationException(kv.getKey());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -18,6 +18,7 @@ package io.delta.kernel.internal;
 import io.delta.kernel.exceptions.InvalidConfigurationValueException;
 import io.delta.kernel.exceptions.UnknownConfigurationException;
 import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.*;
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import java.util.*;
@@ -318,7 +319,9 @@ public class TableConfig<T> {
       String key = kv.getKey().toLowerCase(Locale.ROOT);
       String value = kv.getValue();
 
-      if (key.startsWith("delta.")) {
+      // TableFeature properties validation is handled separately in TransactionBuilder.
+      if (key.startsWith("delta.")
+          && !key.startsWith(TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX)) {
         // If it is a delta table property, make sure it is a supported property and editable
         if (!VALID_PROPERTIES.containsKey(key)) {
           throw DeltaErrors.unknownConfigurationException(kv.getKey());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -320,7 +320,7 @@ public class TableConfig<T> {
       String value = kv.getValue();
 
       boolean isTableFeatureOverrideKey =
-          key.startsWith(TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX);
+          key.startsWith(TableFeatures.SET_TABLE_FEATURE_SUPPORTED_PREFIX);
       boolean isTableConfigKey = key.startsWith("delta.");
       // TableFeature override properties validation is handled separately in TransactionBuilder.
       boolean shouldValidateProperties = isTableConfigKey && !isTableFeatureOverrideKey;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -167,6 +167,14 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     /* ----- 2: Update the PROTOCOL based on the table properties or schema ----- */
     // This is the only place we update the protocol action; takes care of any dependent features
     // Ex: We enable feature `icebergCompatV2` plus dependent features `columnMapping`
+    Optional<Tuple2<Protocol, Metadata>> newProtocolAndMetadata =
+        TableFeatures.updateProtocolWithFeaturePropertyOverrides(
+            newProtocol.orElse(snapshotProtocol), newMetadata.orElse(snapshotMetadata));
+    if (newProtocolAndMetadata.isPresent()) {
+      newProtocol = Optional.of(newProtocolAndMetadata.get()._1);
+      newMetadata = Optional.of(newProtocolAndMetadata.get()._2);
+    }
+
     Optional<Tuple2<Protocol, Set<TableFeature>>> newProtocolAndFeatures =
         TableFeatures.autoUpgradeProtocolBasedOnMetadata(
             newMetadata.orElse(snapshotMetadata),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -129,9 +129,9 @@ public class Metadata {
 
   /**
    * Returns a new metadata object that has a new configuration which is the combination of its
-   * current configuration and {@code configuration}. 
+   * current configuration and {@code configuration}.
    *
-   * For overlapping keys the values from {@code configuration} take precedence.
+   * <p> For overlapping keys the values from {@code configuration} take precedence.
    */
   public Metadata withMergedConfiguration(Map<String, String> configuration) {
     Map<String, String> newConfiguration = new HashMap<>(getConfiguration());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -131,7 +131,7 @@ public class Metadata {
    * Returns a new metadata object that has a new configuration which is the combination of its
    * current configuration and {@code configuration}.
    *
-   * <p> For overlapping keys the values from {@code configuration} take precedence.
+   * <p>For overlapping keys the values from {@code configuration} take precedence.
    */
   public Metadata withMergedConfiguration(Map<String, String> configuration) {
     Map<String, String> newConfiguration = new HashMap<>(getConfiguration());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -127,9 +127,23 @@ public class Metadata {
                         .collect(Collectors.toList())));
   }
 
+  /**
+   * Returns a new metadata object that has a new configuration which is the combination of its
+   * current configuration and {@code configuration}. 
+   *
+   * For overlapping keys the values from {@code configuration} take precedence.
+   */
   public Metadata withMergedConfiguration(Map<String, String> configuration) {
     Map<String, String> newConfiguration = new HashMap<>(getConfiguration());
     newConfiguration.putAll(configuration);
+    return withConfiguration(newConfiguration);
+  }
+
+  /**
+   * Returns a new Metadata object with the configuration provided with newConfiguration (any prior
+   * configuration is replaced).
+   */
+  public Metadata withConfiguration(Map<String, String> newConfiguration) {
     return new Metadata(
         this.id,
         this.name,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -136,14 +136,14 @@ public class Metadata {
   public Metadata withMergedConfiguration(Map<String, String> configuration) {
     Map<String, String> newConfiguration = new HashMap<>(getConfiguration());
     newConfiguration.putAll(configuration);
-    return withConfiguration(newConfiguration);
+    return withReplacedConfiguration(newConfiguration);
   }
 
   /**
    * Returns a new Metadata object with the configuration provided with newConfiguration (any prior
    * configuration is replaced).
    */
-  public Metadata withConfiguration(Map<String, String> newConfiguration) {
+  public Metadata withReplacedConfiguration(Map<String, String> newConfiguration) {
     return new Metadata(
         this.id,
         this.name,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -50,7 +50,7 @@ public class TableFeatures {
    *
    * <p>Disabling features via this method is unsupported.
    */
-  public static String PROPERTIES_FEATURE_OVERRIDE_PREFIX = "delta.feature.";
+  public static String SET_TABLE_FEATURE_SUPPORTED_PREFIX = "delta.feature.";
 
   /////////////////////////////////////////////////////////////////////////////////
   /// START: Define the {@link TableFeature}s                                   ///
@@ -505,7 +505,7 @@ public class TableFeatures {
    * overrides are present.
    *
    * <p>Overrides are specified using a key in th form {@linkplain
-   * #PROPERTIES_FEATURE_OVERRIDE_PREFIX} + {featureName}. (e.g. {@code
+   * #SET_TABLE_FEATURE_SUPPORTED_PREFIX} + {featureName}. (e.g. {@code
    * delta.feature.icebergWriterCompatV1}). The value must be "supported" to add the feature.
    * Currently, removing values is not handled.
    *
@@ -519,8 +519,8 @@ public class TableFeatures {
     Set<TableFeature> features = new HashSet<>();
     Map<String, String> properties = currentMetadata.getConfiguration();
     for (Map.Entry<String, String> entry : properties.entrySet()) {
-      if (entry.getKey().startsWith(PROPERTIES_FEATURE_OVERRIDE_PREFIX)) {
-        String featureName = entry.getKey().substring(PROPERTIES_FEATURE_OVERRIDE_PREFIX.length());
+      if (entry.getKey().startsWith(SET_TABLE_FEATURE_SUPPORTED_PREFIX)) {
+        String featureName = entry.getKey().substring(SET_TABLE_FEATURE_SUPPORTED_PREFIX.length());
 
         TableFeature feature = getTableFeature(featureName);
         features.add(feature);
@@ -539,7 +539,7 @@ public class TableFeatures {
 
     Map<String, String> cleanedProperties =
         properties.entrySet().stream()
-            .filter(e -> !e.getKey().startsWith(PROPERTIES_FEATURE_OVERRIDE_PREFIX))
+            .filter(e -> !e.getKey().startsWith(SET_TABLE_FEATURE_SUPPORTED_PREFIX))
             .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     return new Tuple2<>(
         features, Optional.of(currentMetadata.withReplacedConfiguration(cleanedProperties)));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -478,6 +478,7 @@ public class TableFeatures {
     Set<TableFeature> allNeededTableFeatures =
         extractAllNeededTableFeatures(newMetadata, currentProtocol);
     if (manuallyEnabledFeatures != null && !manuallyEnabledFeatures.isEmpty()) {
+      // Note that any dependent features are handled below in the withFeatures call.
       allNeededTableFeatures =
           Stream.concat(allNeededTableFeatures.stream(), manuallyEnabledFeatures.stream())
               .collect(toSet());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -506,13 +506,13 @@ public class TableFeatures {
    *
    * <p>Overrides are specified using a key in th form {@linkplain
    * #PROPERTIES_FEATURE_OVERRIDE_PREFIX} + {featureName}. (e.g. {@code
-   * delta.feature.icebergWriterCompatV1}). The value should be "true" to add the feature.
+   * delta.feature.icebergWriterCompatV1}). The value must be "supported" to add the feature.
    * Currently, removing values is not handled.
    *
    * @return A set of features that had overrides and Metadata object with the properties removed if
    *     any overrides were present.
    * @throws KernelException if the feature name for the override is invalid or the value is not
-   *     equal to "true".
+   *     equal to "supported".
    */
   public static Tuple2<Set<TableFeature>, Optional<Metadata>> extractFeaturePropertyOverrides(
       Metadata currentMetadata) {
@@ -524,11 +524,11 @@ public class TableFeatures {
 
         TableFeature feature = getTableFeature(featureName);
         features.add(feature);
-        if (!entry.getValue().equals("true")) {
+        if (!entry.getValue().equals("supported")) {
           throw DeltaErrors.invalidConfigurationValueException(
               entry.getKey(),
               entry.getValue(),
-              "TableFeature override options may only have \"true\" as there value");
+              "TableFeature override options may only have \"supported\" as there value");
         }
       }
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/MetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/MetadataSuite.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions
+
+import java.util.{Collections, Optional}
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.data.{ArrayValue, ColumnVector, MapValue}
+import io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector
+import io.delta.kernel.internal.util.VectorUtils.buildColumnVector
+import io.delta.kernel.types.{IntegerType, StringType, StructType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class MetadataSuite extends AnyFunSuite {
+
+  test("withMergedConfig upserts values") {
+    val metadata = testMetadata(Map("a" -> "b", "f" -> "g"))
+
+    val newMetadata = metadata.withMergedConfiguration(Map("a" -> "c", "d" -> "f").asJava)
+
+    assert(newMetadata.getConfiguration.equals(Map("a" -> "c", "d" -> "f", "f" -> "g").asJava))
+  }
+
+  test("withConfiguration replaces values") {
+    val metadata = testMetadata(Map("a" -> "b", "f" -> "g"))
+
+    val newMetadata = metadata.withConfiguration(Map("a" -> "c", "d" -> "f").asJava)
+
+    assert(newMetadata.getConfiguration.equals(Map("a" -> "c", "d" -> "f").asJava))
+  }
+
+  def testMetadata(tblProps: Map[String, String] = Map.empty): Metadata = {
+    val testSchema = new StructType()
+      .add("c1", IntegerType.INTEGER)
+      .add("c2", StringType.STRING)
+    new Metadata(
+      "id",
+      Optional.of("name"),
+      Optional.of("description"),
+      new Format("parquet", Collections.emptyMap()),
+      testSchema.toJson,
+      testSchema,
+      new ArrayValue() { // partitionColumns
+        override def getSize = 1
+
+        override def getElements: ColumnVector = singletonStringColumnVector("c3")
+      },
+      Optional.empty(),
+      new MapValue() { // conf
+        override def getSize = tblProps.size
+        override def getKeys: ColumnVector =
+          buildColumnVector(tblProps.toSeq.map(_._1).asJava, StringType.STRING)
+        override def getValues: ColumnVector =
+          buildColumnVector(tblProps.toSeq.map(_._2).asJava, StringType.STRING)
+      })
+  }
+
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/MetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/MetadataSuite.scala
@@ -36,10 +36,10 @@ class MetadataSuite extends AnyFunSuite {
     assert(newMetadata.getConfiguration.equals(Map("a" -> "c", "d" -> "f", "f" -> "g").asJava))
   }
 
-  test("withConfiguration replaces values") {
+  test("withReplacedConfiguration replaces values") {
     val metadata = testMetadata(Map("a" -> "b", "f" -> "g"))
 
-    val newMetadata = metadata.withConfiguration(Map("a" -> "c", "d" -> "f").asJava)
+    val newMetadata = metadata.withReplacedConfiguration(Map("a" -> "c", "d" -> "f").asJava)
 
     assert(newMetadata.getConfiguration.equals(Map("a" -> "c", "d" -> "f").asJava))
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -982,9 +982,9 @@ class TableFeaturesSuite extends AnyFunSuite {
       test(s"updateProtocolWithFeatureProperty: no change: $currentProtocol $properties") {
         val metadata = testMetadata(tblProps = properties)
 
-        assert(TableFeatures.updateProtocolWithFeaturePropertyOverrides(
+        assert(!TableFeatures.updateProtocolWithFeaturePropertyOverrides(
           currentProtocol,
-          metadata).isEmpty)
+          metadata).isPresent)
       }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -956,8 +956,8 @@ class TableFeaturesSuite extends AnyFunSuite {
   test(
     "extractFeaturePropertyOverrides returns feature options and removes from them from metadata") {
     val metadata = testMetadata(tblProps = Map(
-      "delta.feature.deletionVectors" -> "true",
-      "delta.feature.appendOnly" -> "true",
+      "delta.feature.deletionVectors" -> "supported",
+      "delta.feature.appendOnly" -> "supported",
       "anotherkey" -> "some_value",
       "delta.enableRowTracking" -> "true"))
 
@@ -993,7 +993,7 @@ class TableFeaturesSuite extends AnyFunSuite {
 
   Seq(
     Map("delta.feature.deletionVectors" -> "not_valid_value"),
-    Map("delta.feature.invalidFeatureName" -> "true")).foreach {
+    Map("delta.feature.invalidFeatureName" -> "supported")).foreach {
     properties =>
       test(s"extractFeaturePropertyOverrides throws: $properties") {
         intercept[KernelException] {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -882,23 +882,26 @@ class TableFeaturesSuite extends AnyFunSuite {
               !(manualFeatures & Set(
                 TableFeatures.CLUSTERING_W_FEATURE,
                 TableFeatures.DOMAIN_METADATA_W_FEATURE)).isEmpty
-            ) 7
+            ) { 7 }
             else expectedProtocol.getMinWriterVersion
           assert(newProtocol.getMinWriterVersion == expectedWriterVersion)
 
           // Expected enabled features
-          val expectedEnabledFeatures = expectedNewFeatures.asScala ++ manualFeatures ++ (
-            if (manualFeatures.contains(TableFeatures.CLUSTERING_W_FEATURE)) Set("domainMetadata")
-            else Set.empty
-          )
+          val expectedEnabledFeatures =
+            expectedNewFeatures.asScala ++ manualFeatures.map(_.featureName()).toSet ++ (
+              if (manualFeatures.contains(TableFeatures.CLUSTERING_W_FEATURE)) Set("domainMetadata")
+              else Set.empty
+            )
           assert(newFeaturesEnabled.asScala.map(_.featureName()).toSet == expectedEnabledFeatures)
 
           // Expected supported features
+          val implicitAndExplicitFeatures =
+            expectedProtocol.getImplicitlyAndExplicitlySupportedFeatures.asScala
           val expectedSupportedFeatures =
-            expectedProtocol.getImplicitlyAndExplicitlySupportedFeatures.asScala ++ manualFeatures ++ (
-              if (manualFeatures.contains(TableFeatures.CLUSTERING_W_FEATURE))
+            implicitAndExplicitFeatures ++ manualFeatures ++ (
+              if (manualFeatures.contains(TableFeatures.CLUSTERING_W_FEATURE)) {
                 Set(TableFeatures.DOMAIN_METADATA_W_FEATURE)
-              else Set.empty
+              } else { Set.empty }
             )
           assert(newProtocol.getImplicitlyAndExplicitlySupportedFeatures.asScala
             == expectedSupportedFeatures)
@@ -953,8 +956,8 @@ class TableFeaturesSuite extends AnyFunSuite {
   test(
     "extractFeaturePropertyOverrides returns feature options and removes from them from metadata") {
     val metadata = testMetadata(tblProps = Map(
-      "delta.feature.deletionVectors" -> "supported",
-      "delta.feature.appendOnly" -> "supported",
+      "delta.feature.deletionVectors" -> "true",
+      "delta.feature.appendOnly" -> "true",
       "anotherkey" -> "some_value",
       "delta.enableRowTracking" -> "true"))
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -201,8 +201,9 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
     withTempDirAndEngine { (tablePath, engine) =>
       val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
-      val domainMetadataKey =
-        s"${TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX}${TableFeatures.DOMAIN_METADATA_W_FEATURE.featureName}"
+      val domainMetadataKey = (
+        TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX
+          + TableFeatures.DOMAIN_METADATA_W_FEATURE.featureName)
       val properties = Map(
         "delta.feature.vacuumProtocolCheck" -> "supported",
         domainMetadataKey -> "supported")

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -226,10 +226,8 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
     withTempDirAndEngine { (tablePath, engine) =>
       val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
-      val properties = Map("delta.feature.vacuumProtocolCheck" -> "true")
-      val txn = txnBuilder.withTableProperties(
-        engine,
-        properties.asJava).withSchema(engine, testSchema).build(engine)
+      val properties = Map()
+      val txn = txnBuilder.withDomainMetadataSupported().withSchema(engine, testSchema).build(engine)
       commitTransaction(txn, engine, emptyIterable())
       assert(latestSnapshot(table, engine).getProtocol.getExplicitlySupportedFeatures.contains(
         TableFeatures.DOMAIN_METADATA_W_FEATURE))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -227,7 +227,8 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
       val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
       val properties = Map()
-      val txn = txnBuilder.withDomainMetadataSupported().withSchema(engine, testSchema).build(engine)
+      val txn =
+        txnBuilder.withDomainMetadataSupported().withSchema(engine, testSchema).build(engine)
       commitTransaction(txn, engine, emptyIterable())
       assert(latestSnapshot(table, engine).getProtocol.getExplicitlySupportedFeatures.contains(
         TableFeatures.DOMAIN_METADATA_W_FEATURE))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -203,7 +203,7 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
       val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
       val domainMetadataKey = (
-        TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX
+        TableFeatures.SET_TABLE_FEATURE_SUPPORTED_PREFIX
           + TableFeatures.DOMAIN_METADATA_W_FEATURE.featureName)
       val properties = Map(
         "delta.feature.vacuumProtocolCheck" -> "supported",

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -206,8 +206,8 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
         TableFeatures.PROPERTIES_FEATURE_OVERRIDE_PREFIX
           + TableFeatures.DOMAIN_METADATA_W_FEATURE.featureName)
       val properties = Map(
-        "delta.feature.vacuumProtocolCheck" -> "true",
-        domainMetadataKey -> "true")
+        "delta.feature.vacuumProtocolCheck" -> "supported",
+        domainMetadataKey -> "supported")
       val txn = txnBuilder
         .withTableProperties(engine, properties.asJava)
         .withSchema(engine, testSchema)
@@ -226,7 +226,6 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
     withTempDirAndEngine { (tablePath, engine) =>
       val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
-      val properties = Map()
       val txn =
         txnBuilder.withDomainMetadataSupported().withSchema(engine, testSchema).build(engine)
       commitTransaction(txn, engine, emptyIterable())
@@ -240,7 +239,7 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
       // Create Table
       val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
-      val properties = Map("delta.feature.vacuumProtocolCheck" -> "true")
+      val properties = Map("delta.feature.vacuumProtocolCheck" -> "supported")
       val txn = txnBuilder.withTableProperties(
         engine,
         properties.asJava).withSchema(engine, testSchema).build(engine)
@@ -262,7 +261,7 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
     withTempDirAndEngine { (tablePath, engine) =>
       val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
-      val properties = Map("delta.feature.clustering" -> "true")
+      val properties = Map("delta.feature.clustering" -> "supported")
       val txn = txnBuilder.withTableProperties(
         engine,
         properties.asJava).withSchema(engine, testSchema).build(engine)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?


- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This allows features to be enabled by adding a key value pair of "delta.feature.$feature_name"->"supported" in the table properties when creating a transaction, and have those features enabled for the table.

Disablement is not done in this PR because it is a less common use-case.

Resolves #4331

## How was this patch tested?

Unit tests:
1.  Detailed test for new method added on TableFeature
2. Added a more e2e test in DeltaTableFeaturesSuite
3. Introduced a new MetadataSuite for Metadata action method changes.

## Does this PR introduce _any_ user-facing changes?

Yes.  Features can now be turned on in DeltaLake by using `"delta.feature.<feature_name>": "true"` in table properties.  These keys are removed from the configuration so they don't show up in the Metadata action.
