### PR TITLE
[DELTA-4294] Fix time travel by timestamp with In-Commit Timestamps

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 import io.delta.kernel._
 import io.delta.kernel.Operation.{CREATE_TABLE, WRITE}
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.exceptions.{InvalidTableException, ProtocolChangedException}
+import io.delta.kernel.exceptions.{InvalidTableException, KernelException, ProtocolChangedException}
 import io.delta.kernel.expressions.Literal
 import io.delta.kernel.internal.{DeltaHistoryManager, SnapshotImpl, TableImpl}
 import io.delta.kernel.internal.TableConfig._
@@ -600,6 +600,209 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
       assert(ex.getMessage.contains(String.format("Transaction has encountered a conflict and " +
         "can not be committed. Query needs to be re-executed using the latest version of the " +
         "table.")))
+    }
+  }
+
+  test("Time travel by timestamp should use ICT when enabled") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val startTime = System.currentTimeMillis()
+      val clock = new ManualClock(startTime)
+
+      clock.setTime(startTime)
+      setTablePropAndVerify(
+        engine = engine,
+        tablePath = tablePath,
+        key = IN_COMMIT_TIMESTAMPS_ENABLED,
+        value = "true",
+        expectedValue = true,
+        clock = clock)
+
+      val ver0Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val ver0ICT = getInCommitTimestamp(engine, table, version = 0).get
+      assert(ver0ICT === ver0Snapshot.getTimestamp(engine))
+
+      // Edge case: file timestamp < ICT
+      clock.setTime(startTime - 5000)
+      appendData(
+        engine,
+        tablePath,
+        data = Seq(Map.empty[String, Literal] -> dataBatches1),
+        clock = clock)
+      val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val ver1ICT = getInCommitTimestamp(engine, table, version = 1).get
+      assert(ver1ICT > ver0ICT)
+
+      // Common case: file timestamp > ICT
+      clock.setTime(startTime + 10000)
+      appendData(
+        engine,
+        tablePath,
+        data = Seq(Map.empty[String, Literal] -> dataBatches2),
+        clock = clock)
+      val ver2Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val ver2ICT = getInCommitTimestamp(engine, table, version = 2).get
+      assert(ver2ICT > ver1ICT)
+
+      val logPath = new Path(table.getPath(engine), "_delta_log")
+      val commits = DeltaHistoryManager.getCommitsForTests(engine, logPath, 0)
+      assert(commits.size() === 3)
+      for (i <- 0 until 3) assert(commits.get(i).getVersion === i)
+      assert(commits.get(0).getTimestamp === ver0ICT)
+      assert(commits.get(1).getTimestamp === ver1ICT)
+      assert(commits.get(2).getTimestamp === ver2ICT)
+
+      // Time travel between versions
+      val midTimestamp1 = ver0ICT + (ver1ICT - ver0ICT) / 2
+      assert(table.getSnapshotAsOfTimestamp(engine, midTimestamp1).getVersion === 0)
+
+      val midTimestamp2 = ver1ICT + (ver2ICT - ver1ICT) / 2
+      assert(table.getSnapshotAsOfTimestamp(engine, midTimestamp2).getVersion === 1)
+
+      // Exact timestamp matches
+      assert(table.getSnapshotAsOfTimestamp(engine, ver1ICT).getVersion === 1)
+      assert(table.getSnapshotAsOfTimestamp(engine, ver2ICT).getVersion === 2)
+
+      intercept[KernelException] {
+        table.getSnapshotAsOfTimestamp(engine, ver2ICT + 1000)
+      }
+    }
+  }
+
+  test("Time travel by timestamp for a table with both ICT and non-ICT commits") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // Test mixed ICT/non-ICT commits: v0-v1 use file time, v2-v3 use ICT
+      val table = Table.forPath(engine, tablePath)
+      val startTime = System.currentTimeMillis()
+      val clock = new ManualClock(startTime)
+
+      // v0: Create table without ICT
+      clock.setTime(startTime)
+      val txn = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
+        .withSchema(engine, testSchema)
+        .build(engine)
+      txn.commit(engine, emptyIterable())
+
+      // v1: Append data without ICT
+      clock.setTime(startTime + 10000)
+      appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> dataBatches1), clock = clock)
+
+      // v2: Enable ICT
+      clock.setTime(startTime + 20000)
+      setTablePropAndVerify(
+        engine = engine,
+        tablePath = tablePath,
+        isNewTable = false,
+        key = IN_COMMIT_TIMESTAMPS_ENABLED,
+        value = "true",
+        expectedValue = true,
+        clock = clock)
+
+      // v3: Append data with ICT
+      clock.setTime(startTime + 30000)
+      appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> dataBatches2), clock = clock)
+
+      val ver2ICT = getInCommitTimestamp(engine, table, version = 2).get
+      val ver3ICT = getInCommitTimestamp(engine, table, version = 3).get
+
+      // Verify enablement metadata
+      val ver3Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val enablementVersion =
+        IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetadata(ver3Snapshot.getMetadata).get
+      val enablementTimestamp =
+        IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetadata(ver3Snapshot.getMetadata).get
+      assert(enablementVersion === 2)
+      assert(enablementTimestamp === ver2ICT)
+
+      // Get commits using DeltaHistoryManager
+      val logPath = new Path(table.getPath(engine), "_delta_log")
+      val commits = DeltaHistoryManager.getCommitsForTests(engine, logPath, 0)
+
+      // Verify versions and timestamps
+      assert(commits.size() === 4)
+      for (i <- 0 until 4) assert(commits.get(i).getVersion === i)
+
+      // Verify ICT is used for v2-v3
+      assert(commits.get(2).getTimestamp === ver2ICT)
+      assert(commits.get(3).getTimestamp === ver3ICT)
+
+      // Verify monotonically increasing timestamps
+      for (i <- 0 until 3) {
+        assert(commits.get(i).getTimestamp < commits.get(i + 1).getTimestamp)
+      }
+
+      // Test time travel by timestamp
+      val midpoints = for (i <- 0 until 3) yield {
+        commits.get(i).getTimestamp + (commits.get(i + 1).getTimestamp - commits.get(i).getTimestamp) / 2
+      }
+
+      // Verify correct versions returned for timestamps between versions
+      for (i <- 0 until 3) {
+        val snapshot = table.getSnapshotAsOfTimestamp(engine, midpoints(i))
+        assert(snapshot.getVersion === i)
+      }
+
+      // Verify exact timestamp of v3
+      val snapshotAtVer3 = table.getSnapshotAsOfTimestamp(engine, commits.get(3).getTimestamp)
+      assert(snapshotAtVer3.getVersion === 3)
+    }
+  }
+
+  test("Time travel by timestamp with file timestamp different from ICT") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val table = Table.forPath(engine, tablePath)
+      val startTime = System.currentTimeMillis()
+      val clock = new ManualClock(startTime)
+
+      clock.setTime(startTime)
+      setTablePropAndVerify(
+        engine = engine,
+        tablePath = tablePath,
+        key = IN_COMMIT_TIMESTAMPS_ENABLED,
+        value = "true",
+        expectedValue = true,
+        clock = clock)
+      val ver0ICT = getInCommitTimestamp(engine, table, version = 0).get
+
+      // Edge case: file timestamp < ICT
+      clock.setTime(startTime - 5000)
+      appendData(
+        engine,
+        tablePath,
+        data = Seq(Map.empty[String, Literal] -> dataBatches1),
+        clock = clock)
+      val ver1ICT = getInCommitTimestamp(engine, table, version = 1).get
+
+      // Common case: file timestamp > ICT
+      clock.setTime(startTime + 10000)
+      appendData(
+        engine,
+        tablePath,
+        data = Seq(Map.empty[String, Literal] -> dataBatches2),
+        clock = clock)
+      val ver2ICT = getInCommitTimestamp(engine, table, version = 2).get
+
+      assert(ver1ICT > ver0ICT)
+      assert(ver2ICT > ver1ICT)
+
+      val logPath = new Path(table.getPath(engine), "_delta_log")
+      val commits = DeltaHistoryManager.getCommitsForTests(engine, logPath, 0)
+      assert(commits.size() === 3)
+      for (i <- 0 until 3) assert(commits.get(i).getVersion === i)
+      assert(commits.get(0).getTimestamp === ver0ICT)
+      assert(commits.get(1).getTimestamp === ver1ICT)
+      assert(commits.get(2).getTimestamp === ver2ICT)
+
+      // Time travel between versions
+      val midpoint1 = ver0ICT + (ver1ICT - ver0ICT) / 2
+      assert(table.getSnapshotAsOfTimestamp(engine, midpoint1).getVersion === 0)
+
+      val midpoint2 = ver1ICT + (ver2ICT - ver1ICT) / 2
+      assert(table.getSnapshotAsOfTimestamp(engine, midpoint2).getVersion === 1)
+
+      // Exact timestamp matches
+      assert(table.getSnapshotAsOfTimestamp(engine, ver1ICT).getVersion === 1)
+      assert(table.getSnapshotAsOfTimestamp(engine, ver2ICT).getVersion === 2)
     }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/ManualClock.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/ManualClock.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.utils
