### PR TITLE
[SPARK] Check all not null constraints

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -278,20 +278,6 @@ trait DeltaErrorsBase
       messageParameters = Array(s"${UnresolvedAttribute(constraint.column).name}"))
   }
 
-  def nestedNotNullConstraint(
-      parent: String, nested: DataType, nestType: String): AnalysisException = {
-        new DeltaAnalysisException(
-          errorClass = "DELTA_NESTED_NOT_NULL_CONSTRAINT",
-          messageParameters = Array(
-            s"$nestType",
-            s"$parent",
-            s"${DeltaSQLConf.ALLOW_UNENFORCED_NOT_NULL_CONSTRAINTS.key}",
-            s"$nestType",
-            s"${nested.prettyJson}"
-          )
-        )
-  }
-
   def nullableParentWithNotNullNestedField : Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_NOT_NULL_NESTED_FIELD",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -581,19 +581,6 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       newMetadataTmp = newMetadataTmp.copy(schemaString = schema.json)
     }
 
-    newMetadataTmp = if (snapshot.metadata.schemaString == newMetadataTmp.schemaString) {
-      // Shortcut when the schema hasn't changed to avoid generating spurious schema change logs.
-      // It's fine if two different but semantically equivalent schema strings skip this special
-      // case - that indicates that something upstream attempted to do a no-op schema change, and
-      // we'll just end up doing a bit of redundant work in the else block.
-      newMetadataTmp
-    } else {
-      val fixedSchema = SchemaUtils.removeUnenforceableNotNullConstraints(
-        newMetadataTmp.schema, spark.sessionState.conf).json
-      newMetadataTmp.copy(schemaString = fixedSchema)
-    }
-
-
     if (canAssignAnyNewProtocol) {
       // Check for the new protocol version after the removal of the unenforceable not null
       // constraints

--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/Invariants.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/Invariants.scala
@@ -16,13 +16,17 @@
 
 package org.apache.spark.sql.delta.constraints
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedExtractValue}
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types._
 
 /**
  * List of invariants that can be defined on a Delta table that will allow us to perform
@@ -34,7 +38,13 @@ object Invariants {
   }
 
   /** Used for columns that should never be null. */
