### PR TITLE
[Spark] [Catalog-Owned] Block ALTER TABLE from modifying Catalog-Owned dependent table feature/properties

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -207,6 +207,12 @@
     ],
     "sqlState" : "42809"
   },
+  "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES" : {
+    "message" : [
+      "Cannot override or unset in-commit timestamp table properties because this table is catalog-owned. Remove \"delta.enableInCommitTimestamps\", \"delta.inCommitTimestampEnablementVersion\", and \"delta.inCommitTimestampEnablementTimestamp\" from the TBLPROPERTIES clause and then retry the command."
+    ],
+    "sqlState" : "42616"
+  },
   "DELTA_CANNOT_MODIFY_COORDINATED_COMMITS_DEPENDENCIES" : {
     "message" : [
       "<Command> cannot override or unset in-commit timestamp table properties because coordinated commits is enabled in this table and depends on them. Please remove them (\"delta.enableInCommitTimestamps\", \"delta.inCommitTimestampEnablementVersion\", \"delta.inCommitTimestampEnablementTimestamp\") from the TBLPROPERTIES clause and then retry the command again."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.delta.util.FileNames.{BackfilledDeltaFile, Compacted
 import io.delta.storage.LogStore
 import io.delta.storage.commit.{CommitCoordinatorClient, GetCommitsResponse => JGetCommitsResponse, TableIdentifier}
 import io.delta.storage.commit.actions.AbstractMetadata
-import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -21,7 +21,7 @@ import java.util.Optional
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{CoordinatedCommitsTableFeature, DeltaConfig, DeltaConfigs, DeltaIllegalArgumentException, DeltaLog, Snapshot, SnapshotDescriptor}
+import org.apache.spark.sql.delta.{CoordinatedCommitsTableFeature, DeltaConfig, DeltaConfigs, DeltaErrors, DeltaIllegalArgumentException, DeltaLog, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.commands.CloneTableCommand
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -31,6 +31,7 @@ import org.apache.spark.sql.delta.util.FileNames.{BackfilledDeltaFile, Compacted
 import io.delta.storage.LogStore
 import io.delta.storage.commit.{CommitCoordinatorClient, GetCommitsResponse => JGetCommitsResponse, TableIdentifier}
 import io.delta.storage.commit.actions.AbstractMetadata
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -92,6 +93,61 @@ object CatalogOwnedTableUtils {
       case _ =>
         throw new IllegalStateException(
           "Failed to resolve the catalog: " + identifier)
+    }
+  }
+
+  val ICT_TABLE_PROPERTY_CONFS = Seq(
+    DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED,
+    DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION,
+    DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP)
+
+  /**
+   * The main ICT table properties used as dependencies for Catalog-Owned enabled table.
+   */
+  val ICT_TABLE_PROPERTY_KEYS: Seq[String] = ICT_TABLE_PROPERTY_CONFS.map(_.key)
+
+  /**
+   * Verifies that the property keys do not contain any ICT dependencies for Catalog-Owned.
+   */
+  private[delta] def verifyNotContainsICTConfigurations(propKeys: Seq[String]): Unit = {
+    ICT_TABLE_PROPERTY_KEYS.foreach { key =>
+      if (propKeys.contains(key)) {
+        throw new DeltaIllegalArgumentException(
+          "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+          messageParameters = Array.empty)
+      }
+    }
+  }
+
+  /**
+   * Validates the Catalog-Owned configurations in explicit command overrides for
+   * `AlterTableSetPropertiesDeltaCommand`.
+   *
+   * If [[CatalogOwnedTableFeature]] presents, we do NOT allow users to
+   * modify any ICT properties that Catalog-Owned depends on.
+   */
+  def validatePropertiesForAlterTableSetPropertiesDeltaCommand(
+      snapshot: Snapshot,
+      propertyOverrides: Map[String, String]): Unit = {
+    if (snapshot.isCatalogOwned) {
+      // For Catalog-Owned enabled tables, check the dependent ICT properties.
+      // Note: Upgrade/Downgrade have been blocked earlier, which do not need to be
+      //       checked here.
+      verifyNotContainsICTConfigurations(propKeys = propertyOverrides.keys.toSeq)
+    }
+  }
+
+  /**
+   * Validates the configurations to unset for `AlterTableUnsetPropertiesDeltaCommand`.
+   *
+   * If the table already has [[CatalogOwnedTableFeature]] present,
+   * we do not allow users to unset any of the ICT properties that Catalog-Owned depends on.
+   */
+  def validatePropertiesForAlterTableUnsetPropertiesDeltaCommand(
+      snapshot: Snapshot,
+      propKeysToUnset: Seq[String]): Unit = {
+    if (snapshot.isCatalogOwned) {
+      verifyNotContainsICTConfigurations(propKeys = propKeysToUnset)
     }
   }
 }
@@ -567,7 +623,7 @@ object CoordinatedCommitsUtils extends DeltaLogging {
    *     Coordinated Commits configurations.
    *   - If the table does not exist, the explicit command property overrides must contain exactly
    *     the Coordinator Name and Coordinator Conf, and no Table Conf. Default configurations are
-   *     checked similarly if non of the three properties is present in explicit overrides.
+   *     checked similarly if none of the three properties is present in explicit overrides.
    */
   private[delta] def validateConfigurationsForCreateDeltaTableCommandImpl(
       spark: SparkSession,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -90,7 +90,7 @@ class CatalogOwnedEnablementSuite
   /**
    * Helper function to create a table and run the test.
    *
-   * @param f The test function to run with the generated table name.
+   * @param f The test function to run with the random-generated table name.
    */
   private def withRandomTable(
       createCatalogOwnedTableAtInit: Boolean)(f: String => Unit): Unit = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -105,8 +105,8 @@ class CatalogOwnedEnablementSuite
         spark.sql(s"ALTER TABLE $tableId SET TBLPROPERTIES ('$ICT_ENABLED_KEY' = 'false')")
       }
       checkError(
-        exception = error,
-        condition = "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+        error,
+        "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
         sqlState = "42616",
         parameters = Map[String, String]())
     }
@@ -118,8 +118,8 @@ class CatalogOwnedEnablementSuite
         spark.sql(s"ALTER TABLE $tableId UNSET TBLPROPERTIES ('$ICT_ENABLED_KEY')")
       }
       checkError(
-        exception = error,
-        condition = "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+        error,
+        "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
         sqlState = "42616",
         parameters = Map[String, String]())
     }
@@ -132,8 +132,8 @@ class CatalogOwnedEnablementSuite
         spark.sql(s"ALTER TABLE $tableId DROP FEATURE '${CatalogOwnedTableFeature.name}'")
       }
       checkError(
-        exception = error,
-        condition = "DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE",
+        error,
+        "DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE",
         parameters = Map("feature" -> CatalogOwnedTableFeature.name))
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -136,6 +136,7 @@ class CatalogOwnedEnablementSuite
       checkError(
         error,
         "DELTA_FEATURE_DROP_UNSUPPORTED_CLIENT_FEATURE",
+        sqlState = "0AKDC",
         parameters = Map("feature" -> CatalogOwnedTableFeature.name))
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+import java.util.UUID
+
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.commons.lang3.NotImplementedException
@@ -92,7 +94,7 @@ class CatalogOwnedEnablementSuite
    */
   private def withTableIdAndAlterTableTestSetup(
       createCatalogOwnedTableAtInit: Boolean)(f: String => Unit): Unit = {
-    val tableId = "t1"
+    val tableId = UUID.randomUUID().toString.replace("-", "")
     withTable(tableId) {
       testCatalogOwnedAlterTableSetup(id = tableId, createCatalogOwnedTableAtInit)
       f(tableId)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -127,21 +127,6 @@ class CatalogOwnedEnablementSuite
     }
   }
 
-  test("Catalog-Owned: ALTER TABLE UNSET should be a no-op when trying to unset table feature") {
-    withRandomTable(createCatalogOwnedTableAtInit = true) { tableName =>
-      spark.sql(s"ALTER TABLE $tableName UNSET TBLPROPERTIES " +
-        s"('delta.feature.${CatalogOwnedTableFeature.name}')")
-      val log1 = DeltaLog.forTable(spark, new TableIdentifier(tableName))
-      assert(log1.unsafeVolatileSnapshot.isCatalogOwned === true)
-
-      // Without `delta.feature` namespace this should also hold
-      spark.sql(s"ALTER TABLE $tableName UNSET TBLPROPERTIES " +
-        s"('${CatalogOwnedTableFeature.name}')")
-      val log2 = DeltaLog.forTable(spark, new TableIdentifier(tableName))
-      assert(log2.unsafeVolatileSnapshot.isCatalogOwned === true)
-    }
-  }
-
   test("Catalog-Owned: ALTER TABLE should be blocked if attempts to" +
     " downgrade Catalog-Owned") {
     withRandomTable(createCatalogOwnedTableAtInit = true)  { tableName =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR explicitly/intentionally blocks `ALTER TABLE` command from modifying dependent properties (e.g., ICT) for Catalog-Owned enabled table.

In addition, update/refactor `CatalogOwnedEnablementSuite`.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through newly added UTs in `CatalogOwnedEnablementSuite`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
