### PR TITLE
[Kernel] Support unsetting user table properties + fix a bug where we write all user properties in lower case

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
@@ -26,6 +26,7 @@ import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.types.StructType;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Builder for creating a {@link Transaction} to mutate a Delta table.
@@ -113,6 +114,19 @@ public interface TransactionBuilder {
    * @since 3.3.0
    */
   TransactionBuilder withTableProperties(Engine engine, Map<String, String> properties);
+  
+  /**
+   * Unset the provided table properties on the table. If a property does not exist this is a no-op.
+   * For now this is only supported for user-properties (in other words, does not support 'delta.'
+   * prefixed properties). An exception will be thrown upon calling
+   * {@link TransactionBuilder#build(Engine)} if the same key is both set and unset in the same
+   * transaction.
+   *
+   * @param propertyKeys the table property keys to unset (remove from the table properties)
+   * @return updated {@link TransactionBuilder} instance.
+   * @throws IllegalArgumentException if 'delta.' prefixed keys are provided
+   */
+  TransactionBuilder withUnsetTableProperties(Set<String> propertyKeys);
 
   /**
    * Set the maximum number of times to retry a transaction if a concurrent write is detected. This

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
@@ -105,7 +105,9 @@ public interface TransactionBuilder {
 
   /**
    * Set the table properties for the table. When the table already contains the property with same
-   * key, it gets replaced if it doesn't have the same value.
+   * key, it gets replaced if it doesn't have the same value. Note, user-properties (those without a
+   * '.delta' prefix) are case-sensitive. Delta-properties are case-insensitive and are normalized
+   * to their expected case before writing to the log.
    *
    * @param engine {@link Engine} instance to use.
    * @param properties The table properties to set. These are key-value pairs that can be used to
@@ -114,19 +116,19 @@ public interface TransactionBuilder {
    * @since 3.3.0
    */
   TransactionBuilder withTableProperties(Engine engine, Map<String, String> properties);
-  
+
   /**
    * Unset the provided table properties on the table. If a property does not exist this is a no-op.
    * For now this is only supported for user-properties (in other words, does not support 'delta.'
-   * prefixed properties). An exception will be thrown upon calling
-   * {@link TransactionBuilder#build(Engine)} if the same key is both set and unset in the same
-   * transaction.
+   * prefixed properties). An exception will be thrown upon calling {@link
+   * TransactionBuilder#build(Engine)} if the same key is both set and unset in the same
+   * transaction. Note, user-properties (those without a '.delta' prefix) are case-sensitive.
    *
    * @param propertyKeys the table property keys to unset (remove from the table properties)
    * @return updated {@link TransactionBuilder} instance.
    * @throws IllegalArgumentException if 'delta.' prefixed keys are provided
    */
-  TransactionBuilder withUnsetTableProperties(Set<String> propertyKeys);
+  TransactionBuilder withTablePropertiesRemoved(Set<String> propertyKeys);
 
   /**
    * Set the maximum number of times to retry a transaction if a concurrent write is detected. This

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -257,6 +257,14 @@ public final class DeltaErrors {
         format("Column '%s' was not found in the table schema: %s", column, tableSchema));
   }
 
+  public static KernelException overlappingTablePropertiesSetAndUnset(Set<String> violatingKeys) {
+    return new KernelException(
+        format(
+            "Cannot set and unset the same table property in the same transaction. "
+                + "Properties set and unset: %s",
+            violatingKeys));
+  }
+
   /// Start: icebergCompat exceptions
   public static KernelException icebergCompatMissingNumRecordsStats(
       String compatVersion, DataFileStatus dataFileStatus) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -369,8 +369,8 @@ public class TableConfig<T> {
         tableConfig.validate(value);
         validatedProperties.put(tableConfig.getKey(), value);
       } else {
-        // allow unknown properties to be set
-        validatedProperties.put(key, value);
+        // allow unknown properties to be set (and preserve their original case!)
+        validatedProperties.put(kv.getKey(), value);
       }
     }
     return validatedProperties;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -126,7 +126,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
   }
 
   @Override
-  public TransactionBuilder withUnsetTableProperties(Set<String> propertyKeys) {
+  public TransactionBuilder withTablePropertiesRemoved(Set<String> propertyKeys) {
     checkArgument(
         propertyKeys.stream().noneMatch(key -> key.toLowerCase(Locale.ROOT).startsWith("delta.")),
         "Unsetting 'delta.' table properties is currently unsupported");

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -141,6 +141,16 @@ public class Metadata {
   }
 
   /**
+   * Returns a new metadata object that has a new configuration which does not contain any of the
+   * keys provided in {@code keysToUnset}.
+   */
+  public Metadata withConfigurationKeysUnset(Set<String> keysToUnset) {
+    Map<String, String> newConfiguration = new HashMap<>(getConfiguration());
+    keysToUnset.forEach(newConfiguration::remove);
+    return withReplacedConfiguration(newConfiguration);
+  }
+
+  /**
    * Returns a new Metadata object with the configuration provided with newConfiguration (any prior
    * configuration is replaced).
    */

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
@@ -114,7 +114,7 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
       Seq("delta.checkpointInterval", "DELTA.checkpointInterval").foreach { key =>
         val e = intercept[IllegalArgumentException] {
           createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath.getAbsolutePath))
-            .withUnsetTableProperties(Set(key).asJava)
+            .withTablePropertiesRemoved(Set(key).asJava)
         }
         assert(
           e.getMessage.contains("Unsetting 'delta.' table properties is currently unsupported"))
