### PR TITLE
[Spark] Minor refactor to IcebergTable util

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types.StructType
 
 class IcebergFileManifest(
     spark: SparkSession,
-    table: Table,
+    table: IcebergTableLike,
     partitionSchema: StructType,
     convertStats: Boolean = true) extends ConvertTargetFileManifest with LoggingShims {
 

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergPartitionConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergPartitionConverter.scala
@@ -53,7 +53,7 @@ object IcebergPartitionConverter {
   //                         value, as the partField and partitionData from file1 have different
   //                         ordering and thus same index indicates different column.
   def physicalNameToPartitionField(
-      table: Table, partitionSchema: StructType): Map[String, PartitionField] =
+      table: IcebergTableLike, partitionSchema: StructType): Map[String, PartitionField] =
     table.spec().fields().asScala.collect {
       case field if field.transform().toString != "void" &&
           !field.transform().toString.contains("bucket") =>
@@ -69,7 +69,10 @@ case class IcebergPartitionConverter(
   val timestampFormatter: TimestampFormatter =
       TimestampFormatter(ConvertUtils.timestampPartitionPattern, java.util.TimeZone.getDefault)
 
-  def this(table: Table, partitionSchema: StructType, partitionEvolutionEnabled: Boolean) =
+  def this(
+      table: IcebergTableLike,
+      partitionSchema: StructType,
+      partitionEvolutionEnabled: Boolean) =
     this(table.schema(),
       // We only allow empty partition when partition evolution happened
       // This is an extra safety mechanism as we should have already passed

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.types.StructType
 
 /** Subset of [[Table]] functionality required for conversion to Delta. */
 trait IcebergTableLike {
-  def uuid(): java.util.UUID
   def location(): String
   def schema(): Schema
   def properties(): java.util.Map[String, String]
@@ -52,7 +51,6 @@ trait IcebergTableLike {
  * underlying [[Table]].
  */
 case class DelegatingIcebergTable(table: Table) extends IcebergTableLike {
-  override def uuid(): java.util.UUID = table.uuid()
   override def location(): String = table.location()
   override def schema(): Schema = table.schema()
   override def properties(): java.util.Map[String, String] = table.properties()

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -24,14 +24,44 @@ import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaColumnMappingMode, D
 import org.apache.spark.sql.delta.DeltaErrors.{cloneFromIcebergSourceWithoutSpecs, cloneFromIcebergSourceWithPartitionEvolution}
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.iceberg.{PartitionSpec, Table, TableProperties}
+import org.apache.iceberg.{PartitionSpec, Schema, Snapshot => IcebergSnapshot, Table, TableProperties}
 import org.apache.iceberg.hadoop.HadoopTables
+import org.apache.iceberg.io.FileIO
 import org.apache.iceberg.transforms.{Bucket, IcebergPartitionUtil}
 import org.apache.iceberg.util.PropertyUtil
 
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.types.StructType
+
+/** Subset of [[Table]] functionality required for conversion to Delta. */
+trait IcebergTableLike {
+  def uuid(): java.util.UUID
+  def location(): String
+  def schema(): Schema
+  def properties(): java.util.Map[String, String]
+  def specs(): java.util.Map[Integer, PartitionSpec]
+  def spec(): PartitionSpec
+  def currentSnapshot(): IcebergSnapshot
+  def snapshot(id: Long): IcebergSnapshot
+  def io(): FileIO
+}
+
+/**
+ * Implementation of [[IcebergTableLike]] that can safely rely on the functionality of an
+ * underlying [[Table]].
+ */
+case class DelegatingIcebergTable(table: Table) extends IcebergTableLike {
+  override def uuid(): java.util.UUID = table.uuid()
+  override def location(): String = table.location()
+  override def schema(): Schema = table.schema()
+  override def properties(): java.util.Map[String, String] = table.properties()
+  override def specs(): java.util.Map[Integer, PartitionSpec] = table.specs()
+  override def spec(): PartitionSpec = table.spec()
+  override def currentSnapshot(): IcebergSnapshot = table.currentSnapshot()
+  override def snapshot(id: Long): IcebergSnapshot = table.snapshot(id)
+  override def io(): FileIO = table.io()
+}
 
 /**
  * A target Iceberg table for conversion to a Delta table.
@@ -49,15 +79,24 @@ import org.apache.spark.sql.types.StructType
  */
 class IcebergTable(
     spark: SparkSession,
-    icebergTable: Table,
+    icebergTable: IcebergTableLike,
     deltaSnapshot: Option[Snapshot],
     convertStats: Boolean) extends ConvertTargetTable {
+  def this(
+      spark: SparkSession,
+      table: Table,
+      deltaSnapshot: Option[Snapshot],
+      convertStats: Boolean) =
+    this(spark, DelegatingIcebergTable(table), deltaSnapshot, convertStats)
 
   def this(spark: SparkSession, basePath: String, deltaTable: Option[Snapshot],
            convertStats: Boolean = true) =
     // scalastyle:off deltahadoopconfiguration
-    this(spark, new HadoopTables(spark.sessionState.newHadoopConf).load(basePath),
-      deltaTable, convertStats)
+    this(
+      spark,
+      DelegatingIcebergTable(new HadoopTables(spark.sessionState.newHadoopConf).load(basePath)),
+      deltaTable,
+      convertStats)
     // scalastyle:on deltahadoopconfiguration
 
   protected val existingSchema: Option[StructType] = deltaSnapshot.map(_.schema)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Small refactor in IcebergTable util for CONVERT TO DELTA avoid having to rely on the entire IcebergTable implementation. This scopes the available methods more closely to target what's actually needed for conversion.

## How was this patch tested?
Existing tests should suffice - refactor only.

## Does this PR introduce _any_ user-facing changes?
No