### PR TITLE
[Spark] Stop using deprecated createTable() in CLONE analysis

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -58,7 +58,7 @@ import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttribute
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -816,7 +816,12 @@ class DeltaAnalysis(session: SparkSession)
         //             here we create a table to get the path, then overwrite it with the
         //             cloned table.
         val sourceConfig = sourceTbl.metadata.configuration.asJava
-        val newTable = catalog.createTable(ident, sourceTbl.schema, partitions, sourceConfig)
+        val newTable = catalog.createTable(
+            ident,
+            CatalogV2Util.structTypeToV2Columns(sourceTbl.schema),
+            partitions,
+            sourceConfig
+          )
         try {
           newTable match {
             case targetTable: DeltaTableV2 =>


### PR DESCRIPTION
## Description
During analysis of CLONE command, we attempt to create a table, using a deprecated `createTable()` method.
This leads to a confusing assertion when running against unitycatalog: https://github.com/unitycatalog/unitycatalog/blob/f626a9efba14821808498e5af6d1344854951294/connectors/spark/src/main/scala/io/unitycatalog/spark/UCSingleCatalog.scala#L127

Updating the call to transform the argument and call into the preferred `createTable()` method

## How was this patch tested?
Existing clone tests

## Does this PR introduce _any_ user-facing changes?
No
