### PR TITLE
[Spark] Implement CatalogOwnedTableFeature

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.Action.logSchema
-import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorClient, CommitCoordinatorProvider, CoordinatedCommitsUsageLogs, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CommitCoordinatorClient, CommitCoordinatorProvider, CoordinatedCommitsUsageLogs, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
@@ -288,6 +288,11 @@ class Snapshot(
     }
 
     ReconstructedProtocolMetadataAndICT(protocol, metadata, inCommitTimestamp)
+  }
+
+  def isCatalogOwned: Boolean = {
+    version >= 0 &&
+      protocol.readerAndWriterFeatures.exists(_.name == CatalogOwnedTableFeature.name)
   }
 
   /**
@@ -642,7 +647,12 @@ class Snapshot(
    *   if the delta file for the current version is not found after backfilling.
    */
   def ensureCommitFilesBackfilled(catalogTableOpt: Option[CatalogTable]): Unit = {
-    val tableCommitCoordinatorClient = getTableCommitCoordinatorForWrites.getOrElse {
+    val tableCommitCoordinatorClientOpt = if (isCatalogOwned) {
+      CatalogOwnedTableUtils.populateTableCommitCoordinatorFromCatalog(spark, catalogTableOpt, this)
+    } else {
+      getTableCommitCoordinatorForWrites
+    }
+    val tableCommitCoordinatorClient = tableCommitCoordinatorClientOpt.getOrElse {
       return
     }
     val minUnbackfilledVersion = DeltaCommitFileProvider(this).minUnbackfilledVersion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -326,7 +326,7 @@ case class AlterTableDropFeatureDeltaCommand(
     // Check whether the protocol contains the feature in either the writer features list or
     // the reader+writer features list. Note, protocol needs to denormalized to allow dropping
     // features from legacy protocols.
-    val protocol = table.deltaLog.update().protocol
+    val protocol = table.deltaLog.update(catalogTableOpt = table.catalogTable).protocol
     val protocolContainsFeatureName =
       protocol.implicitlyAndExplicitlySupportedFeatures.map(_.name).contains(featureName)
     if (!protocolContainsFeatureName) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -248,7 +248,8 @@ class DeltaLogSuite extends QueryTest
 
         log.store.write(
           FileNames.unsafeDeltaFile(log.logPath, 0L),
-          Iterator(Action.supportedProtocolVersion(), Metadata(), add)
+          Iterator(Action.supportedProtocolVersion(
+            featuresToExclude = Seq(CatalogOwnedTableFeature)), Metadata(), add)
             .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
@@ -277,7 +278,8 @@ class DeltaLogSuite extends QueryTest
 
         log.store.write(
           FileNames.unsafeDeltaFile(log.logPath, 0L),
-          Iterator(Action.supportedProtocolVersion(), Metadata(), add)
+          Iterator(Action.supportedProtocolVersion(
+            featuresToExclude = Seq(CatalogOwnedTableFeature)), Metadata(), add)
             .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -158,8 +158,10 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     withTempDir { path =>
       val log = createTableWithProtocol(Protocol(1, 1), path)
       assert(log.snapshot.protocol === Protocol(1, 1))
-      log.upgradeProtocol(Action.supportedProtocolVersion())
-      assert(log.snapshot.protocol === Action.supportedProtocolVersion())
+      log.upgradeProtocol(Action.supportedProtocolVersion(
+        featuresToExclude = Seq(CatalogOwnedTableFeature)))
+      assert(log.snapshot.protocol === Action.supportedProtocolVersion(
+        featuresToExclude = Seq(CatalogOwnedTableFeature)))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -2034,7 +2034,8 @@ class DeltaSuite extends QueryTest
 
     // Now make a commit that comes from an "external" writer that deletes existing data and
     // changes the schema
-    val actions = Seq(Action.supportedProtocolVersion(), newMetadata) ++ files.map(_.remove)
+    val actions = Seq(Action.supportedProtocolVersion(
+      featuresToExclude = Seq(CatalogOwnedTableFeature)), newMetadata) ++ files.map(_.remove)
     deltaLog.store.write(
       FileNames.unsafeDeltaFile(deltaLog.logPath, snapshot.version + 1),
       actions.map(_.json).iterator,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -228,9 +228,9 @@ class OptimisticTransactionSuite
       t => t.metadata
     ),
     concurrentWrites = Seq(
-      Action.supportedProtocolVersion()),
+      Action.supportedProtocolVersion(featuresToExclude = Seq(CatalogOwnedTableFeature))),
     actions = Seq(
-      Action.supportedProtocolVersion()))
+      Action.supportedProtocolVersion(featuresToExclude = Seq(CatalogOwnedTableFeature))))
 
   check(
     "taint whole table",
@@ -710,7 +710,8 @@ class OptimisticTransactionSuite
         .add("id", "long")
         .add("part", "string")
       deltaLog.withNewTransaction { txn =>
-        val protocol = Action.supportedProtocolVersion()
+        val protocol = Action.supportedProtocolVersion(
+          featuresToExclude = Seq(CatalogOwnedTableFeature))
         val metadata = Metadata(
           schemaString = schema.json,
           partitionColumns = partitionColumns)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -58,7 +58,8 @@ trait OptimisticTransactionSuiteBase
   protected def check(
       name: String,
       conflicts: Boolean,
-      setup: Seq[Action] = Seq(Metadata(), Action.supportedProtocolVersion()),
+      setup: Seq[Action] = Seq(Metadata(), Action.supportedProtocolVersion(
+        featuresToExclude = Seq(CatalogOwnedTableFeature))),
       reads: Seq[OptimisticTransaction => Unit],
       concurrentWrites: Seq[Action],
       actions: Seq[Action],

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -84,20 +84,4 @@ class CatalogOwnedEnablementSuite
       )
     }
   }
-
-  test("Upgrading other table protocols on CatalogOwned table should not be blocked") {
-    withTable("t1") {
-      spark.sql(s"CREATE TABLE t1 (id INT) USING delta TBLPROPERTIES " +
-        s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
-      spark.sql(s"INSERT INTO t1 VALUES 1") // commit 1
-      spark.sql(s"INSERT INTO t1 VALUES 2") // commit 2
-      var log = DeltaLog.forTable(spark, TableIdentifier("t1"))
-      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = true)
-      spark.sql(s"ALTER TABLE t1 SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name')")
-      log = DeltaLog.forTable(spark, TableIdentifier("t1"))
-      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = true)
-      assert(
-        log.unsafeVolatileSnapshot.protocol.readerAndWriterFeatureNames.contains("columnMapping"))
-    }
-  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.coordinatedcommits
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.commons.lang3.NotImplementedException
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+
+class CatalogOwnedEnablementSuite
+  extends DeltaSQLTestUtils
+  with DeltaSQLCommandTest {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    CatalogOwnedCommitCoordinatorProvider.clearBuilders()
+    CatalogOwnedCommitCoordinatorProvider.registerBuilder(
+      "spark_catalog", TrackingInMemoryCommitCoordinatorBuilder(batchSize = 3))
+  }
+
+  private def validateCompleteEnablement(snapshot: Snapshot, expectEnabled: Boolean): Unit = {
+    assert(snapshot.isCatalogOwned == expectEnabled)
+    Seq(
+      CatalogOwnedTableFeature,
+      VacuumProtocolCheckTableFeature,
+      InCommitTimestampTableFeature
+    ).foreach { feature =>
+      assert(snapshot.protocol.writerFeatures.exists(_.contains(feature.name)) == expectEnabled)
+    }
+    Seq(
+      CatalogOwnedTableFeature,
+      VacuumProtocolCheckTableFeature
+    ).foreach { feature =>
+      assert(snapshot.protocol.readerFeatures.exists(_.contains(feature.name)) == expectEnabled)
+    }
+  }
+
+  test("ALTER TABLE - upgrade not supported") {
+    withTable("t1") {
+      spark.sql(s"CREATE TABLE t1 (id INT) USING delta")
+      spark.sql(s"INSERT INTO t1 VALUES 1") // commit 1
+      spark.sql(s"INSERT INTO t1 VALUES 2") // commit 2
+      val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = false)
+      // UPGRADE is not yet supported.
+      val ex = intercept[NotImplementedException] {
+        sql(s"ALTER TABLE t1 SET TBLPROPERTIES " +
+          s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
+      }
+      assert(ex.getMessage.contains("Upgrading to CatalogOwned table is not yet supported."))
+    }
+  }
+
+  test("CREATE TABLE - catalog-owned table downgrade is blocked") {
+    withTable("t1") {
+      spark.sql(s"CREATE TABLE t1 (id INT) USING delta TBLPROPERTIES " +
+        s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
+      spark.sql(s"INSERT INTO t1 VALUES 1") // commit 1
+      spark.sql(s"INSERT INTO t1 VALUES 2") // commit 2
+      val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = true)
+      // Drop feature should fail as it is not supported.
+      checkError(
+        intercept[DeltaTableFeatureException] {
+          sql(s"ALTER TABLE t1 DROP FEATURE '${CatalogOwnedTableFeature.name}'")
+        },
+        "DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE",
+        parameters = Map("feature" -> CatalogOwnedTableFeature.name)
+      )
+    }
+  }
+
+  test("Upgrading other table protocols on CatalogOwned table should not be blocked") {
+    withTable("t1") {
+      spark.sql(s"CREATE TABLE t1 (id INT) USING delta TBLPROPERTIES " +
+        s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
+      spark.sql(s"INSERT INTO t1 VALUES 1") // commit 1
+      spark.sql(s"INSERT INTO t1 VALUES 2") // commit 2
+      var log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = true)
+      spark.sql(s"ALTER TABLE t1 SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name')")
+      log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = true)
+      assert(
+        log.unsafeVolatileSnapshot.protocol.readerAndWriterFeatureNames.contains("columnMapping"))
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaTestUtilsBase}
-import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol}
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils}
 import io.delta.storage.LogStore
 import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetCommitsResponse => JGetCommitsResponse, TableDescriptor, TableIdentifier, UpdatedActions}
