### PR TITLE
[Kernel] Fix struct::get to not throw a null pointer exception

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel.types;
 
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
@@ -93,7 +95,14 @@ public final class StructType extends DataType {
     return fieldAndOrdinal != null ? fieldAndOrdinal._2 : -1;
   }
 
+  /**
+   * @return the StructField with the given name
+   * @throws IllegalArgumentException if the field does not exist
+   */
   public StructField get(String fieldName) {
+    checkArgument(
+        nameToFieldAndOrdinal.containsKey(fieldName),
+        String.format("Field with name '%s' not found in schema %s", fieldName, this));
     return nameToFieldAndOrdinal.get(fieldName)._1;
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/types/StructTypeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/types/StructTypeSuite.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.types
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class StructTypeSuite extends AnyFunSuite {
+
+  test("get works as expected") {
+    val structField = new StructField("fieldA", IntegerType.INTEGER, true)
+    val struct = new StructType()
+      .add(structField)
+    assert(struct.get("fieldA") == structField)
+
+    assert(intercept[IllegalArgumentException] {
+      struct.get("fieldB")
+    }.getMessage.contains("Field with name 'fieldB' not found in schema"))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Currently StructType::get throws a nullpointerexception if the field doesn't exist. We should at least throw a better exception.

## How was this patch tested?

Adds a test

## Does this PR introduce _any_ user-facing changes?

No