### PR TITLE
[DELTA] Pass catalogTable while constructing deltaLog for DeltaTableV2

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -848,6 +848,13 @@ object DeltaLog extends DeltaLogging {
     apply(spark, rawPath, options = Map.empty, initialCatalogTable, clock)
 
 
+  /** Helper for creating a log for the table. */
+  private[delta] def forTable(spark: SparkSession,
+      dataPath: Path,
+      options: Map[String, String],
+      catalogTable: Option[CatalogTable]): DeltaLog =
+    apply(spark, logPathFor(dataPath), options, catalogTable, new SystemClock)
+
   /** Helper for getting a log, as well as the latest snapshot, of the table */
   def forTableWithSnapshot(spark: SparkSession, dataPath: String): (DeltaLog, Snapshot) =
     withFreshSnapshot { clock =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -849,7 +849,8 @@ object DeltaLog extends DeltaLogging {
 
 
   /** Helper for creating a log for the table. */
-  private[delta] def forTable(spark: SparkSession,
+  private[delta] def forTable(
+      spark: SparkSession,
       dataPath: Path,
       options: Map[String, String],
       catalogTable: Option[CatalogTable]): DeltaLog =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -123,7 +123,11 @@ class DeltaTableV2 private[delta](
       } else {
         options
       }
-      DeltaLog.forTable(spark, rootPath, dataSourceOptions)
+        DeltaLog.forTable(
+          spark,
+          rootPath,
+          dataSourceOptions,
+          catalogTable)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -123,11 +123,11 @@ class DeltaTableV2 private[delta](
       } else {
         options
       }
-        DeltaLog.forTable(
-          spark,
-          rootPath,
-          dataSourceOptions,
-          catalogTable)
+      DeltaLog.forTable(
+        spark,
+        rootPath,
+        dataSourceOptions,
+        catalogTable)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR passes catalogTable while constructing deltaLog in DeltaTableV2, this allows spark to interact with catalog owned tables as an external client.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
E2E integration testing using Delta, Spark and Unity-Catalog
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
