### PR TITLE
[Kernel] Add Universal format TableConfig.

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -282,7 +282,7 @@ public class TableConfig<T> {
      */
     public static final String FORMAT_ICEBERG = "iceberg";
     /**
-     * The value to use to enable uniform exports to Iceberg for {@linkplain
+     * The value to use to enable uniform exports to Hudi for {@linkplain
      * TableConfig#UNIVERSAL_FORMAT_ENABLED_FORMATS}.
      */
     public static final String FORMAT_HUDI = "hudi";

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -273,7 +273,8 @@ public class TableConfig<T> {
           true);
 
   /**
-   * The value that enables uniform exports to Iceberg for {@linkplain #UNIFORM_ENABLED_FORMATS}.
+   * The value that enables uniform exports to Iceberg for {@linkplain
+   * #UNIVERSAL_FORMAT_ENABLED_FORMATS}.
    *
    * <p>{@link #ICEBERG_COMPAT_V2_ENABLED but also be set to true} to fully enable this feature.
    */
@@ -281,7 +282,7 @@ public class TableConfig<T> {
 
   /**
    * The value to use to enable uniform exports to Iceberg for {@linkplain
-   * #UNIFORM_ENABLED_FORMATS}.
+   * #UNIVERSAL_FORMAT_ENABLED_FORMATS}.
    */
   public static final String UNIVERSAL_FORMAT_HUDI = "hudi";
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -272,22 +272,25 @@ public class TableConfig<T> {
           "needs to be a boolean.",
           true);
 
-  /**
-   * The value that enables uniform exports to Iceberg for {@linkplain
-   * #UNIVERSAL_FORMAT_ENABLED_FORMATS}.
-   *
-   * <p>{@link #ICEBERG_COMPAT_V2_ENABLED but also be set to true} to fully enable this feature.
-   */
-  public static final String UNIVERSAL_FORMAT_ICEBERG = "iceberg";
+  public static class UniversalFormats {
 
-  /**
-   * The value to use to enable uniform exports to Iceberg for {@linkplain
-   * #UNIVERSAL_FORMAT_ENABLED_FORMATS}.
-   */
-  public static final String UNIVERSAL_FORMAT_HUDI = "hudi";
+    /**
+     * The value that enables uniform exports to Iceberg for {@linkplain
+     * TableConfig#UNIVERSAL_FORMAT_ENABLED_FORMATS}.
+     *
+     * <p>{@link #ICEBERG_COMPAT_V2_ENABLED but also be set to true} to fully enable this feature.
+     */
+    public static final String FORMAT_ICEBERG = "iceberg";
+    /**
+     * The value to use to enable uniform exports to Iceberg for {@linkplain
+     * TableConfig#UNIVERSAL_FORMAT_ENABLED_FORMATS}.
+     */
+    public static final String FORMAT_HUDI = "hudi";
+  }
 
   private static final Collection<String> ALLOWED_UNIFORM_FORMATS =
-      Collections.unmodifiableList(Arrays.asList(UNIVERSAL_FORMAT_HUDI, UNIVERSAL_FORMAT_ICEBERG));
+      Collections.unmodifiableList(
+          Arrays.asList(UniversalFormats.FORMAT_HUDI, UniversalFormats.FORMAT_ICEBERG));
 
   /** Table config that allows for translation of Delta metadata to other table formats metadata. */
   public static final TableConfig<Set<String>> UNIVERSAL_FORMAT_ENABLED_FORMATS =
@@ -295,7 +298,7 @@ public class TableConfig<T> {
           "delta.universalFormat.enabledFormats",
           null,
           TableConfig::parseStringSet,
-          value -> value.stream().allMatch(ALLOWED_UNIFORM_FORMATS::contains),
+          value -> ALLOWED_UNIFORM_FORMATS.containsAll(value),
           String.format("each value must in the the set: %s", ALLOWED_UNIFORM_FORMATS),
           true);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -33,6 +33,7 @@ import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdater;
+import io.delta.kernel.internal.icebergcompat.IcebergUniversalFormatMetadataValidatorAndUpdater;
 import io.delta.kernel.internal.icebergcompat.IcebergWriterCompatV1MetadataValidatorAndUpdater;
 import io.delta.kernel.internal.metrics.SnapshotMetrics;
 import io.delta.kernel.internal.metrics.SnapshotQueryContext;
@@ -218,6 +219,13 @@ public class TransactionBuilderImpl implements TransactionBuilder {
             isNewTable, newMetadata.orElse(snapshotMetadata), newProtocol.orElse(snapshotProtocol));
     if (icebergCompatV2Metadata.isPresent()) {
       newMetadata = icebergCompatV2Metadata;
+    }
+
+    Optional<Metadata> universalFormatMetadata =
+        IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
+            newMetadata.orElse(snapshotMetadata));
+    if (universalFormatMetadata.isPresent()) {
+      newMetadata = universalFormatMetadata;
     }
 
     /* ----- 4: Update the METADATA with column mapping info if applicable ----- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -221,9 +221,6 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       newMetadata = icebergCompatV2Metadata;
     }
 
-    IcebergUniversalFormatMetadataValidatorAndUpdater.validate(
-        newMetadata.orElse(snapshotMetadata));
-
     /* ----- 4: Update the METADATA with column mapping info if applicable ----- */
     // We update the column mapping info here after all configuration changes are finished
     Optional<Metadata> columnMappingMetadata =
@@ -322,6 +319,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         oldMetadata.getConfiguration(), newMetadata.getConfiguration(), isNewTable);
     IcebergWriterCompatV1MetadataValidatorAndUpdater.validateIcebergWriterCompatV1Change(
         oldMetadata.getConfiguration(), newMetadata.getConfiguration(), isNewTable);
