### PR TITLE
[kernel] Block updating partitioned table with clustering columns

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -345,6 +345,15 @@ public final class DeltaErrors {
     return new KernelException(format(msgT, partitionColumn, tablePath));
   }
 
+  public static KernelException enablingClusteringOnPartitionedTableNotAllowed(
+      String tablePath, Set<String> partitionColNames, List<Column> clusteringCols) {
+    return new KernelException(
+        String.format(
+            "Cannot enable clustering on a partitioned table '%s'. "
+                + "Existing partition columns: '%s', Clustering columns: '%s'.",
+            tablePath, partitionColNames, clusteringCols));
+  }
+
   public static KernelException concurrentTransaction(
       String appId, long txnVersion, long lastUpdated) {
     return new ConcurrentTransactionException(appId, txnVersion, lastUpdated);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -221,7 +221,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     checkArgument(
         isCreateOrReplace || latestSnapshot.isPresent(),
         "Existing snapshot must be provided if not defining a new table definition");
-    latestSnapshot.ifPresent(snapshot -> validateWriteToExistingTable(engine, snapshot));
+    latestSnapshot.ifPresent(
+        snapshot -> validateWriteToExistingTable(engine, snapshot, isCreateOrReplace));
     validateTransactionInputs(engine, isCreateOrReplace);
 
     boolean enablesDomainMetadataSupport =
@@ -494,7 +495,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
    * identifier has been provided in this txn builder, a concurrent write has not already committed
    * this transaction (3) Updating a partitioned table with clustering columns is not allowed.
    */
-  protected void validateWriteToExistingTable(Engine engine, SnapshotImpl snapshot) {
+  protected void validateWriteToExistingTable(
+      Engine engine, SnapshotImpl snapshot, boolean isCreateOrReplace) {
     // Validate the table has no features that Kernel doesn't yet support writing into it.
     TableFeatures.validateKernelCanWriteToTable(
         snapshot.getProtocol(), snapshot.getMetadata(), table.getPath(engine));
@@ -507,9 +509,13 @@ public class TransactionBuilderImpl implements TransactionBuilder {
                 txnId.getAppId(), txnId.getVersion(), lastTxnVersion.get());
           }
         });
-    if (operation != Operation.REPLACE_TABLE && clusteringColumns.isPresent()
+    if (!isCreateOrReplace
+        && clusteringColumns.isPresent()
         && snapshot.getMetadata().getPartitionColumns().getSize() != 0) {
-      throw new KernelException("Cannot set clustering columns on a partitioned table");
+      throw DeltaErrors.enablingClusteringOnPartitionedTableNotAllowed(
+          table.getPath(engine),
+          snapshot.getMetadata().getPartitionColNames(),
+          clusteringColumns.get());
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -492,7 +492,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
    * Validates that Kernel can write to the existing table with the latest snapshot as provided.
    * This means (1) Kernel supports the reader and writer protocol of the table (2) if a transaction
    * identifier has been provided in this txn builder, a concurrent write has not already committed
-   * this transaction.
+   * this transaction (3) Updating a partitioned table with clustering columns is not allowed.
    */
   protected void validateWriteToExistingTable(Engine engine, SnapshotImpl snapshot) {
     // Validate the table has no features that Kernel doesn't yet support writing into it.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -507,7 +507,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
                 txnId.getAppId(), txnId.getVersion(), lastTxnVersion.get());
           }
         });
-    if (clusteringColumns.isPresent()
+    if (operation != Operation.REPLACE_TABLE && clusteringColumns.isPresent()
         && snapshot.getMetadata().getPartitionColumns().getSize() != 0) {
       throw new KernelException("Cannot set clustering columns on a partitioned table");
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -507,6 +507,10 @@ public class TransactionBuilderImpl implements TransactionBuilder {
                 txnId.getAppId(), txnId.getVersion(), lastTxnVersion.get());
           }
         });
+    if (clusteringColumns.isPresent()
+        && snapshot.getMetadata().getPartitionColumns().getSize() != 0) {
+      throw new KernelException("Cannot set clustering columns on a partitioned table");
+    }
   }
 
   /**

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
@@ -292,6 +292,21 @@ class DeltaTableClusteringSuite extends DeltaTableWriteSuiteBase {
     }
   }
 
+  test("update a partitioned table with clustering columns should fail") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createEmptyTable(engine, tablePath, testPartitionSchema, partCols = testPartitionColumns)
+      val ex = intercept[KernelException] {
+        updateTableMetadata(
+          engine,
+          tablePath,
+          clusteringColsOpt = Some(List(new Column("non-exist"))))
+      }
+      assert(
+        ex.getMessage.contains("Clustering columns and partition columns " +
+          "cannot coexist in a table"))
+    }
+  }
+
   test("insert into clustered table - table create from scratch") {
     withTempDirAndEngine { (tablePath, engine) =>
       val testData = Seq(Map.empty[String, Literal] -> dataClusteringBatches1)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
@@ -295,14 +295,26 @@ class DeltaTableClusteringSuite extends DeltaTableWriteSuiteBase {
   test("update a partitioned table with clustering columns should fail") {
     withTempDirAndEngine { (tablePath, engine) =>
       createEmptyTable(engine, tablePath, testPartitionSchema, partCols = testPartitionColumns)
-      val ex = intercept[KernelException] {
+      // test case 1: update with non-empty clustering columns
+      val ex1 = intercept[KernelException] {
         updateTableMetadata(
           engine,
           tablePath,
           clusteringColsOpt = Some(List(new Column("non-exist"))))
       }
       assert(
-        ex.getMessage.contains("Cannot set clustering columns on a partitioned table"))
+        ex1.getMessage.contains("Cannot enable clustering on a partitioned table"))
+
+      // test case 2: update with empty clustering columns,
+      // this would still be regarded as enabling clustering
+      val ex2 = intercept[KernelException] {
+        updateTableMetadata(
+          engine,
+          tablePath,
+          clusteringColsOpt = Some(List()))
+      }
+      assert(
+        ex2.getMessage.contains("Cannot enable clustering on a partitioned table"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
@@ -302,8 +302,7 @@ class DeltaTableClusteringSuite extends DeltaTableWriteSuiteBase {
           clusteringColsOpt = Some(List(new Column("non-exist"))))
       }
       assert(
-        ex.getMessage.contains("Clustering columns and partition columns " +
-          "cannot coexist in a table"))
+        ex.getMessage.contains("Cannot set clustering columns on a partitioned table"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
When the existing table is already a partitioned table, we cannot update it to a clustered table anymore. 
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
