### PR TITLE
[Spark] Introduce CommittedTransaction to store post-commit txn info

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, Metadata, Protocol}
+import org.apache.spark.sql.delta.hooks.PostCommitHook
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * Represents a successfully committed transaction.
+ *
+ * This class encapsulates all relevant information about a transaction that has been successfully
+ * committed. The main usage of this class is in running the post-commit hooks.
+ *
+ * @param txnId                     the unique identifier of the committed transaction.
+ * @param deltaLog                  the [[DeltaLog]] instance for the table the transaction
+ *                                  committed on.
+ * @param catalogTable              the catalog table at the start of the transaction for the
+ *                                  committed table.
+ * @param snapshot                  the snapshot of the table at the time of the transaction's read.
+ * @param metadata                  the metadata of the table after the txn committed.
+ * @param protocol                  the protocol of the table after the txn committed.
+ * @param committedVersion          the version of the table after the txn committed.
+ * @param committedActions          the actions that were committed in this transaction.
+ * @param postCommitSnapshot        the snapshot of the table after the txn successfully committed.
+ *                                  NOTE: This may not match the committedVersion, if racing
+ *                                  commits were written while the snapshot was computed.
+ * @param postCommitHooks           the list of post-commit hooks to run after the commit.
+ * @param finalTxnExecutionTimeMs   the time taken to execute the transaction.
+ * @param finalNeedsCheckpoint      whether a checkpoint is needed after the commit.
+ * @param finalPartitionsAddedToOpt the partitions that this txn added new files to.
+ * @param finalIsBlindAppend        whether this transaction was a blind append.
+ */
+case class CommittedTransaction(
+    txnId: String,
+    deltaLog: DeltaLog,
+    catalogTable: Option[CatalogTable],
+    snapshot: Snapshot,
+    metadata: Metadata,
+    protocol: Protocol,
+    committedVersion: Long,
+    committedActions: Seq[Action],
+    postCommitSnapshot: Snapshot,
+    postCommitHooks: Seq[PostCommitHook],
+    finalTxnExecutionTimeMs: Long,
+    finalNeedsCheckpoint: Boolean,
+    finalPartitionsAddedToOpt: Option[mutable.HashSet[Map[String, String]]],
+    finalIsBlindAppend: Boolean
+)
+  extends DeltaTransaction
+{
+  override def txnExecutionTimeMs: Option[Long] = Some(finalTxnExecutionTimeMs)
+  needsCheckpoint = finalNeedsCheckpoint
+  partitionsAddedToOpt = finalPartitionsAddedToOpt
+  isBlindAppend = finalIsBlindAppend
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -36,8 +36,7 @@ import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.files._
-import org.apache.spark.sql.delta.hooks.{CheckpointHook, GenerateSymlinkManifest, HudiConverterHook, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
-import org.apache.spark.sql.delta.hooks.ChecksumHook
+import org.apache.spark.sql.delta.hooks.{CheckpointHook, ChecksumHook, GenerateSymlinkManifest, HudiConverterHook, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
 import org.apache.spark.sql.delta.implicits.addFileEncoder
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -296,7 +295,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
   protected var readTheWholeTable = false
 
   /** Tracks if this transaction has already committed. */
-  protected var committed = false
+  protected var committed: Option[CommittedTransaction] = None
 
   /** Contains the execution instrumentation set via thread-local. No-op by default. */
   protected[delta] var executionObserver: TransactionExecutionObserver =
@@ -1395,7 +1394,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       tags: Map[String, String]): Option[Long] = recordDeltaOperation(deltaLog, "delta.commit") {
     commitStartNano = System.nanoTime()
 
-    val (version, postCommitSnapshot, actualCommittedActions) = try {
+    val version = try {
       // Check for satisfaction of no redirect rules
       performRedirectCheck(op)
 
@@ -1501,9 +1500,10 @@ trait OptimisticTransactionImpl extends DeltaTransaction
 
       val (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo) =
         doCommitRetryIteratively(firstAttemptVersion, currentTransactionInfo, isolationLevelToUse)
+      setCommitted(commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo.actions)
       logInfo(log"Committed delta #${MDC(DeltaLogKeys.VERSION, commitVersion)} to " +
         log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)}")
-      (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo.actions)
+      commitVersion
     } catch {
       case e: DeltaConcurrentModificationException =>
         recordDeltaEvent(deltaLog, "delta.commit.conflict." + e.conflictType)
@@ -1516,7 +1516,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
         throw e
     }
 
-    runPostCommitHooks(version, postCommitSnapshot, actualCommittedActions)
+    runPostCommitHooks(committed.get)
 
     executionObserver.transactionCommitted()
     Some(version)
@@ -1614,7 +1614,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       context: Map[String, String],
       metrics: Map[String, String]
   ): (Long, Snapshot) = recordDeltaOperation(deltaLog, "delta.commit.large") {
-    assert(!committed, "Transaction already committed.")
+    assert(committed.isEmpty, "Transaction already committed.")
     commitStartNano = System.nanoTime()
     val attemptVersion = getFirstAttemptVersion
     executionObserver.preparingCommit()
@@ -1752,12 +1752,12 @@ trait OptimisticTransactionImpl extends DeltaTransaction
         DeltaSQLConf.DELTA_LAST_COMMIT_VERSION_IN_SESSION,
         Some(attemptVersion))
       commitEndNano = System.nanoTime()
-      committed = true
       executionObserver.beginPostCommit()
       // NOTE: commitLarge cannot run postCommitHooks (such as the CheckpointHook).
       // Instead, manually run any necessary actions in updateAndCheckpoint.
       val postCommitSnapshot = updateAndCheckpoint(
         spark, deltaLog, commitSize, attemptVersion, commitResponse.getCommit, txnId)
+      setCommitted(attemptVersion, postCommitSnapshot, committedActions = Seq.empty)
       val postCommitReconstructionTime = System.nanoTime()
       var stats = CommitStats(
         startVersion = readVersion,
@@ -2021,7 +2021,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       actions: Seq[Action],
       op: DeltaOperations.Operation): Seq[Action] = {
 
-    assert(!committed, "Transaction already committed.")
+    assert(committed.isEmpty, "Transaction already committed.")
 
     val (metadatasAndProtocols, otherActions) = actions
       .partition(a => a.isInstanceOf[Metadata] || a.isInstanceOf[Protocol])
@@ -2320,7 +2320,6 @@ trait OptimisticTransactionImpl extends DeltaTransaction
             updatedCurrentTransactionInfo = newCurrentTransactionInfo
             doCommit(commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel)
           }
-          committed = true
           return (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo)
         } catch {
           case _: FileAlreadyExistsException if isFsToCcCommit =>
@@ -2751,6 +2750,27 @@ trait OptimisticTransactionImpl extends DeltaTransaction
     newCommitFileStatuses
   }
 
+  protected def setCommitted(
+      committedVersion: Long,
+      postCommitSnapshot: Snapshot,
+      committedActions: Seq[Action]): Unit =
+    committed = Some(CommittedTransaction(
+      txnId = txnId,
+      deltaLog = deltaLog,
+      catalogTable = catalogTable,
+      snapshot = snapshot,
+      metadata = metadata,
+      protocol = protocol,
+      committedVersion = committedVersion,
+      committedActions = committedActions,
+      postCommitSnapshot = postCommitSnapshot,
+      postCommitHooks = postCommitHooks.toSeq,
+      finalTxnExecutionTimeMs = txnExecutionTimeMs.get,
+      finalNeedsCheckpoint = needsCheckpoint,
+      finalPartitionsAddedToOpt = partitionsAddedToOpt,
+      finalIsBlindAppend = isBlindAppend
+    ))
+
   /** Register a hook that will be executed once a commit is successful. */
   def registerPostCommitHook(hook: PostCommitHook): Unit = {
     if (!postCommitHooks.contains(hook)) {
@@ -2761,42 +2781,18 @@ trait OptimisticTransactionImpl extends DeltaTransaction
   def containsPostCommitHook(hook: PostCommitHook): Boolean = postCommitHooks.contains(hook)
 
   /** Executes the registered post commit hooks. */
-  protected def runPostCommitHooks(
-      version: Long,
-      postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit = {
-    assert(committed, "Can't call post commit hooks before committing")
+  protected def runPostCommitHooks(committedTransaction: CommittedTransaction): Unit = {
+    assert(committed.isDefined, "Can't call post commit hooks before committing")
+    val postCommitHooksToRun = committedTransaction.postCommitHooks
 
     // Keep track of the active txn because hooks may create more txns and overwrite the active one.
     val activeCommit = OptimisticTransaction.getActive()
     OptimisticTransaction.clearActive()
 
     try {
-      postCommitHooks.foreach(
-        runPostCommitHook(_, version, postCommitSnapshot, committedActions.toIterator))
+      postCommitHooksToRun.foreach(runPostCommitHook(_, committedTransaction))
     } finally {
       activeCommit.foreach(OptimisticTransaction.setActive)
-    }
-  }
-
-  protected def runPostCommitHook(
-      hook: PostCommitHook,
-      version: Long,
-      postCommitSnapshot: Snapshot,
-      committedActions: Iterator[Action]): Unit = {
-    try {
-      hook.run(spark, this, version, postCommitSnapshot, committedActions)
-    } catch {
-      case NonFatal(e) =>
-        logWarning(log"Error when executing post-commit hook " +
-          log"${MDC(DeltaLogKeys.HOOK_NAME, hook.name)} " +
-          log"for commit ${MDC(DeltaLogKeys.VERSION, version)}", e)
-        recordDeltaEvent(deltaLog, "delta.commit.hook.failure", data = Map(
-          "hook" -> hook.name,
-          "version" -> version,
-          "exception" -> e.toString
-        ))
-        hook.handleError(spark, e, version)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
An `OptimisticTransaction` is currently used to keep track of in-progress transaction and also as a container for post-commit information about the transaction. This makes the semantics messy when it comes to post-commit usage. For example, it is possible for a post-commit hook to takes in an in-progress transaction, intentionally or not. A post-commit hook has access to mutable fields and may need to check whether a field is ready to be consumed or not. 

Previously, we introduced `DeltaTransaction` to limit what can be accessed in a post-commit hook. However, that does not solve the in-progress vs. committed semantics problem and requires that if a new transaction implementation is introduced, it has to inherit all the var fields from the trait, so that it can be passed to the post-commit hooks.

This PR is part of a series of PRs to make the refactoring where:
1. [This PR] We introduce a new `CommittedTransaction` class, that is produced by every transaction implementation, to be passed to the post-commit hooks. This class is immutable and contains only the information needed by the post-commit hooks. It is extending `DeltaTransaction` for now so that it can be passed to the post-commit hooks without making too many changes in this PR.
2. We simplify the API of the post-commit hooks' `run` method so that it takes in only the `CommittedTransaction` struct.
3. We remove all var fields from `DeltaTransaction` and make `CommittedTransaction` not extend from `DeltaTransaction`.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No