### PR TITLE
[Kernel] Fix schema id population for iceberg compat v2

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -578,7 +578,8 @@ public class ColumnMapping {
    * @param path The current field path relative to the parent field (aka most recent ancestor with
    *     a StructField). An empty path indicates that there's no parent and we're at the root
    * @param closestStructFieldParentMetadata The metadata builder of the closest struct field parent
-   *     where nested IDs will be stored
+   *     where nested IDs will be stored. For StructFields this is the current field. For
+   *     map/arrays, it is the closest parent that is a struct field.
    * @return A new {@link StructField} with updated {@link FieldMetadata}
    */
   private static StructField transformSchema(
@@ -682,18 +683,18 @@ public class ColumnMapping {
    *
    * </blockquote>
    *
-   * @param field The FieldMetadata.Builder to update with nested IDs
+   * @param fieldMetadataBuilder The FieldMetadata.Builder to update with nested IDs
    * @param key For a map this is <colName>.key or <colName>.value. For an array this is
    *     <colName>.element
    * @param currentFieldId The current maximum field id to increment and use for assignment
    */
   private static void maybeUpdateFieldId(
-      FieldMetadata.Builder field, String key, AtomicInteger currentFieldId) {
+      FieldMetadata.Builder fieldMetadataBuilder, String key, AtomicInteger currentFieldId) {
     // init the nested metadata that holds the nested ids
-    FieldMetadata nestedMetadata = field.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY);
-    if (field.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY) == null) {
-      field.putFieldMetadata(COLUMN_MAPPING_NESTED_IDS_KEY, FieldMetadata.empty());
-      nestedMetadata = field.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY);
+    FieldMetadata nestedMetadata = fieldMetadataBuilder.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY);
+    if (fieldMetadataBuilder.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY) == null) {
+      fieldMetadataBuilder.putFieldMetadata(COLUMN_MAPPING_NESTED_IDS_KEY, FieldMetadata.empty());
+      nestedMetadata = fieldMetadataBuilder.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY);
     }
 
     // assign an id to the nested element and update the metadata
@@ -703,7 +704,7 @@ public class ColumnMapping {
               .fromMetadata(nestedMetadata)
               .putLong(key, currentFieldId.incrementAndGet())
               .build();
-      field.putFieldMetadata(COLUMN_MAPPING_NESTED_IDS_KEY, newNestedMeta);
+      fieldMetadataBuilder.putFieldMetadata(COLUMN_MAPPING_NESTED_IDS_KEY, newNestedMeta);
     }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -574,6 +574,8 @@ public class ColumnMapping {
    * @param structField The field where to start from
    * @param path The current field path relative to the parent field (aka most recent ancestor with
    *     a StructField). An empty path indicates that there's no parent and we're at the root
+   * @param closestStructFieldParentMetadata The metadata builder of the closest struct field parent
+   *     where nested IDs will be stored
    * @return A new {@link StructField} with updated {@link FieldMetadata}
    */
   private static StructField transformSchema(
@@ -662,16 +664,14 @@ public class ColumnMapping {
    *
    * </blockquote>
    *
-   * @param field The current field where to update the COLUMN_MAPPING_NESTED_IDS_KEY
+   * @param field The FieldMetadata.Builder to update with nested IDs
    * @param key For a map this is <colName>.key or <colName>.value. For an array this is
    *     <colName>.element
    * @param currentFieldId The current maximum field id to increment and use for assignment
-   * @return A field with potentially updated {@link FieldMetadata}
    */
   private static void maybeUpdateFieldId(
       FieldMetadata.Builder field, String key, AtomicInteger currentFieldId) {
     // init the nested metadata that holds the nested ids
-    System.out.println("key: " + key);
     FieldMetadata nestedMetadata = field.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY);
     if (field.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY) == null) {
       field.putFieldMetadata(COLUMN_MAPPING_NESTED_IDS_KEY, FieldMetadata.empty());
@@ -687,13 +687,5 @@ public class ColumnMapping {
               .build();
       field.putFieldMetadata(COLUMN_MAPPING_NESTED_IDS_KEY, newNestedMeta);
     }
-    System.out.println("field:" + field.build());
-  }
-
-  private static FieldMetadata.Builder initNestedIdsMetadataBuilder(StructField field) {
-    if (hasNestedColumnIds(field)) {
-      return FieldMetadata.builder().fromMetadata(getNestedColumnIds(field));
-    }
-    return FieldMetadata.builder();
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -556,9 +556,12 @@ public class ColumnMapping {
       newSchema =
           newSchema.add(
               transformSchema(
-                  startId, field, "",
-                  /** current column path */
-                  builder).withNewMetadata(builder.build()));
+                      startId,
+                      field,
+                      "",
+                      /** current column path */
+                      builder)
+                  .withNewMetadata(builder.build()));
     }
     return newSchema;
   }
