### PR TITLE
[Spark] Make all MERGE APIs return a DataFrame instead of Unit

### DIFF
--- a/project/SparkMimaExcludes.scala
+++ b/project/SparkMimaExcludes.scala
@@ -88,6 +88,7 @@ object SparkMimaExcludes {
 
       // Changes in 4.0.0
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaTable.improveUnsupportedOpError"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaMergeBuilder.improveUnsupportedOpError"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaMergeBuilder.execute")
 
       // scalastyle:on line.size.limit

--- a/project/SparkMimaExcludes.scala
+++ b/project/SparkMimaExcludes.scala
@@ -84,7 +84,11 @@ object SparkMimaExcludes {
 
       // Changes in 1.2.0
       ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.LogStore"),
-      ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.CloseableIterator")
+      ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.CloseableIterator"),
+
+      // Changes in 4.0.0
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaTable.improveUnsupportedOpError"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaMergeBuilder.execute")
 
       // scalastyle:on line.size.limit
   )

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -1074,13 +1074,16 @@ class DeltaMergeBuilder(object):
         return DeltaMergeBuilder(self._spark, new_jbuilder)
 
     @since(0.4)  # type: ignore[arg-type]
-    def execute(self) -> None:
+    def execute(self) -> DataFrame:
         """
         Execute the merge operation based on the built matched and not matched actions.
 
         See :py:class:`~delta.tables.DeltaMergeBuilder` for complete usage details.
         """
