### PR TITLE
[Kernel][Type Widening] 10/ Add iceberg compat check for type changes

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -23,6 +23,7 @@ import io.delta.kernel.internal.actions.DomainMetadata;
 import io.delta.kernel.internal.tablefeatures.TableFeature;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.TypeChange;
 import io.delta.kernel.utils.DataFileStatus;
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -295,6 +296,12 @@ public final class DeltaErrors {
       String compatVersion, List<DataType> dataTypes) {
     throw new KernelException(
         format("%s does not support the data types: %s.", compatVersion, dataTypes));
+  }
+
+  public static KernelException icebergCompatUnsupportedTypeWidening(
+      String compatVersion, TypeChange typeChange) {
+    throw new KernelException(
+        format("%s does not type widening present in table: %s.", compatVersion, typeChange));
   }
 
   public static KernelException icebergCompatUnsupportedTypePartitionColumn(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -301,7 +301,8 @@ public final class DeltaErrors {
   public static KernelException icebergCompatUnsupportedTypeWidening(
       String compatVersion, TypeChange typeChange) {
     throw new KernelException(
-        format("%s does not type widening present in table: %s.", compatVersion, typeChange));
+        format(
+            "%s does not support type widening present in table: %s.", compatVersion, typeChange));
   }
 
   public static KernelException icebergCompatUnsupportedTypePartitionColumn(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -168,14 +168,14 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
           "intToLong",
           IntegerType.INTEGER,
           true,
-          FieldMetadata.empty(),
+          FieldMetadata.empty()).withTypeChanges(
           Seq(new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava))
       .add(
         new StructField(
           "decimalToDecimal",
           new DecimalType(10, 2),
           true,
-          FieldMetadata.empty(),
+          FieldMetadata.empty()).withTypeChanges(
           Seq(new TypeChange(new DecimalType(5, 2), new DecimalType(10, 2))).asJava))
 
     val metadata = getCompatEnabledMetadata(schema)
@@ -192,7 +192,7 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
           "dateToTimestamp",
           TimestampNTZType.TIMESTAMP_NTZ,
           true,
-          FieldMetadata.empty(),
+          FieldMetadata.empty()).withTypeChanges(
           Seq(new TypeChange(DateType.DATE, TimestampNTZType.TIMESTAMP_NTZ)).asJava))
 
     val metadata = getCompatEnabledMetadata(schema)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -161,6 +161,50 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
     validateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
   }
 
+  test("compatible type widening is allowed with icebergCompatV2") {
+    val schema = new StructType()
+      .add(
+        new StructField(
+          "intToLong",
+          IntegerType.INTEGER,
+          true,
+          FieldMetadata.empty(),
+          Seq(new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava))
+      .add(
+        new StructField(
+          "decimalToDecimal",
+          new DecimalType(10, 2),
+          true,
+          FieldMetadata.empty(),
+          Seq(new TypeChange(new DecimalType(5, 2), new DecimalType(10, 2))).asJava))
+
+    val metadata = getCompatEnabledMetadata(schema)
+    val protocol = getCompatEnabledProtocol(TYPE_WIDENING_RW_FEATURE)
+
+    // This should not throw an exception
+    validateAndUpdateIcebergCompatV2Metadata(false, metadata, protocol)
+  }
+
+  test("incompatible type widening throws exception with icebergCompatV2") {
+    val schema = new StructType()
+      .add(
+        new StructField(
+          "dateToTimestamp",
+          TimestampNTZType.TIMESTAMP_NTZ,
+          true,
+          FieldMetadata.empty(),
+          Seq(new TypeChange(DateType.DATE, TimestampNTZType.TIMESTAMP_NTZ)).asJava))
+
+    val metadata = getCompatEnabledMetadata(schema)
+    val protocol = getCompatEnabledProtocol(TYPE_WIDENING_RW_FEATURE)
+
+    val e = intercept[KernelException] {
+      validateAndUpdateIcebergCompatV2Metadata(false, metadata, protocol)
+    }
+
+    assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
+  }
+
   Seq(true, false).foreach { isNewTable =>
     test(s"protocol is missing required column mapping feature, isNewTable $isNewTable") {
       val schema = new StructType().add("col", BooleanType.BOOLEAN)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -202,7 +202,7 @@ class IcebergCompatV2MetadataValidatorAndUpdaterSuite
       validateAndUpdateIcebergCompatV2Metadata(false, metadata, protocol)
     }
 
-    assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
+    assert(e.getMessage.contains("icebergCompatV2 does not support type widening present in table"))
   }
 
   Seq(true, false).foreach { isNewTable =>

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -317,7 +317,7 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
       validateAndUpdateIcebergWriterCompatV1Metadata(false, metadata, protocol)
     }
 
-    assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
+    assert(e.getMessage.contains("icebergCompatV2 does not support type widening present in table"))
   }
 
   private def checkUnsupportedOrIncompatibleFeature(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -284,8 +284,9 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
           FieldMetadata.builder()
             .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
             .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1")
-            .build(),
-          Seq(new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava))
+            .build()).withTypeChanges(Seq(new TypeChange(
+          IntegerType.INTEGER,
+          LongType.LONG)).asJava))
 
     val metadata = getCompatEnabledMetadata(schema)
       .withMergedConfiguration(Map(ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY -> "1").asJava)
