### PR TITLE
[Spark] Make MERGE source checkpoint materialization a SQL operation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -83,6 +83,18 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
   protected var materializedSourceRDD: Option[RDD[InternalRow]] = None
 
   /**
+   * True if source materialization is used.
+   * It is set when materializedSourceRDD may not yet be initialized.
+   */
+  private var materializeSource = false
+
+  /**
+   * StorageLevel used for source materialization.
+   * It is set when materializedSourceRDD may not yet be initialized.
+   */
+  private var materializeSourceStorageLevel = StorageLevel.NONE
+
+  /**
    * Track which attempt or retry it is in runWithMaterializedSourceAndRetries
    */
   protected var attempt: Int = 0
@@ -132,6 +144,8 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
         }
         materializedSourceRDD = None
         mergeSource = None
+        materializeSource = false
+        materializeSourceStorageLevel = StorageLevel.NONE
       }
     } while (doRetry)
 
@@ -186,7 +200,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
 
     // Record if we ran out of executor disk space when we materialized the source.
     case s: SparkException
-      if materializedSourceRDD.nonEmpty &&
+      if materializeSource &&
         s.getMessage.contains("java.io.IOException: No space left on device") =>
       // Record situations where we ran out of disk space, possibly because of the space took
       // by the materialized RDD.
@@ -196,8 +210,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
         data = MergeIntoMaterializeSourceError(
           errorType = MergeIntoMaterializeSourceErrorType.OUT_OF_DISK.toString,
           attempt = attempt,
-          materializedSourceRDDStorageLevel =
-            materializedSourceRDD.get.getStorageLevel.toString
+          materializedSourceRDDStorageLevel = materializeSourceStorageLevel.toString
         )
       )
       RetryHandling.RethrowException
@@ -292,6 +305,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       isInsertOnly: Boolean): Unit = {
     val (materialize, materializeReason) =
       shouldMaterializeSource(spark, source, isInsertOnly)
+    materializeSource = materialize
     if (!materialize) {
       // Does not materialize, simply return the dataframe from source plan
       mergeSource = Some(
@@ -310,17 +324,37 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
     val sourceWithSelectedColumns = Project(referencedSourceColumns, source)
     val baseSourcePlanDF = DataFrameUtils.ofRows(spark, sourceWithSelectedColumns)
 
+    // Select appropriate StorageLevel
+    materializeSourceStorageLevel = StorageLevel.fromString(
+      if (attempt == 1) {
+        spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL)
+      } else if (attempt == 2) {
+        // If it failed the first time, potentially use a different storage level on retry. The
+        // first retry has its own conf to allow gradually increasing the replication level.
+        spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL_FIRST_RETRY)
+      } else {
+        spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL_RETRY)
+      }
+    )
+
     // Caches the source in RDD cache using localCheckpoint, which cuts away the RDD lineage,
     // which shall ensure that the source cannot be recomputed and thus become inconsistent.
-    val checkpointedSourcePlanDF = baseSourcePlanDF
-      // Set eager=false for now, even if we should be doing eager, so that we can set the storage
-      // level before executing.
-      .localCheckpoint(eager = false)
+    //
+    // WARNING: if eager == false, the source used during the first Spark Job that uses this may
+    // still be inconsistent with source materialized afterwards.
+    // This is because doCheckpoint that finalizes the lazy checkpoint is called after the Job
+    // that triggered the lazy checkpointing finished.
+    // If blocks were lost during that job, they may still get recomputed and changed compared
+    // to how they were used during the execution of the job.
+    val checkpointedSourcePlanDF =
+      baseSourcePlanDF.localCheckpoint(
+        eager = true, storageLevel = materializeSourceStorageLevel)
 
     // We have to reach through the crust and into the plan of the checkpointed DF
     // to get the RDD that was actually checkpointed, to be able to unpersist it later...
     var checkpointedPlan = checkpointedSourcePlanDF.queryExecution.analyzed
     val rdd = checkpointedPlan.asInstanceOf[LogicalRDD].rdd
+    assert(rdd.isCheckpointed)
     materializedSourceRDD = Some(rdd)
     rdd.setName("mergeMaterializedSource")
 
@@ -335,34 +369,6 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       )
     )
 
