### PR TITLE
[Spark ]Add config to disable schema tracking for type widening

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1309,6 +1309,17 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_TYPE_WIDENING_ENABLE_STREAMING_SCHEMA_TRACKING =
+    buildConf("typeWidening.enableStreamingSchemaTracking")
+      .doc("Whether to enable schema tracking when streaming from a Delta source that had a " +
+        "widening type change applied. This allows blocking the stream on restart until the user " +
+        "acknowledges the type change. When disabled, we will not initialize a schema tracking " +
+        "log when first detecting a type change and will automatically accept the type change " +
+        "instead.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_TYPE_WIDENING_BYPASS_STREAMING_TYPE_CHANGE_CHECK =
     buildConf("typeWidening.bypassStreamingTypeChangeCheck")
       .doc("Controls the check performed when a type change is detected when streaming from a " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.typewidening
 import java.io.File
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.SparkArithmeticException
@@ -618,5 +619,39 @@ trait TypeWideningStreamingSourceTests
         )
       }
     }
+  }
+
+  test("disable schema tracking log using internal conf") {
+     withTempDir { dir =>
+       sql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+       val checkpointDir = new File(dir, "sink_checkpoint")
+
+       def readStream(): DataFrame =
+         spark.readStream.format("delta").load(dir.getCanonicalPath)
+
+       // When we disable schema tracking for widening type changes, the stream should succeed
+       // without requiring the user to provide a schema tracking location or unblock the type
+       // change.
+       withSQLConf(
+         DeltaSQLConf.DELTA_TYPE_WIDENING_ENABLE_STREAMING_SCHEMA_TRACKING.key -> "false") {
+         testStream(readStream())(
+           StartStream(checkpointLocation = checkpointDir.toString),
+           Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+           ProcessAllAvailable(),
+           Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
+           ExpectFailure[DeltaIllegalStateException] { ex =>
+             assert(ex.asInstanceOf[SparkThrowable].getErrorClass ===
+               "DELTA_SCHEMA_CHANGED_WITH_VERSION")
+           }
+         )
+
+         testStream(readStream())(
+           StartStream(checkpointLocation = checkpointDir.toString),
+           Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+           ProcessAllAvailable(),
+           CheckLastBatch(123456789)
+         )
+       }
+     }
   }
 }


### PR DESCRIPTION
## Description
Add an internal config to disable tracking schema used to block widening type changes when streaming from a Delta table.
The default will remain to have schema tracking enabled, this only provides flexibility in case we need to disable this feature.

## How was this patch tested?
Added a test to cover the new config.

## Does this PR introduce _any_ user-facing changes?
No