@@ -579,16 +582,23 @@ public class ColumnMapping {
    * @return A new {@link StructField} with updated {@link FieldMetadata}
    */
   private static StructField transformSchema(
-      AtomicInteger currentFieldId, StructField structField, String path, FieldMetadata.Builder closestStructFieldParentMetadata) {
+      AtomicInteger currentFieldId,
+      StructField structField,
+      String path,
+      FieldMetadata.Builder closestStructFieldParentMetadata) {
     DataType dataType = structField.getDataType();
     if (dataType instanceof StructType) {
       StructType type = (StructType) dataType;
       List<StructField> fields =
           type.fields().stream()
-              .map(field -> {
-                FieldMetadata.Builder metadataBuilder = FieldMetadata.builder().fromMetadata(field.getMetadata());
-                return transformSchema(currentFieldId, field, getPhysicalName(field), metadataBuilder).withNewMetadata(metadataBuilder.build());
-              })
+              .map(
+                  field -> {
+                    FieldMetadata.Builder metadataBuilder =
+                        FieldMetadata.builder().fromMetadata(field.getMetadata());
+                    return transformSchema(
+                            currentFieldId, field, getPhysicalName(field), metadataBuilder)
+                        .withNewMetadata(metadataBuilder.build());
+                  })
               .collect(Collectors.toList());
       return new StructField(
           structField.getName(),
@@ -602,7 +612,11 @@ public class ColumnMapping {
       String elementPath = basePath + "." + type.getElementField().getName();
       maybeUpdateFieldId(closestStructFieldParentMetadata, elementPath, currentFieldId);
       StructField elementType =
-          transformSchema(currentFieldId, type.getElementField(), elementPath, closestStructFieldParentMetadata);
+          transformSchema(
+              currentFieldId,
+              type.getElementField(),
+              elementPath,
+              closestStructFieldParentMetadata);
       return new StructField(
           structField.getName(),
           new ArrayType(elementType),
@@ -614,11 +628,15 @@ public class ColumnMapping {
       String basePath = "".equals(path) ? getPhysicalName(structField) : path;
       String keyPath = basePath + "." + type.getKeyField().getName();
       maybeUpdateFieldId(closestStructFieldParentMetadata, keyPath, currentFieldId);
-      StructField key = transformSchema(currentFieldId, type.getKeyField(), keyPath, closestStructFieldParentMetadata);
+      StructField key =
+          transformSchema(
+              currentFieldId, type.getKeyField(), keyPath, closestStructFieldParentMetadata);
       // update value type metadata and recurse into value type
       String valuePath = basePath + "." + type.getValueField().getName();
       maybeUpdateFieldId(closestStructFieldParentMetadata, valuePath, currentFieldId);
-      StructField value = transformSchema(currentFieldId, type.getValueField(), valuePath, closestStructFieldParentMetadata);
+      StructField value =
+          transformSchema(
+              currentFieldId, type.getValueField(), valuePath, closestStructFieldParentMetadata);
       return new StructField(
           structField.getName(),
           new MapType(key, value),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
@@ -265,13 +265,13 @@ public final class FieldMetadata {
       if (null == value) {
         return null;
       }
-      if (!(value instanceof FieldMetadata)) {
-        throw new io.delta.kernel.exceptions.KernelException(
-            String.format(
-                "Expected '%s' to be of type 'FieldMetadata' but was '%s'",
-                value, value.getClass().getName()));
+      if (value instanceof FieldMetadata) {
+        return (FieldMetadata) value;
       }
-      return (FieldMetadata) value;
+      throw new io.delta.kernel.exceptions.KernelException(
+          String.format(
+              "Expected '%s' to be of type 'FieldMetadata' but was '%s'",
+              value, value.getClass().getName()));
     }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
@@ -261,7 +261,17 @@ public final class FieldMetadata {
     }
 
     public FieldMetadata getMetadata(String key) {
-      return (FieldMetadata) metadata.get(key);
+      Object value = metadata.get(key);
+      if (null == value) {
+        return null;
+      }
+      if (!(value instanceof FieldMetadata)) {
+        throw new io.delta.kernel.exceptions.KernelException(
+            String.format(
+                "Expected '%s' to be of type 'FieldMetadata' but was '%s'",
+                value, value.getClass().getName()));
+      }
+      return (FieldMetadata) value;
     }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
@@ -259,5 +259,9 @@ public final class FieldMetadata {
     public FieldMetadata build() {
       return new FieldMetadata(this.metadata);
     }
+
+    public FieldMetadata getMetadata(String key) {
+      return (FieldMetadata) metadata.get(key);
+    }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
@@ -484,7 +484,10 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
         } else {
           "b."
         }
-        assert(metadata.getSchema.get("b").getMetadata.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY) != null, s"${metadata.getSchema}")
+        assert(
+          metadata.getSchema.get(
+            "b").getMetadata.getMetadata(COLUMN_MAPPING_NESTED_IDS_KEY) != null,
+          s"${metadata.getSchema}")
         // verify nested ids
         assertThat(metadata.getSchema.get("b").getMetadata.getEntries
           .get(COLUMN_MAPPING_NESTED_IDS_KEY).asInstanceOf[FieldMetadata].getEntries)
@@ -518,12 +521,13 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
 
   private def newFieldMetadata(i: Int, map: Map[String, String] = Map.empty[String, String]) = {
     val subBuilder = FieldMetadata.builder()
-    map.foreach { case (k,v) => subBuilder.putString(k, v) }
+    map.foreach { case (k, v) => subBuilder.putString(k, v) }
     FieldMetadata.builder()
       .putLong(COLUMN_MAPPING_ID_KEY, i)
       .putString(COLUMN_MAPPING_PHYSICAL_NAME_KEY, s"col-$i")
       .putFieldMetadata(
-        COLUMN_MAPPING_NESTED_IDS_KEY, subBuilder.build())
+        COLUMN_MAPPING_NESTED_IDS_KEY,
+        subBuilder.build())
       .build()
   }
 
@@ -533,16 +537,26 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
       assume(enableIcebergCompatV2 && isNewTable)
       val schema: StructType =
         new StructType()
-          .add("l", new ArrayType(
-            new MapType(
-                  new StructField("key", StringType.STRING, false),
-                  new StructField("value", new StructType().add("leaf", StringType.STRING, false, newFieldMetadata(5)), false)),
-            /*nullable=*/ false),
-            newFieldMetadata(1, Map("col-1.element"-> "2","col-1.element.key" -> "3", "col-1.element.value" -> "4")))
+          .add(
+            "l",
+            new ArrayType(
+              new MapType(
+                new StructField("key", StringType.STRING, false),
+                new StructField(
+                  "value",
+                  new StructType().add("leaf", StringType.STRING, false, newFieldMetadata(5)),
+                  false)),
+              /*nullable=*/ false),
+            newFieldMetadata(
+              1,
+              Map(
+                "col-1.element" -> "2",
+                "col-1.element.key" -> "3",
+                "col-1.element.value" -> "4")))
 
       var inputMetadata = testMetadata(schema).withColumnMappingEnabled("id")
       inputMetadata = inputMetadata.withIcebergCompatV2Enabled
-       inputMetadata = inputMetadata.withIcebergWriterCompatV1Enabled
+      inputMetadata = inputMetadata.withIcebergWriterCompatV1Enabled
       val metadata = updateColumnMappingMetadataIfNeeded(inputMetadata, isNewTable)
         .orElseGet(() => fail("Metadata should not be empty"))
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
@@ -597,7 +597,8 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
             ArrayType].getElementField.getMetadata == FieldMetadata.empty())
 
           // Requesting the same operation on the same schema shouldn't change anything
-          // as the schema already has the necessary column mapping info
+          // as the schema already has the necessary column mapping info. This includes both
+          // IDs and maxFieldId.
           assertNoOpOnUpdateColumnMappingMetadataRequest(
             metadata.getSchema,
             /* enableIcebergCompatV2= */ true,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
@@ -527,7 +527,9 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
           new ArrayType(
             new ArrayType(
               new MapType(
-                new ArrayType(StringType.STRING, /*nullable=*/ false),
+                new ArrayType(
+                  StringType.STRING,
+                  /* nullable= */ false),
                 new MapType(
                   StringType.STRING,
                   new StructType().add(
@@ -535,16 +537,19 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
                     StringType.STRING,
                     false,
                     FieldMetadata.builder().putBoolean("k1", true).build()),
-                  /*valuesContainNull=*/ false),
-                /*valuesContanNull= */ false),
-              /*nullableElements= */ false),
-            /*nullableElements=*/ false),
-          /*nullable= */ false,
+                  /* valuesContainNull= */ false),
+                /* valuesContainNull= */ false),
+              /* nullableElements= */ false),
+            /* nullableElements= */ false),
+          /* nullable= */ false,
           FieldMetadata.builder().putBoolean("k2", true).build())
     Seq(
       (baseSchema, 1, (md: Metadata) => md.getSchema.get("l")),
       (
-        new StructType().add("p", baseSchema, /*nullable=*/ false),
+        new StructType().add(
+          "p",
+          baseSchema,
+          /* nullable= */ false),
         2,
         (md: Metadata) =>
           md.getSchema.get("p").getDataType.asInstanceOf[StructType].get("l"))).foreach {
@@ -562,8 +567,8 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
             ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY,
             (base + 8).toString)
           val prefix = s"col-$base"
-          // Values are offset by base.  All Ids are assigned in depth first order to StructField's first and then
-          // intermediate nested fields are added to metadata.
+          // Values are offset by base.  All Ids are assigned in depth first order to
+          // StructField's first and then intermediate nested fields are added after.
           val nestedColumnMappingValues = FieldMetadata.builder()
             .putLong(s"$prefix.element", base + 2)
             .putLong(s"$prefix.element.element", base + 3)
@@ -585,7 +590,8 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
           assertThat(firstColumnMetadata.getEntries).containsExactlyInAnyOrderEntriesOf(
             expectedMetadata.getEntries)
 
-          // TODO: It would be nice to have visitor pattern on schema so we can assert all metadata for nested fields
+          // TODO: It would be nice to have visitor pattern on schema so we can assert
+          // all metadata for nested fields
           // are empty but this at least provides a sanity check.
           assert(getter(metadata).getDataType.asInstanceOf[
             ArrayType].getElementField.getMetadata == FieldMetadata.empty())
@@ -594,7 +600,7 @@ class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
           // as the schema already has the necessary column mapping info
           assertNoOpOnUpdateColumnMappingMetadataRequest(
             metadata.getSchema,
-            /*enableIcebergCompatV2=*/ true,
+            /* enableIcebergCompatV2= */ true,
             isNewTable)
         }
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
@@ -209,6 +209,8 @@ trait ColumnMappingSuiteBase extends VectorTestUtils {
       } else {
         "f."
       }
