### PR TITLE
[Spark] Add `vacuum`, `upgrade`, `generate`, `clone` command APIs to Delta Connect (Scala client + server)

### DIFF
--- a/python/delta/connect/proto/commands_pb2.py
+++ b/python/delta/connect/proto/commands_pb2.py
@@ -31,7 +31,7 @@ from delta.connect.proto import base_pb2 as delta_dot_connect_dot_base__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1c\x64\x65lta/connect/commands.proto\x12\rdelta.connect\x1a\x18\x64\x65lta/connect/base.proto"\\\n\x0c\x44\x65ltaCommand\x12<\n\x0b\x63lone_table\x18\x01 \x01(\x0b\x32\x19.delta.connect.CloneTableH\x00R\ncloneTableB\x0e\n\x0c\x63ommand_type"\xec\x02\n\nCloneTable\x12/\n\x05table\x18\x01 \x01(\x0b\x32\x19.delta.connect.DeltaTableR\x05table\x12\x16\n\x06target\x18\x02 \x01(\tR\x06target\x12\x1a\n\x07version\x18\x03 \x01(\x05H\x00R\x07version\x12\x1e\n\ttimestamp\x18\x04 \x01(\tH\x00R\ttimestamp\x12\x1d\n\nis_shallow\x18\x05 \x01(\x08R\tisShallow\x12\x18\n\x07replace\x18\x06 \x01(\x08R\x07replace\x12I\n\nproperties\x18\x07 \x03(\x0b\x32).delta.connect.CloneTable.PropertiesEntryR\nproperties\x1a=\n\x0fPropertiesEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x16\n\x14version_or_timestampB\x1a\n\x16io.delta.connect.protoP\x01\x62\x06proto3'
+    b'\n\x1c\x64\x65lta/connect/commands.proto\x12\rdelta.connect\x1a\x18\x64\x65lta/connect/base.proto"\xb1\x02\n\x0c\x44\x65ltaCommand\x12<\n\x0b\x63lone_table\x18\x01 \x01(\x0b\x32\x19.delta.connect.CloneTableH\x00R\ncloneTable\x12?\n\x0cvacuum_table\x18\x02 \x01(\x0b\x32\x1a.delta.connect.VacuumTableH\x00R\x0bvacuumTable\x12[\n\x16upgrade_table_protocol\x18\x03 \x01(\x0b\x32#.delta.connect.UpgradeTableProtocolH\x00R\x14upgradeTableProtocol\x12\x35\n\x08generate\x18\x04 \x01(\x0b\x32\x17.delta.connect.GenerateH\x00R\x08generateB\x0e\n\x0c\x63ommand_type"\xec\x02\n\nCloneTable\x12/\n\x05table\x18\x01 \x01(\x0b\x32\x19.delta.connect.DeltaTableR\x05table\x12\x16\n\x06target\x18\x02 \x01(\tR\x06target\x12\x1a\n\x07version\x18\x03 \x01(\x05H\x00R\x07version\x12\x1e\n\ttimestamp\x18\x04 \x01(\tH\x00R\ttimestamp\x12\x1d\n\nis_shallow\x18\x05 \x01(\x08R\tisShallow\x12\x18\n\x07replace\x18\x06 \x01(\x08R\x07replace\x12I\n\nproperties\x18\x07 \x03(\x0b\x32).delta.connect.CloneTable.PropertiesEntryR\nproperties\x1a=\n\x0fPropertiesEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x16\n\x14version_or_timestamp"\x80\x01\n\x0bVacuumTable\x12/\n\x05table\x18\x01 \x01(\x0b\x32\x19.delta.connect.DeltaTableR\x05table\x12,\n\x0fretention_hours\x18\x02 \x01(\x01H\x00R\x0eretentionHours\x88\x01\x01\x42\x12\n\x10_retention_hours"\x95\x01\n\x14UpgradeTableProtocol\x12/\n\x05table\x18\x01 \x01(\x0b\x32\x19.delta.connect.DeltaTableR\x05table\x12%\n\x0ereader_version\x18\x02 \x01(\x05R\rreaderVersion\x12%\n\x0ewriter_version\x18\x03 \x01(\x05R\rwriterVersion"O\n\x08Generate\x12/\n\x05table\x18\x01 \x01(\x0b\x32\x19.delta.connect.DeltaTableR\x05table\x12\x12\n\x04mode\x18\x02 \x01(\tR\x04modeB\x1a\n\x16io.delta.connect.protoP\x01\x62\x06proto3'
 )
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
@@ -41,10 +41,16 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._serialized_options = b"\n\026io.delta.connect.protoP\001"
     _CLONETABLE_PROPERTIESENTRY._options = None
     _CLONETABLE_PROPERTIESENTRY._serialized_options = b"8\001"
-    _DELTACOMMAND._serialized_start = 73
-    _DELTACOMMAND._serialized_end = 165
-    _CLONETABLE._serialized_start = 168
-    _CLONETABLE._serialized_end = 532
-    _CLONETABLE_PROPERTIESENTRY._serialized_start = 447
-    _CLONETABLE_PROPERTIESENTRY._serialized_end = 508
+    _DELTACOMMAND._serialized_start = 74
+    _DELTACOMMAND._serialized_end = 379
+    _CLONETABLE._serialized_start = 382
+    _CLONETABLE._serialized_end = 746
+    _CLONETABLE_PROPERTIESENTRY._serialized_start = 661
+    _CLONETABLE_PROPERTIESENTRY._serialized_end = 722
+    _VACUUMTABLE._serialized_start = 749
+    _VACUUMTABLE._serialized_end = 877
+    _UPGRADETABLEPROTOCOL._serialized_start = 880
+    _UPGRADETABLEPROTOCOL._serialized_end = 1029
+    _GENERATE._serialized_start = 1031
+    _GENERATE._serialized_end = 1110
 # @@protoc_insertion_point(module_scope)

--- a/python/delta/connect/proto/commands_pb2.pyi
+++ b/python/delta/connect/proto/commands_pb2.pyi
@@ -52,28 +52,63 @@ class DeltaCommand(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     CLONE_TABLE_FIELD_NUMBER: builtins.int
+    VACUUM_TABLE_FIELD_NUMBER: builtins.int
+    UPGRADE_TABLE_PROTOCOL_FIELD_NUMBER: builtins.int
+    GENERATE_FIELD_NUMBER: builtins.int
     @property
     def clone_table(self) -> global___CloneTable: ...
+    @property
+    def vacuum_table(self) -> global___VacuumTable: ...
+    @property
+    def upgrade_table_protocol(self) -> global___UpgradeTableProtocol: ...
+    @property
+    def generate(self) -> global___Generate: ...
     def __init__(
         self,
         *,
         clone_table: global___CloneTable | None = ...,
+        vacuum_table: global___VacuumTable | None = ...,
+        upgrade_table_protocol: global___UpgradeTableProtocol | None = ...,
+        generate: global___Generate | None = ...,
     ) -> None: ...
     def HasField(
         self,
         field_name: typing_extensions.Literal[
-            "clone_table", b"clone_table", "command_type", b"command_type"
+            "clone_table",
+            b"clone_table",
+            "command_type",
+            b"command_type",
+            "generate",
+            b"generate",
+            "upgrade_table_protocol",
+            b"upgrade_table_protocol",
+            "vacuum_table",
+            b"vacuum_table",
         ],
     ) -> builtins.bool: ...
     def ClearField(
         self,
         field_name: typing_extensions.Literal[
-            "clone_table", b"clone_table", "command_type", b"command_type"
+            "clone_table",
+            b"clone_table",
+            "command_type",
+            b"command_type",
+            "generate",
+            b"generate",
+            "upgrade_table_protocol",
+            b"upgrade_table_protocol",
+            "vacuum_table",
+            b"vacuum_table",
         ],
     ) -> None: ...
     def WhichOneof(
         self, oneof_group: typing_extensions.Literal["command_type", b"command_type"]
-    ) -> typing_extensions.Literal["clone_table"] | None: ...
+    ) -> (
+        typing_extensions.Literal[
+            "clone_table", "vacuum_table", "upgrade_table_protocol", "generate"
+        ]
+        | None
+    ): ...
 
 global___DeltaCommand = DeltaCommand
 
@@ -177,3 +212,119 @@ class CloneTable(google.protobuf.message.Message):
     ) -> typing_extensions.Literal["version", "timestamp"] | None: ...
 
 global___CloneTable = CloneTable
+
+class VacuumTable(google.protobuf.message.Message):
+    """Command that deletes files and directories in the table that are not needed by the table for
+    maintaining older versions up to the given retention threshold
+    """
+
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    TABLE_FIELD_NUMBER: builtins.int
+    RETENTION_HOURS_FIELD_NUMBER: builtins.int
+    @property
+    def table(self) -> delta.connect.proto.base_pb2.DeltaTable:
+        """(Required) The Delta table to vacuum."""
+    retention_hours: builtins.float
+    """(Optional) Number of hours retain history for. If not specified, then the default retention
+    period will be used.
+    """
+    def __init__(
+        self,
+        *,
+        table: delta.connect.proto.base_pb2.DeltaTable | None = ...,
+        retention_hours: builtins.float | None = ...,
+    ) -> None: ...
+    def HasField(
+        self,
+        field_name: typing_extensions.Literal[
+            "_retention_hours",
+            b"_retention_hours",
+            "retention_hours",
+            b"retention_hours",
+            "table",
+            b"table",
+        ],
+    ) -> builtins.bool: ...
+    def ClearField(
+        self,
+        field_name: typing_extensions.Literal[
+            "_retention_hours",
+            b"_retention_hours",
+            "retention_hours",
+            b"retention_hours",
+            "table",
+            b"table",
+        ],
+    ) -> None: ...
+    def WhichOneof(
+        self, oneof_group: typing_extensions.Literal["_retention_hours", b"_retention_hours"]
+    ) -> typing_extensions.Literal["retention_hours"] | None: ...
+
+global___VacuumTable = VacuumTable
+
+class UpgradeTableProtocol(google.protobuf.message.Message):
+    """Command to updates the protocol version of the table so that new features can be used."""
+
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    TABLE_FIELD_NUMBER: builtins.int
+    READER_VERSION_FIELD_NUMBER: builtins.int
+    WRITER_VERSION_FIELD_NUMBER: builtins.int
+    @property
+    def table(self) -> delta.connect.proto.base_pb2.DeltaTable:
+        """(Required) The Delta table to upgrade the protocol of."""
+    reader_version: builtins.int
+    """(Required) The minimum required reader protocol version."""
+    writer_version: builtins.int
+    """(Required) The minimum required writer protocol version."""
+    def __init__(
+        self,
+        *,
+        table: delta.connect.proto.base_pb2.DeltaTable | None = ...,
+        reader_version: builtins.int = ...,
+        writer_version: builtins.int = ...,
+    ) -> None: ...
+    def HasField(
+        self, field_name: typing_extensions.Literal["table", b"table"]
+    ) -> builtins.bool: ...
+    def ClearField(
+        self,
+        field_name: typing_extensions.Literal[
+            "reader_version",
+            b"reader_version",
+            "table",
+            b"table",
+            "writer_version",
+            b"writer_version",
+        ],
+    ) -> None: ...
+
+global___UpgradeTableProtocol = UpgradeTableProtocol
+
+class Generate(google.protobuf.message.Message):
+    """Command that generates manifest files for a given Delta table."""
+
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    TABLE_FIELD_NUMBER: builtins.int
+    MODE_FIELD_NUMBER: builtins.int
+    @property
+    def table(self) -> delta.connect.proto.base_pb2.DeltaTable:
+        """(Required) The Delta table to generate the manifest files for."""
+    mode: builtins.str
+    """(Required) The type of manifest file to be generated."""
+    def __init__(
+        self,
+        *,
+        table: delta.connect.proto.base_pb2.DeltaTable | None = ...,
+        mode: builtins.str = ...,
+    ) -> None: ...
+    def HasField(
+        self, field_name: typing_extensions.Literal["table", b"table"]
+    ) -> builtins.bool: ...
+    def ClearField(
+        self, field_name: typing_extensions.Literal["mode", b"mode", "table", b"table"]
+    ) -> None: ...
+
+global___Generate = Generate

--- a/python/delta/connect/proto/commands_pb2.pyi
+++ b/python/delta/connect/proto/commands_pb2.pyi
@@ -215,7 +215,7 @@ global___CloneTable = CloneTable
 
 class VacuumTable(google.protobuf.message.Message):
     """Command that deletes files and directories in the table that are not needed by the table for
-    maintaining older versions up to the given retention threshold
+    maintaining older versions up to the given retention threshold.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor

--- a/spark-connect/client/src/main/scala-spark-master/io/delta/connect/tables/DeltaTable.scala
+++ b/spark-connect/client/src/main/scala-spark-master/io/delta/connect/tables/DeltaTable.scala
@@ -67,6 +67,15 @@ class DeltaTable private[tables](
    */
   def toDF: Dataset[Row] = df
 
+  /**
+   * Helper method for the vacuum APIs.
+   *
+   * @param retentionHours The retention threshold in hours. Files required by the table for
+   *                       reading versions earlier than this will be preserved and the
+   *                       rest of them will be deleted.
+   *
+   * @since 4.0.0
+   */
   private def executeVacuum(retentionHours: Option[Double]): DataFrame = {
     val vacuum = proto.VacuumTable
       .newBuilder()

--- a/spark-connect/client/src/main/scala-spark-master/io/delta/connect/tables/DeltaTable.scala
+++ b/spark-connect/client/src/main/scala-spark-master/io/delta/connect/tables/DeltaTable.scala
@@ -436,9 +436,9 @@ class DeltaTable private[tables](
       target: String,
       isShallow: Boolean,
       replace: Boolean,
-      version: Option[Int],
-      timestamp: Option[String],
-      properties: Map[String, String]): DeltaTable = {
+      properties: Map[String, String],
+      versionAsOf: Option[Int] = None,
+      timestampAsOf: Option[String] = None): DeltaTable = {
     val clone = proto.CloneTable
       .newBuilder()
       .setTable(table)
@@ -446,8 +446,8 @@ class DeltaTable private[tables](
       .setIsShallow(isShallow)
       .setReplace(replace)
       .putAllProperties(properties.asJava)
-    version.foreach(clone.setVersion)
-    timestamp.foreach(clone.setTimestamp)
+    versionAsOf.foreach(clone.setVersion)
+    timestampAsOf.foreach(clone.setTimestamp)
     val command = proto.DeltaCommand.newBuilder().setCloneTable(clone).build()
     execute(command)
     DeltaTable.forPath(sparkSession, target)
@@ -480,7 +480,7 @@ class DeltaTable private[tables](
       isShallow: Boolean,
       replace: Boolean,
       properties: Map[String, String]): DeltaTable = {
-    executeClone(target, isShallow, replace, version = None, timestamp = None, properties)
+    executeClone(target, isShallow, replace, properties, versionAsOf = None, timestampAsOf = None)
   }
 
   /**
@@ -571,7 +571,7 @@ class DeltaTable private[tables](
       isShallow: Boolean,
       replace: Boolean,
       properties: Map[String, String]): DeltaTable = {
-    executeClone(target, isShallow, replace, version = Some(version), timestamp = None, properties)
+    executeClone(target, isShallow, replace, properties, versionAsOf = Some(version), timestampAsOf = None)
   }
 
   /**
@@ -675,7 +675,7 @@ class DeltaTable private[tables](
       replace: Boolean,
       properties: Map[String, String]): DeltaTable = {
     executeClone(
-      target, isShallow, replace, version = None, timestamp = Some(timestamp), properties)
+      target, isShallow, replace, properties, versionAsOf = None, timestampAsOf = Some(timestamp))
   }
 
   /**

--- a/spark-connect/client/src/main/scala-spark-master/io/delta/connect/tables/DeltaTable.scala
+++ b/spark-connect/client/src/main/scala-spark-master/io/delta/connect/tables/DeltaTable.scala
@@ -524,23 +524,6 @@ class DeltaTable private[tables](
   }
 
   /**
-   * Clone a DeltaTable to a given destination to mirror the existing table's data and metadata.
-   *
-   * An example would be
-   * {{{
-   *   io.delta.tables.DeltaTable.clone(
-   *     "/some/path/to/table")
-   * }}}
-   *
-   * @param target The path or table name to create the clone.
-   *
-   * @since 4.0.0
-   */
-  def clone(target: String): DeltaTable = {
-    clone(target, isShallow = false)
-  }
-
-  /**
    * Clone a DeltaTable at a specific version to a given destination to mirror the existing
    * table's data and metadata at that version.
    *
@@ -619,26 +602,6 @@ class DeltaTable private[tables](
    */
   def cloneAtVersion(version: Int, target: String, isShallow: Boolean): DeltaTable = {
     cloneAtVersion(version, target, isShallow, replace = false)
-  }
-
-  /**
-   * Clone a DeltaTable at a specific version to a given destination to mirror the existing
-   * table's data and metadata at that version.
-   *
-   * An example would be
-   * {{{
-   *   io.delta.tables.DeltaTable.cloneAtVersion(
-   *     5,
-   *     "/some/path/to/table")
-   * }}}
-   *
-   * @param version The version of this table to clone from.
-   * @param target The path or table name to create the clone.
-   *
-   * @since 4.0.0
-   */
-  def cloneAtVersion(version: Int, target: String): DeltaTable = {
-    cloneAtVersion(version, target, isShallow = false)
   }
 
   /**
@@ -727,28 +690,6 @@ class DeltaTable private[tables](
    */
   def cloneAtTimestamp(timestamp: String, target: String, isShallow: Boolean): DeltaTable = {
     cloneAtTimestamp(timestamp, target, isShallow, replace = false)
-  }
-
-  /**
-   * Clone a DeltaTable at a specific timestamp to a given destination to mirror the existing
-   * table's data and metadata at that timestamp.
-   *
-   * Timestamp can be of the format yyyy-MM-dd or yyyy-MM-dd HH:mm:ss.
-   *
-   * An example would be
-   * {{{
-   *   io.delta.tables.DeltaTable.cloneAtTimestamp(
-   *     "2019-01-01",
-   *     "/some/path/to/table")
-   * }}}
-   *
-   * @param timestamp The timestamp of this table to clone from.
-   * @param target The path or table name to create the clone.
-   *
-   * @since 4.0.0
-   */
-  def cloneAtTimestamp(timestamp: String, target: String): DeltaTable = {
-    cloneAtTimestamp(timestamp, target, isShallow = false)
   }
 
   /**

--- a/spark-connect/client/src/test/scala-spark-master/io/delta/connect/tables/DeltaTableSuite.scala
+++ b/spark-connect/client/src/test/scala-spark-master/io/delta/connect/tables/DeltaTableSuite.scala
@@ -222,7 +222,7 @@ class DeltaTableSuite extends DeltaQueryTest with RemoteSparkSession {
       spark.range(10).write.format("delta").save(srcDir)
 
       val srcTable = io.delta.tables.DeltaTable.forPath(spark, srcDir)
-      srcTable.clone(dstDir)
+      srcTable.clone(dstDir, true)
 
       checkAnswer(
         spark.read.format("delta").load(dstDir),
@@ -252,7 +252,7 @@ class DeltaTableSuite extends DeltaQueryTest with RemoteSparkSession {
 
       val srcTable = io.delta.tables.DeltaTable.forPath(spark, srcDir)
 
-      srcTable.cloneAtVersion(1, dstDir)
+      srcTable.cloneAtVersion(1, dstDir, true)
 
       checkAnswer(
         spark.read.format("delta").load(dstDir),

--- a/spark-connect/common/src/main/protobuf/delta/connect/commands.proto
+++ b/spark-connect/common/src/main/protobuf/delta/connect/commands.proto
@@ -27,6 +27,9 @@ option java_package = "io.delta.connect.proto";
 message DeltaCommand {
   oneof command_type {
     CloneTable clone_table = 1;
+    VacuumTable vacuum_table = 2;
+    UpgradeTableProtocol upgrade_table_protocol = 3;
+    Generate generate = 4;
   }
 }
 
@@ -56,4 +59,36 @@ message CloneTable {
   // (Required) User-defined table properties that override properties with the same key in the
   // source table.
   map<string, string> properties = 7;
+}
+
+// Command that deletes files and directories in the table that are not needed by the table for
+// maintaining older versions up to the given retention threshold
+message VacuumTable {
+  // (Required) The Delta table to vacuum.
+  DeltaTable table = 1;
+
+  // (Optional) Number of hours retain history for. If not specified, then the default retention
+  // period will be used.
+  optional double retention_hours = 2;
+}
+
+// Command to updates the protocol version of the table so that new features can be used.
+message UpgradeTableProtocol {
+  // (Required) The Delta table to upgrade the protocol of.
+  DeltaTable table = 1;
+
+  // (Required) The minimum required reader protocol version.
+  int32 reader_version = 2;
+
+  // (Required) The minimum required writer protocol version.
+  int32 writer_version = 3;
+}
+
+// Command that generates manifest files for a given Delta table.
+message Generate {
+  // (Required) The Delta table to generate the manifest files for.
+  DeltaTable table = 1;
+
+  // (Required) The type of manifest file to be generated.
+  string mode = 2;
 }

--- a/spark-connect/common/src/main/protobuf/delta/connect/commands.proto
+++ b/spark-connect/common/src/main/protobuf/delta/connect/commands.proto
@@ -62,7 +62,7 @@ message CloneTable {
 }
 
 // Command that deletes files and directories in the table that are not needed by the table for
-// maintaining older versions up to the given retention threshold
+// maintaining older versions up to the given retention threshold.
 message VacuumTable {
   // (Required) The Delta table to vacuum.
   DeltaTable table = 1;

--- a/spark-connect/common/src/main/scala-spark-master/io/delta/connect/ImplicitProtoConversions.scala
+++ b/spark-connect/common/src/main/scala-spark-master/io/delta/connect/ImplicitProtoConversions.scala
@@ -33,6 +33,17 @@ object ImplicitProtoConversions {
     delta_spark_proto.Relation.parseFrom(relation.toByteArray)
   }
 
+  implicit def convertCommandToSpark(
+      command: delta_spark_proto.Command): spark_proto.Command = {
+    ConnectProtoUtils.parseCommandWithRecursionLimit(command.toByteArray, recursionLimit = 1024)
+  }
+
+  implicit def convertCommandToDelta(
+      command: spark_proto.Command): delta_spark_proto.Command = {
+    // TODO: Recursion limits
+    delta_spark_proto.Command.parseFrom(command.toByteArray)
+  }
+
   implicit def convertExpressionToSpark(
       expr: delta_spark_proto.Expression): spark_proto.Expression = {
     ConnectProtoUtils.parseExpressionWithRecursionLimit(expr.toByteArray, recursionLimit = 1024)

--- a/spark-connect/server/src/main/scala-spark-master/io/delta/connect/DeltaPlannerBase.scala
+++ b/spark-connect/server/src/main/scala-spark-master/io/delta/connect/DeltaPlannerBase.scala
@@ -19,19 +19,20 @@ package org.apache.spark.sql.connect.delta
 import io.delta.connect.proto
 import io.delta.tables.DeltaTable
 
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 
 /**
  * Base trait for the planner plugins of Delta Connect.
  */
 trait DeltaPlannerBase {
   protected def transformDeltaTable(
-      spark: SparkSession, deltaTable: proto.DeltaTable): DeltaTable = {
-    deltaTable.getAccessTypeCase match {
+      planner: SparkConnectPlanner, deltaTable: proto.DeltaTable): DeltaTable = {
+     deltaTable.getAccessTypeCase match {
       case proto.DeltaTable.AccessTypeCase.PATH =>
-        DeltaTable.forPath(spark, deltaTable.getPath.getPath, deltaTable.getPath.getHadoopConfMap)
+        DeltaTable.forPath(
+          planner.session, deltaTable.getPath.getPath, deltaTable.getPath.getHadoopConfMap)
       case proto.DeltaTable.AccessTypeCase.TABLE_OR_VIEW_NAME =>
-        DeltaTable.forName(spark, deltaTable.getTableOrViewName)
+        DeltaTable.forName(planner.session, deltaTable.getTableOrViewName)
     }
   }
 }

--- a/spark-connect/server/src/main/scala-spark-master/io/delta/connect/DeltaPlannerBase.scala
+++ b/spark-connect/server/src/main/scala-spark-master/io/delta/connect/DeltaPlannerBase.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 trait DeltaPlannerBase {
   protected def transformDeltaTable(
       planner: SparkConnectPlanner, deltaTable: proto.DeltaTable): DeltaTable = {
-     deltaTable.getAccessTypeCase match {
+    deltaTable.getAccessTypeCase match {
       case proto.DeltaTable.AccessTypeCase.PATH =>
         DeltaTable.forPath(
           planner.session, deltaTable.getPath.getPath, deltaTable.getPath.getHadoopConfMap)

--- a/spark-connect/server/src/test/scala-spark-master/io/delta/connect/DeltaConnectPlannerSuite.scala
+++ b/spark-connect/server/src/test/scala-spark-master/io/delta/connect/DeltaConnectPlannerSuite.scala
@@ -306,7 +306,7 @@ class DeltaConnectPlannerSuite
       spark.range(start = 0, end = 2000, step = 1, numPartitions = 2)
         .write.format("delta").mode("append").save(dir.getAbsolutePath)
 
-      val log = DeltaLog.forTable(spark, dir)
+      val deltaLog = DeltaLog.forTable(spark, dir)
       val input = createSparkRelation(
         proto.DeltaRelation
           .newBuilder()
@@ -317,7 +317,7 @@ class DeltaConnectPlannerSuite
                   proto.DeltaTable.Path.newBuilder().setPath(dir.getAbsolutePath)
                 )
               )
-              .setTimestamp(getTimestampForVersion(log, version = 0))
+              .setTimestamp(getTimestampForVersion(deltaLog, version = 0))
           )
       )
 
@@ -484,9 +484,9 @@ class DeltaConnectPlannerSuite
           spark.read.format("delta").load(targetDir.getAbsolutePath),
           spark.read.table(sourceTableName))
 
-        // Check that a shallow clone was performed
-        val log = DeltaLog.forTable(spark, targetDir)
-        log.update().allFiles.collect().foreach { f =>
+        // Check that a shallow clone was performed.
+        val deltaLog = DeltaLog.forTable(spark, targetDir)
+        deltaLog.update().allFiles.collect().foreach { f =>
           assert(f.pathAsUri.isAbsolute)
         }
       }
@@ -518,9 +518,9 @@ class DeltaConnectPlannerSuite
     withTable(tableName) {
       // Set up a Delta table with an untracked file.
       spark.range(1000).write.format("delta").saveAsTable(tableName)
-      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
       val tempFile =
-        new File(DeltaFileOperations.absolutePath(log.dataPath.toString, "abc.parquet").toUri)
+        new File(DeltaFileOperations.absolutePath(deltaLog.dataPath.toString, "abc.parquet").toUri)
       tempFile.createNewFile()
 
       // Run a vacuum with the untracked file still within the retention period.
@@ -552,9 +552,9 @@ class DeltaConnectPlannerSuite
     withTable(tableName) {
       // Set up a Delta table with an untracked file.
       spark.range(1000).write.format("delta").saveAsTable(tableName)
-      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
       val tempFile =
-        new File(DeltaFileOperations.absolutePath(log.dataPath.toString, "abc.parquet").toUri)
+        new File(DeltaFileOperations.absolutePath(deltaLog.dataPath.toString, "abc.parquet").toUri)
       tempFile.createNewFile()
 
       // Run a vacuum with the untracked file still within the retention period.
@@ -585,8 +585,8 @@ class DeltaConnectPlannerSuite
       // Check that protocol version is as expected, before we upgrade it.
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
       val oldProtocol = deltaLog.update().protocol
-      assert(oldProtocol.minReaderVersion == oldReaderVersion)
-      assert(oldProtocol.minWriterVersion == oldWriterVersion)
+      assert(oldProtocol.minReaderVersion === oldReaderVersion)
+      assert(oldProtocol.minWriterVersion === oldWriterVersion)
 
       // Use Delta Connect to upgrade the protocol of the table.
       val newReaderVersion = 2
@@ -603,8 +603,8 @@ class DeltaConnectPlannerSuite
 
       // Check that protocol version is as expected, after we have upgraded it.
       val newProtocol = deltaLog.update().protocol
-      assert(newProtocol.minReaderVersion == newReaderVersion)
-      assert(newProtocol.minWriterVersion == newWriterVersion)
+      assert(newProtocol.minReaderVersion === newReaderVersion)
+      assert(newProtocol.minWriterVersion === newWriterVersion)
     }
   }
 
@@ -622,7 +622,9 @@ class DeltaConnectPlannerSuite
                 proto.DeltaTable.newBuilder()
                   .setPath(proto.DeltaTable.Path.newBuilder().setPath(dir.getAbsolutePath)))
               .setMode("symlink_format_manifest"))))
+
       assert(manifestFile.exists())
+
     }
   }
 

--- a/spark-connect/server/src/test/scala-spark-master/io/delta/connect/DeltaConnectPlannerSuite.scala
+++ b/spark-connect/server/src/test/scala-spark-master/io/delta/connect/DeltaConnectPlannerSuite.scala
@@ -26,21 +26,23 @@ import io.delta.connect.spark.{proto => spark_proto}
 import io.delta.tables.DeltaTable
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.delta.ImplicitProtoConversions._
-import org.apache.spark.sql.connect.planner.{SparkConnectPlanner, SparkConnectPlanTest}
+import org.apache.spark.sql.connect.planner.{SparkConnectPlanTest, SparkConnectPlanner}
 import org.apache.spark.sql.connect.service.{SessionHolder, SparkConnectService}
-import org.apache.spark.sql.delta.{DataFrameUtils, DeltaHistory, DeltaLog}
+import org.apache.spark.sql.delta.{DataFrameUtils, DeltaConfigs, DeltaHistory, DeltaLog}
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.commands.{DescribeDeltaDetailCommand, DescribeDeltaHistory}
+import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.util.{DeltaFileOperations, FileNames}
 import org.apache.spark.sql.functions._
 
 class DeltaConnectPlannerSuite
@@ -51,6 +53,11 @@ class DeltaConnectPlannerSuite
   protected override def sparkConf: SparkConf = {
     super.sparkConf
       .set(Connect.CONNECT_EXTENSIONS_RELATION_CLASSES.key, classOf[DeltaRelationPlugin].getName)
+      .set(Connect.CONNECT_EXTENSIONS_COMMAND_CLASSES.key, classOf[DeltaCommandPlugin].getName)
+  }
+
+  private def createSparkCommand(command: proto.DeltaCommand.Builder): spark_proto.Command = {
+    spark_proto.Command.newBuilder().setExtension(protobuf.Any.pack(command.build())).build()
   }
 
   private def createSparkRelation(relation: proto.DeltaRelation.Builder): spark_proto.Relation = {
@@ -452,6 +459,170 @@ class DeltaConnectPlannerSuite
         spark.read.table(tableName),
         Seq.tabulate(1000)(i => Row(i, if (i % 2 == 0) i + 1 else i))
       )
+    }
+  }
+
+  test("clone - shallow") {
+    withTempDir { targetDir =>
+      val sourceTableName = "source_table"
+      withTable(sourceTableName) {
+        spark.range(end = 1000).write.format("delta").saveAsTable(sourceTableName)
+
+        transform(createSparkCommand(
+          proto.DeltaCommand.newBuilder()
+            .setCloneTable(
+              proto.CloneTable.newBuilder()
+                .setTable(proto.DeltaTable.newBuilder().setTableOrViewName(sourceTableName))
+                .setTarget(targetDir.getAbsolutePath)
+                .setIsShallow(true)
+                .setReplace(true)
+            )
+        ))
+
+        // Check that we have successfully cloned the table.
+        checkAnswer(
+          spark.read.format("delta").load(targetDir.getAbsolutePath),
+          spark.read.table(sourceTableName))
+
+        // Check that a shallow clone was performed
+        val log = DeltaLog.forTable(spark, targetDir)
+        log.update().allFiles.collect().foreach { f =>
+          assert(f.pathAsUri.isAbsolute)
+        }
+      }
+    }
+  }
+
+  test("vacuum - without retention hours argument") {
+    val tableName = "test_table"
+
+    def runVacuum(): Unit = {
+      transform(createSparkCommand(
+        proto.DeltaCommand.newBuilder()
+          .setVacuumTable(
+            proto.VacuumTable.newBuilder()
+              .setTable(proto.DeltaTable.newBuilder().setTableOrViewName(tableName))
+          )
+      ))
+    }
+
+    def setRetentionInterval(retentionInterval: String): Unit = {
+      spark.sql(
+        s"""ALTER TABLE $tableName
+           |SET TBLPROPERTIES (
+           |  '${DeltaConfigs.TOMBSTONE_RETENTION.key}' = '$retentionInterval'
+           |)""".stripMargin
+      )
+    }
+
+    withTable(tableName) {
+      // Set up a Delta table with an untracked file.
+      spark.range(1000).write.format("delta").saveAsTable(tableName)
+      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val tempFile =
+        new File(DeltaFileOperations.absolutePath(log.dataPath.toString, "abc.parquet").toUri)
+      tempFile.createNewFile()
+
+      // Run a vacuum with the untracked file still within the retention period.
+      setRetentionInterval(retentionInterval = "1000 hours")
+      runVacuum()
+      assert(tempFile.exists())
+
+      // Run a vacuum with the untracked file outside of the retention period.
+      setRetentionInterval(retentionInterval = "0 hours")
+      runVacuum()
+      assert(!tempFile.exists())
+    }
+  }
+
+  test("vacuum - with retention hours argument") {
+    val tableName = "test_table"
+
+    def runVacuum(retentionHours: Float): Unit = {
+      transform(createSparkCommand(
+        proto.DeltaCommand.newBuilder()
+          .setVacuumTable(
+            proto.VacuumTable.newBuilder()
+              .setTable(proto.DeltaTable.newBuilder().setTableOrViewName(tableName))
+              .setRetentionHours(retentionHours)
+          )
+      ))
+    }
+
+    withTable(tableName) {
+      // Set up a Delta table with an untracked file.
+      spark.range(1000).write.format("delta").saveAsTable(tableName)
+      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val tempFile =
+        new File(DeltaFileOperations.absolutePath(log.dataPath.toString, "abc.parquet").toUri)
+      tempFile.createNewFile()
+
+      // Run a vacuum with the untracked file still within the retention period.
+      runVacuum(retentionHours = 1000.0f)
+      assert(tempFile.exists())
+
+      // Run a vacuum with the untracked file outside of the retention period.
+      withSQLConf(DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false") {
+        runVacuum(retentionHours = 0.0f)
+      }
+      assert(!tempFile.exists())
+    }
+  }
+
+  test("upgrade table protocol") {
+    val tableName = "test_table"
+    withTable(tableName) {
+      // Create a Delta table with protocol version (1, 1).
+      val oldReaderVersion = 1
+      val oldWriterVersion = 1
+      spark.range(1000)
+        .write
+        .format("delta")
+        .option(DeltaConfigs.MIN_READER_VERSION.key, oldReaderVersion)
+        .option(DeltaConfigs.MIN_WRITER_VERSION.key, oldWriterVersion)
+        .saveAsTable(tableName)
+
+      // Check that protocol version is as expected, before we upgrade it.
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val oldProtocol = deltaLog.update().protocol
+      assert(oldProtocol.minReaderVersion == oldReaderVersion)
+      assert(oldProtocol.minWriterVersion == oldWriterVersion)
+
+      // Use Delta Connect to upgrade the protocol of the table.
+      val newReaderVersion = 2
+      val newWriterVersion = 5
+      transform(createSparkCommand(
+        proto.DeltaCommand.newBuilder()
+          .setUpgradeTableProtocol(
+            proto.UpgradeTableProtocol.newBuilder()
+              .setTable(proto.DeltaTable.newBuilder().setTableOrViewName(tableName))
+              .setReaderVersion(newReaderVersion)
+              .setWriterVersion(newWriterVersion)
+          )
+      ))
+
+      // Check that protocol version is as expected, after we have upgraded it.
+      val newProtocol = deltaLog.update().protocol
+      assert(newProtocol.minReaderVersion == newReaderVersion)
+      assert(newProtocol.minWriterVersion == newWriterVersion)
+    }
+  }
+
+  test("generate manifest") {
+    withTempDir { dir =>
+      spark.range(1000).write.format("delta").mode("overwrite").save(dir.getAbsolutePath)
+
+      val manifestFile = new File(dir, GenerateSymlinkManifest.MANIFEST_LOCATION)
+      assert(!manifestFile.exists())
+      transform(createSparkCommand(
+        proto.DeltaCommand.newBuilder()
+          .setGenerate(
+            proto.Generate.newBuilder()
+              .setTable(
+                proto.DeltaTable.newBuilder()
+                  .setPath(proto.DeltaTable.Path.newBuilder().setPath(dir.getAbsolutePath)))
+              .setMode("symlink_format_manifest"))))
+      assert(manifestFile.exists())
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [] Other

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
- Adds the following new API to the Scala Delta Connect client : `clone`, `vacuum`, `generate` and `upgradeTableProtocol`.
- Adds the proto definitions for the aforementioned APIs.
- Adds the server-side implementation of the aforementioned APIs.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New tests in `DeltaConnectPlannerSuite` (server-side changes) and in `DeltaTableSuite` (Note: these tests are set to `ignore` until https://github.com/delta-io/delta/pull/4468 is merged)

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. 
Adds the `clone`, `vacuum`, `generate` and `upgradeTableProtocol` APIs to the Scala Delta Connect client.