### PR TITLE
[WIP][Kernel][RFC] Add type change history to StructField

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -60,6 +60,9 @@ public class StructField {
   private final DataType dataType;
   private final boolean nullable;
   private final FieldMetadata metadata;
+  // A list of preivious types that this field held. Only applicable to
+  // fields for BasePrimitiveType. Higher indexed elements are new types.
+  private final List<BasePrimitiveType> previousTypes = new ArrayList<>();
 
   public StructField(String name, DataType dataType, boolean nullable) {
     this(name, dataType, nullable, FieldMetadata.empty());
@@ -73,6 +76,16 @@ public class StructField {
     FieldMetadata collationMetadata = fetchCollationMetadata();
     this.metadata =
         new FieldMetadata.Builder().fromMetadata(metadata).fromMetadata(collationMetadata).build();
+  }
+
+  public StructField(String name, DataType dataType, boolean nullable, FieldMetadata metadata) {
+    this.name = name;
+    this.dataType = dataType;
+    this.nullable = nullable;
+
+    FieldMetadata collationMetadata = fetchCollationMetadata();
+    this.metadata =
+            new FieldMetadata.Builder().fromMetadata(metadata).fromMetadata(collationMetadata).build();
   }
 
   /** @return the name of this field */
@@ -104,6 +117,10 @@ public class StructField {
     return !isMetadataColumn();
   }
 
+  public List<BasePrimitiveType> getPreviousTypes() {
+    return new ArrayList<>(previousTypes);
+  }
+
   @Override
   public String toString() {
     return String.format(
@@ -122,12 +139,13 @@ public class StructField {
     return nullable == that.nullable
         && name.equals(that.name)
         && dataType.equals(that.dataType)
-        && metadata.equals(that.metadata);
+        && metadata.equals(that.metadata)
+            && previousTypes.equals(that.previousTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, dataType, nullable, metadata);
+    return Objects.hash(name, dataType, nullable, metadata, previousTypes);
   }
 
   public StructField withNewMetadata(FieldMetadata metadata) {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

As part of supporting write support for [type widening the kernel](https://github.com/delta-io/delta/issues/4491). We run into a similar design issue as Collation.  Where type changes are stored in [FieldMetadata](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#type-change-metadata) at the nearest parent struct field, but for maps/arrays we need to construct a path separately.  

This change serves as a discussion point on two questions:
1.  Should we add a separate member at all to `StructField` and make use of similar logic in collation to collect it up to the nearest non-map/array parent?
2. What should its representation be.  In this PR I currently use a list which assumes linear transitions.  In theory during typeChange cleanup, one could remove a link, so it might be worth while to create a minimal `TypeChange` class to wrap from/to.  If we want to proceed with the new member on `StructField` I will update the PR to include the new class as well.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
