### PR TITLE
[Spark] Use CommittedTransaction in all post-commit hooks

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.Breaks._
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaFileNotFoundException, DeltaFileProviderUtils, DeltaTransaction, IcebergConstants, Snapshot, UniversalFormat, UniversalFormatConverter}
+import org.apache.spark.sql.delta.{CommittedTransaction, DeltaErrors, DeltaFileNotFoundException, DeltaFileProviderUtils, DeltaOperations, IcebergConstants, Snapshot, UniversalFormat, UniversalFormatConverter}
 import org.apache.spark.sql.delta.DeltaOperations.OPTIMIZE_OPERATION_NAME
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
 import org.apache.spark.sql.delta.hooks.IcebergConverterHook
@@ -79,9 +79,9 @@ class IcebergConverter(spark: SparkSession)
   // Save an atomic reference of the snapshot being converted, and the txn that triggered
   // resulted in the specified snapshot
   protected val currentConversion =
-    new AtomicReference[(Snapshot, DeltaTransaction)]()
+    new AtomicReference[(Snapshot, CommittedTransaction)]()
   protected val standbyConversion =
-    new AtomicReference[(Snapshot, DeltaTransaction)]()
+    new AtomicReference[(Snapshot, CommittedTransaction)]()
 
   // Whether our async converter thread is active. We may already have an alive thread that is
   // about to shutdown, but in such cases this value should return false.
@@ -100,7 +100,7 @@ class IcebergConverter(spark: SparkSession)
    */
   override def enqueueSnapshotForConversion(
       snapshotToConvert: Snapshot,
-      txn: DeltaTransaction): Unit = {
+      txn: CommittedTransaction): Unit = {
     if (!UniversalFormat.icebergEnabled(snapshotToConvert.metadata)) {
       return
     }
@@ -150,7 +150,7 @@ class IcebergConverter(spark: SparkSession)
               }
 
           // Get a snapshot to convert from the icebergQueue. Sets the queue to null after.
