### PR TITLE
[Kernel]Try loading crc file on conflict resolution

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -369,7 +369,7 @@ public class TransactionImpl implements Transaction {
         ConflictChecker.resolveConflicts(engine, readSnapshot, commitAsVersion, this, dataActions);
     long rebasedVersion = rebaseState.getLatestVersion();
     this.currentCrcInfo =
-            ChecksumReader.getCRCInfo(engine, logPath, rebasedVersion, rebasedVersion);
+        ChecksumReader.getCRCInfo(engine, logPath, rebasedVersion, rebasedVersion);
     long newCommitAsVersion = rebasedVersion + 1;
     checkArgument(
         commitAsVersion < newCommitAsVersion,
@@ -601,9 +601,9 @@ public class TransactionImpl implements Transaction {
               ));
     }
 
-    return  currentCrcInfo
-            // Ensure current currentCrcInfo is exactly commitAtVersion - 1
-            .filter(crcInfo -> commitAtVersion == crcInfo.getVersion() + 1)
+    return currentCrcInfo
+        // Ensure current currentCrcInfo is exactly commitAtVersion - 1
+        .filter(crcInfo -> commitAtVersion == crcInfo.getVersion() + 1)
         .map(
             lastCrcInfo ->
                 new CRCInfo(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -900,7 +900,6 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
 
   test("insert into table - write stats and validate they can be read by Spark ") {
     withTempDirAndEngine { (tblPath, engine) =>
-
       // Configure the table property for stats collection via TableConfig.
       val numIndexedCols = 5
       val tableProperties = Map(TableConfig.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
This PR fixes https://github.com/delta-io/delta/issues/4177, we will try to load crc of resolved version so that crc will be present on conflict txn.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Make skipped concurrent tests working


<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No