### PR TITLE
[Uniform]Propagate the user-defined table properties to Iceberg metadata

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3104,6 +3104,13 @@
     ],
     "sqlState" : "55019"
   },
+  "DUPLICATE_KEY_IN_ICEBERG_TABLE_PROPERTY" : {
+    "message" : [
+      "Duplicate keys <tblProperties> found in table properties on Iceberg Table, please check the ",
+      "if these properties with and without prefix \"delta.universalformat.config.iceberg\" are both set"
+    ],
+    "sqlState" : "23505"
+  },
   "INCORRECT_NUMBER_OF_ARGUMENTS" : {
     "message" : [
       "<failure>, <functionName> requires at least <minArgs> arguments and at most <maxArgs> arguments."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3092,6 +3092,13 @@ trait DeltaErrorsBase
     new DeltaIllegalArgumentException(errorClass = "DELTA_PARTITION_SCHEMA_IN_ICEBERG_TABLES")
   }
 
+  def icebergTablePropertiesConflictException(duplicatedKeys: Set[String]): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DUPLICATE_KEY_IN_ICEBERG_TABLE_PROPERTY",
+      messageParameters = Array(duplicatedKeys.mkString(", "))
+    )
+  }
+
   def icebergClassMissing(sparkConf: SparkConf, cause: Throwable): Throwable = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_MISSING_ICEBERG_CLASS",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->
This PR propagate the user-defined table properties to iceberg metadata, user-defined properties refer to the ones not starting with "delta.".

To avoid breaking change(some user might have started using "delta.universalformat.config.iceberg.abc" to set properties "abc"), we still keep propagating the ones with prefix "delta.universalformat.config.iceberg" by stripping the prefix instead of ignoring them.

However, we will do a duplication check to avoid both "delta.universalformat.config.iceberg.abc" and "abc" are set

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (uniform)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Tested with running set tblProperties on spark


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No