### PR TITLE
[Spark] Issue with MERGE/UPDATE on target with CHAR column, generated column and readSideCharPadding

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -603,7 +603,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
    * not handle the aliasing).
    *
    * This function checks if the target plan is a bare reference to the Delta table, or if the
-   * transofrmations are the result of internal processing introduced not by the user, but
+   * transformations are the result of internal processing introduced not by the user, but
    * internally during analysis, which need to be taken into account and allowed.
    *
    * @param deltaLogicalPlan Target plan of the DML (Merge or Update)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -33,9 +33,11 @@ import org.apache.spark.sql.{AnalysisException, Column, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.Analyzer
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
+import org.apache.spark.sql.catalyst.optimizer.CollapseProject
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, CaseInsensitiveMap}
+import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, CaseInsensitiveMap, CharVarcharCodegenUtils}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.types._
@@ -585,6 +587,69 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
       ))
 
     resolvedPartitionFilters
+  }
+
+  /**
+   * Check whether executing DML (Merge or Update) with this plan as the target plan and
+   * generated column is allowed.
+   * It is already checked by the caller that the table is a Delta table, and that it has
+   * generated columns, so it is not checked again here.
+   *
+   * In general it is allowed to Merge or Update into a temporary view over a Delta table, but
+   * this is not allowed if the table contains a generated column. This is because the generated
+   * column definition is a SQL expression text, and it would not handle any transformation done by
+   * the view (e.g. if the view was `SELECT a as b, b as a FROM table`, the generated column would
+   * not handle the aliasing).
+   *
+   * This function checks if the target plan is a bare reference to the Delta table, or if the
+   * transofrmations are the result of internal processing introduced not by the user, but
+   * internally during analysis, which need to be taken into account and allowed.
+   *
+   * @param deltaLogicalPlan Target plan of the DML (Merge or Update)
+   * @param conf SQLConf object.
+   * @return true if allowed,
+   *         false if DeltaErrors.operationOnTempViewWithGenerateColsNotSupported should be thrown.
+   */
+  def allowDMLTargetPlan(deltaLogicalPlan: LogicalPlan, conf: SQLConf): Boolean = {
+    // Simple quick path: pure scan.
+    // It is already checked by PreprocessTable{Merge|Update} that this is a Delta scan.
+    deltaLogicalPlan.isInstanceOf[LogicalRelation] || (
+      CollapseProject(deltaLogicalPlan) match {
+        case Project(projectList, r: LogicalRelation) if conf.readSideCharPadding =>
+          // Check if s is a char padding applied to a.
+          def isCharPadding(s: StaticInvoke, a: Attribute): Boolean = {
+            s.staticObject == classOf[CharVarcharCodegenUtils] &&
+            s.functionName == "readSidePadding" &&
+            s.arguments.size == 2 &&
+            (s.arguments(0) match {
+              case arg: Attribute => arg.exprId == a.exprId
+              case _ => false
+            })
+          }
+
+          projectList.length == r.output.length &&
+          projectList.zip(r.output).forall {
+            // Attribute forwarding.
+            case (p: Attribute, a: Attribute) if p.exprId == a.exprId => true
+            // See Spark's ApplyCharTypePaddingHelper.readSidePadding which applies this projection.
+            // p alias must have the same name as input attribute a,
+            // and be char padding applied to it.
+            case (p: Alias, a: Attribute) if conf.resolver(p.name, a.name) =>
+              p.child match {
+                case s: StaticInvoke if isCharPadding(s, a) => true
+                case _ => false
+              }
+            case _ => false
+          }
+
+        // Pure scan.
+        // It is already checked by PreprocessTable{Merge|Update} that this is a Delta scan.
+        case _: LogicalRelation =>
+          true
+
+        case _ => false
+      }
+    )
   }
 
   private val DATE_FORMAT_YEAR_MONTH = "yyyy-MM"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, CaseInsensitiveMap, CharVarcharCodegenUtils}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.{Metadata => FieldMetadata}
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -91,7 +91,8 @@ case class PreprocessTableMerge(override val conf: SQLConf)
     }
     val generatedColumns = GeneratedColumn.getGeneratedColumns(
       tahoeFileIndex.snapshotAtAnalysis)
-    if (generatedColumns.nonEmpty && !deltaLogicalPlan.isInstanceOf[LogicalRelation]) {
+    if (generatedColumns.nonEmpty &&
+        !GeneratedColumn.allowDMLTargetPlan(deltaLogicalPlan, conf)) {
       throw DeltaErrors.operationOnTempViewWithGenerateColsNotSupported("MERGE INTO")
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -56,7 +56,8 @@ case class PreprocessTableUpdate(sqlConf: SQLConf)
     }
 
     val generatedColumns = GeneratedColumn.getGeneratedColumns(index)
-    if (generatedColumns.nonEmpty && !deltaLogicalNode.isInstanceOf[LogicalRelation]) {
+    if (generatedColumns.nonEmpty &&
+        !GeneratedColumn.allowDMLTargetPlan(deltaLogicalNode, conf)) {
       // Disallow temp views referring to a Delta table that contains generated columns. When the
       // user doesn't provide expressions for generated columns, we need to create update
       // expressions for them automatically. Currently, we assume `update.child.output` is the same


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Currently, GeneratedColumn is very strict in MERGE and UPDATE, not accepting anything else than a pure LogicalRelation as the target plan.
This is because, as generated column is defined as a piece of SQL text, it would have issues resolving against a view that does anything more tricky, which we (unfortunately and originally by accident) support, like e.g. if the view was select a as b, b as a from deltaTable, it would confuse the generated column which input columns to use.

Unfortunately, when CHAR columns are present on the table, ApplyCharTypePadding adds a projection with padding, which then Generated Columns does not accept. Refine the check, so that the char padding is allowed. Similar handling has been added in https://github.com/delta-io/delta/pull/1852/files#diff-e68090b34015f52fa61e949ad9d0b3fa527c7781a606ca8260796b441c996de8R374 in the past.

## How was this patch tested?

Test added.

## Does this PR introduce _any_ user-facing changes?

No.