### PR TITLE
[SPARK] Actualize sqlState for delta feature drop errors

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -984,7 +984,7 @@
     "message" : [
       "Unable to operate on this table because the following table features are enabled in metadata but not listed in protocol: <features>."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "KD004"
   },
   "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT" : {
     "message" : [
@@ -996,7 +996,7 @@
       "",
       "Current supported feature(s): <supportedFeatures>."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "42000"
   },
   "DELTA_FEATURE_CAN_ONLY_DROP_CHECKPOINT_PROTECTION_WITH_HISTORY_TRUNCATION" : {
     "message" : [
@@ -1033,20 +1033,20 @@
       "Please try the operation again.",
       "<concurrentCommit>"
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "40000"
   },
   "DELTA_FEATURE_DROP_DEPENDENT_FEATURE" : {
     "message" : [
       "Cannot drop table feature `<feature>` because some other features (<dependentFeatures>) in this table depends on `<feature>`.",
       "Consider dropping them first before dropping this feature."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "55000"
   },
   "DELTA_FEATURE_DROP_FEATURE_NOT_PRESENT" : {
     "message" : [
       "Cannot drop <feature> from this table because it is not currently present in the table's protocol."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "55000"
   },
   "DELTA_FEATURE_DROP_HISTORICAL_VERSIONS_EXIST" : {
     "message" : [
@@ -1058,26 +1058,26 @@
       "and then run:",
       "    ALTER TABLE table_name DROP FEATURE feature_name TRUNCATE HISTORY"
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "22KD0"
   },
   "DELTA_FEATURE_DROP_HISTORY_TRUNCATION_NOT_ALLOWED" : {
     "message" : [
       "The particular feature does not require history truncation."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "42000"
   },
   "DELTA_FEATURE_DROP_NONREMOVABLE_FEATURE" : {
     "message" : [
       "Cannot drop <feature> because dropping this feature is not supported."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "0AKDC"
   },
   "DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE" : {
     "message" : [
       "Cannot drop <feature> because it is not supported by this Delta version.",
       "Consider using Delta with a higher version."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "0AKDC"
   },
   "DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD" : {
     "message" : [
@@ -1095,19 +1095,19 @@
       "and then run:",
       "    ALTER TABLE table_name DROP FEATURE feature_name TRUNCATE HISTORY"
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "22KD0"
   },
   "DELTA_FEATURE_REQUIRES_HIGHER_READER_VERSION" : {
     "message" : [
       "Unable to enable table feature <feature> because it requires a higher reader protocol version (current <current>). Consider upgrading the table's reader protocol version to <required>, or to a version which supports reader table features. Refer to <docLink> for more information on table protocol versions."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "0AKDC"
   },
   "DELTA_FEATURE_REQUIRES_HIGHER_WRITER_VERSION" : {
     "message" : [
       "Unable to enable table feature <feature> because it requires a higher writer protocol version (current <current>). Consider upgrading the table's writer protocol version to <required>, or to a version which supports writer table features. Refer to <docLink> for more information on table protocol versions."
     ],
-    "sqlState" : "0AKDE"
+    "sqlState" : "0AKDC"
   },
   "DELTA_FILE_ALREADY_EXISTS" : {
     "message" : [

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1600,7 +1600,7 @@ trait DeltaErrorsSuiteBase
         throw DeltaErrors.tableFeatureDropHistoryTruncationNotAllowed()
       }
       checkErrorMessage(e, Some("DELTA_FEATURE_DROP_HISTORY_TRUNCATION_NOT_ALLOWED"),
-        Some("0AKDE"), Some("The particular feature does not require history truncation."))
+        Some("42000"), Some("The particular feature does not require history truncation."))
     }
     {
       val logRetention = DeltaConfigs.LOG_RETENTION
@@ -1624,7 +1624,7 @@ trait DeltaErrorsSuiteBase
           |Alternatively, please wait for the TRUNCATE HISTORY retention period to expire (24 hours)
           |and then run:
           |    ALTER TABLE table_name DROP FEATURE feature_name TRUNCATE HISTORY""".stripMargin
-      checkErrorMessage(e, Some("DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD"), Some("0AKDE"),
+      checkErrorMessage(e, Some("DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD"), Some("22KD0"),
         Some(expectedMessage))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

sqlState is visible to user, so followed error codes will use new sqlStates:

DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH: KD004 (Delta protocol version error)
DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT: 42000 (Syntax error or access rule violation)
DELTA_FEATURE_DROP_CONFLICT_REVALIDATION_FAIL: 40000 (transaction rollback)
DELTA_FEATURE_DROP_DEPENDENT_FEATURE: 55000 (Object Not In Prerequisite State)
DELTA_FEATURE_DROP_FEATURE_NOT_PRESENT: 55000 (Object Not In Prerequisite State)
DELTA_FEATURE_DROP_HISTORICAL_VERSIONS_EXIST: 22KD0 (Data exception: transient error)
DELTA_FEATURE_DROP_HISTORY_TRUNCATION_NOT_ALLOWED: 42000 (syntax error or access rule violation)
DELTA_FEATURE_DROP_NONREMOVABLE_FEATURE: 0AKDC (Not supported in Delta)
DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE: 0AKDC (Not supported in Delta)
DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD: 22KD0 (Data exception: transient error)
DELTA_FEATURE_REQUIRES_HIGHER_READER_VERSION: 0AKDC (Not supported in Delta)
DELTA_FEATURE_REQUIRES_HIGHER_WRITER_VERSION: 0AKDC (Not supported in Delta)

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
