### PR TITLE
[Delta] Upgrade to User-Facing Error with Proper Error Class in Time Travel

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -430,8 +430,8 @@ class DeltaAnalysis(session: SparkSession)
               )
             case tUnstable: TemporallyUnstableInputException =>
               throw DeltaErrors.restoreTimestampGreaterThanLatestException(
-                tUnstable.userTimestamp.toString,
-                tUnstable.commitTs.toString
+                tUnstable.userTs.toString,
+                tUnstable.lastCommitTs.toString
               )
           }
           // TODO: Fetch the table version from deltaLog.update().version to guarantee freshness.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1492,13 +1492,10 @@ trait DeltaErrorsBase
          """.stripMargin)
 
   def timestampGreaterThanLatestCommit(
-      userTimestamp: java.sql.Timestamp,
-      commitTs: java.sql.Timestamp,
-      timestampString: String): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
-      messageParameters = Array(s"$userTimestamp", s"$commitTs", timestampString)
-    )
+      userTs: java.sql.Timestamp,
+      lastCommitTs: java.sql.Timestamp,
+      maximumTsStr: String): Throwable = {
+    TemporallyUnstableInputException(userTs, lastCommitTs, maximumTsStr)
   }
 
   def timestampInvalid(expr: Expression): Throwable = {
@@ -1509,15 +1506,12 @@ trait DeltaErrorsBase
   }
 
   case class TemporallyUnstableInputException(
-      userTimestamp: java.sql.Timestamp,
-      commitTs: java.sql.Timestamp,
-      timestampString: String,
-      commitVersion: Long) extends AnalysisException(
-    s"""The provided timestamp: $userTimestamp is after the latest commit timestamp of
-         |$commitTs. If you wish to query this version of the table, please either provide
-         |the version with "VERSION AS OF $commitVersion" or use the exact timestamp
-         |of the last commit: "TIMESTAMP AS OF '$timestampString'".
-       """.stripMargin)
+      userTs: java.sql.Timestamp,
+      lastCommitTs: java.sql.Timestamp,
+      maximumTsStr: String)
+    extends DeltaAnalysisException(
+      errorClass = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+      messageParameters = Array(s"$userTs", s"$lastCommitTs", maximumTsStr))
 
   def restoreVersionNotExistException(
       userVersion: Long,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -327,8 +327,7 @@ class DeltaHistoryManager(
       throw DeltaErrors.TimestampEarlierThanCommitRetentionException(timestamp, commitTs, tsString)
     } else if (commit.version == latestVersion && !canReturnLastCommit) {
       if (commit.timestamp < time) {
-        throw DeltaErrors.TemporallyUnstableInputException(
-          timestamp, commitTs, tsString, commit.version)
+        throw DeltaErrors.timestampGreaterThanLatestCommit(timestamp, commitTs, tsString)
       }
     }
     commit

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1843,9 +1843,9 @@ trait OptimisticTransactionImpl extends DeltaTransaction
           CatalogOwnedTableUtils.getCatalogName(
             spark,
             identifier = ct.identifier)
-        }.getOrElse("CATALOG_EMPTY")
+        }.getOrElse("CATALOG_MISSING")
       } else {
-        metadataToUse.coordinatedCommitsCoordinatorName.getOrElse("")
+        metadataToUse.coordinatedCommitsCoordinatorName.getOrElse("NONE")
       },
       // For Catalog-Owned table, the coordinator conf for UC-CC is [[Map.empty]]
       // so we don't distinguish between CO/CC here.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -119,9 +119,7 @@ object CatalogOwnedTableUtils {
   def getCatalogName(spark: SparkSession, identifier: CatalystTableIdentifier): Option[String] = {
     identifier.nameParts match {
       case spark.sessionState.analyzer.CatalogAndIdentifier(catalog, _) =>
-        if (catalog.getClass.getName ==
-            UCCommitCoordinatorBuilder.UNITY_CATALOG_CONNECTOR_CLASS
-        ) {
+        if (catalog.getClass.getName == UCCommitCoordinatorBuilder.UNITY_CATALOG_CONNECTOR_CLASS) {
           // UC is the current commit coordinator.
           Some("unity-catalog")
         } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -373,7 +373,7 @@ trait DeltaTimeTravelTests extends QueryTest
       }
       checkError(
         e1,
-        condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
@@ -386,7 +386,7 @@ trait DeltaTimeTravelTests extends QueryTest
       }
       checkError(
         e2,
-        condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -374,6 +374,7 @@ trait DeltaTimeTravelTests extends QueryTest
       checkError(
         e1,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        sqlState = 42816,
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",
@@ -386,6 +387,7 @@ trait DeltaTimeTravelTests extends QueryTest
       checkError(
         e2,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        sqlState = 42816,
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -368,17 +368,29 @@ trait DeltaTimeTravelTests extends QueryTest
         .select($"ts".cast("string")).as[String].collect()
         .map(i => s"'$i'")
 
-      val e1 = intercept[AnalysisException] {
+      val e1 = intercept[DeltaErrors.TemporallyUnstableInputException] {
         sql(s"select count(*) from ${timestampAsOf(tblName, ts(0))}").collect()
       }
-      assert(e1.getMessage.contains("VERSION AS OF 0"))
-      assert(e1.getMessage.contains("TIMESTAMP AS OF '2018-10-24 14:14:18'"))
+      checkError(
+        e1,
+        condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        parameters = Map(
+          "providedTimestamp" -> "2018-10-24 14:24:18.0",
+          "tableName" -> "2018-10-24 14:14:18.0",
+          "maximumTimestamp" -> "2018-10-24 14:14:18")
+      )
 
-      val e2 = intercept[AnalysisException] {
+      val e2 = intercept[DeltaErrors.TemporallyUnstableInputException] {
         sql(s"select count(*) from ${timestampAsOf(tblName, start + 10.minutes)}").collect()
       }
-      assert(e2.getMessage.contains("VERSION AS OF 0"))
-      assert(e2.getMessage.contains("TIMESTAMP AS OF '2018-10-24 14:14:18'"))
+      checkError(
+        e2,
+        condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        parameters = Map(
+          "providedTimestamp" -> "2018-10-24 14:24:18.0",
+          "tableName" -> "2018-10-24 14:14:18.0",
+          "maximumTimestamp" -> "2018-10-24 14:14:18")
+      )
 
       checkAnswer(
         sql(s"select count(*) from ${timestampAsOf(tblName, "'2018-10-24 14:14:18'")}"),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -374,7 +374,7 @@ trait DeltaTimeTravelTests extends QueryTest
       checkError(
         e1,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
-        sqlState = 42816,
+        sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",
@@ -387,7 +387,7 @@ trait DeltaTimeTravelTests extends QueryTest
       checkError(
         e2,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
-        sqlState = 42816,
+        sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -215,7 +215,7 @@ class DeltaTimeTravelSuite extends QueryTest
       }
       checkError(
         e,
-        condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 17:34:18.0",
@@ -535,7 +535,7 @@ class DeltaTimeTravelSuite extends QueryTest
       }
       checkError(
         e1,
-        condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
@@ -549,7 +549,7 @@ class DeltaTimeTravelSuite extends QueryTest
       }
       checkError(
         e2,
-        condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
@@ -796,7 +796,7 @@ class DeltaTimeTravelSuite extends QueryTest
 
         checkError(
           ex2,
-          condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+          "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
           sqlState = "42816",
           parameters = Map(
             "providedTimestamp" -> "2018-10-24 20:14:18.0",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -216,7 +216,7 @@ class DeltaTimeTravelSuite extends QueryTest
       checkError(
         e,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
-        sqlState = 42816,
+        sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 17:34:18.0",
           "tableName" -> "2018-10-24 17:14:18.0",
@@ -536,7 +536,7 @@ class DeltaTimeTravelSuite extends QueryTest
       checkError(
         e1,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
-        sqlState = 42816,
+        sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",
@@ -550,7 +550,7 @@ class DeltaTimeTravelSuite extends QueryTest
       checkError(
         e2,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
-        sqlState = 42816,
+        sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",
@@ -797,7 +797,7 @@ class DeltaTimeTravelSuite extends QueryTest
         checkError(
           ex2,
           condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
-          sqlState = 42816,
+          sqlState = "42816",
           parameters = Map(
             "providedTimestamp" -> "2018-10-24 20:14:18.0",
             "tableName" -> "2018-10-24 14:34:18.0",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -216,6 +216,7 @@ class DeltaTimeTravelSuite extends QueryTest
       checkError(
         e,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        sqlState = 42816,
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 17:34:18.0",
           "tableName" -> "2018-10-24 17:14:18.0",
@@ -535,6 +536,7 @@ class DeltaTimeTravelSuite extends QueryTest
       checkError(
         e1,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        sqlState = 42816,
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",
@@ -548,6 +550,7 @@ class DeltaTimeTravelSuite extends QueryTest
       checkError(
         e2,
         condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        sqlState = 42816,
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
           "tableName" -> "2018-10-24 14:14:18.0",
@@ -794,6 +797,7 @@ class DeltaTimeTravelSuite extends QueryTest
         checkError(
           ex2,
           condition = "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+          sqlState = 42816,
           parameters = Map(
             "providedTimestamp" -> "2018-10-24 20:14:18.0",
             "tableName" -> "2018-10-24 14:34:18.0",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -654,7 +654,7 @@ class InCommitTimestampSuite
           catalogTableOpt = None,
           canReturnLastCommit = false)
       }
-      assert(e.getMessage.contains("The provided timestamp:") && e.getMessage.contains("is after"))
+      assert(e.getMessage.contains("The provided timestamp") && e.getMessage.contains("is after"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -84,9 +84,9 @@ class CatalogOwnedEnablementSuite
     // Insert initial data to the table
     spark.sql(s"INSERT INTO $tableName VALUES 1") // commit 1
     spark.sql(s"INSERT INTO $tableName VALUES 2") // commit 2
-    val log = DeltaLog.forTable(spark, new TableIdentifier(table = tableName))
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))
     validateCatalogOwnedCompleteEnablement(
-      snapshot = log.unsafeVolatileSnapshot,
+      snapshot = snapshot,
       expectEnabled = createCatalogOwnedTableAtInit)
   }
 
@@ -104,7 +104,7 @@ class CatalogOwnedEnablementSuite
     }
   }
 
-  test("Catalog-Owned: ALTER TABLE should be blocked if attempts to disable ICT") {
+  test("ALTER TABLE should be blocked if attempts to disable ICT") {
     withRandomTable(createCatalogOwnedTableAtInit = true) { tableName =>
       val error = interceptWithUnwrapping[DeltaIllegalArgumentException] {
         spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES ('$ICT_ENABLED_KEY' = 'false')")
@@ -117,7 +117,7 @@ class CatalogOwnedEnablementSuite
     }
   }
 
-  test("Catalog-Owned: ALTER TABLE should be blocked if attempts to unset ICT") {
+  test("ALTER TABLE should be blocked if attempts to unset ICT") {
     withRandomTable(createCatalogOwnedTableAtInit = true) { tableName =>
       val error = interceptWithUnwrapping[DeltaIllegalArgumentException] {
         spark.sql(s"ALTER TABLE $tableName UNSET TBLPROPERTIES ('$ICT_ENABLED_KEY')")
@@ -130,8 +130,7 @@ class CatalogOwnedEnablementSuite
     }
   }
 
-  test("Catalog-Owned: ALTER TABLE should be blocked if attempts to" +
-    " downgrade Catalog-Owned") {
+  test("ALTER TABLE should be blocked if attempts to downgrade Catalog-Owned") {
     withRandomTable(createCatalogOwnedTableAtInit = true)  { tableName =>
       val error = intercept[DeltaTableFeatureException] {
         spark.sql(s"ALTER TABLE $tableName DROP FEATURE '${CatalogOwnedTableFeature.name}'")
@@ -144,7 +143,7 @@ class CatalogOwnedEnablementSuite
     }
   }
 
-  test("Catalog-Owned: Upgrade should be blocked since it is not supported yet") {
+  test("Upgrade should be blocked since it is not supported yet") {
     withRandomTable(
       // Do not enable Catalog-Owned at the beginning when creating table
       createCatalogOwnedTableAtInit = false
@@ -154,6 +153,32 @@ class CatalogOwnedEnablementSuite
           s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
       }
       assert(error.getMessage.contains("Upgrading to CatalogOwned table is not yet supported."))
+    }
+  }
+
+  test("Dropping CatalogOwned dependent features should be blocked") {
+    withRandomTable(createCatalogOwnedTableAtInit = true) { tableName =>
+      val error1 = intercept[DeltaTableFeatureException] {
+        spark.sql(s"ALTER TABLE $tableName DROP FEATURE '${InCommitTimestampTableFeature.name}'")
+      }
+      checkError(
+        error1,
+        "DELTA_FEATURE_DROP_DEPENDENT_FEATURE",
+        sqlState = "55000",
+        parameters = Map(
+          "feature" -> InCommitTimestampTableFeature.name,
+          "dependentFeatures" -> CatalogOwnedTableFeature.name))
+
+      val error2 = intercept[DeltaTableFeatureException] {
+        spark.sql(s"ALTER TABLE $tableName DROP FEATURE '${VacuumProtocolCheckTableFeature.name}'")
+      }
+      checkError(
+        error2,
+        "DELTA_FEATURE_DROP_DEPENDENT_FEATURE",
+        sqlState = "55000",
+        parameters = Map(
+          "feature" -> VacuumProtocolCheckTableFeature.name,
+          "dependentFeatures" -> CatalogOwnedTableFeature.name))
     }
   }
 
@@ -185,7 +210,7 @@ class CatalogOwnedEnablementSuite
         CoordinatedCommitsStats(
           coordinatedCommitsType = CoordinatedCommitType.FS_TO_CO_UPGRADE_COMMIT.toString,
           // catalogTable is not available for FS_TO_CO_UPGRADE_COMMIT
-          commitCoordinatorName = "CATALOG_EMPTY",
+          commitCoordinatorName = "CATALOG_MISSING",
           commitCoordinatorConf = Map.empty))
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1037,7 +1037,7 @@ abstract class CommitCoordinatorSuiteBase
         val commitStatsUsageLogs4 = filterUsageRecords(usageLogs4, "delta.commit.stats")
         val commitStats4 = JsonUtils.fromJson[CommitStats](commitStatsUsageLogs4.head.blob)
         assert(commitStats4.coordinatedCommitsInfo ===
-          CoordinatedCommitsStats(FS_COMMIT.toString, "", Map.empty))
+          CoordinatedCommitsStats(FS_COMMIT.toString, "NONE", Map.empty))
 
         // Now transfer the table to another commit-coordinator
         // [upgradeExistingTable = false] Commit-5


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Upgraded TemporallyUnstableInputException to user-facing error with proper error class. Reused the existing error class `DELTA_TIMESTAMP_GREATER_THAN_COMMIT`, which is currently being used by streaming reads. Make `DeltaErrors.timestampGreaterThanLatestCommit` also return `TemporallyUnstableInputException`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Updated existing UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.