### PR TITLE
[Kernel] Persist maxColumnId if not present.

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -358,7 +358,12 @@ public class ColumnMapping {
     // If this becomes hotspot, we can consider updating the methods to pass around AtomicBoolean
     // to track if the schema has changed. It is a bit convoluted to pass around and update the
     // AtomicBoolean in the recursive and multiple methods.
-    if (oldSchema.equals(newSchema)) {
+    boolean schemasEqual = oldSchema.equals(newSchema);
+    // If IDs are prepopulated on a schema then this value might not have been put in metadata yet
+    // so ensure we write the values in this case.
+    boolean maxIdPresent =
+        metadata.getConfiguration().containsKey(COLUMN_MAPPING_MAX_COLUMN_ID_KEY);
+    if (schemasEqual && maxIdPresent) {
       checkArgument(
           oldMaxColumnId == maxColumnId.get(),
           "The schema hasn't changed but the max column id has changed from %s to %s",

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
@@ -17,6 +17,8 @@ package io.delta.kernel.internal.util
 
 import java.util
 
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.expressions.Column
 import io.delta.kernel.internal.actions.Metadata
@@ -606,6 +608,12 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
     var metadata = testMetadata(schemaWithCMInfo).withColumnMappingEnabled("id")
     if (enableIcebergCompatV2) {
       metadata = metadata.withIcebergCompatV2Enabled
+    }
+    if (!metadata.getConfiguration.containsKey(COLUMN_MAPPING_MAX_COLUMN_ID_KEY)) {
+      // A hack, if the metadata doesn't have max column ID in it,
+      // then new metadata is always returned.
+      metadata =
+        metadata.withMergedConfiguration(Map(COLUMN_MAPPING_MAX_COLUMN_ID_KEY -> "100").asJava)
     }
 
     assertThat(updateColumnMappingMetadataIfNeeded(metadata, isNewTable)).isEmpty

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
@@ -21,8 +21,8 @@ import scala.collection.immutable.Seq
 import io.delta.kernel.Table
 import io.delta.kernel.exceptions.InvalidConfigurationValueException
 import io.delta.kernel.internal.TableConfig
-import io.delta.kernel.internal.util.ColumnMappingSuiteBase
-import io.delta.kernel.types.{IntegerType, StringType, StructType}
+import io.delta.kernel.internal.util.{ColumnMapping, ColumnMappingSuiteBase}
+import io.delta.kernel.types.{FieldMetadata, IntegerType, StringType, StructField, StructType}
 
 class DeltaColumnMappingSuite extends DeltaTableWriteSuiteBase with ColumnMappingSuiteBase {
 
@@ -86,8 +86,29 @@ class DeltaColumnMappingSuite extends DeltaTableWriteSuiteBase with ColumnMappin
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("b"), 2)
 
+      val config = getMetadata(engine, tablePath).getConfiguration.asScala
+      assert(config.get(TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey).contains("2"))
+
       val protocol = getProtocol(engine, tablePath)
       assert(protocol.getMinReaderVersion == 2 && protocol.getMinWriterVersion == 7)
+    }
+  }
+
+  test("new table with existing column mappings in schema writes COLUMN_MAPPING_MAX_COLUMN_ID") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val props = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> "id")
+      val fieldMetadata = FieldMetadata.builder()
+        .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
+        .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-0").build()
+      val structField = new StructField("col_name", IntegerType.INTEGER, false, fieldMetadata)
+      val schema = new StructType(Seq(structField).asJava)
+      createEmptyTable(engine, tablePath, schema, tableProperties = props)
+
+      val structtype = getMetadata(engine, tablePath).getSchema
+      assertColumnMapping(structtype.get("col_name"), 1)
+
+      val config = getMetadata(engine, tablePath).getConfiguration.asScala
+      assert(config.get(TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey).contains("1"))
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR changes the check in ColumnMapping class for when to return new metadata to ensure `delta.columnMapping.maxColumnId` is populated if it isn't present in the `Metadata` action and column mapping is turned on.

Without this change if a user passes in a schema with preset field IDs (a use case we want to support for new tables) then `delta.columnMapping.maxColumnId` is not populated leaving metadata in an invalid state.

Resolves #4363

## How was this patch tested?

Added unit tests.

## Does this PR introduce _any_ user-facing changes?

Yes. Previously
If yes, `delta.columnMapping.maxColumnId` would not have been populated in some cases.  All previous Delta Lake Kernel releases would have had this issue.