+    IcebergUniversalFormatMetadataValidatorAndUpdater.validate(newMetadata);
 
     // TODO In the future validate any schema change
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -223,7 +223,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
 
     Optional<Metadata> universalFormatMetadata =
         IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-            newMetadata.orElse(snapshotMetadata));
+            newMetadata.orElse(snapshotMetadata), snapshotMetadata);
     if (universalFormatMetadata.isPresent()) {
       newMetadata = universalFormatMetadata;
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -221,9 +221,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       newMetadata = icebergCompatV2Metadata;
     }
 
-    if (newMetadata.isPresent()) {
-      IcebergUniversalFormatMetadataValidatorAndUpdater.validate(newMetadata.get());
-    }
+    IcebergUniversalFormatMetadataValidatorAndUpdater.validate(
+        newMetadata.orElse(snapshotMetadata));
 
     /* ----- 4: Update the METADATA with column mapping info if applicable ----- */
     // We update the column mapping info here after all configuration changes are finished

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -223,7 +223,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
 
     Optional<Metadata> universalFormatMetadata =
         IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-            newMetadata.orElse(snapshotMetadata), snapshotMetadata);
+            snapshotMetadata, newMetadata.orElse(snapshotMetadata));
     if (universalFormatMetadata.isPresent()) {
       newMetadata = universalFormatMetadata;
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -221,11 +221,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       newMetadata = icebergCompatV2Metadata;
     }
 
