### PR TITLE
[Kernel] Support passing tags for generateIcebergCompatWriterV1AddAction

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -256,7 +256,8 @@ public interface Transaction {
                   dataFileStatus,
                   ((DataWriteContextImpl) dataWriteContext).getPartitionValues(),
                   true /* dataChange */,
-                  Collections.emptyMap());
+                  // TODO: populate tags in generateAppendActions
+                  Collections.emptyMap() /* tags */);
           return SingleAction.createAddFileSingleAction(addFileRow.toRow());
         });
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -40,6 +40,7 @@ import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.*;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -254,7 +255,8 @@ public interface Transaction {
                   tableRoot,
                   dataFileStatus,
                   ((DataWriteContextImpl) dataWriteContext).getPartitionValues(),
-                  true /* dataChange */);
+                  true /* dataChange */,
+                  Collections.emptyMap());
           return SingleAction.createAddFileSingleAction(addFileRow.toRow());
         });
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -81,6 +81,8 @@ public class AddFile extends RowBackedAction {
       Map<String, Literal> partitionValues,
       boolean dataChange,
       Map<String, String> tags) {
+    Optional<MapValue> tagMapValue =
+        !tags.isEmpty() ? Optional.of(VectorUtils.stringStringMapValue(tags)) : Optional.empty();
     Row row =
         createAddFileRow(
             physicalSchema,
@@ -90,7 +92,7 @@ public class AddFile extends RowBackedAction {
             dataFileStatus.getModificationTime(),
             dataChange,
             Optional.empty(), // deletionVector
-            Optional.of(VectorUtils.stringStringMapValue(tags)), // tags
+            tagMapValue, // tags
             Optional.empty(), // baseRowId
             Optional.empty(), // defaultRowCommitVersion
             dataFileStatus.getStatistics());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -31,10 +31,7 @@ import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.DataFileStatus;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 /** Delta log action representing an `AddFile` */
 public class AddFile extends RowBackedAction {
@@ -82,7 +79,8 @@ public class AddFile extends RowBackedAction {
       URI tableRoot,
       DataFileStatus dataFileStatus,
       Map<String, Literal> partitionValues,
-      boolean dataChange) {
+      boolean dataChange,
+      Map<String, String> tags) {
     Row row =
         createAddFileRow(
             physicalSchema,
@@ -92,7 +90,7 @@ public class AddFile extends RowBackedAction {
             dataFileStatus.getModificationTime(),
             dataChange,
             Optional.empty(), // deletionVector
-            Optional.empty(), // tags
+            Optional.of(VectorUtils.stringStringMapValue(tags)), // tags
             Optional.empty(), // baseRowId
             Optional.empty(), // defaultRowCommitVersion
             dataFileStatus.getStatistics());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtils.java
@@ -39,6 +39,7 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.kernel.utils.DataFileStatus;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -64,7 +65,8 @@ public final class GenerateIcebergCompatActionUtils {
       Row transactionState,
       DataFileStatus fileStatus,
       Map<String, Literal> partitionValues,
-      boolean dataChange) {
+      boolean dataChange,
+      Map<String, String> tags) {
     Map<String, String> configuration = TransactionStateRow.getConfiguration(transactionState);
 
     /* ----- Validate that this is a valid usage of this API ----- */
@@ -90,8 +92,18 @@ public final class GenerateIcebergCompatActionUtils {
             tableRoot,
             fileStatus,
             partitionValues,
-            dataChange);
+            dataChange,
+            tags);
     return SingleAction.createAddFileSingleAction(addFile.toRow());
+  }
+
+  public static Row generateIcebergCompatWriterV1AddAction(
+      Row transactionState,
+      DataFileStatus fileStatus,
+      Map<String, Literal> partitionValues,
+      boolean dataChange) {
+    return generateIcebergCompatWriterV1AddAction(
+        transactionState, fileStatus, partitionValues, dataChange, Collections.emptyMap());
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtils.java
@@ -55,6 +55,7 @@ public final class GenerateIcebergCompatActionUtils {
    * @param fileStatus the file status to create the add with (contains path, time, size, and stats)
    * @param partitionValues the partition values for the add
    * @param dataChange whether or not the add constitutes a dataChange (i.e. append vs. compaction)
+   * @param tags key-value metadata to be attached to the add action
    * @return add action row that can be included in the transaction
    * @throws UnsupportedOperationException if icebergWriterCompatV1 is not enabled
    * @throws UnsupportedOperationException if maxRetries != 0 in the transaction

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CommitIcebergActionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CommitIcebergActionSuite.scala
@@ -434,7 +434,7 @@ class CommitIcebergActionSuite extends DeltaTableWriteSuiteBase {
     }
   }
 
-  test("add tags for addFile") {
+  test("Tags can be successfully passed for generating addFile") {
     withTempDirAndEngine { (tablePath, engine) =>
       // Create table
       createEmptyTable(
@@ -463,7 +463,7 @@ class CommitIcebergActionSuite extends DeltaTableWriteSuiteBase {
         .getChanges(engine, version, version, Set(DeltaAction.ADD, DeltaAction.REMOVE).asJava)
         .toSeq
         .flatMap(_.getRows.toSeq)
-      val fileActions = rows.flatMap { row =>
+      rows.foreach { row =>
         if (!row.isNullAt(row.getSchema.indexOf("add"))) {
           val addFile = new AddFile(row.getStruct(row.getSchema.indexOf("add")))
           assert(addFile.getPartitionValues.getSize == 0)
@@ -479,8 +479,6 @@ class CommitIcebergActionSuite extends DeltaTableWriteSuiteBase {
             addFile.getSize,
             addFile.getModificationTime,
             addFile.getDataChange))
-        } else {
-          None
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When the client call generateIcebergCompatWriterV1AddAction, now they can pass the tags so that it would be persist in the AddFile
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
