### PR TITLE
[Kernel][Type Widening] 4/ rework compute field ID to avoid recursion

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
@@ -39,10 +39,15 @@ class SchemaChanges {
   public static class SchemaUpdate {
     private final StructField fieldBefore;
     private final StructField fieldAfter;
+    // Note this is a by name. If we want to be able to track changes
+    // at the where an element is moved to a different location in the
+    // schema we need to add more paths here.
+    private final String pathToAfterField;
 
-    SchemaUpdate(StructField fieldBefore, StructField fieldAfter) {
+    SchemaUpdate(StructField fieldBefore, StructField fieldAfter, String pathToAfterField) {
       this.fieldBefore = fieldBefore;
       this.fieldAfter = fieldAfter;
+      this.pathToAfterField = pathToAfterField;
     }
 
     public StructField before() {
@@ -51,6 +56,10 @@ class SchemaChanges {
 
     public StructField after() {
       return fieldAfter;
+    }
+
+    public String getPathToAfterField() {
+      return pathToAfterField;
     }
   }
 
@@ -82,8 +91,9 @@ class SchemaChanges {
       return this;
     }
 
-    public Builder withUpdatedField(StructField existingField, StructField newField) {
-      updatedFields.add(new SchemaUpdate(existingField, newField));
+    public Builder withUpdatedField(
+        StructField existingField, StructField newField, String pathToAfterField) {
+      updatedFields.add(new SchemaUpdate(existingField, newField, pathToAfterField));
       return this;
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
@@ -39,6 +39,10 @@ class SchemaChanges {
   public static class SchemaUpdate {
     private final StructField fieldBefore;
     private final StructField fieldAfter;
+    // This is a "." concatenated path to the field. Names containing "." are wrapped in back-ticks (`).
+    // For example in the schema <a.b : array<StructType<c : Int>>> the path to "c" would be:
+    // "`a.b`.element.c". In general, though the format should not be relid upon since this
+    // is used for surfacing errors to users.
     // Note this is a by name. If we want to be able to track changes
     // at the where an element is moved to a different location in the
     // schema we need to add more paths here.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
@@ -39,7 +39,8 @@ class SchemaChanges {
   public static class SchemaUpdate {
     private final StructField fieldBefore;
     private final StructField fieldAfter;
-    // This is a "." concatenated path to the field. Names containing "." are wrapped in back-ticks (`).
+    // This is a "." concatenated path to the field. Names containing "." are wrapped in
+    // back-ticks (`).
     // For example in the schema <a.b : array<StructType<c : Int>>> the path to "c" would be:
     // "`a.b`.element.c". In general, though the format should not be relid upon since this
     // is used for surfacing errors to users.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaIterable.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaIterable.java
@@ -203,6 +203,14 @@ public class SchemaIterable implements Iterable<SchemaIterable.SchemaElement> {
      * [<prefix>.]((key|value|element).)*(key|value|element)}
      */
     String getPathFromNearestStructFieldAncestor(String prefix);
+
+    /**
+     * Returns true if this element is a StructField (as compared to an array element or a map
+     * key/value).
+     */
+    default boolean isStructField() {
+      return false;
+    }
   }
   /**
    * Interface for manipulating Schema elements.
@@ -474,6 +482,11 @@ public class SchemaIterable implements Iterable<SchemaIterable.SchemaElement> {
   private static class StructSchemaZipper extends SchemaZipper {
     StructSchemaZipper(List<SchemaZipper> parents, StructType structType) {
       super(parents, structType.fields());
+    }
+
+    @Override
+    public boolean isStructField() {
+      return true;
     }
 
     @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -434,13 +434,13 @@ public class SchemaUtils {
         // path would be "element" here and either "key" or "value" in the previous schema. Nothing
         // is done for the new "element" path if it isn't a field addition there must be at least
         // one ancestor node in common (at least the nearest struct field) which would get added as
-        // an update below. This logic is inductive. If the previous schema was a array<array<x>> and
-        // was not a new addition and the new schema was array<array<array<x>>> then this path would
-        // be reached on element.element.element but the type the code would move past this block for
-        // element.element which would have a type change detected from x to array<x>.
+        // an update below. This logic is inductive. If the previous schema was a array<array<x>>
+        // and was not a new addition and the new schema was array<array<array<x>>> then this path
+        // would be reached on element.element.element but the type the code would move past this
+        // block for element.element which would have a type change detected from x to array<x>.
         // concretely if the new schema was <a id=1 : array<struct<b (id=2) : Int>>> then
-        // <"element, "1"> would be skipped here but the type change would be detected for <"", 1> from
-        // map to array.
+        // <"element, "1"> would be skipped here but the type change would be detected for <"", 1>
+        // from map to array.
         continue;
       }
       StructField updatedField = newElement.getField();

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -903,6 +903,91 @@ class SchemaUtilsSuite extends AnyFunSuite {
       "Cannot change the type of existing field id from integer to string")
   }
 
+  private val invalidTypeChangesNested = Table(
+    ("schemaBefore", "schemaWithInvalidTypeChange"),
+    // Array to Map
+    (
+      newSchema((
+        1,
+        new StructField(
+          "array",
+          new ArrayType(
+            IntegerType.INTEGER,
+            false),
+          true))),
+      newSchema((
+        1,
+        new StructField(
+          "to_map",
+          new MapType(
+            IntegerType.INTEGER,
+            IntegerType.INTEGER,
+            false),
+          true)))),
+
+    // Array to Map
+    (
+      newSchema((
+        1,
+        new StructField(
+          "map",
+          new MapType(
+            IntegerType.INTEGER,
+            IntegerType.INTEGER,
+            false),
+          true))),
+      newSchema((
+        1,
+        new StructField(
+          "to_array",
+          new ArrayType(
+            IntegerType.INTEGER,
+            false),
+          true)))),
+    // nested array change
+    (
+      newSchema((
+        1,
+        new StructField(
+          "array",
+          new ArrayType(
+            new ArrayType(IntegerType.INTEGER, false),
+            false),
+          true))),
+      newSchema((
+        1,
+        new StructField(
+          "to_map",
+          new ArrayType(
+            new MapType(IntegerType.INTEGER, IntegerType.INTEGER, false),
+            false),
+          true)))),
+    // nested map change
+    (
+      newSchema((
+        1,
+        new StructField(
+          "map",
+          new MapType(
+            IntegerType.INTEGER,
+            new ArrayType(IntegerType.INTEGER, false),
+            false),
+          true))),
+      newSchema((
+        1,
+        new StructField(
+          "to_nested_array_to_primitive",
+          new MapType(
+            IntegerType.INTEGER,
+            IntegerType.INTEGER,
+            false),
+          false)))))
+  test("validateUpdatedSchema fails when invalid type change is performed on nested fields") {
+    assertSchemaEvolutionFailure[KernelException](
+      invalidTypeChangesNested,
+      "Cannot change the type of existing field.*")
+  }
+
   private val validateAddedFields = Table(
     ("schemaBefore", "schemaWithAddedField"),
     (

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -849,14 +849,14 @@ class SchemaUtilsSuite extends AnyFunSuite {
     "allowNewRequiredFields=false") {
     assertSchemaEvolutionFailure[KernelException](
       existingFieldNullabilityTightened,
-      "Cannot tighten the nullability of existing field id")
+      "Cannot tighten the nullability of existing field .*id")
   }
 
   test("validateUpdatedSchema fails when existing nullability is tightened with " +
     "allowNewRequiredFields=true") {
     assertSchemaEvolutionFailure[KernelException](
       existingFieldNullabilityTightened,
-      "Cannot tighten the nullability of existing field id",
+      "Cannot tighten the nullability of existing field .*id",
       allowNewRequiredFields = true)
   }
 
@@ -1101,7 +1101,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
           allowNewRequiredFields)
       }
 
-      assert(e.getMessage.matches(expectedMessage))
+      assert(e.getMessage.matches(expectedMessage), s"${e.getMessage} ~= $expectedMessage")
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -1177,7 +1177,7 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
         table,
         engine,
         newSchema,
-        "Cannot tighten the nullability of existing field a")
+        "Cannot tighten the nullability of existing field renamed_a")
     }
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4567/files) to review incremental changes.
- [**stack/tw_proper_addressing**](https://github.com/delta-io/delta/pull/4567) [[Files changed](https://github.com/delta-io/delta/pull/4567/files)]
  - [stack/tw_type_changes](https://github.com/delta-io/delta/pull/4568) [[Files changed](https://github.com/delta-io/delta/pull/4568/files/7a07781a45a757873a5dbf519f84c3e25f3af4e3..2c2f71a4a6b775abb4da3b141058ed20196cd099)]
    - [stack/tw_type_changes_to_field_metadata](https://github.com/delta-io/delta/pull/4588) [[Files changed](https://github.com/delta-io/delta/pull/4588/files/2c2f71a4a6b775abb4da3b141058ed20196cd099..d8f0abb884b33b12333f1b53b6d1aed124d3277a)]
      - [stack/tw_type_changes_to_field_metadata_impl](https://github.com/delta-io/delta/pull/4589) [[Files changed](https://github.com/delta-io/delta/pull/4589/files/d8f0abb884b33b12333f1b53b6d1aed124d3277a..1426562ddfbcb0954b481ecf8432785b84059e84)]
        - [stack/tw_serde_refactor](https://github.com/delta-io/delta/pull/4592) [[Files changed](https://github.com/delta-io/delta/pull/4592/files/1426562ddfbcb0954b481ecf8432785b84059e84..9a8462ad2abd1eb920b021fc5de9497223e844a4)]
          - [stack/add_type_change_parsing](https://github.com/delta-io/delta/pull/4593) [[Files changed](https://github.com/delta-io/delta/pull/4593/files/9a8462ad2abd1eb920b021fc5de9497223e844a4..1da4e2fe660ebd2d4d9eb9aa3702a9ec6d4ed837)]
            - [stack/tw_upgrade_downgrade](https://github.com/delta-io/delta/pull/4603) [[Files changed](https://github.com/delta-io/delta/pull/4603/files/1da4e2fe660ebd2d4d9eb9aa3702a9ec6d4ed837..6148941b110f389616819cf3e64ec10243f32776)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR uses the new SchemaIterable class introduced in a prior PR to calculate schema changes.  It takes the opportunity to eliminate recursive methods by doing change comparison at every element in a Schema tree (by creating a custom ID object and finding changes at ever level first).  This trades off some memory for, IMO, cleaner code.  In theory in a future iteration we can also avoid the implicit recursion on `DataType.equivelant` and `StructField.equal` but this can be done as a follow-up.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.
