### PR TITLE
[Kernel][Catalog-Managed] ParsedCheckpointData ordering

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointInstance.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointInstance.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+// TODO: Delete this in favor of ParsedCheckpointData.
 /** Metadata about Delta checkpoint. */
 public class CheckpointInstance implements Comparable<CheckpointInstance> {
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -23,7 +23,9 @@ import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
-public class ParsedCheckpointData extends ParsedLogData {
+public class ParsedCheckpointData extends ParsedLogData
+    implements Comparable<ParsedCheckpointData> {
+
   public static ParsedCheckpointData forFileStatus(FileStatus fileStatus) {
     final String path = fileStatus.getPath();
 
@@ -64,5 +66,52 @@ public class ParsedCheckpointData extends ParsedLogData {
       Optional<ColumnarBatch> inlineDataOpt) {
     super(version, type, fileStatusOpt, inlineDataOpt);
     checkArgument(type.category == ParsedLogCategory.CHECKPOINT, "Must be a checkpoint");
+  }
+
+  @Override
+  public int compareTo(ParsedCheckpointData that) {
+    // Compare versions.
+    if (version != that.version) {
+      return Long.compare(version, that.version);
+    }
+
+    // Compare types.
+    if (type != that.type) {
+      return Integer.compare(type.ordinal(), that.type.ordinal());
+    }
+
+    // Use type-specific tiebreakers if versions and types are the same.
+    switch (type) {
+      case CLASSIC_CHECKPOINT:
+      case V2_CHECKPOINT:
+        return getTieBreaker(that);
+      case MULTIPART_CHECKPOINT:
+        final ParsedMultiPartCheckpointData thisCasted = (ParsedMultiPartCheckpointData) this;
+        final ParsedMultiPartCheckpointData thatCasted = (ParsedMultiPartCheckpointData) that;
+        final int numPartsComparison = Long.compare(thisCasted.numParts, thatCasted.numParts);
+        if (numPartsComparison != 0) {
+          return numPartsComparison;
+        } else {
+          return getTieBreaker(that);
+        }
+      default:
+        throw new IllegalStateException("Unexpected type: " + type);
+    }
+  }
+
+  /**
+   * Here, we prefer inline data -- if the data is already stored in memory, we should read that
+   * instead of going to the cloud store to read a file status.
+   */
+  private int getTieBreaker(ParsedCheckpointData that) {
+    if (this.isInline() && that.isMaterialized()) {
+      return 1; // Prefer this
+    } else if (this.isMaterialized() && that.isInline()) {
+      return -1; // Prefer that
+    } else if (this.isMaterialized() && that.isMaterialized()) {
+      return this.getFileStatus().getPath().compareTo(that.getFileStatus().getPath());
+    } else {
+      return 0;
+    }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -89,12 +89,7 @@ public class ParsedCheckpointData extends ParsedLogData
       case MULTIPART_CHECKPOINT:
         final ParsedMultiPartCheckpointData thisCasted = (ParsedMultiPartCheckpointData) this;
         final ParsedMultiPartCheckpointData thatCasted = (ParsedMultiPartCheckpointData) that;
-        final int numPartsComparison = Long.compare(thisCasted.numParts, thatCasted.numParts);
-        if (numPartsComparison != 0) {
-          return numPartsComparison;
-        } else {
-          return getTieBreaker(that);
-        }
+        return thisCasted.compareToMultiPart(thatCasted);
       default:
         throw new IllegalStateException("Unexpected type: " + type);
     }
@@ -104,7 +99,7 @@ public class ParsedCheckpointData extends ParsedLogData
    * Here, we prefer inline data -- if the data is already stored in memory, we should read that
    * instead of going to the cloud store to read a file status.
    */
-  private int getTieBreaker(ParsedCheckpointData that) {
+  protected int getTieBreaker(ParsedCheckpointData that) {
     if (this.isInline() && that.isMaterialized()) {
       return 1; // Prefer this
     } else if (this.isMaterialized() && that.isInline()) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -68,6 +68,7 @@ public class ParsedCheckpointData extends ParsedLogData
     checkArgument(type.category == ParsedLogCategory.CHECKPOINT, "Must be a checkpoint");
   }
 
+  /** Here, returning 1 means that `this` is preferred over (i.e. greater than) `that`. */
   @Override
   public int compareTo(ParsedCheckpointData that) {
     // Compare versions.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -47,10 +47,13 @@ public class ParsedLogData {
     RATIFIED_STAGED_COMMIT(ParsedLogCategory.DELTA),
     RATIFIED_INLINE_COMMIT(ParsedLogCategory.DELTA),
     LOG_COMPACTION(ParsedLogCategory.LOG_COMPACTION),
+    CHECKSUM(ParsedLogCategory.CHECKSUM),
+
+    // Note that the order of these checkpoint enum values is important for comparison of checkpoint
+    // files as we prefer V2 > MULTI_PART > CLASSIC.
     CLASSIC_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
     MULTIPART_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
-    V2_CHECKPOINT(ParsedLogCategory.CHECKPOINT),
-    CHECKSUM(ParsedLogCategory.CHECKSUM);
+    V2_CHECKPOINT(ParsedLogCategory.CHECKPOINT);
 
     public final ParsedLogCategory category;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedMultiPartCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedMultiPartCheckpointData.java
@@ -77,4 +77,13 @@ public class ParsedMultiPartCheckpointData extends ParsedCheckpointData {
   public int hashCode() {
     return Objects.hash(super.hashCode(), part, numParts);
   }
+
+  public int compareToMultiPart(ParsedMultiPartCheckpointData that) {
+    final int numPartsComparison = Long.compare(this.numParts, that.numParts);
+    if (numPartsComparison != 0) {
+      return numPartsComparison;
+    } else {
+      return getTieBreaker(that);
+    }
+  }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4597/files) to review incremental changes.
- [**stack/kernel_parsed_checkpoint_ordering**](https://github.com/delta-io/delta/pull/4597) [[Files changed](https://github.com/delta-io/delta/pull/4597/files)]
  - [stack/kernel_parsed_complete_checkpoint_group](https://github.com/delta-io/delta/pull/4634) [[Files changed](https://github.com/delta-io/delta/pull/4634/files/52a6f8c8a5c618e1d16999d366b3f075065d1193..adfa8162be992222ad45cbc9ea3491e2538c21bf)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Update `ParsedCheckpointData` to supporting comparable, for ordering. This will be used to be able to group checkpoints together and identify the max (preferred), similar to CheckpointInstance today.

## How was this patch tested?

New UT

## Does this PR introduce _any_ user-facing changes?

No.
