### PR TITLE
Clarify that variant defaults should be null

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1924,6 +1924,7 @@ When enabled:
 - The `metadata` for the column in the table schema MAY contain the key `CURRENT_DEFAULT`.
 - The value of `CURRENT_DEFAULT` SHOULD be parsed as a SQL expression.
 - Writers MUST enforce that before writing any rows to the table, for each such requested row that lacks any explicit value (including NULL) for columns with default values, the writing system will assign the result of evaluating the default value expression for each such column as the value for that column in the row. By the same token, if the engine specified the explicit `DEFAULT` SQL keyword for any column, the expression result must be substituted in the same way.
+- All columns of `variant` type must default to null.
 
 ## Identity Columns
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Protocol

## Description

Clarifies that the default value should be `null` for variant data type

## How was this patch tested?

n/a

## Does this PR introduce _any_ user-facing changes?

No