@@ -305,7 +306,7 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
           FieldMetadata.builder()
             .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
             .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1")
-            .build(),
+            .build()).withTypeChanges(
           Seq(new TypeChange(ByteType.BYTE, new DecimalType(10, 0))).asJava))
 
     val metadata = getCompatEnabledMetadata(schema)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -22,9 +22,9 @@ import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.actions.{Metadata, Protocol}
 import io.delta.kernel.internal.icebergcompat.IcebergWriterCompatV1MetadataValidatorAndUpdater.validateAndUpdateIcebergWriterCompatV1Metadata
 import io.delta.kernel.internal.tablefeatures.TableFeature
-import io.delta.kernel.internal.tablefeatures.TableFeatures.{COLUMN_MAPPING_RW_FEATURE, ICEBERG_COMPAT_V2_W_FEATURE, ICEBERG_WRITER_COMPAT_V1}
+import io.delta.kernel.internal.tablefeatures.TableFeatures.{COLUMN_MAPPING_RW_FEATURE, ICEBERG_COMPAT_V2_W_FEATURE, ICEBERG_WRITER_COMPAT_V1, TYPE_WIDENING_RW_FEATURE}
 import io.delta.kernel.internal.util.ColumnMapping
-import io.delta.kernel.types.{ByteType, DataType, FieldMetadata, IntegerType, ShortType, StructType}
+import io.delta.kernel.types.{ByteType, DataType, DecimalType, FieldMetadata, IntegerType, LongType, ShortType, StructField, StructType, TypeChange}
 
 class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
     extends IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase {
@@ -272,6 +272,51 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
     val metadata = getCompatEnabledMetadata(cmTestSchema())
     validateAndUpdateIcebergWriterCompatV1Metadata(true, metadata, protocol)
     validateAndUpdateIcebergWriterCompatV1Metadata(false, metadata, protocol)
+  }
+
+  test("compatible type widening is allowed with icebergWriterCompatV1") {
+    val schema = new StructType()
+      .add(
+        new StructField(
+          "intToLong",
+          IntegerType.INTEGER,
+          true,
+          FieldMetadata.builder()
+            .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
+            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1")
+            .build(),
+          Seq(new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava))
+
+    val metadata = getCompatEnabledMetadata(schema)
+      .withMergedConfiguration(Map(ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY -> "1").asJava)
+    val protocol = getCompatEnabledProtocol(TYPE_WIDENING_RW_FEATURE)
+
+    // This should not throw an exception
+    validateAndUpdateIcebergWriterCompatV1Metadata(false, metadata, protocol)
+  }
+
+  test("incompatible type widening throws exception with icebergWriterCompatV1") {
+    val schema = new StructType()
+      .add(
+        new StructField(
+          "intToLong",
+          IntegerType.INTEGER,
+          true,
+          FieldMetadata.builder()
+            .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
+            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1")
+            .build(),
+          Seq(new TypeChange(ByteType.BYTE, new DecimalType(10, 0))).asJava))
+
+    val metadata = getCompatEnabledMetadata(schema)
+      .withMergedConfiguration(Map(ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY -> "1").asJava)
+    val protocol = getCompatEnabledProtocol(TYPE_WIDENING_RW_FEATURE)
+
+    val e = intercept[KernelException] {
+      validateAndUpdateIcebergWriterCompatV1Metadata(false, metadata, protocol)
+    }
+
+    assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
   }
 
   private def checkUnsupportedOrIncompatibleFeature(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/TypeWideningCheckerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/TypeWideningCheckerSuite.scala
@@ -161,6 +161,22 @@ class TypeWideningCheckerSuite extends AnyFunSuite {
   }
 
   test("iceberg V2 unsupported type widening") {
+    /////////////////////////////////////////////////////////////////////////////////////
+    // Test generally unsupported widening operations
+    /////////////////////////////////////////////////////////////////////////////////////
+    assert(!TypeWideningChecker.isIcebergV2Compatible(StringType.STRING, BinaryType.BINARY))
+    assert(!TypeWideningChecker.isIcebergV2Compatible(IntegerType.INTEGER, StringType.STRING))
+    assert(!TypeWideningChecker.isIcebergV2Compatible(DateType.DATE, StringType.STRING))
+    assert(!TypeWideningChecker.isIcebergV2Compatible(DoubleType.DOUBLE, new DecimalType(10, 2)))
+    assert(!TypeWideningChecker.isIcebergV2Compatible(DateType.DATE, TimestampType.TIMESTAMP))
+    assert(!TypeWideningChecker.isIcebergV2Compatible(
+      TimestampNTZType.TIMESTAMP_NTZ,
+      DateType.DATE))
+
+    ////////////////////////////////////////////////////////////////////////////////////
+    // Test invalid widening that are generally supported by Delta but not by Iceberg V2
+    ////////////////////////////////////////////////////////////////////////////////////
+
     // Integer to Double widening (not supported by Iceberg)
     assert(!TypeWideningChecker.isIcebergV2Compatible(ByteType.BYTE, DoubleType.DOUBLE))
     assert(!TypeWideningChecker.isIcebergV2Compatible(ShortType.SHORT, DoubleType.DOUBLE))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.defaults
 
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.reflect.ClassTag
 
@@ -23,8 +24,8 @@ import io.delta.kernel.data.Row
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.tablefeatures.TableFeatures
-import io.delta.kernel.internal.util.{ColumnMappingSuiteBase, VectorUtils}
-import io.delta.kernel.types.{DataType, StructType}
+import io.delta.kernel.internal.util.{ColumnMapping, ColumnMappingSuiteBase, VectorUtils}
+import io.delta.kernel.types.{DataType, DateType, FieldMetadata, IntegerType, LongType, StructField, StructType, TimestampNTZType, TypeChange}
 
 /** This suite tests reading or writing into Delta table that have `icebergCompatV2` enabled. */
 class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMappingSuiteBase {
@@ -219,6 +220,83 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
         ver3Metadata.getMap(ver3Metadata.getSchema.indexOf("configuration")))
         .get("key")
       assert(result === "value")
+    }
+  }
+
+  test("compatible type widening is allowed with icebergCompatV2") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // Create a table with icebergCompatV2 and type widening enabled
+      val schema = new StructType()
+        .add(new StructField(
+          "intToLong",
+          LongType.LONG,
+          false).withTypeChanges(Seq(new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava))
+
+      val tblProps = Map(
+        TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
+        TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")
+
+      // This should not throw an exception
+      createEmptyTable(engine, tablePath, schema, tableProperties = tblProps)
+      appendData(engine, tablePath, data = Seq.empty)
+
+      val protocol = getProtocol(engine, tablePath)
+      assert(protocol.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
+      val metadata = getMetadata(engine, tablePath)
+      assert(metadata.getSchema.get("intToLong").getTypeChanges.asScala == schema.get(
+        "intToLong").getTypeChanges.asScala)
+    }
+  }
+
+  test("incompatible type widening throws exception with icebergCompatV2") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // Try to create a table with icebergCompatV2 and incompatible type widening
+      val schema = new StructType()
+        .add(
+          new StructField(
+            "dateToTimestamp",
+            TimestampNTZType.TIMESTAMP_NTZ,
+            false).withTypeChanges(Seq(
+            new TypeChange(DateType.DATE, TimestampNTZType.TIMESTAMP_NTZ)).asJava))
+
+      val tblProps = Map(
+        TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
+        TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")
+
+      val e = intercept[KernelException] {
+        createEmptyTable(engine, tablePath, schema, tableProperties = tblProps)
+      }
+
+      assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
+    }
+  }
+
+  test(
+    "incompatible type widening throws exception with icebergCompatV2 enabled on existing table") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val schema = new StructType()
+        .add(new StructField(
+          "dateToTimestamp",
+          TimestampNTZType.TIMESTAMP_NTZ,
+          false,
+          FieldMetadata.builder()
+            .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
+            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1").build(),
+          Seq(new TypeChange(DateType.DATE, TimestampNTZType.TIMESTAMP_NTZ)).asJava))
+
+      val tblProps = Map(TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")
+      createEmptyTable(engine, tablePath, schema, tableProperties = tblProps)
+
+      val e = intercept[KernelException] {
+        updateTableMetadata(
+          engine,
+          tablePath,
+          tableProperties = Map(
+            TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true",
+            TableConfig.COLUMN_MAPPING_MODE.getKey -> "ID"))
+      }
+
+      assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -281,7 +281,9 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
           false,
           FieldMetadata.builder()
             .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
-            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1").build(),
+            .putString(
+              ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY,
+              "col-1").build()).withTypeChanges(
           Seq(new TypeChange(DateType.DATE, TimestampNTZType.TIMESTAMP_NTZ)).asJava))
 
       val tblProps = Map(TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -267,7 +267,8 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
         createEmptyTable(engine, tablePath, schema, tableProperties = tblProps)
       }
 
