### PR TITLE
[Kernel][Type Widening] 5/ Add type changes rules for type widening

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -505,7 +505,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
               : existingClusteringCols;
 
       Optional<Metadata> schemaUpdatedMetadata =
-          validateMetadataChange(
+          validateMetadataChangeAndUpdateMetadata(
               effectiveClusteringCols,
               baseMetadata,
               newMetadata.get(),
@@ -614,8 +614,11 @@ public class TransactionBuilderImpl implements TransactionBuilder {
    *   <li>Enabling/disabling row tracking on existing tables is blocked
    *   <li>Materialized row tracking column names do not conflict with schema
    * </ul>
+   *
+   * @return An updated metadata object if any changes where made. Currently, changed schemas can
+   *     require a new metadata object to be returned, but other changes do not.
    */
-  private Optional<Metadata> validateMetadataChange(
+  private Optional<Metadata> validateMetadataChangeAndUpdateMetadata(
       Optional<List<Column>> clusteringCols,
       Metadata oldMetadata,
       Metadata newMetadata,
@@ -656,7 +659,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
               .collect(toSet());
 
       updatedMetadata =
-          SchemaUtils.validateUpdatedSchema(
+          SchemaUtils.validateUpdatedSchemaAndGetUpdatedSchema(
                   oldMetadata,
                   newMetadata,
                   clusteringColumnPhysicalNames,
@@ -683,7 +686,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       // We only need to check fieldId re-use when cmMode != none
       if (newMode != ColumnMappingMode.NONE) {
         updatedMetadata =
-            SchemaUtils.validateUpdatedSchema(
+            SchemaUtils.validateUpdatedSchemaAndGetUpdatedSchema(
                     latestSnapshot.get().getMetadata(),
                     updatedMetadata.orElse(newMetadata),
                     // We already validate clustering columns elsewhere for isCreateOrReplace no

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaChanges.java
@@ -16,9 +16,11 @@
 package io.delta.kernel.internal.util;
 
 import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * SchemaChanges encapsulates a list of added, removed, renamed, or updated fields in a schema
@@ -71,20 +73,24 @@ class SchemaChanges {
   private List<StructField> addedFields;
   private List<StructField> removedFields;
   private List<SchemaUpdate> updatedFields;
+  private Optional<StructType> updatedSchema;
 
   private SchemaChanges(
       List<StructField> addedFields,
       List<StructField> removedFields,
-      List<SchemaUpdate> updatedFields) {
+      List<SchemaUpdate> updatedFields,
+      Optional<StructType> updatedSchema) {
     this.addedFields = Collections.unmodifiableList(addedFields);
     this.removedFields = Collections.unmodifiableList(removedFields);
     this.updatedFields = Collections.unmodifiableList(updatedFields);
+    this.updatedSchema = updatedSchema;
   }
 
   static class Builder {
     private List<StructField> addedFields = new ArrayList<>();
     private List<StructField> removedFields = new ArrayList<>();
     private List<SchemaUpdate> updatedFields = new ArrayList<>();
+    private Optional<StructType> updatedSchema = Optional.empty();
 
     public Builder withAddedField(StructField addedField) {
       addedFields.add(addedField);
@@ -102,8 +108,13 @@ class SchemaChanges {
       return this;
     }
 
+    public Builder withUpdatedSchema(StructType updatedSchema) {
+      this.updatedSchema = Optional.of(updatedSchema);
+      return this;
+    }
+
     public SchemaChanges build() {
-      return new SchemaChanges(addedFields, removedFields, updatedFields);
+      return new SchemaChanges(addedFields, removedFields, updatedFields, updatedSchema);
     }
   }
 
@@ -124,5 +135,9 @@ class SchemaChanges {
   /* Updated Fields (e.g. rename, type change) represented */
   public List<SchemaUpdate> updatedFields() {
     return updatedFields;
+  }
+
+  public Optional<StructType> updatedSchema() {
+    return updatedSchema;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -148,6 +148,8 @@ public class SchemaUtils {
    *     schema
    * @throws IllegalArgumentException if the schema evolution is invalid
    */
+  // TODO: Consider renaming or refactoring to avoid returning the
+  // StructType here.
   public static Optional<StructType> validateSchemaEvolutionById(
       StructType currentSchema,
       StructType newSchema,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -92,7 +92,8 @@ public class SchemaUtils {
    * base for validation. ColumnMapping must be enabled to call this.
    *
    * <p>Returns an updated schema if metadata (i.e. TypeChanges needs to be copied over from
-   * currentSchema).
+   * currentSchema and new type changes need to be recorded. Kernel is expected to handle this work
+   * instead of clients).
    *
    * <p>The following checks are performed:
    *
@@ -105,7 +106,7 @@ public class SchemaUtils {
    *   <li>ToDo: Nested IDs for array/map types are preserved in the new schema for IcebergCompatV2
    * </ul>
    */
-  public static Optional<StructType> validateUpdatedSchema(
+  public static Optional<StructType> validateUpdatedSchemaAndGetUpdatedSchema(
       Metadata currentMetadata,
       Metadata newMetadata,
       Set<String> clusteringColumnPhysicalNames,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -144,10 +144,8 @@ public class SchemaUtils {
    * @param allowNewRequiredFields If `false`, adding new required columns throws an error. If
    *     `true`, new required columns are allowed
    * @param icebergWriterCompatV1Enabled `true` if icebergCompatV1 is enabled on the table
-   *
-   * @return an updated schema if metadata (e.g. TypeChanges needs to be copied over from
-   *   the old schema
-   *
+   * @return an updated schema if metadata (e.g. TypeChanges needs to be copied over from the old
+   *     schema
    * @throws IllegalArgumentException if the schema evolution is invalid
    */
   public static Optional<StructType> validateSchemaEvolutionById(
@@ -156,19 +154,20 @@ public class SchemaUtils {
       Set<String> clusteringColumnPhysicalNames,
       int oldMaxFieldId,
       boolean allowNewRequiredFields,
-      boolean icebergWriterCompatV1Enabled) {
+      boolean icebergWriterCompatV1Enabled,
+      boolean typeWideningEnabled) {
     SchemaChanges schemaChanges = computeSchemaChangesById(currentSchema, newSchema);
     validatePhysicalNameConsistency(schemaChanges.updatedFields());
     // Validates that the updated schema does not contain breaking changes in terms of types and
     // nullability
     validateUpdatedSchemaCompatibility(
-            schemaChanges,
-            oldMaxFieldId,
-            allowNewRequiredFields,
-            icebergWriterCompatV1Enabled,
-            typeWideningEnabled);
+        schemaChanges,
+        oldMaxFieldId,
+        allowNewRequiredFields,
+        icebergWriterCompatV1Enabled,
+        typeWideningEnabled);
     validateClusteringColumnsNotDropped(
-            schemaChanges.removedFields(), clusteringColumnPhysicalNames);
+        schemaChanges.removedFields(), clusteringColumnPhysicalNames);
     return schemaChanges.updatedSchema();
     // ToDo Potentially validate IcebergCompatV2 nested IDs
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -517,6 +517,10 @@ public class SchemaUtils {
         if (!isNestedType(existingField)
             && !isNestedType(newField)
             && !existingField.getDataType().equivalent(newField.getDataType())) {
+          // Type changes only apply to non-nested types.  This loop evaluates both
+          // nested and non-nested, so we narrow down updates here. Actual type differences
+          // between nested types are validated against SchemaChanges returned by this
+          // function.
           List<TypeChange> changes = new ArrayList<>(newField.getTypeChanges());
           changes.add(new TypeChange(existingField.getDataType(), newField.getDataType()));
           newElement.updateField(newField.withTypeChanges(changes));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/TypeChange.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/TypeChange.java
@@ -25,19 +25,19 @@ import java.util.Objects;
  * types.
  */
 public class TypeChange {
-  private final BasePrimitiveType from;
-  private final BasePrimitiveType to;
+  private final DataType from;
+  private final DataType to;
 
-  public TypeChange(BasePrimitiveType from, BasePrimitiveType to) {
+  public TypeChange(DataType from, DataType to) {
     this.from = Objects.requireNonNull(from, "from type cannot be null");
     this.to = Objects.requireNonNull(to, "to type cannot be null");
   }
 
-  public BasePrimitiveType getFrom() {
+  public DataType getFrom() {
     return from;
   }
 
-  public BasePrimitiveType getTo() {
+  public DataType getTo() {
     return to;
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -27,10 +27,10 @@ import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.actions.{Format, Metadata}
 import io.delta.kernel.internal.types.DataTypeJsonSerDe
-import io.delta.kernel.internal.util.ColumnMapping.{COLUMN_MAPPING_ID_KEY, COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_NESTED_IDS_KEY, COLUMN_MAPPING_PHYSICAL_NAME_KEY, ColumnMappingMode}
+import io.delta.kernel.internal.util.ColumnMapping.{COLUMN_MAPPING_ID_KEY, COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_PHYSICAL_NAME_KEY}
 import io.delta.kernel.internal.util.SchemaUtils.{computeSchemaChangesById, filterRecursively, validateSchema, validateUpdatedSchema}
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
-import io.delta.kernel.types.{ArrayType, DataType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructField, StructType}
+import io.delta.kernel.types.{ArrayType, ByteType, DataType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructField, StructType, TypeChange}
 import io.delta.kernel.types.IntegerType.INTEGER
 import io.delta.kernel.types.LongType.LONG
 import io.delta.kernel.types.TimestampType.TIMESTAMP
@@ -49,6 +49,22 @@ class SchemaUtilsSuite extends AnyFunSuite {
     assert(
       shouldContain.map(_.toLowerCase(Locale.ROOT)).forall(msg.contains),
       s"Error message '$msg' didn't contain: $shouldContain")
+  }
+
+  private def newSchema(tuple: (Int, StructField)*): StructType = {
+    val fields = tuple.map { case (id, field) =>
+      addFieldId(id, field)
+    }
+    val schemaWithIds = new StructType(fields.asJava)
+    schemaWithIds
+  }
+
+  private def addFieldId(id: Int, field: StructField) = {
+    val metadataWithFieldIds = FieldMetadata.builder().fromMetadata(field.getMetadata)
+      .putLong("delta.columnMapping.id", id)
+      .putString("delta.columnMapping.physicalName", s"col-$id")
+      .build()
+    field.withNewMetadata(metadataWithFieldIds)
   }
 
   ///////////////////////////////////////////////////////////////////////////
@@ -1231,6 +1247,233 @@ class SchemaUtilsSuite extends AnyFunSuite {
       .putString("delta.columnMapping.physicalName", s"col-$id")
       .build()
     field.withNewMetadata(metadataWithFieldIds)
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Type Changes Tests
+  ///////////////////////////////////////////////////////////////////////////
+
+  test("Compute schema changes adds schema change") {
+    val currentSchema = newSchema((1, new StructField("id", IntegerType.INTEGER, true)))
+    val updatedSchema = newSchema((1, new StructField("id", LongType.LONG, true)))
+
+    val schemaChanges = computeSchemaChangesById(currentSchema, updatedSchema)
+
+    // Verify that we have one updated field
+    assert(schemaChanges.updatedFields().size() == 1)
+    val schemaUpdate = schemaChanges.updatedFields().get(0)
+
+    // Verify that the updated field has the expected before and after values
+    assert(schemaUpdate.getFieldBefore == currentSchema.get("id"))
+    assert(schemaUpdate.getFieldAfter == updatedSchema.get("id"))
+
+    // Verify that the updated schema has a TypeChange recorded
+    assert(schemaChanges.updatedSchema().isPresent)
+    val updatedField = schemaChanges.updatedSchema().get().get("id")
+    val typeChanges = updatedField.getTypeChanges
+    assert(typeChanges.size() == 1)
+    val typeChange = typeChanges.get(0)
+    assert(typeChange.getFrom == IntegerType.INTEGER)
+    assert(typeChange.getTo == LongType.LONG)
+  }
+
+  test("Type changes are preserved across schema updates") {
+    // Create a field with integer type and an existing type change from byte to int
+    val byteType = ByteType.BYTE
+    val intType = IntegerType.INTEGER
+
+    val existingTypeChange = new TypeChange(byteType, intType)
+    val fieldWithTypeChange = new StructField(
+      "id",
+      intType,
+      true,
+      fieldMetadata(1, "id")).withTypeChanges(List(existingTypeChange).asJava)
+
+    val currentSchema = new StructType(List(fieldWithTypeChange).asJava)
+    // Change the type to long without specifying the previous type change
+    val updatedSchema = newSchema((1, new StructField("id", intType, true)))
+
+    val schemaChanges = computeSchemaChangesById(currentSchema, updatedSchema)
+
+    // Verify that the updated schema has the TypeChange preserved and a new one added
+    assert(schemaChanges.updatedSchema().isPresent)
+    val updatedField = schemaChanges.updatedSchema().get().get("id")
+
+    // Check that both type changes are recorded (the original and the new one)
+    val typeChanges = updatedField.getTypeChanges
+    assert(typeChanges.size() == 1)
+    assert(typeChanges.get(0).getFrom == byteType)
+    assert(typeChanges.get(0).getTo == intType)
+  }
+
+  test("Type changes are preserved across schema updates and new ones are added") {
+    // Create a field with integer type and an existing type change from byte to int
+    val byteType = ByteType.BYTE
+    val intType = IntegerType.INTEGER
+    val longType = LongType.LONG
+
+    val existingTypeChange = new TypeChange(byteType, intType)
+    val fieldWithTypeChange = new StructField(
+      "id",
+      intType,
+      true,
+      fieldMetadata(1, "id")).withTypeChanges(List(existingTypeChange).asJava)
+
+    val currentSchema = new StructType(List(fieldWithTypeChange).asJava)
+    // Change the type to long without specifying the previous type change
+    val updatedSchema = newSchema((1, new StructField("id", longType, true)))
+
+    val schemaChanges = computeSchemaChangesById(currentSchema, updatedSchema)
+
+    // Verify that the updated schema has the TypeChange preserved and a new one added
+    assert(schemaChanges.updatedSchema().isPresent)
+    val updatedField = schemaChanges.updatedSchema().get().get("id")
+
+    // Check that both type changes are recorded (the original and the new one)
+    val typeChanges = updatedField.getTypeChanges
+    assert(typeChanges.size() == 2)
+    val typeChange = typeChanges.get(0)
+    assert(typeChange.getFrom == byteType)
+    assert(typeChange.getTo == intType)
+    val newTypeChange = typeChanges.get(1)
+    assert(newTypeChange.getFrom == intType)
+    assert(newTypeChange.getTo == longType)
+  }
+
+  test("Throws exception when type changes are inconsistent") {
+    // Create a field with integer type and an existing type change from byte to int
+    val byteType = ByteType.BYTE
+    val intType = IntegerType.INTEGER
+    val longType = LongType.LONG
+
+    val existingTypeChange = new TypeChange(byteType, intType)
+    val fieldWithTypeChange = new StructField(
+      "id",
+      intType,
+      true,
+      fieldMetadata(1, "id")).withTypeChanges(List(existingTypeChange).asJava)
+
+    val currentSchema = new StructType(List(fieldWithTypeChange).asJava)
+
+    // Create a new field with a different type change history
+    val differentTypeChange = new TypeChange(longType, intType)
+    val fieldWithDifferentTypeChange = new StructField(
+      "id",
+      intType,
+      true,
+      fieldMetadata(1, "id")).withTypeChanges(List(differentTypeChange).asJava)
+
+    val updatedSchema = new StructType(List(fieldWithDifferentTypeChange).asJava)
+
+    // This should throw an exception because the type changes are not equal
+    expectFailure(
+      "detected a modified type changes field at 'id'",
+      "typechange(from=byte,to=integer)",
+      "typechange(from=long,to=integer)") {
+      computeSchemaChangesById(currentSchema, updatedSchema)
+    }
+  }
+
+  private val validTypeWideningSchemas = Table(
+    (
+      "schemaBefore",
+      "schemaAfter",
+      "typeWideningEnabled",
+      "icebergWriterCompatV1Enabled",
+      "shouldSucceed"),
+    // Integer widening: Int -> Long (always allowed with type widening)
+    (
+      primitiveSchema,
+      new StructType().add(
+        "id",
+        LongType.LONG,
+        true,
+        fieldMetadata(id = 1, physicalName = "id")),
+      /* typeWideningEnabled= */ true,
+      /* icebergWriterCompatv1enabled= */ false,
+      /* shouldSucceed= */ true),
+    // Integer widening: Int -> Long (not allowed without type widening)
+    (
+      primitiveSchema,
+      new StructType().add(
+        "id",
+        LongType.LONG,
+        true,
+        fieldMetadata(id = 1, physicalName = "id")),
+      /* typeWideningEnabled= */ false,
+      /* icebergWriterCompatv1enabled= */ false,
+      /* shouldSucceed= */ false),
+    // Integer to Double widening (allowed with type widening but not with Iceberg compat)
+    (
+      primitiveSchema,
+      new StructType().add(
+        "id",
+        DoubleType.DOUBLE,
+        true,
+        fieldMetadata(id = 1, physicalName = "id")),
+      /* typeWideningEnabled= */ true,
+      /* icebergWriterCompatv1enabled= */ false,
+      /* shouldSucceed= */ true),
+    // Integer to Double widening (not allowed with Iceberg compat)
+    (
+      primitiveSchema,
+      new StructType().add(
+        "id",
+        DoubleType.DOUBLE,
+        true,
+        fieldMetadata(id = 1, physicalName = "id")),
+      /* typeWideningEnabled= */ true,
+      /* icebergwritercompatv1enabled= */ true,
+      /* shouldSucceed= */ false),
+    // Invalid type change: Int -> String (never allowed)
+    (
+      primitiveSchema,
+      new StructType().add(
+        "id",
+        StringType.STRING,
+        true,
+        fieldMetadata(id = 1, physicalName = "id")),
+      /* typeWideningEnabled= */ true,
+      /* typeWideningEnabled= */ false,
+      /* shouldSucceed= */ false))
+
+  forAll(validTypeWideningSchemas) {
+    (
+        schemaBefore,
+        schemaAfter,
+        typeWideningEnabled,
+        icebergWriterCompatV1Enabled,
+        shouldSucceed) =>
+      test("validateUpdatedSchema with type widening " +
+        s"$schemaBefore $schemaAfter $typeWideningEnabled $icebergWriterCompatV1Enabled") {
+
+        val tblProperties = Map(
+          ColumnMapping.COLUMN_MAPPING_MODE_KEY -> "id",
+          TableConfig.TYPE_WIDENING_ENABLED.getKey -> typeWideningEnabled.toString,
+          TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.getKey ->
+            icebergWriterCompatV1Enabled.toString)
+
+        if (shouldSucceed) {
+          // Should not throw an exception
+          validateUpdatedSchema(
+            metadata(schemaBefore, tblProperties),
+            metadata(schemaAfter, tblProperties),
+            emptySet(),
+            false /* allowNewRequiredFields */
+          )
+        } else {
+          // Should throw an exception
+          val e = intercept[KernelException] {
+            validateUpdatedSchema(
+              metadata(schemaBefore, tblProperties),
+              metadata(schemaAfter, tblProperties),
+              emptySet(),
+              false /* allowNewRequiredFields */
+            )
+          }
+          assert(e.getMessage.contains("Cannot change the type of existing field"))
+        }
+      }
   }
 
   ///////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -32,6 +32,7 @@ import io.delta.kernel.internal.util.{ColumnMapping, ColumnMappingSuiteBase}
 import io.delta.kernel.types.{ArrayType, DecimalType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructType}
 import io.delta.kernel.utils.CloseableIterable
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
+
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables
 
@@ -1335,9 +1336,9 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
         .add("d", StringType.STRING, true)
 
       val txn = table.createTransactionBuilder(
-          engine,
-          testEngineInfo,
-          Operation.MANUAL_UPDATE)
+        engine,
+        testEngineInfo,
+        Operation.MANUAL_UPDATE)
         .withSchema(engine, newSchema)
         .withClusteringColumns(engine, List(new Column("d")).asJava)
         .build(engine)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -29,10 +29,9 @@ import io.delta.kernel.internal.{SnapshotImpl, TableConfig}
 import io.delta.kernel.internal.actions.DomainMetadata
 import io.delta.kernel.internal.clustering.ClusteringMetadataDomain
 import io.delta.kernel.internal.util.{ColumnMapping, ColumnMappingSuiteBase}
-import io.delta.kernel.types.{ArrayType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructType}
+import io.delta.kernel.types.{ArrayType, DecimalType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructType}
 import io.delta.kernel.utils.CloseableIterable
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
-
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables
 
@@ -1336,9 +1335,9 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
         .add("d", StringType.STRING, true)
 
       val txn = table.createTransactionBuilder(
-        engine,
-        testEngineInfo,
-        Operation.MANUAL_UPDATE)
+          engine,
+          testEngineInfo,
+          Operation.MANUAL_UPDATE)
         .withSchema(engine, newSchema)
         .withClusteringColumns(engine, List(new Column("d")).asJava)
         .build(engine)
@@ -1358,6 +1357,100 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
 
       verifyClusteringDomainMetadata(snapshot.asInstanceOf[SnapshotImpl], expectedDomainMetadata)
     }
+  }
+
+  private val typeWideningTestCases = Tables.Table(
+    (
+      "testName",
+      "initialType",
+      "newType",
+      "typeWideningEnabled",
+      "icebergV1Enabled",
+      "shouldSucceed",
+      "errorMessageFragment"),
+    (
+      "Integer widening (Int -> Long) with type widening enabled",
+      IntegerType.INTEGER,
+      LongType.LONG,
+      /* typeWideningEnabled= */ true,
+      /* icebergV1Enabled= */ false,
+      /* shouldSucceed= */ true,
+      ""),
+    (
+      "Integer widening (Int -> Long) with type widening disabled",
+      IntegerType.INTEGER,
+      LongType.LONG,
+      /* typeWideningEnabled= */ false,
+      /* icebergV1Enabled= */ false,
+      /* shouldSucceed= */ false,
+      "Cannot change the type of existing field id from integer to long"),
+    (
+      "Decimal precision and scale increase",
+      new DecimalType(10, 2),
+      new DecimalType(15, 5),
+      /* typeWideningEnabled= */ true,
+      /* icebergV1Enabled= */ false,
+      /* shouldSucceed= */ true,
+      ""),
+    (
+      "Decimal precision and scale increase with Iceberg V1 compatibility",
+      new DecimalType(10, 2),
+      new DecimalType(15, 5),
+      /* typeWideningEnabled= */ true,
+      /* icebergV1Enabled= */ true,
+      /* shouldSucceed= */ false,
+      "Cannot change the type of existing field id"))
+
+  forAll(typeWideningTestCases) {
+    (
+        testName,
+        initialType,
+        newType,
+        typeWideningEnabled,
+        icebergV1Enabled,
+        shouldSucceed,
+        errorMessageFragment) =>
+      test(s"Type widening scenarios $testName") {
+        withTempDirAndEngine { (tablePath, engine) =>
+          val table = Table.forPath(engine, tablePath)
+          val initialSchema = new StructType()
+            .add("id", initialType, true)
+            .add("data", StringType.STRING, true)
+
+          createEmptyTable(
+            engine,
+            tablePath,
+            initialSchema,
+            tableProperties = Map(
+              TableConfig.COLUMN_MAPPING_MODE.getKey -> "id",
+              TableConfig.TYPE_WIDENING_ENABLED.getKey -> typeWideningEnabled.toString,
+              TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.getKey -> icebergV1Enabled.toString,
+              TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
+
+          val currentSchema = table.getLatestSnapshot(engine).getSchema()
+          val newSchema = new StructType()
+            .add("id", newType, true, currentSchema.get("id").getMetadata)
+            .add("data", StringType.STRING, true, currentSchema.get("data").getMetadata)
+
+          if (shouldSucceed) {
+            // This should succeed because conditions allow type widening
+            table.createTransactionBuilder(engine, testEngineInfo, Operation.MANUAL_UPDATE)
+              .withSchema(engine, newSchema)
+              .build(engine).commit(engine, emptyIterable())
+
+            val updatedSchema = table.getLatestSnapshot(engine).getSchema
+            assert(updatedSchema.get("id").getDataType == newType)
+            // TODO: Add checks for type changes once SerDe is supported.
+          } else {
+            // This should fail because conditions don't allow type widening
+            assertSchemaEvolutionFails[KernelException](
+              table,
+              engine,
+              newSchema,
+              errorMessageFragment)
+          }
+        }
+      }
   }
 
   def fieldMetadataForColumn(
@@ -1418,4 +1511,5 @@ class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with Colum
     TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID
       .fromMetadata(getMetadata(engine, tablePath))
   }
+
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4568/files) to review incremental changes.
- [**stack/tw_type_changes**](https://github.com/delta-io/delta/pull/4568) [[Files changed](https://github.com/delta-io/delta/pull/4568/files)]
  - [stack/tw_type_changes_to_field_metadata](https://github.com/delta-io/delta/pull/4588) [[Files changed](https://github.com/delta-io/delta/pull/4588/files/3cc7f9fce24cf8d1c3cd13fff9cb9ac8b2aa3f61..cd9d0a002af5ae669ff0f5951053fc9f0f696509)]
    - [stack/tw_type_changes_to_field_metadata_impl](https://github.com/delta-io/delta/pull/4589) [[Files changed](https://github.com/delta-io/delta/pull/4589/files/cd9d0a002af5ae669ff0f5951053fc9f0f696509..61dd9cf9cc4620c2f2123acae907eb3df1b56326)]
      - [stack/tw_serde_refactor](https://github.com/delta-io/delta/pull/4592) [[Files changed](https://github.com/delta-io/delta/pull/4592/files/61dd9cf9cc4620c2f2123acae907eb3df1b56326..071397255cb5b4ef6e1c4521169de5fac4ab3397)]
        - [stack/add_type_change_parsing](https://github.com/delta-io/delta/pull/4593) [[Files changed](https://github.com/delta-io/delta/pull/4593/files/071397255cb5b4ef6e1c4521169de5fac4ab3397..582ff88d12131a235e9898df84ce8d120011618f)]
          - [stack/tw_upgrade_downgrade](https://github.com/delta-io/delta/pull/4603) [[Files changed](https://github.com/delta-io/delta/pull/4603/files/582ff88d12131a235e9898df84ce8d120011618f..e321508cfa79786493b3500cab62f36f4581d6fa)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR updates schema validation to take into account type widening rules.  It does the following:

1.  Add switch logic to appropriately validate type changes and not throw if they type widening is enabled and the change is allowed under type widening (also accounting for iceberg ability.
2. Updates the new schema by copying over existing type widening values if none are present on the new schema, and adds in the type changes detected as changes.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
