### PR TITLE
[Spark] Convert CoordinatedCommits table feature test to CatalogOwned

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -66,6 +66,22 @@ object CatalogOwnedTableUtils {
       )
     }
     .orElse {
+      if (Utils.isTesting) {
+        // In unit test with a path based access, it is possible to enable CatalogOwned with
+        // in-memory commit coordinator. In this case, we return table commit coordinator
+        // registered in the provider so that it can still test CatalogOwned table feature
+        // capability.
+        CatalogOwnedCommitCoordinatorProvider.getBuilder("spark_catalog")
+          .flatMap(builder => Some(builder.buildForCatalog(spark, "spark_catalog")))
+          .map { cc =>
+            return Some(TableCommitCoordinatorClient(
+              cc,
+              snapshot.deltaLog.logPath,
+              snapshot.metadata.configuration,
+              snapshot.deltaLog.newDeltaHadoopConf(),
+              snapshot.deltaLog.store))
+          }
+      }
       // This table is catalog owned table but catalogTableOpt is not defined. This means
       // that the caller is accessing this table by path-based or the calling code path is missing
       // the CatalogTable.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -264,7 +264,7 @@ class InCommitTimestampSuite
   }
 
   test("CREATE OR REPLACE should not disable ICT") {
-    withoutCoordinatedCommitsDefaultTableProperties {
+    withoutDefaultCCTableFeature {
       withSQLConf(
         DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
       ) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -339,6 +339,7 @@ abstract class CommitCoordinatorSuiteBase
   extends QueryTest
   with CommitCoordinatorUtilBase
   with DeltaSQLTestUtils
+  with DeltaTestUtilsBase
   with SharedSparkSession
   with DeltaSQLCommandTest
   with DeltaExceptionTestUtils {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.{CommitStats, CoordinatedCommitsStats, Coordin
 import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, CommitCoordinatorGetCommitsFailedException, DeltaIllegalArgumentException}
 import org.apache.spark.sql.delta.CoordinatedCommitType._
 import org.apache.spark.sql.delta.DeltaConfigs.{CHECKPOINT_INTERVAL, COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF, IN_COMMIT_TIMESTAMPS_ENABLED}
-import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTestUtilsBase}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.DummySnapshot
 import org.apache.spark.sql.delta.LogSegment

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -55,7 +55,6 @@ import org.apache.spark.util.ManualClock
 
 class CoordinatedCommitsSuite
   extends CommitCoordinatorSuiteBase
-  with DeltaTestUtilsBase
   with CoordinatedCommitsBaseSuite {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -55,6 +55,7 @@ import org.apache.spark.util.ManualClock
 
 class CoordinatedCommitsSuite
   extends CommitCoordinatorSuiteBase
+  with DeltaTestUtilsBase
   with CoordinatedCommitsBaseSuite {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1798,7 +1798,8 @@ abstract class CommitCoordinatorSuiteBase
     }
   }
 
-  test("CREATE LIKE does not copy commit coordinated related feature config from the source table.") {
+  test("CREATE LIKE does not copy commit coordinated related feature config " +
+    "from the source table.") {
     registerBuilder(TrackingInMemoryCommitCoordinatorBuilder(1))
 
     val source = "sourcetable"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -25,11 +25,11 @@ import scala.collection.mutable.ArrayBuffer
 
 import com.databricks.spark.util.Log4jUsageLogger
 import com.databricks.spark.util.UsageRecord
-import org.apache.spark.sql.delta.{CommitStats, CoordinatedCommitsStats, CoordinatedCommitsTableFeature, DeltaOperations, DeltaUnsupportedOperationException, V2CheckpointTableFeature}
+import org.apache.spark.sql.delta.{CommitStats, CoordinatedCommitsStats, CoordinatedCommitsTableFeature, DeltaOperations, DeltaTestUtilsBase, DeltaUnsupportedOperationException, V2CheckpointTableFeature}
 import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, CommitCoordinatorGetCommitsFailedException, DeltaIllegalArgumentException}
 import org.apache.spark.sql.delta.CoordinatedCommitType._
 import org.apache.spark.sql.delta.DeltaConfigs.{CHECKPOINT_INTERVAL, COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF, IN_COMMIT_TIMESTAMPS_ENABLED}
-import org.apache.spark.sql.delta.{DeltaLog, DeltaTestUtilsBase}
+import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.DummySnapshot
 import org.apache.spark.sql.delta.LogSegment

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -76,9 +76,10 @@ trait CommitCoordinatorUtilBase {
 }
 
 trait CatalogOwnedTestBaseSuite
-    extends SparkFunSuite
-    with CommitCoordinatorUtilBase
-    with SharedSparkSession {
+  extends SparkFunSuite
+  with DeltaTestUtilsBase
+  with CommitCoordinatorUtilBase
+  with SharedSparkSession {
   val defaultCatalogOwnedFeatureEnabledKey =
     TableFeatureProtocolUtils.defaultPropertyKey(CatalogOwnedTableFeature)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -48,13 +48,13 @@ trait CommitCoordinatorUtilBase {
    * Runs the function `f` with commit coordinator table feature unset.
    * Any table created in function `f` have CatalogOwned/CoordinatedCommits disabled by default.
    */
-  def withoutDefaultCCTableFeature[T](f: => T): T
+  def withoutDefaultCCTableFeature(f: => Unit): Unit
 
   /**
    * Runs the function `f` with commit coordinator table feature set.
    * Any table created in function `f` have CatalogOwned/CoordinatedCommits enabled by default.`
    */
-  def withDefaultCCTableFeature[T](f: => T): T
+  def withDefaultCCTableFeature(f: => Unit): Unit
 
   /** Run the test with different backfill batch sizes: 1, 2, 10 */
   def testWithDifferentBackfillInterval(testName: String)(f: Int => Unit): Unit
@@ -123,7 +123,7 @@ trait CatalogOwnedTestBaseSuite
     }
   }
 
-  override def withDefaultCCTableFeature[T](f: => T): T = {
+  override def withDefaultCCTableFeature(f: => Unit): Unit = {
     val oldConfig = spark.conf.getOption(defaultCatalogOwnedFeatureEnabledKey)
     spark.conf.set(defaultCatalogOwnedFeatureEnabledKey, "supported")
     try { f } finally {
@@ -133,7 +133,7 @@ trait CatalogOwnedTestBaseSuite
     }
   }
 
-  override def withoutDefaultCCTableFeature[T](f: => T): T = {
+  override def withoutDefaultCCTableFeature(f: => Unit): Unit = {
     val oldConfig = spark.conf.getOption(defaultCatalogOwnedFeatureEnabledKey)
     spark.conf.unset(defaultCatalogOwnedFeatureEnabledKey)
     try { f } finally {
@@ -192,7 +192,7 @@ trait CoordinatedCommitsTestUtils
     }
   }
 
-  override def withDefaultCCTableFeature[T](f: => T): T = {
+  override def withDefaultCCTableFeature(f: => Unit): Unit = {
     val confJson = JsonUtils.toJson(defaultCommitsCoordinatorConf)
     withSQLConf(
       DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.defaultTablePropertyKey ->
@@ -202,7 +202,7 @@ trait CoordinatedCommitsTestUtils
     }
   }
 
-  override def withoutDefaultCCTableFeature[T](f: => T): T = {
+  override def withoutDefaultCCTableFeature(f: => Unit): Unit = {
     val defaultCoordinatedCommitsConfs = CoordinatedCommitsUtils
       .getDefaultCCConfigurations(spark, withDefaultKey = true)
     defaultCoordinatedCommitsConfs.foreach { case (defaultKey, _) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -80,6 +80,7 @@ trait CatalogOwnedTestBaseSuite
   with DeltaTestUtilsBase
   with CommitCoordinatorUtilBase
   with SharedSparkSession {
+
   val defaultCatalogOwnedFeatureEnabledKey =
     TableFeatureProtocolUtils.defaultPropertyKey(CatalogOwnedTableFeature)
 
@@ -166,7 +167,6 @@ trait CatalogOwnedTestBaseSuite
 trait CoordinatedCommitsTestUtils
   extends DeltaTestUtilsBase
   with CommitCoordinatorUtilBase { self: SparkFunSuite with SharedSparkSession =>
-
 
   protected val defaultCommitsCoordinatorName = "tracking-in-memory"
   protected val defaultCommitsCoordinatorConf = Map("randomConf" -> "randomConfValue")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtilsSuite.scala
@@ -77,7 +77,7 @@ class CoordinatedCommitsUtilsSuite extends QueryTest
       propertyOverrides: Map[String, String],
       defaultConfs: Seq[(String, String)],
       errorOpt: Option[DeltaIllegalArgumentException]): Unit = {
-    withoutCoordinatedCommitsDefaultTableProperties {
+    withoutDefaultCCTableFeature {
       withSQLConf(defaultConfs: _*) {
         if (errorOpt.isDefined) {
           val e = intercept[DeltaIllegalArgumentException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
With the new RFC proposal for the table feature "CatalogOwned" and reject to the existing table feature "CoordinatedCommits", this PR provides a basic conversion to the suite. Note that we still need to keep CoordinatedCommit tests due to all other existing old tests, and we can remove them eventually once we remove/convert all old table feature tests.

## How was this patch tested?
This PR is a test.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
