### PR TITLE
Fix the logging bug where we use the incorrect snapshot

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1060,7 +1060,7 @@ trait SnapshotManagement { self: DeltaLog =>
           val newSnapshot = updateInternal(
             isAsync = false,
             catalogTableOpt)
-          sendEvent(newSnapshot = capturedSnapshot.snapshot)
+          sendEvent(newSnapshot = newSnapshot)
           newSnapshot
         }
       }


### PR DESCRIPTION
## Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Currently when we reconstruct the snapshot, we incorrectly record the old snapshot as the new one. This PR fixes it.

## How was this patch tested?

Existing tests to catch regressions.

## Does this PR introduce _any_ user-facing changes?

No