### PR TITLE
[Spark] Make merge operationMetric numSourceRows more accurate

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -324,6 +324,8 @@ object DeltaOperations {
 
       var strMetrics = super.transformMetrics(metrics)
 
+      strMetrics += "numSourceRows" -> metrics("operationNumSourceRows").value.toString
+
       // We have to recalculate "numOutputRows" to avoid counting CDC rows
       if (metrics.contains("numTargetRowsInserted") &&
           metrics.contains("numTargetRowsUpdated") &&

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -209,6 +209,7 @@ case class MergeIntoCommand(
     checkNonDeterministicSource(spark)
 
     // Metrics should be recorded before commit (where they are written to delta logs).
+    setOperationNumSourceRowsMetric()
     metrics("executionTimeMs").set(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime))
     deltaTxn.registerSQLMetrics(spark, metrics)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -334,6 +334,10 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
       }
     }
 
+    if (joinType == "fullOuter" || joinType == "leftOuter") {
+      secondSourceScanWasFullScan = true
+    }
+
     logDebug(s"""writeAllChanges using $joinType join:
        |  source.output: ${source.outputSet}
        |  target.output: ${target.outputSet}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

There were cases when the merge operation could report incorrect `numSourceRows` operation metric if the source side got pruned. Although couldn't reproduce this exact issue, with this PR the metric should be more reliable.

Added a new metric `operationNumSourceRows` which uses `numSourceRowsInSecondScan` if it was a full scan, or `numSourceRows` otherwise. This new metric is reported as `numSourceRows` in the operation metrics.

## How was this patch tested?

Didn't add new tests because couldn't reproduce the original issue, but made sure that the added code is covered by the existing test cases, specifically by the `DescribeDeltaHistorySuite` and its metrics tests.

## Does this PR introduce _any_ user-facing changes?

No