-    Optional<Metadata> universalFormatMetadata =
-        IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-            snapshotMetadata, newMetadata.orElse(snapshotMetadata));
-    if (universalFormatMetadata.isPresent()) {
-      newMetadata = universalFormatMetadata;
+    if (newMetadata.isPresent()) {
+      IcebergUniversalFormatMetadataValidatorAndUpdater.validate(newMetadata.get());
     }
 
     /* ----- 4: Update the METADATA with column mapping info if applicable ----- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
@@ -53,8 +53,6 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
     boolean isIcebergEnabled = targetFormats.contains(TableConfig.UniversalFormats.FORMAT_ICEBERG);
     boolean isIcebergCompatV2Enabled = TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(metadata);
     if (isIcebergEnabled && !isIcebergCompatV2Enabled) {
-      // ICEBERG universal format is enabled but ICEBERG_COMPAT_V2_ENABLED is not set to true
-      // in metadata.
       throw new InvalidConfigurationValueException(
           TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey(),
           TableConfig.UniversalFormats.FORMAT_ICEBERG,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
@@ -33,7 +33,7 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
    *
    * <p>If required {@linkplain TableConfig}s are no longer set to a supported a target format the
    * target format will be removed from the returned {@linkplain Metadata} object. If the required
-   * configs were not set in {@argument currentMetadata} then an exception is raised.
+   * configs were not set in {@code currentMetadata} then an exception is raised.
    *
    * <p>"hudi" is trivially compatible with Metadata.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.internal.icebergcompat;
 
+import io.delta.kernel.exceptions.InvalidConfigurationValueException;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import java.util.Collections;
@@ -28,34 +29,54 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
   private IcebergUniversalFormatMetadataValidatorAndUpdater() {}
 
   /**
-   * Ensures the metadata is consistent with the enabled Universal output targets.
+   * Ensures the newMetadata is consistent with the enabled Universal output targets.
    *
-   * <p>If required {@linkplain TableConfig}s are not set to a supported a target format the target
-   * format will be removed from the returned {@linkplain Metadata} object.
+   * <p>If required {@linkplain TableConfig}s are no longer set to a supported a target format the
+   * target format will be removed from the returned {@linkplain Metadata} object. If the required
+   * configs were not set in {@argument currentMetadata} then an exception is raised.
    *
    * <p>"hudi" is trivially compatible with Metadata.
    *
    * <p>"iceberg" requires that {@linkplain TableConfig#ICEBERG_COMPAT_V2_ENABLED} is set to true.
    *
-   * @return An updated metadata that removes invalid uniform values if the other required
+   * @return An updated newMetadata that removes invalid uniform values if the other required
    *     TableConfig properties are not set. Optional.empty() is returned if no changes are
    *     necessary.
+   * @throws InvalidConfigurationValueException newMetadata has ICEBERG universal format enabled and
+   *     {@linkplain TableConfig#ICEBERG_COMPAT_V2_ENABLED} is not enabled in newMetadata and not
+   *     enabled in currentMetadata.
    */
-  public static Optional<Metadata> validateAndUpdate(Metadata metadata) {
-    if (!metadata
+  public static Optional<Metadata> validateAndUpdate(
+      Metadata newMetadata, Metadata currentMetadata) {
+    if (!newMetadata
         .getConfiguration()
         .containsKey(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey())) {
       return Optional.empty();
     }
-    Set<String> targetFormats = TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(metadata);
+    Set<String> targetFormats =
+        TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(newMetadata);
     if (!targetFormats.contains(TableConfig.UNIVERSAL_FORMAT_ICEBERG)) {
       return Optional.empty();
     }
 
-    if (TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(metadata)) {
+    if (TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(newMetadata)) {
       return Optional.empty();
     }
 
+    boolean wasIcebergCompatEnabled =
+        TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(currentMetadata);
+    if (!wasIcebergCompatEnabled) {
+      // The user is trying to turn on the new iceberg universal format without enabling iceberg v2.
+      throw new InvalidConfigurationValueException(
+          TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey(),
+          TableConfig.UNIVERSAL_FORMAT_ICEBERG,
+          String.format(
+              "%s must be set to \"true\" to enable iceberg uniform format.",
+              TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey()));
+    }
+
+    // The user disabled iceberg compat v2, so automatically remove iceberg from the list of target
+    // formats.
     String updatedFormats =
         targetFormats.stream()
             .filter(s -> !TableConfig.UNIVERSAL_FORMAT_ICEBERG.equals(s))
@@ -64,8 +85,8 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
     if (updatedFormats.isEmpty()) {
       // No reason to keep the key in the map.
       return Optional.of(
-          metadata.withReplacedConfiguration(
-              metadata.getConfiguration().entrySet().stream()
+          newMetadata.withReplacedConfiguration(
+              newMetadata.getConfiguration().entrySet().stream()
                   .filter(
                       e ->
                           !e.getKey().equals(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey()))
@@ -74,6 +95,6 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
     Map<String, String> updatedTargetMap =
         Collections.singletonMap(
             TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey(), updatedFormats);
-    return Optional.of(metadata.withMergedConfiguration(updatedTargetMap));
+    return Optional.of(newMetadata.withMergedConfiguration(updatedTargetMap));
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
@@ -57,7 +57,7 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
           TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey(),
           TableConfig.UniversalFormats.FORMAT_ICEBERG,
           String.format(
-              "%s must be set to \"true\" to enable iceberg uniform format.",
+              "'%s' must be set to \"true\" to enable iceberg uniform format.",
               TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey()));
     }
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.icebergcompat;
+
+import io.delta.kernel.internal.TableConfig;
+import io.delta.kernel.internal.actions.Metadata;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Utility class that enforces dependencies of UNIVERSAL_FORMAT_* options. */
+public class IcebergUniversalFormatMetadataValidatorAndUpdater {
+  private IcebergUniversalFormatMetadataValidatorAndUpdater() {}
+
+  /**
+   * Ensures the metadata is consistent with the enabled Universal output targets.
+   *
+   * <p>If required {@linkplain TableConfig}s are not set to a supported a target format the target
+   * format will be removed from the returned {@linkplain Metadata} object.
+   *
+   * <p>"hudi" is trivially compatible with Metadata.
+   *
+   * <p>"iceberg" requires that {@linkplain TableConfig#ICEBERG_COMPAT_V2_ENABLED} is set to true.
+   *
+   * @return An updated metadata that removes invalid uniform values if the other required
+   *     TableConfig properties are not set. Optional.empty() is returned if no changes are
+   *     necessary.
+   */
+  public static Optional<Metadata> validateAndUpdate(Metadata metadata) {
+    if (!metadata
+        .getConfiguration()
+        .containsKey(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey())) {
+      return Optional.empty();
+    }
+    Set<String> targetFormats = TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(metadata);
+    if (!targetFormats.contains(TableConfig.UNIVERSAL_FORMAT_ICEBERG)) {
+      return Optional.empty();
+    }
+
+    if (TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(metadata)) {
+      return Optional.empty();
+    }
+
+    String updatedFormats =
+        targetFormats.stream()
+            .filter(s -> !TableConfig.UNIVERSAL_FORMAT_ICEBERG.equals(s))
+            .collect(Collectors.joining(","));
+
+    if (updatedFormats.isEmpty()) {
+      // No reason to keep the key in the map.
+      return Optional.of(
+          metadata.withReplacedConfiguration(
+              metadata.getConfiguration().entrySet().stream()
+                  .filter(
+                      e ->
+                          !e.getKey().equals(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey()))
+                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+    }
+    Map<String, String> updatedTargetMap =
+        Collections.singletonMap(
+            TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey(), updatedFormats);
+    return Optional.of(metadata.withMergedConfiguration(updatedTargetMap));
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
@@ -47,7 +47,7 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
    *     enabled in currentMetadata.
    */
   public static Optional<Metadata> validateAndUpdate(
-      Metadata newMetadata, Metadata currentMetadata) {
+      Metadata currentMetadata, Metadata newMetadata) {
     if (!newMetadata
         .getConfiguration()
         .containsKey(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey())) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdater.java
@@ -55,7 +55,7 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
     }
     Set<String> targetFormats =
         TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(newMetadata);
-    if (!targetFormats.contains(TableConfig.UNIVERSAL_FORMAT_ICEBERG)) {
+    if (!targetFormats.contains(TableConfig.UniversalFormats.FORMAT_ICEBERG)) {
       return Optional.empty();
     }
 
@@ -69,7 +69,7 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
       // The user is trying to turn on the new iceberg universal format without enabling iceberg v2.
       throw new InvalidConfigurationValueException(
           TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey(),
-          TableConfig.UNIVERSAL_FORMAT_ICEBERG,
+          TableConfig.UniversalFormats.FORMAT_ICEBERG,
           String.format(
               "%s must be set to \"true\" to enable iceberg uniform format.",
               TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey()));
@@ -79,7 +79,7 @@ public class IcebergUniversalFormatMetadataValidatorAndUpdater {
     // formats.
     String updatedFormats =
         targetFormats.stream()
-            .filter(s -> !TableConfig.UNIVERSAL_FORMAT_ICEBERG.equals(s))
+            .filter(s -> !TableConfig.UniversalFormats.FORMAT_ICEBERG.equals(s))
             .collect(Collectors.joining(","));
 
     if (updatedFormats.isEmpty()) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -32,7 +32,8 @@ class TableConfigSuite extends AnyFunSuite {
         TableConfig.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.getKey -> "1",
         TableConfig.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.getKey -> "1",
         TableConfig.COLUMN_MAPPING_MODE.getKey -> "name",
-        TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true").asJava)
+        TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
+        TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg").asJava)
   }
 
   test("check TableConfig.MAX_COLUMN_ID.editable is false") {
@@ -50,5 +51,25 @@ class TableConfigSuite extends AnyFunSuite {
       s"The Delta table property " +
       s"'${TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey}'" +
       s" is an internal property and cannot be updated.")
+  }
+
+  Seq(
+    Map[String, String](),
+    Map(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "")).foreach {
+    config =>
+      {
+        test(
+          s"Parsing UNIVERSAL_ENABLED formats returns empty set when key is not present $config") {
+          val formats = TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(config.asJava)
+          assert(formats.isEmpty)
+        }
+      }
+  }
+
+  test("Parsing UNIVERSAL_ENABLED_FORMATS can parse spaces") {
+    val FORMATS_KEY = TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey
+    val config = Map(FORMATS_KEY -> "iceberg, hudi ").asJava
+    val formats = TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(config)
+    assert(formats == Set("iceberg", "hudi").asJava)
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
@@ -61,9 +61,9 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
       val exc = intercept[InvalidConfigurationValueException] {
         IcebergUniversalFormatMetadataValidatorAndUpdater.validate(metadata)
       }
-      assert(exc.getMessage == "Invalid value for table property 'delta.universalFormat.enabledFormats': 'iceberg'." +
-        " 'delta.enableIcebergCompatV2' must be set to \"true\" to enable iceberg uniform format.")
-
+      assert(exc.getMessage == "Invalid value for table property " +
+        "'delta.universalFormat.enabledFormats': 'iceberg'. " +
+        "'delta.enableIcebergCompatV2' must be set to \"true\" to enable iceberg uniform format.")
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
@@ -31,8 +31,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
   test("validateAndUpdate should return empty when UNIVERSAL_FORMAT_ENABLED_FORMATS is not set") {
     val metadata = createMetadata(Map("unrelated_key" -> "unrelated_value"))
     val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-      metadata,
-      createMetadata())
+      createMetadata(),
+      metadata)
     assert(!result.isPresent)
   }
 
@@ -42,8 +42,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
       TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "hudi",
       "unrelated_key" -> "unrelated_value"))
     val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-      metadata,
-      createMetadata())
+      createMetadata(),
+      metadata)
     assert(!result.isPresent)
   }
 
@@ -54,8 +54,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
       TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
       "unrelated_key" -> "unrelated_value"))
     val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-      metadata,
-      createMetadata())
+      createMetadata(),
+      metadata)
     assert(!result.isPresent)
   }
 
@@ -68,8 +68,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
         TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg,hudi",
         "unrelated_key" -> "unrelated_value") ++ disabledIcebergCompatV2Enabled)
       val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-        metadata,
