### PR TITLE
Add exceptions

### DIFF
--- a/python/delta/connect/exceptions.py
+++ b/python/delta/connect/exceptions.py
@@ -1,0 +1,141 @@
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+from typing import TYPE_CHECKING
+
+from pyspark.errors.exceptions.connect import SparkConnectException
+
+from delta.exceptions.base import (
+    DeltaConcurrentModificationException as BaseDeltaConcurrentModificationException,
+    ConcurrentWriteException as BaseConcurrentWriteException,
+    MetadataChangedException as BaseMetadataChangedException,
+    ProtocolChangedException as BaseProtocolChangedException,
+    ConcurrentAppendException as BaseConcurrentAppendException,
+    ConcurrentDeleteReadException as BaseConcurrentDeleteReadException,
+    ConcurrentDeleteDeleteException as BaseConcurrentDeleteDeleteException,
+    ConcurrentTransactionException as BaseConcurrentTransactionException,
+)
+
+if TYPE_CHECKING:
+    from google.rpc.error_details_pb2 import ErrorInfo
+
+
+class DeltaConcurrentModificationException(SparkConnectException, BaseDeltaConcurrentModificationException):
+    """
+    The basic class for all Delta commit conflict exceptions.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentWriteException(SparkConnectException, BaseConcurrentWriteException):
+    """
+    Thrown when a concurrent transaction has written data after the current transaction read the
+    table.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+class MetadataChangedException(SparkConnectException, BaseMetadataChangedException):
+    """
+    Thrown when the metadata of the Delta table has changed between the time of read
+    and the time of commit.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+class ProtocolChangedException(SparkConnectException, BaseProtocolChangedException):
+    """
+    Thrown when the protocol version has changed between the time of read
+    and the time of commit.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentAppendException(SparkConnectException, BaseConcurrentAppendException):
+    """
+    Thrown when files are added that would have been read by the current transaction.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentDeleteReadException(SparkConnectException, BaseConcurrentDeleteReadException):
+    """
+    Thrown when the current transaction reads data that was deleted by a concurrent transaction.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentDeleteDeleteException(SparkConnectException, BaseConcurrentDeleteDeleteException):
+    """
+    Thrown when the current transaction deletes data that was deleted by a concurrent transaction.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentTransactionException(SparkConnectException, BaseConcurrentTransactionException):
+    """
+    Thrown when concurrent transaction both attempt to update the same idempotent transaction.
+
+    .. versionadded:: 4.0
+
+    .. note:: Evolving
+    """
+
+
+def _convert_delta_exception(info: "ErrorInfo", message: str):
+    classes = []
+    if "classes" in info.metadata:
+        classes = json.loads(info.metadata["classes"])
+
+    if "io.delta.exceptions.ConcurrentWriteException" in classes:
+        return ConcurrentWriteException(message)
+    if "io.delta.exceptions.MetadataChangedException" in classes:
+        return MetadataChangedException(message)
+    if "io.delta.exceptions.ProtocolChangedException" in classes:
+        return ProtocolChangedException(message)
+    if "io.delta.exceptions.ConcurrentAppendException" in classes:
+        return ConcurrentAppendException(message)
+    if "io.delta.exceptions.ConcurrentDeleteReadException" in classes:
+        return ConcurrentDeleteReadException(message)
+    if "io.delta.exceptions.ConcurrentDeleteDeleteException" in classes:
+        return ConcurrentDeleteDeleteException(message)
+    if "io.delta.exceptions.ConcurrentTransactionException" in classes:
+        return ConcurrentTransactionException(message)
+    if "io.delta.exceptions.DeltaConcurrentModificationException" in classes:
+        return DeltaConcurrentModificationException(message)
+    return None

--- a/python/delta/exceptions/__init__.py
+++ b/python/delta/exceptions/__init__.py
@@ -1,0 +1,37 @@
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from delta.exceptions.base import (
+    DeltaConcurrentModificationException,
+    ConcurrentWriteException,
+    MetadataChangedException,
+    ProtocolChangedException,
+    ConcurrentAppendException,
+    ConcurrentDeleteReadException,
+    ConcurrentDeleteDeleteException,
+    ConcurrentTransactionException,
+)
+
+__all__ = [
+    "DeltaConcurrentModificationException",
+    "ConcurrentWriteException",
+    "MetadataChangedException",
+    "ProtocolChangedException",
+    "ConcurrentAppendException",
+    "ConcurrentDeleteReadException",
+    "ConcurrentDeleteDeleteException",
+    "ConcurrentTransactionException",
+]

--- a/python/delta/exceptions/base.py
+++ b/python/delta/exceptions/base.py
@@ -1,0 +1,99 @@
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.errors.exceptions.base import PySparkException
+
+class DeltaConcurrentModificationException(PySparkException):
+    """
+    The basic class for all Delta commit conflict exceptions.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentWriteException(PySparkException):
+    """
+    Thrown when a concurrent transaction has written data after the current transaction read the
+    table.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class MetadataChangedException(PySparkException):
+    """
+    Thrown when the metadata of the Delta table has changed between the time of read
+    and the time of commit.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ProtocolChangedException(PySparkException):
+    """
+    Thrown when the protocol version has changed between the time of read
+    and the time of commit.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentAppendException(PySparkException):
+    """
+    Thrown when files are added that would have been read by the current transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentDeleteReadException(PySparkException):
+    """
+    Thrown when the current transaction reads data that was deleted by a concurrent transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentDeleteDeleteException(PySparkException):
+    """
+    Thrown when the current transaction deletes data that was deleted by a concurrent transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentTransactionException(PySparkException):
+    """
+    Thrown when concurrent transaction both attempt to update the same idempotent transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """

--- a/python/delta/exceptions/captured.py
+++ b/python/delta/exceptions/captured.py
@@ -1,0 +1,171 @@
+#
+# Copyright (2023) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import TYPE_CHECKING, Optional
+
+from pyspark import SparkContext
+from pyspark.errors.exceptions.captured import CapturedException
+
+from delta.exceptions.base import (
+    DeltaConcurrentModificationException as BaseDeltaConcurrentModificationException,
+    ConcurrentWriteException as BaseConcurrentWriteException,
+    MetadataChangedException as BaseMetadataChangedException,
+    ProtocolChangedException as BaseProtocolChangedException,
+    ConcurrentAppendException as BaseConcurrentAppendException,
+    ConcurrentDeleteReadException as BaseConcurrentDeleteReadException,
+    ConcurrentDeleteDeleteException as BaseConcurrentDeleteDeleteException,
+    ConcurrentTransactionException as BaseConcurrentTransactionException,
+)
+
+if TYPE_CHECKING:
+    from py4j.java_gateway import JavaObject, JVMView  # type: ignore[import]
+
+
+class DeltaConcurrentModificationException(CapturedException, BaseDeltaConcurrentModificationException):
+    """
+    The basic class for all Delta commit conflict exceptions.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentWriteException(CapturedException, BaseConcurrentWriteException):
+    """
+    Thrown when a concurrent transaction has written data after the current transaction read the
+    table.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class MetadataChangedException(CapturedException, BaseMetadataChangedException):
+    """
+    Thrown when the metadata of the Delta table has changed between the time of read
+    and the time of commit.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ProtocolChangedException(CapturedException, BaseProtocolChangedException):
+    """
+    Thrown when the protocol version has changed between the time of read
+    and the time of commit.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentAppendException(CapturedException, BaseConcurrentAppendException):
+    """
+    Thrown when files are added that would have been read by the current transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentDeleteReadException(CapturedException, BaseConcurrentDeleteReadException):
+    """
+    Thrown when the current transaction reads data that was deleted by a concurrent transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentDeleteDeleteException(CapturedException, BaseConcurrentDeleteDeleteException):
+    """
+    Thrown when the current transaction deletes data that was deleted by a concurrent transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+class ConcurrentTransactionException(CapturedException, BaseConcurrentTransactionException):
+    """
+    Thrown when concurrent transaction both attempt to update the same idempotent transaction.
+
+    .. versionadded:: 1.0
+
+    .. note:: Evolving
+    """
+
+
+_delta_exception_patched = False
+
+
+def _convert_delta_exception(e: "JavaObject") -> Optional[CapturedException]:
+    """
+    Convert Delta's Scala concurrent exceptions to the corresponding Python exceptions.
+    """
+    s: str = e.toString()
+    c: "JavaObject" = e.getCause()
+
+    jvm: "JVMView" = SparkContext._jvm  # type: ignore[attr-defined]
+    gw = SparkContext._gateway  # type: ignore[attr-defined]
+    stacktrace = jvm.org.apache.spark.util.Utils.exceptionString(e)
+
+    if s.startswith('io.delta.exceptions.DeltaConcurrentModificationException: '):
+        return DeltaConcurrentModificationException(s.split(': ', 1)[1], stacktrace, c)
+    if s.startswith('io.delta.exceptions.ConcurrentWriteException: '):
+        return ConcurrentWriteException(s.split(': ', 1)[1], stacktrace, c)
+    if s.startswith('io.delta.exceptions.MetadataChangedException: '):
+        return MetadataChangedException(s.split(': ', 1)[1], stacktrace, c)
+    if s.startswith('io.delta.exceptions.ProtocolChangedException: '):
+        return ProtocolChangedException(s.split(': ', 1)[1], stacktrace, c)
+    if s.startswith('io.delta.exceptions.ConcurrentAppendException: '):
+        return ConcurrentAppendException(s.split(': ', 1)[1], stacktrace, c)
+    if s.startswith('io.delta.exceptions.ConcurrentDeleteReadException: '):
+        return ConcurrentDeleteReadException(s.split(': ', 1)[1], stacktrace, c)
+    if s.startswith('io.delta.exceptions.ConcurrentDeleteDeleteException: '):
+        return ConcurrentDeleteDeleteException(s.split(': ', 1)[1], stacktrace, c)
+    if s.startswith('io.delta.exceptions.ConcurrentTransactionException: '):
+        return ConcurrentTransactionException(s.split(': ', 1)[1], stacktrace, c)
+    return None
+
+
+def _patch_convert_exception() -> None:
+    """
+    Patch PySpark's exception convert method to convert Delta's Scala concurrent exceptions to the
+    corresponding Python exceptions.
+    """
+    original_convert_sql_exception = utils.convert_exception
+
+    def convert_delta_exception(e: "JavaObject") -> CapturedException:
+        delta_exception = _convert_delta_exception(e)
+        if delta_exception is not None:
+            return delta_exception
+        return original_convert_sql_exception(e)
+
+    utils.convert_exception = convert_delta_exception
+
+
+if not _delta_exception_patched:
+    _patch_convert_exception()
+    _delta_exception_patched = True


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
