### PR TITLE
[Kernel][Catalog-Managed] ParsedCheckpointData ordering

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointInstance.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointInstance.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+// TODO: Delete this in favor of ParsedCheckpointData.
 /** Metadata about Delta checkpoint. */
 public class CheckpointInstance implements Comparable<CheckpointInstance> {
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -23,7 +23,9 @@ import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
-public class ParsedCheckpointData extends ParsedLogData {
+public class ParsedCheckpointData extends ParsedLogData
+    implements Comparable<ParsedCheckpointData> {
+
   public static ParsedCheckpointData forFileStatus(FileStatus fileStatus) {
     final String path = fileStatus.getPath();
 
@@ -64,5 +66,52 @@ public class ParsedCheckpointData extends ParsedLogData {
       Optional<ColumnarBatch> inlineDataOpt) {
     super(version, type, fileStatusOpt, inlineDataOpt);
     checkArgument(type.category == ParsedLogCategory.CHECKPOINT, "Must be a checkpoint");
+  }
+
+  @Override
+  public int compareTo(ParsedCheckpointData that) {
+    // Compare versions.
+    if (version != that.version) {
+      return Long.compare(version, that.version);
+    }
+
+    // Compare types.
+    if (type != that.type) {
+      return Integer.compare(type.ordinal(), that.type.ordinal());
+    }
+
+    // Use type-specific tiebreakers if versions and types are the same.
+    switch (type) {
+      case CLASSIC_CHECKPOINT:
+      case V2_CHECKPOINT:
+        return getTieBreaker(that);
+      case MULTIPART_CHECKPOINT:
+        final ParsedMultiPartCheckpointData thisCasted = (ParsedMultiPartCheckpointData) this;
+        final ParsedMultiPartCheckpointData thatCasted = (ParsedMultiPartCheckpointData) that;
+        final int numPartsComparison = Long.compare(thisCasted.numParts, thatCasted.numParts);
+        if (numPartsComparison != 0) {
+          return numPartsComparison;
+        } else {
+          return getTieBreaker(that);
+        }
+      default:
+        throw new IllegalStateException("Unexpected type: " + type);
+    }
+  }
+
+  /**
+   * Here, we prefer inline data -- if the data is already stored in memory, we should read that
+   * instead of going to the cloud store to read a file status.
+   */
+  private int getTieBreaker(ParsedCheckpointData that) {
+    if (this.isInline() && that.isMaterialized()) {
+      return 1; // Prefer this
+    } else if (this.isMaterialized() && that.isInline()) {
+      return -1; // Prefer that
+    } else if (this.isMaterialized() && that.isMaterialized()) {
+      return this.getFileStatus().getPath().compareTo(that.getFileStatus().getPath());
+    } else {
+      return 0;
+    }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.files;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.utils.FileStatus;
+import java.util.Optional;
+
+public class ParsedCheckpointData extends ParsedLogData {
+  public static ParsedCheckpointData forFileStatus(FileStatus fileStatus) {
+    final String path = fileStatus.getPath();
+
+    if (FileNames.isMultiPartCheckpointFile(path)) {
+      return ParsedMultiPartCheckpointData.forFileStatus(fileStatus);
+    }
+
+    final long version;
+    final ParsedLogType type;
+
+    if (FileNames.isClassicCheckpointFile(path)) {
+      version = FileNames.checkpointVersion(path);
+      type = ParsedLogType.CLASSIC_CHECKPOINT;
+    } else if (FileNames.isV2CheckpointFile(path)) {
+      version = FileNames.checkpointVersion(path);
+      type = ParsedLogType.V2_CHECKPOINT;
+    } else {
+      throw new IllegalArgumentException("File is not a recognized checkpoint type: " + path);
+    }
+
+    return new ParsedCheckpointData(version, type, Optional.of(fileStatus), Optional.empty());
+  }
+
+  public static ParsedCheckpointData forInlineData(
+      long version, ParsedLogType type, ColumnarBatch inlineData) {
+    if (type == ParsedLogType.MULTIPART_CHECKPOINT) {
+      throw new IllegalArgumentException(
+          "For MULTIPART_CHECKPOINT, use ParsedMultiPartCheckpointData.forInlineData() instead");
+    }
+
+    return new ParsedCheckpointData(version, type, Optional.empty(), Optional.of(inlineData));
+  }
+
+  protected ParsedCheckpointData(
+      long version,
+      ParsedLogType type,
+      Optional<FileStatus> fileStatusOpt,
+      Optional<ColumnarBatch> inlineDataOpt) {
+    super(version, type, fileStatusOpt, inlineDataOpt);
+    checkArgument(type.category == ParsedLogCategory.CHECKPOINT, "Must be a checkpoint");
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -68,6 +68,7 @@ public class ParsedCheckpointData extends ParsedLogData
     checkArgument(type.category == ParsedLogCategory.CHECKPOINT, "Must be a checkpoint");
   }
 
+  /** Here, returning 1 means that `this` is preferred over (i.e. greater than) `that`. */
   @Override
   public int compareTo(ParsedCheckpointData that) {
     // Compare versions.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogCompactionData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogCompactionData.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.files;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.internal.util.Tuple2;
+import io.delta.kernel.utils.FileStatus;
+import java.util.Objects;
+import java.util.Optional;
+
+// TODO: Add the comparable logic from CheckpointInstance.
+public class ParsedLogCompactionData extends ParsedLogData {
+  public static ParsedLogCompactionData forFileStatus(FileStatus fileStatus) {
+    final Tuple2<Long, Long> startEnd = FileNames.logCompactionVersions(fileStatus.getPath());
+    return new ParsedLogCompactionData(
+        startEnd._1, startEnd._2, Optional.of(fileStatus), Optional.empty());
+  }
+
+  public static ParsedLogCompactionData forInlineData(
+      int start, int end, ColumnarBatch inlineData) {
+    return new ParsedLogCompactionData(start, end, Optional.empty(), Optional.of(inlineData));
+  }
+
+  public final long startVersion;
+  public final long endVersion;
+
+  private ParsedLogCompactionData(
+      long startVersion,
+      long endVersion,
+      Optional<FileStatus> fileStatusOpt,
+      Optional<ColumnarBatch> inlineDataOpt) {
+    super(endVersion, ParsedLogType.LOG_COMPACTION, fileStatusOpt, inlineDataOpt);
+    checkArgument(
+        startVersion >= 0 && endVersion >= 0, "startVersion and endVersion must be non-negative");
+    checkArgument(startVersion < endVersion, "startVersion must be less than endVersion");
+    this.startVersion = startVersion;
+    this.endVersion = endVersion;
+  }
+
+  @Override
+  protected void appendAdditionalToStringFields(StringBuilder sb) {
+    sb.append(", startVersion=").append(startVersion);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    ParsedLogCompactionData that = (ParsedLogCompactionData) o;
+    return startVersion == that.startVersion && endVersion == that.endVersion;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), startVersion, endVersion);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -47,10 +47,13 @@ public class ParsedLogData {
     RATIFIED_STAGED_COMMIT(ParsedLogCategory.DELTA),
     RATIFIED_INLINE_COMMIT(ParsedLogCategory.DELTA),
     LOG_COMPACTION(ParsedLogCategory.LOG_COMPACTION),
+    CHECKSUM(ParsedLogCategory.CHECKSUM),
+
+    // Note that the order of these checkpoint enum values is important for comparison of checkpoint
+    // files as we prefer V2 > MULTI_PART > CLASSIC.
     CLASSIC_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
     MULTIPART_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
-    V2_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
-    CHECKSUM(ParsedLogCategory.CHECKSUM);
+    V2_CHECKPOINT(ParsedLogCategory.CHECKPOINT);
 
     public final ParsedLogCategory category;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.files;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.utils.FileStatus;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ParsedLogData {
+
+  ///////////////////////////////////////
+  // Static enums, fields, and methods //
+  ///////////////////////////////////////
+
+  public enum ParsedLogCategory {
+    DELTA,
+    LOG_COMPACTION,
+    CHECKPOINT,
+    CHECKSUM
+  }
+
+  public enum ParsedLogType {
+    PUBLISHED_DELTA(ParsedLogCategory.DELTA),
+    RATIFIED_STAGED_DELTA(ParsedLogCategory.DELTA),
+    RATIFIED_INLINE_DELTA(ParsedLogCategory.DELTA),
+    LOG_COMPACTION(ParsedLogCategory.LOG_COMPACTION),
+    CLASSIC_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
+    MULTIPART_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
+    V2_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
+    CHECKSUM(ParsedLogCategory.CHECKSUM);
+
+    public final ParsedLogCategory category;
+
+    ParsedLogType(ParsedLogCategory category) {
+      this.category = category;
+    }
+  }
+
+  public static ParsedLogData forFileStatus(FileStatus fileStatus) {
+    final String path = fileStatus.getPath();
+
+    if (FileNames.isLogCompactionFile(path)) {
+      return ParsedLogCompactionData.forFileStatus(fileStatus);
+    } else if (FileNames.isCheckpointFile(path)) {
+      return ParsedCheckpointData.forFileStatus(fileStatus);
+    }
+
+    final long version;
+    final ParsedLogType type;
+
+    if (FileNames.isPublishedDeltaFile(path)) {
+      version = FileNames.deltaVersion(path);
+      type = ParsedLogType.PUBLISHED_DELTA;
+    } else if (FileNames.isStagedDeltaFile(path)) {
+      version = FileNames.deltaVersion(path);
+      type = ParsedLogType.RATIFIED_STAGED_DELTA;
+    } else if (FileNames.isChecksumFile(path)) {
+      version = FileNames.checksumVersion(path);
+      type = ParsedLogType.CHECKSUM;
+    } else {
+      throw new IllegalArgumentException("Unknown log file type: " + path);
+    }
+
+    return new ParsedLogData(version, type, Optional.of(fileStatus), Optional.empty());
+  }
+
+  public static ParsedLogData forInlineData(
+      long version, ParsedLogType type, ColumnarBatch inlineData) {
+    if (type == ParsedLogType.LOG_COMPACTION) {
+      throw new IllegalArgumentException(
+          "For LOG_COMPACTION, use ParsedLogCompactionData.forInlineData() instead");
+    } else if (type.category == ParsedLogCategory.CHECKPOINT) {
+      return ParsedCheckpointData.forInlineData(version, type, inlineData);
+    }
+    return new ParsedLogData(version, type, Optional.empty(), Optional.of(inlineData));
+  }
+
+  ///////////////////////////////
+  // Member fields and methods //
+  ///////////////////////////////
+
+  public final long version;
+  public final ParsedLogType type;
+  public final Optional<FileStatus> fileStatusOpt;
+  public final Optional<ColumnarBatch> inlineDataOpt;
+
+  protected ParsedLogData(
+      long version,
+      ParsedLogType type,
+      Optional<FileStatus> fileStatusOpt,
+      Optional<ColumnarBatch> inlineDataOpt) {
+    checkArgument(
+        fileStatusOpt.isPresent() ^ inlineDataOpt.isPresent(),
+        "Exactly one of fileStatusOpt or inlineDataOpt must be present");
+    checkArgument(version >= 0, "version must be non-negative");
+    this.version = version;
+    this.type = type;
+    this.fileStatusOpt = fileStatusOpt;
+    this.inlineDataOpt = inlineDataOpt;
+  }
+
+  public boolean isMaterialized() {
+    return fileStatusOpt.isPresent();
+  }
+
+  public boolean isInline() {
+    return inlineDataOpt.isPresent();
+  }
+
+  public FileStatus getFileStatus() {
+    return fileStatusOpt.get();
+  }
+
+  public ColumnarBatch getInlineData() {
+    return inlineDataOpt.get();
+  }
+
+  public ParsedLogCategory getCategory() {
+    return type.category;
+  }
+
+  /** Protected method for subclasses to override to add output to {@link #toString}. */
+  protected void appendAdditionalToStringFields(StringBuilder sb) {
+    // Default implementation does nothing
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ParsedLogData that = (ParsedLogData) o;
+    return version == that.version
+        && type == that.type
+        && Objects.equals(fileStatusOpt, that.fileStatusOpt)
+        && Objects.equals(inlineDataOpt, that.inlineDataOpt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, type, fileStatusOpt, inlineDataOpt);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb =
+        new StringBuilder(getClass().getSimpleName())
+            .append("{version=")
+            .append(version)
+            .append(", type=")
+            .append(type)
+            .append(", source=");
+    if (isMaterialized()) {
+      sb.append(fileStatusOpt.get());
+    } else {
+      sb.append("inline");
+    }
+
+    appendAdditionalToStringFields(sb);
+
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -39,8 +39,8 @@ public class ParsedLogData {
 
   public enum ParsedLogType {
     PUBLISHED_DELTA(ParsedLogCategory.DELTA),
-    RATIFIED_STAGED_DELTA(ParsedLogCategory.DELTA),
-    RATIFIED_INLINE_DELTA(ParsedLogCategory.DELTA),
+    STAGED_COMMIT(ParsedLogCategory.DELTA),
+    RATIFIED_INLINE_COMMIT(ParsedLogCategory.DELTA),
     LOG_COMPACTION(ParsedLogCategory.LOG_COMPACTION),
     CLASSIC_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
     MULTIPART_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
@@ -71,7 +71,7 @@ public class ParsedLogData {
       type = ParsedLogType.PUBLISHED_DELTA;
     } else if (FileNames.isStagedDeltaFile(path)) {
       version = FileNames.deltaVersion(path);
-      type = ParsedLogType.RATIFIED_STAGED_DELTA;
+      type = ParsedLogType.STAGED_COMMIT;
     } else if (FileNames.isChecksumFile(path)) {
       version = FileNames.checksumVersion(path);
       type = ParsedLogType.CHECKSUM;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedMultiPartCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedMultiPartCheckpointData.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.files;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.internal.util.Tuple2;
+import io.delta.kernel.utils.FileStatus;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ParsedMultiPartCheckpointData extends ParsedCheckpointData {
+  public static ParsedMultiPartCheckpointData forFileStatus(FileStatus fileStatus) {
+    final long version = FileNames.checkpointVersion(fileStatus.getPath());
+    final Tuple2<Integer, Integer> partInfo =
+        FileNames.multiPartCheckpointPartAndNumParts(fileStatus.getPath());
+    return new ParsedMultiPartCheckpointData(
+        version, partInfo._1, partInfo._2, Optional.of(fileStatus), Optional.empty());
+  }
+
+  public static ParsedMultiPartCheckpointData forInlineData(
+      long version, int part, int numParts, ColumnarBatch inlineData) {
+    return new ParsedMultiPartCheckpointData(
+        version, part, numParts, Optional.empty(), Optional.of(inlineData));
+  }
+
+  public final int part;
+  public final int numParts;
+
+  private ParsedMultiPartCheckpointData(
+      long version,
+      int part,
+      int numParts,
+      Optional<FileStatus> fileStatusOpt,
+      Optional<ColumnarBatch> inlineDataOpt) {
+    super(version, ParsedLogType.MULTIPART_CHECKPOINT, fileStatusOpt, inlineDataOpt);
+    checkArgument(numParts > 0, "numParts must be greater than 0");
+    checkArgument(part > 0 && part <= numParts, "part must be between 1 and numParts");
+    this.part = part;
+    this.numParts = numParts;
+  }
+
+  @Override
+  protected void appendAdditionalToStringFields(StringBuilder sb) {
+    sb.append(", part=").append(part).append(", numParts=").append(numParts);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    ParsedMultiPartCheckpointData that = (ParsedMultiPartCheckpointData) o;
+    return part == that.part && numParts == that.numParts;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), part, numParts);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -20,6 +20,7 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.utils.FileStatus;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class FileNames {
@@ -30,6 +31,7 @@ public final class FileNames {
   // File name patterns and other static values //
   ////////////////////////////////////////////////
 
+  // TODO: Delete this in favor of ParsedLogCategory.
   public enum DeltaLogFileType {
     COMMIT,
     LOG_COMPACTION,
@@ -79,8 +81,13 @@ public final class FileNames {
       Pattern.compile("(\\d+)\\.checkpoint\\.[^.]+\\.(json|parquet)");
 
   /** Example: 00000000000000000001.checkpoint.0000000020.0000000060.parquet */
-  private static final Pattern MULTI_PART_CHECKPOINT_FILE_PATTERN =
-      Pattern.compile("(\\d+)\\.checkpoint\\.\\d+\\.\\d+\\.parquet");
+  public static final Pattern MULTI_PART_CHECKPOINT_FILE_PATTERN =
+      Pattern.compile("(\\d+)\\.checkpoint\\.(\\d+)\\.(\\d+)\\.parquet");
+
+  private static final String MULTI_PART_CHECKPOINT_FILE_FORMAT =
+      "%020d.checkpoint.%010d.%010d.parquet";
+
+  public static final String STAGED_COMMIT_DIRECTORY = "_staged_commits";
 
   public static final String SIDECAR_DIRECTORY = "_sidecars";
 
@@ -155,6 +162,22 @@ public final class FileNames {
     return Long.parseLong(name.split("\\.")[0]);
   }
 
+  public static Tuple2<Integer, Integer> multiPartCheckpointPartAndNumParts(Path path) {
+    final String fileName = path.getName();
+    final Matcher matcher = MULTI_PART_CHECKPOINT_FILE_PATTERN.matcher(fileName);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          String.format("Path is not a multi-part checkpoint file: %s", fileName));
+    }
+    final int partNum = Integer.parseInt(matcher.group(2));
+    final int numParts = Integer.parseInt(matcher.group(3));
+    return new Tuple2<>(partNum, numParts);
+  }
+
+  public static Tuple2<Integer, Integer> multiPartCheckpointPartAndNumParts(String path) {
+    return multiPartCheckpointPartAndNumParts(new Path(path));
+  }
+
   ///////////////////////////////////
   // File path and prefix builders //
   ///////////////////////////////////
@@ -176,6 +199,10 @@ public final class FileNames {
 
   public static long checksumVersion(Path path) {
     return Long.parseLong(path.getName().split("\\.")[0]);
+  }
+
+  public static long checksumVersion(String path) {
+    return checksumVersion(new Path(path));
   }
 
   /**
@@ -212,6 +239,11 @@ public final class FileNames {
     return new Path(String.format("%s/%s/%s.parquet", path.toString(), SIDECAR_DIRECTORY, uuid));
   }
 
+  public static Path multiPartCheckpointFile(Path path, long version, int part, int numParts) {
+    return new Path(
+        path, String.format(MULTI_PART_CHECKPOINT_FILE_FORMAT, version, part, numParts));
+  }
+
   /**
    * Returns the paths for all parts of the checkpoint up to the given version.
    *
@@ -225,8 +257,7 @@ public final class FileNames {
     final List<Path> output = new ArrayList<>();
     for (int i = 1; i < numParts + 1; i++) {
       output.add(
-          new Path(
-              path, String.format("%020d.checkpoint.%010d.%010d.parquet", version, i, numParts)));
+          new Path(path, String.format(MULTI_PART_CHECKPOINT_FILE_FORMAT, version, i, numParts)));
     }
     return output;
   }
@@ -267,6 +298,19 @@ public final class FileNames {
     final String fileName = new Path(path).getName();
     return DELTA_FILE_PATTERN.matcher(fileName).matches()
         || UUID_DELTA_FILE_REGEX.matcher(fileName).matches();
+  }
+
+  public static boolean isPublishedDeltaFile(String path) {
+    final String fileName = new Path(path).getName();
+    return DELTA_FILE_PATTERN.matcher(fileName).matches();
+  }
+
+  public static boolean isStagedDeltaFile(String path) {
+    final Path p = new Path(path);
+    if (!p.getParent().getName().equals(STAGED_COMMIT_DIRECTORY)) {
+      return false;
+    }
+    return UUID_DELTA_FILE_REGEX.matcher(p.getName()).matches();
   }
 
   public static boolean isLogCompactionFile(String path) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -16,6 +16,8 @@
 
 package io.delta.kernel.internal.util;
 
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.utils.FileStatus;
 import java.util.ArrayList;
@@ -163,10 +165,8 @@ public final class FileNames {
   public static Tuple2<Integer, Integer> multiPartCheckpointPartAndNumParts(Path path) {
     final String fileName = path.getName();
     final Matcher matcher = MULTI_PART_CHECKPOINT_FILE_PATTERN.matcher(fileName);
-    if (!matcher.matches()) {
-      throw new IllegalArgumentException(
-          String.format("Path is not a multi-part checkpoint file: %s", fileName));
-    }
+    checkArgument(
+        matcher.matches(), String.format("Path is not a multi-part checkpoint file: %s", fileName));
     final int partNum = Integer.parseInt(matcher.group(2));
     final int numParts = Integer.parseInt(matcher.group(3));
     return new Tuple2<>(partNum, numParts);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/files/ParsedLogDataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/files/ParsedLogDataSuite.scala
@@ -127,7 +127,7 @@ class ParsedLogDataSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("Correctly parses classic checkpoint file") {
-    val fileStatus = singularCheckpointFileStatuses(Seq(10)).head
+    val fileStatus = classicCheckpointFileStatus(10)
     val parsed = ParsedLogData.forFileStatus(fileStatus)
 
     assert(parsed.isInstanceOf[ParsedCheckpointData])
@@ -140,13 +140,9 @@ class ParsedLogDataSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("Classic checkpoint file equality") {
-    val fileStatus1 = singularCheckpointFileStatuses(Seq(10)).head
-    val fileStatus2 = singularCheckpointFileStatuses(Seq(10)).head
-    val fileStatus3 = singularCheckpointFileStatuses(Seq(11)).head
-
-    val cp1 = ParsedLogData.forFileStatus(fileStatus1)
-    val cp2 = ParsedLogData.forFileStatus(fileStatus2)
-    val cp3 = ParsedLogData.forFileStatus(fileStatus3)
+    val cp1 = ParsedLogData.forFileStatus(classicCheckpointFileStatus(10))
+    val cp2 = ParsedLogData.forFileStatus(classicCheckpointFileStatus(10))
+    val cp3 = ParsedLogData.forFileStatus(classicCheckpointFileStatus(11))
 
     assert(cp1 == cp1)
     assert(cp1 == cp2)
@@ -203,7 +199,7 @@ class ParsedLogDataSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("Correctly parses multi-part checkpoint file") {
-    val chkpt_15_1_3 = multiCheckpointFileStatuses(Seq(15), 3).head
+    val chkpt_15_1_3 = multiPartCheckpointFileStatus(15, 1, 3)
     val parsed = ParsedLogData
       .forFileStatus(chkpt_15_1_3)
       .asInstanceOf[ParsedMultiPartCheckpointData]
@@ -243,17 +239,11 @@ class ParsedLogDataSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("Multi-part checkpoint file equality") {
-    val chkpt_15_1_3_a = multiCheckpointFileStatuses(Seq(15), 3).head
-    val chkpt_15_1_3_b = multiCheckpointFileStatuses(Seq(15), 3).head
-    val chkpt_15_2_3 = multiCheckpointFileStatuses(Seq(15), 3)(1)
-    val chkpt_15_1_4 = multiCheckpointFileStatuses(Seq(15), 4).head
-    val chkpt_16_1_3 = multiCheckpointFileStatuses(Seq(16), 3).head
-
-    val parsed_15_1_3_a = ParsedLogData.forFileStatus(chkpt_15_1_3_a)
-    val parsed_15_1_3_b = ParsedLogData.forFileStatus(chkpt_15_1_3_b)
-    val parsed_15_2_3 = ParsedLogData.forFileStatus(chkpt_15_2_3)
-    val parsed_15_1_4 = ParsedLogData.forFileStatus(chkpt_15_1_4)
-    val parsed_16_1_3 = ParsedLogData.forFileStatus(chkpt_16_1_3)
+    val parsed_15_1_3_a = ParsedLogData.forFileStatus(multiPartCheckpointFileStatus(15, 1, 3))
+    val parsed_15_1_3_b = ParsedLogData.forFileStatus(multiPartCheckpointFileStatus(15, 1, 3))
+    val parsed_15_2_3 = ParsedLogData.forFileStatus(multiPartCheckpointFileStatus(15, 2, 3))
+    val parsed_15_1_4 = ParsedLogData.forFileStatus(multiPartCheckpointFileStatus(15, 1, 4))
+    val parsed_16_1_3 = ParsedLogData.forFileStatus(multiPartCheckpointFileStatus(16, 1, 3))
 
     assert(parsed_15_1_3_a == parsed_15_1_3_a)
     assert(parsed_15_1_3_a == parsed_15_1_3_b)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/files/ParsedLogDataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/files/ParsedLogDataSuite.scala
@@ -1,0 +1,370 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.files
+
+import java.util.Optional
+
+import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
+import io.delta.kernel.internal.files.ParsedLogData.ParsedLogType
+import io.delta.kernel.internal.util.FileNames
+import io.delta.kernel.test.MockFileSystemClientUtils
+import io.delta.kernel.types.StructType
+import io.delta.kernel.utils.FileStatus
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ParsedLogDataSuite extends AnyFunSuite with MockFileSystemClientUtils {
+
+  private val emptyColumnarBatch = new ColumnarBatch {
+    override def getSchema: StructType = null
+    override def getColumnVector(ordinal: Int): ColumnVector = null
+    override def getSize: Int = 0
+  }
+
+  /////////////
+  // General //
+  /////////////
+
+  test("Throws on unknown log file") {
+    val fileStatus = FileStatus.of("unknown", 0, 0)
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogData.forFileStatus(fileStatus)
+    }.getMessage
+    assert(exMsg.contains("Unknown log file type"))
+  }
+
+  test("Throws on version < 0") {
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogData.forInlineData(-1, ParsedLogType.RATIFIED_INLINE_DELTA, emptyColumnarBatch)
+    }.getMessage
+    assert(exMsg.contains("version must be non-negative"))
+  }
+
+  test("Throws on both fileStatusOpt and inlineDataOpt present") {
+    val fileStatusOpt = Optional.of(deltaFileStatus(5))
+    val inlineDataOpt = Optional.of(emptyColumnarBatch)
+    val exMsg = intercept[IllegalArgumentException] {
+      new ParsedLogData(10, ParsedLogType.PUBLISHED_DELTA, fileStatusOpt, inlineDataOpt)
+    }.getMessage
+    assert(exMsg.contains("Exactly one of fileStatusOpt or inlineDataOpt must be present"))
+  }
+
+  test("Throws on both fileStatusOpt and inlineDataOpt empty") {
+    val exMsg = intercept[IllegalArgumentException] {
+      new ParsedLogData(10, ParsedLogType.PUBLISHED_DELTA, Optional.empty(), Optional.empty())
+    }.getMessage
+    assert(exMsg.contains("Exactly one of fileStatusOpt or inlineDataOpt must be present"))
+  }
+
+  ////////////
+  // Deltas //
+  ////////////
+
+  test("Correctly parses published delta file") {
+    val fileStatus = deltaFileStatus(5)
+    val parsed = ParsedLogData.forFileStatus(fileStatus)
+
+    assert(parsed.version == 5)
+    assert(parsed.getCategory == ParsedLogData.ParsedLogCategory.DELTA)
+    assert(parsed.isMaterialized)
+    assert(!parsed.isInline)
+    assert(parsed.getFileStatus == fileStatus)
+  }
+
+  test("Delta file equality") {
+    val fileStatus1 = deltaFileStatus(5)
+    val fileStatus2 = deltaFileStatus(5)
+    val fileStatus3 = deltaFileStatus(6)
+
+    val delta1 = ParsedLogData.forFileStatus(fileStatus1)
+    val delta2 = ParsedLogData.forFileStatus(fileStatus2)
+    val delta3 = ParsedLogData.forFileStatus(fileStatus3)
+
+    assert(delta1 == delta1)
+    assert(delta1 == delta2)
+    assert(delta1 != delta3)
+  }
+
+  /////////////////
+  // Checkpoints //
+  /////////////////
+
+  test("Inline classic checkpoint") {
+    ParsedLogData.forInlineData(10, ParsedLogType.CLASSIC_CHECKPOINT, emptyColumnarBatch)
+    ParsedCheckpointData.forInlineData(10, ParsedLogType.CLASSIC_CHECKPOINT, emptyColumnarBatch)
+  }
+
+  test("Inline v2 checkpoint") {
+    ParsedLogData.forInlineData(10, ParsedLogType.V2_CHECKPOINT, emptyColumnarBatch)
+    ParsedCheckpointData.forInlineData(10, ParsedLogType.V2_CHECKPOINT, emptyColumnarBatch)
+  }
+
+  test("Correctly parses classic checkpoint file") {
+    val fileStatus = singularCheckpointFileStatuses(Seq(10)).head
+    val parsed = ParsedLogData.forFileStatus(fileStatus)
+
+    assert(parsed.isInstanceOf[ParsedCheckpointData])
+    assert(parsed.version == 10)
+    assert(parsed.getCategory == ParsedLogData.ParsedLogCategory.CHECKPOINT)
+    assert(parsed.isMaterialized)
+    assert(!parsed.isInline)
+    assert(parsed.getFileStatus == fileStatus)
+  }
+
+  test("Classic checkpoint file equality") {
+    val fileStatus1 = singularCheckpointFileStatuses(Seq(10)).head
+    val fileStatus2 = singularCheckpointFileStatuses(Seq(10)).head
+    val fileStatus3 = singularCheckpointFileStatuses(Seq(11)).head
+
+    val cp1 = ParsedLogData.forFileStatus(fileStatus1)
+    val cp2 = ParsedLogData.forFileStatus(fileStatus2)
+    val cp3 = ParsedLogData.forFileStatus(fileStatus3)
+
+    assert(cp1 == cp1)
+    assert(cp1 == cp2)
+    assert(cp1 != cp3)
+  }
+
+  test("Correctly parses V2 checkpoint file") {
+    val fileStatus = v2CheckpointFileStatuses(Seq((20, true, 0)), "parquet").head._1
+    val parsed = ParsedLogData.forFileStatus(fileStatus)
+
+    assert(parsed.isInstanceOf[ParsedCheckpointData])
+    assert(parsed.version == 20)
+    assert(parsed.getCategory == ParsedLogData.ParsedLogCategory.CHECKPOINT)
+    assert(parsed.isMaterialized)
+    assert(!parsed.isInline)
+    assert(parsed.getFileStatus == fileStatus)
+  }
+
+  test("V2 checkpoint file equality") {
+    val fileStatus1 = v2CheckpointFileStatuses(Seq((20, false, 0)), "parquet").head._1
+    val fileStatus2 = v2CheckpointFileStatuses(Seq((20, false, 0)), "parquet").head._1
+    val fileStatus3 = v2CheckpointFileStatuses(Seq((21, true, 0)), "parquet").head._1
+
+    val parsed1 = ParsedLogData.forFileStatus(fileStatus1)
+    val parsed2 = ParsedLogData.forFileStatus(fileStatus2)
+    val parsed3 = ParsedLogData.forFileStatus(fileStatus3)
+
+    assert(parsed1 == parsed1)
+    assert(parsed1 == parsed2)
+    assert(parsed1 != parsed3)
+  }
+
+  ////////////////////////////
+  // Multi-Part Checkpoints //
+  ////////////////////////////
+
+  test("Inline multi-part checkpoint") {
+    ParsedMultiPartCheckpointData.forInlineData(10, 1, 3, emptyColumnarBatch)
+  }
+
+  test("Throws on inline multi-part checkpoint using wrong factory") {
+    val exMsg1 = intercept[IllegalArgumentException] {
+      ParsedLogData.forInlineData(10, ParsedLogType.MULTIPART_CHECKPOINT, emptyColumnarBatch)
+    }.getMessage
+    assert(exMsg1 ==
+      "For MULTIPART_CHECKPOINT, use ParsedMultiPartCheckpointData.forInlineData() instead")
+
+    val exMsg2 = intercept[IllegalArgumentException] {
+      ParsedCheckpointData.forInlineData(10, ParsedLogType.MULTIPART_CHECKPOINT, emptyColumnarBatch)
+    }.getMessage
+    assert(exMsg2 ==
+      "For MULTIPART_CHECKPOINT, use ParsedMultiPartCheckpointData.forInlineData() instead")
+  }
+
+  test("Correctly parses multi-part checkpoint file") {
+    val chkpt_15_1_3 = multiCheckpointFileStatuses(Seq(15), 3).head
+    val parsed = ParsedLogData
+      .forFileStatus(chkpt_15_1_3)
+      .asInstanceOf[ParsedMultiPartCheckpointData]
+
+    assert(parsed.version == 15)
+    assert(parsed.getCategory == ParsedLogData.ParsedLogCategory.CHECKPOINT)
+    assert(parsed.isMaterialized)
+    assert(!parsed.isInline)
+    assert(parsed.getFileStatus == chkpt_15_1_3)
+    assert(parsed.part == 1)
+    assert(parsed.numParts == 3)
+  }
+
+  test("Throws on multi-part checkpoint with part > numParts") {
+    val path = FileNames.multiPartCheckpointFile(logPath, 10, 5, 3) // part = 5, numParts = 3
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogData.forFileStatus(FileStatus.of(path.toString))
+    }.getMessage
+    assert(exMsg.contains("part must be between 1 and numParts"))
+  }
+
+  test("Throws on multi-part checkpoint with numParts = 0") {
+    val path = FileNames.multiPartCheckpointFile(logPath, 10, 0, 0) // part = 0, numParts = 0
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogData.forFileStatus(FileStatus.of(path.toString))
+    }.getMessage
+    assert(exMsg.contains("numParts must be greater than 0"))
+  }
+
+  test("Throws on multi-part checkpoint with part = 0") {
+    val path = FileNames.multiPartCheckpointFile(logPath, 10, 0, 3) // part = 0, numParts = 3
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogData.forFileStatus(FileStatus.of(path.toString))
+    }.getMessage
+    assert(exMsg.contains("part must be between 1 and numParts"))
+  }
+
+  test("Multi-part checkpoint file equality") {
+    val chkpt_15_1_3_a = multiCheckpointFileStatuses(Seq(15), 3).head
+    val chkpt_15_1_3_b = multiCheckpointFileStatuses(Seq(15), 3).head
+    val chkpt_15_2_3 = multiCheckpointFileStatuses(Seq(15), 3)(1)
+    val chkpt_15_1_4 = multiCheckpointFileStatuses(Seq(15), 4).head
+    val chkpt_16_1_3 = multiCheckpointFileStatuses(Seq(16), 3).head
+
+    val parsed_15_1_3_a = ParsedLogData.forFileStatus(chkpt_15_1_3_a)
+    val parsed_15_1_3_b = ParsedLogData.forFileStatus(chkpt_15_1_3_b)
+    val parsed_15_2_3 = ParsedLogData.forFileStatus(chkpt_15_2_3)
+    val parsed_15_1_4 = ParsedLogData.forFileStatus(chkpt_15_1_4)
+    val parsed_16_1_3 = ParsedLogData.forFileStatus(chkpt_16_1_3)
+
+    assert(parsed_15_1_3_a == parsed_15_1_3_a)
+    assert(parsed_15_1_3_a == parsed_15_1_3_b)
+    assert(parsed_15_1_3_a != parsed_15_2_3)
+    assert(parsed_15_1_3_a != parsed_15_1_4)
+    assert(parsed_15_1_3_a != parsed_16_1_3)
+  }
+
+  /////////////////////
+  // Log compactions //
+  /////////////////////
+
+  test("inline log compaction") {
+    ParsedLogCompactionData.forInlineData(10, 20, emptyColumnarBatch)
+  }
+
+  test("Throws on inline log compaction using wrong factory") {
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogData.forInlineData(10, ParsedLogType.LOG_COMPACTION, emptyColumnarBatch)
+    }.getMessage
+    assert(exMsg ==
+      "For LOG_COMPACTION, use ParsedLogCompactionData.forInlineData() instead")
+  }
+
+  test("Correctly parses log compaction file") {
+    val fileStatus = logCompactionStatus(25, 30)
+    val parsed = ParsedLogData.forFileStatus(fileStatus).asInstanceOf[ParsedLogCompactionData]
+
+    assert(parsed.version == 30)
+    assert(parsed.getCategory == ParsedLogData.ParsedLogCategory.LOG_COMPACTION)
+    assert(parsed.isMaterialized)
+    assert(!parsed.isInline)
+    assert(parsed.getFileStatus == fileStatus)
+    assert(parsed.startVersion == 25)
+    assert(parsed.endVersion == 30)
+  }
+
+  test("Throws on log compaction with startVersion < 0") {
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogCompactionData.forInlineData(-1, 3, emptyColumnarBatch)
+    }.getMessage
+    assert(exMsg.contains("startVersion and endVersion must be non-negative"))
+  }
+
+  test("Throws on log compaction with endVersion < 0") {
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogCompactionData.forInlineData(1, -1, emptyColumnarBatch)
+    }.getMessage
+    assert(exMsg.contains("version must be non-negative"))
+  }
+
+  test("Throws on log compaction with startVersion > endVersion") {
+    val exMsg = intercept[IllegalArgumentException] {
+      ParsedLogCompactionData.forInlineData(3, 1, emptyColumnarBatch)
+    }.getMessage
+    assert(exMsg.contains("startVersion must be less than endVersion"))
+  }
+
+  test("Log compaction file equality") {
+    val fileStatus1 = logCompactionStatus(25, 30)
+    val fileStatus2 = logCompactionStatus(25, 30)
+    val fileStatus3 = logCompactionStatus(31, 32)
+
+    val parsed1 = ParsedLogData.forFileStatus(fileStatus1)
+    val parsed2 = ParsedLogData.forFileStatus(fileStatus2)
+    val parsed3 = ParsedLogData.forFileStatus(fileStatus3)
+
+    assert(parsed1 == parsed1)
+    assert(parsed1 == parsed2)
+    assert(parsed1 != parsed3)
+  }
+
+  //////////////
+  // Checksum //
+  //////////////
+
+  test("Correctly parses checksum file") {
+    val fileStatus = checksumFileStatus(5)
+    val parsed = ParsedLogData.forFileStatus(fileStatus)
+
+    assert(parsed.version == 5)
+    assert(parsed.getCategory == ParsedLogData.ParsedLogCategory.CHECKSUM)
+    assert(parsed.getFileStatus == fileStatus)
+  }
+
+  test("Checksum file equality") {
+    val fileStatus1 = checksumFileStatus(5)
+    val fileStatus2 = checksumFileStatus(5)
+    val fileStatus3 = checksumFileStatus(6)
+
+    val parsed1 = ParsedLogData.forFileStatus(fileStatus1)
+    val parsed2 = ParsedLogData.forFileStatus(fileStatus2)
+    val parsed3 = ParsedLogData.forFileStatus(fileStatus3)
+
+    assert(parsed1 == parsed1)
+    assert(parsed1 == parsed2)
+    assert(parsed1 != parsed3)
+  }
+
+  //////////////
+  // toString //
+  //////////////
+
+  test("published delta file toString") {
+    val parsed = ParsedLogData.forFileStatus(deltaFileStatus(5))
+    // scalastyle:off line.size.limit
+    val expected =
+      "ParsedLogData{version=5, type=PUBLISHED_DELTA, source=FileStatus{path='/fake/path/to/table/_delta_log/00000000000000000005.json', size=5, modificationTime=50}}"
+    // scalastyle:on line.size.limit
+    assert(parsed.toString === expected)
+  }
+
+  test("multi-part checkpoint toString") {
+    val parsed = ParsedMultiPartCheckpointData.forInlineData(10, 1, 3, emptyColumnarBatch)
+    // scalastyle:off line.size.limit
+    val expected =
+      "ParsedMultiPartCheckpointData{version=10, type=MULTIPART_CHECKPOINT, source=inline, part=1, numParts=3}"
+    // scalastyle:on line.size.limit
+    assert(parsed.toString === expected)
+  }
+
+  test("log compaction toString") {
+    val parsed = ParsedLogCompactionData.forInlineData(10, 20, emptyColumnarBatch)
+    // scalastyle:off line.size.limit
+    val expected =
+      "ParsedLogCompactionData{version=20, type=LOG_COMPACTION, source=inline, startVersion=10}"
+    // scalastyle:on line.size.limit
+    assert(parsed.toString === expected)
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/files/ParsedLogDataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/files/ParsedLogDataSuite.scala
@@ -150,7 +150,7 @@ class ParsedLogDataSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("Correctly parses V2 checkpoint file") {
-    val fileStatus = v2CheckpointFileStatuses(Seq((20, true, 0)), "parquet").head._1
+    val fileStatus = v2CheckpointFileStatus(20)
     val parsed = ParsedLogData.forFileStatus(fileStatus)
 
     assert(parsed.isInstanceOf[ParsedCheckpointData])
@@ -163,13 +163,9 @@ class ParsedLogDataSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("V2 checkpoint file equality") {
-    val fileStatus1 = v2CheckpointFileStatuses(Seq((20, false, 0)), "parquet").head._1
-    val fileStatus2 = v2CheckpointFileStatuses(Seq((20, false, 0)), "parquet").head._1
-    val fileStatus3 = v2CheckpointFileStatuses(Seq((21, true, 0)), "parquet").head._1
-
-    val parsed1 = ParsedLogData.forFileStatus(fileStatus1)
-    val parsed2 = ParsedLogData.forFileStatus(fileStatus2)
-    val parsed3 = ParsedLogData.forFileStatus(fileStatus3)
+    val parsed1 = ParsedLogData.forFileStatus(v2CheckpointFileStatus(20, useUUID = false))
+    val parsed2 = ParsedLogData.forFileStatus(v2CheckpointFileStatus(20, useUUID = false))
+    val parsed3 = ParsedLogData.forFileStatus(v2CheckpointFileStatus(21))
 
     assert(parsed1 == parsed1)
     assert(parsed1 == parsed2)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -37,6 +37,10 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
   val dataPath = new Path("/fake/path/to/table/")
   val logPath = new Path(dataPath, "_delta_log")
 
+  /** Staged commit file status where the timestamp = 10*version */
+  def stagedCommitFile(v: Long): FileStatus =
+    FileStatus.of(FileNames.stagedCommitFile(logPath, v), v, v * 10)
+
   /** Delta file status where the timestamp = 10*version */
   def deltaFileStatus(v: Long): FileStatus =
     FileStatus.of(FileNames.deltaFile(logPath, v), v, v * 10)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -95,6 +95,20 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
         .map(p => FileStatus.of(p.toString, v, v * 10)))
   }
 
+  /** Checkpoint file status for a top-level V2 checkpoint file. */
+  def v2CheckpointFileStatus(
+      version: Long,
+      useUUID: Boolean = true,
+      fileType: String = "json"): FileStatus = {
+    val path = if (useUUID) {
+      val uuid = UUID.randomUUID().toString
+      FileNames.topLevelV2CheckpointFile(logPath, version, uuid, fileType).toString
+    } else {
+      FileNames.checkpointFileSingular(logPath, version).toString
+    }
+    FileStatus.of(path, version, version * 10)
+  }
+
   /**
    * Checkpoint file status for a top-level V2 checkpoint file.
    *
@@ -106,18 +120,7 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
       checkpointVersions: Seq[(Long, Boolean, Int)],
       fileType: String): Seq[(FileStatus, Seq[FileStatus])] = {
     checkpointVersions.map { case (v, useUUID, numSidecars) =>
-      val topLevelFile = if (useUUID) {
-        FileStatus.of(
-          FileNames.topLevelV2CheckpointFile(
-            logPath,
-            v,
-            UUID.randomUUID().toString,
-            fileType).toString,
-          v,
-          v * 10)
-      } else {
-        FileStatus.of(FileNames.checkpointFileSingular(logPath, v).toString, v, v * 10)
-      }
+      val topLevelFile = v2CheckpointFileStatus(v, useUUID, fileType)
       val sidecars = (0 until numSidecars).map { _ =>
         FileStatus.of(
           FileNames.v2CheckpointSidecarFile(logPath, UUID.randomUUID().toString).toString,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -67,11 +67,22 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
     FileStatus.of(FileNames.checksumFile(logPath, deltaVersion).toString, 10, 10)
   }
 
+  /** Classic checkpoint file status where the timestamp = 10*version */
+  def classicCheckpointFileStatus(v: Long): FileStatus = {
+    FileStatus.of(FileNames.checkpointFileSingular(logPath, v).toString, v, v * 10)
+  }
+
   /** Checkpoint file statuses where the timestamp = 10*version */
   def singularCheckpointFileStatuses(checkpointVersions: Seq[Long]): Seq[FileStatus] = {
     assert(checkpointVersions.size == checkpointVersions.toSet.size)
     checkpointVersions.map(v =>
       FileStatus.of(FileNames.checkpointFileSingular(logPath, v).toString, v, v * 10))
+  }
+
+  /** Multi-part checkpoint file status where the timestamp = 10*version */
+  def multiPartCheckpointFileStatus(version: Long, part: Integer, numParts: Integer): FileStatus = {
+    val path = FileNames.multiPartCheckpointFile(logPath, version, part, numParts)
+    FileStatus.of(path.toString, version, version * 10)
   }
 
   /** Checkpoint file statuses where the timestamp = 10*version */


### PR DESCRIPTION
Stacked PR -- please see the last 2 commits.

#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Update `ParsedCheckpointData` to supporting comparable, for ordering. This will be used to be able to group checkpoints together and identify the max (preferred), similar to CheckpointInstance today.

## How was this patch tested?

New UT.

## Does this PR introduce _any_ user-facing changes?

No.