-        self._jbuilder.execute()
+        return DataFrame(
+            self._jbuilder.execute(),
+            getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
+            )
 
     def __getMatchedBuilder(
         self, condition: OptionalExpressionOrColumn = None

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -1082,8 +1082,7 @@ class DeltaMergeBuilder(object):
         """
         return DataFrame(
             self._jbuilder.execute(),
-            getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
-            )
+            getattr(self._spark, "_wrapped", self._spark))  # type: ignore[attr-defined]
 
     def __getMatchedBuilder(
         self, condition: OptionalExpressionOrColumn = None

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -153,17 +153,27 @@ class DeltaTableTestsMixin:
 
         # String expressions in merge condition and dicts
         reset_table()
-        dt.merge(source, "key = k") \
+        merge_output = dt.merge(source, "key = k") \
             .whenMatchedUpdate(set={"value": "v + 0"}) \
             .whenNotMatchedInsert(values={"key": "k", "value": "v + 0"}) \
             .whenNotMatchedBySourceUpdate(set={"value": "value + 0"}) \
             .execute()
+        self.__checkAnswer(merge_output,
+           ([Row(6, # affected rows
+                4, # updated rows (a and b in WHEN MATCHED and c and d in WHEN NOT MATCHED BY SOURCE)
+                0, # deleted rows
+                2 # inserted rows (e and f)
+                )]),
+                StructType([StructField('num_affected_rows', LongType(), False),
+                            StructField('num_updated_rows', LongType(), False),
+                            StructField('num_deleted_rows', LongType(), False),
+                            StructField('num_inserted_rows', LongType(), False)]))
         self.__checkAnswer(dt.toDF(),
                            ([('a', -1), ('b', 0), ('c', 3), ('d', 4), ('e', -5), ('f', -6)]))
 
         # Column expressions in merge condition and dicts
         reset_table()
-        dt.merge(source, expr("key = k")) \
+        merge_output = dt.merge(source, expr("key = k")) \
             .whenMatchedUpdate(set={"value": col("v") + 0}) \
             .whenNotMatchedInsert(values={"key": "k", "value": col("v") + 0}) \
             .whenNotMatchedBySourceUpdate(set={"value": col("value") + 0}) \

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -159,15 +159,15 @@ class DeltaTableTestsMixin:
             .whenNotMatchedBySourceUpdate(set={"value": "value + 0"}) \
             .execute()
         self.__checkAnswer(merge_output,
-           ([Row(6, # affected rows
-                4, # updated rows (a and b in WHEN MATCHED and c and d in WHEN NOT MATCHED BY SOURCE)
-                0, # deleted rows
-                2 # inserted rows (e and f)
-                )]),
-                StructType([StructField('num_affected_rows', LongType(), False),
-                            StructField('num_updated_rows', LongType(), False),
-                            StructField('num_deleted_rows', LongType(), False),
-                            StructField('num_inserted_rows', LongType(), False)]))
+                           ([Row(6,  # affected rows
+                                 4,  # updated rows (a and b in WHEN MATCHED
+                                     # and c and d in WHEN NOT MATCHED BY SOURCE)
+                                 0,  # deleted rows
+                                 2)]),  # inserted rows (e and f)
+                           StructType([StructField('num_affected_rows', LongType(), False),
+                                        StructField('num_updated_rows', LongType(), False),
+                                        StructField('num_deleted_rows', LongType(), False),
+                                        StructField('num_inserted_rows', LongType(), False)]))
         self.__checkAnswer(dt.toDF(),
                            ([('a', -1), ('b', 0), ('c', 3), ('d', 4), ('e', -5), ('f', -6)]))
 

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -291,7 +291,7 @@ class DeltaMergeBuilder private(
    *
    * @since 0.3.0
    */
-  def execute(): Unit = improveUnsupportedOpError {
+  def execute(): DataFrame = improveUnsupportedOpError {
     val sparkSession = targetTable.toDF.sparkSession
     withActiveSession(sparkSession) {
       // Note: We are explicitly resolving DeltaMergeInto plan rather than going to through the

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
@@ -92,7 +92,7 @@ trait AnalysisHelper {
     DataFrameUtils.ofRows(sparkSession, logicalPlan)
   }
 
-  protected def improveUnsupportedOpError(f: => Unit): Unit = {
+  protected def improveUnsupportedOpError[T](f: => T): T = {
     val possibleErrorMsgs = Seq(
       "is only supported with v2 table", // full error: DELETE is only supported with v2 tables
       "is not supported temporarily",    // full error: UPDATE TABLE is not supported temporarily

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
@@ -317,16 +317,26 @@ trait MergeIntoMetricsBase
   def checkMergeResultMetrics(
       mergeResultDf: DataFrame,
       metrics: Map[String, Int]): Unit = {
+    val numRowsUpdated = metrics.get("numTargetRowsUpdated").map(_.toLong).getOrElse(0L)
+    val numRowsDeleted = metrics.get("numTargetRowsDeleted").map(_.toLong).getOrElse(0L)
+    val numRowsInserted = metrics.get("numTargetRowsInserted").map(_.toLong).getOrElse(0L)
     val numRowsTouched =
-      metrics("numTargetRowsDeleted").toLong +
-        metrics("numTargetRowsUpdated").toLong
+      numRowsUpdated +
+        numRowsDeleted + 
+        numRowsInserted
 
-    checkAnswer(
-      mergeResultDf,
-      Seq(Row(numRowsTouched,
-        metrics("numTargetRowsUpdated").toLong,
-        metrics("numTargetRowsDeleted").toLong,
-        metrics("numTargetRowsInserted").toLong))
+    assert(mergeResultDf.collect() === 
+      Array(Row(numRowsTouched,
+        numRowsUpdated,
+        numRowsDeleted,
+        numRowsInserted))
+
+    // checkAnswer(
+    //   mergeResultDf,
+    //   Seq(Row(numRowsTouched,
+    //     numRowsUpdated,
+    //     numRowsDeleted,
+    //     numRowsInserted))
     )
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
@@ -322,10 +322,10 @@ trait MergeIntoMetricsBase
     val numRowsInserted = metrics.get("numTargetRowsInserted").map(_.toLong).getOrElse(0L)
     val numRowsTouched =
       numRowsUpdated +
-        numRowsDeleted + 
+        numRowsDeleted +
         numRowsInserted
 
-    assert(mergeResultDf.collect() === 
+    assert(mergeResultDf.collect() ===
       Array(Row(numRowsTouched,
         numRowsUpdated,
         numRowsDeleted,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
@@ -314,7 +314,7 @@ trait MergeIntoMetricsBase
     }
   }
 
-  def checkMergeResultMetrics(
+  private def checkMergeResultMetrics(
       mergeResultDf: DataFrame,
       metrics: Map[String, Int]): Unit = {
     val numRowsUpdated = metrics.get("numTargetRowsUpdated").map(_.toLong).getOrElse(0L)
@@ -329,15 +329,7 @@ trait MergeIntoMetricsBase
       Array(Row(numRowsTouched,
         numRowsUpdated,
         numRowsDeleted,
-        numRowsInserted))
-
-    // checkAnswer(
-    //   mergeResultDf,
-    //   Seq(Row(numRowsTouched,
-    //     numRowsUpdated,
-    //     numRowsDeleted,
-    //     numRowsInserted))
-    )
+        numRowsInserted)))
   }
 
   /////////////////////////////


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Ensure that all public MERGE APIs return a DataFrame with the affected rows like the SQL API does, so they are all consistent.

## How was this patch tested?

- Added some minimal testing to the connector and Python tests.
- Added full coverage to the Scala suite to ensure the results returned always match what goes into the table history (operation metrics).

## Does this PR introduce _any_ user-facing changes?

Yes, the Scala `DeltaMergeBuilder.execute()` now returns a `DataFrame` instead of `Unit`, and so does the Python equivalent (instead of a `None` value).
This is a **breaking** API change, as it can lead the Scala compiler to infer different surrounding types that expect in some places.
