### PR TITLE
[Spark] Fix `REPLACE` and `CREATE LIKE` for CatalogOwned

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -805,16 +805,6 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       CoordinatedCommitsUtils.getExplicitICTConfigurations(snapshot.metadata.configuration)
     // Update the metadata.
     updateMetadataForNewTable(metadata)
-    // Ignore the [[CatalogOwnedTableFeature]] if we are replacing an existing table.
-    // This remove the default spark config for Catalog-Owned if being added above.
-    // Users are *NOT* allowed to create a Catalog-Owned table with REPLACE TABLE
-    // so it's fine to filter it out here.
-    newProtocol = newProtocol match {
-      case Some(protocol) =>
-        Some(CatalogOwnedTableUtils.filterOutCatalogOwnedTableFeature(protocol))
-      case None =>
-        newProtocol
-    }
     // Now the `txn.metadata` contains all the command-specified properties and all the default
     // properties. The latter might still contain Coordinated Commits configurations, so we need
     // to remove them and retain the Coordinated Commits configurations from the existing table.
@@ -822,11 +812,43 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS
     var newConfs: Map[String, String] = newConfsWithoutCC ++ existingCCConfs ++
       existingUCTableIdConf
+
+    val isCatalogOwnedEnabledBeforeReplace = snapshot.protocol
+      .readerAndWriterFeatureNames.contains(CatalogOwnedTableFeature.name)
+    if (!isCatalogOwnedEnabledBeforeReplace) {
+      // Ignore the [[CatalogOwnedTableFeature]] if we are replacing an existing normal
+      // table *without* CatalogOwned enabled.
+      // This removes [[CatalogOwnedTableFeature]] that may have been added as a result of
+      // the CatalogOwned spark configuration that enables it by default.
+      // Users are *NOT* allowed to create a Catalog-Owned table with REPLACE TABLE
+      // so it's fine to filter it out here.
+      newProtocol = newProtocol.map(CatalogOwnedTableUtils.filterOutCatalogOwnedTableFeature)
+
+      val isICTEnabledBeforeReplace = existingICTConfs.nonEmpty ||
+        // To prevent any potential protocol downgrade issue we check the existing
+        // protocol as well.
+        snapshot.protocol.readerAndWriterFeatureNames
+          .contains(InCommitTimestampTableFeature.name)
+      // Note that we only need to get explicit ICT configurations from `newConfs` here,
+      // because all the default spark configurations should have been merged in the prior
+      // `updateMetadataForNewTable` call.
+      val isEnablingICTDuringReplace =
+        CoordinatedCommitsUtils.getExplicitICTConfigurations(newConfs).nonEmpty
+      if (!isICTEnabledBeforeReplace && !isEnablingICTDuringReplace) {
+        // If existing table does *not* have ICT enabled, and we are *not* trying
+        // to enable ICT manually through explicit overrides, then we should
+        // filter any unintended [[InCommitTimestampTableFeature]] out here.
+        newProtocol = newProtocol.map { p =>
+          p.copy(writerFeatures = p.writerFeatures.map(
+              _.filterNot(_ == InCommitTimestampTableFeature.name)))
+        }
+      }
+    }
     // We also need to retain the existing ICT dependency configurations, but only when the
-    // existing table does have Coordinated Commits configurations or Catalog-Owned property.
+    // existing table does have Coordinated Commits configurations or Catalog-Owned enabled.
     // Otherwise, we treat the ICT configurations the same as any other configurations,
     // by merging them from the default.
-    if (existingCCConfs.nonEmpty || existingUCTableIdConf.nonEmpty) {
+    if (existingCCConfs.nonEmpty || isCatalogOwnedEnabledBeforeReplace) {
       val newConfsWithoutICT = newConfs -- CoordinatedCommitsUtils.ICT_TABLE_PROPERTY_KEYS
       newConfs = newConfsWithoutICT ++ existingICTConfs
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -572,6 +572,20 @@ object CoordinatedCommitsUtils extends DeltaLogging {
   }
 
   /**
+   * Fetches the SparkSession default configurations for ICT. The `withDefaultKey`
+   * flag controls whether the keys in the returned map should have the default prefix or not.
+   */
+  def getDefaultICTConfigurations(
+      spark: SparkSession, withDefaultKey: Boolean = false): Map[String, String] = {
+    ICT_TABLE_PROPERTY_CONFS.flatMap { conf =>
+      spark.conf.getOption(conf.defaultTablePropertyKey).map { value =>
+        val finalKey = if (withDefaultKey) conf.defaultTablePropertyKey else conf.key
+        finalKey -> value
+      }
+    }.toMap
+  }
+
+  /**
    * Fetches the SparkSession default configurations for Coordinated Commits. The `withDefaultKey`
    * flag controls whether the keys in the returned map should have the default prefix or not.
    * For example, if property 'coordinatedCommits.commitCoordinator-preview' is set to 'dynamodb'

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -129,6 +129,8 @@ trait CatalogOwnedTestBaseSuite
     try { f } finally {
       if (oldConfig.isDefined) {
         spark.conf.set(defaultCatalogOwnedFeatureEnabledKey, oldConfig.get)
+      } else {
+        spark.conf.unset(defaultCatalogOwnedFeatureEnabledKey)
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR fixes two subtle but critical parts for CatalogOwned enable table.

- For `CREATE LIKE`, enable CatalogOwned w/ default spark configuration.
  - This is different from the normal behavior/semantic of `CREATE LIKE`, where the source table protocol will take precedence and override any default (table feature) enablement.
- For `REPLACE`, only filter out `CatalogOwnedTableFeature` if the existing table does **_not_** have CatalogOwned enabled - otherwise there would be protocol downgrade issue if we are adding new table feature (e.g., `ClusteringTableFeature`) at the same time.
  - We also filter out any **_unintended_** `InCommitTimestampTableFeature` if the original table does not have ICT enabled, and users are not enabling ICT via explicit overrides or default ICT spark configuration.
    - The unintended `InCommitTimestampTableFeature` may be generated as part of the default CatalogOwned enablement, and we do not support enabling CatalogOwned through `REPLACE`.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
N/A

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