@@ -129,7 +129,7 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
 
       val e = intercept[KernelException] {
         createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
-          .withUnsetTableProperties(Set("foo.key").asJava)
+          .withTablePropertiesRemoved(Set("foo.key").asJava)
           .withTableProperties(defaultEngine, Map("foo.key" -> "value").asJava)
           .build(defaultEngine)
       }
@@ -152,7 +152,7 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
       // Try to set and unset the existing property
       val e = intercept[KernelException] {
         createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
-          .withUnsetTableProperties(Set("foo.key").asJava)
+          .withTablePropertiesRemoved(Set("foo.key").asJava)
           .withTableProperties(defaultEngine, Map("foo.key" -> "value").asJava)
           .build(defaultEngine)
       }
@@ -175,7 +175,7 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
 
       // Remove 1 of the properties set
       createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
-        .withUnsetTableProperties(Set("foo.key").asJava)
+        .withTablePropertiesRemoved(Set("foo.key").asJava)
         .build(defaultEngine)
         .commit(defaultEngine, emptyIterable())
       assertPropsDNE(tablePath, Set("foo.key"))
@@ -184,7 +184,7 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
 
       // Can unset a property that DNE
       createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
-        .withUnsetTableProperties(Set("not.a.key").asJava)
+        .withTablePropertiesRemoved(Set("not.a.key").asJava)
         .build(defaultEngine)
         .commit(defaultEngine, emptyIterable())
       assertPropsDNE(tablePath, Set("not.a.key"))
@@ -193,7 +193,7 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
 
       // Can be simultaneous with setTblProps as long as no overlap
       createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
-        .withUnsetTableProperties(Set("FOO.KEY").asJava)
+        .withTablePropertiesRemoved(Set("FOO.KEY").asJava)
         .withTableProperties(defaultEngine, Map("foo.key" -> "value-new").asJava)
         .build(defaultEngine)
         .commit(defaultEngine, emptyIterable())

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
@@ -15,11 +15,12 @@
  */
 package io.delta.kernel.defaults
 
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 
 import io.delta.kernel.Table
