### PR TITLE
[Kernel][IcebergWriterCompatV1] Update column mapping so physicalName='col-{columnId}' and enforce this as part of our checks

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -304,6 +304,22 @@ public final class DeltaErrors {
     throw new KernelException(
         format("%s: requires the feature '%s' to be enabled.", compatVersion, feature));
   }
+
+  public static KernelException enablingIcebergWriterCompatV1OnExistingTable(String key) {
+    return new KernelException(
+        String.format(
+            "Cannot enable %s on an existing table. "
+                + "Enablement is only supported upon table creation.",
+            key));
+  }
+
+  public static KernelException icebergWriterCompatInvalidPhysicalName(List<String> invalidFields) {
+    return new KernelException(
+        String.format(
+            "IcebergWriterCompatV1 requires column mapping field physical names be equal to "
+                + "'col-[fieldId]', but this is not true for the following fields %s",
+            invalidFields));
+  }
   // End: icebergCompat exceptions
 
   public static KernelException partitionColumnMissingInData(
@@ -374,14 +390,6 @@ public final class DeltaErrors {
     return new KernelException(
         "Feature 'rowTracking' is supported and depends on feature 'domainMetadata',"
             + " but 'domainMetadata' is unsupported");
-  }
-
-  public static KernelException enablingIcebergWriterCompatV1OnExistingTable(String key) {
-    return new KernelException(
-        String.format(
-            "Cannot enable %s on an existing table. "
-                + "Enablement is only supported upon table creation.",
-            key));
   }
 
   /* ------------------------ HELPER METHODS ----------------------------- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -219,6 +219,12 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     // Ex: We enable column mapping mode in the configuration such that our properties now include
     // Map(delta.enableIcebergCompatV2 -> true, delta.columnMapping.mode -> name)
 
+    // Validate this is a valid config change earlier for a clearer error message
+    newMetadata.ifPresent(
+        metadata ->
+            IcebergWriterCompatV1MetadataValidatorAndUpdater.validateIcebergWriterCompatV1Change(
+                snapshotMetadata.getConfiguration(), metadata.getConfiguration(), isNewTable));
+
     // We must do our icebergWriterCompatV1 checks/updates FIRST since it has stricter column
     // mapping requirements (id mode) than icebergCompatV2. It also may enable icebergCompatV2.
     Optional<Metadata> icebergWriterCompatV1 =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.internal.icebergcompat;
 
 import static io.delta.kernel.internal.tablefeatures.TableFeatures.*;
+import static io.delta.kernel.internal.util.SchemaUtils.concatWithDot;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -117,7 +118,12 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
       new IcebergCompatRequiredTablePropertyEnforcer<>(
           TableConfig.COLUMN_MAPPING_MODE,
           (value) -> ColumnMapping.ColumnMappingMode.ID == value,
-          ColumnMapping.ColumnMappingMode.ID.value);
+          ColumnMapping.ColumnMappingMode.ID.value,
+          // We need to update the CM info in the schema here because we check that the physical
+          // name is correctly set as part of icebergWriterCompatV1 checks
+          (inputContext) ->
+              ColumnMapping.updateColumnMappingMetadataIfNeeded(
+                  inputContext.newMetadata, inputContext.isCreatingNewTable));
 
   private static final IcebergCompatRequiredTablePropertyEnforcer ICEBERG_COMPAT_V2_ENABLED =
       new IcebergCompatRequiredTablePropertyEnforcer<>(
@@ -199,6 +205,38 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
       };
 
   /**
+   * Checks that in the schema column mapping is set up such that the physicalName is equal to
+   * "col-[fieldId]". This check assumes column mapping is enabled (and so should be performed after
+   * that check).
+   */
+  private static final IcebergCompatCheck PHYSICAL_NAMES_MATCH_FIELD_IDS_CHECK =
+      (inputContext) -> {
+        List<Tuple2<List<String>, StructField>> invalidFields =
+            SchemaUtils.filterRecursively(
+                inputContext.newMetadata.getSchema(),
+                /* recurseIntoMapAndArrayTypes= */ true,
+                /* stopOnFirstMatch = */ false,
+                field -> {
+                  String physicalName = ColumnMapping.getPhysicalName(field);
+                  long columnId = ColumnMapping.getColumnId(field);
+                  return !physicalName.equals(String.format("col-%s", columnId));
+                });
+        if (!invalidFields.isEmpty()) {
+          List<String> invalidFieldsFormatted =
+              invalidFields.stream()
+                  .map(
+                      pair ->
+                          String.format(
+                              "%s(physicalName='%s', columnId=%s)",
+                              concatWithDot(pair._1),
+                              ColumnMapping.getPhysicalName(pair._2),
+                              ColumnMapping.getColumnId(pair._2)))
+                  .collect(toList());
+          throw DeltaErrors.icebergWriterCompatInvalidPhysicalName(invalidFieldsFormatted);
+        }
+      };
+
+  /**
    * Checks that the table feature `invariants` is not active in the table, meaning there are no
    * invariants stored in the table schema.
    */
@@ -237,7 +275,11 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
 
   @Override
   List<IcebergCompatCheck> icebergCompatChecks() {
-    return Stream.of(UNSUPPORTED_FEATURES_CHECK, UNSUPPORTED_TYPES_CHECK, INVARIANTS_INACTIVE_CHECK)
+    return Stream.of(
+            UNSUPPORTED_FEATURES_CHECK,
+            UNSUPPORTED_TYPES_CHECK,
+            PHYSICAL_NAMES_MATCH_FIELD_IDS_CHECK,
+            INVARIANTS_INACTIVE_CHECK)
         .collect(toList());
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -123,6 +123,14 @@ public class ColumnMapping {
     }
   }
 
+  /** Returns the column id for a given {@link StructField} */
+  public static int getColumnId(StructField field) {
+    checkArgument(
+        field.getMetadata().contains(COLUMN_MAPPING_ID_KEY),
+        "Field does not have column id set in it's metadata");
+    return field.getMetadata().getLong(COLUMN_MAPPING_ID_KEY).intValue();
+  }
+
   public static void verifyColumnMappingChange(
       Map<String, String> oldConfig, Map<String, String> newConfig, boolean isNewTable) {
     ColumnMappingMode oldMappingMode = getColumnMappingMode(oldConfig);
@@ -208,10 +216,6 @@ public class ColumnMapping {
 
   static boolean hasPhysicalName(StructField field) {
     return field.getMetadata().contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
-  }
-
-  static int getColumnId(StructField field) {
-    return field.getMetadata().getLong(COLUMN_MAPPING_ID_KEY).intValue();
   }
 
   private static int findMaxColumnId(StructField field, int maxColumnId) {
@@ -315,7 +319,8 @@ public class ColumnMapping {
   /**
    * For each column/field in a {@link Metadata}'s schema, assign an id using the current maximum id
    * as the basis and increment from there. Additionally, assign a physical name based on a random
-   * UUID or re-use the old display name if the mapping mode is updated on an existing table.
+   * UUID or re-use the old display name if the mapping mode is updated on an existing table. When
+   * `icebergWriterCompatV1` is enabled, we assign physical names as 'col-[colId]'.
    *
    * @param metadata The new metadata to assign ids and physical names to
    * @param isNewTable whether this is part of a commit that sets the mapping mode on a new table
@@ -325,6 +330,10 @@ public class ColumnMapping {
   private static Optional<Metadata> assignColumnIdAndPhysicalName(
       Metadata metadata, boolean isNewTable) {
     StructType oldSchema = metadata.getSchema();
+
+    // When icebergWriterCompatV1 is enabled we require physicalName='col-[columnId]'
+    boolean useColumnIdForPhysicalName =
+        TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.fromMetadata(metadata);
 
     // This is the maxColumnId to use when assigning any new field-ids; we update this as we
     // traverse the schema and after traversal this is the value that should be stored in the
@@ -344,9 +353,11 @@ public class ColumnMapping {
       newSchema =
           newSchema.add(
               transformAndAssignColumnIdAndPhysicalName(
-                  assignColumnIdAndPhysicalNameToField(field, maxColumnId, isNewTable),
+                  assignColumnIdAndPhysicalNameToField(
+                      field, maxColumnId, isNewTable, useColumnIdForPhysicalName),
                   maxColumnId,
-                  isNewTable));
+                  isNewTable,
+                  useColumnIdForPhysicalName));
     }
 
     if (Boolean.parseBoolean(
@@ -389,12 +400,17 @@ public class ColumnMapping {
    *     id value is used to keep the current value always the max id
    * @param isNewTable Whether this is a new or an existing table. For existing tables the physical
    *     name will be re-used from the old display name
+   * @param useColumnIdForPhysicalName Whether we should assign physical names to 'col-[colId]'.
+   *     When false uses the default behavior described above.
    * @return A new {@link StructField} with updated metadata under the {@link
    *     ColumnMapping#COLUMN_MAPPING_ID_KEY} and the {@link
    *     ColumnMapping#COLUMN_MAPPING_PHYSICAL_NAME_KEY} keys
    */
   private static StructField transformAndAssignColumnIdAndPhysicalName(
-      StructField field, AtomicInteger maxColumnId, boolean isNewTable) {
+      StructField field,
+      AtomicInteger maxColumnId,
+      boolean isNewTable,
+      boolean useColumnIdForPhysicalName) {
     DataType dataType = field.getDataType();
     if (dataType instanceof StructType) {
       StructType type = (StructType) dataType;
@@ -403,24 +419,28 @@ public class ColumnMapping {
         schema =
             schema.add(
                 transformAndAssignColumnIdAndPhysicalName(
-                    assignColumnIdAndPhysicalNameToField(f, maxColumnId, isNewTable),
+                    assignColumnIdAndPhysicalNameToField(
+                        f, maxColumnId, isNewTable, useColumnIdForPhysicalName),
                     maxColumnId,
-                    isNewTable));
+                    isNewTable,
+                    useColumnIdForPhysicalName));
       }
       return new StructField(field.getName(), schema, field.isNullable(), field.getMetadata());
     } else if (dataType instanceof ArrayType) {
       ArrayType type = (ArrayType) dataType;
       StructField elementField =
           transformAndAssignColumnIdAndPhysicalName(
-              type.getElementField(), maxColumnId, isNewTable);
+              type.getElementField(), maxColumnId, isNewTable, useColumnIdForPhysicalName);
       return new StructField(
           field.getName(), new ArrayType(elementField), field.isNullable(), field.getMetadata());
     } else if (dataType instanceof MapType) {
       MapType type = (MapType) dataType;
       StructField key =
-          transformAndAssignColumnIdAndPhysicalName(type.getKeyField(), maxColumnId, isNewTable);
+          transformAndAssignColumnIdAndPhysicalName(
+              type.getKeyField(), maxColumnId, isNewTable, useColumnIdForPhysicalName);
       StructField value =
-          transformAndAssignColumnIdAndPhysicalName(type.getValueField(), maxColumnId, isNewTable);
+          transformAndAssignColumnIdAndPhysicalName(
+              type.getValueField(), maxColumnId, isNewTable, useColumnIdForPhysicalName);
       return new StructField(
           field.getName(), new MapType(key, value), field.isNullable(), field.getMetadata());
     }
@@ -437,12 +457,17 @@ public class ColumnMapping {
    *     id value is used to keep the current value always the max id
    * @param isNewTable Whether this is a new or an existing table. For existing tables the physical
    *     name will be re-used from the old display name
+   * @param useColumnIdForPhysicalName Whether we should assign physical names to 'col-[colId]'.
+   *     When false uses the default behavior described above.
    * @return A new {@link StructField} with updated metadata under the {@link
    *     ColumnMapping#COLUMN_MAPPING_ID_KEY} and the {@link
    *     ColumnMapping#COLUMN_MAPPING_PHYSICAL_NAME_KEY} keys
    */
   private static StructField assignColumnIdAndPhysicalNameToField(
-      StructField field, AtomicInteger maxColumnId, boolean isNewTable) {
+      StructField field,
+      AtomicInteger maxColumnId,
+      boolean isNewTable,
+      boolean useColumnIdForPhysicalName) {
     if (!hasColumnId(field)) {
       field =
           field.withNewMetadata(
@@ -454,6 +479,11 @@ public class ColumnMapping {
     if (!hasPhysicalName(field)) {
       // re-use old display names as physical names when a table is updated
       String physicalName = isNewTable ? "col-" + UUID.randomUUID() : field.getName();
+      if (useColumnIdForPhysicalName) {
+        long columnId = getColumnId(field);
+        physicalName = String.format("col-%s", columnId);
+      }
+
       field =
           field.withNewMetadata(
               FieldMetadata.builder()

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -478,10 +478,12 @@ public class ColumnMapping {
     }
     if (!hasPhysicalName(field)) {
       // re-use old display names as physical names when a table is updated
-      String physicalName = isNewTable ? "col-" + UUID.randomUUID() : field.getName();
+      String physicalName;
       if (useColumnIdForPhysicalName) {
         long columnId = getColumnId(field);
         physicalName = String.format("col-%s", columnId);
+      } else {
+        physicalName = isNewTable ? "col-" + UUID.randomUUID() : field.getName();
       }
 
       field =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -547,7 +547,7 @@ public class SchemaUtils {
   }
 
   /** column name by concatenating the column path elements (think of nested) with dots */
-  private static String concatWithDot(List<String> columnPath) {
+  public static String concatWithDot(List<String> columnPath) {
     return columnPath.stream().map(SchemaUtils::escapeDots).collect(Collectors.joining("."));
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -279,6 +279,11 @@ public class SchemaUtils {
     return result;
   }
 
+  /** @return column name by concatenating the column path elements (think of nested) with dots */
+  public static String concatWithDot(List<String> columnPath) {
+    return columnPath.stream().map(SchemaUtils::escapeDots).collect(Collectors.joining("."));
+  }
+
   /////////////////////////////////////////////////////////////////////////////////////////////////
   /// Private methods                                                                           ///
   /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -544,11 +549,6 @@ public class SchemaUtils {
     }
 
     return columnIdToField;
-  }
-
-  /** column name by concatenating the column path elements (think of nested) with dots */
-  public static String concatWithDot(List<String> columnPath) {
-    return columnPath.stream().map(SchemaUtils::escapeDots).collect(Collectors.joining("."));
   }
 
   private static String escapeDots(String name) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -170,7 +170,8 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
       }
       assert(e.getMessage.contains(
         "IcebergWriterCompatV1 requires column mapping field physical names be equal to "
-          + "'col-[fieldId]', but this is not true for the following fields"))
+          + "'col-[fieldId]', but this is not true for the following fields " +
+          "[c1(physicalName='c1', columnId=1)]"))
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
@@ -353,9 +353,9 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
         (k: AnyRef) => assertThat(k).asString.startsWith("col-"))
   }
 
-  runWithIcebergCompatV2ComboForNewAndExistingTables(
+  runWithIcebergCompatComboForNewAndExistingTables(
     "assign id and physical name to schema with nested struct type") {
-    (isNewTable, enableIcebergCompatV2) =>
+    (isNewTable, enableIcebergCompatV2, enableIcebergWriterCompatV1) =>
       val schema: StructType =
         new StructType()
           .add("a", StringType.STRING)
@@ -370,15 +370,18 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
       if (enableIcebergCompatV2) {
         inputMetadata = inputMetadata.withIcebergCompatV2Enabled
       }
+      if (enableIcebergWriterCompatV1) {
+        inputMetadata = inputMetadata.withIcebergWriterCompatV1Enabled
+      }
       val metadata = updateColumnMappingMetadataIfNeeded(inputMetadata, isNewTable)
         .orElseGet(() => fail("Metadata should not be empty"))
 
-      assertColumnMapping(metadata.getSchema.get("a"), 1L, if (isNewTable) "UUID" else "a")
-      assertColumnMapping(metadata.getSchema.get("b"), 2L, if (isNewTable) "UUID" else "b")
+      assertColumnMapping(metadata.getSchema.get("a"), 1L, isNewTable, enableIcebergWriterCompatV1)
+      assertColumnMapping(metadata.getSchema.get("b"), 2L, isNewTable, enableIcebergWriterCompatV1)
       val innerStruct = metadata.getSchema.get("b").getDataType.asInstanceOf[StructType]
-      assertColumnMapping(innerStruct.get("d"), 3L, if (isNewTable) "UUID" else "d")
-      assertColumnMapping(innerStruct.get("e"), 4L, if (isNewTable) "UUID" else "e")
-      assertColumnMapping(metadata.getSchema.get("c"), 5L, if (isNewTable) "UUID" else "c")
+      assertColumnMapping(innerStruct.get("d"), 3L, isNewTable, enableIcebergWriterCompatV1)
+      assertColumnMapping(innerStruct.get("e"), 4L, isNewTable, enableIcebergWriterCompatV1)
+      assertColumnMapping(metadata.getSchema.get("c"), 5L, isNewTable, enableIcebergWriterCompatV1)
 
       assertThat(metadata.getConfiguration)
         .containsEntry(ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY, "5")
@@ -391,9 +394,9 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
         isNewTable)
   }
 
-  runWithIcebergCompatV2ComboForNewAndExistingTables(
+  runWithIcebergCompatComboForNewAndExistingTables(
     "assign id and physical name to schema with array type") {
-    (isNewTable, enableIcebergCompatV2) =>
+    (isNewTable, enableIcebergCompatV2, enableIcebergWriterCompatV1) =>
       val schema: StructType =
         new StructType()
           .add("a", StringType.STRING)
@@ -404,20 +407,30 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
       if (enableIcebergCompatV2) {
         inputMetadata = inputMetadata.withIcebergCompatV2Enabled
       }
+      if (enableIcebergWriterCompatV1) {
+        inputMetadata = inputMetadata.withIcebergWriterCompatV1Enabled
+      }
       val metadata = updateColumnMappingMetadataIfNeeded(inputMetadata, isNewTable)
         .orElseGet(() => fail("Metadata should not be empty"))
 
-      assertColumnMapping(metadata.getSchema.get("a"), 1L, if (isNewTable) "UUID" else "a")
-      assertColumnMapping(metadata.getSchema.get("b"), 2L, if (isNewTable) "UUID" else "b")
-      assertColumnMapping(metadata.getSchema.get("c"), 3L, if (isNewTable) "UUID" else "c")
+      assertColumnMapping(metadata.getSchema.get("a"), 1L, isNewTable, enableIcebergWriterCompatV1)
+      assertColumnMapping(metadata.getSchema.get("b"), 2L, isNewTable, enableIcebergWriterCompatV1)
+      assertColumnMapping(metadata.getSchema.get("c"), 3L, isNewTable, enableIcebergWriterCompatV1)
 
       if (enableIcebergCompatV2) {
+        val colPrefix = if (enableIcebergWriterCompatV1) {
+          "col-2."
+        } else if (isNewTable) {
+          "col-"
+        } else {
+          "b."
+        }
         // verify nested ids
         assertThat(metadata.getSchema.get("b").getMetadata.getEntries
           .get(COLUMN_MAPPING_NESTED_IDS_KEY).asInstanceOf[FieldMetadata].getEntries)
           .hasSize(1)
           .anySatisfy((k: AnyRef, v: AnyRef) => {
-            assertThat(k).asString.startsWith(if (isNewTable) "col-" else "b.")
+            assertThat(k).asString.startsWith(colPrefix)
             assertThat(k).asString.endsWith(".element")
             assertThat(v).isEqualTo(4L)
           })
@@ -440,9 +453,9 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
         isNewTable)
   }
 
-  runWithIcebergCompatV2ComboForNewAndExistingTables(
+  runWithIcebergCompatComboForNewAndExistingTables(
     "assign id and physical name to schema with map type") {
-    (isNewTable, enableIcebergCompatV2) =>
+    (isNewTable, enableIcebergCompatV2, enableIcebergWriterCompatV1) =>
       val schema: StructType =
         new StructType()
           .add("a", StringType.STRING)
@@ -453,25 +466,35 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
       if (enableIcebergCompatV2) {
         inputMetadata = inputMetadata.withIcebergCompatV2Enabled
       }
+      if (enableIcebergWriterCompatV1) {
+        inputMetadata = inputMetadata.withIcebergWriterCompatV1Enabled
+      }
       val metadata = updateColumnMappingMetadataIfNeeded(inputMetadata, isNewTable)
         .orElseGet(() => fail("Metadata should not be empty"))
 
-      assertColumnMapping(metadata.getSchema.get("a"), 1L, if (isNewTable) "UUID" else "a")
-      assertColumnMapping(metadata.getSchema.get("b"), 2L, if (isNewTable) "UUID" else "b")
-      assertColumnMapping(metadata.getSchema.get("c"), 3L, if (isNewTable) "UUID" else "c")
+      assertColumnMapping(metadata.getSchema.get("a"), 1L, isNewTable, enableIcebergWriterCompatV1)
+      assertColumnMapping(metadata.getSchema.get("b"), 2L, isNewTable, enableIcebergWriterCompatV1)
+      assertColumnMapping(metadata.getSchema.get("c"), 3L, isNewTable, enableIcebergWriterCompatV1)
 
       if (enableIcebergCompatV2) {
+        val colPrefix = if (enableIcebergWriterCompatV1) {
+          "col-2."
+        } else if (isNewTable) {
+          "col-"
+        } else {
+          "b."
+        }
         // verify nested ids
         assertThat(metadata.getSchema.get("b").getMetadata.getEntries
           .get(COLUMN_MAPPING_NESTED_IDS_KEY).asInstanceOf[FieldMetadata].getEntries)
           .hasSize(2)
           .anySatisfy((k: AnyRef, v: AnyRef) => {
-            assertThat(k).asString.startsWith(if (isNewTable) "col-" else "b.")
+            assertThat(k).asString.startsWith(colPrefix)
             assertThat(k).asString.endsWith(".key")
             assertThat(v).isEqualTo(4L)
           })
           .anySatisfy((k: AnyRef, v: AnyRef) => {
-            assertThat(k).asString.startsWith(if (isNewTable) "col-" else "b.")
+            assertThat(k).asString.startsWith(colPrefix)
             assertThat(k).asString.endsWith(".value")
             assertThat(v).isEqualTo(5L)
           })
@@ -492,19 +515,26 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
         isNewTable)
   }
 
-  runWithIcebergCompatV2ComboForNewAndExistingTables(
+  runWithIcebergCompatComboForNewAndExistingTables(
     "assign id and physical name to schema with nested schema") {
-    (isNewTable, enableIcebergCompatV2) =>
+    (isNewTable, enableIcebergCompatV2, enableIcebergWriterCompatV1) =>
       val schema: StructType = cmTestSchema()
 
       var inputMetadata = testMetadata(schema).withColumnMappingEnabled("id")
       if (enableIcebergCompatV2) {
         inputMetadata = inputMetadata.withIcebergCompatV2Enabled
       }
+      if (enableIcebergWriterCompatV1) {
+        inputMetadata = inputMetadata.withIcebergWriterCompatV1Enabled
+      }
       val metadata = updateColumnMappingMetadataIfNeeded(inputMetadata, isNewTable)
         .orElseGet(() => fail("Metadata should not be empty"))
 
-      verifyCMTestSchemaHasValidColumnMappingInfo(metadata, isNewTable, enableIcebergCompatV2)
+      verifyCMTestSchemaHasValidColumnMappingInfo(
+        metadata,
+        isNewTable,
+        enableIcebergCompatV2,
+        enableIcebergWriterCompatV1)
 
       // Requesting the same operation on the same schema shouldn't change anything
       // as the schema already has the necessary column mapping info
@@ -619,15 +649,25 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
     assertThat(updateColumnMappingMetadataIfNeeded(metadata, isNewTable)).isEmpty
   }
 
-  def runWithIcebergCompatV2ComboForNewAndExistingTables(testName: String)(f: (
+  def runWithIcebergCompatComboForNewAndExistingTables(testName: String)(f: (
+      Boolean,
       Boolean,
       Boolean) => Unit): Unit = {
     for {
       isNewTable <- Seq(true, false)
       enableIcebergCompatV2 <- Seq(true, false)
     } {
-      test(s"$testName, enableIcebergCompatV2=$enableIcebergCompatV2, isNewTable=$isNewTable") {
-        f(isNewTable, enableIcebergCompatV2)
+      // We only test icebergWriterCompatV1 when icebergCompatV2 is enabled
+      val icebergWriterCompatV1Modes = if (enableIcebergCompatV2) {
+        Seq(true, false)
+      } else {
+        Seq(false)
+      }
+      icebergWriterCompatV1Modes.foreach { enableIcebergWriterCompatV1 =>
+        test(s"$testName, enableIcebergCompatV2=$enableIcebergCompatV2, " +
+          s"isNewTable=$isNewTable, enableIcebergWriterCompatV1=$enableIcebergWriterCompatV1") {
+          f(isNewTable, enableIcebergCompatV2, enableIcebergWriterCompatV1)
+        }
       }
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
@@ -211,7 +211,7 @@ class DeltaColumnMappingSuite extends DeltaTableWriteSuiteBase with ColumnMappin
         verifyCMTestSchemaHasValidColumnMappingInfo(
           getMetadata(engine, tablePath),
           isNewTable = true,
-          enableIcebergComaptV2 = withIcebergCompatV2)
+          enableIcebergCompatV2 = withIcebergCompatV2)
       }
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -74,7 +74,9 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
             cmTestSchema(),
             tableProperties = tblPropertiesIcebergWriterCompatV1Enabled ++ tblProperties)
           verifyIcebergWriterCompatV1Enabled(tablePath, engine)
-          verifyCMTestSchemaHasValidColumnMappingInfo(getMetadata(engine, tablePath))
+          verifyCMTestSchemaHasValidColumnMappingInfo(
+            getMetadata(engine, tablePath),
+            enableIcebergWriterCompatV1 = true)
         }
       }
   }
@@ -225,9 +227,11 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
             .build(engine)
             .commit(engine, emptyIterable())
         }
+        val expectedInvalidColumnId = if (isNewTable) 1 else 2
         assert(e.getMessage.contains(
           "IcebergWriterCompatV1 requires column mapping field physical names be equal to "
-            + "'col-[fieldId]', but this is not true for the following fields"))
+            + "'col-[fieldId]', but this is not true for the following fields " +
+            s"[c2(physicalName='c2', columnId=$expectedInvalidColumnId)]"))
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Part of https://github.com/delta-io/delta/issues/4289

Per-the-RFC when icebergWriterCompatV1 is enabled we want column mapping physicalName to be equal to `col-[fieldId]`. This PR enforces that as part of our icebergWriterCompatV1 metadata validations, and also updates our column mapping code to follow that behavior when icebergWriterCompatV1 is enabled.

## How was this patch tested?

Adds new tests and modifies existing tests to check the new changes.