### PR TITLE
[Spark] [Catalog-Owned] Block `ALTER TABLE` from modifying `Catalog-Owned` related table properties & Upgrade/Downgrade

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -207,6 +207,12 @@
     ],
     "sqlState" : "42809"
   },
+  "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES" : {
+    "message" : [
+      "Cannot override or unset in-commit timestamp table properties because this table is catalog-owned. Remove \"delta.enableInCommitTimestamps\", \"delta.inCommitTimestampEnablementVersion\", and \"delta.inCommitTimestampEnablementTimestamp\" from the TBLPROPERTIES clause and then retry the command."
+    ],
+    "sqlState" : "42616"
+  },
   "DELTA_CANNOT_MODIFY_COORDINATED_COMMITS_DEPENDENCIES" : {
     "message" : [
       "<Command> cannot override or unset in-commit timestamp table properties because coordinated commits is enabled in this table and depends on them. Please remove them (\"delta.enableInCommitTimestamps\", \"delta.inCommitTimestampEnablementVersion\", \"delta.inCommitTimestampEnablementTimestamp\") from the TBLPROPERTIES clause and then retry the command again."

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -16,8 +16,14 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+import java.util.UUID
+
+import scala.jdk.CollectionConverters._
+
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.commons.lang3.NotImplementedException
 
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -33,8 +39,37 @@ class CatalogOwnedEnablementSuite
       "spark_catalog", TrackingInMemoryCommitCoordinatorBuilder(batchSize = 3))
   }
 
