### PR TITLE
[Spark] Add a new option to workaround incorrect schema automatically created in external catalog

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
@@ -114,7 +114,7 @@ trait CreateDeltaTableLike extends SQLConfHelper {
         ignoreIfExists = false,
         validateLocation = false)
     }
-    if (conf.getConf(DeltaSQLConf.FORCE_ALTER_TABLE_DATA_SCHEMA)) {
+    if (conf.getConf(DeltaSQLConf.HMS_FORCE_ALTER_TABLE_DATA_SCHEMA)) {
       spark.sessionState.catalog.alterTableDataSchema(cleaned.identifier, cleaned.schema)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -666,14 +666,14 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
-  val FORCE_ALTER_TABLE_DATA_SCHEMA =
-    buildConf("schema.forceAlterTableDataSchema")
+  val HMS_FORCE_ALTER_TABLE_DATA_SCHEMA =
+    buildConf("hms.schema.forceAlterTableDataSchema")
       .internal()
       .doc(
         """
-          | This conf fix the schema in tableCatalog object and force an alter table
+          | This conf fixes the schema in tableCatalog object and force an alter table
           | schema command after upload the schema. As in spark project the schema is removed
-          | because delta is not a valid serDe configuration.
+          | because delta is not a valid serDe configuration. This is a problem known only to HMS.
           |""".stripMargin)
       .booleanConf
       .createWithDefault(false)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuite.scala
@@ -590,38 +590,4 @@ class DeltaUpdateCatalogSuite
       )
     }
   }
-
-  test("create table with DELTA_UPDATE_CATALOG_ENABLED should store correct schema in catalog") {
-    withSQLConf(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED.key -> "true") {
-      withTable(tbl) {
-        val df = spark.range(10).withColumn("name", lit("test")).withColumn("value", lit(1.0))
-        df.writeTo(tbl).using("delta").create()
-
-        // Verify the schema is correctly stored in the in-memory catalog
-        verifyTableMetadata(
-          expectedSchema = df.schema.asNullable,
-          expectedProperties = getBaseProperties(snapshot)
-        )
-      }
-    }
-  }
-
-  test("create table with FORCE_ALTER_TABLE_DATA_SCHEMA should store same schema " +
-    "as DELTA_UPDATE_CATALOG_ENABLED") {
-    withSQLConf(
-      DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED.key -> "false",
-      DeltaSQLConf.FORCE_ALTER_TABLE_DATA_SCHEMA.key -> "true") {
-      withTable(tbl) {
-        val df = spark.range(10).withColumn("name", lit("test")).withColumn("value", lit(1.0))
-        df.writeTo(tbl).using("delta").create()
-
-        // Verify the schema is correctly stored in the in-memory catalog
-        // This should result in the same schema being uploaded to the catalog as the first test
-        verifyTableMetadata(
-          expectedSchema = df.schema.asNullable,
-          expectedProperties = getBaseProperties(snapshot)
-        )
-      }
-    }
-  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR is continuation of https://github.com/delta-io/delta/pull/2310.
* This PR resolves issue 1 in the issue https://github.com/delta-io/delta/issues/1679.
* The PR will change how the catalog schema is saved in Hive Metastore.

Technical details:
* Added a new boolean parameter `spark.databricks.delta.schema.forceAlterTableDataSchema` in `DeltaSqlConf`.
* When this parameter is true, then in the class `CreateDeltaTableCommand`, in `updateCatalog` function, after create a table in the catalog it will update the table schema using a session catalog function (`alterTableDataSchema`)

## How was this patch tested?

See https://docs.google.com/document/d/e/2PACX-1vRl4lWFyx1ASeYCUoj575fLM0dFKhXM5MekWS__NVnwJJESfMflGS71OKHoFjEoHFjmidLHeEXHoreb/pub

### Reason not to add unit tests
The new config and logic is designed to trigger ALTER TABLE.
Since we don't have a straightforward way to mock or spy on the catalog in this test environment, additional tet cases are not added.

### Reason not to add integration tests
The original issue occurs with external catalog such as AWS Glue Data Catalog.
Since we do not want to introduce extra dependency just to test this patch into the integration test, additional test cases are not added.
While we can't directly test against AWS Glue Data Catalog in unit tests, I created the above doc to summarize the integration test results.

### Reason not to cover the existing test in the previous PR
The previous PR https://github.com/delta-io/delta/pull/2310 had two test cases, but I verified that both test cases did not capture the original issue.


## Does this PR introduce _any_ user-facing changes?

Yes. This PR introduces a new configuration `spark.databricks.delta.schema.forceAlterTableDataSchema` to force ALTER TABLE when Delta table is created into catalog.