### PR TITLE
[Backport][Kernel] Throw TableAlreadyExistsException when the table already exists and operation = CREATE_TABLE

### DIFF
--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java
@@ -266,7 +266,7 @@ public class CreateTableAndInsertData extends BaseTableWriter {
                 table.createTransactionBuilder(
                         engine,
                         "Examples", /* engineInfo */
-                        Operation.CREATE_TABLE);
+                        Operation.WRITE);
 
         // Build the transaction - no need to provide the schema as the table already exists.
         Transaction txn = txnBuilder.build(engine);
@@ -337,7 +337,7 @@ public class CreateTableAndInsertData extends BaseTableWriter {
                 table.createTransactionBuilder(
                         engine,
                         "Examples", /* engineInfo */
-                        Operation.CREATE_TABLE);
+                        Operation.WRITE);
 
         // Set the transaction identifiers for idempotent writes
         // Delta/Kernel makes sure that there exists only one transaction in the Delta log

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
@@ -20,6 +20,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.ConcurrentTransactionException;
 import io.delta.kernel.exceptions.DomainDoesNotExistException;
 import io.delta.kernel.exceptions.InvalidConfigurationValueException;
+import io.delta.kernel.exceptions.TableAlreadyExistsException;
 import io.delta.kernel.exceptions.UnknownConfigurationException;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.TableConfig;
@@ -150,6 +151,9 @@ public interface TransactionBuilder {
    *     TableConfig}.
    * @throws DomainDoesNotExistException if removing a domain that does not exist in the latest
    *     version of the table
+   * @throws TableAlreadyExistsException if the operation provided when calling {@link
+   *     Table#createTransactionBuilder(Engine, String, Operation)} is CREATE_TABLE and the table
+   *     already exists
    */
   Transaction build(Engine engine);
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toSet;
 import io.delta.kernel.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.KernelException;
+import io.delta.kernel.exceptions.TableAlreadyExistsException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.actions.*;
@@ -142,6 +143,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     SnapshotImpl snapshot;
     try {
       snapshot = (SnapshotImpl) table.getLatestSnapshot(engine);
+      if (operation == Operation.CREATE_TABLE) {
+        throw new TableAlreadyExistsException(table.getPath(engine), "Operation = CREATE_TABLE");
+      }
     } catch (TableNotFoundException tblf) {
       String tablePath = table.getPath(engine);
       logger.info("Table {} doesn't exist yet. Trying to create a new table.", tablePath);

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -24,7 +24,7 @@ import scala.collection.immutable.{ListMap, Seq}
 
 import io.delta.golden.GoldenTableUtils.goldenTablePath
 import io.delta.kernel.{Meta, Operation, Table, Transaction, TransactionBuilder, TransactionCommitResult}
-import io.delta.kernel.Operation.CREATE_TABLE
+import io.delta.kernel.Operation.MANUAL_UPDATE
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector, FilteredColumnarBatch, Row}
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
 import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
@@ -499,7 +499,7 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       version: Long,
       partitionCols: Seq[String] = Seq.empty,
       isBlindAppend: Boolean = true,
-      operation: Operation = CREATE_TABLE): Unit = {
+      operation: Operation = MANUAL_UPDATE): Unit = {
     val row = spark.sql(s"DESCRIBE HISTORY delta.`$tablePath`")
       .filter(s"version = $version")
       .select(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -22,7 +22,7 @@ import scala.collection.immutable.Seq
 
 import io.delta.golden.GoldenTableUtils.goldenTablePath
 import io.delta.kernel._
-import io.delta.kernel.Operation.{CREATE_TABLE, WRITE}
+import io.delta.kernel.Operation.{CREATE_TABLE, MANUAL_UPDATE, WRITE}
 import io.delta.kernel.data.{ColumnarBatch, FilteredColumnarBatch, Row}
 import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
 import io.delta.kernel.defaults.utils.TestRow
@@ -177,7 +177,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       assert(txnResult.getVersion === 0)
       assertCheckpointReadiness(txnResult, isReadyForCheckpoint = false)
 
-      verifyCommitInfo(tablePath = tablePath, version = 0)
+      verifyCommitInfo(tablePath = tablePath, version = 0, operation = CREATE_TABLE)
       verifyWrittenContent(tablePath, testSchema, Seq.empty)
     }
   }
@@ -393,7 +393,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       assert(txnResult.getVersion === 0)
       assertCheckpointReadiness(txnResult, isReadyForCheckpoint = false)
 
-      verifyCommitInfo(tablePath, version = 0, Seq("Part1", "part2"))
+      verifyCommitInfo(tablePath, version = 0, Seq("Part1", "part2"), operation = CREATE_TABLE)
       verifyWrittenContent(tablePath, schema, Seq.empty)
     }
   }
@@ -414,7 +414,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         assert(txnResult.getVersion === 0)
         assertCheckpointReadiness(txnResult, isReadyForCheckpoint = false)
 
-        verifyCommitInfo(tablePath, version = 0)
+        verifyCommitInfo(tablePath, version = 0, operation = CREATE_TABLE)
         verifyWrittenContent(tablePath, schema, Seq.empty)
       }
     }
@@ -1181,7 +1181,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       tablePath: String,
       schema: Option[StructType] = None): Transaction = {
     val table = Table.forPath(engine, tablePath)
-    var txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
+    var txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, MANUAL_UPDATE)
     schema.foreach(s => txnBuilder = txnBuilder.withSchema(engine, s))
     txnBuilder.build(engine)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Previously we only threw tableAlreadyExists operation when partition columns or schema was provided on txnBuilder but the table already existed. Now, with schema evolution, we no longer throw that error when withSchema is used, and instead may throw a confusing exception if the intention is to "create table if does not exist".

Instead, we should use the `operation` provided to fail early in the create new table case when it already exists.

## How was this patch tested?

Updates tests.