### PR TITLE
[Kernel] Read the fileSizeHistogram from CRCInfo and propagate it through transaction metrics

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -259,7 +259,7 @@ public class TransactionImpl implements Transaction {
     TransactionMetrics transactionMetrics =
         isNewTable
             ? TransactionMetrics.forNewTable()
-            : TransactionMetrics.withExistingFileSizeHistogram(
+            : TransactionMetrics.withExistingTableFileSizeHistogram(
                 readSnapshot.getCurrentCrcInfo().flatMap(CRCInfo::getFileSizeHistogram));
     try {
       long committedVersion =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -254,7 +254,13 @@ public class TransactionImpl implements Transaction {
   public TransactionCommitResult commit(Engine engine, CloseableIterable<Row> dataActions)
       throws ConcurrentWriteException {
     checkState(!closed, "Transaction is already attempted to commit. Create a new transaction.");
-    TransactionMetrics transactionMetrics = new TransactionMetrics();
+    // For a new table or when fileSizeHistogram is available in the CRC of the readSnapshot
+    // we update it in the commit. When it is not available we do nothing.
+    TransactionMetrics transactionMetrics =
+        isNewTable
+            ? TransactionMetrics.forNewTable()
+            : TransactionMetrics.withExistingFileSizeHistogram(
+                readSnapshot.getCurrentCrcInfo().flatMap(CRCInfo::getFileSizeHistogram));
     try {
       long committedVersion =
           transactionMetrics.totalCommitTimer.time(
@@ -329,6 +335,9 @@ public class TransactionImpl implements Transaction {
             commitAsVersion = rebaseState.getLatestVersion() + 1;
             dataActions = rebaseState.getUpdatedDataActions();
             domainMetadatas = Optional.of(rebaseState.getUpdatedDomainMetadatas());
+            // Action counters may be partially incremented from previous tries, reset the counters
+            // to 0 and drop fileSizeHistogram
+            transactionMetrics.resetActionMetricsForRetry();
           }
         }
         numTries++;
@@ -442,8 +451,6 @@ public class TransactionImpl implements Transaction {
         }
       }
 
-      // Action counters may be partially incremented from previous tries, reset the counters to 0
-      transactionMetrics.resetCounters();
       boolean isAppendOnlyTable = APPEND_ONLY_ENABLED.fromMetadata(metadata);
 
       // Write the staged data to a delta file
@@ -482,17 +489,12 @@ public class TransactionImpl implements Transaction {
   private void incrementMetricsForFileActionRow(TransactionMetrics txnMetrics, Row fileActionRow) {
     txnMetrics.totalActionsCounter.increment();
     if (!fileActionRow.isNullAt(ADD_FILE_ORDINAL)) {
-      txnMetrics.addFilesCounter.increment();
-      txnMetrics.addFilesSizeInBytesCounter.increment(
-          new AddFile(fileActionRow.getStruct(ADD_FILE_ORDINAL)).getSize());
-      // TODO increment fileSizeHistogram
+      txnMetrics.updateForAddFile(new AddFile(fileActionRow.getStruct(ADD_FILE_ORDINAL)).getSize());
     } else if (!fileActionRow.isNullAt(REMOVE_FILE_ORDINAL)) {
-      txnMetrics.removeFilesCounter.increment();
       RemoveFile removeFile = new RemoveFile(fileActionRow.getStruct(REMOVE_FILE_ORDINAL));
-      long fileSize =
+      long removeFileSize =
           removeFile.getSize().orElseThrow(DeltaErrorsInternal::missingRemoveFileSizeDuringCommit);
-      txnMetrics.removeFilesSizeInBytesCounter.increment(fileSize);
-      // TODO decrement fileSizeHistogram
+      txnMetrics.updateForRemoveFile(removeFileSize);
     }
   }
 
@@ -579,6 +581,8 @@ public class TransactionImpl implements Transaction {
   private Optional<CRCInfo> buildPostCommitCrcInfoIfCurrentCrcAvailable(
       long commitAtVersion, TransactionMetricsResult metricsResult) {
     if (isNewTable) {
+      // We don't need to worry about conflicting transaction here since new tables always commit
+      // metadata (and thus fail any conflicts)
       return Optional.of(
           new CRCInfo(
               commitAtVersion,
@@ -586,7 +590,9 @@ public class TransactionImpl implements Transaction {
               protocol,
               metricsResult.getTotalAddFilesSizeInBytes(),
               metricsResult.getNumAddFiles(),
-              Optional.of(txnId.toString())));
+              Optional.of(txnId.toString()),
+              Optional.empty() // once we support writing CRC populate here
+              ));
     }
 
     return readSnapshot
@@ -603,7 +609,9 @@ public class TransactionImpl implements Transaction {
                     // TODO: handle RemoveFiles for calculating table size and num of files.
                     lastCrcInfo.getTableSizeBytes() + metricsResult.getTotalAddFilesSizeInBytes(),
                     lastCrcInfo.getNumFiles() + metricsResult.getNumAddFiles(),
-                    Optional.of(txnId.toString())));
+                    Optional.of(txnId.toString()),
+                    Optional.empty() // once we support writing CRC populate here
+                    ));
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/stats/FileSizeHistogram.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/stats/FileSizeHistogram.java
@@ -23,6 +23,7 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.util.InternalUtils;
 import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.metrics.FileSizeHistogramResult;
 import io.delta.kernel.types.ArrayType;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructType;
@@ -159,6 +160,8 @@ public class FileSizeHistogram {
     return boundaries;
   }
 
+  // TODO factory from FileSizeHistogramResult
+
   ////////////////////////////////////
   // Member variables and methods  //
   ////////////////////////////////////
@@ -255,6 +258,30 @@ public class FileSizeHistogram {
         VectorUtils.buildArrayValue(
             Arrays.stream(totalBytes).boxed().collect(Collectors.toList()), LongType.LONG));
     return new GenericRow(FULL_SCHEMA, value);
+  }
+
+  public FileSizeHistogramResult captureFileSizeHistogramResult() {
+    return new FileSizeHistogramResult() {
+      final long[] copiedSortedBinBoundaries =
+          Arrays.copyOf(sortedBinBoundaries, sortedBinBoundaries.length);
+      final long[] copiedFileCounts = Arrays.copyOf(fileCounts, fileCounts.length);
+      final long[] copiedTotalBytes = Arrays.copyOf(totalBytes, totalBytes.length);
+
+      @Override
+      public long[] getSortedBinBoundaries() {
+        return copiedSortedBinBoundaries;
+      }
+
+      @Override
+      public long[] getFileCounts() {
+        return copiedFileCounts;
+      }
+
+      @Override
+      public long[] getTotalBytes() {
+        return copiedTotalBytes;
+      }
+    };
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/FileSizeHistogramResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/FileSizeHistogramResult.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.metrics;
+
+/** Stores the file size histogram information to track file size distribution and their counts. */
+public interface FileSizeHistogramResult {
+
+  /**
+   * Sorted list of bin boundaries where each element represents the start of the bin (inclusive)
+   * and the next element represents the end of the bin (exclusive).
+   */
+  long[] getSortedBinBoundaries();
+
+  /**
+   * The total number of files in each bin of {@link
+   * FileSizeHistogramResult#getSortedBinBoundaries()}
+   */
+  long[] getFileCounts();
+
+  /**
+   * The total number of bytes in each bin of {@link
+   * FileSizeHistogramResult#getSortedBinBoundaries()}
+   */
+  long[] getTotalBytes();
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
@@ -72,5 +72,5 @@ public interface TransactionMetricsResult {
    *     transaction. For a failed transaction this metric may be incomplete.
    */
   @JsonIgnore
-  Optional<FileSizeHistogramResult> getFileSizeHistogram();
+  Optional<FileSizeHistogramResult> getTableFileSizeHistogram();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
@@ -15,7 +15,9 @@
  */
 package io.delta.kernel.metrics;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Optional;
 
 /** Stores the metrics results for a {@link TransactionReport} */
 @JsonPropertyOrder({
@@ -65,5 +67,10 @@ public interface TransactionMetricsResult {
    */
   long getTotalRemoveFilesSizeInBytes();
 
-  // TODO add fileSizeHistogram
+  /**
+   * @return the file size histogram information for the table version committed in this
+   *     transaction. For a failed transaction this metric may be incomplete.
+   */
+  @JsonIgnore
+  Optional<FileSizeHistogramResult> getFileSizeHistogram();
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumWriterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumWriterSuite.scala
@@ -47,6 +47,7 @@ class ChecksumWriterSuite extends AnyFunSuite with MockEngineUtils {
   private val TXN_ID_IDX = CRC_FILE_SCHEMA.indexOf("txnId")
   private val METADATA_IDX = CRC_FILE_SCHEMA.indexOf("metadata")
   private val PROTOCOL_IDX = CRC_FILE_SCHEMA.indexOf("protocol")
+  private val FILE_SIZE_HISTOGRAM_IDX = CRC_FILE_SCHEMA.indexOf("fileSizeHistogram")
 
   test("write checksum") {
     val jsonHandler = new MockCheckSumFileJsonWriter()
@@ -59,9 +60,10 @@ class ChecksumWriterSuite extends AnyFunSuite with MockEngineUtils {
       val tableSizeBytes = 100L
       val numFiles = 1L
 
+      // TODO when we support writing fileSizeHistogram as part of CRC update this to be non-empty
       checksumWriter.writeCheckSum(
         mockEngine(jsonHandler = jsonHandler),
-        new CRCInfo(version, metadata, protocol, tableSizeBytes, numFiles, txn))
+        new CRCInfo(version, metadata, protocol, tableSizeBytes, numFiles, txn, Optional.empty()))
 
       verifyChecksumFile(jsonHandler, version)
       verifyChecksumContent(
@@ -107,6 +109,8 @@ class ChecksumWriterSuite extends AnyFunSuite with MockEngineUtils {
     } else {
       assert(actualCheckSumRow.isNullAt(TXN_ID_IDX))
     }
+    // TODO once we support writing fileSizeHistogram as part of CRC check it here
+    assert(actualCheckSumRow.isNullAt(FILE_SIZE_HISTOGRAM_IDX))
   }
 
   private def createTestMetadata(): Metadata = {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -188,7 +188,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       "test-engine-2",
       Optional.empty(), /* committedVersion */
       // empty/un-incremented transaction metrics
-      TransactionMetrics.withExistingFileSizeHistogram(Optional.empty()),
+      TransactionMetrics.withExistingTableFileSizeHistogram(Optional.empty()),
       snapshotReport2,
       Optional.empty() /* exception */
     )

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
@@ -124,7 +124,9 @@ class ChecksumSimpleComparisonSuite extends DeltaTableWriteSuiteBase with TestUt
         crcInfo.getProtocol,
         crcInfo.getTableSizeBytes,
         crcInfo.getNumFiles,
-        Optional.empty())
+        Optional.empty(),
+        // This will be empty since neither Kernel nor Spark writes fileSizeHistogram to CRCInfo yet
+        crcInfo.getFileSizeHistogram)
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -136,14 +136,14 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       // support.
       expectedFileSizeHistogramResult match {
         case Some(expectedHistogram) =>
-          assert(txnMetrics.getFileSizeHistogram.isPresent)
-          txnMetrics.getFileSizeHistogram.toScala.foreach { foundHistogram =>
+          assert(txnMetrics.getTableFileSizeHistogram.isPresent)
+          txnMetrics.getTableFileSizeHistogram.toScala.foreach { foundHistogram =>
             assert(expectedHistogram.getSortedBinBoundaries sameElements
               foundHistogram.getSortedBinBoundaries)
             assert(expectedHistogram.getFileCounts sameElements foundHistogram.getFileCounts)
             assert(expectedHistogram.getTotalBytes sameElements foundHistogram.getTotalBytes)
           }
-        case None => assert(!txnMetrics.getFileSizeHistogram.isPresent)
+        case None => assert(!txnMetrics.getTableFileSizeHistogram.isPresent)
       }
     }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -132,7 +132,8 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       assert(txnMetrics.getTotalRemoveFilesSizeInBytes == expectedTotalRemoveFilesSizeInBytes)
 
       // For now since we don't support writing fileSizeHistogram yet we only expect this to be
-      // present on the first write to a table. We will update these tests when we add write support.
+      // present on the first write to a table. We will update these tests when we add write
+      // support.
       expectedFileSizeHistogramResult match {
         case Some(expectedHistogram) =>
           assert(txnMetrics.getFileSizeHistogram.isPresent)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Reads the fileSizeHistogram from CRC and add it as part of transaction metrics. Updates it as the transaction is executed.

Note, this is a little weird since it only adds read support and no write support, so we only actually have histograms available for new tables in E2E tests. But https://github.com/delta-io/delta/pull/4328 will add write support and fill out the full feature afterward. Documented throughout the changes needed when adding write support.

## How was this patch tested?

Updates tests.

## Does this PR introduce _any_ user-facing changes?

No