### PR TITLE
[Kernel] Schema validation for clustering columns

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -373,24 +373,26 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         throw new KernelException("Cannot update mapping mode and perform schema evolution");
       }
 
+      // If the column mapping restriction is removed, clustering columns
+      // will need special handling during schema evolution since they won't have physical names
+      // ToDo: Support adding clustering columns
+
       if (!isColumnMappingModeEnabled(updatedMappingMode)) {
         throw new KernelException("Cannot update schema for table when column mapping is disabled");
       }
 
-      // TODO: revisit this once we want to support schema evolution with clustering columns
-      Optional<List<Column>> clusteringColumns =
-          ClusteringUtils.getClusteringColumnsOptional(snapshot);
-      if (clusteringColumns.isPresent() && !clusteringColumns.get().isEmpty()) {
-        throw new KernelException(
-            format(
-                "Update schema for table with clustering columns %s is not yet supported",
-                clusteringColumns.get()));
-      }
+      // Clustering columns will be guaranteed to have physical names at this point
+      Set<String> clusteringColumnPhysicalNames =
+          ClusteringUtils.getClusteringColumnsOptional(snapshot).orElse(Collections.emptyList())
+              .stream()
+              .map(col -> col.getNames()[0])
+              .collect(toSet());
 
       SchemaUtils.validateUpdatedSchema(
           oldMetadata.getSchema(),
           newMetadata.getSchema(),
           oldMetadata.getPartitionColNames(),
+          clusteringColumnPhysicalNames,
           newMetadata);
     }
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -382,10 +382,14 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       }
 
       // Clustering columns will be guaranteed to have physical names at this point
+      // Only the leaf part of the overall column needs to be taken since
+      // validation is performed on the leaf struct fields
+      // E.g. getClusteringColumns returns <physical_name_of_struct>.<physical_name_inner>,
+      // Only physical_name_inner is required for validation
       Set<String> clusteringColumnPhysicalNames =
           ClusteringUtils.getClusteringColumnsOptional(snapshot).orElse(Collections.emptyList())
               .stream()
-              .map(col -> col.getNames()[0])
+              .map(col -> col.getNames()[col.getNames().length - 1])
               .collect(toSet());
 
       SchemaUtils.validateUpdatedSchema(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -465,6 +465,8 @@ public class SchemaUtils {
   private static void validateClusteringColumnsNotDropped(
       List<StructField> droppedFields, Set<String> clusteringColumnPhysicalNames) {
     for (StructField droppedField : droppedFields) {
+      // ToDo: At some point plumb through mapping of ID to full name, so we get better error
+      // messages
       if (clusteringColumnPhysicalNames.contains(getPhysicalName(droppedField))) {
         throw new KernelException(
             String.format("Cannot drop clustering column %s", droppedField.getName()));

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -17,6 +17,7 @@ package io.delta.kernel.internal.util
 
 import java.util
 import java.util.{Locale, Optional}
+import java.util.Collections.emptySet
 
 import scala.collection.JavaConverters._
 import scala.collection.JavaConverters.mapAsJavaMapConverter
@@ -490,7 +491,8 @@ class SchemaUtilsSuite extends AnyFunSuite {
       validateUpdatedSchema(
         current,
         updated,
-        Set.empty.asJava,
+        emptySet(),
+        emptySet(),
         metadata(current, properties = tblProperties))
     }
 
@@ -683,7 +685,12 @@ class SchemaUtilsSuite extends AnyFunSuite {
   test("validateUpdatedSchema fails with schema with duplicate column ID") {
     forAll(updatedSchemaHasDuplicateColumnId) { (schemaBefore, schemaAfter) =>
       val e = intercept[IllegalArgumentException] {
-        validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
+        validateUpdatedSchema(
+          schemaBefore,
+          schemaAfter,
+          emptySet(),
+          emptySet(),
+          metadata(schemaBefore))
       }
 
       assert(e.getMessage.matches("Field duplicate_id with id .* already exists"))
@@ -732,7 +739,12 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("validateUpdatedSchema succeeds with valid ID and physical name") {
     forAll(validUpdatedSchemas) { (schemaBefore, schemaAfter) =>
-      validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
+      validateUpdatedSchema(
+        schemaBefore,
+        schemaAfter,
+        emptySet(),
+        emptySet(),
+        metadata(schemaBefore))
     }
   }
 
@@ -918,7 +930,12 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("validateUpdatedSchema succeeds when adding field") {
     forAll(validateAddedFields) { (schemaBefore, schemaAfter) =>
-      validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
+      validateUpdatedSchema(
+        schemaBefore,
+        schemaAfter,
+        emptySet(),
+        emptySet(),
+        metadata(schemaBefore))
     }
   }
 
@@ -952,7 +969,12 @@ class SchemaUtilsSuite extends AnyFunSuite {
 
   test("validateUpdatedSchema succeeds when updating field metadata") {
     forAll(validateMetadataChange) { (schemaBefore, schemaAfter) =>
-      validateUpdatedSchema(schemaBefore, schemaAfter, Set.empty.asJava, metadata(schemaBefore))
+      validateUpdatedSchema(
+        schemaBefore,
+        schemaAfter,
+        emptySet(),
+        emptySet(),
+        metadata(schemaBefore))
     }
   }
 
@@ -1002,7 +1024,8 @@ class SchemaUtilsSuite extends AnyFunSuite {
         validateUpdatedSchema(
           schemaBefore,
           schemaAfter,
-          Set.empty.asJava,
+          emptySet(),
+          emptySet(),
           metadata(schemaBefore, tableProperties))
       }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR includes validation for clustering columns. Namely, that clustering columns cannot be dropped.
It allows for schema evolutions where clustering columns are renamed.

## How was this patch tested?

Updated/added new unit tests

## Does this PR introduce _any_ user-facing changes?
The `withSchema` API will allow certain operations like renames to be performed on clustering columns