### PR TITLE
[Spark] Add invariant checks to DML commands

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -540,6 +540,14 @@
     ],
     "sqlState" : "2200G"
   },
+  "DELTA_COMMAND_INVARIANT_VIOLATION" : {
+    "message" : [
+      "A command internal invariant was violated in '<operation>'.",
+      "Please retry the command.",
+      "Exception reference: <uuid>."
+    ],
+    "sqlState" : "XXKDS"
+  },
   "DELTA_COMMIT_INTERMEDIATE_REDIRECT_STATE" : {
     "message" : [
       "Cannot handle commit of table within redirect table state '<state>'."
@@ -1987,6 +1995,14 @@
       "Delta doesn't accept NullTypes in the schema for streaming writes."
     ],
     "sqlState" : "42P18"
+  },
+  "DELTA_NUM_RECORDS_MISMATCH" : {
+    "message" : [
+      "Failed to validate the number of records in <operation>.",
+      "Added <numAddedRecords> records and removed <numRemovedRecords> records.",
+      "This is a bug."
+    ],
+    "sqlState" : "XXKDS"
   },
   "DELTA_ONEOF_IN_TIMETRAVEL" : {
     "message" : [

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.{FileNotFoundException, IOException}
 import java.nio.file.FileAlreadyExistsException
-import java.util.ConcurrentModificationException
+import java.util.{ConcurrentModificationException, UUID}
 
 import scala.collection.JavaConverters._
 
@@ -3721,6 +3721,25 @@ trait DeltaErrorsBase
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_UNSUPPORTED_CATALOG_OWNED_TABLE_CREATION",
       messageParameters = Array.empty)
+  }
+
+  def numRecordsMismatch(
+      operation: String,
+      numAddedRecords: Long,
+      numRemovedRecords: Long): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_NUM_RECORDS_MISMATCH",
+      messageParameters = Array(operation, numAddedRecords.toString, numRemovedRecords.toString)
+    )
+  }
+
+  def commandInvariantViolationException(
+      operation: String,
+      id: UUID): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_COMMAND_INVARIANT_VIOLATION",
+      messageParameters = Array(operation, id.toString)
+    )
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/NumRecordsStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/NumRecordsStats.scala
@@ -30,7 +30,8 @@ case class NumRecordsStats (
     numDeletionVectorRecordsAdded: Long,
     numDeletionVectorRecordsRemoved: Long,
     numFilesAddedWithoutNumRecords: Long,
-    numFilesRemovedWithoutNumRecords: Long) {
+    numFilesRemovedWithoutNumRecords: Long,
+    numLogicalRecordsAddedInFilesWithDeletionVectorsPartial: Long) {
 
   def allFilesHaveNumRecords: Boolean =
     numFilesAddedWithoutNumRecords == 0 && numFilesRemovedWithoutNumRecords == 0
@@ -48,6 +49,14 @@ case class NumRecordsStats (
    */
   def numLogicalRecordsRemoved: Option[Long] = Option.when(numFilesRemovedWithoutNumRecords == 0)(
     numLogicalRecordsRemovedPartial)
+
+  /**
+   * The number of logical records in all AddFile actions that have a deletion vector or None
+   * if any file does not contain statistics.
+   */
+  def numLogicalRecordsAddedInFilesWithDeletionVectors: Option[Long] =
+    Option.when(numFilesAddedWithoutNumRecords == 0)(
+      numLogicalRecordsAddedInFilesWithDeletionVectorsPartial)
 }
 
 object NumRecordsStats {
@@ -60,6 +69,7 @@ object NumRecordsStats {
     var numLogicalRecordsRemovedPartial: Long = 0L
     var numDeletionVectorRecordsAdded = 0L
     var numDeletionVectorRecordsRemoved = 0L
+    var numLogicalRecordsAddedInFilesWithDeletionVectorsPartial = 0L
 
     actions.foreach {
       case a: AddFile =>
@@ -69,6 +79,10 @@ object NumRecordsStats {
           0L
         }
         numDeletionVectorRecordsAdded += a.numDeletedRecords
+        if (a.deletionVector != null) {
+          numLogicalRecordsAddedInFilesWithDeletionVectorsPartial +=
+            a.numLogicalRecords.getOrElse(0L)
+        }
       case r: RemoveFile =>
         numFilesRemoved += 1
         numLogicalRecordsRemovedPartial += r.numLogicalRecords.getOrElse {
@@ -85,6 +99,9 @@ object NumRecordsStats {
       numDeletionVectorRecordsAdded = numDeletionVectorRecordsAdded,
       numDeletionVectorRecordsRemoved = numDeletionVectorRecordsRemoved,
       numFilesAddedWithoutNumRecords = numFilesAddedWithoutNumRecords,
-      numFilesRemovedWithoutNumRecords = numFilesRemovedWithoutNumRecords)
+      numFilesRemovedWithoutNumRecords = numFilesRemovedWithoutNumRecords,
+      numLogicalRecordsAddedInFilesWithDeletionVectorsPartial =
+        numLogicalRecordsAddedInFilesWithDeletionVectorsPartial
+    )
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.delta.commands
 
 import java.util.concurrent.TimeUnit
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.ClassicColumnConversions._
@@ -36,6 +38,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
+import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
@@ -127,9 +130,12 @@ case class DeleteCommand(
         }
 
         val (deleteActions, deleteMetrics) = performDelete(sparkSession, deltaLog, txn)
+        val numRecordsStats = NumRecordsStats.fromActions(deleteActions)
+        val operation = DeltaOperations.Delete(condition.toSeq)
+        validateNumRecords(deleteActions, numRecordsStats, operation)
         val commitVersion = txn.commitIfNeeded(
           actions = deleteActions,
-          op = DeltaOperations.Delete(condition.toSeq),
+          op = operation,
           tags = RowTracking.addPreservedRowTrackingTagIfNotSet(txn.snapshot))
         recordDeltaEvent(
           deltaLog,
@@ -471,6 +477,111 @@ case class DeleteCommand(
       spark: SparkSession, txn: OptimisticTransaction): Boolean = {
     spark.conf.get(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS) &&
       DeletionVectorUtils.deletionVectorsWritable(txn.snapshot)
+  }
+
+  /**
+   * Validates that the number of records does not increase.
+   *
+   * Note: ideally we would also compare the number of added/removed rows in the statistics with the
+   * number of deleted/copied rows in the SQL metrics, but unfortunately this is not possible, as
+   * sql metrics are not reliable when there are task or stage retries.
+   */
+  private def validateNumRecords(
+      actions: Seq[Action],
+      numRecordsStats: NumRecordsStats,
+      op: Operation): Unit = {
+    (numRecordsStats.numLogicalRecordsAdded,
+      numRecordsStats.numLogicalRecordsRemoved,
+      numRecordsStats.numLogicalRecordsAddedInFilesWithDeletionVectors) match {
+      case (
+        Some(numAddedRecords),
+        Some(numRemovedRecords),
+        Some(numRecordsNotCopied)) =>
+        if (numAddedRecords > numRemovedRecords) {
+          logNumRecordsMismatch(deltaLog, actions, numRecordsStats, op)
+          if (conf.getConf(DeltaSQLConf.NUM_RECORDS_VALIDATION_ENABLED)) {
+            throw DeltaErrors.numRecordsMismatch(
+              operation = "DELETE",
+              numAddedRecords,
+              numRemovedRecords
+            )
+          }
+        }
+
+        if (conf.getConf(DeltaSQLConf.COMMAND_INVARIANT_CHECKS_USE_UNRELIABLE)) {
+          // and also using regular (unreliable) metrics for baseline
+          validateMetricBasedCommandInvariants(
+            numAddedRecords, numRemovedRecords, numRecordsNotCopied, op, deltaLog)
+        }
+
+      case _ =>
+        recordDeltaEvent(deltaLog, opType = "delta.assertions.statsNotPresentForNumRecordsCheck")
+        logWarning(log"Could not validate number of records due to missing statistics.")
+    }
+  }
+
+  private def validateMetricBasedCommandInvariants(
+      numAddedRecords: Long,
+      numRemovedRecords: Long,
+      numRecordsNotCopied: Long,
+      op: Operation,
+      deltaLog: DeltaLog): Unit = try {
+
+    val numRowsDeleted = CommandInvariantMetricValueFromSingle(metrics("numDeletedRows"))
+    val numRowsCopied = CommandInvariantMetricValueFromSingle(metrics("numCopiedRows"))
+
+    val recordMetricsFromMetadata = conf.getConf(DeltaSQLConf.DELTA_DML_METRICS_FROM_METADATA)
+    if (numRowsDeleted.getOrDummy == 0 && !recordMetricsFromMetadata) {
+      // If we don't record metrics we can't use them to perform invariant checks.
+      return
+    }
+
+    checkCommandInvariant(
+      invariant = () =>
+        numRowsDeleted.getOrThrow + numRowsCopied.getOrThrow + numRecordsNotCopied
+          == numRemovedRecords,
+      label = "numRowsDeleted + numRowsCopied + numRecordsNotCopied + " +
+        "numRowsRemovedByMetadataOnlyDelete == numRemovedRecords",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsDeleted" -> numRowsDeleted.getOrDummy,
+        "numRowsCopied" -> numRowsCopied.getOrDummy,
+        "numRemovedRecords" -> numRemovedRecords,
+        "numRecordsNotCopied" -> numRecordsNotCopied
+      ),
+      additionalInfo = Map(
+        DeltaSQLConf.DELTA_DML_METRICS_FROM_METADATA.key -> recordMetricsFromMetadata.toString
+      )
+    )
+
+    checkCommandInvariant(
+      invariant = () => numRowsCopied.getOrThrow + numRecordsNotCopied == numAddedRecords,
+      label = "numRowsCopied + numRecordsNotCopied == numAddedRecords",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsCopied" -> numRowsCopied.getOrDummy,
+        "numAddedRecords" -> numAddedRecords,
+        "numRecordsNotCopied" -> numRecordsNotCopied
+      ),
+      additionalInfo = Map(
+        DeltaSQLConf.DELTA_DML_METRICS_FROM_METADATA.key -> recordMetricsFromMetadata.toString
+      )
+    )
+  } catch {
+    // Immediately re-throw actual command invariant violations, so we don't re-wrap them below.
+    case e: DeltaIllegalStateException if e.getErrorClass == "DELTA_COMMAND_INVARIANT_VIOLATION" =>
+      throw e
+    case NonFatal(e) =>
+      logWarning(log"Unexpected error in validateMetricBasedCommandInvariants", e)
+      checkCommandInvariant(
+        invariant = () => false,
+        label = "Unexpected error in validateMetricBasedCommandInvariants",
+        op = op,
+        deltaLog = deltaLog,
+        parameters = Map.empty
+      )
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaErrors, DeltaLog, DeltaOptions, DeltaTableIdentifier, DeltaTableUtils, OptimisticTransaction, ResolvedPathBasedNonDeltaTable}
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaErrors, DeltaLog, DeltaOptions, DeltaTableIdentifier, DeltaTableUtils, NumRecordsStats, OptimisticTransaction, ResolvedPathBasedNonDeltaTable}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.{DeltaTableV2, IcebergTablePlaceHolder}
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
@@ -40,6 +40,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.V1Table
+import org.apache.spark.sql.delta.DeltaOperations.Operation
+import org.apache.spark.sql.delta.sources.DeltaSQLConf.DELTA_COLLECT_STATS
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelationWithTable}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -48,7 +50,7 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 /**
  * Helper trait for all delta commands.
  */
-trait DeltaCommand extends DeltaLogging {
+trait DeltaCommand extends DeltaLogging with DeltaCommandInvariants {
   /**
    * Converts string predicates into [[Expression]]s relative to a transaction.
    *
@@ -440,4 +442,50 @@ trait DeltaCommand extends DeltaLogging {
     (txnVersion, txnAppId, fromSessionConf)
   }
 
+  protected def logNumRecordsMismatch(
+      deltaLog: DeltaLog,
+      actions: Seq[Action],
+      stats: NumRecordsStats,
+      op: Operation): Unit = {
+
+    var numRemove = 0
+    var numAdd = 0
+    actions.foreach {
+      case _: AddFile =>
+        numAdd += 1
+      case _: RemoveFile =>
+        numRemove += 1
+      case _ =>
+    }
+
+    val info = NumRecordsCheckInfo(
+      operation = op.name,
+      numAdd = numAdd,
+      numRemove = numRemove,
+      numRecordsRemoved = stats.numLogicalRecordsRemovedPartial,
+      numRecordsAdded = stats.numLogicalRecordsAddedPartial,
+      numDeletionVectorRecordsRemoved = stats.numDeletionVectorRecordsRemoved,
+      numDeletionVectorRecords = stats.numDeletionVectorRecordsAdded,
+      operationParameters = op.jsonEncodedValues,
+      statsCollectionEnabled = SparkSession.getActiveSession.get.conf.get(DELTA_COLLECT_STATS)
+    )
+    recordDeltaEvent(deltaLog, opType = "delta.assertions.numRecordsChanged", data = info)
+    logWarning(log"Number of records validation failed. Number of added records" +
+      log" (${MDC(DeltaLogKeys.NUM_RECORDS, stats.numLogicalRecordsAddedPartial)})" +
+      log" does not match removed records" +
+      log" (${MDC(DeltaLogKeys.NUM_RECORDS2, stats.numLogicalRecordsRemovedPartial)})")
+  }
 }
+
+// Recorded when number of records check for unchanged data fails.
+case class NumRecordsCheckInfo(
+    operation: String,
+    numAdd: Int,
+    numRemove: Int,
+    numRecordsAdded: Long,
+    numRecordsRemoved: Long,
+    numDeletionVectorRecordsRemoved: Long = 0, // number of DV records removed by the RemoveFiles
+    numDeletionVectorRecords: Long = 0, // number of DV records present in all AddFiles
+    operationParameters: Map[String, String],
+    statsCollectionEnabled: Boolean
+)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommandInvariants.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommandInvariants.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import java.util.UUID
+
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog}
+import org.apache.spark.sql.delta.DeltaOperations.Operation
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.internal.{LogEntry, Logging, MDC}
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+trait DeltaCommandInvariants extends DeltaLogging with SQLConfHelper with Logging {
+  /**
+   * Evaluate that `invariant` "holds" (evaluates to `true`) or log the violation.
+   * @param invariant The invariant to evaluate.
+   * @param label  It's suggested to make `label` the same text as `invariant` so it's easy to
+   *               see in the logs what was evaluated.
+   * @param op Operation name.
+   * @param deltaLog Delta log of the table this invariant is evaluated on.
+   * @param parameters Parameters that were used to evaluate the invariant.
+   * @param additionalInfo Additional info to be included in usage logs.
+   */
+  protected def checkCommandInvariant(
+      invariant: () => Boolean,
+      label: String,
+      op: Operation,
+      deltaLog: DeltaLog,
+      parameters: => Map[String, Long],
+      additionalInfo: => Map[String, String] = Map.empty): Unit = {
+    val id = UUID.randomUUID()
+    val invariantResult = try {
+      invariant()
+    } catch {
+      case NonFatal(e) =>
+        logWarning(log"Exception thrown while evaluating command invariant." +
+          log" Reference: ${MDC(DeltaLogKeys.ERROR_ID, id.toString)}.", e)
+        false
+    }
+    if (!invariantResult) {
+      val shouldFail = conf.getConf(DeltaSQLConf.COMMAND_INVARIANT_CHECKS_THROW)
+      try {
+        val opType =
+          "delta.assertions.unreliable.commandInvariantViolated"
+        val info = CommandInvariantCheckInfo(
+          exceptionThrown = shouldFail,
+          id = id,
+          invariantExpression = label,
+          invariantParameters = parameters,
+          operation = op.name,
+          operationParameters = op.jsonEncodedValues,
+          additionalInfo = additionalInfo
+        )
+        recordDeltaEvent(
+          deltaLog,
+          opType = opType,
+          data = info)
+
+        // Log this to Spark logs as well, so someone looking through there knows to look for the
+        // details in usage logs.
+        // FIXME: Needs inline type annotations because otherwise compiler gets confused on
+        //        implicit conversions.
+        val logEntry: LogEntry = log"Delta Command Invariant violated." +
+          log" Reference: ${MDC(DeltaLogKeys.ERROR_ID, id.toString)}." +
+          log" Info: ${MDC(DeltaLogKeys.INVARIANT_CHECK_INFO, info)}."
+        logWarning(logEntry)
+      } catch {
+        case NonFatal(e) =>
+          logWarning(log"Unexpected error while logging command invariant violation." +
+            log" Reference: ${MDC(DeltaLogKeys.ERROR_ID, id.toString)}.", e)
+      }
+
+      if (shouldFail) {
+        throw DeltaErrors.commandInvariantViolationException(operation = op.name, id = id)
+      }
+    }
+  }
+}
+
+// Recorded when a command invariant is violated.
+case class CommandInvariantCheckInfo(
+    exceptionThrown: Boolean,
+    id: UUID,
+    invariantExpression: String,
+    invariantParameters: Map[String, Long],
+    operation: String,
+    operationParameters: Map[String, String],
+    additionalInfo: Map[String, String])
+
+abstract class CommandInvariantMetricValue extends Logging {
+
+  protected def value: Try[Long]
+
+  def getOrThrow: Long = value.get
+
+  def getOrDummy: Long = value.getOrElse(-1L)
+}
+
+case class CommandInvariantMetricValueFromSingle(
+    metric: SQLMetric) extends CommandInvariantMetricValue  {
+  override protected val value: Try[Long] = Try {
+    metric.value
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -214,14 +214,17 @@ case class MergeIntoCommand(
 
     val finalActions = createSetTransaction(spark, targetDeltaLog).toSeq ++ mergeActions
     val numRecordsStats = NumRecordsStats.fromActions(finalActions)
+    val operation = DeltaOperations.Merge(
+      predicate = Option(condition),
+      matchedPredicates = matchedClauses.map(DeltaOperations.MergePredicate(_)),
+      notMatchedPredicates = notMatchedClauses.map(DeltaOperations.MergePredicate(_)),
+      notMatchedBySourcePredicates =
+        notMatchedBySourceClauses.map(DeltaOperations.MergePredicate(_))
+    )
+    validateNumRecords(finalActions, numRecordsStats, operation, deltaTxn.deltaLog)
     val commitVersion = deltaTxn.commitIfNeeded(
       actions = finalActions,
-      op = DeltaOperations.Merge(
-        predicate = Option(condition),
-        matchedPredicates = matchedClauses.map(DeltaOperations.MergePredicate(_)),
-        notMatchedPredicates = notMatchedClauses.map(DeltaOperations.MergePredicate(_)),
-        notMatchedBySourcePredicates =
-          notMatchedBySourceClauses.map(DeltaOperations.MergePredicate(_))),
+      op = operation,
       tags = RowTracking.addPreservedRowTrackingTagIfNotSet(deltaTxn.snapshot))
     val stats = collectMergeStats(deltaTxn, materializeSourceReason, commitVersion, numRecordsStats)
     recordDeltaEvent(targetDeltaLog, "delta.dml.merge.stats", data = stats)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -128,15 +128,15 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
     }
   }
 
-  /** Whether this merge statement has only MATCHED clauses. */
+  /** Whether this merge statement only has MATCHED clauses. */
   protected def isMatchedOnly: Boolean = notMatchedClauses.isEmpty && matchedClauses.nonEmpty &&
     notMatchedBySourceClauses.isEmpty
 
-  /** Whether this merge statement only has only insert (NOT MATCHED) clauses. */
+  /** Whether this merge statement only has insert (NOT MATCHED) clauses. */
   protected def isInsertOnly: Boolean = matchedClauses.isEmpty && notMatchedClauses.nonEmpty &&
     notMatchedBySourceClauses.isEmpty
 
-  /** Whether this merge statement only has only delete clauses. */
+  /** Whether this merge statement only has delete clauses. */
   protected lazy val isDeleteOnly: Boolean =
     matchedClauses.forall(_.isInstanceOf[DeltaMergeIntoMatchedDeleteClause]) &&
       notMatchedClauses.isEmpty &&

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -19,16 +19,16 @@ package org.apache.spark.sql.delta.commands
 import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.actions.{AddFile, FileAction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.merge.{MergeIntoMaterializeSource, MergeIntoMaterializeSourceReason, MergeStats}
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex, TransactionalWrite}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{ImplicitMetadataOperation, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions._
@@ -135,6 +135,12 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
   /** Whether this merge statement only has only insert (NOT MATCHED) clauses. */
   protected def isInsertOnly: Boolean = matchedClauses.isEmpty && notMatchedClauses.nonEmpty &&
     notMatchedBySourceClauses.isEmpty
+
+  /** Whether this merge statement only has only delete clauses. */
+  protected lazy val isDeleteOnly: Boolean =
+    matchedClauses.forall(_.isInstanceOf[DeltaMergeIntoMatchedDeleteClause]) &&
+      notMatchedClauses.isEmpty &&
+      notMatchedBySourceClauses.forall(_.isInstanceOf[DeltaMergeIntoNotMatchedBySourceDeleteClause])
 
   /** Whether this merge statement includes inserts statements. */
   protected def includesInserts: Boolean = notMatchedClauses.nonEmpty
@@ -514,6 +520,190 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
       matchedClauses.forall(isConditionDeterministic) &&
       notMatchedClauses.forall(isConditionDeterministic) &&
       notMatchedBySourceClauses.forall(isConditionDeterministic)
+  }
+
+  /**
+   * Validates that the number of records does not increase if there are no insert clauses, and does
+   * not decrease if there are no delete clauses.
+   *
+   * Note: ideally we would also compare the number of added/removed rows in the statistics with the
+   * number of inserted/updated/deleted/copied rows in the SQL metrics, but unfortunately this is
+   * not possible, as sql metrics are not reliable when there are task or stage retries.
+   */
+  protected def validateNumRecords(
+      actions: Seq[Action],
+      numRecordsStats: NumRecordsStats,
+      op: DeltaOperations.Merge,
+      deltaLog: DeltaLog): Unit = {
+    (numRecordsStats.numLogicalRecordsAdded,
+      numRecordsStats.numLogicalRecordsRemoved,
+      numRecordsStats.numLogicalRecordsAddedInFilesWithDeletionVectors) match {
+      case (
+        Some(numAddedRecords),
+        Some(numRemovedRecords),
+        Some(numRecordsNotCopied)) =>
+        if (!includesInserts && numAddedRecords > numRemovedRecords) {
+          logNumRecordsMismatch(targetDeltaLog, actions, numRecordsStats, op)
+          if (conf.getConf(DeltaSQLConf.NUM_RECORDS_VALIDATION_ENABLED)) {
+            throw DeltaErrors.numRecordsMismatch(
+              operation = "MERGE without INSERT clauses",
+              numAddedRecords,
+              numRemovedRecords
+            )
+          }
+        }
+        if (!includesDeletes && numAddedRecords < numRemovedRecords) {
+          logNumRecordsMismatch(targetDeltaLog, actions, numRecordsStats, op)
+          if (conf.getConf(DeltaSQLConf.NUM_RECORDS_VALIDATION_ENABLED)) {
+            throw DeltaErrors.numRecordsMismatch(
+              operation = "MERGE without DELETE clauses",
+              numAddedRecords,
+              numRemovedRecords
+            )
+          }
+        }
+
+        if (conf.getConf(DeltaSQLConf.COMMAND_INVARIANT_CHECKS_USE_UNRELIABLE)) {
+          // and also using regular (unreliable) metrics for baseline
+          validateMetricBasedCommandInvariants(
+            numAddedRecords, numRemovedRecords, numRecordsNotCopied, op, deltaLog)
+        }
+
+      case _ =>
+        recordDeltaEvent(
+          targetDeltaLog, opType = "delta.assertions.statsNotPresentForNumRecordsCheck")
+        logWarning(log"Could not validate number of records due to missing statistics.")
+    }
+  }
+
+  private def validateMetricBasedCommandInvariants(
+      numAddedRecords: Long,
+      numRemovedRecords: Long,
+      numRecordsNotCopied: Long,
+      op: DeltaOperations.Merge,
+      deltaLog: DeltaLog): Unit = try {
+
+    val numRowsInserted = CommandInvariantMetricValueFromSingle(metrics("numTargetRowsInserted"))
+    val numRowsUpdated = CommandInvariantMetricValueFromSingle(metrics("numTargetRowsUpdated"))
+    val numRowsDeleted = CommandInvariantMetricValueFromSingle(metrics("numTargetRowsDeleted"))
+    val numRowsCopied = CommandInvariantMetricValueFromSingle(metrics("numTargetRowsCopied"))
+
+    checkCommandInvariant(
+      invariant = () => includesInserts || numRowsInserted.getOrThrow == 0,
+      label = "includesInserts || numRowsInserted == 0",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsInserted" -> numRowsInserted.getOrDummy
+      )
+    )
+
+    checkCommandInvariant(
+      invariant = () => includesDeletes || numRowsDeleted.getOrThrow == 0,
+      label = "includesDeletes || numRowsDeleted == 0",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsDeleted" -> numRowsDeleted.getOrDummy
+      )
+    )
+
+    checkCommandInvariant(
+      invariant = () => !isDeleteOnly ||
+        numRowsUpdated.getOrThrow + numRowsInserted.getOrThrow == 0,
+      label = "!isDeleteOnlyMerge || numRowsUpdated + numRowsInserted == 0",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsUpdated" -> numRowsUpdated.getOrDummy,
+        "numRowsInserted" -> numRowsInserted.getOrDummy
+      )
+    )
+
+    if (conf.getConf(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED)) {
+      checkCommandInvariant(
+        invariant = () => !isInsertOnly ||
+          numRowsUpdated.getOrThrow +
+            numRowsDeleted.getOrThrow +
+            numRowsCopied.getOrThrow +
+            numRecordsNotCopied == 0,
+        label = "!isInsertOnly" +
+          " || numRowsUpdated + numRowsDeleted + numRowsCopied + numRecordsNotCopied == 0",
+        op = op,
+        deltaLog = deltaLog,
+        parameters = Map(
+          "numRowsUpdated" -> numRowsUpdated.getOrDummy,
+          "numRowsDeleted" -> numRowsDeleted.getOrDummy,
+          "numRowsCopied" -> numRowsCopied.getOrDummy,
+          "numRecordsNotCopied" -> numRecordsNotCopied
+        )
+      )
+    } else {
+      // When the special insert-only codepath is disabled, we may end up copying some rows.
+      checkCommandInvariant(
+        invariant = () => !isInsertOnly ||
+          numRowsUpdated.getOrThrow + numRowsDeleted.getOrThrow == 0,
+        label = "!isInsertOnly" +
+          " || numRowsUpdated + numRowsDeleted == 0",
+        op = op,
+        deltaLog = deltaLog,
+        parameters = Map(
+          "numRowsUpdated" -> numRowsUpdated.getOrDummy,
+          "numRowsDeleted" -> numRowsDeleted.getOrDummy
+        )
+      )
+    }
+
+    checkCommandInvariant(
+      invariant = () =>
+        numRowsUpdated.getOrThrow +
+          numRowsDeleted.getOrThrow +
+          numRowsCopied.getOrThrow +
+          numRecordsNotCopied == numRemovedRecords,
+      label = "numRowsUpdated + numRowsDeleted + numRowsCopied + numRecordsNotCopied ==" +
+        " numRemovedRecords",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsUpdated" -> numRowsUpdated.getOrDummy,
+        "numRowsDeleted" -> numRowsDeleted.getOrDummy,
+        "numRowsCopied" -> numRowsCopied.getOrDummy,
+        "numRemovedRecords" -> numRemovedRecords,
+        "numRecordsNotCopied" -> numRecordsNotCopied
+      )
+    )
+
+    checkCommandInvariant(
+      invariant = () =>
+        numRowsInserted.getOrThrow +
+          numRowsUpdated.getOrThrow +
+          numRowsCopied.getOrThrow +
+          numRecordsNotCopied == numAddedRecords,
+      label = "numRowsInserted + numRowsUpdated + numRowsCopied + numRecordsNotCopied ==" +
+        " numAddedRecords",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsInserted" -> numRowsInserted.getOrDummy,
+        "numRowsUpdated" -> numRowsUpdated.getOrDummy,
+        "numRowsCopied" -> numRowsCopied.getOrDummy,
+        "numAddedRecords" -> numAddedRecords,
+        "numRecordsNotCopied" -> numRecordsNotCopied
+      )
+    )
+  } catch {
+    // Immediately re-throw actual command invariant violations, so we don't re-wrap them below.
+    case e: DeltaIllegalStateException if e.getErrorClass == "DELTA_COMMAND_INVARIANT_VIOLATION" =>
+      throw e
+    case NonFatal(e) =>
+      logWarning(log"Unexpected error in validateMetricBasedCommandInvariants", e)
+      checkCommandInvariant(
+        invariant = () => false,
+        label = "Unexpected error in validateMetricBasedCommandInvariants",
+        op = op,
+        deltaLog = deltaLog,
+        parameters = Map.empty
+      )
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -19,10 +19,12 @@ package org.apache.spark.sql.delta.commands
 // scalastyle:off import.ordering.noEmptyLine
 import java.util.concurrent.TimeUnit
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.ClassicColumnConversions._
-import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, FileAction}
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_TYPE_COLUMN_NAME, CDC_TYPE_NOT_CDC, CDC_TYPE_UPDATE_POSTIMAGE, CDC_TYPE_UPDATE_PREIMAGE}
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -37,6 +39,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
@@ -298,9 +301,11 @@ case class UpdateCommand(
 
     val finalActions = createSetTransaction(sparkSession, deltaLog).toSeq ++ totalActions
     val numRecordsStats = NumRecordsStats.fromActions(finalActions)
+    val operation = DeltaOperations.Update(condition)
+    validateNumRecords(finalActions, numRecordsStats, operation)
     val commitVersion = txn.commitIfNeeded(
       actions = finalActions,
-      op = DeltaOperations.Update(condition),
+      op = operation,
       tags = RowTracking.addPreservedRowTrackingTagIfNotSet(txn.snapshot))
     sendDriverMetrics(sparkSession, metrics)
 
@@ -390,6 +395,106 @@ case class UpdateCommand(
       spark: SparkSession, txn: OptimisticTransaction): Boolean = {
     spark.conf.get(DeltaSQLConf.UPDATE_USE_PERSISTENT_DELETION_VECTORS) &&
       DeletionVectorUtils.deletionVectorsWritable(txn.snapshot)
+  }
+
+  /**
+   * Validates that the number of records does not change.
+   */
+  private def validateNumRecords(
+      actions: Seq[Action],
+      numRecordsStats: NumRecordsStats,
+      op: Operation): Unit = {
+    val deltaLog = tahoeFileIndex.deltaLog
+
+    (numRecordsStats.numLogicalRecordsAdded,
+      numRecordsStats.numLogicalRecordsRemoved,
+      numRecordsStats.numLogicalRecordsAddedInFilesWithDeletionVectors) match {
+      case (
+        Some(numAddedRecords),
+        Some(numRemovedRecords),
+        Some(numRecordsNotCopied)) =>
+        if (numAddedRecords != numRemovedRecords) {
+          logNumRecordsMismatch(deltaLog, actions, numRecordsStats, op)
+          if (conf.getConf(DeltaSQLConf.NUM_RECORDS_VALIDATION_ENABLED)) {
+            throw DeltaErrors.numRecordsMismatch(
+              operation = "UPDATE",
+              numAddedRecords,
+              numRemovedRecords
+            )
+          }
+        }
+
+        if (conf.getConf(DeltaSQLConf.COMMAND_INVARIANT_CHECKS_USE_UNRELIABLE)) {
+          // and also using regular (unreliable) metrics for baseline
+          validateMetricBasedCommandInvariants(
+            numAddedRecords, numRemovedRecords, numRecordsNotCopied, op, deltaLog)
+        }
+
+      case _ =>
+        recordDeltaEvent(deltaLog, opType = "delta.assertions.statsNotPresentForNumRecordsCheck")
+        logWarning(log"Could not validate number of records due to missing statistics.")
+    }
+  }
+
+  private def validateMetricBasedCommandInvariants(
+      numAddedRecords: Long,
+      numRemovedRecords: Long,
+      numRecordsNotCopied: Long,
+      op: Operation,
+      deltaLog: DeltaLog): Unit = try {
+
+    // Note: These are redundant w.r.t. validateNumRecords, but they ensure correct metrics.
+    val numRowsUpdated = CommandInvariantMetricValueFromSingle(metrics("numUpdatedRows"))
+    val numRowsCopied = CommandInvariantMetricValueFromSingle(metrics("numCopiedRows"))
+
+    // There's a bug where Spark eliminates the entire plan and just rewrites the input files 1:1
+    // for no-op updates and in this case we don't record any metrics.
+    if (numRowsUpdated.getOrDummy == 0 && numRowsCopied.getOrDummy == 0) {
+      return
+    }
+
+    checkCommandInvariant(
+      invariant = () =>
+        numRowsUpdated.getOrThrow + numRowsCopied.getOrThrow + numRecordsNotCopied
+          == numRemovedRecords,
+      label = "numRowsUpdated + numRowsCopied + numRecordsNotCopied == numRemovedRecords",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsUpdated" -> numRowsUpdated.getOrDummy,
+        "numRowsCopied" -> numRowsCopied.getOrDummy,
+        "numRemovedRecords" -> numRemovedRecords,
+        "numRecordsNotCopied" -> numRecordsNotCopied
+      )
+    )
+
+    checkCommandInvariant(
+      invariant = () =>
+        numRowsUpdated.getOrThrow + numRowsCopied.getOrDummy + numRecordsNotCopied
+          == numAddedRecords,
+      label = "numRowsUpdated + numRowsCopied + numRecordsNotCopied == numAddedRecords",
+      op = op,
+      deltaLog = deltaLog,
+      parameters = Map(
+        "numRowsUpdated" -> numRowsUpdated.getOrDummy,
+        "numRowsCopied" -> numRowsCopied.getOrDummy,
+        "numAddedRecords" -> numAddedRecords,
+        "numRecordsNotCopied" -> numRecordsNotCopied
+      )
+    )
+  } catch {
+    // Immediately re-throw actual command invariant violations, so we don't re-wrap them below.
+    case e: DeltaIllegalStateException if e.getErrorClass == "DELTA_COMMAND_INVARIANT_VIOLATION" =>
+      throw e
+    case NonFatal(e) =>
+      logWarning(log"Unexpected error in validateMetricBasedCommandInvariants", e)
+      checkCommandInvariant(
+        invariant = () => false,
+        label = "Unexpected error in validateMetricBasedCommandInvariants",
+        op = op,
+        deltaLog = deltaLog,
+        parameters = Map.empty
+      )
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
@@ -61,6 +61,7 @@ trait DeltaLogKeysBase {
   case object DELTA_METADATA extends LogKeyShims
   case object DIR extends LogKeyShims
   case object DURATION extends LogKeyShims
+  case object ERROR_ID extends LogKeyShims
   case object END_INDEX extends LogKeyShims
   case object END_OFFSET extends LogKeyShims
   case object END_VERSION extends LogKeyShims
@@ -75,6 +76,7 @@ trait DeltaLogKeysBase {
   case object FILTER extends LogKeyShims
   case object FILTER2 extends LogKeyShims
   case object HOOK_NAME extends LogKeyShims
+  case object INVARIANT_CHECK_INFO extends LogKeyShims
   case object ISOLATION_LEVEL extends LogKeyShims
   case object IS_DRY_RUN extends LogKeyShims
   case object IS_INIT_SNAPSHOT extends LogKeyShims
@@ -86,6 +88,7 @@ trait DeltaLogKeysBase {
   case object METADATA_NEW extends LogKeyShims
   case object METADATA_OLD extends LogKeyShims
   case object METRICS extends LogKeyShims
+  case object METRIC_NAME extends LogKeyShims
   case object MIN_SIZE extends LogKeyShims
   case object NUM_ACTIONS extends LogKeyShims
   case object NUM_ACTIONS2 extends LogKeyShims
@@ -97,6 +100,7 @@ trait DeltaLogKeysBase {
   case object NUM_PARTITIONS extends LogKeyShims
   case object NUM_PREDICATES extends LogKeyShims
   case object NUM_RECORDS extends LogKeyShims
+  case object NUM_RECORDS2 extends LogKeyShims
   case object NUM_SKIPPED extends LogKeyShims
   case object OFFSET extends LogKeyShims
   case object OPERATION extends LogKeyShims

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2591,6 +2591,49 @@ trait DeltaSQLConfBase {
         |""".stripMargin)
     .booleanConf
     .createWithDefault(true)
+
+  //////////////////
+  // CORRECTNESS
+  //////////////////
+
+  val NUM_RECORDS_VALIDATION_ENABLED =
+    buildConf("numRecordsValidation.enabled")
+      .internal()
+      .doc(
+        """
+          |When enabled, adds a check to MERGE, UPDATE and DELETE that validates the number of
+          |records that were added and removed.
+          |
+          |- For MERGE without INSERT statements it checks that the number of records does not
+          |  increase.
+          |- For MERGE without DELETE statements it checks that the number of records does not
+          |  decrease.
+          |- For UPDATE statements it checks that the number of records does not change.
+          |- For DELETE statements it checks that the number of records does not increase.
+          |
+          |When disabled, we only log a warning.
+          |""".stripMargin
+      )
+      .booleanConf
+      .createWithDefault(true)
+
+
+  val COMMAND_INVARIANT_CHECKS_USE_UNRELIABLE =
+    buildConf("commandInvariantChecksUseUnreliable")
+      .internal()
+      .doc("When enabled all DML commands will check and log invariants using unreliable metrics.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COMMAND_INVARIANT_CHECKS_THROW =
+    buildConf("commandInvariantChecksThrow")
+      .internal()
+      .doc(
+        """When disabled all DML commands using reliable metrics just log a warning on command
+          |invariant violation and proceed to commit.
+          |When enabled, it's decided by a per-command flag.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/DeltaCommandInvariantsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/DeltaCommandInvariantsSuite.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import scala.util.{Failure, Success, Try}
+
+import com.databricks.spark.util.Log4jUsageLogger
+
+import org.apache.spark.{SparkFunSuite, SparkThrowable}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.DeltaOperations.EmptyCommit
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
+
+class DeltaCommandInvariantsSuite extends SparkFunSuite with DeltaSQLCommandTest {
+
+  for {
+    shouldSucceed <- BOOLEAN_DOMAIN
+    shouldThrow <- BOOLEAN_DOMAIN
+  } test("command invariant check - " +
+    s"shouldSucceed=$shouldSucceed, shouldThrow=$shouldThrow") {
+    withTempDir { dir =>
+      val path = dir.toString
+      spark.range(10).write.format("delta").save(path)
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val opType =
+        "delta.assertions.unreliable.commandInvariantViolated"
+      val events = Log4jUsageLogger.track {
+        val result = Try {
+          withSQLConf(
+            DeltaSQLConf.COMMAND_INVARIANT_CHECKS_THROW.key -> shouldThrow.toString) {
+            // Create an anonymous class, since checkCommandInvariant is protected here.
+            new DeltaCommand {
+              checkCommandInvariant(
+                invariant = () => shouldSucceed,
+                label = "shouldSucceed",
+                op = EmptyCommit,
+                deltaLog = deltaLog,
+                parameters = Map("unused" -> 123),
+                additionalInfo = Map("shouldSucceed" -> shouldSucceed.toString))
+            }
+          }
+        }
+        if (!shouldSucceed && shouldThrow) {
+          result match {
+            case Failure(e: SparkThrowable) =>
+              checkErrorMatchPVals(
+                e,
+                "DELTA_COMMAND_INVARIANT_VIOLATION",
+                parameters = Map(
+                  "operation" -> "Empty Commit",
+                  "uuid" -> ".*" // Doesn't matter
+                )
+              )
+            case Failure(e) => throw e
+            case Success(_) => fail("Expected Failure but got Success")
+          }
+        } else {
+          assert(result.isSuccess)
+        }
+      }
+      val violationEvents =
+        events.filter(_.tags.get("opType").contains(opType))
+      if (shouldSucceed) {
+        assert(violationEvents.isEmpty)
+      } else {
+        assert(violationEvents.size === 1)
+        val violationEvent = violationEvents.head
+        val violationEventInfo = JsonUtils.fromJson[CommandInvariantCheckInfo](violationEvent.blob)
+        assert(violationEventInfo === CommandInvariantCheckInfo(
+          exceptionThrown = shouldThrow,
+          id = violationEventInfo.id, // Don't check this, it's random.
+          invariantExpression = "shouldSucceed",
+          invariantParameters = Map("unused" -> 123),
+          operation = "Empty Commit",
+          operationParameters = Map.empty,
+          additionalInfo = Map("shouldSucceed" -> shouldSucceed.toString)))
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR adds invariant checks to DELETE, UPDATE, and MERGE to detect bugs in Spark and Delta, and to prevent these DML statements from committing if they suffered from the bug.

These invariants come in two flavors:
- Unreliable checks using the commit stats (i.e. number of rows in the files added and removed) and the SQL metrics. These checks are disabled by default, as Spark can overcount metrics when there are retries.
- Reliable checks based purely on the commit stats. These checks are enabled by default, but cannot detect every occurrence of a bug.

## How was this patch tested?

- Manually ran existing DML tests with all invariant checks enabled by default to confirm that the checks do not cause any issues.
- Manually ran existing DML tests with all invariant checks enabled by default with a bug introduced to confirm that the checks trigger.
- Added `DeltaCommandInvariantsSuite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No