### PR TITLE
[Spark] [CatalogOwned] CatalogOwned specific `CREATE/REPLACE/CLONE` logic

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -25,18 +25,20 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.catalyst.TimeTravel
 import org.apache.spark.sql.delta.DataFrameUtils
 import org.apache.spark.sql.delta.DeltaErrors.{TemporallyUnstableInputException, TimestampEarlierThanCommitRetentionException}
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.catalog.IcebergTablePlaceHolder
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.constraints.{AddConstraint, DropConstraint}
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CoordinatedCommitsUtils}
 import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources._
 import org.apache.spark.sql.delta.util.AnalysisHelper
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{AnalysisException, Dataset, SaveMode, SparkSession}
@@ -142,6 +144,10 @@ class DeltaAnalysis(session: SparkSession)
           CatalogTableType.EXTERNAL
         }
 
+
+      // Whether we are enabling Catalog-Owned via explicit property overrides.
+      var isEnablingCatalogOwnedViaExplicitPropertyOverrides: Boolean = false
+
       val catalogTableTarget =
         // If source table is Delta format
         if (src.provider.exists(DeltaSourceUtils.isDeltaDataSourceName)) {
@@ -151,16 +157,38 @@ class DeltaAnalysis(session: SparkSession)
           // used on the source delta table, then the corresponding fields would be set for the
           // sourceTable and needs to be removed from the targetTable's configuration. The fields
           // will then be set in the targetTable's configuration internally after.
-          // Coordinated commits configurations from the source delta table should also be left out,
-          // since CREATE LIKE is similar to CLONE, and we do not copy the commit coordinator from
-          // the source table. If users want a commit coordinator for the target table, they can
+          //
+          // Coordinated commits/Catalog-Owned configurations from the source delta table should
+          // also be left out, since CREATE LIKE is similar to CLONE, and we do not copy the
+          // commit coordinator from the source table.
+          // If users want a commit coordinator for the target table, they can
           // specify the configurations in the CREATE LIKE command explicitly.
           val sourceMetadata = deltaLogSrc.initialSnapshot.metadata
+
+          // Catalog-Owned: Specifying the table UUID in the TBLPROPERTIES clause
+          // should be blocked.
+          CatalogOwnedTableUtils.validateUCTableIdNotPresent(property = ctl.properties)
+
+          // Check whether we are trying to enable Catalog-Owned via explicit property overrides.
+          // The reason to check this is, if the source table is a Catalog-Owned table, and
+          // we are also trying to enable Catalog-Owned for the target table - We do *NOT*
+          // want to filter out [[CatalogOwnedTableFeature]] from the source table. If we do that,
+          // the resulting target table's protocol will *NOT* have CatalogOwned table feature
+          // present though we have explicitly specified it in the TBLPROPERTIES clause.
+          // This only applies to cases where source table has Catalog-Owned enabled.
+          // It works as intended if source table is a normal delta table.
+          if (TableFeatureProtocolUtils.getSupportedFeaturesFromTableConfigs(
+                configs = ctl.properties).contains(CatalogOwnedTableFeature)) {
+            isEnablingCatalogOwnedViaExplicitPropertyOverrides = true
+          }
+
           val config =
             sourceMetadata.configuration.-("delta.columnMapping.maxColumnId")
               .-(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)
               .-(MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP)
               .filterKeys(!CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(_)).toMap
+              // Catalog-Owned: Do not copy table UUID from source table
+              .filterKeys(_ != UCCommitCoordinatorClient.UC_TABLE_ID_KEY).toMap
 
           new CatalogTable(
             identifier = targetTableIdentifier,
@@ -197,6 +225,25 @@ class DeltaAnalysis(session: SparkSession)
         } else {
           None
         }
+      // Catalog-Owned: Do not copy over [[CatalogOwnedTableFeature]] from source table
+      //                except the certain case.
+      val protocolAfterFilteringCatalogOwnedFromSource = protocol match {
+        case Some(p) if !isEnablingCatalogOwnedViaExplicitPropertyOverrides =>
+          // Only filter out [[CatalogOwnedTableFeature]] when target table is not enabling
+          // CatalogOwned.
+          // E.g.,
+          // - CREATE TABLE t1 LIKE t2
+          //   - Filter CatalogOwned table feature out since target table is not enabling
+          //     CatalogOwned explicitly.
+          // - CREATE TABLE t1 LIKE t2 TBLPROPERTIES (
+          //     'delta.feature.catalogOwned-preview' = 'supported'
+          //   )
+          //   - Do not filter CatalogOwned table feature out if target table is enabling
+          //     CatalogOwned.
+          Some(CatalogOwnedTableUtils.filterOutCatalogOwnedTableFeature(protocol = p))
+        case _ =>
+          protocol
+      }
       val newDeltaCatalog = new DeltaCatalog()
       val existingTableOpt = newDeltaCatalog.getExistingTableIfExists(catalogTableTarget.identifier)
       val newTable = newDeltaCatalog
@@ -210,7 +257,7 @@ class DeltaAnalysis(session: SparkSession)
         mode = saveMode,
         query = None,
         output = ctl.output,
-        protocol = protocol,
+        protocol = protocolAfterFilteringCatalogOwnedFromSource,
         tableByPath = isTableByPath)
 
     // INSERT OVERWRITE by ordinal and df.insertInto()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -157,7 +157,6 @@ class DeltaAnalysis(session: SparkSession)
           // used on the source delta table, then the corresponding fields would be set for the
           // sourceTable and needs to be removed from the targetTable's configuration. The fields
           // will then be set in the targetTable's configuration internally after.
-          //
           // Coordinated commits/Catalog-Owned configurations from the source delta table should
           // also be left out, since CREATE LIKE is similar to CLONE, and we do not copy the
           // commit coordinator from the source table.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -433,7 +433,7 @@ abstract class CloneTableBase(
     // For CREATE CLONE, check the default spark configuration for Catalog-Owned.
     val catalogOwnedEnabledByDefaultConf =
       if (CatalogOwnedTableUtils.defaultCatalogOwnedEnabled(spark)
-        && !tableExists(txn.snapshot)) {
+          && !tableExists(txn.snapshot)) {
         // Append [[CatalogOwnedTableFeature]] to the `configWithOverrides` below if table
         // does not exist, to ensure the final target protocol contains CatalogOwned
         // if enabled by default.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.delta.DeltaColumnMapping.filterColumnMappingProperti
 import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.commands.DMLUtils.TaggedCommitData
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CoordinatedCommitsUtils}
 import org.apache.spark.sql.delta.hooks.{HudiConverterHook, IcebergConverterHook, UpdateCatalog, UpdateCatalogFactory}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -142,6 +142,8 @@ case class CreateDeltaTableCommand(
     }
     val deltaLog = DeltaLog.forTable(sparkSession, tableLocation, fileSystemOptions)
     CoordinatedCommitsUtils.validateConfigurationsForCreateDeltaTableCommand(
+      sparkSession, deltaLog.tableExists, query, tableWithLocation.properties)
+    CatalogOwnedTableUtils.validatePropertiesForCreateDeltaTableCommand(
       sparkSession, deltaLog.tableExists, query, tableWithLocation.properties)
 
     recordDeltaOperation(deltaLog, "delta.ddl.createTable") {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
-import java.util.Locale
 import java.util.Optional
 
 import scala.collection.JavaConverters._


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR includes CatalogOwned-specific logic for `CREATE/REPLACE/CLONE`.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
N/A

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