-import io.delta.kernel.exceptions.UnknownConfigurationException
-import io.delta.kernel.internal.SnapshotImpl
+import io.delta.kernel.exceptions.{KernelException, UnknownConfigurationException}
+import io.delta.kernel.internal.{SnapshotImpl, TableConfig}
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
 
 /**
@@ -88,6 +89,120 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
     }
   }
 
+  test("Case is preserved for user properties and is case sensitive") {
+    // This aligns with Spark's behavior
+    withTempDir { tempFile =>
+      val tablePath = tempFile.getAbsolutePath
+      createUpdateTableWithProps(
+        tablePath,
+        createTable = true,
+        Map("user.facing.PROP" -> "20"))
+      assertHasProp(tablePath, expProps = Map("user.facing.PROP" -> "20"))
+
+      // Try updating in an existing table
+      createUpdateTableWithProps(
+        tablePath,
+        props = Map("user.facing.prop" -> "30"))
+      assertHasProp(
+        tablePath,
+        expProps = Map("user.facing.PROP" -> "20", "user.facing.prop" -> "30"))
+    }
+  }
+
+  test("Cannot unset delta table properties") {
+    withTempDir { tablePath =>
+      Seq("delta.checkpointInterval", "DELTA.checkpointInterval").foreach { key =>
+        val e = intercept[IllegalArgumentException] {
+          createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath.getAbsolutePath))
+            .withUnsetTableProperties(Set(key).asJava)
+        }
+        assert(
+          e.getMessage.contains("Unsetting 'delta.' table properties is currently unsupported"))
+      }
+    }
+  }
+
+  test("Cannot set and unset the same table property in same txn - new property") {
+    withTempDir { tempFile =>
+      val tablePath = tempFile.getAbsolutePath
+      createEmptyTable(tablePath = tablePath, schema = testSchema)
+
+      val e = intercept[KernelException] {
+        createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
+          .withUnsetTableProperties(Set("foo.key").asJava)
+          .withTableProperties(defaultEngine, Map("foo.key" -> "value").asJava)
+          .build(defaultEngine)
+      }
+      assert(e.getMessage.contains(
+        "Cannot set and unset the same table property in the same transaction. "
+          + "Properties set and unset: [foo.key]"))
+    }
+  }
+
+  test("Cannot set and unset the same table property in same txn - existing property") {
+    // i.e. we don't only check against the new properties
+    withTempDir { tempFile =>
+      val tablePath = tempFile.getAbsolutePath
+      // Create initial table with the property
+      createEmptyTable(
+        tablePath = tablePath,
+        schema = testSchema,
+        tableProperties = Map("foo.key" -> "value"))
+
+      // Try to set and unset the existing property
+      val e = intercept[KernelException] {
+        createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
+          .withUnsetTableProperties(Set("foo.key").asJava)
+          .withTableProperties(defaultEngine, Map("foo.key" -> "value").asJava)
+          .build(defaultEngine)
+      }
+      assert(e.getMessage.contains(
+        "Cannot set and unset the same table property in the same transaction. "
+          + "Properties set and unset: [foo.key]"))
+    }
+  }
+
+  test("Unset valid cases - properties are removed from the table") {
+    withTempDir { tempFile =>
+      val tablePath = tempFile.getAbsolutePath
+      // Create initial table with properties
+      // This test also validates the operation is case-sensitive
+      createEmptyTable(
+        tablePath = tablePath,
+        schema = testSchema,
+        tableProperties = Map("foo.key" -> "value", "FOO.KEY" -> "VALUE"))
+      assertHasProp(tablePath, Map("foo.key" -> "value", "FOO.KEY" -> "VALUE"))
+
+      // Remove 1 of the properties set
+      createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
+        .withUnsetTableProperties(Set("foo.key").asJava)
+        .build(defaultEngine)
+        .commit(defaultEngine, emptyIterable())
+      assertPropsDNE(tablePath, Set("foo.key"))
+      // Check that the other property is not touched
+      assertHasProp(tablePath, Map("FOO.KEY" -> "VALUE"))
+
+      // Can unset a property that DNE
+      createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
+        .withUnsetTableProperties(Set("not.a.key").asJava)
+        .build(defaultEngine)
+        .commit(defaultEngine, emptyIterable())
+      assertPropsDNE(tablePath, Set("not.a.key"))
+      // Check that the other property is not touched
+      assertHasProp(tablePath, Map("FOO.KEY" -> "VALUE"))
+
+      // Can be simultaneous with setTblProps as long as no overlap
+      createWriteTxnBuilder(Table.forPath(defaultEngine, tablePath))
+        .withUnsetTableProperties(Set("FOO.KEY").asJava)
+        .withTableProperties(defaultEngine, Map("foo.key" -> "value-new").asJava)
+        .build(defaultEngine)
+        .commit(defaultEngine, emptyIterable())
+      assertPropsDNE(tablePath, Set("FOO.KEY"))
+      // Check that the other property is added successfully
+      assertHasProp(tablePath, Map("foo.key" -> "value-new"))
+    }
+  }
+
   def createUpdateTableWithProps(
       tablePath: String,
       createTable: Boolean = false,
@@ -103,5 +218,10 @@ class TablePropertiesSuite extends DeltaTableWriteSuiteBase {
     expProps.foreach { case (key, value) =>
       assert(snapshot.getMetadata.getConfiguration.get(key) === value, key)
     }
+  }
+
+  def assertPropsDNE(tablePath: String, keys: Set[String]): Unit = {
+    val metadata = getMetadata(defaultEngine, tablePath)
+    assert(keys.forall(!metadata.getConfiguration.containsKey(_)))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Adds to the txn builder `withUnsetTableProperties` to support removing table properties from the table configuration. For now this only supports user-properties (those that do not start with 'delta.') since there is additional complexity and validation when removing delta properties.

Also fixes a bug where we were writing all user properties to the log with lower-case keys. Looking at delta-spark's behavior user properties should be case-sensitive.
(I can separate this fix into a separate PR but it's a 1 line change + 1 test added so left it together for now)


## How was this patch tested?

Adds tests.