### PR TITLE
[Kernel] Add `removeFileSizeInBytes` to transaction metrics and increment when removes are committed

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
@@ -22,6 +22,8 @@ package io.delta.kernel.internal;
  */
 public class DeltaErrorsInternal {
 
+  private DeltaErrorsInternal() {}
+
   public static IllegalStateException missingRemoveFileSizeDuringCommit() {
     return new IllegalStateException(
         "Kernel APIs for creating remove file rows require that "

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal;
+
+/**
+ * Contains methods to create developer-facing exceptions. See <a
+ * href="https://github.com/delta-io/delta/blob/master/kernel/EXCEPTION_PRINCIPLES.md">Exception
+ * Principles</a> for more information on what these are and how to use them.
+ */
+public class DeltaErrorsInternal {
+
+  public static IllegalStateException missingRemoveFileSizeDuringCommit() {
+    return new IllegalStateException(
+        "Kernel APIs for creating remove file rows require that "
+            + "file size be provided but found null file size");
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -490,14 +490,7 @@ public class TransactionImpl implements Transaction {
       txnMetrics.removeFilesCounter.increment();
       RemoveFile removeFile = new RemoveFile(fileActionRow.getStruct(REMOVE_FILE_ORDINAL));
       long fileSize =
-          removeFile
-              .getSize()
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "Kernel APIs for creating remove file rows "
-                              + "require that file size be provided but "
-                              + "found null file size"));
+          removeFile.getSize().orElseThrow(DeltaErrorsInternal::missingRemoveFileSizeDuringCommit);
       txnMetrics.removeFilesSizeInBytesCounter.increment(fileSize);
       // TODO decrement fileSizeHistogram
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -443,7 +443,7 @@ public class TransactionImpl implements Transaction {
       }
 
       // Action counters may be partially incremented from previous tries, reset the counters to 0
-      transactionMetrics.resetActionCounters();
+      transactionMetrics.resetCounters();
       boolean isAppendOnlyTable = APPEND_ONLY_ENABLED.fromMetadata(metadata);
 
       // Write the staged data to a delta file
@@ -455,7 +455,7 @@ public class TransactionImpl implements Transaction {
                     FileNames.deltaFile(logPath, commitAsVersion),
                     dataAndMetadataActions.map(
                         action -> {
-                          incrementMetricsForFileActionRow(action, transactionMetrics);
+                          incrementMetricsForFileActionRow(transactionMetrics, action);
                           if (!action.isNullAt(REMOVE_FILE_ORDINAL)) {
                             RemoveFile removeFile =
                                 new RemoveFile(action.getStruct(REMOVE_FILE_ORDINAL));
@@ -479,7 +479,7 @@ public class TransactionImpl implements Transaction {
     }
   }
 
-  private void incrementMetricsForFileActionRow(Row fileActionRow, TransactionMetrics txnMetrics) {
+  private void incrementMetricsForFileActionRow(TransactionMetrics txnMetrics, Row fileActionRow) {
     txnMetrics.totalActionsCounter.increment();
     if (!fileActionRow.isNullAt(ADD_FILE_ORDINAL)) {
       txnMetrics.addFilesCounter.increment();
@@ -499,7 +499,7 @@ public class TransactionImpl implements Transaction {
                               + "require that file size be provided but "
                               + "found null file size"));
       txnMetrics.removeFilesSizeInBytesCounter.increment(fileSize);
-      // TODO increment fileSizeHistogram
+      // TODO decrement fileSizeHistogram
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtils.java
@@ -199,7 +199,8 @@ public final class GenerateIcebergCompatActionUtils {
   // within RemoveFile.java until we add full support for deletes (which will likely involve
   // generating RemoveFiles directly from AddFiles anyway)
 
-  private static Row convertRemoveDataFileStatus(
+  @VisibleForTesting
+  public static Row convertRemoveDataFileStatus(
       StructType physicalSchema,
       URI tableRoot,
       DataFileStatus dataFileStatus,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
@@ -47,7 +47,7 @@ public class TransactionMetrics {
    * (i.e. if an exception interrupts a file write). This allows us to reset the counters so that we
    * can increment them correctly from 0 on a retry.
    */
-  public void resetActionCounters() {
+  public void resetCounters() {
     addFilesCounter.reset();
     addFilesSizeInBytesCounter.reset();
     removeFilesCounter.reset();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
@@ -39,7 +39,7 @@ public class TransactionMetrics {
 
   public final Counter addFilesSizeInBytesCounter = new Counter();
 
-  // TODO: add removeFilesSizeInBytesCounter (and to TransactionMetricsResult)
+  public final Counter removeFilesSizeInBytesCounter = new Counter();
 
   /**
    * Resets the action counters (addFilesCounter, removeFilesCounter and totalActionsCounter) to 0.
@@ -52,6 +52,7 @@ public class TransactionMetrics {
     addFilesSizeInBytesCounter.reset();
     removeFilesCounter.reset();
     totalActionsCounter.reset();
+    removeFilesSizeInBytesCounter.reset();
   }
 
   public TransactionMetricsResult captureTransactionMetricsResult() {
@@ -63,6 +64,7 @@ public class TransactionMetrics {
       final long totalAddFilesSizeInBytes = addFilesSizeInBytesCounter.value();
       final long numRemoveFiles = removeFilesCounter.value();
       final long numTotalActions = totalActionsCounter.value();
+      final long totalRemoveFileSizeInBytes = removeFilesSizeInBytesCounter.value();
 
       @Override
       public long getTotalCommitDurationNs() {
@@ -93,6 +95,11 @@ public class TransactionMetrics {
       public long getTotalAddFilesSizeInBytes() {
         return totalAddFilesSizeInBytes;
       }
+
+      @Override
+      public long getTotalRemoveFilesSizeInBytes() {
+        return totalRemoveFileSizeInBytes;
+      }
     };
   }
 
@@ -100,12 +107,14 @@ public class TransactionMetrics {
   public String toString() {
     return String.format(
         "TransactionMetrics(totalCommitTimer=%s, commitAttemptsCounter=%s, addFilesCounter=%s, "
-            + "removeFilesCounter=%s, totalActionsCounter=%s, totalAddFilesSizeInBytes=%s)",
+            + "removeFilesCounter=%s, totalActionsCounter=%s, totalAddFilesSizeInBytes=%s,"
+            + "totalRemoveFilesSizeInBytes=%s)",
         totalCommitTimer,
         commitAttemptsCounter,
         addFilesCounter,
         removeFilesCounter,
         totalActionsCounter,
-        addFilesSizeInBytesCounter);
+        addFilesSizeInBytesCounter,
+        removeFilesSizeInBytesCounter);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   "numAddFiles",
   "numRemoveFiles",
   "numTotalActions",
-  "totalAddFilesSizeInBytes"
+  "totalAddFilesSizeInBytes",
+  "totalRemoveFilesSizeInBytes"
 })
 public interface TransactionMetricsResult {
 
@@ -57,6 +58,12 @@ public interface TransactionMetricsResult {
    *     this metric may be incomplete.
    */
   long getTotalAddFilesSizeInBytes();
+
+  /**
+   * @return the sum of size of removed files committed in this transaction. For a failed
+   *     transaction this metric may be incomplete.
+   */
+  long getTotalRemoveFilesSizeInBytes();
 
   // TODO add fileSizeHistogram
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -120,7 +120,8 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"numAddFiles":${transactionMetrics.getNumAddFiles},
          |"numRemoveFiles":${transactionMetrics.getNumRemoveFiles},
          |"numTotalActions":${transactionMetrics.getNumTotalActions},
-         |"totalAddFilesSizeInBytes":${transactionMetrics.getTotalAddFilesSizeInBytes}
+         |"totalAddFilesSizeInBytes":${transactionMetrics.getTotalAddFilesSizeInBytes},
+         |"totalRemoveFilesSizeInBytes":${transactionMetrics.getTotalRemoveFilesSizeInBytes}
          |}
          |}
          |""".stripMargin.replaceAll("\n", "")
@@ -139,6 +140,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
     transactionMetrics1.addFilesCounter.increment(82)
     transactionMetrics1.totalActionsCounter.increment(90)
     transactionMetrics1.addFilesSizeInBytesCounter.increment(100)
+    transactionMetrics1.removeFilesSizeInBytesCounter.increment(1000)
 
     val transactionReport1 = new TransactionReportImpl(
       "/table/path",
@@ -167,7 +169,8 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"numAddFiles":82,
          |"numRemoveFiles":0,
          |"numTotalActions":90,
-         |"totalAddFilesSizeInBytes":100
+         |"totalAddFilesSizeInBytes":100,
+         |"totalRemoveFilesSizeInBytes":1000
          |}
          |}
          |""".stripMargin.replaceAll("\n", "")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Follow-up to https://github.com/delta-io/delta/commit/bdd3c520ca20c03733d07bfff4261c2ebfc8db90.


## How was this patch tested?

Adds and updates unit tests.

## Does this PR introduce _any_ user-facing changes?

No