### PR TITLE
[Kernel] Allow kernel to write Type Widening enable

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -175,18 +175,6 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
         }
       };
 
-  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPE_WIDENING =
-      (inputContext) -> {
-        if (inputContext.newProtocol.supportsFeature(TYPE_WIDENING_RW_FEATURE)) {
-          // TODO: Currently Kernel has no support for writing with type widening. When it is
-          //  supported extend this to allow a whitelist of supported type widening in Iceberg
-          return;
-        } else if (inputContext.newProtocol.supportsFeature(TYPE_WIDENING_PREVIEW_TABLE_FEATURE)) {
-          throw DeltaErrors.unsupportedTableFeature(
-              TYPE_WIDENING_PREVIEW_TABLE_FEATURE.featureName());
-        }
-      };
-
   @Override
   String compatFeatureName() {
     return "icebergCompatV2";
@@ -214,8 +202,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
             ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPES,
             ICEBERG_COMPAT_V2_CHECK_HAS_ALLOWED_PARTITION_TYPES,
             ICEBERG_COMPAT_V2_CHECK_HAS_NO_PARTITION_EVOLUTION,
-            ICEBERG_COMPAT_V2_CHECK_HAS_NO_DELETION_VECTORS,
-            ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPE_WIDENING)
+            ICEBERG_COMPAT_V2_CHECK_HAS_NO_DELETION_VECTORS)
         .collect(toList());
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -180,7 +180,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
         if (inputContext.newProtocol.supportsFeature(TYPE_WIDENING_RW_FEATURE)) {
           // TODO: Currently Kernel has no support for writing with type widening. When it is
           //  supported extend this to allow a whitelist of supported type widening in Iceberg
-          throw DeltaErrors.unsupportedTableFeature(TYPE_WIDENING_RW_FEATURE.featureName());
+          return;
         } else if (inputContext.newProtocol.supportsFeature(TYPE_WIDENING_PREVIEW_TABLE_FEATURE)) {
           throw DeltaErrors.unsupportedTableFeature(
               TYPE_WIDENING_PREVIEW_TABLE_FEATURE.featureName());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -304,7 +304,7 @@ public class TableFeatures {
 
     @Override
     public boolean hasKernelWriteSupport(Metadata metadata) {
-      return false; // TODO: yet to support it.
+      return true;
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -120,26 +120,6 @@ trait IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase extends AnyFunSuite
   }
 
   Seq(true, false).foreach { isNewTable =>
-    Seq(TYPE_WIDENING_RW_FEATURE, TYPE_WIDENING_PREVIEW_TABLE_FEATURE).foreach {
-      typeWideningFeature =>
-        test(s"can't enable icebergCompatV2 on a table with $typeWideningFeature supported, " +
-          s"isNewTable = $isNewTable") {
-          val schema = new StructType().add("col", BooleanType.BOOLEAN)
-          val metadata = getCompatEnabledMetadata(schema)
-          val protocol = getCompatEnabledProtocol(typeWideningFeature)
-
-          val ex = intercept[KernelException] {
-            runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
-          }
-          assert(ex.getMessage.contains(
-            s"Unsupported Delta table feature: table requires feature " +
-              s""""${typeWideningFeature.featureName()}" which is unsupported by this version """ +
-              s"of Delta Kernel."))
-        }
-    }
-  }
-
-  Seq(true, false).foreach { isNewTable =>
     test(s"can't enable icebergCompatV2 on a table with icebergCompatv1 enabled, " +
       s"isNewTable = $isNewTable") {
       val schema = new StructType().add("col", BooleanType.BOOLEAN)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -265,8 +265,8 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
       "v2Checkpoint",
       "inCommitTimestamp",
       "clustering",
-      // "typeWidening", add this to this test once we support typeWidening
-      // "typeWidening-preview", add this to this test once we support typeWidening
+      "typeWidening",
+      "typeWidening-preview",
       "timestampNtz")
     val protocol = new Protocol(3, 7, readerFeatures.asJava, writerFeatures.asJava)
     val metadata = getCompatEnabledMetadata(cmTestSchema())
@@ -293,19 +293,6 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
       }
       assert(e.getMessage.contains(expectedErrorMessageContains))
     }
-  }
-
-  Seq("typeWidening", "typeWidening-preview").foreach {
-    unsupportedCompatibleFeature =>
-      test(s"cannot enable with compatible UNSUPPORTED feature $unsupportedCompatibleFeature") {
-        // We add this test here so that it will fail when we add Kernel support for these features
-        // When this happens -> add the feature to the test above
-        checkUnsupportedOrIncompatibleFeature(
-          unsupportedCompatibleFeature,
-          "Unsupported Delta table feature: table requires feature " +
-            s""""$unsupportedCompatibleFeature" which is unsupported by this version of """ +
-            "Delta Kernel")
-      }
   }
 
   Seq(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -238,6 +238,8 @@ class TableFeaturesSuite extends AnyFunSuite {
       "changeDataFeed",
       "timestampNtz",
       "identityColumns",
+      "typeWidening-preview",
+      "typeWidening",
       "icebergWriterCompatV1",
       "clustering")
 
@@ -504,13 +506,13 @@ class TableFeaturesSuite extends AnyFunSuite {
     testMetadata(includeTimestampNtzTypeCol = true))
 
   Seq("typeWidening", "typeWidening-preview").foreach { feature =>
-    checkWriteUnsupported(
+    checkWriteSupported(
       s"validateKernelCanWriteToTable: protocol 7 with $feature, " +
         s"metadata doesn't contains $feature",
       new Protocol(3, 7, singleton(feature), singleton(feature)),
       testMetadata())
 
-    checkWriteUnsupported(
+    checkWriteSupported(
       s"validateKernelCanWriteToTable: protocol 7 with $feature, " +
         s"metadata contains $feature",
       new Protocol(3, 7, singleton(feature), singleton(feature)),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -183,17 +183,6 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
     }
   }
 
-  test("can't enable icebergCompatV2 on a table with type widening supported also enabled") {
-    withTempDirAndEngine { (tablePath, engine) =>
-      checkError[KernelException]("Unsupported Delta writer feature") {
-        val tblProps = Map(
-          TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true",
-          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
-        createEmptyTable(engine, tablePath, testSchema, tableProperties = tblProps)
-      }
-    }
-  }
-
   ignore("can't enable icebergCompatV2 on a table with icebergCompatv1 enabled") {
     // We can't test this as Kernel throws error when enabling icebergCompatV1
     // as there is no support it in the current version.

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -558,7 +558,13 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
 
   test("legacy table features allowed with icebergWriterCompatV1 if inactive") {
     val tblProperties =
-      Seq("invariants", "changeDataFeed", "checkConstraints", "identityColumns", "generatedColumns", "typeWidening")
+      Seq(
+        "invariants",
+        "changeDataFeed",
+        "checkConstraints",
+        "identityColumns",
+        "generatedColumns",
+        "typeWidening")
         .map(tableFeature => s"delta.feature.$tableFeature" -> "supported")
         .toMap
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -564,7 +564,8 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
         "checkConstraints",
         "identityColumns",
         "generatedColumns",
-        "typeWidening")
+        "typeWidening",
+        "typeWidening-preview")
         .map(tableFeature => s"delta.feature.$tableFeature" -> "supported")
         .toMap
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -558,7 +558,7 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
 
   test("legacy table features allowed with icebergWriterCompatV1 if inactive") {
     val tblProperties =
-      Seq("invariants", "changeDataFeed", "checkConstraints", "identityColumns", "generatedColumns")
+      Seq("invariants", "changeDataFeed", "checkConstraints", "identityColumns", "generatedColumns", "typeWidening")
         .map(tableFeature => s"delta.feature.$tableFeature" -> "supported")
         .toMap
 
@@ -599,6 +599,7 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
       assert(protocol.supportsFeature(TableFeatures.CONSTRAINTS_W_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.CHANGE_DATA_FEED_W_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.INVARIANTS_W_FEATURE))
+      assert(protocol.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
     }
   }
 
@@ -610,7 +611,8 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
       TableConfig.APPEND_ONLY_ENABLED.getKey -> "true", // appendOnly
       TableConfig.CHECKPOINT_POLICY.getKey -> "v2", // checkpointV2
       TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true", // inCommitTimestamp
-      TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.getKey -> "true")
+      TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.getKey -> "true",
+      TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")
     val schema = new StructType()
       .add("c1", IntegerType.INTEGER)
       .add("c2", TimestampNTZType.TIMESTAMP_NTZ) // timestampNtz
@@ -660,24 +662,13 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
       // assert(protocol.supportsFeature(TableFeatures.TIMESTAMP_NTZ_RW_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.DOMAIN_METADATA_W_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.INVARIANTS_W_FEATURE))
-      // TODO in the future add typeWidening and clustering once they are supported
+      assert(protocol.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
+      // TODO in the future add clustering once they are supported
     }
   }
 
   /* -------------------- Enforcements blocked by icebergCompatV2 -------------------- */
   // We test the deletionVector checks above as part of blocked table feature tests
-
-  // We don't support typeWidening yet in Kernel or for icebergCompatV2; when we add support update
-  // these tests (only certain transforms allowed) and add to the above test for compatible table
-  // features
-
-  testIncompatibleUnsupportedTableFeature(
-    "typeWidening",
-    tablePropertiesToEnable = Map("delta.enableTypeWidening" -> "true"))
-
-  testIncompatibleUnsupportedTableFeature(
-    "typeWidening inactive",
-    tablePropertiesToEnable = Map("delta.feature.typeWidening" -> "supported"))
 
   // We cannot test enabling icebergCompatV1 since it is not a table feature in Kernel; This is
   // tested in the unit tests in IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Currently having this flag return 'false' prevents kernel from writing any table where this is feature is present.  this is the first change for #4491 .

## How was this patch tested?

N/A flag flip

## Does this PR introduce _any_ user-facing changes?

Yes, kernel will now be able to write the table with this table feature set.