-  private def validateCompleteEnablement(snapshot: Snapshot, expectEnabled: Boolean): Unit = {
+  /**
+   * Add `ucTableId` to the table [[Metadata.configuration]] to simulate the behavior
+   * when we populate table UUID for a Catalog-Owned enabled table.
+   */
+  private def addCatalogOwnedUCTableId(
+      deltaLog: DeltaLog,
+      tableUUID: String): Unit = {
+    val oldMetadata = deltaLog.update().metadata
+    val newMetadata =
+      oldMetadata.copy(configuration = oldMetadata.configuration ++ Map(
+        CATALOG_OWNED_UC_TABLE_ID -> tableUUID))
+    deltaLog.startTransaction(catalogTableOpt = deltaLog.initialCatalogTable)
+      .commitManually(newMetadata)
+  }
+
+  private val CATALOG_OWNED_UC_TABLE_ID = UCCommitCoordinatorClient.UC_TABLE_ID_KEY
+
+  private val ICT_ENABLED_KEY = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key
+
+  private val allowedOperationsForTest = Set("SET", "UNSET", "UPGRADE", "DOWNGRADE")
+
+  /**
+   * Validate that the snapshot has the expected enablement of Catalog-Owned table feature.
+   *
+   * @param snapshot The snapshot to validate.
+   * @param expectEnabled Whether the Catalog-Owned table features should be enabled or not.
+   */
+  private def validateCatalogOwnedCompleteEnablement(
+      snapshot: Snapshot, expectEnabled: Boolean): Unit = {
     assert(snapshot.isCatalogOwned == expectEnabled)
+    assert(snapshot.metadata.configuration.contains(CATALOG_OWNED_UC_TABLE_ID) == expectEnabled)
     Seq(
       CatalogOwnedTableFeature,
       VacuumProtocolCheckTableFeature,
@@ -50,38 +85,161 @@ class CatalogOwnedEnablementSuite
     }
   }
 
-  test("ALTER TABLE - upgrade not supported") {
-    withTable("t1") {
-      spark.sql(s"CREATE TABLE t1 (id INT) USING delta")
-      spark.sql(s"INSERT INTO t1 VALUES 1") // commit 1
-      spark.sql(s"INSERT INTO t1 VALUES 2") // commit 2
-      val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
-      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = false)
-      // UPGRADE is not yet supported.
-      val ex = intercept[NotImplementedException] {
-        sql(s"ALTER TABLE t1 SET TBLPROPERTIES " +
+  /**
+   * Test the blocking logic for ALTER TABLE command on Catalog-Owned enabled table.
+   *
+   * Specifically, we test the following two scenarios:
+   * 1. Any SET/UNSET operation should be blocked for both [[CATALOG_OWNED_UC_TABLE_ID]]
+    *   and [[ICT_ENABLED_KEY]].
+   * 2. Both Upgrade/Downgrade should be blocked.
+   *
+   * @param property The optional property to be validated through blocking logic.
+   * @param operation Whether the operation is SET/UNSET/UPGRADE/DOWNGRADE.
+   * @param expectedErrorClass The expected error class/condition.
+   * @param expectedMessageParameters The expected message parameters.
+   * @param tableId The tableId to be used for the test.
+   * @param setValue The value to be set for the property, this is only useful
+   *                 for ALTER TABLE SET cases.
+   */
+  private def testCatalogOwnedBlockingAlterTable(
+      property: String,
+      operation: String,
+      expectedErrorClass: String = "",
+      expectedMessageParameters: Array[String] = Array.empty,
+      tableId: String,
+      setValue: Option[String],
+      createCatalogOwnedTableAtInit: Boolean = true): Unit = {
+    require(allowedOperationsForTest.contains(operation), s"Unsupported operation: $operation")
+    withTable(tableId) {
+      if (createCatalogOwnedTableAtInit) {
+        spark.sql(s"CREATE TABLE $tableId (id INT) USING delta TBLPROPERTIES " +
           s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
+        // Add the mock UC_TABLE_ID to [[Metadata.configuration]],
+        // this simulates the behavior when we populate table UUID
+        // after catalog discovery phase for a Catalog-Owned enabled table.
+        val log = DeltaLog.forTable(spark, new TableIdentifier(tableId))
+        addCatalogOwnedUCTableId(log, tableUUID = UUID.randomUUID().toString)
+      } else {
+        spark.sql(s"CREATE TABLE $tableId (id INT) USING delta")
       }
-      assert(ex.getMessage.contains("Upgrading to CatalogOwned table is not yet supported."))
+      spark.sql(s"INSERT INTO $tableId VALUES 1") // commit 1
+      spark.sql(s"INSERT INTO $tableId VALUES 2") // commit 2
+      val log = DeltaLog.forTable(spark, new TableIdentifier(tableId))
+      validateCatalogOwnedCompleteEnablement(
+        log.update(), expectEnabled = createCatalogOwnedTableAtInit)
+      // Blocking logic validation
+      val sqlStr = operation match {
+        case "SET" =>
+          val value = setValue.getOrElse {
+            throw new IllegalArgumentException(
+              s"SET operation requires a value to be set for property: $property")
+          }
+          s"ALTER TABLE $tableId SET TBLPROPERTIES ('$property' = '$value')"
+        case "UNSET" =>
+          s"ALTER TABLE $tableId UNSET TBLPROPERTIES ('$property')"
+        case "UPGRADE" =>
+          s"ALTER TABLE $tableId SET TBLPROPERTIES " +
+            s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')"
+        case "DOWNGRADE" =>
+          s"ALTER TABLE $tableId DROP FEATURE '${CatalogOwnedTableFeature.name}'"
+      }
+      if (operation == "UPGRADE") {
+        val error = intercept[NotImplementedException] { sql(sqlStr) }
+        assert(error.getMessage.contains("Upgrading to CatalogOwned table is not yet supported."))
+      } else {
+        val (error, expectedError) = operation match {
+          case "SET" | "UNSET" =>
+            if (property == CATALOG_OWNED_UC_TABLE_ID) {
+              // [[DeltaUnsupportedOperationException]] will only be thrown when trying to SET/UNSET
+              // [[CATALOG_OWNED_UC_TABLE_ID]] via ALTER TABLE.
+              (intercept[DeltaUnsupportedOperationException] { sql(sqlStr) },
+                new DeltaUnsupportedOperationException(
+                  expectedErrorClass, expectedMessageParameters))
+            } else {
+              // [[DeltaIllegalArgumentException]] will be thrown when trying to SET/UNSET
+              // [[ICT_ENABLED_KEY]] via ALTER TABLE.
+              (intercept[DeltaIllegalArgumentException] { sql(sqlStr) },
+                new DeltaIllegalArgumentException(
+                  expectedErrorClass, expectedMessageParameters))
+            }
+          case "DOWNGRADE" =>
+            (intercept[DeltaTableFeatureException] { sql(sqlStr) },
+              new DeltaTableFeatureException(expectedErrorClass, expectedMessageParameters))
+          case _ =>
+            throw new IllegalArgumentException(
+              s"Unsupported operation: $operation for property: $property")
+        }
+        checkError(
+          exception = error,
+          condition = expectedError.getErrorClass,
+          sqlState = if (operation != "DOWNGRADE") Some(expectedError.getSqlState) else None,
+          parameters = expectedError.getMessageParameters.asScala.toMap)
+      }
     }
   }
 
-  test("CREATE TABLE - catalog-owned table downgrade is blocked") {
-    withTable("t1") {
-      spark.sql(s"CREATE TABLE t1 (id INT) USING delta TBLPROPERTIES " +
-        s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
-      spark.sql(s"INSERT INTO t1 VALUES 1") // commit 1
-      spark.sql(s"INSERT INTO t1 VALUES 2") // commit 2
-      val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
-      validateCompleteEnablement(log.unsafeVolatileSnapshot, expectEnabled = true)
-      // Drop feature should fail as it is not supported.
-      checkError(
-        intercept[DeltaTableFeatureException] {
-          sql(s"ALTER TABLE t1 DROP FEATURE '${CatalogOwnedTableFeature.name}'")
-        },
-        "DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE",
-        parameters = Map("feature" -> CatalogOwnedTableFeature.name)
-      )
-    }
+  test("Catalog-Owned: ALTER TABLE should be blocked if attempts to modify ICT") {
+    // Should block the ALTER TABLE command that tries to disable [[ICT_ENABLED_KEY]]
+    // for Catalog-Owned enabled table.
+    testCatalogOwnedBlockingAlterTable(
+      property = ICT_ENABLED_KEY,
+      operation = "SET",
+      expectedErrorClass = "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+      expectedMessageParameters = Array("ALTER"),
+      tableId = "t1",
+      setValue = Some("false"))
+
+    // Should block the ALTER TABLE command that tries to UNSET [[ICT_ENABLED_KEY]]
+    // for Catalog-Owned enabled table.
+    testCatalogOwnedBlockingAlterTable(
+      property = ICT_ENABLED_KEY,
+      operation = "UNSET",
+      expectedErrorClass = "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+      expectedMessageParameters = Array("ALTER"),
+      tableId = "t2",
+      setValue = None)
   }
+
+  test("Catalog-Owned: ALTER TABLE should be blocked if attempts to modify UC_TABLE_ID") {
+    // Should block the ALTER TABLE command that tries to modify `ucTableId`
+    // for Catalog-Owned enabled table.
+    testCatalogOwnedBlockingAlterTable(
+      property = CATALOG_OWNED_UC_TABLE_ID,
+      operation = "SET",
+      expectedErrorClass = "DELTA_CANNOT_MODIFY_TABLE_PROPERTY",
+      expectedMessageParameters = Array(CATALOG_OWNED_UC_TABLE_ID),
+      tableId = "t1",
+      setValue = Some(UUID.randomUUID().toString))
+
+    // Should block the ALTER TABLE command that tries to UNSET `ucTableId`
+    // for Catalog-Owned enabled table.
+    testCatalogOwnedBlockingAlterTable(
+      property = CATALOG_OWNED_UC_TABLE_ID,
+      operation = "UNSET",
+      expectedErrorClass = "DELTA_CANNOT_MODIFY_TABLE_PROPERTY",
+      expectedMessageParameters = Array(CATALOG_OWNED_UC_TABLE_ID),
+      tableId = "t2",
+      setValue = None)
+  }
+
+  test("Catalog-Owned: ALTER TABLE should be blocked if attempts to" +
+    " downgrade Catalog-Owned") {
+    testCatalogOwnedBlockingAlterTable(
+      property = "",
+      operation = "DOWNGRADE",
+      expectedErrorClass = "DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE",
+      expectedMessageParameters = Array(CatalogOwnedTableFeature.name),
+      tableId = "t1",
+      setValue = None)
+  }
+
+  test("Catalog-Owned: Upgrade should be blocked since it is not supported yet") {
+    testCatalogOwnedBlockingAlterTable(
+      property = "",
+      operation = "UPGRADE",
+      tableId = "t1",
+      setValue = None,
+      createCatalogOwnedTableAtInit = false)
+  }
+
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -170,10 +170,10 @@ class CatalogOwnedEnablementSuite
               s"Unsupported operation: $operation for property: $property")
         }
         checkError(
-          exception = error,
-          condition = expectedError.getErrorClass,
-          sqlState = if (operation != "DOWNGRADE") Some(expectedError.getSqlState) else None,
-          parameters = expectedError.getMessageParameters.asScala.toMap)
+          error,
+          expectedError.getErrorClass,
+          if (operation != "DOWNGRADE") Some(expectedError.getSqlState) else None,
+          expectedError.getMessageParameters.asScala.toMap)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.commons.lang3.NotImplementedException
@@ -30,7 +30,8 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 
 class CatalogOwnedEnablementSuite
   extends DeltaSQLTestUtils
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with DeltaExceptionTestUtils {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -159,7 +160,7 @@ class CatalogOwnedEnablementSuite
             } else {
               // [[DeltaIllegalArgumentException]] will be thrown when trying to SET/UNSET
               // [[ICT_ENABLED_KEY]] via ALTER TABLE.
-              (intercept[DeltaIllegalArgumentException] { sql(sqlStr) },
+              (interceptWithUnwrapping[DeltaIllegalArgumentException] { sql(sqlStr) },
                 new DeltaIllegalArgumentException(
                   expectedErrorClass, expectedMessageParameters))
             }
@@ -186,7 +187,7 @@ class CatalogOwnedEnablementSuite
       property = ICT_ENABLED_KEY,
       operation = "SET",
       expectedErrorClass = "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
-      expectedMessageParameters = Array("ALTER"),
+      expectedMessageParameters = Array.empty,
       tableId = "t1",
       setValue = Some("false"))
 
@@ -196,7 +197,7 @@ class CatalogOwnedEnablementSuite
       property = ICT_ENABLED_KEY,
       operation = "UNSET",
       expectedErrorClass = "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
-      expectedMessageParameters = Array("ALTER"),
+      expectedMessageParameters = Array.empty,
       tableId = "t2",
       setValue = None)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -47,7 +47,7 @@ class CatalogOwnedEnablementSuite
       deltaLog: DeltaLog,
       tableUUID: String): Unit = {
     val oldMetadata = deltaLog.update(
-      catalogTableOpt = deltaLog.unsafeVolatileCatalogTable).metadata
+      catalogTableOpt = deltaLog.initialCatalogTable).metadata
     val newMetadata =
       oldMetadata.copy(configuration = oldMetadata.configuration ++ Map(
         CATALOG_OWNED_UC_TABLE_ID -> tableUUID))
@@ -127,7 +127,7 @@ class CatalogOwnedEnablementSuite
       spark.sql(s"INSERT INTO $tableId VALUES 2") // commit 2
       val log = DeltaLog.forTable(spark, new TableIdentifier(tableId))
       validateCatalogOwnedCompleteEnablement(
-        log.update(catalogTableOpt = log.unsafeVolatileCatalogTable),
+        log.update(catalogTableOpt = log.initialCatalogTable),
         expectEnabled = createCatalogOwnedTableAtInit)
       // Blocking logic validation
       val sqlStr = operation match {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -46,7 +46,8 @@ class CatalogOwnedEnablementSuite
   private def addCatalogOwnedUCTableId(
       deltaLog: DeltaLog,
       tableUUID: String): Unit = {
-    val oldMetadata = deltaLog.update().metadata
+    val oldMetadata = deltaLog.update(
+      catalogTableOpt = deltaLog.unsafeVolatileCatalogTable).metadata
     val newMetadata =
       oldMetadata.copy(configuration = oldMetadata.configuration ++ Map(
         CATALOG_OWNED_UC_TABLE_ID -> tableUUID))
@@ -126,7 +127,8 @@ class CatalogOwnedEnablementSuite
       spark.sql(s"INSERT INTO $tableId VALUES 2") // commit 2
       val log = DeltaLog.forTable(spark, new TableIdentifier(tableId))
       validateCatalogOwnedCompleteEnablement(
-        log.update(), expectEnabled = createCatalogOwnedTableAtInit)
+        log.update(catalogTableOpt = log.unsafeVolatileCatalogTable),
+        expectEnabled = createCatalogOwnedTableAtInit)
       // Blocking logic validation
       val sqlStr = operation match {
         case "SET" =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -46,8 +46,7 @@ class CatalogOwnedEnablementSuite
   private def addCatalogOwnedUCTableId(
       deltaLog: DeltaLog,
       tableUUID: String): Unit = {
-    val oldMetadata = deltaLog.update(
-      catalogTableOpt = deltaLog.initialCatalogTable).metadata
+    val oldMetadata = deltaLog.unsafeVolatileSnapshot.metadata
     val newMetadata =
       oldMetadata.copy(configuration = oldMetadata.configuration ++ Map(
         CATALOG_OWNED_UC_TABLE_ID -> tableUUID))
@@ -127,7 +126,7 @@ class CatalogOwnedEnablementSuite
       spark.sql(s"INSERT INTO $tableId VALUES 2") // commit 2
       val log = DeltaLog.forTable(spark, new TableIdentifier(tableId))
       validateCatalogOwnedCompleteEnablement(
-        log.update(catalogTableOpt = log.initialCatalogTable),
+        log.unsafeVolatileSnapshot,
         expectEnabled = createCatalogOwnedTableAtInit)
       // Blocking logic validation
       val sqlStr = operation match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR explicitly/intentionally blocks `ALTER TABLE` command from modifying (`SET`/`UNSET`) table UUID (`ucTableId`)
and dependent properties (e.g., ICT) for Catalog-Owned enabled table.

In addition, we block both `UPGRADE` and `DOWNGRADE` for Catalog-Owned enabled table.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through newly added UTs in `CatalogOwnedEnablementSuite`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