+      assert(innerStruct.get("f").getMetadata.getEntries
+        .get(COLUMN_MAPPING_NESTED_IDS_KEY) != null, s"${metadata.getSchema}")
       assertThat(innerStruct.get("f").getMetadata.getEntries
         .get(COLUMN_MAPPING_NESTED_IDS_KEY).asInstanceOf[FieldMetadata].getEntries)
         .hasSize(1)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
@@ -185,11 +185,13 @@ trait ColumnMappingSuiteBase extends VectorTestUtils {
         .anySatisfy((k: AnyRef, v: AnyRef) => {
           assertThat(k).asString.startsWith(colBPrefix)
           assertThat(k).asString.endsWith(".key")
+          assert(k.asInstanceOf[String].count(_ == '.') == 1)
           assertThat(v).isEqualTo(nextFieldId)
         })
         .anySatisfy((k: AnyRef, v: AnyRef) => {
           assertThat(k).asString.startsWith(colBPrefix)
           assertThat(k).asString.endsWith(".value")
+          assert(k.asInstanceOf[String].count(_ == '.') == 1)
           assertThat(v).isEqualTo(nextFieldId)
         })
 
@@ -219,6 +221,7 @@ trait ColumnMappingSuiteBase extends VectorTestUtils {
         .anySatisfy((k: AnyRef, v: AnyRef) => {
           assertThat(k).asString.startsWith(colFPrefix)
           assertThat(k).asString.endsWith(".element")
+          assert(k.asInstanceOf[String].count(_ == '.') == 1)
           assertThat(v).isEqualTo(nextFieldId)
         })
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
@@ -209,8 +209,10 @@ trait ColumnMappingSuiteBase extends VectorTestUtils {
       } else {
         "f."
       }
-      assert(innerStruct.get("f").getMetadata.getEntries
-        .get(COLUMN_MAPPING_NESTED_IDS_KEY) != null, s"${metadata.getSchema}")
+      assert(
+        innerStruct.get("f").getMetadata.getEntries
+          .get(COLUMN_MAPPING_NESTED_IDS_KEY) != null,
+        s"${metadata.getSchema}")
       assertThat(innerStruct.get("f").getMetadata.getEntries
         .get(COLUMN_MAPPING_NESTED_IDS_KEY).asInstanceOf[FieldMetadata].getEntries)
         .hasSize(1)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
@@ -113,4 +113,31 @@ class FieldMetadataSuite extends AnyFunSuite {
     assertThat(meta.getMetadataArray("fieldMetadataArrayKey"))
       .isEqualTo(Seq(innerMeta).toArray)
   }
+
+  test("builder.getMetadata handles null correctly") {
+    val builder = FieldMetadata.builder()
+    assertThat(builder.getMetadata("non-existing")).isNull()
+  }
+
+  test("builder.getMetadata with wrong type throws KernelException") {
+    val builder = FieldMetadata.builder()
+      .putLong("longKey", 23L)
+      .putString("stringKey", "test")
+
+    assertThatThrownBy(() => builder.getMetadata("longKey"))
+      .isInstanceOf(classOf[io.delta.kernel.exceptions.KernelException])
+      .hasMessageContaining("Expected '23' to be of type 'FieldMetadata'")
+
+    assertThatThrownBy(() => builder.getMetadata("stringKey"))
+      .isInstanceOf(classOf[io.delta.kernel.exceptions.KernelException])
+      .hasMessageContaining("Expected 'test' to be of type 'FieldMetadata'")
+  }
+
+  test("builder.getMetadata with correct type returns value") {
+    val innerMeta = FieldMetadata.builder().putBoolean("key", true).build()
+    val builder = FieldMetadata.builder()
+      .putFieldMetadata("fieldMetadataKey", innerMeta)
+
+    assertThat(builder.getMetadata("fieldMetadataKey")).isEqualTo(innerMeta)
+  }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel.types
 
+import io.delta.kernel.exceptions.KernelException
+
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -122,15 +124,12 @@ class FieldMetadataSuite extends AnyFunSuite {
   test("builder.getMetadata with wrong type throws KernelException") {
     val builder = FieldMetadata.builder()
       .putLong("longKey", 23L)
-      .putString("stringKey", "test")
 
-    assertThatThrownBy(() => builder.getMetadata("longKey"))
-      .isInstanceOf(classOf[io.delta.kernel.exceptions.KernelException])
-      .hasMessageContaining("Expected '23' to be of type 'FieldMetadata'")
+    val err = intercept[KernelException] {
+      builder.getMetadata("longKey")
+    }
 
-    assertThatThrownBy(() => builder.getMetadata("stringKey"))
-      .isInstanceOf(classOf[io.delta.kernel.exceptions.KernelException])
-      .hasMessageContaining("Expected 'test' to be of type 'FieldMetadata'")
+    assert(err.getMessage.contains("Expected '23' to be of type 'FieldMetadata'"))
   }
 
   test("builder.getMetadata with correct type returns value") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -296,7 +296,11 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("map"), 4, "map")
       assert(structType.get("map").getMetadata.get(ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY)
-        == FieldMetadata.builder().putLong("map.key", 5).putLong("map.value", 6).build())
+        == FieldMetadata.builder()
+          .putLong("map.key", 5)
+          .putLong("map.value", 6)
+          .putLong("map.value.element", 7)
+          .build())
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -292,7 +292,8 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
         .withSchema(engine, newSchema)
         .build(engine).commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema
+      val latestSnapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val structType = latestSnapshot.getSchema
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("map"), 4, "map")
       assert(structType.get("map").getMetadata.get(ColumnMapping.COLUMN_MAPPING_NESTED_IDS_KEY)
@@ -301,6 +302,8 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
           .putLong("map.value", 6)
           .putLong("map.value.element", 7)
           .build())
+      val configuration = latestSnapshot.getMetadata.getConfiguration
+      assert(configuration.get(ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY) == "7")
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes how nested field IDs are populated on metadata.  Before this change metadata was added directly to the parent StructField no matter how deeply maps/arrays where nested.  With this change we populate metadata correctly on the near parent StructField (ignoring intermediate StructFields  in Maps/Array which are just a nicety for the schema object model).  This also has the impact of not incrementing max field ID for pre-populated fields.

Resolve #4535

## How was this patch tested?

Added unit tests/existing tests.

## Does this PR introduce _any_ user-facing changes?

It fixes a bug.
