### PR TITLE
[Spark] [Catalog-Owned] Use `_staged_commits/` folder for staged/unbackfilled commit files

### DIFF
--- a/spark/src/main/java/io/delta/dynamodbcommitcoordinator/integration_tests/dynamodb_commitcoordinator_integration_test.py
+++ b/spark/src/main/java/io/delta/dynamodbcommitcoordinator/integration_tests/dynamodb_commitcoordinator_integration_test.py
@@ -193,7 +193,7 @@ def check_for_delta_file_in_filesystem(delta_table_path, version, is_backfilled,
     s3_client = boto3.client("s3")
     relative_table_path = delta_table_path.replace(bucket_prefix, "")
     relative_delta_log_path = relative_table_path + "/_delta_log/"
-    relative_commit_folder_path = relative_delta_log_path if is_backfilled else os.path.join(relative_delta_log_path, "_commits")
+    relative_commit_folder_path = relative_delta_log_path if is_backfilled else os.path.join(relative_delta_log_path, "_staged_commits")
     listing_prefix = os.path.join(relative_commit_folder_path, f"{version:020}.").lstrip("/")
     print(f"querying {listing_prefix} from bucket {s3_bucket} for version {version}")
     response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=listing_prefix)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -364,7 +364,7 @@ trait Checkpoints extends DeltaLogging {
     //
     // Sample directory structure with a gap if we don't backfill commit files:
     // _delta_log/
-    //   _commits/
+    //   _staged_commits/
     //     00017.$uuid.json
     //     00018.$uuid.json
     //   00015.json

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/AbstractBatchBackfillingCommitCoordinatorClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/AbstractBatchBackfillingCommitCoordinatorClient.scala
@@ -91,7 +91,7 @@ trait AbstractBatchBackfillingCommitCoordinatorClient
         null)
     }
 
-    // Write new commit file in _commits directory
+    // Write new commit file in `_staged_commits` directory
     val fileStatus = JCoordinatedCommitsUtils.writeUnbackfilledCommitFile(
       logStore, hadoopConf, logPath.toString, commitVersion, actions, generateUUID())
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.Path
  * This class is part of the changes introduced to accommodate the adoption of coordinated-commits
  * in Delta Lake. Previously, certain code paths assumed the existence of delta files for a specific
  * version at a predictable path `_delta_log/$version.json`. With coordinated-commits, delta files