-        createMetadata(Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")))
+        createMetadata(Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")),
+        metadata)
       assert(result.isPresent)
       assert(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(result.get()) == Set(
         "hudi").asJava)
@@ -88,8 +88,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
         TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg",
         "unrelated_key" -> "unrelated_value"))
       val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-        metadata,
-        createMetadata(Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")))
+        createMetadata(Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")),
+        metadata)
       assert(result.isPresent)
       val updatedConfig = result.get().getConfiguration
       assert(!updatedConfig.containsKey(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey))
@@ -107,8 +107,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
         "unrelated_key" -> "unrelated_value"))
       intercept[KernelException] {
         IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(
-          metadata,
-          createMetadata())
+          createMetadata(),
+          metadata)
       }
     }
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
@@ -42,7 +42,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
     assert(result.isEmpty)
   }
 
-  test("validateAndUpdate should return empty when iceberg is enabled and ICEBERG_COMPAT_V2_ENABLED is true") {
+  test("validateAndUpdate should return empty when iceberg is enabled" +
+    " and ICEBERG_COMPAT_V2_ENABLED is true") {
     val metadata = createMetadata(Map(
       TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg,hudi",
       TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
@@ -54,7 +55,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
   Seq(
     Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false"),
     Map[String, String]()).foreach { disabledIcebergCompatV2Enabled =>
-    test(s"validateAndUpdate should remove iceberg when ICEBERG_COMPAT_V2_ENABLED $disabledIcebergCompatV2Enabled") {
+    test(s"validateAndUpdate should remove iceberg when" +
+      s" ICEBERG_COMPAT_V2_ENABLED $disabledIcebergCompatV2Enabled") {
       val metadata = createMetadata(Map(
         TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg,hudi",
         "unrelated_key" -> "unrelated_value") ++ disabledIcebergCompatV2Enabled)
@@ -71,7 +73,8 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
   Seq(
     Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false"),
     Map[String, String]()).foreach { disableIcebergCompatV2Enabled =>
-    test(s"validateAndUpdate should remove key entirely when only iceberg is present and not compatible $disableIcebergCompatV2Enabled") {
+    test("validateAndUpdate should remove key entirely when only iceberg is present " +
+      s"and not compatible $disableIcebergCompatV2Enabled") {
       val metadata = createMetadata(Map(
         TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg",
         "unrelated_key" -> "unrelated_value"))

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
@@ -15,8 +15,6 @@
  */
 package io.delta.kernel.internal.icebergcompat
 
-import scala.collection.JavaConverters._
-
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.actions.Metadata
@@ -35,7 +33,7 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
   }
 
   test(
-    "validate shouldn't throw with valid Hudi properties") {
+    "validate shouldn't throw with valid Hudi enabled.") {
     val metadata = createMetadata(Map(
       TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "hudi",
       "unrelated_key" -> "unrelated_value"))
@@ -43,7 +41,7 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
   }
 
   test(
-    "validate shouldn't throw with Iceberg UNIVERSAL_FORMAT_ENABLED_FORMATS when compat is enabled") {
+    "validate can enable iceberg universal compat is enabled and icebergCompatV2 is enabled") {
     val metadata = createMetadata(Map(
       TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg,hudi",
       TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
@@ -53,9 +51,10 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
 
   Seq(
     Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false"),
-    Map[String, String]()).foreach { disableIcebergCompatV2Enabled =>
+    Map[String, String]()).foreach { disableIcebergCompatV2 =>
     test(
-      s"validate should throw when iceberg compat is not enabled $disableIcebergCompatV2Enabled") {
+      "validate should throw when iceberg universal format is enabled and "
+        + s"icebergCompatV2 isn't $disableIcebergCompatV2") {
       val metadata = createMetadata(Map(
         TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg",
         "unrelated_key" -> "unrelated_value"))

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
@@ -15,7 +15,7 @@
  */
 package io.delta.kernel.internal.icebergcompat
 
-import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.exceptions.{InvalidConfigurationValueException, KernelException}
 import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.actions.Metadata
 import io.delta.kernel.internal.util.ColumnMappingSuiteBase
@@ -57,10 +57,13 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
         + s"icebergCompatV2 isn't $disableIcebergCompatV2") {
       val metadata = createMetadata(Map(
         TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg",
-        "unrelated_key" -> "unrelated_value"))
-      intercept[KernelException] {
+        "unrelated_key" -> "unrelated_value") ++ disableIcebergCompatV2)
+      val exc = intercept[InvalidConfigurationValueException] {
         IcebergUniversalFormatMetadataValidatorAndUpdater.validate(metadata)
       }
+      assert(exc.getMessage == "Invalid value for table property 'delta.universalFormat.enabledFormats': 'iceberg'." +
+        " 'delta.enableIcebergCompatV2' must be set to \"true\" to enable iceberg uniform format.")
+
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
@@ -30,7 +30,7 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
   test("validateAndUpdate should return empty when UNIVERSAL_FORMAT_ENABLED_FORMATS is not set") {
     val metadata = createMetadata(Map("unrelated_key" -> "unrelated_value"))
     val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
-    assert(result.isEmpty)
+    assert(!result.isPresent)
   }
 
   test(
@@ -39,7 +39,7 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
       TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "hudi",
       "unrelated_key" -> "unrelated_value"))
     val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
-    assert(result.isEmpty)
+    assert(!result.isPresent)
   }
 
   test("validateAndUpdate should return empty when iceberg is enabled" +
@@ -49,7 +49,7 @@ class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuite
       TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
       "unrelated_key" -> "unrelated_value"))
     val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
-    assert(result.isEmpty)
+    assert(!result.isPresent)
   }
 
   Seq(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergUniversalFormatMetadataValidatorAndUpdaterSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.icebergcompat
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.internal.TableConfig
+import io.delta.kernel.internal.actions.Metadata
+import io.delta.kernel.internal.util.ColumnMappingSuiteBase
+import io.delta.kernel.types.IntegerType
+import io.delta.kernel.types.StructType
+
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class IcebergUniversalFormatMetadataValidatorAndUpdaterSuite extends AnyFunSuiteLike
+    with ColumnMappingSuiteBase {
+  test("validateAndUpdate should return empty when UNIVERSAL_FORMAT_ENABLED_FORMATS is not set") {
+    val metadata = createMetadata(Map("unrelated_key" -> "unrelated_value"))
+    val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
+    assert(result.isEmpty)
+  }
+
+  test(
+    "validateAndUpdate should return empty when no iceberg in UNIVERSAL_FORMAT_ENABLED_FORMATS") {
+    val metadata = createMetadata(Map(
+      TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "hudi",
+      "unrelated_key" -> "unrelated_value"))
+    val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
+    assert(result.isEmpty)
+  }
+
+  test("validateAndUpdate should return empty when iceberg is enabled and ICEBERG_COMPAT_V2_ENABLED is true") {
+    val metadata = createMetadata(Map(
+      TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg,hudi",
+      TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
+      "unrelated_key" -> "unrelated_value"))
+    val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
+    assert(result.isEmpty)
+  }
+
+  Seq(
+    Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false"),
+    Map[String, String]()).foreach { disabledIcebergCompatV2Enabled =>
+    test(s"validateAndUpdate should remove iceberg when ICEBERG_COMPAT_V2_ENABLED $disabledIcebergCompatV2Enabled") {
+      val metadata = createMetadata(Map(
+        TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg,hudi",
+        "unrelated_key" -> "unrelated_value") ++ disabledIcebergCompatV2Enabled)
+      val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
+      assert(result.isPresent)
+      assert(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(result.get()) == Set(
+        "hudi").asJava)
+
+      val updatedConfig = result.get().getConfiguration
+      assert(updatedConfig.get("unrelated_key") === "unrelated_value")
+    }
+  }
+
+  Seq(
+    Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false"),
+    Map[String, String]()).foreach { disableIcebergCompatV2Enabled =>
+    test(s"validateAndUpdate should remove key entirely when only iceberg is present and not compatible $disableIcebergCompatV2Enabled") {
+      val metadata = createMetadata(Map(
+        TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg",
+        "unrelated_key" -> "unrelated_value"))
+      val result = IcebergUniversalFormatMetadataValidatorAndUpdater.validateAndUpdate(metadata)
+      assert(result.isPresent)
+      val updatedConfig = result.get().getConfiguration
+      assert(!updatedConfig.containsKey(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey))
+      assert(updatedConfig.get("unrelated_key") === "unrelated_value")
+    }
+  }
+
+  def createMetadata(tblProps: Map[String, String]): Metadata = {
+    val schema = new StructType()
+      .add("c1", IntegerType.INTEGER)
+    testMetadata(schema, tblProps = tblProps)
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -24,7 +24,7 @@ import io.delta.kernel.{Operation, Table}
 import io.delta.kernel.Operation.CREATE_TABLE
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.Literal
-import io.delta.kernel.internal.SnapshotImpl
+import io.delta.kernel.internal.{SnapshotImpl, TableConfig}
 import io.delta.kernel.internal.actions.{Protocol => KernelProtocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.types.{StructType, TimestampNTZType}
@@ -281,6 +281,32 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
         s"${writtenSnapshot.getProtocol.getExplicitlySupportedFeatures}")
       assert(writtenSnapshot.getMetadata.getConfiguration == Map(
         "delta.enableDeletionVectors" -> "true").asJava)
+    }
+  }
+
+  test("UNIVERSAL_FORMAT feature can be populated") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val properties =
+        Map(
+          TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.getKey -> "iceberg",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
+      createEmptyTable(engine, tablePath, testSchema, tableProperties = properties)
+
+      val table = Table.forPath(engine, tablePath)
+      val writtenSnapshot = latestSnapshot(table, engine)
+      assert(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(
+        writtenSnapshot.getMetadata).contains(TableConfig.UNIVERSAL_FORMAT_ICEBERG))
+
+      val txn = table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+        .withTableProperties(
+          engine,
+          Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false").asJava)
+        .build(engine)
+      txn.commit(engine, emptyIterable())
+
+      val updatedSnapshot = latestSnapshot(table, engine)
+      assert(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(
+        updatedSnapshot.getMetadata).isEmpty)
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -298,17 +298,6 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
       val writtenSnapshot = latestSnapshot(table, engine)
       assert(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(
         writtenSnapshot.getMetadata).contains(UniversalFormats.FORMAT_ICEBERG))
-
-      val txn = table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
-        .withTableProperties(
-          engine,
-          Map(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "false").asJava)
-        .build(engine)
-      txn.commit(engine, emptyIterable())
-
-      val updatedSnapshot = latestSnapshot(table, engine)
-      assert(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(
-        updatedSnapshot.getMetadata).isEmpty)
     }
   }
 
@@ -317,7 +306,6 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
       createEmptyTable(engine, tablePath, testSchema)
 
       val table = Table.forPath(engine, tablePath)
-      val writtenSnapshot = latestSnapshot(table, engine)
 
       intercept[InvalidConfigurationValueException] {
         table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -26,6 +26,7 @@ import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.{InvalidConfigurationValueException, KernelException}
 import io.delta.kernel.expressions.Literal
 import io.delta.kernel.internal.{SnapshotImpl, TableConfig}
+import io.delta.kernel.internal.TableConfig.UniversalFormats
 import io.delta.kernel.internal.actions.{Protocol => KernelProtocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.types.{StructType, TimestampNTZType}
@@ -296,7 +297,7 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
       val table = Table.forPath(engine, tablePath)
       val writtenSnapshot = latestSnapshot(table, engine)
       assert(TableConfig.UNIVERSAL_FORMAT_ENABLED_FORMATS.fromMetadata(
-        writtenSnapshot.getMetadata).contains(TableConfig.UNIVERSAL_FORMAT_ICEBERG))
+        writtenSnapshot.getMetadata).contains(UniversalFormats.FORMAT_ICEBERG))
 
       val txn = table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
         .withTableProperties(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -301,7 +301,7 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
     }
   }
 
-  test("UNIVERSAL_FORMAT feature will throw if IcebergCompat was not enabled") {
+  test("UNIVERSAL_FORMAT feature will throw if icebergCompatV2 was not enabled") {
     withTempDirAndEngine { (tablePath, engine) =>
       createEmptyTable(engine, tablePath, testSchema)
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This added Uniform TableConfig properties and a validator/updater for metadata that ensures uniform values for iceberg are not set unless table compat v2 is not set.  The existing delta code is [here](https://github.com/delta-io/delta/blob/ae4a83fb879259b10807ce02166c188c04214aab/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala#L169) for reference)

Resolves #4374

## How was this patch tested?

Added tests for:

* TableConfig property
* The updater/validator
* An additional e2e test in DeltaTableFeaturesSuite

## Does this PR introduce _any_ user-facing changes?

Yes, it allows users to set Universal format table properties.
