### PR TITLE
[Spark] Add additional clustering columns test in Delta Table Python APIs

### DIFF
--- a/python/delta/connect/tables.py
+++ b/python/delta/connect/tables.py
@@ -296,7 +296,6 @@ class DeltaTable(object):
         self._spark.client.execute_command(command)
         return DeltaTable.forName(self._spark, target)
 
-
     def cloneAtVersion(
         self,
         version: int,
@@ -336,8 +335,6 @@ class DeltaTable(object):
         ).command(session=self._spark.client)
         self._spark.client.execute_command(command)
         return DeltaTable.forName(self._spark, target)
-
-    cloneAtTimestamp.__doc__ = LocalDeltaTable.cloneAtTimestamp.__doc__
 
     def _to_proto(self) -> proto.DeltaTable:
         result = proto.DeltaTable()

--- a/python/delta/connect/tests/test_deltatable.py
+++ b/python/delta/connect/tests/test_deltatable.py
@@ -168,19 +168,19 @@ class DeltaTableTests(DeltaTableTestsMixin, DeltaTestCase):
     def test_optimize_zorder_by_w_partition_filter(self):
         pass
 
-    @unittest.skip("create has not been implemented yet")
+    @unittest.skip("clusterBy has not been implemented yet")
     def test_create_table_with_cluster_by(self):
         pass
 
-    @unittest.skip("create has not been implemented yet")
+    @unittest.skip("clusterBy has not been implemented yet")
     def test_replace_table_with_cluster_by(self):
         pass
 
-    @unittest.skip("create has not been implemented yet")
+    @unittest.skip("clusterBy has not been implemented yet")
     def __test_table_with_cluster_by(self) -> None:
         pass
 
-    @unittest.skip("create has not been implemented yet")
+    @unittest.skip("clusterBy has not been implemented yet")
     def test_cluster_by_bad_args(self) -> None:
         pass
 

--- a/python/delta/connect/tests/test_deltatable.py
+++ b/python/delta/connect/tests/test_deltatable.py
@@ -168,6 +168,21 @@ class DeltaTableTests(DeltaTableTestsMixin, DeltaTestCase):
     def test_optimize_zorder_by_w_partition_filter(self):
         pass
 
+    @unittest.skip("create has not been implemented yet")
+    def test_create_table_with_cluster_by(self):
+        pass
+
+    @unittest.skip("create has not been implemented yet")
+    def test_replace_table_with_cluster_by(self):
+        pass
+
+    @unittest.skip("create has not been implemented yet")
+    def __test_table_with_cluster_by(self) -> None:
+        pass
+
+    @unittest.skip("create has not been implemented yet")
+    def test_cluster_by_bad_args(self) -> None:
+        pass
 
 if __name__ == "__main__":
     try:

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -21,6 +21,7 @@ import os
 from multiprocessing.pool import ThreadPool
 from typing import List, Set, Dict, Optional, Any, Callable, Union, Tuple
 
+from py4j.java_gateway import JavaObject
 from py4j.protocol import Py4JJavaError
 from pyspark.errors.exceptions.base import UnsupportedOperationException
 from pyspark.sql import DataFrame, Row
@@ -1490,7 +1491,7 @@ class DeltaTableTestsMixin:
         self.assertEqual('all', metrics.zOrderStats.strategyName)
         self.assertEqual(1, metrics.zOrderStats.numOutputCubes)  # one per each affected partition
 
-    def test_create_table_with_cluster_by(self):
+    def test_create_table_with_cluster_by(self) -> None:
         with self.table("test"):
             builder = DeltaTable.create(self.spark)
             self.__test_table_with_cluster_by(
@@ -1498,7 +1499,7 @@ class DeltaTableTestsMixin:
                 lambda builder: builder.clusterBy(["value2", "value"]),
                 expected=["value", "value2"])
 
-    def test_replace_table_with_cluster_by(self):
+    def test_replace_table_with_cluster_by(self) -> None:
         with self.table("test"):
             self.spark.sql("CREATE TABLE test (c1 int) USING DELTA")
             builder = DeltaTable.replace(self.spark)
@@ -1525,7 +1526,7 @@ class DeltaTableTestsMixin:
                                    nullables={"key", "value", "value2"},
                                    clusteringColumns=expected)
 
-    def test_cluster_by_bad_args(self):
+    def test_cluster_by_bad_args(self) -> None:
         builder = DeltaTable.create(self.spark).location(self.tempFile)
         # bad clusterBy col name
         with self.assertRaises(TypeError):

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -1495,7 +1495,7 @@ class DeltaTableTestsMixin:
             builder = DeltaTable.create(self.spark)
             self.__test_table_with_cluster_by(
                 builder,
-                lambda builder : builder.clusterBy(["value2", "value"]),
+                lambda builder: builder.clusterBy(["value2", "value"]),
                 expected=["value", "value2"])
 
     def test_replace_table_with_cluster_by(self):
@@ -1504,7 +1504,7 @@ class DeltaTableTestsMixin:
             builder = DeltaTable.replace(self.spark)
             self.__test_table_with_cluster_by(
                 builder,
-                lambda builder : builder.clusterBy("value2", "value"),
+                lambda builder: builder.clusterBy("value2", "value"),
                 expected=["value", "value2"])
 
     # type: ignore[arg-type]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Adds additional DeltaTable Python `clusterBy` tests, on top of https://github.com/delta-io/delta/pull/2880.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added UTs.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.
