### PR TITLE
Revert "[Uniform]Propagate the user-defined table properties to Iceberg metadata (#4357)"

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta.icebergShaded
 
 import org.apache.spark.sql.delta.{DeltaConfig, DeltaConfigs, IcebergCompat}
 import org.apache.spark.sql.delta.DeltaConfigs.{LOG_RETENTION, TOMBSTONE_RETENTION}
-import org.apache.spark.sql.delta.DeltaErrors.icebergTablePropertiesConflictException
 import shadedForDelta.org.apache.iceberg.{TableProperties => IcebergTableProperties}
 
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -31,42 +30,24 @@ object DeltaToIcebergConvert {
   object TableProperties {
     /**
      * We generate Iceberg Table properties from Delta table properties
-     * using three methods.
+     * using two methods.
      * 1. If a Delta property key starts with "delta.universalformat.config.iceberg"
      * we strip the prefix from the key and include the property pair.
      * Note the key is already normalized to lower case.
-     * 2. If it is a non delta property, i.e. property not starting with "delta.",
-     * include the property pair.
-     * 3. We compute Iceberg properties from Delta using custom logic
+     * 2. We compute Iceberg properties from Delta using custom logic
      * This now includes
      * a) Iceberg format version
      * b) Iceberg snapshot retention
      */
     def apply(deltaProperties: Map[String, String]): Map[String, String] = {
       val prefix = DeltaConfigs.DELTA_UNIVERSAL_FORMAT_ICEBERG_CONFIG_PREFIX
-      // Key with delta.universalformat.config.iceberg prefix
-      // will have the prefix stripped and copied to iceberg
-      val stripedPrefixProperties =
+      val copiedFromDelta =
         deltaProperties
           .filterKeys(_.startsWith(prefix))
           .map { case (key, value) => key.stripPrefix(prefix) -> value }
           .toSeq
           .toMap
 
-      // Key without delta. prefix will be copied to Iceberg directly.
-      val customProperties = deltaProperties.filterKeys(!_.startsWith("delta."))
-
-      // Setting "delta.universalformat.config.iceberg.property_name_foo"
-      // and "property_name_foo" will be considered as duplicate because
-      // "delta.universalformat.config.iceberg.property_name_foo" will be
-      // converted to "property_name_foo" after stripping prefix.
-      val duplicateUserSpecifiedProperties =
-        stripedPrefixProperties.keySet.intersect(customProperties.keySet)
-      if (duplicateUserSpecifiedProperties.nonEmpty) {
-        throw icebergTablePropertiesConflictException(duplicateUserSpecifiedProperties)
-      }
-
-      val copiedFromDelta = stripedPrefixProperties ++ customProperties
       val computers = Seq(FormatVersionComputer, RetentionPeriodComputer)
       val computed: Map[String, String] = computers
         .map(_.apply(deltaProperties, copiedFromDelta))

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3104,13 +3104,6 @@
     ],
     "sqlState" : "55019"
   },
-  "DUPLICATE_KEY_IN_ICEBERG_TABLE_PROPERTY" : {
-    "message" : [
-      "Duplicate keys <tblProperties> found in table properties on Iceberg Table, please check the ",
-      "if these properties with and without prefix \"delta.universalformat.config.iceberg\" are both set"
-    ],
-    "sqlState" : "23505"
-  },
   "INCORRECT_NUMBER_OF_ARGUMENTS" : {
     "message" : [
       "<failure>, <functionName> requires at least <minArgs> arguments and at most <maxArgs> arguments."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3092,13 +3092,6 @@ trait DeltaErrorsBase
     new DeltaIllegalArgumentException(errorClass = "DELTA_PARTITION_SCHEMA_IN_ICEBERG_TABLES")
   }
 
-  def icebergTablePropertiesConflictException(duplicatedKeys: Set[String]): Throwable = {
-    new DeltaIllegalStateException(
-      errorClass = "DUPLICATE_KEY_IN_ICEBERG_TABLE_PROPERTY",
-      messageParameters = Array(duplicatedKeys.mkString(", "))
-    )
-  }
-
   def icebergClassMissing(sparkConf: SparkConf, cause: Throwable): Throwable = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_MISSING_ICEBERG_CLASS",


### PR DESCRIPTION
Revert "[Uniform]Propagate the user-defined table properties to Iceberg metadata (#4357)"

This reverts commit 39af931dda3a2a0f66870e7f75f9e5d164939298.

We need more discussion of behavior and error code

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
