### PR TITLE
[Spark][Version Checksum][3.3] Clean up stale checksum files during cleanup

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -141,8 +141,8 @@ trait MetadataCleanup extends DeltaLogging {
   }
 
   /** Helper function for getting the version of a checkpoint or a commit. */
-  def getDeltaFileOrCheckpointVersion(filePath: Path): Long = {
-    require(isCheckpointFile(filePath) || isDeltaFile(filePath))
+  def getDeltaFileChecksumOrCheckpointVersion(filePath: Path): Long = {
+    require(isCheckpointFile(filePath) || isDeltaFile(filePath) || isChecksumFile(filePath))
     getFileVersion(filePath)
   }
 
@@ -157,10 +157,10 @@ trait MetadataCleanup extends DeltaLogging {
     if (latestCheckpoint.isEmpty) return Iterator.empty
     val threshold = latestCheckpoint.get.version - 1L
     val files = store.listFrom(listingPrefix(logPath, 0), newDeltaHadoopConf())
-      .filter(f => isCheckpointFile(f) || isDeltaFile(f))
+      .filter(f => isCheckpointFile(f) || isDeltaFile(f) || isChecksumFile(f))
 
     new BufferingLogDeletionIterator(
-      files, fileCutOffTime, threshold, getDeltaFileOrCheckpointVersion)
+      files, fileCutOffTime, threshold, getDeltaFileChecksumOrCheckpointVersion)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -177,7 +177,7 @@ trait MetadataCleanup extends DeltaLogging {
     if (checkpointProtectionVersion <= 0) return true
 
     def versionGreaterOrEqualToThreshold(file: FileStatus): Boolean =
-      getDeltaFileOrCheckpointVersion(file.getPath) >= checkpointProtectionVersion - 1
+      getDeltaFileChecksumOrCheckpointVersion(file.getPath) >= checkpointProtectionVersion - 1
 
     val expiredDeltaLogs = listExpiredDeltaLogs(fileCutOffTime)
     expiredDeltaLogs.isEmpty || expiredDeltaLogs.exists(versionGreaterOrEqualToThreshold)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -181,14 +181,21 @@ trait DeltaRetentionSuiteBase extends QueryTest
     }
     if (!checkpointOnly) {
       val deltaPath = new Path(log.logPath, new Path(f"$version%020d.json"))
+      val ts = day(startTime, dayNum) + version * 1000
       if (fs.exists(deltaPath)) {
         // Add some second offset so that we don't have files with same timestamps
-        fs.setTimes(deltaPath, day(startTime, dayNum) + version * 1000, 0)
+        fs.setTimes(deltaPath, ts, 0)
+      }
+      // Add the same timestamp for the crc file as well.
+      val crcPath = new Path(log.logPath, new Path(f"$version%020d.crc"))
+      if (fs.exists(crcPath)) {
+          // Add some second offset so that we don't have files with same timestamps
+          fs.setTimes(crcPath, ts, 0)
       }
       // Add the same timestamp for unbackfilled delta files as well
       fs.listStatus(FileNames.commitDirPath(log.logPath))
         .find(_.getPath.getName.startsWith(f"$version%020d"))
-        .foreach(f => fs.setTimes(f.getPath, day(startTime, dayNum) + version * 1000, 0))
+        .foreach(f => fs.setTimes(f.getPath, ts, 0))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -89,6 +89,16 @@ trait DeltaRetentionSuiteBase extends QueryTest
     files.map(f => f.getName()).map(s => s.substring(0, s.indexOf(".")).toLong).toSet
   }
 
+  protected def getCrcFiles(dir: File): Seq[File] =
+    dir.listFiles().filter(f => FileNames.isChecksumFile(new Path(f.getCanonicalPath)))
+
+  protected def getCrcVersions(dir: File): Set[Long] =
+    getFileVersions(getCrcFiles(dir))
+
+  protected def getDeltaAndCrcFiles(dir: File): Seq[File] =
+    getDeltaFiles(dir) ++ getCrcFiles(dir)
+
+
   protected def getDeltaVersions(dir: File): Set[Long] = {
     val backfilledDeltaVersions = getFileVersions(getDeltaFiles(dir))
     val unbackfilledDeltaVersions = getUnbackfilledDeltaVersions(dir)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines:
https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]
Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
5. If possible, provide a concise example to reproduce the issue for a
faster review.
6. If applicable, include the corresponding issue number in the PR title
and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull
request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to
correctly link and close the issue upon merge.
-->
Backport of https://github.com/delta-io/delta/commit/d47c09ac528a9481dd9fccd502fa33c7ef1f8a9f to 3.3.
Fixes Metadata Cleanup so that checksum files are also considered for
removal. Resolves https://github.com/delta-io/delta/issues/4475

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test
the changes thoroughly including negative and positive cases if
possible.
If the changes were tested in any way other than unit tests, please
clarify how you tested step by step (ideally copy and paste-able, so
that other reviewers can test and check, and descendants can verify in
the future).
If the changes were not tested, please explain why.
-->
Updated DeltaRetentionSuite

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR
proposes - provide the console output, description and/or an example to
show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change
compared to the released Delta Lake versions or within the unreleased
branches such as master.
If no, write 'No'.
-->