### PR TITLE
[VARIANT] Add automaticallyUpdateProtocolOfExistingTables to variantType features

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -682,6 +682,8 @@ trait BinaryVariantTableFeature {
 object VariantTypePreviewTableFeature extends ReaderWriterFeature(name = "variantType-preview")
   with FeatureAutomaticallyEnabledByMetadata
     with BinaryVariantTableFeature {
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
+
   override def metadataRequiresFeatureToBeEnabled(
       protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
     if (forcePreviewTableFeature) {
@@ -700,6 +702,8 @@ object VariantTypePreviewTableFeature extends ReaderWriterFeature(name = "varian
 object VariantTypeTableFeature extends ReaderWriterFeature(name = "variantType")
     with FeatureAutomaticallyEnabledByMetadata
     with BinaryVariantTableFeature {
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
+
   override def metadataRequiresFeatureToBeEnabled(
       protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
     if (forcePreviewTableFeature) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`variantType` and `variantType-preview` features did not have the `automaticallyUpdateProtocolOfExistingTables` flag enabled which disallowed adding Variant columns to an existing Delta table unless the feature was explicitly added. This PR enables this flag for these features.

## How was this patch tested?

Unit tests.

## Does this PR introduce _any_ user-facing changes?

Yes, it allows users to add Variant columns to tables easily.