### PR TITLE
[Delta Kernel] List compacted log files in SnapshotManager

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -243,6 +243,10 @@ public class DeltaLogActionUtils {
 
               final long fileVersion;
               if (FileNames.isLogCompactionFile(fileName)) {
+                // We use start version here. Below this is used to determine if we should stop
+                // listing because we've listed past the required version. But with a log compaction
+                // file, if the end version is passed the requested version, we don't want to stop,
+                // we just won't use the compaction file.
                 fileVersion = FileNames.logCompactionVersions(new Path(fs.getPath()))._1;
               } else {
                 fileVersion = FileNames.getFileVersion(new Path(fs.getPath()));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/compaction/LogCompactionWriter.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/compaction/LogCompactionWriter.java
@@ -17,7 +17,6 @@ package io.delta.kernel.internal.compaction;
 
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineExceptionThrowsIO;
 import static io.delta.kernel.internal.lang.ListUtils.getLast;
-import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.data.Row;
@@ -100,7 +99,13 @@ public class LogCompactionWriter {
     final long lastCommitTimestamp = getLast(deltas).getModificationTime();
 
     LogSegment segment =
-        new LogSegment(dataPath, endVersion, deltas, emptyList(), lastCommitTimestamp);
+        new LogSegment(
+            dataPath,
+            endVersion,
+            deltas,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            lastCommitTimestamp);
     CreateCheckpointIterator checkpointIterator =
         new CreateCheckpointIterator(engine, segment, minFileRetentionTimestampMillis);
     wrapEngineExceptionThrowsIO(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -103,7 +103,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
     this.checkpointPredicate = checkpointPredicate;
     this.filesList = new LinkedList<>();
     this.filesList.addAll(
-        files.stream().map(DeltaLogFile::forCommitOrCheckpoint).collect(Collectors.toList()));
+        files.stream().map(DeltaLogFile::forFileStatus).collect(Collectors.toList()));
     this.deltaReadSchema = deltaReadSchema;
     this.checkpointReadSchema = checkpointReadSchema;
     this.actionsIter = Optional.empty();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
@@ -27,6 +27,7 @@ import io.delta.kernel.utils.FileStatus;
 public class DeltaLogFile {
   public enum LogType {
     COMMIT,
+    LOG_COMPACTION,
     CHECKPOINT_CLASSIC,
     MULTIPART_CHECKPOINT,
     V2_CHECKPOINT_MANIFEST,
@@ -40,6 +41,9 @@ public class DeltaLogFile {
     if (FileNames.isCommitFile(fileName)) {
       logType = LogType.COMMIT;
       version = FileNames.deltaVersion(fileName);
+    } else if (FileNames.isLogCompactionFile(fileName)) {
+      logType = LogType.LOG_COMPACTION;
+      version = FileNames.logCompactionVersions(fileName)._1;
     } else if (FileNames.isClassicCheckpointFile(fileName)) {
       logType = LogType.CHECKPOINT_CLASSIC;
       version = FileNames.checkpointVersion(fileName);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
@@ -43,7 +43,8 @@ public class DeltaLogFile {
       version = FileNames.deltaVersion(fileName);
     } else if (FileNames.isLogCompactionFile(fileName)) {
       logType = LogType.LOG_COMPACTION;
-      version = FileNames.logCompactionVersions(fileName)._1;
+      // use end version, similar to a checkpoint
+      version = FileNames.logCompactionVersions(fileName)._2;
     } else if (FileNames.isClassicCheckpointFile(fileName)) {
       logType = LogType.CHECKPOINT_CLASSIC;
       version = FileNames.checkpointVersion(fileName);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
@@ -34,7 +34,7 @@ public class DeltaLogFile {
     SIDECAR
   }
 
-  public static DeltaLogFile forCommitOrCheckpoint(FileStatus file) {
+  public static DeltaLogFile forFileStatus(FileStatus file) {
     String fileName = new Path(file.getPath()).getName();
     LogType logType = null;
     long version = -1;
@@ -56,7 +56,7 @@ public class DeltaLogFile {
       version = FileNames.checkpointVersion(fileName);
     } else {
       throw new IllegalArgumentException(
-          "File is not a commit or checkpoint file: " + file.getPath());
+          "File is not a recognized delta log type: " + file.getPath());
     }
     return new DeltaLogFile(file, logType, version);
   }
@@ -83,6 +83,10 @@ public class DeltaLogFile {
     return logType;
   }
 
+  /**
+   * Get the version for this log file. Note that for LOG_COMPACTION files this returns the end
+   * version, similar to a checkpoint
+   */
   public long getVersion() {
     return version;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
@@ -120,8 +120,6 @@ public class LogSegment {
             .allMatch(v -> checkpointVersionOpt.get().equals(v)),
         "All checkpoint files must have the same version");
 
-    // todo: ensure compactions don't overlap
-
     if (version != -1) {
       checkArgument(!deltas.isEmpty() || !checkpoints.isEmpty(), "No files to read");
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
@@ -221,6 +221,10 @@ public class LogSegment {
     return deltas;
   }
 
+  public List<FileStatus> getCompactions() {
+    return compactions;
+  }
+
   public List<FileStatus> getCheckpoints() {
     return checkpoints;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -240,6 +240,8 @@ public class SnapshotManager {
    */
   @VisibleForTesting
   public LogSegment getLogSegmentForVersion(Engine engine, Optional<Long> versionToLoadOpt) {
+    final boolean USE_COMPACTED_FILES = true; // TODO: Where to config this
+
     final String versionToLoadStr = versionToLoadOpt.map(String::valueOf).orElse("latest");
     logger.info("Loading log segment for version {}", versionToLoadStr);
 
@@ -273,11 +275,17 @@ public class SnapshotManager {
     // Step 3: List the files from $startVersion to $versionToLoad //
     /////////////////////////////////////////////////////////////////
 
+    HashSet fileTypes =
+        new HashSet<>(Arrays.asList(DeltaLogFileType.COMMIT, DeltaLogFileType.CHECKPOINT));
+    if (USE_COMPACTED_FILES) {
+      fileTypes.add(DeltaLogFileType.LOG_COMPACTION);
+    }
+
     final long startTimeMillis = System.currentTimeMillis();
     final List<FileStatus> listedFileStatuses =
         DeltaLogActionUtils.listDeltaLogFilesAsIter(
                 engine,
-                new HashSet<>(Arrays.asList(DeltaLogFileType.COMMIT, DeltaLogFileType.CHECKPOINT)),
+                fileTypes,
                 tablePath,
                 listFromStartVersion,
                 versionToLoadOpt,
@@ -310,18 +318,31 @@ public class SnapshotManager {
 
     logDebugFileStatuses("listedFileStatuses", listedFileStatuses);
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Step 5: Partition $listedFileStatuses into the checkpoints and deltas. //
-    ////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Step 5: Partition $listedFileStatuses into the checkpoints, deltas, and compactions. //
+    //////////////////////////////////////////////////////////////////////////////////////////
 
-    final Tuple2<List<FileStatus>, List<FileStatus>> listedCheckpointAndDeltaFileStatuses =
+    // initially partition in checkpoint | delta or compaction
+    final Tuple2<List<FileStatus>, List<FileStatus>>
+        listedCheckpointAndDeltaPlusCompactionFileStatuses =
+            ListUtils.partition(
+                listedFileStatuses,
+                fileStatus -> FileNames.isCheckpointFile(new Path(fileStatus.getPath()).getName()));
+    final List<FileStatus> listedCheckpointFileStatuses =
+        listedCheckpointAndDeltaPlusCompactionFileStatuses._1;
+    final List<FileStatus> listedDeltaPlusCompactionFileStatuses =
+        listedCheckpointAndDeltaPlusCompactionFileStatuses._2;
+
+    // now partition into checkpoint | delta | compaction
+    final Tuple2<List<FileStatus>, List<FileStatus>> listedDeltaAndCompactionFileStatuses =
         ListUtils.partition(
-            listedFileStatuses,
-            fileStatus -> FileNames.isCheckpointFile(new Path(fileStatus.getPath()).getName()));
-    final List<FileStatus> listedCheckpointFileStatuses = listedCheckpointAndDeltaFileStatuses._1;
-    final List<FileStatus> listedDeltaFileStatuses = listedCheckpointAndDeltaFileStatuses._2;
+            listedDeltaPlusCompactionFileStatuses,
+            fileStatus -> FileNames.isLogCompactionFile(new Path(fileStatus.getPath()).getName()));
+    final List<FileStatus> listedCompactionFileStatuses = listedDeltaAndCompactionFileStatuses._1;
+    final List<FileStatus> listedDeltaFileStatuses = listedDeltaAndCompactionFileStatuses._2;
 
     logDebugFileStatuses("listedCheckpointFileStatuses", listedCheckpointFileStatuses);
+    logDebugFileStatuses("listedCompactionFileStatuses", listedCompactionFileStatuses);
     logDebugFileStatuses("listedDeltaFileStatuses", listedDeltaFileStatuses);
 
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -369,9 +390,34 @@ public class SnapshotManager {
 
     logDebugFileStatuses("deltasAfterCheckpoint", deltasAfterCheckpoint);
 
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // Step 7.5: Grab all compactions in range [$latestCompleteCheckpointVersion + 1,
+    // $versionToLoad] //
+    /////////////////////////////////////////////////////////////////////////////////////////////
+
+    final List<FileStatus> compactionsAfterCheckpoint;
+    if (USE_COMPACTED_FILES) {
+      compactionsAfterCheckpoint =
+          listedCompactionFileStatuses.stream()
+              .filter(
+                  fs -> {
+                    final Tuple2<Long, Long> compactionVersions =
+                        FileNames.logCompactionVersions(new Path(fs.getPath()));
+                    return latestCompleteCheckpointVersion + 1 <= compactionVersions._1
+                        && compactionVersions._2 <= versionToLoadOpt.orElse(Long.MAX_VALUE);
+                  })
+              .collect(Collectors.toList());
+    } else {
+      compactionsAfterCheckpoint = Collections.emptyList();
+    }
+
+    logDebugFileStatuses("compactionsAfterCheckpoint", compactionsAfterCheckpoint);
+
     ////////////////////////////////////////////////////////////////////
     // Step 8: Determine the version of the snapshot we can now load. //
     ////////////////////////////////////////////////////////////////////
+
+    // TODO: need to check compactions too?
 
     final List<Long> deltaVersionsAfterCheckpoint =
         deltasAfterCheckpoint.stream()
@@ -492,6 +538,7 @@ public class SnapshotManager {
         logPath,
         newVersion,
         deltasAfterCheckpoint,
+        compactionsAfterCheckpoint,
         latestCompleteCheckpointFileStatuses,
         lastCommitTimestamp);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -277,7 +277,7 @@ public class SnapshotManager {
     // Step 3: List the files from $startVersion to $versionToLoad //
     /////////////////////////////////////////////////////////////////
 
-    HashSet fileTypes =
+    Set<DeltaLogFileType> fileTypes =
         new HashSet<>(Arrays.asList(DeltaLogFileType.COMMIT, DeltaLogFileType.CHECKPOINT));
     if (USE_COMPACTED_FILES) {
       fileTypes.add(DeltaLogFileType.LOG_COMPACTION);
@@ -379,7 +379,6 @@ public class SnapshotManager {
     /////////////////////////////////////////////////////////////////////////////////////////////
     // Step 7: Grab all deltas in range [$latestCompleteCheckpointVersion + 1, $versionToLoad] //
     /////////////////////////////////////////////////////////////////////////////////////////////
-
     final List<FileStatus> deltasAfterCheckpoint =
         listedDeltaFileStatuses.stream()
             .filter(
@@ -392,10 +391,10 @@ public class SnapshotManager {
 
     logDebugFileStatuses("deltasAfterCheckpoint", deltasAfterCheckpoint);
 
-    /////////////////////////////////////////////////////////////////////////////////////////////
-    // Step 8: Grab all compactions in range [$latestCompleteCheckpointVersion + 1,
-    // $versionToLoad] //
-    /////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////
+    // Step 8: Grab all compactions in range [$latestCompleteCheckpointVersion + 1, //
+    //         $versionToLoad]                                                      //
+    //////////////////////////////////////////////////////////////////////////////////
 
     final List<FileStatus> compactionsAfterCheckpoint;
     if (USE_COMPACTED_FILES) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -394,21 +394,16 @@ public class SnapshotManager {
     //         $versionToLoad]                                                      //
     //////////////////////////////////////////////////////////////////////////////////
 
-    final List<FileStatus> compactionsAfterCheckpoint;
-    if (USE_COMPACTED_FILES) {
-      compactionsAfterCheckpoint =
-          listedCompactionFileStatuses.stream()
-              .filter(
-                  fs -> {
-                    final Tuple2<Long, Long> compactionVersions =
-                        FileNames.logCompactionVersions(new Path(fs.getPath()));
-                    return latestCompleteCheckpointVersion + 1 <= compactionVersions._1
-                        && compactionVersions._2 <= versionToLoadOpt.orElse(Long.MAX_VALUE);
-                  })
-              .collect(Collectors.toList());
-    } else {
-      compactionsAfterCheckpoint = Collections.emptyList();
-    }
+    final List<FileStatus> compactionsAfterCheckpoint =
+        listedCompactionFileStatuses.stream()
+            .filter(
+                fs -> {
+                  final Tuple2<Long, Long> compactionVersions =
+                      FileNames.logCompactionVersions(new Path(fs.getPath()));
+                  return latestCompleteCheckpointVersion + 1 <= compactionVersions._1
+                      && compactionVersions._2 <= versionToLoadOpt.orElse(Long.MAX_VALUE);
+                })
+            .collect(Collectors.toList());
 
     logDebugFileStatuses("compactionsAfterCheckpoint", compactionsAfterCheckpoint);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -416,8 +416,6 @@ public class SnapshotManager {
     // Step 9: Determine the version of the snapshot we can now load. //
     ////////////////////////////////////////////////////////////////////
 
-    // TODO: need to check compactions too?
-
     final List<Long> deltaVersionsAfterCheckpoint =
         deltasAfterCheckpoint.stream()
             .map(fileStatus -> FileNames.deltaVersion(new Path(fileStatus.getPath())))

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -240,7 +240,9 @@ public class SnapshotManager {
    */
   @VisibleForTesting
   public LogSegment getLogSegmentForVersion(Engine engine, Optional<Long> versionToLoadOpt) {
-    final boolean USE_COMPACTED_FILES = true; // TODO: Where to config this
+    // Defaulting to listing the files for now. This has low cost. We can make this a configurable
+    // option in the future if we need to.
+    final boolean USE_COMPACTED_FILES = true;
 
     final String versionToLoadStr = versionToLoadOpt.map(String::valueOf).orElse("latest");
     logger.info("Loading log segment for version {}", versionToLoadStr);
@@ -391,7 +393,7 @@ public class SnapshotManager {
     logDebugFileStatuses("deltasAfterCheckpoint", deltasAfterCheckpoint);
 
     /////////////////////////////////////////////////////////////////////////////////////////////
-    // Step 7.5: Grab all compactions in range [$latestCompleteCheckpointVersion + 1,
+    // Step 8: Grab all compactions in range [$latestCompleteCheckpointVersion + 1,
     // $versionToLoad] //
     /////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -414,7 +416,7 @@ public class SnapshotManager {
     logDebugFileStatuses("compactionsAfterCheckpoint", compactionsAfterCheckpoint);
 
     ////////////////////////////////////////////////////////////////////
-    // Step 8: Determine the version of the snapshot we can now load. //
+    // Step 9: Determine the version of the snapshot we can now load. //
     ////////////////////////////////////////////////////////////////////
 
     // TODO: need to check compactions too?
@@ -432,7 +434,7 @@ public class SnapshotManager {
     logger.info("New version to load: {}", newVersion);
 
     /////////////////////////////////////////////
-    // Step 9: Perform some basic validations. //
+    // Step 10: Perform some basic validations. //
     /////////////////////////////////////////////
 
     // Check that we have found at least one checkpoint or delta file
@@ -490,7 +492,7 @@ public class SnapshotManager {
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////
-    // Step 10: Grab the actual checkpoint file statuses for latestCompleteCheckpointVersion. //
+    // Step 11: Grab the actual checkpoint file statuses for latestCompleteCheckpointVersion. //
     ////////////////////////////////////////////////////////////////////////////////////////////
 
     final List<FileStatus> latestCompleteCheckpointFileStatuses =
@@ -526,7 +528,7 @@ public class SnapshotManager {
             .orElse(Collections.emptyList());
 
     ///////////////////////////////////////////////////
-    // Step 11: Construct the LogSegment and return. //
+    // Step 12: Construct the LogSegment and return. //
     ///////////////////////////////////////////////////
 
     logger.info("Successfully constructed LogSegment at version {}", newVersion);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -17,6 +17,7 @@
 package io.delta.kernel.internal.util;
 
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.utils.FileStatus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -81,6 +82,20 @@ public final class FileNames {
       Pattern.compile("(\\d+)\\.checkpoint\\.\\d+\\.\\d+\\.parquet");
 
   public static final String SIDECAR_DIRECTORY = "_sidecars";
+
+  public static DeltaLogFileType determineFileType(FileStatus file) {
+    final String fileName = file.getPath().toString();
+
+    if (isCommitFile(fileName)) {
+      return DeltaLogFileType.COMMIT;
+    } else if (isCheckpointFile(fileName)) {
+      return DeltaLogFileType.CHECKPOINT;
+    } else if (isLogCompactionFile(fileName)) {
+      return DeltaLogFileType.LOG_COMPACTION;
+    } else {
+      throw new IllegalStateException("Unexpected file type: " + fileName);
+    }
+  }
 
   ////////////////////////
   // Version extractors //

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -141,10 +141,6 @@ public final class FileNames {
     return logCompactionVersions(new Path(path));
   }
 
-  // public static boolean deltaIsCoveredBy(String deltaPath, List<String> compactionFiles) {
-
-  // }
-
   /** Returns the version for the given checkpoint path. */
   public static long checkpointVersion(Path path) {
     return Long.parseLong(path.getName().split("\\.")[0]);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -123,10 +123,7 @@ public final class FileNames {
   }
 
   public static Tuple2<Long, Long> logCompactionVersions(String path) {
-    final int slashIdx = path.lastIndexOf(Path.SEPARATOR);
-    final String name = path.substring(slashIdx + 1);
-    final String[] split = name.split("\\.");
-    return new Tuple2<>(Long.parseLong(split[0]), Long.parseLong(split[1]));
+    return logCompactionVersions(new Path(path));
   }
 
   // public static boolean deltaIsCoveredBy(String deltaPath, List<String> compactionFiles) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
@@ -321,27 +321,27 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
     files = deltaFileStatuses(0L to 4L) ++ compactedFileStatuses(Seq((3, 4))),
     startVersion = 0,
     endVersion = Optional.empty(),
-    expectedListedFiles = deltaFileStatuses(0L to 2L) ++ compactedFileStatuses(Seq((
-      3,
-      4))) ++ deltaFileStatuses(3L to 4L))
+    expectedListedFiles = deltaFileStatuses(0L to 2L) ++
+      compactedFileStatuses(Seq((3, 4))) ++
+      deltaFileStatuses(3L to 4L))
 
   testListWithCompactions(
     "compaction at end, with endVersion",
     files = deltaFileStatuses(0L to 4L) ++ compactedFileStatuses(Seq((3, 4))),
     startVersion = 0,
     endVersion = Optional.of(4),
-    expectedListedFiles = deltaFileStatuses(0L to 2L) ++ compactedFileStatuses(Seq((
-      3,
-      4))) ++ deltaFileStatuses(3L to 4L))
+    expectedListedFiles = deltaFileStatuses(0L to 2L) ++
+      compactedFileStatuses(Seq((3, 4))) ++
+      deltaFileStatuses(3L to 4L))
 
   testListWithCompactions(
     "compaction in middle, no endVersion",
     files = deltaFileStatuses(0L to 4L) ++ compactedFileStatuses(Seq((2, 4))),
     startVersion = 0,
     endVersion = Optional.empty(),
-    expectedListedFiles = deltaFileStatuses(0L to 1L) ++ compactedFileStatuses(Seq((
-      2,
-      4))) ++ deltaFileStatuses(2L to 4L))
+    expectedListedFiles = deltaFileStatuses(0L to 1L) ++
+      compactedFileStatuses(Seq((2, 4))) ++
+      deltaFileStatuses(2L to 4L))
 
   testListWithCompactions(
     "compaction over end, with endVersion",
@@ -369,29 +369,30 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
     files = deltaFileStatuses(0L to 7L) ++ compactedFileStatuses(Seq((2, 4), (5, 7))),
     startVersion = 0,
     endVersion = Optional.empty(),
-    expectedListedFiles = deltaFileStatuses(0L to 1L) ++ compactedFileStatuses(Seq((
-      2,
-      4))) ++ deltaFileStatuses(2L to 4L) ++ compactedFileStatuses(Seq((
-      5,
-      7))) ++ deltaFileStatuses(5L to 7L))
+    expectedListedFiles = deltaFileStatuses(0L to 1L) ++
+      compactedFileStatuses(Seq((2, 4))) ++
+      deltaFileStatuses(2L to 4L) ++
+      compactedFileStatuses(Seq((5, 7))) ++
+      deltaFileStatuses(5L to 7L))
 
   testListWithCompactions(
     "multiple compactions, with endVersion, don't return second compaction",
     files = deltaFileStatuses(0L to 7L) ++ compactedFileStatuses(Seq((2, 4), (5, 7))),
     startVersion = 0,
     endVersion = Optional.of(6),
-    expectedListedFiles = deltaFileStatuses(0L to 1L) ++ compactedFileStatuses(Seq((
-      2,
-      4))) ++ deltaFileStatuses(2L to 4L) ++ deltaFileStatuses(5L to 6L))
+    expectedListedFiles = deltaFileStatuses(0L to 1L) ++
+      compactedFileStatuses(Seq((2, 4))) ++
+      deltaFileStatuses(2L to 4L) ++
+      deltaFileStatuses(5L to 6L))
 
   testListWithCompactions(
     "multiple compactions, no endVersion, start after first compaction",
     files = deltaFileStatuses(0L to 7L) ++ compactedFileStatuses(Seq((2, 4), (5, 7))),
     startVersion = 3,
     endVersion = Optional.empty(),
-    expectedListedFiles = deltaFileStatuses(3L to 4L) ++ compactedFileStatuses(Seq((
-      5,
-      7))) ++ deltaFileStatuses(5L to 7L))
+    expectedListedFiles = deltaFileStatuses(3L to 4L) ++
+      compactedFileStatuses(Seq((5, 7))) ++
+      deltaFileStatuses(5L to 7L))
 
   testListWithCompactions(
     "multiple compactions, with endVersion, return no compactions",
@@ -399,5 +400,4 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
     startVersion = 3,
     endVersion = Optional.of(6),
     expectedListedFiles = deltaFileStatuses(3L to 6L))
-
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -69,6 +69,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       logSegment: LogSegment,
       expectedVersion: Long,
       expectedDeltas: Seq[FileStatus],
+      expectedCompactions: Seq[FileStatus],
       expectedCheckpoints: Seq[FileStatus],
       expectedCheckpointVersion: Option[Long],
       expectedLastCommitTimestamp: Long): Unit = {
@@ -77,6 +78,8 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     assert(logSegment.getVersion == expectedVersion)
     assert(expectedDeltas.map(f => (f.getPath, f.getSize, f.getModificationTime)) sameElements
       logSegment.getDeltas.asScala.map(f => (f.getPath, f.getSize, f.getModificationTime)))
+    assert(expectedCompactions.map(f => (f.getPath, f.getSize, f.getModificationTime)) sameElements
+      logSegment.getCompactions.asScala.map(f => (f.getPath, f.getSize, f.getModificationTime)))
 
     val expectedCheckpointStatuses = expectedCheckpoints
       .map(f => (f.getPath, f.getSize, f.getModificationTime)).sortBy(_._1)
@@ -117,7 +120,8 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       numParts: Int = -1,
       startCheckpoint: Optional[java.lang.Long] = Optional.empty(),
       versionToLoad: Optional[java.lang.Long] = Optional.empty(),
-      v2CheckpointSpec: Seq[(Long, Boolean, Int)] = Seq.empty): Unit = {
+      v2CheckpointSpec: Seq[(Long, Boolean, Int)] = Seq.empty,
+      compactionVersions: Seq[(Long, Long)] = Seq.empty): Unit = {
     val deltas = deltaFileStatuses(deltaVersions)
     val singularCheckpoints = singularCheckpointFileStatuses(checkpointVersions)
     val multiCheckpoints = multiCheckpointFileStatuses(multiCheckpointVersions, numParts)
@@ -155,9 +159,11 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
         }
       }.getOrElse((Seq.empty, Seq.empty))
 
+      val compactions = compactedFileStatuses(compactionVersions)
+
       val logSegment = snapshotManager.getLogSegmentForVersion(
         createMockFSListFromEngine(
-          listFromProvider(deltas ++ checkpointFiles)("/"),
+          listFromProvider(deltas ++ compactions ++ checkpointFiles)("/"),
           new MockSidecarParquetHandler(expectedSidecars),
           new MockSidecarJsonHandler(expectedSidecars)),
         versionToLoad)
@@ -175,11 +181,18 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
           multiCheckpointFileStatuses(Seq(v), numParts)
         }
       }.getOrElse(Seq.empty)
+      val expectedCompactions = compactedFileStatuses(
+        compactionVersions.filter { case (s, e) =>
+          // we can only use a compaction if it starts after the checkpoint and ends at or before
+          // the version we're trying to load
+          s > expectedCheckpointVersion.getOrElse(-1L) && e <= versionToLoad.orElse(Long.MaxValue)
+        })
 
       checkLogSegment(
         logSegment,
         expectedVersion = versionToLoad.orElse(deltaVersions.max),
         expectedDeltas = expectedDeltas,
+        expectedCompactions = expectedCompactions,
         expectedCheckpoints = expectedCheckpoints,
         expectedCheckpointVersion = expectedCheckpointVersion,
         expectedLastCommitTimestamp = versionToLoad.orElse(deltaVersions.max) * 10)
@@ -195,6 +208,19 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       checkpointVersions = Seq.empty,
       multiCheckpointVersions = Seq.empty,
       versionToLoad = versionToLoad)
+  }
+
+  /** Simple test with only json and compactions */
+  def testWithCompactionsNoCheckpoint(
+      deltaVersions: Seq[Long],
+      compactionVersions: Seq[(Long, Long)],
+      versionToLoad: Optional[java.lang.Long] = Optional.empty()): Unit = {
+    testWithCheckpoints(
+      deltaVersions,
+      checkpointVersions = Seq.empty,
+      multiCheckpointVersions = Seq.empty,
+      versionToLoad = versionToLoad,
+      compactionVersions = compactionVersions)
   }
 
   /**
@@ -416,6 +442,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
         logSegment,
         expectedVersion = 24,
         expectedDeltas = deltaFileStatuses(21L until 25L),
+        expectedCompactions = Seq.empty,
         expectedCheckpoints = singularCheckpointFileStatuses(Seq(20L)),
         expectedCheckpointVersion = Some(20),
         expectedLastCommitTimestamp = 240L)
@@ -687,6 +714,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
         expectedVersion = deltaVersions.max,
         expectedDeltas = deltaFileStatuses(
           deltaVersions.filter(_ > checkpointVersion.getOrElse(-1L))),
+        expectedCompactions = Seq.empty,
         expectedCheckpoints = checkpoints,
         expectedCheckpointVersion = checkpointVersion,
         expectedLastCommitTimestamp = deltaVersions.max * 10)
@@ -701,6 +729,47 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     }.getMessage
 
     assert(exMsg.contains("Missing checkpoint at version 1"))
+  }
+
+  test("One compaction") {
+    testWithCompactionsNoCheckpoint(
+      Seq(0, 1, 2, 3, 4, 5),
+      Seq((0, 4)))
+    testWithCompactionsNoCheckpoint(
+      Seq(0, 1, 2, 3, 4, 5),
+      Seq((0, 4)),
+      Optional.of(4))
+  }
+
+  test("Compaction extends too far") {
+    testWithCompactionsNoCheckpoint(
+      Seq(0, 1, 2, 3, 4, 5),
+      Seq((3, 5)),
+      Optional.of(4))
+  }
+
+  test("Compaction after checkpoint") {
+    testWithCheckpoints(
+      Seq(0, 1, 2, 3, 4, 5),
+      Seq(2),
+      multiCheckpointVersions = Seq.empty,
+      compactionVersions = Seq((3, 5)))
+  }
+
+  test("Compaction starting before checkpoint") {
+    testWithCheckpoints(
+      Seq(0, 1, 2, 3, 4, 5),
+      Seq(2),
+      multiCheckpointVersions = Seq.empty,
+      compactionVersions = Seq((1, 5)))
+  }
+
+  test("Compaction starting same as checkpoint") {
+    testWithCheckpoints(
+      Seq(0, 1, 2, 3, 4, 5),
+      Seq(2),
+      multiCheckpointVersions = Seq.empty,
+      compactionVersions = Seq((2, 5)))
   }
 }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -733,41 +733,42 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
 
   test("One compaction") {
     testWithCompactionsNoCheckpoint(
-      Seq(0, 1, 2, 3, 4, 5),
-      Seq((0, 4)))
+      deltaVersions = 0L until 5L,
+      compactionVersions = Seq((0, 4)))
+
     testWithCompactionsNoCheckpoint(
-      Seq(0, 1, 2, 3, 4, 5),
-      Seq((0, 4)),
-      Optional.of(4))
+      deltaVersions = 0L until 5L,
+      compactionVersions = Seq((0, 4)),
+      versionToLoad = Optional.of(4))
   }
 
   test("Compaction extends too far") {
     testWithCompactionsNoCheckpoint(
-      Seq(0, 1, 2, 3, 4, 5),
-      Seq((3, 5)),
-      Optional.of(4))
+      deltaVersions = 0L until 5L,
+      compactionVersions = Seq((3, 5)),
+      versionToLoad = Optional.of(4))
   }
 
   test("Compaction after checkpoint") {
     testWithCheckpoints(
-      Seq(0, 1, 2, 3, 4, 5),
-      Seq(2),
+      deltaVersions = 0L until 5L,
+      checkpointVersions = Seq(2),
       multiCheckpointVersions = Seq.empty,
       compactionVersions = Seq((3, 5)))
   }
 
   test("Compaction starting before checkpoint") {
     testWithCheckpoints(
-      Seq(0, 1, 2, 3, 4, 5),
-      Seq(2),
+      deltaVersions = 0L until 5L,
+      checkpointVersions = Seq(2),
       multiCheckpointVersions = Seq.empty,
       compactionVersions = Seq((1, 5)))
   }
 
   test("Compaction starting same as checkpoint") {
     testWithCheckpoints(
-      Seq(0, 1, 2, 3, 4, 5),
-      Seq(2),
+      deltaVersions = 0L until 5L,
+      checkpointVersions = Seq(2),
       multiCheckpointVersions = Seq.empty,
       compactionVersions = Seq((2, 5)))
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
@@ -20,7 +20,6 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
-import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.test.MockFileSystemClientUtils
 import io.delta.kernel.utils.FileStatus
 
@@ -31,9 +30,6 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
   private val deltaFs11List = deltaFileStatuses(Seq(11)).toList.asJava
   private val deltaFs12List = deltaFileStatuses(Seq(12)).toList.asJava
   private val deltasFs11To12List = deltaFileStatuses(Seq(11, 12)).toList.asJava
-  private val compactionFs3To5List = compactedFileStatuses(Seq((3, 5))).toList.asJava
-  private val compactionFs3To5And8To10List =
-    compactedFileStatuses(Seq((3, 5), (8, 10))).toList.asJava
   private val badJsonsList = Collections.singletonList(
     FileStatus.of(s"${logPath.toString}/gibberish.json", 1, 1))
   private val badCheckpointsList = Collections.singletonList(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
@@ -20,6 +20,7 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
+import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.test.MockFileSystemClientUtils
 import io.delta.kernel.utils.FileStatus
 
@@ -30,6 +31,9 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
   private val deltaFs11List = deltaFileStatuses(Seq(11)).toList.asJava
   private val deltaFs12List = deltaFileStatuses(Seq(12)).toList.asJava
   private val deltasFs11To12List = deltaFileStatuses(Seq(11, 12)).toList.asJava
+  private val compactionFs3To5List = compactedFileStatuses(Seq((3, 5))).toList.asJava
+  private val compactionFs3To5And8To10List =
+    compactedFileStatuses(Seq((3, 5), (8, 10))).toList.asJava
   private val badJsonsList = Collections.singletonList(
     FileStatus.of(s"${logPath.toString}/gibberish.json", 1, 1))
   private val badCheckpointsList = Collections.singletonList(
@@ -40,74 +44,114 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("constructor -- valid case (non-empty)") {
-    new LogSegment(logPath, 12, deltasFs11To12List, checkpointFs10List, 1)
+    new LogSegment(logPath, 12, deltasFs11To12List, Collections.emptyList(), checkpointFs10List, 1)
   }
 
   test("constructor -- null arguments => throw") {
     // logPath is null
     intercept[NullPointerException] {
-      new LogSegment(null, 1, Collections.emptyList(), Collections.emptyList(), -1)
+      new LogSegment(
+        null,
+        1,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        -1)
     }
     // deltas is null
     intercept[NullPointerException] {
-      new LogSegment(logPath, 1, null, Collections.emptyList(), -1)
+      new LogSegment(logPath, 1, null, Collections.emptyList(), Collections.emptyList(), -1)
+    }
+    // compactions is null
+    intercept[NullPointerException] {
+      new LogSegment(logPath, 1, Collections.emptyList(), null, Collections.emptyList(), -1)
     }
     // checkpoints is null
     intercept[NullPointerException] {
-      new LogSegment(logPath, 1, Collections.emptyList(), null, -1)
+      new LogSegment(logPath, 1, Collections.emptyList(), Collections.emptyList(), null, -1)
     }
   }
 
   test("constructor -- non-empty deltas or checkpoints with version -1 => throw") {
     val exMsg1 = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, -1, deltasFs11To12List, Collections.emptyList(), 1)
+      new LogSegment(
+        logPath,
+        -1,
+        deltasFs11To12List,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        1)
     }.getMessage
     assert(exMsg1 === "Version -1 should have no files")
 
     val exMsg2 = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, -1, Collections.emptyList(), checkpointFs10List, 1)
+      new LogSegment(
+        logPath,
+        -1,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        checkpointFs10List,
+        1)
     }.getMessage
     assert(exMsg2 === "Version -1 should have no files")
   }
 
   test("constructor -- all deltas must be actual delta files") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, 12, badJsonsList, checkpointFs10List, 1)
+      new LogSegment(logPath, 12, badJsonsList, Collections.emptyList(), checkpointFs10List, 1)
     }.getMessage
     assert(exMsg === "deltas must all be actual delta (commit) files")
   }
 
   test("constructor -- all checkpoints must be actual checkpoint files") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, 12, deltasFs11To12List, badCheckpointsList, 1)
+      new LogSegment(
+        logPath,
+        12,
+        deltasFs11To12List,
+        Collections.emptyList(),
+        badCheckpointsList,
+        1)
     }.getMessage
     assert(exMsg === "checkpoints must all be actual checkpoint files")
   }
 
   test("constructor -- if version >= 0 then both deltas and checkpoints cannot be empty") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, 12, Collections.emptyList(), Collections.emptyList(), 1)
+      new LogSegment(
+        logPath,
+        12,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        1)
     }.getMessage
     assert(exMsg === "No files to read")
   }
 
   test("constructor -- if deltas non-empty then first delta must equal checkpointVersion + 1") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, 12, deltaFs12List, checkpointFs10List, 1)
+      new LogSegment(logPath, 12, deltaFs12List, Collections.emptyList(), checkpointFs10List, 1)
     }.getMessage
     assert(exMsg === "First delta file version must equal checkpointVersion + 1")
   }
 
   test("constructor -- if deltas non-empty then last delta must equal version") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, 12, deltaFs11List, checkpointFs10List, 1)
+      new LogSegment(logPath, 12, deltaFs11List, Collections.emptyList(), checkpointFs10List, 1)
     }.getMessage
     assert(exMsg === "Last delta file version must equal the version of this LogSegment")
   }
 
   test("constructor -- if no deltas then checkpointVersion must equal version") {
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, 11, Collections.emptyList(), checkpointFs10List, 1)
+      new LogSegment(
+        logPath,
+        11,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        checkpointFs10List,
+        1)
     }.getMessage
     assert(exMsg ===
       "If there are no deltas, then checkpointVersion must equal the version of this LogSegment")
@@ -116,7 +160,7 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
   test("constructor -- deltas not contiguous") {
     val deltas = deltaFileStatuses(Seq(11, 13)).toList.asJava
     val exMsg = intercept[IllegalArgumentException] {
-      new LogSegment(logPath, 13, deltas, checkpointFs10List, 1)
+      new LogSegment(logPath, 13, deltas, Collections.emptyList(), checkpointFs10List, 1)
     }.getMessage
     assert(exMsg === "Delta versions must be contiguous: [11, 13]")
   }
@@ -124,23 +168,42 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
   test("isComplete") {
     {
       // case 1: checkpoint and deltas => complete
-      val logSegment = new LogSegment(logPath, 12, deltasFs11To12List, checkpointFs10List, 1)
+      val logSegment = new LogSegment(
+        logPath,
+        12,
+        deltasFs11To12List,
+        Collections.emptyList(),
+        checkpointFs10List,
+        1)
       assert(logSegment.isComplete)
     }
     {
       // case 2: checkpoint only => complete
-      val logSegment = new LogSegment(logPath, 10, Collections.emptyList(), checkpointFs10List, 1)
+      val logSegment = new LogSegment(
+        logPath,
+        10,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        checkpointFs10List,
+        1)
       assert(logSegment.isComplete)
     }
     {
       // case 3: deltas from 0 to N with no checkpoint => complete
       val deltaFiles = deltaFileStatuses((0L to 17L)).toList.asJava
-      val logSegment = new LogSegment(logPath, 17, deltaFiles, Collections.emptyList(), 1)
+      val logSegment =
+        new LogSegment(logPath, 17, deltaFiles, Collections.emptyList(), Collections.emptyList(), 1)
       assert(logSegment.isComplete)
     }
     {
       // case 4: just deltas from 11 to 12 with no checkpoint => incomplete
-      val logSegment = new LogSegment(logPath, 12, deltasFs11To12List, Collections.emptyList(), 1)
+      val logSegment = new LogSegment(
+        logPath,
+        12,
+        deltasFs11To12List,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        1)
       assert(!logSegment.isComplete)
     }
     {
@@ -150,7 +213,13 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("toString") {
-    val logSegment = new LogSegment(logPath, 12, deltasFs11To12List, checkpointFs10List, 1)
+    val logSegment = new LogSegment(
+      logPath,
+      12,
+      deltasFs11To12List,
+      Collections.emptyList(),
+      checkpointFs10List,
+      1)
     // scalastyle:off line.size.limit
     val expectedToString =
       """LogSegment {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -43,6 +43,14 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
     deltaVersions.map(v => FileStatus.of(FileNames.deltaFile(logPath, v), v, v * 10))
   }
 
+  /** Delta file statuses where the timestamp = 10*version */
+  def compactedFileStatuses(compactedVersions: Seq[(Long, Long)]): Seq[FileStatus] = {
+    // todo: validate no overlap?
+    compactedVersions.map { case (s, e) =>
+      FileStatus.of(FileNames.logCompactionPath(logPath, s, e).toString, s, s * 10)
+    }
+  }
+
   /** Checkpoint file statuses where the timestamp = 10*version */
   def singularCheckpointFileStatuses(checkpointVersions: Seq[Long]): Seq[FileStatus] = {
     assert(checkpointVersions.size == checkpointVersions.toSet.size)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -43,9 +43,8 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
     deltaVersions.map(v => FileStatus.of(FileNames.deltaFile(logPath, v), v, v * 10))
   }
 
-  /** Delta file statuses where the timestamp = 10*version */
+  /** Compaction file statuses where the timestamp = 10*version */
   def compactedFileStatuses(compactedVersions: Seq[(Long, Long)]): Seq[FileStatus] = {
-    // todo: validate no overlap?
     compactedVersions.map { case (s, e) =>
       FileStatus.of(FileNames.logCompactionPath(logPath, s, e).toString, s, s * 10)
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Splitting up #4443 as requested. This part just lists relevant compaction files and stores them in the `LogSegment`. A follow-on PR will do the work to actually use them during log reply.

This PR includes a boolean to turn on/off listing, but it's just hard-coded to true. I'm happy to just remove that all together, but I suspect we'll want to configure it in the future so figured I'd leave that in.

## How was this patch tested?

Unit tests. 

## Does this PR introduce _any_ user-facing changes?
No