### PR TITLE
[Kernel] Fix a case where we miss the protocol validation during reads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -680,6 +680,8 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
     javafmtCheckSettings,
     scalafmtCheckSettings,
     Test / javaOptions ++= Seq("-ea"),
+    // This allows generating tables with unsupported test table features in delta-spark
+    Test / envVars += ("DELTA_TESTING", "1"),
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -161,9 +161,16 @@ public class LogReplay {
             engine, logSegment, snapshotHint, logSegment.getVersion());
     this.protocolAndMetadata =
         snapshotMetrics.loadInitialDeltaActionsTimer.time(
-            () ->
-                loadTableProtocolAndMetadata(
-                    engine, logSegment, newerSnapshotHint, logSegment.getVersion()));
+            () -> {
+              Tuple2<Protocol, Metadata> protocolAndMetadata =
+                  loadTableProtocolAndMetadata(
+                      engine, logSegment, newerSnapshotHint, logSegment.getVersion());
+
+              TableFeatures.validateKernelCanReadTheTable(
+                  protocolAndMetadata._1, dataPath.toString());
+
+              return protocolAndMetadata;
+            });
     // Lazy loading of domain metadata only when needed
     this.activeDomainMetadataMap = new Lazy<>(() -> loadDomainMetadataMap(engine));
   }
@@ -319,7 +326,6 @@ public class LogReplay {
 
               if (protocol != null) {
                 // Stop since we have found the latest Protocol and Metadata.
-                TableFeatures.validateKernelCanReadTheTable(protocol, dataPath.toString());
                 return new Tuple2<>(protocol, metadata);
               }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -317,6 +317,36 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
     }
   }
 
+  test("read throws if the table contains unsupported table feature") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createEmptyTable(engine, tablePath, testSchema)
+      appendData(
+        engine,
+        tablePath,
+        isNewTable = false,
+        testSchema,
+        partCols = Seq.empty,
+        Seq(Map.empty[String, Literal] -> dataBatches1))
+
+      checkTable(tablePath, expectedAnswer = dataBatches1.flatMap(_.toTestRows))
+
+      // If test is running in intelliJ, set DELTA_TESTING=1 in env variables.
+      // This will enable the testReaderWriter feature in delta-spark. In CI jobs,
+      // build.sbt already has set and effective.
+      spark.sql("ALTER TABLE delta.`" + tablePath +
+        "` SET TBLPROPERTIES ('delta.feature.testReaderWriter' = 'supported')")
+
+      // try to read the table
+      val ex = intercept[KernelException] {
+        checkTable(
+          tablePath,
+          expectedAnswer = Seq.empty /* it doesn't matter as expect failure in reading */ )
+      }
+      assert(ex.getMessage.contains(
+        "feature \"testReaderWriter\" which is unsupported by this version of Delta Kernel"))
+    }
+  }
+
   ///////////////////////////////////////////////////////////////////////////
   // Helper methods
   ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
Currently, we miss a case in loading protocol and metadata where the `metadata` action is received after the `protocol` action.

## How was this patch tested?
Integration test that throws an error if the protocol expected has an unsupported reader feature.