+
+/**
+ * A clock that can be manually advanced for testing time-dependent functionality.
+ */
+class ManualClock(private var time: Long) {
+
+  def getTimeMillis(): Long = time
+
+  def setTime(time: Long): Unit = {
+    this.time = time
+  }
+
+  def advance(timeToAdd: Long): Unit = {
+    time += timeToAdd
+  }
+}


### PR DESCRIPTION
This PR fixes a bug where time travel by timestamp doesn't account for In-Commit Timestamps (ICT), causing incorrect version loading. The fix ensures that when ICT is enabled, time travel by timestamp uses the ICT values instead of file timestamps.

The changes include:
1. Improved handling of timestamps in DeltaHistoryManager
2. Enhanced tests in InCommitTimestampSuite to verify correct behavior

Fixes #4294

## Which Delta project/connector is this regarding?
- [x] Kernel

## Description
This PR addresses a bug in the Delta Kernel where time travel by timestamp doesn't properly account for In-Commit Timestamps (ICT). When a table has ICT enabled, the system should use those timestamps for time travel operations instead of file timestamps.

The bug was causing incorrect versions to be returned when using time travel by timestamp on tables with ICT enabled.

## How was this patch tested?
Enhanced tests in InCommitTimestampSuite to verify correct behavior, including:
- Edge case where file timestamp < ICT (clock skew)
- Common case where file timestamp > ICT (normal operation)
- Mixed tables with both ICT and non-ICT commits

All tests pass successfully.

## Does this PR introduce any user-facing changes?
No, this is a bug fix that ensures the documented behavior of time travel by timestamp works correctly with In-Commit Timestamps.