### PR TITLE
[DELTA] Refactor errors thrown for alter table drop feature for more clarity

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1043,6 +1043,12 @@
     ],
     "sqlState" : "55000"
   },
+  "DELTA_FEATURE_DROP_FEATURE_IS_DELTA_PROPERTY" : {
+    "message" : [
+      "Cannot drop `<property>` from this table because this is a delta table property not a table feature."
+    ],
+    "sqlState" : "55000"
+  },
   "DELTA_FEATURE_DROP_FEATURE_NOT_PRESENT" : {
     "message" : [
       "Cannot drop <feature> from this table because it is not currently present in the table's protocol."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2518,6 +2518,12 @@ trait DeltaErrorsBase
       messageParameters = Array(feature))
   }
 
+  def dropTableFeatureFeatureIsADeltaProperty(feature: String): DeltaTableFeatureException = {
+    new DeltaTableFeatureException(
+      errorClass = "DELTA_FEATURE_DROP_FEATURE_IS_DELTA_PROPERTY",
+      messageParameters = Array(feature))
+  }
+
   def dropTableFeatureNotDeltaTableException(): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_ONLY_OPERATION",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -324,20 +324,23 @@ case class AlterTableDropFeatureDeltaCommand(
   private val NUMBER_OF_BARRIER_CHECKPOINTS = 3
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val removableFeature = TableFeature.featureNameToFeature(featureName) match {
-      case Some(feature: RemovableFeature) => feature
-      case Some(_) => throw DeltaErrors.dropTableFeatureNonRemovableFeature(featureName)
-      case None => throw DeltaErrors.dropTableFeatureFeatureNotSupportedByClient(featureName)
-    }
-
     // Check whether the protocol contains the feature in either the writer features list or
     // the reader+writer features list. Note, protocol needs to denormalized to allow dropping
     // features from legacy protocols.
     val protocol = table.deltaLog.update(catalogTableOpt = table.catalogTable).protocol
     val protocolContainsFeatureName =
       protocol.implicitlyAndExplicitlySupportedFeatures.map(_.name).contains(featureName)
-    if (!protocolContainsFeatureName) {
-      throw DeltaErrors.dropTableFeatureFeatureNotSupportedByProtocol(featureName)
+    val removableFeature = TableFeature.featureNameToFeature(featureName) match {
+      // Check if a property was passed instead of a feature, featureName has to
+      // be normalized in case this was prefixed with "delta."
+      case _ if !protocolContainsFeatureName && DeltaConfigs.getAllConfigs.contains(
+        DeltaConfigs.normalizeConfigKey(Some(featureName)).get) =>
+          throw DeltaErrors.dropTableFeatureFeatureIsADeltaProperty(featureName)
+      case Some(_) if !protocolContainsFeatureName =>
+        throw DeltaErrors.dropTableFeatureFeatureNotSupportedByClient(featureName)
+      case Some(feature: RemovableFeature) => feature
+      case Some(_) => throw DeltaErrors.dropTableFeatureNonRemovableFeature(featureName)
+      case None => throw DeltaErrors.dropTableFeatureFeatureNotSupportedByClient(featureName)
     }
 
     val historyTruncationEligibleFeature = removableFeature.requiresHistoryProtection ||

--- a/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -735,6 +735,8 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
         table.dropFeatureSupport(TestRemovableReaderWriterFeature.name)
       }.getErrorClass === "DELTA_FEATURE_DROP_FEATURE_NOT_PRESENT")
 
+      table.addFeatureSupport(TestReaderWriterFeature.name)
+
       // Try to drop a non-removable feature.
       assert(intercept[DeltaTableFeatureException] {
         table.dropFeatureSupport(TestReaderWriterFeature.name)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3251,6 +3251,26 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
+  test(s"Correct error is thrown when attempting to drop a table property using drop feature") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
+
+      val command = AlterTableDropFeatureDeltaCommand(
+        DeltaTableV2(spark, deltaLog.dataPath),
+        s"delta.${TestRemovableWriterFeature.name}")
+
+      val e = intercept[DeltaTableFeatureException] {
+        command.run(spark)
+      }
+      checkError(
+        e,
+        "DELTA_FEATURE_DROP_FEATURE_IS_DELTA_PROPERTY",
+        parameters = Map("property" -> s"delta.${TestRemovableWriterFeature.name}")
+      )
+    }
+  }
+
   protected def testProtocolVersionDowngrade(
       initialMinReaderVersion: Int,
       initialMinWriterVersion: Int,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Reorder errors thrown, this also introduces a new error to throw a more friendly message when a user attempts to a property instead of a feature.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UTs

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
