### PR TITLE
[Kernel] Update column mapping and schema evolution code to support usage with replace table

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -611,7 +611,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
           oldMetadata,
           newMetadata,
           clusteringColumnPhysicalNames,
-          false /* allowNewNonNullFields*/);
+          false /* allowNewRequiredFields*/);
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -608,11 +608,10 @@ public class TransactionBuilderImpl implements TransactionBuilder {
               .collect(toSet());
 
       SchemaUtils.validateUpdatedSchema(
-          oldMetadata.getSchema(),
-          newMetadata.getSchema(),
-          oldMetadata.getPartitionColNames(),
+          oldMetadata,
+          newMetadata,
           clusteringColumnPhysicalNames,
-          newMetadata);
+          false /* allowNewNonNullFields*/);
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -131,14 +131,6 @@ public class ColumnMapping {
     return field.getMetadata().getLong(COLUMN_MAPPING_ID_KEY).intValue();
   }
 
-  public static boolean hasColumnId(StructField field) {
-    return field.getMetadata().contains(COLUMN_MAPPING_ID_KEY);
-  }
-
-  public static boolean hasPhysicalName(StructField field) {
-    return field.getMetadata().contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
-  }
-
   public static void verifyColumnMappingChange(
       Map<String, String> oldConfig, Map<String, String> newConfig, boolean isNewTable) {
     ColumnMappingMode oldMappingMode = getColumnMappingMode(oldConfig);
@@ -216,6 +208,14 @@ public class ColumnMapping {
       maxColumnId = findMaxColumnId(field, maxColumnId);
     }
     return maxColumnId;
+  }
+
+  static boolean hasColumnId(StructField field) {
+    return field.getMetadata().contains(COLUMN_MAPPING_ID_KEY);
+  }
+
+  static boolean hasPhysicalName(StructField field) {
+    return field.getMetadata().contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
   }
 
   private static int findMaxColumnId(StructField field, int maxColumnId) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -101,18 +101,27 @@ public class SchemaUtils {
    * </ul>
    */
   public static void validateUpdatedSchema(
-      StructType currentSchema,
-      StructType newSchema,
-      Set<String> currentPartitionColumns,
+      Metadata currentMetadata,
+      Metadata newMetadata,
       Set<String> clusteringColumnPhysicalNames,
-      Metadata newMetadata) {
+      boolean allowNewNonNullFields) {
     checkArgument(
         isColumnMappingModeEnabled(
             ColumnMapping.getColumnMappingMode(newMetadata.getConfiguration())),
         "Cannot validate updated schema when column mapping is disabled");
-    validateSchema(newSchema, true /*columnMappingEnabled*/);
-    validatePartitionColumns(newSchema, new ArrayList<>(currentPartitionColumns));
-    validateSchemaEvolution(currentSchema, newSchema, newMetadata, clusteringColumnPhysicalNames);
+    validateSchema(newMetadata.getSchema(), true /*columnMappingEnabled*/);
+    validatePartitionColumns(
+        newMetadata.getSchema(), new ArrayList<>(newMetadata.getPartitionColNames()));
+    int currentMaxFieldId =
+        Integer.parseInt(
+            currentMetadata.getConfiguration().getOrDefault(COLUMN_MAPPING_MAX_COLUMN_ID_KEY, "0"));
+    validateSchemaEvolution(
+        currentMetadata.getSchema(),
+        newMetadata.getSchema(),
+        ColumnMapping.getColumnMappingMode(newMetadata.getConfiguration()),
+        clusteringColumnPhysicalNames,
+        currentMaxFieldId,
+        allowNewNonNullFields);
   }
 
   /**
@@ -426,21 +435,25 @@ public class SchemaUtils {
   private static void validateSchemaEvolution(
       StructType currentSchema,
       StructType newSchema,
-      Metadata metadata,
-      Set<String> clusteringColumnPhysicalNames) {
-    ColumnMappingMode columnMappingMode =
-        ColumnMapping.getColumnMappingMode(metadata.getConfiguration());
-    switch (columnMappingMode) {
+      ColumnMappingMode cmMode,
+      Set<String> clusteringColumnPhysicalNames,
+      int currentMaxFieldId,
+      boolean allowNewNonNullFields) {
+    switch (cmMode) {
       case ID:
       case NAME:
-        validateSchemaEvolutionById(currentSchema, newSchema, clusteringColumnPhysicalNames);
+        validateSchemaEvolutionById(
+            currentSchema,
+            newSchema,
+            clusteringColumnPhysicalNames,
+            currentMaxFieldId,
+            allowNewNonNullFields);
         return;
       case NONE:
         throw new UnsupportedOperationException(
             "Schema evolution without column mapping is not supported");
       default:
-        throw new UnsupportedOperationException(
-            "Unknown column mapping mode: " + columnMappingMode);
+        throw new UnsupportedOperationException("Unknown column mapping mode: " + cmMode);
     }
   }
 
@@ -449,14 +462,18 @@ public class SchemaUtils {
    * fields
    */
   private static void validateSchemaEvolutionById(
-      StructType currentSchema, StructType newSchema, Set<String> clusteringColumnPhysicalNames) {
+      StructType currentSchema,
+      StructType newSchema,
+      Set<String> clusteringColumnPhysicalNames,
+      int oldMaxFieldId,
+      boolean allowNewNonNullFields) {
     Map<Integer, StructField> currentFieldsById = fieldsById(currentSchema);
     Map<Integer, StructField> updatedFieldsById = fieldsById(newSchema);
     SchemaChanges schemaChanges = computeSchemaChangesById(currentFieldsById, updatedFieldsById);
     validatePhysicalNameConsistency(schemaChanges.updatedFields());
     // Validates that the updated schema does not contain breaking changes in terms of types and
     // nullability
-    validateUpdatedSchemaCompatibility(schemaChanges);
+    validateUpdatedSchemaCompatibility(schemaChanges, oldMaxFieldId, allowNewNonNullFields);
     validateClusteringColumnsNotDropped(
         schemaChanges.removedFields(), clusteringColumnPhysicalNames);
     // ToDo Potentially validate IcebergCompatV2 nested IDs
@@ -480,11 +497,20 @@ public class SchemaUtils {
    *
    * <p>ToDo: Prevent moving fields outside of their containing struct
    */
-  private static void validateUpdatedSchemaCompatibility(SchemaChanges schemaChanges) {
+  private static void validateUpdatedSchemaCompatibility(
+      SchemaChanges schemaChanges, int oldMaxFieldId, boolean allowNewNonNullFields) {
     for (StructField addedField : schemaChanges.addedFields()) {
-      if (!addedField.isNullable()) {
+      if (!allowNewNonNullFields && !addedField.isNullable()) {
         throw new KernelException(
             String.format("Cannot add non-nullable field %s", addedField.getName()));
+      }
+      int colId = getColumnId(addedField);
+      if (colId <= oldMaxFieldId) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Cannot add a new column with a fieldId <= maxFieldId. Found field: %s with"
+                    + "fieldId=%s. Current maxFieldId in the table is: %s",
+                addedField, colId, oldMaxFieldId));
       }
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -104,7 +104,7 @@ public class SchemaUtils {
       Metadata currentMetadata,
       Metadata newMetadata,
       Set<String> clusteringColumnPhysicalNames,
-      boolean allowNewNonNullFields) {
+      boolean allowNewRequiredFields) {
     checkArgument(
         isColumnMappingModeEnabled(
             ColumnMapping.getColumnMappingMode(newMetadata.getConfiguration())),
@@ -121,7 +121,7 @@ public class SchemaUtils {
         ColumnMapping.getColumnMappingMode(newMetadata.getConfiguration()),
         clusteringColumnPhysicalNames,
         currentMaxFieldId,
-        allowNewNonNullFields);
+        allowNewRequiredFields);
   }
 
   /**
@@ -435,11 +435,11 @@ public class SchemaUtils {
   private static void validateSchemaEvolution(
       StructType currentSchema,
       StructType newSchema,
-      ColumnMappingMode cmMode,
+      ColumnMappingMode columnMappingMode,
       Set<String> clusteringColumnPhysicalNames,
       int currentMaxFieldId,
-      boolean allowNewNonNullFields) {
-    switch (cmMode) {
+      boolean allowNewRequiredFields) {
+    switch (columnMappingMode) {
       case ID:
       case NAME:
         validateSchemaEvolutionById(
@@ -447,13 +447,14 @@ public class SchemaUtils {
             newSchema,
             clusteringColumnPhysicalNames,
             currentMaxFieldId,
-            allowNewNonNullFields);
+            allowNewRequiredFields);
         return;
       case NONE:
         throw new UnsupportedOperationException(
             "Schema evolution without column mapping is not supported");
       default:
-        throw new UnsupportedOperationException("Unknown column mapping mode: " + cmMode);
+        throw new UnsupportedOperationException(
+            "Unknown column mapping mode: " + columnMappingMode);
     }
   }
 
@@ -466,14 +467,14 @@ public class SchemaUtils {
       StructType newSchema,
       Set<String> clusteringColumnPhysicalNames,
       int oldMaxFieldId,
-      boolean allowNewNonNullFields) {
+      boolean allowNewRequiredFields) {
     Map<Integer, StructField> currentFieldsById = fieldsById(currentSchema);
     Map<Integer, StructField> updatedFieldsById = fieldsById(newSchema);
     SchemaChanges schemaChanges = computeSchemaChangesById(currentFieldsById, updatedFieldsById);
     validatePhysicalNameConsistency(schemaChanges.updatedFields());
     // Validates that the updated schema does not contain breaking changes in terms of types and
     // nullability
-    validateUpdatedSchemaCompatibility(schemaChanges, oldMaxFieldId, allowNewNonNullFields);
+    validateUpdatedSchemaCompatibility(schemaChanges, oldMaxFieldId, allowNewRequiredFields);
     validateClusteringColumnsNotDropped(
         schemaChanges.removedFields(), clusteringColumnPhysicalNames);
     // ToDo Potentially validate IcebergCompatV2 nested IDs
@@ -498,9 +499,9 @@ public class SchemaUtils {
    * <p>ToDo: Prevent moving fields outside of their containing struct
    */
   private static void validateUpdatedSchemaCompatibility(
-      SchemaChanges schemaChanges, int oldMaxFieldId, boolean allowNewNonNullFields) {
+      SchemaChanges schemaChanges, int oldMaxFieldId, boolean allowNewRequiredFields) {
     for (StructField addedField : schemaChanges.addedFields()) {
-      if (!allowNewNonNullFields && !addedField.isNullable()) {
+      if (!allowNewRequiredFields && !addedField.isNullable()) {
         throw new KernelException(
             String.format("Cannot add non-nullable field %s", addedField.getName()));
       }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
@@ -626,6 +626,35 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
     }
   }
 
+  test("both id and physical name must be provided if one is provided") {
+    val schemaWithoutPhysicalName = new StructType()
+      .add(
+        new StructField(
+          "col1",
+          StringType.STRING,
+          true,
+          FieldMetadata.builder()
+            .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 0)
+            .build()))
+    val schemaWithoutId = new StructType()
+      .add(
+        new StructField(
+          "col1",
+          StringType.STRING,
+          true,
+          FieldMetadata.builder()
+            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "physical-name-col1")
+            .build()))
+
+    Seq(schemaWithoutId, schemaWithoutPhysicalName).foreach { schema =>
+      val e = intercept[IllegalArgumentException] {
+        updateColumnMappingMetadataIfNeeded(testMetadata(schema).withColumnMappingEnabled(), true)
+      }
+      assert(e.getMessage.contains(
+        "Both columnId and physicalName must be present if one is present"))
+    }
+  }
+
   /**
    * A struct type with all necessary CM info won't cause metadata change by
    * [[updateColumnMappingMetadataIfNeeded]]

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -1034,7 +1034,11 @@ class SchemaUtilsSuite extends AnyFunSuite {
             "renamed_id",
             IntegerType.INTEGER,
             fieldMetadata(4, "id"))
-            .add("too_low_field_id_field", IntegerType.INTEGER, true, fieldMetadata(0, "too_low_field_id_field")),
+            .add(
+              "too_low_field_id_field",
+              IntegerType.INTEGER,
+              true,
+              fieldMetadata(0, "too_low_field_id_field")),
           true),
         arrayName = "renamed_array")))
 
@@ -1086,7 +1090,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
       expectedMessage: String,
       tableProperties: Map[String, String] =
         Map(ColumnMapping.COLUMN_MAPPING_MODE_KEY -> "id"),
-    allowNewRequiredFields: Boolean = false)(implicit classTag: ClassTag[T]) {
+      allowNewRequiredFields: Boolean = false)(implicit classTag: ClassTag[T]) {
     forAll(evolutionCases) { (schemaBefore, schemaAfter) =>
       val e = intercept[T] {
         validateUpdatedSchema(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -393,7 +393,7 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
                 .add(
                   "field_to_add",
                   IntegerType.INTEGER,
-                  fieldMetadataForColumn(6, "field_to_add")),
+                  fieldMetadataForColumn(7, "field_to_add")),
               true),
             false),
           true,
@@ -411,7 +411,7 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
       val updatedArrayValue = mapType.getValueField.getDataType.asInstanceOf[ArrayType]
       val updatedInnerStruct = updatedArrayValue.getElementType.asInstanceOf[StructType]
 
-      assertColumnMapping(updatedInnerStruct.get("field_to_add"), 6, "field_to_add")
+      assertColumnMapping(updatedInnerStruct.get("field_to_add"), 7, "field_to_add")
 
     }
   }
@@ -978,7 +978,12 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
               true),
             false),
           true,
-          fieldMetadataForMapColumn(4, "map", "map", 5, 6))
+          fieldMetadataForMapColumn(
+            2,
+            ColumnMapping.getPhysicalName(currentSchema.get("map")),
+            "map",
+            4,
+            5))
 
       assertSchemaEvolutionFails[KernelException](
         table,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Update SchemaUtils and ColumnMapping with unit tests in order to support REPLACE TABLE with column mapping + fieldId re-use in PR #2. Specifically this involves the following changes (not necessarily related, but combined in this PR)

1) When a connector provides its own column mapping info in the schema pre-populated we require that it's complete (i.e. fieldId AND physicalName must be present)
2) We add an argument to our schema validation checks `allowNewNonNullableFields`. This is useful in cases where we can be sure the table state has been completely cleared, and thus new non-null fields are valid (like REPLACE).
3) We don't allow adding a new column with a fieldId less than the maxColId. For now, do this proactively for safety. In the future in the case of something like RESTORE in the future we will likely need a config to bypass this check.

## How was this patch tested?

Updates unit tests.

Also, all the changes in this PR are used by https://github.com/delta-io/delta/pull/4520 which adds a lot more E2E tests with multiple schema scenarios.

## Does this PR introduce _any_ user-facing changes?

No.