-      assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
+      assert(
+        e.getMessage.contains("icebergCompatV2 does not support type widening present in table"))
     }
   }
 
@@ -298,7 +299,8 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
             TableConfig.COLUMN_MAPPING_MODE.getKey -> "ID"))
       }
 
-      assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
+      assert(
+        e.getMessage.contains("icebergCompatV2 does not support type widening present in table"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -27,7 +27,7 @@ import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAn
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.{ColumnMapping, ColumnMappingSuiteBase}
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode
-import io.delta.kernel.types.{ByteType, DataType, FieldMetadata, IntegerType, ShortType, StructType, TimestampNTZType, VariantType}
+import io.delta.kernel.types.{ByteType, DataType, DateType, FieldMetadata, IntegerType, LongType, ShortType, StructField, StructType, TimestampNTZType, TypeChange, VariantType}
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
 
 import org.assertj.core.api.Assertions.assertThat
@@ -639,6 +639,54 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
       assert(protocol.supportsFeature(TableFeatures.INVARIANTS_W_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
       // TODO in the future add clustering once they are supported
+    }
+  }
+
+  test("compatible type widening is allowed with icebergWriterCompatV1") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // Create a table with icebergWriterCompatV1 and type widening enabled
+      val schema = new StructType()
+        .add(new StructField(
+          "intToLong",
+          LongType.LONG,
+          false,
+          FieldMetadata.builder()
+            .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
+            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1").build(),
+          Seq(new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava))
+
+      val tblProps = tblPropertiesIcebergWriterCompatV1Enabled ++
+        Map(TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")
+
+      // This should not throw an exception
+      createEmptyTable(engine, tablePath, schema, tableProperties = tblProps)
+
+      val protocol = getProtocol(engine, tablePath)
+      assert(protocol.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
+    }
+  }
+
+  test("incompatible type widening throws exception with icebergWriterCompatV1 on new Table") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // Try to create a table with icebergWriterCompatV1 and incompatible type widening
+      val schema = new StructType()
+        .add(new StructField(
+          "dateToTimestamp",
+          TimestampNTZType.TIMESTAMP_NTZ,
+          false,
+          FieldMetadata.builder()
+            .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
+            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1").build(),
+          Seq(new TypeChange(DateType.DATE, TimestampNTZType.TIMESTAMP_NTZ)).asJava))
+
+      val tblProps = tblPropertiesIcebergWriterCompatV1Enabled ++
+        Map(TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")
+
+      val e = intercept[KernelException] {
+        createEmptyTable(engine, tablePath, schema, tableProperties = tblProps)
+      }
+
+      assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -690,7 +690,8 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
         createEmptyTable(engine, tablePath, schema, tableProperties = tblProps)
       }
 
-      assert(e.getMessage.contains("icebergCompatV2 does not type widening present in table"))
+      assert(
+        e.getMessage.contains("icebergCompatV2 does not support type widening present in table"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -652,7 +652,9 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
           false,
           FieldMetadata.builder()
             .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
-            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1").build(),
+            .putString(
+              ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY,
+              "col-1").build()).withTypeChanges(
           Seq(new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava))
 
       val tblProps = tblPropertiesIcebergWriterCompatV1Enabled ++
@@ -676,7 +678,9 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
           false,
           FieldMetadata.builder()
             .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, 1)
-            .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "col-1").build(),
+            .putString(
+              ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY,
+              "col-1").build()).withTypeChanges(
           Seq(new TypeChange(DateType.DATE, TimestampNTZType.TIMESTAMP_NTZ)).asJava))
 
       val tblProps = tblPropertiesIcebergWriterCompatV1Enabled ++


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4603/files) to review incremental changes.
- [**stack/tw_upgrade_downgrade**](https://github.com/delta-io/delta/pull/4603) [[Files changed](https://github.com/delta-io/delta/pull/4603/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR adds a validator to ensure only iceberg compatible type changes are present before enabling IcebergCompatV2.

Resolves #4491

## How was this patch tested?

Added direct unit tests, and integration tests to check that the feature can be turned on with valid type changes, and throws an exception when invalid type changes are present.

## Does this PR introduce _any_ user-facing changes?

This adds validation for type-widening so if there are tables that do not follow the protocol, it could start rejecting some writes.
