### PR TITLE
[Spark] Fix double-use iterator bug

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1454,7 +1454,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
         throw e
     }
 
-    runPostCommitHooks(version, postCommitSnapshot, actualCommittedActions.toIterator)
+    runPostCommitHooks(version, postCommitSnapshot, actualCommittedActions)
 
     executionObserver.transactionCommitted()
     Some(version)
@@ -2683,7 +2683,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
   protected def runPostCommitHooks(
       version: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Iterator[Action]): Unit = {
+      committedActions: Seq[Action]): Unit = {
     assert(committed, "Can't call post commit hooks before committing")
 
     // Keep track of the active txn because hooks may create more txns and overwrite the active one.
@@ -2691,7 +2691,8 @@ trait OptimisticTransactionImpl extends DeltaTransaction
     OptimisticTransaction.clearActive()
 
     try {
-      postCommitHooks.foreach(runPostCommitHook(_, version, postCommitSnapshot, committedActions))
+      postCommitHooks.foreach(
+        runPostCommitHook(_, version, postCommitSnapshot, committedActions.toIterator))
     } finally {
       activeCommit.foreach(OptimisticTransaction.setActive)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

A previous refactoring https://github.com/delta-io/delta/pull/4314/ introduced a bug that may cause an iterator to be used more than once. This PR fix this issue.

## How was this patch tested?
Existing tests

## Does this PR introduce _any_ user-facing changes?
No