### PR TITLE
[BUG][kernel] Fix txn action conflict detection to always conflict when app_ids match

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -356,9 +356,7 @@ public class ConflictChecker {
         losingTxnId -> {
           for (int rowId = 0; rowId < txnVector.getSize(); rowId++) {
             SetTransaction winningTxn = SetTransaction.fromColumnVector(txnVector, rowId);
-            if (winningTxn != null
-                && winningTxn.getAppId().equals(losingTxnId.getAppId())
-                && winningTxn.getVersion() >= losingTxnId.getVersion()) {
+            if (winningTxn != null && winningTxn.getAppId().equals(losingTxnId.getAppId())) {
               throw DeltaErrors.concurrentTransaction(
                   losingTxnId.getAppId(), losingTxnId.getVersion(), winningTxn.getVersion());
             }


### PR DESCRIPTION
According to the Delta protocol, two  actions with the same  should always conflict. However, the kernel's conflict detection logic was incorrectly allowing transactions with the same  to not conflict when the 'winning' version was less than the 'losing' version.

This PR fixes the issue by removing the version comparison condition in the  method of . Now, any two transactions with the same  will always conflict, regardless of their versions.

Fixes #4442

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

- Describe what this PR changes.
This PR fixes a bug in the conflict detection logic for transactions with the same app_id. The current implementation only throws a conflict exception when the winning transaction's version is >= the losing transaction's version, but according to the protocol, any two transactions with the same app_id should conflict regardless of version.
- Describe why we need the change.
This change is needed to correctly implement the Delta protocol specification for transaction conflict detection.
 

## How was this patch tested?
Added comprehensive tests in both standalone connector and Spark module to verify that transactions with the same app ID will conflict regardless of their version numbers:

1. Test where the winning transaction has a lower version than the losing transaction (this was the bug we fixed)
2. Test where the winning transaction has a higher version than the losing transaction (this was already working correctly)

## Does this PR introduce _any_ user-facing changes?
'No'.