### PR TITLE
[Spark] Add option to DeltaParquetFileFormat to allow missing Row Tracking metadata fields

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
@@ -41,9 +41,9 @@ object DefaultRowCommitVersion {
   }
 
   def createDefaultRowCommitVersionField(
-      protocol: Protocol, metadata: Metadata): Option[StructField] = {
+      protocol: Protocol, metadata: Metadata, nullable: Boolean): Option[StructField] = {
     Option.when(RowTracking.isEnabled(protocol, metadata)) {
-      MetadataStructField()
+      MetadataStructField(nullable)
     }
   }
 
@@ -52,11 +52,11 @@ object DefaultRowCommitVersion {
   private object MetadataStructField {
     private val METADATA_COL_ATTR_KEY = "__default_row_version_metadata_col"
 
-    def apply(): StructField =
+    def apply(nullable: Boolean): StructField =
       StructField(
         METADATA_STRUCT_FIELD_NAME,
         LongType,
-        nullable = false,
+        nullable,
         metadata = metadata)
 
     def unapply(field: StructField): Option[StructField] =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -151,7 +151,6 @@ case class DeltaParquetFileFormat(
         ff.columnMappingMode == columnMappingMode &&
         ff.referenceSchema == referenceSchema &&
         ff.nullableRowTrackingConstantFields == nullableRowTrackingConstantFields &&
-        ff.nullableRowTrackingGeneratedFields == nullableRowTrackingGeneratedFields &&
         ff.optimizationsEnabled == optimizationsEnabled
       case _ => false
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GenerateRowIDs.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GenerateRowIDs.scala
@@ -58,7 +58,7 @@ object GenerateRowIDs extends Rule[LogicalPlan] {
       // Update nullability in the scan `metadataOutput` by updating the delta file format.
       val newFileFormat = baseRelation.fileFormat match {
         case format: DeltaParquetFileFormat =>
-          format.copy(nullableRowTrackingFields = true)
+          format.copy(nullableRowTrackingGeneratedFields = true)
       }
       val newBaseRelation = baseRelation.copy(fileFormat = newFileFormat)(baseRelation.sparkSession)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -141,11 +141,11 @@ object RowId {
       .putBoolean(BASE_ROW_ID_METADATA_COL_ATTR_KEY, value = true)
       .build()
 
-    def apply(): StructField =
+    def apply(nullable: Boolean): StructField =
       StructField(
         BASE_ROW_ID,
         LongType,
-        nullable = false,
+        nullable,
         metadata = metadata)
 
     def unapply(field: StructField): Option[StructField] =
@@ -165,9 +165,10 @@ object RowId {
   /**
    * The field readers can use to access the base row id column.
    */
-  def createBaseRowIdField(protocol: Protocol, metadata: Metadata): Option[StructField] =
+  def createBaseRowIdField(
+      protocol: Protocol, metadata: Metadata, nullable: Boolean): Option[StructField] =
     Option.when(RowId.isEnabled(protocol, metadata)) {
-      BaseRowIdMetadataStructField()
+      BaseRowIdMetadataStructField(nullable)
     }
 
   /** Row ID column name */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
@@ -72,11 +72,13 @@ object RowTracking {
   def createMetadataStructFields(
       protocol: Protocol,
       metadata: Metadata,
-      nullable: Boolean): Iterable[StructField] = {
-    RowId.createRowIdField(protocol, metadata, nullable) ++
-      RowId.createBaseRowIdField(protocol, metadata) ++
-      DefaultRowCommitVersion.createDefaultRowCommitVersionField(protocol, metadata) ++
-      RowCommitVersion.createMetadataStructField(protocol, metadata, nullable)
+      nullableConstantFields: Boolean,
+      nullableGeneratedFields: Boolean): Iterable[StructField] = {
+    RowId.createRowIdField(protocol, metadata, nullableGeneratedFields) ++
+      RowId.createBaseRowIdField(protocol, metadata, nullableConstantFields) ++
+      DefaultRowCommitVersion.createDefaultRowCommitVersionField(
+        protocol, metadata, nullableConstantFields) ++
+      RowCommitVersion.createMetadataStructField(protocol, metadata, nullableGeneratedFields)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -151,7 +151,8 @@ class DeltaParquetFileFormatSuite extends DeltaParquetFileFormatSuiteBase {
           val deltaParquetFormat = new DeltaParquetFileFormat(
             deltaLog.snapshot.protocol,
             metadata,
-            nullableRowTrackingFields = false,
+            nullableRowTrackingConstantFields = false,
+            nullableRowTrackingGeneratedFields = false,
             optimizationsEnabled = false,
             if (enableDVs) Some(tablePath) else None)
 
@@ -257,7 +258,8 @@ class DeltaParquetFileFormatWithPredicatePushdownSuite extends DeltaParquetFileF
       val deltaParquetFormat = new DeltaParquetFileFormat(
         deltaLog.update().protocol,
         metadata,
-        nullableRowTrackingFields = false,
+        nullableRowTrackingConstantFields = false,
+        nullableRowTrackingGeneratedFields = false,
         optimizationsEnabled = true,
         Some(tablePath))
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.rowid
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalStateException, DeltaLog, DeltaOperations, MaterializedRowId, RowId, RowTrackingFeature, Serializable, SnapshotIsolation}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalStateException, DeltaLog, DeltaOperations, DeltaTableUtils, MaterializedRowCommitVersion, MaterializedRowId, RowCommitVersion, RowId, RowTrackingFeature, Serializable, SnapshotIsolation}
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
@@ -31,7 +31,8 @@ import org.apache.parquet.column.Encoding
 import org.apache.parquet.column.ParquetProperties
 import org.apache.parquet.hadoop.ParquetOutputFormat
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
@@ -825,6 +826,58 @@ class RowIdSuite extends QueryTest
           spark.read.format("delta").load(dir.toString).select("id", RowId.QUALIFIED_COLUMN_NAME),
           (0 until 10).map(i => Row(i, i)))
       }
+    }
+  }
+
+  test("missing base row ids and default row commit versions") {
+    val tableName = "my_table"
+    withTable(tableName) {
+      // Create a table with some rows without row tracking enabled.
+      spark.range(start = 0, end = 10).repartition(1).sortWithinPartitions("id")
+        .write.format("delta").mode("overwrite").saveAsTable(tableName)
+
+      // Hack to enable row tracking without triggering a backfill.
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val snapshot = deltaLog.update()
+      val actions = Seq(
+        snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration ++ Map(
+            DeltaConfigs.ROW_TRACKING_ENABLED.key -> "true",
+            MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP -> "x",
+            MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP -> "y"
+          )
+        )
+      )
+      deltaLog.startTransaction().commit(actions, DeltaOperations.ManualUpdate)
+
+      // Append some rows with base row ids and default row commit set on the files.
+      spark.range(start = 10, end = 20).repartition(1).sortWithinPartitions("id")
+        .write.format("delta").mode("append").saveAsTable(tableName)
+
+      // Ensure that we cannot read the row id and row commit version by default.
+      intercept[SparkException] {
+        spark.read.table(tableName).select("id", RowId.QUALIFIED_COLUMN_NAME).collect()
+      }
+      intercept[SparkException] {
+        spark.read.table(tableName).select("id", RowCommitVersion.QUALIFIED_COLUMN_NAME).collect()
+      }
+
+      // Create a dataframe that allows reading missing row ids and row commit versions.
+      var df = spark.read.table(tableName)
+      val plan = DeltaTableUtils.transformFileFormat(df.queryExecution.analyzed) {
+        case format =>
+          format.copy(
+            nullableRowTrackingConstantFields = true,
+            nullableRowTrackingGeneratedFields = true
+          )
+      }
+      df = Dataset.ofRows(spark, plan)
+
+      checkAnswer(
+        df.select("id", RowId.QUALIFIED_COLUMN_NAME, RowCommitVersion.QUALIFIED_COLUMN_NAME),
+        (0 until 10).map(i => Row(i, null, null)) ++
+          (0 until 10).map(i => Row(10 + i, i, 2))
+      )
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR:

- Renames `nullableRowTrackingFields` in `DeltaParquetFileFormat` to `nullableRowTrackingGeneratedFields`.
- Adds another field called `nullableRowTrackingConstantFields` in `DeltaParquetFileFormat`, which allows reading row ids and row commit versions when the `baseRowId` and `defaultRowCommitVersion`s are missing (returning a NULL in this case).
- It adds a helper function `transformFileFormat` to `DeltaTableUtils` to make it easier to set the new field.

## How was this patch tested?

Added a test to `RowIdSuite`.

## Does this PR introduce _any_ user-facing changes?

No