### PR TITLE
[Kernel] Quickfix isBlindAppend field in CommitInfo for writes

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -450,9 +450,10 @@ public class TransactionImpl implements Transaction {
   }
 
   public boolean isBlindAppend() {
-    // For now, Kernel just supports blind append.
-    // Change this when read-after-write is supported.
-    return true;
+    // TODO: for now we hard code this to false to avoid erroneously setting this to true for a
+    //  non-blind-append operation. We should revisit how to safely set this to true for actual
+    //  blind appends.
+    return false;
   }
 
   private List<PostCommitHook> generatePostCommitHooks(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -111,7 +111,9 @@ public class ConflictChecker {
       List<DomainMetadata> domainMetadatas,
       CloseableIterable<Row> dataActions)
       throws ConcurrentWriteException {
-    checkArgument(transaction.isBlindAppend(), "Current support is for blind appends only.");
+    // We currently set isBlindAppend=false in our CommitInfo to avoid unsafe resolution by other
+    // connectors. Here, we still can assume that conflict resolution is safe to perform in Kernel.
+    // checkArgument(transaction.isBlindAppend(), "Current support is for blind appends only.");
     return new ConflictChecker(snapshot, transaction, attemptVersion, domainMetadatas, dataActions)
         .resolveConflicts(engine);
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -508,7 +508,6 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       tablePath: String,
       version: Long,
       partitionCols: Seq[String] = Seq.empty,
-      isBlindAppend: Boolean = true,
       operation: Operation = MANUAL_UPDATE): Unit = {
     val row = spark.sql(s"DESCRIBE HISTORY delta.`$tablePath`")
       .filter(s"version = $version")
@@ -523,7 +522,9 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
     assert(row.getAs[Long]("version") === version)
     assert(row.getAs[Long]("partitionBy") ===
       (if (partitionCols == null) null else OBJ_MAPPER.writeValueAsString(partitionCols.asJava)))
-    assert(row.getAs[Boolean]("isBlindAppend") === isBlindAppend)
+    // For now we've hardcoded isBlindAppend=false, once we support more precise setting of this
+    // field we should update this check
+    assert(!row.getAs[Boolean]("isBlindAppend"))
     assert(row.getAs[Seq[String]]("engineInfo") ===
       "Kernel-" + Meta.KERNEL_VERSION + "/" + testEngineInfo)
     assert(row.getAs[String]("operation") === operation.getDescription)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Currently we assume every transaction in Kernel is a blind append operation. But we don't actually have any clear mechanism to indicate or require that this is true. For now, we set isBlindAppend=false to ensure safety (as this is always safe to do) and we will revisit how to more accurately set this field in the future (especially if addressing intent-based APIs).

## How was this patch tested?

 Updated existing unit tests.