### PR TITLE
Fix Redirect so that redirect-rw take precedence over redirect-w

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
@@ -490,6 +490,10 @@ object RedirectFeature {
     mapper.readValue(configString, classOf[TableRedirectConfiguration])
   }
 
+  /**
+   * Get the current `TableRedirectConfiguration` object from the table properties.
+   * Note that the redirect-rw takes precedence over redirect-w.
+   */
   def getRedirectConfiguration(
       properties: Map[String, String]): Option[TableRedirectConfiguration] = {
     properties.get(DeltaConfigs.REDIRECT_READER_WRITER.key)
@@ -514,13 +518,12 @@ object RedirectFeature {
     }
   }
 
-  /** Get the current `TableRedirectConfiguration` object from the snapshot. */
+  /**
+   * Get the current `TableRedirectConfiguration` object from the snapshot.
+   * Note that the redirect-rw takes precedence over redirect-w.
+   */
   def getRedirectConfiguration(snapshot: Snapshot): Option[TableRedirectConfiguration] = {
-    if (RedirectWriterOnly.isFeatureSupported(snapshot)) {
-      RedirectWriterOnly.getRedirectConfiguration(snapshot.metadata)
-    } else {
-      RedirectReaderWriter.getRedirectConfiguration(snapshot.metadata)
-    }
+    getRedirectConfiguration(snapshot.metadata.configuration)
   }
 
   /** Determines whether `configs` contains redirect configuration. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
@@ -492,7 +492,7 @@ object RedirectFeature {
 
   /**
    * Get the current `TableRedirectConfiguration` object from the table properties.
-   * Note that the redirect-rw takes precedence over redirect-w.
+   * Note that the redirect-reader-writer takes precedence over redirect-writer-only.
    */
   def getRedirectConfiguration(
       properties: Map[String, String]): Option[TableRedirectConfiguration] = {
@@ -520,7 +520,7 @@ object RedirectFeature {
 
   /**
    * Get the current `TableRedirectConfiguration` object from the snapshot.
-   * Note that the redirect-rw takes precedence over redirect-w.
+   * Note that the redirect-reader-writer takes precedence over redirect-writer-only.
    */
   def getRedirectConfiguration(snapshot: Snapshot): Option[TableRedirectConfiguration] = {
     getRedirectConfiguration(snapshot.metadata.configuration)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TableRedirectSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TableRedirectSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.redirect.{
   EnableRedirectInProgress,
   NoRedirectRule,
   PathBasedRedirectSpec,
+  RedirectFeature,
   RedirectReaderWriter,
   RedirectReady,
   RedirectSpec,
@@ -395,5 +396,24 @@ class TableRedirectSuite extends QueryTest
           result = sql("select * from t1").collect()
           assert(result.length == 4)
     }
+  }
+
+  test("test getRedirectConfiguration") {
+    val redirectSpec = new PathBasedRedirectSpec("sourcePath", "targetPath")
+    val properties1 = RedirectReaderWriter.generateRedirectMetadata(
+      PathBasedRedirectSpec.REDIRECT_TYPE,
+      EnableRedirectInProgress,
+      redirectSpec,
+      noRedirectRules = Set.empty)
+    val properties2 = RedirectWriterOnly.generateRedirectMetadata(
+      PathBasedRedirectSpec.REDIRECT_TYPE,
+      RedirectReady,
+      redirectSpec,
+      noRedirectRules = Set.empty)
+
+    val configuration = RedirectFeature.getRedirectConfiguration(properties1 ++ properties2)
+    assert(configuration.isDefined)
+    // RedirectReaderWriter should be preferred over RedirectWriterOnly.
+    assert(configuration.get.redirectState == EnableRedirectInProgress)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TableRedirectSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TableRedirectSuite.scala
@@ -413,7 +413,8 @@ class TableRedirectSuite extends QueryTest
 
     val configuration = RedirectFeature.getRedirectConfiguration(properties1 ++ properties2)
     assert(configuration.isDefined)
-    // RedirectReaderWriter should be preferred over RedirectWriterOnly.
-    assert(configuration.get.redirectState == EnableRedirectInProgress)
+    // redirect-reader-writer should be preferred over redirect-writer-only.
+    assert(JsonUtils.toJson(configuration.get) ==
+      properties1(DeltaConfigs.REDIRECT_READER_WRITER.key))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
When both redirect-rw and redirect-w configuration exist, we want redirect-rw take precedence over redirect-w. 

## How was this patch tested?
`TableRedirectSuite.scala`
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
