### PR TITLE
[Kernel] Support writing data in REPLACE TABLE transactions (RTAS)

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -326,6 +326,11 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         throw new UnsupportedOperationException(
             "REPLACE TABLE is not yet supported with column mapping");
       }
+      if (newProtocol.orElse(baseProtocol).supportsFeature(TableFeatures.ROW_TRACKING_W_FEATURE)) {
+        // Block this for now to be safe, we will return to this in the future
+        throw new UnsupportedOperationException(
+            "REPLACE TABLE is not yet supported on row tracking tables");
+      }
     }
 
     return new TransactionImpl(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -387,11 +387,6 @@ public class TransactionImpl implements Transaction {
     try (CloseableIterator<Row> userStageDataIter = dataActions.iterator()) {
       final CloseableIterator<Row> completeFileActionIter;
       if (isReplaceTable()) {
-        // For now, block RTAS; this will be unblocked in a follow-up PR
-        if (userStageDataIter.hasNext()) {
-          throw new UnsupportedOperationException(
-              "Inserting data is not yet supported with REPLACE");
-        }
         // If this is a replace table operation we need to internally generate the remove file
         // actions to reset the table state
         completeFileActionIter = getRemoveActionsForReplace(engine).combine(userStageDataIter);

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -18,10 +18,13 @@ package io.delta.kernel.defaults.metrics
 import java.util.{Collections, Objects, Optional}
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
 
 import io.delta.kernel._
 import io.delta.kernel.data.Row
+import io.delta.kernel.defaults.DeltaTableWriteSuiteBase
 import io.delta.kernel.engine._
+import io.delta.kernel.expressions.Literal
 import io.delta.kernel.internal.{TableConfig, TableImpl}
 import io.delta.kernel.internal.actions.{GenerateIcebergCompatActionUtils, SingleAction}
 import io.delta.kernel.internal.data.TransactionStateRow
@@ -36,7 +39,7 @@ import io.delta.kernel.utils.CloseableIterable.{emptyIterable, inMemoryIterable}
 
 import org.scalatest.funsuite.AnyFunSuite
 
-class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
+class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReportTestUtils {
 
   /**
    * Creates a [[Transaction]] using `getTransaction`, requests actions to commit using
@@ -457,40 +460,60 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     }
   }
 
-  test("TransactionReport: REPLACE a non-empty table") {
-    withTempDir { tempDir =>
-      val path = tempDir.getCanonicalPath
-      // Set up a non-empty table at version 0 with add file size that we know
-      val txn = Table.forPath(defaultEngine, path)
-        .createTransactionBuilder(defaultEngine, "testEngineInfo", Operation.CREATE_TABLE)
-        .withSchema(defaultEngine, new StructType().add("col1", IntegerType.INTEGER))
-        .withDomainMetadataSupported()
-        .build(defaultEngine)
-      txn.addDomainMetadata("user-domain", "some config")
-      val result = txn.commit(
-        defaultEngine,
-        generateAppendActions(fileStatusIter1)(txn, defaultEngine))
-      // Write out the CRC so that we will have fileSizeHistogram in the next commit
-      result.getPostCommitHooks.asScala.foreach(_.threadSafeInvoke(defaultEngine))
+  Seq(true, false).foreach { includeData =>
+    test(s"TransactionReport: REPLACE a non-empty table, includeData=$includeData") {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        // Set up a non-empty table at version 0 with add file size that we know
+        val txn = Table.forPath(defaultEngine, path)
+          .createTransactionBuilder(defaultEngine, "testEngineInfo", Operation.CREATE_TABLE)
+          .withSchema(defaultEngine, new StructType().add("col1", IntegerType.INTEGER))
+          .withDomainMetadataSupported()
+          .build(defaultEngine)
+        txn.addDomainMetadata("user-domain", "some config")
+        val result = txn.commit(
+          defaultEngine,
+          generateAppendActions(fileStatusIter1)(txn, defaultEngine))
+        // Write out the CRC so that we will have fileSizeHistogram in the next commit
+        result.getPostCommitHooks.asScala.foreach(_.threadSafeInvoke(defaultEngine))
 
-      // Check TransactionReport for REPLACE operation
-      checkTransactionReport(
-        generateCommitActions = (_, _) => emptyIterable(), // for now no RTAS
-        path,
-        expectException = false,
-        expectedBaseSnapshotVersion = 0,
-        expectedNumRemoveFiles = 1,
-        expectedNumTotalActions = 5, // protocol, metadata, commitInfo, domainMetadata (tombstone)
-        expectedCommitVersion = Some(1),
-        expectedTotalRemoveFilesSizeInBytes = 100,
-        expectedFileSizeHistogramResult = Some(
-          FileSizeHistogram.createDefaultHistogram().captureFileSizeHistogramResult()),
-        buildTransaction = (transBuilder, engine) => {
-          transBuilder
-            .withSchema(engine, new StructType().add("col1_new", IntegerType.INTEGER))
-            .build(engine)
-        },
-        operation = Operation.REPLACE_TABLE)
+        def generateCommitActions: (Transaction, Engine) => CloseableIterable[Row] =
+          if (!includeData) {
+            case (_, _) => emptyIterable()
+          }
+          else {
+            generateAppendActions(fileStatusIter1)
+          }
+        val numAddFiles = if (includeData) 1 else 0
+        val expectedFileSizeHistogram = if (includeData) {
+          incrementFileSizeHistogram(
+            FileSizeHistogram.createDefaultHistogram(),
+            fileStatusIter1).captureFileSizeHistogramResult()
+        } else {
+          FileSizeHistogram.createDefaultHistogram().captureFileSizeHistogramResult()
+        }
+
+        // Check TransactionReport for REPLACE operation
+        checkTransactionReport(
+          generateCommitActions,
+          path,
+          expectException = false,
+          expectedBaseSnapshotVersion = 0,
+          expectedNumAddFiles = numAddFiles,
+          expectedNumRemoveFiles = 1,
+          // protocol, metadata, commitInfo, domainMetadata (tombstone)
+          expectedNumTotalActions = numAddFiles + 5,
+          expectedCommitVersion = Some(1),
+          expectedTotalRemoveFilesSizeInBytes = 100,
+          expectedTotalAddFilesSizeInBytes = 100 * numAddFiles,
+          expectedFileSizeHistogramResult = Some(expectedFileSizeHistogram),
+          buildTransaction = (transBuilder, engine) => {
+            transBuilder
+              .withSchema(engine, new StructType().add("id", IntegerType.INTEGER))
+              .build(engine)
+          },
+          operation = Operation.REPLACE_TABLE)
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Supports writing data as part of a REPLACE TABLE transaction. In https://github.com/delta-io/delta/pull/4481 we explicitly blocked this, this PR unblocks it and adds tests for it. Also blocks rowTracking tables for now as we need to spend a little bit more time investigating how to treat rowTracking for `REPLACE` and what the fields in the new adds should look like.

## How was this patch tested?

Updates our unit tests.
