### PR TITLE
[Spark] Improve `DeltaVersionsNotContiguousException` error message & add extra logging

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -257,7 +257,11 @@ class HudiConverter(spark: SparkSession)
         // Read the actions directly from the delta json files.
         // TODO: Run this as a spark job on executors
         val deltaFiles = DeltaFileProviderUtils.getDeltaFilesInVersionRange(
-          spark, log, prevSnapshot.version + 1, snapshotToConvert.version)
+          spark = spark,
+          deltaLog = log,
+          startVersion = prevSnapshot.version + 1,
+          endVersion = snapshotToConvert.version,
+        )
 
         recordDeltaEvent(
           snapshotToConvert.deltaLog,

--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -260,8 +260,7 @@ class HudiConverter(spark: SparkSession)
           spark = spark,
           deltaLog = log,
           startVersion = prevSnapshot.version + 1,
-          endVersion = snapshotToConvert.version,
-        )
+          endVersion = snapshotToConvert.version)
 
         recordDeltaEvent(
           snapshotToConvert.deltaLog,

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -351,7 +351,10 @@ class IcebergConverter(spark: SparkSession)
         // Read the actions directly from the delta json files.
         // TODO: Run this as a spark job on executors
         val deltaFiles = DeltaFileProviderUtils.getDeltaFilesInVersionRange(
-          spark, log, prevSnapshot.version + 1, snapshotToConvert.version)
+          spark = spark,
+          deltaLog = log,
+          startVersion = prevSnapshot.version + 1,
+          endVersion = snapshotToConvert.version)
 
         recordDeltaEvent(
           snapshotToConvert.deltaLog,

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3037,7 +3037,8 @@
   },
   "DELTA_VERSIONS_NOT_CONTIGUOUS" : {
     "message" : [
-      "Versions (<versionList>) are not contiguous."
+      "Versions (<versionList>) are not contiguous. ",
+      "A gap in the delta log between versions <startVersion> and <endVersion> was detected while trying to load version <versionToLoad>."
     ],
     "sqlState" : "KD00C"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1088,10 +1088,18 @@ trait DeltaErrorsBase
   }
 
   def deltaVersionsNotContiguousException(
-      spark: SparkSession, deltaVersions: Seq[Long]): Throwable = {
+      spark: SparkSession,
+      deltaVersions: Seq[Long],
+      startVersion: Long,
+      endVersion: Long,
+      versionToLoad: Long): Throwable = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_VERSIONS_NOT_CONTIGUOUS",
-      messageParameters = Array(deltaVersions.mkString(", "))
+      messageParameters = Array(
+        deltaVersions.mkString(", "),
+        startVersion.toString,
+        endVersion.toString,
+        versionToLoad.toString))
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1099,7 +1099,8 @@ trait DeltaErrorsBase
         deltaVersions.mkString(", "),
         startVersion.toString,
         endVersion.toString,
-        versionToLoad.toString))
+        versionToLoad.toString
+      )
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.types.UTF8String
 
-object DeltaFileProviderUtils {
+object DeltaFileProviderUtils extends DeltaLogging {
 
   protected def readThreadPool = SnapshotManagement.deltaLogAsyncUpdateThreadPool
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.ClosableIterator
 import org.apache.spark.sql.delta.util.FileNames.DeltaFile
 import org.apache.hadoop.conf.Configuration
@@ -68,7 +69,33 @@ object DeltaFileProviderUtils {
         .toSeq
     // Verify that we got the entire range requested
     if (result.size.toLong != endVersion - startVersion + 1) {
-      throw DeltaErrors.deltaVersionsNotContiguousException(spark, result.map(_._2))
+      // [[unsafeVolatileSnapshot]] maybe null, which needs to be explicitly filtered out.
+      val snapshot = Some(deltaLog.unsafeVolatileSnapshot).filter(_ != null)
+      recordDeltaEvent(
+        deltaLog = deltaLog,
+        opType = "delta.exceptions.deltaVersionsNotContiguous",
+        data = Map(
+          // Remove the first element of the stack trace since this represents
+          // the [[Thread.getStackTrace]] call itself.
+          "stackTrace" -> Thread.currentThread().getStackTrace.tail.mkString("\n\t"),
+          "startVersion" -> startVersion,
+          "endVersion" -> endVersion,
+          "unsafeVolatileSnapshot.latestCheckpointVersion" ->
+            snapshot.map(_.checkpointProvider.version).getOrElse(-1L),
+          "unsafeVolatileSnapshot.latestSnapshotVersion" ->
+            snapshot.map(_.version).getOrElse(-1L),
+          "unsafeVolatileSnapshot.checksumOpt" ->
+            snapshot.map(_.checksumOpt).orNull
+        ))
+      throw DeltaErrors.deltaVersionsNotContiguousException(
+        spark = spark,
+        deltaVersions = result.map(_._2),
+        startVersion = startVersion,
+        endVersion = endVersion,
+        // Get the latest snapshot version for visibility when throwing the exception,
+        // this is not exactly "the version to load snapshot" but
+        // we just use the latest snapshot version here.
+        versionToLoad = snapshot.map(_.version).getOrElse(-1L))
     }
     result.map(_._1)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The current error message of `DeltaVersionsNotContiguousException` needs to be improved in order to provide detailed context regarding the table state when throwing the exception.

Specifically, we add `startVersion`, `endVersion`, and `versionToLoad` to the error message, which could be useful to identify the table state and potentially help investigate the root cause of `DeltaVersionsNotContiguousException`.

In addition, we add detailed logging (`usage_log`) to provide more specific context when throwing `DeltaVersionsNotContiguousException`, which includes the entire calling stack and could help improve future visibility.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through UTs in `SnapshotManagementSuite`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Improve the error message of the user-facing `DeltaVersionsNotContiguousException`.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