-          private def getNextSnapshot: (Snapshot, DeltaTransaction) =
+          private def getNextSnapshot: (Snapshot, CommittedTransaction) =
             asyncThreadLock.synchronized {
               val potentialSnapshotAndTxn = standbyConversion.get()
               currentConversion.set(potentialSnapshotAndTxn)
@@ -216,7 +216,7 @@ class IcebergConverter(spark: SparkSession)
    * @return Converted Delta version and commit timestamp
    */
   override def convertSnapshot(
-      snapshotToConvert: Snapshot, txn: DeltaTransaction): Option[(Long, Long)] = {
+      snapshotToConvert: Snapshot, txn: CommittedTransaction): Option[(Long, Long)] = {
     try {
       txn.catalogTable match {
         case Some(table) => convertSnapshotWithRetry(snapshotToConvert, Some(txn), table)
@@ -246,7 +246,7 @@ class IcebergConverter(spark: SparkSession)
    */
   private def convertSnapshotWithRetry(
       snapshotToConvert: Snapshot,
-      txnOpt: Option[DeltaTransaction],
+      txnOpt: Option[CommittedTransaction],
       catalogTable: CatalogTable,
       maxRetry: Int =
         spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_UNIFORM_ICEBERG_RETRY_TIMES)
@@ -287,7 +287,7 @@ class IcebergConverter(spark: SparkSession)
    */
   private def convertSnapshot(
       snapshotToConvert: Snapshot,
-      txnOpt: Option[DeltaTransaction],
+      txnOpt: Option[CommittedTransaction],
       catalogTable: CatalogTable): Option[(Long, Long)] =
       recordFrameProfile("Delta", "IcebergConverter.convertSnapshot") {
     val cleanedCatalogTable =
@@ -457,7 +457,7 @@ class IcebergConverter(spark: SparkSession)
   private def cleanCatalogTableIfEnablingUniform(
       table: CatalogTable,
       snapshotToConvert: Snapshot,
-      txnOpt: Option[DeltaTransaction]): CatalogTable = {
+      txnOpt: Option[CommittedTransaction]): CatalogTable = {
     val disabledIceberg = txnOpt.map(txn =>
       !UniversalFormat.icebergEnabled(txn.snapshot.metadata)
     ).getOrElse(!UniversalFormat.icebergEnabled(table.properties))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTransaction.scala
@@ -101,12 +101,7 @@ trait DeltaTransaction extends DeltaLogging {
       committedTransaction: CommittedTransaction): Unit = {
     val version = committedTransaction.committedVersion
     try {
-      hook.run(
-        spark,
-        committedTransaction,
-        committedTransaction.committedVersion,
-        committedTransaction.postCommitSnapshot,
-        committedTransaction.committedActions.toIterator)
+      hook.run(spark, committedTransaction)
     } catch {
       case NonFatal(e) =>
         logWarning(log"Error when executing post-commit hook " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -296,6 +296,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
 
   /** Tracks if this transaction has already committed. */
   protected var committed: Option[CommittedTransaction] = None
+  def getCommitted: Option[CommittedTransaction] = committed
 
   /** Contains the execution instrumentation set via thread-local. No-op by default. */
   protected[delta] var executionObserver: TransactionExecutionObserver =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
-import org.apache.spark.sql.delta.commands.WriteIntoDelta
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
@@ -301,7 +300,7 @@ abstract class UniversalFormatConverter(spark: SparkSession) {
    */
   def enqueueSnapshotForConversion(
     snapshotToConvert: Snapshot,
-    txn: DeltaTransaction): Unit
+    txn: CommittedTransaction): Unit
 
   /**
    * Perform a blocking conversion when performing an OptimisticTransaction
@@ -314,7 +313,7 @@ abstract class UniversalFormatConverter(spark: SparkSession) {
    * @return Converted Delta version and commit timestamp
    */
   def convertSnapshot(
-    snapshotToConvert: Snapshot, txn: DeltaTransaction): Option[(Long, Long)]
+    snapshotToConvert: Snapshot, txn: CommittedTransaction): Option[(Long, Long)]
 
   /**
    * Perform a blocking conversion for the given catalogTable

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -393,7 +393,7 @@ abstract class ConvertToDeltaCommandBase(
       )
       metrics("numConvertedFiles") += numFiles
       sendDriverMetrics(spark, metrics)
-      val (committedVersion, postCommitSnapshot) = txn.commitLarge(
+      txn.commitLarge(
         spark,
         addFilesIter,
         Some(txn.protocol),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -86,7 +86,7 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
   private[hooks] def shouldSkipAutoCompact(
       autoCompactTypeOpt: Option[AutoCompactType],
       spark: SparkSession,
-      txn: DeltaTransaction): Boolean = {
+      txn: CommittedTransaction): Boolean = {
     // If auto compact type is empty, then skip compaction
     if (autoCompactTypeOpt.isEmpty) return true
 
@@ -97,21 +97,15 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
 
   }
 
-  override def run(
-      spark: SparkSession,
-      txn: DeltaTransaction,
-      committedVersion: Long,
-      postCommitSnapshot: Snapshot,
-      actions: Iterator[Action]): Unit = {
+  override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
     val conf = spark.sessionState.conf
-    val autoCompactTypeOpt = getAutoCompactType(conf, postCommitSnapshot.metadata)
+    val autoCompactTypeOpt = getAutoCompactType(conf, txn.postCommitSnapshot.metadata)
     // Skip Auto Compact if current transaction is not qualified or the table is not qualified
     // based on the value of autoCompactTypeOpt.
     if (shouldSkipAutoCompact(autoCompactTypeOpt, spark, txn)) return
     compactIfNecessary(
         spark,
         txn,
-        postCommitSnapshot,
         OP_TYPE,
         maxDeletedRowsRatio = None)
   }
@@ -122,8 +116,7 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
    */
   private[delta] def compactIfNecessary(
       spark: SparkSession,
-      txn: DeltaTransaction,
-      postCommitSnapshot: Snapshot,
+      txn: CommittedTransaction,
       opType: String,
       maxDeletedRowsRatio: Option[Double]
   ): Seq[OptimizeMetrics] = {
@@ -131,8 +124,6 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
     val autoCompactRequest = AutoCompactUtils.prepareAutoCompactRequest(
       spark,
       txn,
-      postCommitSnapshot,
-      txn.partitionsAddedToOpt.map(_.toSet),
       opType,
       maxDeletedRowsRatio)
     if (autoCompactRequest.shouldCompact) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -16,8 +16,7 @@
 
 package org.apache.spark.sql.delta.hooks
 
-import org.apache.spark.sql.delta.{DeltaTransaction, Snapshot}
-import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.CommittedTransaction
 
 import org.apache.spark.sql.SparkSession
 
@@ -25,19 +24,14 @@ import org.apache.spark.sql.SparkSession
 object CheckpointHook extends PostCommitHook {
   override val name: String = "Post commit checkpoint trigger"
 
-  override def run(
-      spark: SparkSession,
-      txn: DeltaTransaction,
-      committedVersion: Long,
-      postCommitSnapshot: Snapshot,
-      committedActions: Iterator[Action]): Unit = {
+  override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
     if (!txn.needsCheckpoint) return
 
     // Since the postCommitSnapshot isn't guaranteed to match committedVersion, we have to
     // explicitly checkpoint the snapshot at the committedVersion.
-    val cp = postCommitSnapshot.checkpointProvider
+    val cp = txn.postCommitSnapshot.checkpointProvider
     val snapshotToCheckpoint = txn.deltaLog.getSnapshotAt(
-      committedVersion,
+      txn.committedVersion,
       lastCheckpointHint = None,
       lastCheckpointProvider = Some(cp),
       catalogTableOpt = txn.catalogTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -71,13 +71,8 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
 
   override val name: String = "Generate Symlink Format Manifest"
 
-  override def run(
-      spark: SparkSession,
-      txn: DeltaTransaction,
-      committedVersion: Long,
-      postCommitSnapshot: Snapshot,
-      committedActions: Iterator[Action]): Unit = {
-    generateIncrementalManifest(spark, txn, postCommitSnapshot, committedActions)
+  override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
+    generateIncrementalManifest(spark, txn, txn.postCommitSnapshot)
   }
 
   override def handleError(spark: SparkSession, error: Throwable, version: Long): Unit = {
@@ -95,9 +90,8 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
    */
   protected def generateIncrementalManifest(
       spark: SparkSession,
-      txn: DeltaTransaction,
-      currentSnapshot: Snapshot,
-      actions: Iterator[Action]): Unit = recordManifestGeneration(txn.deltaLog, full = false) {
+      txn: CommittedTransaction,
+      currentSnapshot: Snapshot): Unit = recordManifestGeneration(txn.deltaLog, full = false) {
 
     import org.apache.spark.sql.delta.implicits._
 
@@ -115,6 +109,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
 
     // Find all the manifest partitions that need to updated or deleted
     val (allFilesInUpdatedPartitions, nowEmptyPartitions) = if (partitionCols.nonEmpty) {
+      val actions = txn.committedActions
       val (addFiles, otherActions) = actions.partition(_.isInstanceOf[AddFile])
       val (removeFiles, _) = otherActions.partition(_.isInstanceOf[RemoveFile])
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
@@ -28,25 +28,14 @@ import org.apache.spark.sql.SparkSession
  */
 trait PostCommitHook {
 
-  /** A user friendly name for the hook for error reporting purposes. */
+  /** A user-friendly name for the hook for error reporting purposes. */
   val name: String
 
   /**
    * Executes the hook.
    * @param txn The txn that made the commit, after which this PostCommitHook was run
-   * @param committedVersion The version that was committed by the txn
-   * @param postCommitSnapshot the snapshot of the table after the txn successfully committed.
-   *                           NOTE: This may not match the committedVersion, if racing
-   *                           commits were written while the snapshot was computed.
-   * @param committedActions the actions that were committed in the txn. *May* be empty
-   *                         if the list of actions was too large.
    */
-  def run(
-    spark: SparkSession,
-    txn: DeltaTransaction,
-    committedVersion: Long,
-    postCommitSnapshot: Snapshot,
-    committedActions: Iterator[Action]): Unit
+  def run(spark: SparkSession, txn: CommittedTransaction): Unit
 
   /**
    * Handle any error caused while running the hook. By default, all errors are ignored as

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -33,8 +33,7 @@ import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.constraints.CharVarcharConstraint
 import org.apache.spark.sql.delta.constraints.Constraints
 import org.apache.spark.sql.delta.constraints.Constraints.NotNull
-import org.apache.spark.sql.delta.hooks.AutoCompactType
-import org.apache.spark.sql.delta.hooks.PostCommitHook
+import org.apache.spark.sql.delta.hooks.{AutoCompactType, PostCommitHook}
 import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, InvariantViolationException, SchemaMergingUtils, SchemaUtils, UnsupportedDataTypeInfo}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -799,9 +798,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaRuntimeException] {
         throw DeltaErrors.postCommitHookFailedException(new PostCommitHook() {
           override val name: String = "DummyPostCommitHook"
-          override def run(
-            spark: SparkSession, txn: DeltaTransaction, committedVersion: Long,
-            postCommitSnapshot: Snapshot, committedActions: Iterator[Action]): Unit = {}
+          override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {}
         }, 0, "msg", null)
       }
       checkError(e, "DELTA_POST_COMMIT_HOOK_FAILED", "2DKD0",
@@ -811,9 +808,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaRuntimeException] {
         throw DeltaErrors.postCommitHookFailedException(new PostCommitHook() {
           override val name: String = "DummyPostCommitHook"
-          override def run(
-            spark: SparkSession, txn: DeltaTransaction, committedVersion: Long,
-            postCommitSnapshot: Snapshot, committedActions: Iterator[Action]): Unit = {}
+          override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {}
         }, 0, null, null)
       }
       checkError(e, "DELTA_POST_COMMIT_HOOK_FAILED", "2DKD0", Map(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Continuation of https://github.com/delta-io/delta/pull/4557

An `OptimisticTransaction` is currently used to keep track of in-progress transaction and also as a container for post-commit information about the transaction. This makes the semantics messy when it comes to post-commit usage. For example, it is possible for a post-commit hook to takes in an in-progress transaction, intentionally or not. A post-commit hook has access to mutable fields and may need to check whether a field is ready to be consumed or not.

Previously, we introduced `DeltaTransaction` to limit what can be accessed in a post-commit hook. However, that does not solve the in-progress vs. committed semantics problem and requires that if a new transaction implementation is introduced, it has to inherit all the var fields from the trait, so that it can be passed to the post-commit hooks.

This PR is part of a series of PRs to make the refactoring where:

- We introduce a new CommittedTransaction class, that is produced by every transaction implementation, to be passed to the post-commit hooks. 
- [This PR] We simplify the API of the post-commit hooks' run method so that it takes in only the CommittedTransaction struct.
- We remove all var fields from DeltaTransaction and make CommittedTransaction not extend from DeltaTransaction.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No