### PR TITLE
[Kernel] Fix REPLACE to correctly retain the clustering domain metadata when replacing a clustered table with a non-clustered table

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -777,6 +777,17 @@ public class TransactionImpl implements Transaction {
             ClusteringUtils.getClusteringDomainMetadata(clusteringColumnsOpt.get());
         addDomain(
             clusteringDomainMetadata.getDomain(), clusteringDomainMetadata.getConfiguration());
+      } else if (TableFeatures.isClusteringTableFeatureSupported(protocol)
+          && isReplaceTable()
+          && !clusteringColumnsOpt.isPresent()) {
+        // When clustering is in the writer features we require there to be a clustering domain
+        // metadata present; when the table is no longer a clustered table this means we must have
+        // a domain metadata with clusteringColumns=[]
+        DomainMetadata emptyClusteringDomainMetadata =
+            ClusteringUtils.getClusteringDomainMetadata(Collections.emptyList());
+        addDomain(
+            emptyClusteringDomainMetadata.getDomain(),
+            emptyClusteringDomainMetadata.getConfiguration());
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

When the `clustering` table feature is in a tables writerFeatures it is required that a clustering domain metadata is present. During replace we never downgrade the protocol, so when transitioning from a clustered table to a non-clustered table we need to retain a clustering domain metadata, but with `clusteringColumns=[]`.

Currently we just remove the existing clustering domain metadata which is incorrect.

## How was this patch tested?

Updates existing tests.