- * may alternatively be located at `_delta_log/_commits/$version.$uuid.json`.
+ * may alternatively be located at `_delta_log/_staged_commits/$version.$uuid.json`.
  * DeltaCommitFileProvider attempts to locate the correct delta files from the Snapshot's
  * LogSegment.
  *

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
@@ -47,7 +47,8 @@ object FileNames {
    *
    * @param logPath The root path of the delta log.
    * @param version The version of the delta file.
-   * @return The path to the un-backfilled delta file: <logPath>/_commits/<version>.<uuid>.json
+   * @return The path to the un-backfilled delta file:
+   *         `<logPath>/_staged_commits/<version>.<uuid>.json`
    */
   def unbackfilledDeltaFile(
       logPath: Path,
@@ -187,7 +188,7 @@ object FileNames {
       unapply(f.getPath).map { case (_, version) => (f, version) }
     def unapply(path: Path): Option[(Path, Long)] = {
       val parentDirName = path.getParent.getName
-      // If parent is _commits dir, then match against unbackfilled commit file.
+      // If parent is `_staged_commits` dir, then match against unbackfilled commit file.
       val regex = if (parentDirName == COMMIT_SUBDIR) uuidDeltaFileRegex else deltaFileRegex
       regex.unapplySeq(path.getName).map(path -> _.head.toLong)
     }
@@ -209,7 +210,7 @@ object FileNames {
     def unapply(f: FileStatus): Option[(FileStatus, Long)] =
       unapply(f.getPath).map { case (_, version) => (f, version) }
     def unapply(path: Path): Option[(Path, Long)] = {
-      // Don't match files in the _commits sub-directory.
+      // Don't match files in the `_staged_commits` subdirectory.
       if (path.getParent.getName == COMMIT_SUBDIR) {
         None
       } else {
@@ -223,7 +224,7 @@ object FileNames {
     def unapply(f: FileStatus): Option[(FileStatus, Long, String)] =
       unapply(f.getPath).map { case (_, version, uuidString) => (f, version, uuidString) }
     def unapply(path: Path): Option[(Path, Long, String)] = {
-      // If parent is _commits dir, then match against uuid commit file.
+      // If parent is `_staged_commits` dir, then match against uuid commit file.
       if (path.getParent.getName == COMMIT_SUBDIR) {
         uuidDeltaFileRegex
           .unapplySeq(path.getName)
@@ -258,10 +259,12 @@ object FileNames {
   }
 
   val SIDECAR_SUBDIR = "_sidecars"
-  val COMMIT_SUBDIR = "_commits"
+
   /** Returns path to the sidecar directory */
   def sidecarDirPath(logPath: Path): Path = new Path(logPath, SIDECAR_SUBDIR)
 
-  /** Returns path to the sidecar directory */
+  val COMMIT_SUBDIR = "_staged_commits"
+
+  /** Returns path to the staged commit directory */
   def commitDirPath(logPath: Path): Path = new Path(logPath, COMMIT_SUBDIR)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/FileNamesSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/FileNamesSuite.scala
@@ -35,8 +35,8 @@ class FileNamesSuite extends SparkFunSuite {
     // UUID Files
     assert(!isDeltaFile(new Path("/a/123.uuid.json")))
     assert(!isDeltaFile(new Path("/a/_delta_log/123.uuid.json")))
-    assert(isDeltaFile(new Path("/a/_delta_log/_commits/123.uuid.json")))
-    assert(!isDeltaFile(new Path("/a/_delta_log/_commits/123.uuid1.uuid2.json")))
+    assert(isDeltaFile(new Path("/a/_delta_log/_staged_commits/123.uuid.json")))
+    assert(!isDeltaFile(new Path("/a/_delta_log/_staged_commits/123.uuid1.uuid2.json")))
   }
 
   test("DeltaFile.unapply") {
@@ -52,9 +52,10 @@ class FileNamesSuite extends SparkFunSuite {
     // UUID Files
     assert(DeltaFile.unapply(new Path("/a/123.uuid.json")).isEmpty)
     assert(DeltaFile.unapply(new Path("/a/_delta_log/123.uuid.json")).isEmpty)
-    assert(DeltaFile.unapply(new Path("/a/_delta_log/_commits/123.uuid.json")) ===
-      Some((new Path("/a/_delta_log/_commits/123.uuid.json"), 123)))
-    assert(DeltaFile.unapply(new Path("/a/_delta_log/_commits/123.uuid1.uuid2.json")).isEmpty)
+    assert(DeltaFile.unapply(new Path("/a/_delta_log/_staged_commits/123.uuid.json")) ===
+      Some((new Path("/a/_delta_log/_staged_commits/123.uuid.json"), 123)))
+    assert(DeltaFile.unapply(
+      new Path("/a/_delta_log/_staged_commits/123.uuid1.uuid2.json")).isEmpty)
   }
 
   test("isCheckpointFile") {
@@ -98,8 +99,8 @@ class FileNamesSuite extends SparkFunSuite {
 
   test("commitDirPath") {
     assert(commitDirPath(logPath = new Path("/a/_delta_log")) ===
-      new Path("/a/_delta_log/_commits"))
+      new Path("/a/_delta_log/_staged_commits"))
     assert(commitDirPath(logPath = new Path("/a/_delta_log/")) ===
-      new Path("/a/_delta_log/_commits"))
+      new Path("/a/_delta_log/_staged_commits"))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -313,7 +313,7 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       new File(tempDir, "_delta_log").listFiles().filter(_.getName.endsWith(".json"))
         .foreach(_.delete())
       if (coordinatedCommitsEnabledInTests) {
-        new File(new File(tempDir, "_delta_log"), "_commits")
+        new File(new File(tempDir, "_delta_log"), "_staged_commits")
           .listFiles()
           .filter(_.getName.endsWith(".json"))
           .foreach(_.delete())

--- a/storage/src/main/java/io/delta/storage/commit/CoordinatedCommitsUtils.java
+++ b/storage/src/main/java/io/delta/storage/commit/CoordinatedCommitsUtils.java
@@ -39,7 +39,7 @@ public class CoordinatedCommitsUtils {
     private static final String LOG_DIR_NAME = "_delta_log";
 
     /** The subdirectory in which to store the unbackfilled commit files. */
-    private static final String COMMIT_SUBDIR = "_commits";
+    private static final String COMMIT_SUBDIR = "_staged_commits";
 
     /** The configuration key for the coordinated commits owner name. */
     private static final String COORDINATED_COMMITS_COORDINATOR_NAME_KEY =
@@ -56,7 +56,8 @@ public class CoordinatedCommitsUtils {
 
     /**
      * Creates a new unbackfilled delta file path for the given commit version.
-     * The path is of the form `tablePath/_delta_log/_commits/00000000000000000001.uuid.json`.
+     * The path is of the form:
+     * `tablePath/_delta_log/_staged_commits/00000000000000000001.uuid.json`.
      */
     public static Path generateUnbackfilledDeltaFilePath(
             Path logPath,
@@ -102,7 +103,7 @@ public class CoordinatedCommitsUtils {
      *
      * @param logPath The root path of the delta log.
      * @param version The version of the delta file.
-     * @return The path to the un-backfilled delta file: logPath/_commits/version.uuid.json
+     * @return The path to the un-backfilled delta file: logPath/_staged_commits/version.uuid.json
      */
     public static Path getUnbackfilledDeltaFile(
             Path logPath, long version, Optional<String> uuidString) {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/InvalidTargetTableException.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/InvalidTargetTableException.java
@@ -20,7 +20,7 @@ package io.delta.storage.commit.uccommitcoordinator;
  * This exception is thrown by the UC client in case a commit attempt tried to add
  * a UUID-based commit to the wrong table. The table is wrong if the path prefixes
  * of the table and the UUID commit do not match.
- * For example, adding /path/to/table1/_commits/01-uuid.json to the table at
+ * For example, adding /path/to/table1/_staged_commits/01-uuid.json to the table at
  * /path/to/table2 is not allowed.
  */
 public class InvalidTargetTableException extends UCCommitCoordinatorException {

--- a/storage/src/test/scala/io/delta/storage/commit/InMemoryCommitCoordinator.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/InMemoryCommitCoordinator.scala
@@ -121,7 +121,7 @@ class InMemoryCommitCoordinator(val batchSize: Long) extends CommitCoordinatorCl
         tablePath)
       backfillToVersion(logStore, hadoopConf, tableDesc, commitVersion - 1, null)
     }
-    // Write new commit file in _commits directory
+    // Write new commit file in `_staged_commits` directory
     val fileStatus = CoordinatedCommitsUtils.writeUnbackfilledCommitFile(
       logStore, hadoopConf, logPath.toString, commitVersion, actions, generateUUID())
     // Do the actual commit


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Per [Catalog-Owned RFC](https://github.com/delta-io/delta/pull/4382), we decided to use `_delta_log/_staged_commits/` folder to store all staged/unbackfilled commit files, which is different from [Manged Commits RFC](https://github.com/delta-io/delta/blob/master/protocol_rfcs/managed-commits.md)'s `_delta_log/_commits/` folder.

This PR changes the `COMMIT_SUBDIR` in both `CoordinatedCommitsUtils.java` and `FilesNames.scala`, plus update all the relevant comments/UTs.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through existing UTs.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No, the change for commit subdirectory should **_not_** be a user-facing change.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
