### PR TITLE
[Sparl] Ensure structs nested in maps get updated by name in MERGE/UPDATE expressions

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -1823,7 +1823,7 @@ trait MergeIntoNestedStructEvolutionTests {
       .add("key", StringType)
       .add("map", MapType(
           StringType,
-          new StructType().add("a", IntegerType).add("b", IntegerType).add("c", IntegerType))),
+          new StructType().add("b", IntegerType).add("a", IntegerType).add("c", IntegerType))),
     resultSchema = new StructType()
       .add("key", StringType)
       .add("map", MapType(
@@ -1875,7 +1875,7 @@ trait MergeIntoNestedStructEvolutionTests {
       .add("map", MapType(
           StringType,
           ArrayType(
-          new StructType().add("a", IntegerType).add("b", IntegerType).add("c", IntegerType)))),
+          new StructType().add("b", IntegerType).add("c", IntegerType).add("a", IntegerType)))),
     resultSchema = new StructType()
       .add("key", StringType)
       .add("map", MapType(
@@ -1938,11 +1938,11 @@ trait MergeIntoNestedStructEvolutionTests {
     sourceData = Seq((1, 10, 30, 1), (2, 20, 40, 2)).toDF("key", "a", "b", "value")
       .selectExpr("key", "map(named_struct('b', b, 'a', a), value) as x"),
     clauses = update("*") :: insert("*") :: Nil,
-    expected = Seq((1, 30, 10, 1), (2, 40, 20, 2), (3, 5, 6, 7))
+    expected = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
       .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
       .toDF("key", "a", "b", "value")
       .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x"),
-    expectedWithoutEvolution = Seq((1, 30, 10, 1), (2, 40, 20, 2), (3, 5, 6, 7))
+    expectedWithoutEvolution = Seq((1, 10, 30, 1), (2, 20, 40, 2), (3, 5, 6, 7))
       .asInstanceOf[List[(Integer, Integer, Integer, Integer)]]
       .toDF("key", "a", "b", "value")
       .selectExpr("key", "map(named_struct('a', a, 'b', b), value) as x")
@@ -2906,13 +2906,15 @@ trait MergeIntoNestedStructEvolutionTests {
   testEvolution("struct in different order")(
     targetData = Seq((1, (1, 10, 100)), (2, (2, 20, 200))).toDF("key", "x")
       .selectExpr("key", "named_struct('a', x._1, 'b', x._2, 'c', x._3) as x"),
-    sourceData = Seq((1, (100, 10, 1)), (3, (300, 30, 3))).toDF("key", "x")
+    sourceData = Seq((1, (1111, 111, 11)), (3, (3333, 333, 33))).toDF("key", "x")
       .selectExpr("key", "named_struct('c', x._1, 'b', x._2, 'a', x._3) as x"),
     clauses = update("*") :: insert("*") :: Nil,
-    expected = ((1, (1, 10, 100)) +: (2, (2, 20, 200)) +: (3, (3, 30, 300)) +: Nil).toDF("key", "x")
+    expected = ((1, (11, 111, 1111)) :: (2, (2, 20, 200)) :: (3, (33, 333, 3333)) :: Nil)
+      .toDF("key", "x")
       .selectExpr("key", "named_struct('a', x._1, 'b', x._2, 'c', x._3) as x"),
     expectedWithoutEvolution =
-      ((1, (1, 10, 100)) +: (2, (2, 20, 200)) +: (3, (3, 30, 300)) +: Nil).toDF("key", "x")
+      ((1, (11, 111, 1111)) :: (2, (2, 20, 200)) :: (3, (33, 333, 3333)) :: Nil)
+      .toDF("key", "x")
       .selectExpr("key", "named_struct('a', x._1, 'b', x._2, 'c', x._3) as x")
   )
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Within DML commands when we update some field values (in UPDATE or MERGE) we normally resolve struct fields by name, as opposed to the by-position behaviour that struct casts have by default. However, due to a couple of buggy test cases, this was not happening when the struct was nested somewhere inside a map (either on key or value side).

This PR changes the semantics to be more consistent, so that also within map types struct fields are updated by name.

## How was this patch tested?

Existing tests (corrected).

## Does this PR introduce _any_ user-facing changes?

Yes.
Instead of updating struct fields nested within map types by position in MERGE/UPDATE expressions, we now update them by name, like we do for other nested struct fields.
