### PR TITLE
[Kernel] Load existing DM metadata in even narrower case -- only when DM are removed (optimization)

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -662,17 +662,15 @@ public class TransactionImpl implements Transaction {
       }
 
       generateClusteringDomainMetadataIfNeeded();
-
-      if (domainsToAdd.isEmpty() && domainsToRemove.isEmpty()) {
-        // If no domain metadatas are added or removed, return an empty list. This is to avoid
-        // unnecessary loading of the domain metadatas from the snapshot (which is an expensive
-        // operation).
-        computedMetadatas = Optional.of(Collections.emptyList());
-        return Collections.emptyList();
-      }
-
       // Add all domains added in the transaction
       List<DomainMetadata> result = new ArrayList<>(domainsToAdd.values());
+
+      if (domainsToRemove.isEmpty()) {
+        // If no domain metadatas are removed we don't need to load the existing domain metadatas
+        // from the snapshot (which is an expensive operation)
+        computedMetadatas = Optional.of(result);
+        return result;
+      }
 
       // Generate the tombstones for removed domains
       Map<String, DomainMetadata> snapshotDomainMetadataMap = readSnapshot.getDomainMetadataMap();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Currently we avoid loading the existing domain metadata whenever no DM is added or removed in the txn. We only need to load existing DM when DM is removed -- further improve this optimization.

## How was this patch tested?

Existing tests should suffice that this does not break any functionality. Testing whether we actually load/don't load the DM map is out of scope for now.

## Does this PR introduce _any_ user-facing changes?

No.