-  case object NotNull extends Rule { override val name: String = "NOT NULL" }
+  case class NotNull(fieldPath: Seq[String], expression: Expression) extends Rule {
+    override val name: String = s"${fieldPath.mkString(".")} NOT NULL"
+
+    def mapExpr(f: Expression => Expression): NotNull = {
+      copy(expression = f(expression))
+    }
+  }
 
   sealed trait RulePersistedInMetadata {
     def wrap: PersistedRule
@@ -69,24 +79,155 @@ object Invariants {
     override def wrap: PersistedRule = PersistedRule(expression = this)
   }
 
+  /**
+   * Find all non-nullable fields in the schema, creating expressions for each that checks if
+   * any nullable parent is null or the final field is not null.
+   *
+   * Arrays are checked using an ArrayForall expression to check each element in the list.
+   * Maps are checked an ArrayForall on the keys and the values.
+   *
+   * @param dataType the data type of the current field
+   * @param fieldPath the path to the current field
+   * @param parentExtraction the expression to extract the current field
+   * @return
+   */
+  private def traverseNullCheckExpressions(
+      dataType: DataType,
+      fieldPath: Seq[String],
+      parentExtraction: Option[Expression] = None
+  ): Seq[NotNull] = {
+    val nullCheckExpressions = new ArrayBuffer[NotNull]
+
+    dataType match {
+      case StructType(fields) => fields.map { field =>
+        val childFieldPath = fieldPath :+ field.name
+
+        // If it's a top level field, we create a new attribute, otherwise get a nested struct
+        // field
+        val fieldExtraction = parentExtraction.map(UnresolvedExtractValue(_, Literal(field.name)))
+          .getOrElse(UnresolvedAttribute(Seq(field.name)))
+
+        var childNullCheckExpressions = traverseNullCheckExpressions(
+          field.dataType,
+          childFieldPath,
+          Some(fieldExtraction))
+
+        if (!field.nullable) {
+          // If the field is non-nullable, we return a check for this field not being null
+          // or any of it's nullable parents being null
+          nullCheckExpressions +=
+            NotNull(childFieldPath, IsNotNull(fieldExtraction))
+        } else {
+          // If the field is nullable, we include the null check of the field as an allowable
+          // condition
+          childNullCheckExpressions = childNullCheckExpressions.map { n =>
+            n.mapExpr(Or(IsNull(fieldExtraction), _))
+          }
+        }
+
+        nullCheckExpressions ++= childNullCheckExpressions
+      }
+      case ArrayType(elementType, containsNull) =>
+        val childFieldPath = fieldPath :+ "element"
+        val elementVar = UnresolvedNamedLambdaVariable(Seq("elementVar"))
+        val lambdaCheckExpressions = ArrayBuffer.empty[Expression]
+
+        // Traverse into the child type in case it's a complex type and include it's checks
+        // on the lambda variable
+        var childNullCheckExpressions = traverseNullCheckExpressions(
+          elementType,
+          childFieldPath,
+          Some(elementVar)
+        )
+
+        if (!containsNull) {
+          nullCheckExpressions += NotNull(childFieldPath, ArrayForAll(parentExtraction.get,
+            LambdaFunction(IsNotNull(elementVar), Seq(elementVar))))
+        } else {
+          childNullCheckExpressions = childNullCheckExpressions.map { n =>
+            n.mapExpr(Or(IsNull(elementVar), _))
+          }
+        }
+
+        nullCheckExpressions ++= childNullCheckExpressions.map { n =>
+          n.mapExpr { lambdaExpression =>
+            ArrayForAll(parentExtraction.get, LambdaFunction(lambdaExpression, Seq(elementVar)))
+          }
+        }
+      case MapType(keyType, valueType, valueContainsNull) =>
+        val keyFieldPath = fieldPath :+ "key"
+        val keyVar = UnresolvedNamedLambdaVariable(Seq("keyVar"))
+        val keyCheckExpressions = ArrayBuffer.empty[Expression]
+
+        val valueFieldPath = fieldPath :+ "value"
+        val valueVar = UnresolvedNamedLambdaVariable(Seq("valueVar"))
+        val valueCheckExpressions = ArrayBuffer.empty[Expression]
+
+        // Traverse into the key and value types in case it's a complex type and include it's checks
+        // on the lambda variable
+        var keyNullCheckExpressions = traverseNullCheckExpressions(
+          keyType,
+          keyFieldPath,
+          Some(keyVar)
+        )
+        var valueNullCheckExpressions = traverseNullCheckExpressions(
+          valueType,
+          valueFieldPath,
+          Some(valueVar)
+        )
+
+        if (!valueContainsNull) {
+          // If the value is non-nullable, add a check that each element is not null
+          nullCheckExpressions += NotNull(valueFieldPath,
+            ArrayForAll(MapValues(parentExtraction.get),
+            LambdaFunction(IsNotNull(valueVar), Seq(valueVar))))
+        } else {
+          valueNullCheckExpressions = valueNullCheckExpressions.map { n =>
+            n.mapExpr(Or(IsNull(valueVar), _))
+          }
+        }
+
+        nullCheckExpressions ++= keyNullCheckExpressions.map { n =>
+          n.mapExpr { lambdaExpression =>
+            ArrayForAll(MapKeys(parentExtraction.get),
+              LambdaFunction(lambdaExpression, Seq(keyVar)))
+          }
+        }
+
+        nullCheckExpressions ++= valueNullCheckExpressions.map { n =>
+          n.mapExpr { lambdaExpression =>
+            ArrayForAll(MapValues(parentExtraction.get),
+              LambdaFunction(lambdaExpression, Seq(valueVar)))
+          }
+        }
+
+      case _ => ()
+    }
+
+    nullCheckExpressions.toSeq
+  }
+
   /** Extract invariants from the given schema */
   def getFromSchema(schema: StructType, spark: SparkSession): Seq[Constraint] = {
-    val columns = SchemaUtils.filterRecursively(schema, checkComplexTypes = false) { field =>
-      !field.nullable || field.metadata.contains(INVARIANTS_FIELD)
+    val nullConstraints = traverseNullCheckExpressions(schema, Seq.empty).map {
+      case NotNull(fieldPath, expr) => Constraints.NotNull(fieldPath, expr)
     }
-    columns.map {
-      case (parents, field) if !field.nullable =>
-        Constraints.NotNull(parents :+ field.name)
-      case (parents, field) =>
-        val rule = field.metadata.getString(INVARIANTS_FIELD)
-        val invariant = Option(JsonUtils.mapper.readValue[PersistedRule](rule).unwrap) match {
-          case Some(PersistedExpression(exprString)) =>
-            ArbitraryExpression(spark, exprString)
-          case _ =>
-            throw DeltaErrors.unrecognizedInvariant()
-        }
-        Constraints.Check(invariant.name, invariant.expression)
+
+    val checkConstraints = SchemaUtils.filterRecursively(schema,
+        checkComplexTypes = false) { field =>
+      field.metadata.contains(INVARIANTS_FIELD)
+    }.map { case (parents, field) =>
+      val rule = field.metadata.getString(INVARIANTS_FIELD)
+      val invariant = Option(JsonUtils.mapper.readValue[PersistedRule](rule).unwrap) match {
+        case Some(PersistedExpression(exprString)) =>
+          ArbitraryExpression(spark, exprString)
+        case _ =>
+          throw DeltaErrors.unrecognizedInvariant()
+      }
+      Constraints.Check(invariant.name, invariant.expression)
     }
+
+    nullConstraints ++ checkConstraints
   }
 
   val INVARIANTS_FIELD = "delta.invariants"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -933,14 +933,6 @@ trait DeltaSQLConfBase {
       .checkValue(_ >= 0, "the version must be >= 0")
       .createOptional
 
-  val ALLOW_UNENFORCED_NOT_NULL_CONSTRAINTS =
-    buildConf("constraints.allowUnenforcedNotNull.enabled")
-      .internal()
-      .doc("If enabled, NOT NULL constraints within array and map types will be permitted in " +
-        "Delta table creation, even though Delta can't enforce them.")
-      .booleanConf
-      .createWithDefault(false)
-
   val CHECKPOINT_SCHEMA_WRITE_THRESHOLD_LENGTH =
     buildConf("checkpointSchema.writeThresholdLength")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -266,20 +266,6 @@ trait DeltaErrorsSuiteBase
         "from the data being written into the table."))
     }
     {
-      val parent = "parent"
-      val nested = IntegerType
-      val nestType = "nestType"
-      val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.nestedNotNullConstraint(parent, nested, nestType)
-      }
-      checkErrorMessage(e, Some("DELTA_NESTED_NOT_NULL_CONSTRAINT"), Some("0AKDC"),
-        Some(s"The $nestType type of the field $parent contains a NOT NULL " +
-        s"constraint. Delta does not support NOT NULL constraints nested within arrays or maps. " +
-        s"To suppress this error and silently ignore the specified constraints, set " +
-        s"${DeltaSQLConf.ALLOW_UNENFORCED_NOT_NULL_CONSTRAINTS.key} = true.\n" +
-        s"Parsed $nestType type:\n${nested.prettyJson}"))
-    }
-    {
       val e = intercept[DeltaInvariantViolationException] {
         throw DeltaInvariantViolationException(Constraints.NotNull(Seq("col1")))
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -1984,8 +1984,7 @@ trait GeneratedColumnSuiteBase
       val e1 = intercept[DeltaInvariantViolationException] {
         df1.write.format("delta").mode("append").saveAsTable("tbl")
       }
-      assert(e1.getMessage.contains("Column c2, which has a NOT NULL constraint," +
-        " is missing from the data being written into the table."))
+      assert(e1.getMessage.contains("NOT NULL constraint violated for column: c2"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves #4345 

Update the invariant checker to support checking for null values in non-nullable fields inside arrays and maps, and updates all nested field handling to consider the nullability of it's parents.

The config `constraints.allowUnenforcedNotNull.enabled` is removed, as it is no longer needed.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New and updated UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, allows non-nullable fields in arrays and maps and removes the unenforced not null config.