### PR TITLE
[Spark] Fix `REPLACE` and `CREATE LIKE` for CatalogOwned

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -410,7 +410,19 @@ case class CreateDeltaTableCommand(
         // Remove 'EXISTS_DEFAULT' because it is not required for tables created with CREATE TABLE.
         txn.removeExistsDefaultFromSchema()
         protocol.foreach { protocol =>
-          txn.updateProtocol(protocol)
+          // For commands like CREATE LIKE, the `protocol` here may contain table features
+          // from source table. It will override the `newProtocol` being created in the above
+          // `txn.updateMetadataForNewTable`.
+          // In order to enable CatalogOwned for target table w/ default spark config,
+          // we need to manually append [[CatalogOwnedTableFeature]] here to the existing
+          // source table protocol.
+          val finalizedProtocol = if (CatalogOwnedTableUtils.defaultCatalogOwnedEnabled(
+              spark = sparkSession)) {
+            CatalogOwnedTableUtils.appendCatalogOwnedTableFeature(protocol)
+          } else {
+            protocol
+          }
+          txn.updateProtocol(finalizedProtocol)
         }
         ClusteredTableUtils.getDomainMetadataFromTransaction(
           ClusteredTableUtils.getClusterBySpecOptional(table), txn).toSeq

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -243,6 +243,24 @@ object CatalogOwnedTableUtils {
   }
 
   /**
+   * Appends [[CatalogOwnedTableFeature]] to the provided protocol.
+   * This is used to ensure that the CatalogOwnedTableFeature is included in the protocol
+   * for specific DDL commands w/ default spark config of CatalogOwned, e.g., `CREATE LIKE`.
+   *
+   * @param protocol The protocol to append.
+   */
+  def appendCatalogOwnedTableFeature(protocol: Protocol): Protocol = {
+    /** Helper function to append CatalogOwnedTableFeature to the provided table features. */
+    def appendImpl(tableFeatures: Option[Set[String]]): Option[Set[String]] = {
+      tableFeatures.map(_ + CatalogOwnedTableFeature.name)
+    }
+    protocol.copy(
+      readerFeatures = appendImpl(tableFeatures = protocol.readerFeatures),
+      writerFeatures = appendImpl(tableFeatures = protocol.writerFeatures)
+    )
+  }
+
+  /**
    * Validates that the UC table ID is not present in the provided property (overrides).
    * Errors out if it is present.
    *


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR fixes two subtle but critical parts for CatalogOwned enable table.

- For `CREATE LIKE`, enable CatalogOwned w/ default spark configuration.
- For `REPLACE`, only filter out `CatalogOwnedTableFeature` if the existing table does not have CatalogOwned enabled - otherwise there would be protocol downgrade issue if we are adding new table feature (e.g., `ClusteringTableFeature`) at the same time.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
N/A
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