@@ -182,7 +182,7 @@ case class TrackingInMemoryCommitCoordinatorBuilder(
     batchSize: Long,
     defaultCommitCoordinatorClientOpt: Option[CommitCoordinatorClient] = None,
     defaultCommitCoordinatorName: String = "tracking-in-memory")
-  extends CommitCoordinatorBuilder {
+  extends CatalogOwnedCommitCoordinatorBuilder {
   lazy val trackingInMemoryCommitCoordinatorClient =
     defaultCommitCoordinatorClientOpt.getOrElse {
       new TrackingCommitCoordinatorClient(
@@ -191,6 +191,11 @@ case class TrackingInMemoryCommitCoordinatorBuilder(
 
   override def getName: String = defaultCommitCoordinatorName
   override def build(spark: SparkSession, conf: Map[String, String]): CommitCoordinatorClient = {
+    trackingInMemoryCommitCoordinatorClient
+  }
+
+  override def buildForCatalog(
+      spark: SparkSession, catalogName: String): CommitCoordinatorClient = {
     trackingInMemoryCommitCoordinatorClient
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -74,7 +74,8 @@ class RowTrackingConflictResolutionSuite extends QueryTest
   /** Add Row tracking table feature support. */
   private def activateRowTracking(): Unit = {
     require(!latestSnapshot.protocol.isFeatureSupported(RowTrackingFeature))
-    deltaLog.upgradeProtocol(Action.supportedProtocolVersion())
+    deltaLog.upgradeProtocol(Action.supportedProtocolVersion(
+      featuresToExclude = Seq(CatalogOwnedTableFeature)))
   }
 
   // Add 'numRecords' records to the table.
@@ -115,7 +116,10 @@ class RowTrackingConflictResolutionSuite extends QueryTest
 
       val txn = deltaLog.startTransaction()
       deltaLog.startTransaction().commit(
-        Seq(Action.supportedProtocolVersion(), addFile("other_path")), DeltaOperations.ManualUpdate)
+        Seq(
+          Action.supportedProtocolVersion(featuresToExclude = Seq(CatalogOwnedTableFeature)),
+          addFile("other_path")
+        ), DeltaOperations.ManualUpdate)
       txn.commit(Seq(addFile(filePath)), DeltaOperations.ManualUpdate)
 
       assertRowIdsAreValid(deltaLog)
@@ -180,7 +184,8 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       f2,
       f3,
       f4,
-      Action.supportedProtocolVersion().withFeature(RowTrackingFeature)
+      Action.supportedProtocolVersion(
+        featuresToExclude = Seq(CatalogOwnedTableFeature)).withFeature(RowTrackingFeature)
     )
 
     log.startTransaction().commit(setupActions, ManualUpdate)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.test
 import java.io.File
 import java.sql.Timestamp
 
-import org.apache.spark.sql.delta.{DeltaHistoryManager, DeltaLog, OptimisticTransaction, Snapshot}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaHistoryManager, DeltaLog, OptimisticTransaction, Snapshot}
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Operation, Write}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, Metadata, Protocol}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
@@ -67,7 +67,10 @@ object DeltaTestImplicits {
             // If neither metadata nor protocol is explicitly passed, then use default Metadata and
             // with the maximum protocol.
             txn.updateMetadataForNewTable(Metadata())
-            txn.updateProtocol(Action.supportedProtocolVersion())
+            txn.updateProtocol(Action.supportedProtocolVersion(
+              // CatalogOwnedTableFeature is enabled by protocol only without metadata, and should
+              // not be enabled by default.
+              featuresToExclude = Seq(CatalogOwnedTableFeature)))
         }
         txn.commit(otherActions, op)
       } else {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR implements the RFC "CatalogOwned" table feature to Delta-IO. https://github.com/delta-io/delta/pull/4382

## How was this patch tested?

Existing & New unit tests. More tests will be added.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
