### PR TITLE
[Spark] Fix minor bug in NumRecordsStats

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/NumRecordsStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/NumRecordsStats.scala
@@ -89,7 +89,7 @@ object NumRecordsStats {
           numFilesRemovedWithoutNumRecords += 1
           0L
         }
-        numDeletionVectorRecordsRemoved = r.numDeletedRecords
+        numDeletionVectorRecordsRemoved += r.numDeletedRecords
       case _ =>
         // Do nothing
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix incorrect calculation of numDeletionVectorRecordsRemoved in NumRecordsStats. This struct is used only to provide debug information in num records sanity checks.


## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No