### PR TITLE
Adding a Spark config to force Delta Sharing return delta format

### DIFF
--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -376,6 +376,35 @@ trait DeltaSharingDataSourceDeltaSuiteBase
             "parquet"
           )
         }
+
+        // Build a parquet table and query with delta format
+        // Use a unique table name for this test as assertRequestedFormat is using a global map
+        val sharedParquetTableForDeltaFormat = "shared_parquet_table_for_delta_format"
+        // Use prepareMockedClientAndFileSystemResult not ForParquet because fromJson requires DeltaSharingMetadata
+        prepareMockedClientAndFileSystemResult(
+          deltaTableName,
+          sharedParquetTableForDeltaFormat
+        )
+        prepareMockedClientAndFileSystemResult(
+          deltaTableName,
+          sharedParquetTableForDeltaFormat,
+          limitHint = Some(1)
+        )
+        prepareMockedClientAndFileSystemResult(
+          deltaTableName,
+          sharedParquetTableForDeltaFormat,
+          versionAsOf = Some(1)
+        )
+        prepareMockedClientGetTableVersion(deltaTableName, sharedParquetTableForDeltaFormat)
+        val overrideConfigs = Map(DeltaSQLConf.DELTA_SHARING_FORCE_DELTA_FORMAT.key -> "true")
+        withSQLConf((overrideConfigs ++ getDeltaSharingClassesSQLConf).toSeq: _*) {
+          val profileFile = prepareProfileFile(tempDir)
+          testAutoResolve(
+            s"${profileFile.getCanonicalPath}#share1.default.$sharedParquetTableForDeltaFormat",
+            s"share1.default.$sharedParquetTableForDeltaFormat",
+            "delta"
+          )
+        }
       }
     }
   }

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -102,7 +102,8 @@ private[spark] class TestClientForDeltaFormatSharing(
     while (iterator.hasNext) {
       linesBuilder += iterator.next()
     }
-    if (table.name.contains("shared_parquet_table")) {
+    if (table.name.contains("shared_parquet_table") &&
+      responseFormat.contains(DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET)) {
       val lines = linesBuilder.result()
       val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
       val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
@@ -170,7 +171,8 @@ private[spark] class TestClientForDeltaFormatSharing(
     while (iterator.hasNext) {
       linesBuilder += iterator.next()
     }
-    if (table.name.contains("shared_parquet_table")) {
+    if (table.name.contains("shared_parquet_table") &&
+      responseFormat.contains(DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET)) {
       val lines = linesBuilder.result()
       val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
       val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2496,6 +2496,13 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_SHARING_FORCE_DELTA_FORMAT =
+    buildConf("spark.sql.delta.sharing.forceDeltaFormat")
+      .doc("Force queries to use delta format when no responseFormat is specified.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   ///////////////////
   // IDENTITY COLUMN
   ///////////////////


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
When the source delta table doesn't have advanced delta features like deletion vector, Spark query against a delta shared table would use parquet format. Adding a Spark config to force returning delta format even if the source table doesn't have advanced features. 

This will help performance benchmark to test delta format code path and parquet format code path with the same table. 

## How was this patch tested?
Adding a new test case to validate Spark config

## Does this PR introduce _any_ user-facing changes?
No
