### PR TITLE
[Kernel] Expose withSchema API to enable schema evolution

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
@@ -34,11 +34,29 @@ import java.util.Map;
 @Evolving
 public interface TransactionBuilder {
   /**
-   * Set the schema of the table when creating a new table.
+   * Set the schema of the table. If setting the schema on an existing table for a schema evolution,
+   * then column mapping must be enabled. This API will preserve field metadata for fields such as
+   * field IDs and physical names. If field metadata is not specified for a field, it is considered
+   * as a new column and new IDs/physical names will be specified. The possible schema evolutions
+   * supported include column additions, removals, renames, and moves. If a schema evolution is
+   * performed, implementations must perform the following validations:
+   *
+   * <ul>
+   *   <li>No duplicate columns are allowed
+   *   <li>Column names contain only valid characters
+   *   <li>Data types are supported
+   *   <li>No new non-nullable fields are added
+   *   <li>Physical column name consistency is preserved in the new schema
+   *   <li>No type changes
+   *   <li>ToDo: Nested IDs for array/map types are preserved in the new schema
+   *   <li>ToDo: Validate invalid field reorderings
+   * </ul>
    *
    * @param engine {@link Engine} instance to use.
    * @param schema The new schema of the table.
    * @return updated {@link TransactionBuilder} instance.
+   * @throws io.delta.kernel.exceptions.KernelException in case column mapping is not enabled
+   * @throws IllegalArgumentException in case of any validation failure
    */
   TransactionBuilder withSchema(Engine engine, StructType schema);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -29,6 +29,7 @@ import static java.util.stream.Collectors.toSet;
 
 import io.delta.kernel.*;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.fs.Path;
@@ -162,7 +163,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       newMetadata = Optional.of(snapshotMetadata.withMergedConfiguration(newProperties));
     }
 
-    // TODO In the future update metadata with new schema if provided
+    if (schema.isPresent() && !isNewTable) {
+      newMetadata = Optional.of(newMetadata.orElse(snapshotMetadata).withNewSchema(schema.get()));
+    }
 
     /* ----- 2: Update the PROTOCOL based on the table properties or schema ----- */
     // This is the only place we update the protocol action; takes care of any dependent features