-
-    // Sets appropriate StorageLevel
-    val storageLevel = StorageLevel.fromString(
-      if (attempt == 1) {
-        spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL)
-      } else if (attempt == 2) {
-        // If it failed the first time, potentially use a different storage level on retry. The
-        // first retry has its own conf to allow gradually increasing the replication level.
-        spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL_FIRST_RETRY)
-      } else {
-        spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL_RETRY)
-      }
-    )
-    rdd.persist(storageLevel)
-
-    // WARNING: if eager == false, the source used during the first Spark Job that uses this may
-    // still be inconsistent with source materialized afterwards.
-    // This is because doCheckpoint that finalizes the lazy checkpoint is called after the Job
-    // that triggered the lazy checkpointing finished.
-    // If blocks were lost during that job, they may still get recomputed and changed compared
-    // to how they were used during the execution of the job.
-    if (spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_EAGER)) {
-      // Force the evaluation of the `rdd`, since we cannot access `doCheckpoint()` from here.
-      rdd
-        .mapPartitions(_ => Iterator.empty.asInstanceOf[Iterator[InternalRow]])
-        .foreach((_: InternalRow) => ())
-      assert(rdd.isCheckpointed)
-    }
 
     logDebug(s"Materializing MERGE with pruned columns $referencedSourceColumns.")
     logDebug(s"Materialized MERGE source plan:\n${getMergeSource.df.queryExecution}")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -919,13 +919,6 @@ trait DeltaSQLConfBase {
       .intConf
       .createWithDefault(4)
 
-  val MERGE_MATERIALIZE_SOURCE_EAGER =
-    buildConf("merge.materializeSource.eager")
-      .internal()
-      .doc("Materialize the source eagerly before Job 1")
-      .booleanConf
-      .createWithDefault(true)
-
   val DELTA_LAST_COMMIT_VERSION_IN_SESSION =
     buildConf("lastCommitVersionInSession")
       .doc("The version of the last commit made in the SparkSession for any table.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
@@ -80,12 +80,10 @@ trait MergeIntoMaterializeSourceTests
 
 
   for {
-    eager <- BOOLEAN_DOMAIN
     materialized <- BOOLEAN_DOMAIN
-  }  test(s"merge logs out of disk errors - eager=$eager, materialized=$materialized") {
+  }  test(s"merge logs out of disk errors - materialized=$materialized") {
     import DeltaSQLConf.MergeMaterializeSource
     withSQLConf(
-        DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_EAGER.key -> eager.toString,
         DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key ->
           (if (materialized) MergeMaterializeSource.AUTO else MergeMaterializeSource.NONE)) {
       val injectEx = new java.io.IOException("No space left on device")
@@ -262,47 +260,40 @@ trait MergeIntoMaterializeSourceTests
 
     // For 1 to maxAttempts - 1 RDD block lost failures, merge should retry and succeed.
     for {
-      eager <- BOOLEAN_DOMAIN
       kills <- 1 to maxAttempts - 1
     } {
-      test(s"materialize source unpersist with $kills kill attempts succeeds - eager=$eager") {
+      test(s"materialize source unpersist with $kills kill attempts succeeds") {
         withTable(tblName) {
-          withSQLConf(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_EAGER.key -> eager.toString) {
-            val allDeltaEvents = testMergeMaterializedSourceUnpersist(tblName, kills)
-            val events =
-              allDeltaEvents.filter(_.tags.get("opType").contains("delta.dml.merge.stats"))
-            assert(events.length == 1, s"allDeltaEvents:\n$allDeltaEvents")
-            val mergeStats = JsonUtils.fromJson[MergeStats](events(0).blob)
-            assert(mergeStats.materializeSourceAttempts.isDefined, s"MergeStats:\n$mergeStats")
-            assert(
-              mergeStats.materializeSourceAttempts.get == kills + 1,
-              s"MergeStats:\n$mergeStats")
+          val allDeltaEvents = testMergeMaterializedSourceUnpersist(tblName, kills)
+          val events =
+            allDeltaEvents.filter(_.tags.get("opType").contains("delta.dml.merge.stats"))
+          assert(events.length == 1, s"allDeltaEvents:\n$allDeltaEvents")
+          val mergeStats = JsonUtils.fromJson[MergeStats](events(0).blob)
+          assert(mergeStats.materializeSourceAttempts.isDefined, s"MergeStats:\n$mergeStats")
+          assert(
+            mergeStats.materializeSourceAttempts.get == kills + 1,
+            s"MergeStats:\n$mergeStats")
 
-            // Check query result after merge
-            val tab = sql(s"select * from $tblName order by id")
-              .collect()
-              .map(row => row.getLong(0))
-              .toSeq
-            assert(tab == (0L until 90L) ++ (100L until 120L))
-          }
+          // Check query result after merge
+          val tab = sql(s"select * from $tblName order by id")
+            .collect()
+            .map(row => row.getLong(0))
+            .toSeq
+          assert(tab == (0L until 90L) ++ (100L until 120L))
         }
       }
     }
 
     // Eventually it should fail after exceeding maximum number of attempts.
-    for (eager <- BOOLEAN_DOMAIN) {
-      test(s"materialize source unpersist with $maxAttempts kill attempts fails - eager=$eager") {
-        withSQLConf(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_EAGER.key -> eager.toString) {
-          withTable(tblName) {
-            val allDeltaEvents = testMergeMaterializedSourceUnpersist(tblName, maxAttempts)
-            val events = allDeltaEvents
-              .filter(_.tags.get("opType").contains(MergeIntoMaterializeSourceError.OP_TYPE))
-            assert(events.length == 1, s"allDeltaEvents:\n$allDeltaEvents")
-            val error = JsonUtils.fromJson[MergeIntoMaterializeSourceError](events(0).blob)
-            assert(error.errorType == MergeIntoMaterializeSourceErrorType.RDD_BLOCK_LOST.toString)
-            assert(error.attempt == maxAttempts)
-          }
-        }
+    test(s"materialize source unpersist with $maxAttempts kill attempts fails") {
+      withTable(tblName) {
+        val allDeltaEvents = testMergeMaterializedSourceUnpersist(tblName, maxAttempts)
+        val events = allDeltaEvents
+          .filter(_.tags.get("opType").contains(MergeIntoMaterializeSourceError.OP_TYPE))
+        assert(events.length == 1, s"allDeltaEvents:\n$allDeltaEvents")
+        val error = JsonUtils.fromJson[MergeIntoMaterializeSourceError](events(0).blob)
+        assert(error.errorType == MergeIntoMaterializeSourceErrorType.RDD_BLOCK_LOST.toString)
+        assert(error.attempt == maxAttempts)
       }
     }
   }
@@ -356,8 +347,7 @@ trait MergeIntoMaterializeSourceTests
     hints
   }
 
-  for (eager <- BOOLEAN_DOMAIN)
-  test(s"materialize source preserves dataframe hints - eager=$eager") {
+  test(s"materialize source preserves dataframe hints") {
     withTable("A", "B", "T") {
       sql("select id, id as v from range(50000)").write.format("delta").saveAsTable("T")
       sql("select id, id+2 as v from range(10000)").write.format("csv").saveAsTable("A")
@@ -365,7 +355,6 @@ trait MergeIntoMaterializeSourceTests
 
       // Manually added broadcast hint will mess up the expected hints hence disable it
       withSQLConf(
-        DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_EAGER.key -> eager.toString,
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
         // Simple BROADCAST hint
         val hSimple = getHints(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Because forcing source checkpoint in MergeIntoMaterializeSource.prepareMergeSource is triggered with RDD operation, it doesn't show in SQL UI and in QPL. Now in Spark 4.0, Dataset.localCheckpoint supports passing storageLevel natively, so we can use that directly without using eager = false and triggering evaluation ourselves.

We also remove the MERGE_MATERIALIZE_SOURCE_EAGER flag, as it was shown that it's incorrect to use lazy materialization.

## How was this patch tested?

Existing tests.
* MergeIntoMaterializedSourceSuite: no changes needed. There are some tests checking plans but they check for the existance of RDD named "mergeMaterializedSource" in the plan. Before: it didn't appear during materialization, because it was not a SQL operation, so there was no plan recorded. After: it doesn't appear, because the RDD is only named after materialization finishes.

## Does this PR introduce _any_ user-facing changes?

No