@@ -269,12 +272,6 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         snapshot.getProtocol(), snapshot.getMetadata(), tablePath);
 
     if (!isNewTable) {
-      if (schema.isPresent()) {
-        throw tableAlreadyExists(
-            tablePath,
-            "Table already exists, but provided a new schema. "
-                + "Schema can only be set on a new table.");
-      }
       if (partitionColumns.isPresent()) {
         throw tableAlreadyExists(
             tablePath,
@@ -319,7 +316,26 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     IcebergWriterCompatV1MetadataValidatorAndUpdater.validateIcebergWriterCompatV1Change(
         oldMetadata.getConfiguration(), newMetadata.getConfiguration(), isNewTable);
 
-    // TODO In the future validate any schema change
+    // Validate the conditions for schema evolution and the updated schema if applicable
+    if (schema.isPresent() && !isNewTable) {
+      ColumnMappingMode updatedMappingMode =
+          ColumnMapping.getColumnMappingMode(newMetadata.getConfiguration());
+      ColumnMappingMode currentMappingMode =
+          ColumnMapping.getColumnMappingMode(oldMetadata.getConfiguration());
+      if (currentMappingMode != updatedMappingMode) {
+        throw new KernelException("Cannot update mapping mode and perform schema evolution");
+      }
+
+      if (!isColumnMappingModeEnabled(updatedMappingMode)) {
+        throw new KernelException("Cannot update schema for table when column mapping is disabled");
+      }
+
+      SchemaUtils.validateUpdatedSchema(
+          oldMetadata.getSchema(),
+          newMetadata.getSchema(),
+          oldMetadata.getPartitionColNames(),
+          newMetadata);
+    }
   }
 
   private class InitialSnapshot extends SnapshotImpl {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.internal.icebergcompat;
 
 import static io.delta.kernel.internal.tablefeatures.TableFeatures.*;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
@@ -131,9 +132,15 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
               .newMetadata
               .getPartitionColNames()
               .forEach(
-                  partitonCol -> {
+                  partitionCol -> {
+                    int partitionFieldIndex =
+                        inputContext.newMetadata.getSchema().indexOf(partitionCol);
+                    checkArgument(
+                        partitionFieldIndex != -1,
+                        "Partition column %s not found in the schema",
+                        partitionCol);
                     DataType dataType =
-                        inputContext.newMetadata.getSchema().get(partitonCol).getDataType();
+                        inputContext.newMetadata.getSchema().at(partitionFieldIndex).getDataType();
                     boolean validType =
                         dataType instanceof ByteType
                             || dataType instanceof ShortType

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -99,12 +99,17 @@ public class SchemaUtils {
    * </ul>
    */
   public static void validateUpdatedSchema(
-      StructType currentSchema, StructType newSchema, Metadata metadata) {
+      StructType currentSchema,
+      StructType newSchema,
+      Set<String> currentPartitionColumns,
+      Metadata newMetadata) {
     checkArgument(
-        isColumnMappingModeEnabled(ColumnMapping.getColumnMappingMode(metadata.getConfiguration())),
+        isColumnMappingModeEnabled(
+            ColumnMapping.getColumnMappingMode(newMetadata.getConfiguration())),
         "Cannot validate updated schema when column mapping is disabled");
     validateSchema(newSchema, true /*columnMappingEnabled*/);
-    validateSchemaEvolution(currentSchema, newSchema, metadata);
+    validatePartitionColumns(newSchema, new ArrayList<>(currentPartitionColumns));
+    validateSchemaEvolution(currentSchema, newSchema, newMetadata);
   }
 
   /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -490,6 +490,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
       validateUpdatedSchema(
         current,
         updated,
+        Set.empty.asJava,
         metadata(current, properties = tblProperties))
     }
 
@@ -682,7 +683,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
   test("validateUpdatedSchema fails with schema with duplicate column ID") {
     forAll(updatedSchemaHasDuplicateColumnId) { (schemaBefore, schemaAfter) =>
       val e = intercept[IllegalArgumentException] {
-        validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
+        validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
       }
 
       assert(e.getMessage.matches("Field duplicate_id with id .* already exists"))
@@ -731,7 +732,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("validateUpdatedSchema succeeds with valid ID and physical name") {
     forAll(validUpdatedSchemas) { (schemaBefore, schemaAfter) =>
-      validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
+      validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
     }
   }
 
@@ -917,7 +918,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("validateUpdatedSchema succeeds when adding field") {
     forAll(validateAddedFields) { (schemaBefore, schemaAfter) =>
-      validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
+      validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
     }
   }
 
@@ -951,7 +952,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("validateUpdatedSchema succeeds when updating field metadata") {
     forAll(validateMetadataChange) { (schemaBefore, schemaAfter) =>
-      validateUpdatedSchema(schemaBefore, schemaAfter, metadata(schemaBefore))
+      validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
     }
   }
 
@@ -1001,6 +1002,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
         validateUpdatedSchema(
           schemaBefore,
           schemaAfter,
+          Set.empty.asJava,
           metadata(schemaBefore, tableProperties))
       }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -1,0 +1,1212 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+
+import io.delta.kernel.{Operation, Table}
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.internal.TableConfig
+import io.delta.kernel.internal.util.{ColumnMapping, ColumnMappingSuiteBase}
+import io.delta.kernel.types.{ArrayType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructType}
+import io.delta.kernel.utils.CloseableIterable.emptyIterable
+
+/**
+ * ToDo: Clean this up by moving some common schemas to fixtures and abstracting
+ * the setup/run schema evolution/assert loop
+ */
+class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with ColumnMappingSuiteBase {
+
+  test("Add nullable column succeeds") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema()
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("d", IntegerType.INTEGER, true, fieldMetadataForColumn(4, "d"))
+            .add("e", IntegerType.INTEGER, true, fieldMetadataForColumn(5, "e")),
+          true,
+          fieldMetadataForColumn(3, "b"))
+        .add("c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+
+      val innerStruct = structType.get("b").getDataType.asInstanceOf[StructType]
+      assertColumnMapping(innerStruct.get("d"), 4, "d")
+      assertColumnMapping(innerStruct.get("e"), 5, "e")
+      assertColumnMapping(structType.get("c"), 2)
+    }
+  }
+
+  test("Drop column succeeds") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema()
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+    }
+  }
+
+  test("Rename fields") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add(
+          "b",
+          new StructType()
+            .add("d", IntegerType.INTEGER, true)
+            .add("e", IntegerType.INTEGER, true),
+          true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema()
+
+      val innerStruct = currentSchema.get("b").getDataType.asInstanceOf[StructType]
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("renamed-d", IntegerType.INTEGER, true, innerStruct.get("d").getMetadata)
+            .add("e", IntegerType.INTEGER, true, innerStruct.get("e").getMetadata),
+          true,
+          currentSchema.get("b").getMetadata)
+        .add("renamed-c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val updatedSchema = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(updatedSchema.get("a"), 1)
+
+      val updatedInnerStruct = updatedSchema.get("b").getDataType.asInstanceOf[StructType]
+      assertColumnMapping(updatedInnerStruct.get("renamed-d"), 3)
+      assertColumnMapping(updatedInnerStruct.get("e"), 4)
+      assertColumnMapping(updatedSchema.get("renamed-c"), 5)
+    }
+  }
+
+  test("Move fields") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add(
+          "b",
+          new StructType()
+            .add("d", IntegerType.INTEGER, true)
+            .add("e", IntegerType.INTEGER, true),
+          true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema()
+
+      val innerStruct = currentSchema.get("b").getDataType.asInstanceOf[StructType]
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add("c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("e", IntegerType.INTEGER, true, innerStruct.get("e").getMetadata)
+            .add("d", IntegerType.INTEGER, true, innerStruct.get("d").getMetadata),
+          true,
+          currentSchema.get("b").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val updatedSchema = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(updatedSchema.get("a"), 1)
+
+      val updatedInnerStruct = updatedSchema.get("b").getDataType.asInstanceOf[StructType]
+      assertColumnMapping(updatedInnerStruct.get("d"), 3)
+      assertColumnMapping(updatedInnerStruct.get("e"), 4)
+      assertColumnMapping(updatedSchema.get("c"), 5)
+
+      // Verify the top level and nested field reordering is maintained
+      val topLevelFields = updatedSchema.fieldNames().asScala
+      assert(topLevelFields == Array("a", "c", "b").toSeq)
+      val innerFields = updatedInnerStruct.fieldNames().asScala
+      assert(innerFields == Array("e", "d").toSeq)
+    }
+  }
+
+  test("Updating schema with adding an array and map type") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "arr",
+          new ArrayType(StringType.STRING, false),
+          true,
+          fieldMetadataForArrayColumn(2, "arr", "arr", 3))
+        .add(
+          "map",
+          new MapType(StringType.STRING, StringType.STRING, false),
+          true,
+          fieldMetadataForMapColumn(4, "map", "map", 5, 6))
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("arr"), 2, "arr")
+      assertColumnMapping(structType.get("map"), 4, "map")
+      assert(structType.get("arr").getMetadata.get(ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY)
+        == FieldMetadata.builder().putLong("arr.element", 3).build())
+      assert(structType.get("map").getMetadata.get(ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY)
+        == FieldMetadata.builder().putLong("map.key", 5).putLong("map.value", 6).build())
+    }
+  }
+
+  test("Add map whose values are array of struct") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new ArrayType(
+              new StructType().add(
+                "nested_map_value",
+                IntegerType.INTEGER,
+                fieldMetadataForColumn(3, "some-physical-column")),
+              true),
+            false),
+          true,
+          fieldMetadataForMapColumn(4, "map", "map", 5, 6))
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("map"), 4, "map")
+      assert(structType.get("map").getMetadata.get(ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY)
+        == FieldMetadata.builder().putLong("map.key", 5).putLong("map.value", 6).build())
+    }
+  }
+
+  test("Drop nested struct field in map<int, array<struct>>") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new ArrayType(
+              new StructType().add("field", IntegerType.INTEGER)
+                .add("field_to_drop", IntegerType.INTEGER),
+              true),
+            false),
+          true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val mapSchema = currentSchema.get("map").getDataType.asInstanceOf[MapType]
+      val arrayValue = mapSchema.getValueType.asInstanceOf[ArrayType]
+      val innerStruct = arrayValue.getElementType.asInstanceOf[StructType]
+
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new ArrayType(
+              new StructType()
+                .add("field", IntegerType.INTEGER, innerStruct.get("field").getMetadata),
+              true),
+            false),
+          true,
+          currentSchema.get("map").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("map"), 2)
+    }
+  }
+
+  test("Add nested struct field to map<int, array<struct>>") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new ArrayType(
+              new StructType().add("field", IntegerType.INTEGER),
+              true),
+            false),
+          true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val mapSchema = currentSchema.get("map").getDataType.asInstanceOf[MapType]
+      val arrayValue = mapSchema.getValueType.asInstanceOf[ArrayType]
+      val innerStruct = arrayValue.getElementType.asInstanceOf[StructType]
+
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new ArrayType(
+              new StructType()
+                .add("field", IntegerType.INTEGER, innerStruct.get("field").getMetadata)
+                .add(
+                  "field_to_add",
+                  IntegerType.INTEGER,
+                  fieldMetadataForColumn(6, "field_to_add")),
+              true),
+            false),
+          true,
+          currentSchema.get("map").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("map"), 2)
+
+      val mapType = structType.get("map").getDataType.asInstanceOf[MapType]
+      val updatedArrayValue = mapType.getValueField.getDataType.asInstanceOf[ArrayType]
+      val updatedInnerStruct = updatedArrayValue.getElementType.asInstanceOf[StructType]
+
+      assertColumnMapping(updatedInnerStruct.get("field_to_add"), 6, "field_to_add")
+
+    }
+  }
+
+  test("Add nested array field to map<int, struct> with already assigned IDs") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType().add("field", IntegerType.INTEGER),
+            false),
+          true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val mapSchema = currentSchema.get("map").getDataType.asInstanceOf[MapType]
+      val innerStruct = mapSchema.getValueType.asInstanceOf[StructType]
+
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType()
+              .add("field", IntegerType.INTEGER, innerStruct.get("field").getMetadata)
+              .add(
+                "array_field_to_add",
+                new ArrayType(IntegerType.INTEGER, true),
+                FieldMetadata.builder()
+                  .putFieldMetadata(
+                    ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY,
+                    FieldMetadata.builder().putLong("array_field_to_add", 7).build())
+                  .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 6)
+                  .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "array_field_to_add")
+                  .build()),
+            false),
+          true,
+          currentSchema.get("map").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("map"), 2)
+      val mapType = structType.get("map").getDataType.asInstanceOf[MapType]
+      val updatedInnerStruct = mapType.getValueType.asInstanceOf[StructType]
+
+      assertColumnMapping(updatedInnerStruct.get("array_field_to_add"), 6, "array_field_to_add")
+    }
+  }
+
+  test("Add nested array field to map<int, struct> with fresh IDs") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType().add("field", IntegerType.INTEGER),
+            false),
+          true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val mapSchema = currentSchema.get("map").getDataType.asInstanceOf[MapType]
+      val innerStruct = mapSchema.getValueType.asInstanceOf[StructType]
+
+      val newSchema = new StructType()
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType()
+              .add(
+                "array_field_to_add",
+                new ArrayType(IntegerType.INTEGER, true))
+              .add("field", IntegerType.INTEGER, innerStruct.get("field").getMetadata),
+            false),
+          true,
+          currentSchema.get("map").getMetadata)
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("map"), 2)
+      val mapType = structType.get("map").getDataType.asInstanceOf[MapType]
+      val updatedInnerStruct = mapType.getValueType.asInstanceOf[StructType]
+
+      assertColumnMapping(updatedInnerStruct.get("array_field_to_add"), 6, "array_field_to_add")
+    }
+  }
+
+  test("Drop nested array field in map<int, struct>") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType().add("field", IntegerType.INTEGER)
+              .add("array_field_to_drop", new ArrayType(IntegerType.INTEGER, true)),
+            false),
+          true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val mapSchema = currentSchema.get("map").getDataType.asInstanceOf[MapType]
+      val innerStruct = mapSchema.getValueType.asInstanceOf[StructType]
+
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType()
+              .add("field", IntegerType.INTEGER, innerStruct.get("field").getMetadata),
+            false),
+          true,
+          currentSchema.get("map").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("map"), 2)
+      val mapType = structType.get("map").getDataType.asInstanceOf[MapType]
+      val updatedInnerStruct = mapType.getValueType.asInstanceOf[StructType]
+
+      assert(updatedInnerStruct == innerStruct.withoutField("array_field_to_drop"))
+    }
+  }
+
+  test("Rename nested array field in map<int, struct>") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType().add("field", IntegerType.INTEGER)
+              .add("array_field_to_rename", new ArrayType(IntegerType.INTEGER, true)),
+            false),
+          true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val mapSchema = currentSchema.get("map").getDataType.asInstanceOf[MapType]
+      val innerStruct = mapSchema.getValueType.asInstanceOf[StructType]
+
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new StructType()
+              .add("field", IntegerType.INTEGER, innerStruct.get("field").getMetadata)
+              .add(
+                "renamed_array_field",
+                new ArrayType(IntegerType.INTEGER, true),
+                innerStruct.get("array_field_to_rename").getMetadata),
+            false),
+          true,
+          currentSchema.get("map").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+      assertColumnMapping(structType.get("map"), 2)
+      val mapType = structType.get("map").getDataType.asInstanceOf[MapType]
+      val updatedInnerStruct = mapType.getValueType.asInstanceOf[StructType]
+
+      assert(updatedInnerStruct.get("renamed_array_field").getDataType
+        == innerStruct.get("array_field_to_rename").getDataType)
+      assert(updatedInnerStruct.get("renamed_array_field").getMetadata
+        == innerStruct.get("array_field_to_rename").getMetadata)
+    }
+  }
+
+  test("Adding struct of structs") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "name",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema()
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add(
+              "d",
+              new StructType().add("e", IntegerType.INTEGER, fieldMetadataForColumn(5, "e")),
+              true,
+              fieldMetadataForColumn(4, "d")),
+          true,
+          fieldMetadataForColumn(3, "b"))
+        .add("c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val structType = table.getLatestSnapshot(engine).getSchema
+      assertColumnMapping(structType.get("a"), 1)
+
+      val firstInnerStruct = structType.get("b").getDataType.asInstanceOf[StructType]
+      assertColumnMapping(firstInnerStruct.get("d"), 4, "d")
+
+      val secondInnerStruct = firstInnerStruct.get("d").getDataType.asInstanceOf[StructType]
+      assertColumnMapping(secondInnerStruct.get("e"), 5, "e")
+    }
+  }
+
+  test("Add array of arrays") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema()
+
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "array_of_arrays",
+          new ArrayType(new ArrayType(IntegerType.INTEGER, true), true),
+          true,
+          FieldMetadata.builder()
+            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "array_of_arrays")
+            .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 4L)
+            .putFieldMetadata(
+              ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY,
+              FieldMetadata.builder().putLong("array_of_arrays.element", 2L)
+                .putLong("array_of_arrays.element.element", 3L).build()).build())
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+
+      val updatedSchema = table.getLatestSnapshot(engine).getSchema()
+
+      assertColumnMapping(updatedSchema.get("a"), 1)
+      assertColumnMapping(updatedSchema.get("array_of_arrays"), 4L, "array_of_arrays")
+
+      val arrayMetadata = updatedSchema.get("array_of_arrays").getMetadata
+      assert(arrayMetadata.getMetadata(ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY)
+        .getLong("array_of_arrays.element") == 2L)
+      assert(arrayMetadata.getMetadata(ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY)
+        .getLong("array_of_arrays.element.element") == 3L)
+    }
+  }
+
+  test("Changing column mapping on table and evolve schema at same time fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      // Create a table initially without column mapping
+      createEmptyTable(engine, tablePath, initialSchema)
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema()
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("d", IntegerType.INTEGER, true, fieldMetadataForColumn(4, "d"))
+            .add("e", IntegerType.INTEGER, true, fieldMetadataForColumn(5, "e")),
+          true,
+          fieldMetadataForColumn(3, "b"))
+        .add("c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Cannot update mapping mode and perform schema evolution",
+        Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "name",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+    }
+  }
+
+  test("Updating schema on table when column mapping disabled fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(engine, tablePath, initialSchema, tableProperties = Map.empty)
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("d", IntegerType.INTEGER, true, fieldMetadataForColumn(4, "d")),
+          true,
+          fieldMetadataForColumn(3, "b"))
+        .add("c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      assertSchemaEvolutionFails[KernelException](
+        table,
+        engine,
+        newSchema,
+        "Cannot update schema for table when column mapping is disabled")
+    }
+  }
+
+  test("Move partition columns") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("partition1", StringType.STRING, true)
+        .add("partition2", IntegerType.INTEGER, true)
+        .add("data", StringType.STRING, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        partCols = Seq("partition1", "partition2"),
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "name",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("partition2", IntegerType.INTEGER, true, currentSchema.get("partition2").getMetadata)
+        .add("partition1", StringType.STRING, true, currentSchema.get("partition1").getMetadata)
+        .add("data", StringType.STRING, true, currentSchema.get("data").getMetadata)
+
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .build(engine).commit(engine, emptyIterable())
+      val updatedSchema = table.getLatestSnapshot(engine).getSchema
+
+      // Verify the ordering is expected
+      val topLevelFields = updatedSchema.fieldNames().asScala
+      assert(topLevelFields == Array("partition2", "partition1", "data").toSeq)
+    }
+  }
+
+  test("Updating schema with duplicate field IDs fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("duplicate_field_id", IntegerType.INTEGER, true, fieldMetadataForColumn(1, "d"))
+            .add("e", IntegerType.INTEGER, true, fieldMetadataForColumn(5, "e")),
+          true,
+          fieldMetadataForColumn(3, "b"))
+        .add("c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Field duplicate_field_id with id 1 already exists")
+    }
+  }
+
+  test("Adding non-nullable field fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("non_nullable_field", IntegerType.INTEGER, false, fieldMetadataForColumn(4, "d"))
+            .add("e", IntegerType.INTEGER, true, fieldMetadataForColumn(5, "e")),
+          true,
+          fieldMetadataForColumn(3, "b"))
+        .add("c", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      assertSchemaEvolutionFails[KernelException](
+        table,
+        engine,
+        newSchema,
+        "Cannot add non-nullable field non_nullable_field")
+    }
+  }
+
+  test("Adding non-nullable field to map value which is a struct fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new ArrayType(
+              new StructType().add("nested_map_value", IntegerType.INTEGER),
+              true),
+            false))
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "name",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val mapSchema = currentSchema.get("map").getDataType.asInstanceOf[MapType]
+      val arrayValue = mapSchema.getValueType.asInstanceOf[ArrayType]
+      val innerStruct = arrayValue.getElementType.asInstanceOf[StructType]
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "map",
+          new MapType(
+            StringType.STRING,
+            new ArrayType(
+              new StructType().add(
+                "nested_map_value",
+                IntegerType.INTEGER,
+                innerStruct.get("nested_map_value").getMetadata)
+                .add(
+                  "new_required_field",
+                  IntegerType.INTEGER,
+                  false,
+                  fieldMetadataForColumn(7, "7")),
+              true),
+            false),
+          true,
+          fieldMetadataForMapColumn(4, "map", "map", 5, 6))
+
+      assertSchemaEvolutionFails[KernelException](
+        table,
+        engine,
+        newSchema,
+        "Cannot add non-nullable field new_required_field")
+    }
+  }
+
+  test("Cannot drop a partition column") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        partCols = Seq("c"),
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add(
+          "b",
+          new StructType()
+            .add("d", IntegerType.INTEGER, true, fieldMetadataForColumn(4, "d"))
+            .add("e", IntegerType.INTEGER, true, fieldMetadataForColumn(5, "e")),
+          true,
+          fieldMetadataForColumn(3, "b"))
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Partition column c not found in the schema")
+    }
+  }
+
+  test("Cannot rename a partition column") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        partCols = Seq("c"),
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add("e", IntegerType.INTEGER, true, currentSchema.get("c").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Partition column c not found in the schema")
+    }
+  }
+
+  test("Cannot change types") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+        .add("c", LongType.LONG, true, currentSchema.get("c").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Cannot change the type of existing field c from integer to long")
+    }
+  }
+
+  test("Updating schema if physical columns are not preserved fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add(
+          "a",
+          StringType.STRING,
+          true,
+          fieldMetadataForColumn(1, "not-preserving-physical-column"))
+        .add("c", LongType.LONG, true, currentSchema.get("c").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Existing field with id 1 in current schema has physical name")
+    }
+  }
+
+  test("Updating schema and tightening nullability on existing field fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("renamed_a", IntegerType.INTEGER, false, currentSchema.get("a").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Cannot tighten the nullability of existing field a")
+    }
+  }
+
+  test("Cannot tighten nullability on renamed array element") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true)
+        .add(
+          "arr",
+          new ArrayType(StringType.STRING, true))
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("a", IntegerType.INTEGER, true, currentSchema.get("a").getMetadata)
+        .add(
+          "some_renamed_array",
+          new ArrayType(StringType.STRING, false),
+          currentSchema.get("arr").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Cannot tighten the nullability of existing field")
+    }
+  }
+
+  test("Cannot change a partition column type") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val initialSchema = new StructType()
+        .add("a", StringType.STRING, true)
+        .add("c", IntegerType.INTEGER, true)
+
+      createEmptyTable(
+        engine,
+        tablePath,
+        initialSchema,
+        partCols = Seq("c"),
+        tableProperties = Map(
+          TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+      val currentSchema = table.getLatestSnapshot(engine).getSchema
+      val newSchema = new StructType()
+        .add("c", StringType.STRING, true, currentSchema.get("c").getMetadata)
+        .add("a", StringType.STRING, true, currentSchema.get("a").getMetadata)
+
+      assertSchemaEvolutionFails[IllegalArgumentException](
+        table,
+        engine,
+        newSchema,
+        "Cannot change the type of existing field c from integer to string")
+    }
+  }
+
+  def fieldMetadataForColumn(
+      columnId: Long,
+      physicalColumnId: String): FieldMetadata = {
+    FieldMetadata.builder()
+      .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, columnId)
+      .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, physicalColumnId)
+      .build()
+  }
+
+  def fieldMetadataForArrayColumn(
+      columnId: Long,
+      physicalColumnId: String,
+      arrayFieldName: String,
+      nestedElementId: Long): FieldMetadata = {
+    FieldMetadata.builder()
+      .fromMetadata(fieldMetadataForColumn(columnId, physicalColumnId))
+      .putFieldMetadata(
+        ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY,
+        FieldMetadata.builder().putLong(s"$arrayFieldName.element", nestedElementId).build())
+      .build()
+  }
+
+  def fieldMetadataForMapColumn(
+      columnId: Long,
+      physicalColumnId: String,
+      mapFieldName: String,
+      keyId: Long,
+      valueId: Long): FieldMetadata = {
+    FieldMetadata.builder()
+      .fromMetadata(fieldMetadataForColumn(columnId, physicalColumnId))
+      .putFieldMetadata(
+        ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY,
+        FieldMetadata.builder().putLong(s"$mapFieldName.key", keyId)
+          .putLong(s"$mapFieldName.value", valueId).build())
+      .build()
+  }
+
+  private def assertSchemaEvolutionFails[T <: Throwable](
+      table: Table,
+      engine: Engine,
+      newSchema: StructType,
+      expectedMessageContained: String,
+      tableProperties: Map[String, String] = Map.empty): Unit = {
+    val e = intercept[Exception] {
+      table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withSchema(engine, newSchema)
+        .withTableProperties(engine, tableProperties.asJava)
+        .build(engine).commit(engine, emptyIterable())
+    }
+
+    assert(e.isInstanceOf[T])
+    assert(e.getMessage.contains(expectedMessageContained))
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -99,15 +99,6 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       {
         val ex = intercept[TableAlreadyExistsException] {
           table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
-            .withSchema(engine, testSchema)
-            .build(engine)
-        }
-        assert(ex.getMessage.contains("Table already exists, but provided a new schema. " +
-          "Schema can only be set on a new table."))
-      }
-      {
-        val ex = intercept[TableAlreadyExistsException] {
-          table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
             .withPartitionColumns(engine, Seq("part1", "part2").asJava)
             .build(engine)
         }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR exposes withSchema API which will enable users to do non intent-based schema evolution with the documented validation .

## How was this patch tested?

Added the same E2E tests as in https://github.com/delta-io/delta/pull/4196 except for nested ID consistency, since that is being reworked as part of https://github.com/delta-io/delta/pull/4360 and that validation is not there.

## Does this PR introduce _any_ user-facing changes?

Yeah the transaction API exposes a withSchema API which allows users to pass in their own schema for evolution.