### PR TITLE
[DELTA] Handle fully qualified table names in DeltaTable.forName

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -1141,7 +1141,7 @@ object DeltaTable {
           CatalogResolver.getCatalogPluginAndIdentifier(sparkSession, parts.head, parts.tail)
         new DeltaTable(
           sparkSession.table(tableName),
-          CatalogResolver.getTableFromCatalog(sparkSession, catalog, ident)
+          CatalogResolver.getDeltaTableFromCatalog(sparkSession, catalog, ident)
         )
       case _ =>
         getDeltaTableFromSessionCatalog(sparkSession, tableName)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/CatalogResolver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/CatalogResolver.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaTableIdentifier}
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, CatalogPlugin, Identifier, Table, V1Table}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
+
+/**
+ * Helper object for resolving tables using a *non-session* catalog.
+ */
+object CatalogResolver {
+  private def asDeltaTable(spark: SparkSession, table: Table): DeltaTableV2 = table match {
+    case v2: DeltaTableV2 => v2
+    case v1: V1Table if DeltaSourceUtils.isDeltaTable(v1.v1Table.provider) =>
+      DeltaTableV2(spark, new Path(v1.v1Table.location), Some(v1.v1Table))
+    case _ => throw DeltaErrors.notADeltaTableException(
+      DeltaTableIdentifier(table = Some(TableIdentifier(table.name()))))
+  }
+
+  /**
+   Returns a [[(CatalogPlugin, Identifier)]] if a catalog exists with the
+   input name, otherwise throws a [[CatalogNotFoundException]]
+  */
+  def getCatalogPluginAndIdentifier(
+      spark: SparkSession,
+      catalog: String,
+      ident: Seq[String]): (CatalogPlugin, Identifier) = {
+    (spark.sessionState.catalogManager.catalog(catalog),
+      MultipartIdentifierHelper(ident).asIdentifier)
+  }
+
+  def getTableFromCatalog(
+      spark: SparkSession,
+      catalog: CatalogPlugin,
+      ident: Identifier): DeltaTableV2 = {
+    val tblCatalog = catalog.asTableCatalog
+    if (tblCatalog.tableExists(ident)) {
+      asDeltaTable(spark, tblCatalog.loadTable(ident))
+    } else {
+      throw DeltaErrors.nonExistentDeltaTable(
+        DeltaTableIdentifier(table = Some(TableIdentifier(ident.name()))))
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/CatalogResolver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/CatalogResolver.scala
@@ -50,7 +50,7 @@ object CatalogResolver {
       MultipartIdentifierHelper(ident).asIdentifier)
   }
 
-  def getTableFromCatalog(
+  def getDeltaTableFromCatalog(
       spark: SparkSession,
       catalog: CatalogPlugin,
       ident: Identifier): DeltaTableV2 = {

--- a/spark/src/test/scala/io/delta/tables/DeltaTableForNameSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableForNameSuite.scala
@@ -131,21 +131,6 @@ class DeltaTableForNameSuite extends QueryTest
       s"$catalogName.$nonSessionCatalogNonDefaultSchema.$nonDefaultSchemaUniqueTbl")
   }
 
-  ignore(s"forName resolves partially qualified tables in non session catalog correctly") {
-    sql(s"SET CATALOG $catalogName")
-    validateForNameTableId(s"$defaultSchema.$commonTblName",
-      Some(tableNameToId(s"$catalogName.$defaultSchema.$commonTblName")))
-    validateForNameTableId(s"$defaultSchema.$defaultSchemaUniqueTbl",
-      Some(tableNameToId(s"$catalogName.$defaultSchema.$defaultSchemaUniqueTbl")))
-
-    validateForNameTableId(s"$nonSessionCatalogNonDefaultSchema.$commonTblName",
-      Some(tableNameToId(s"$catalogName.$nonSessionCatalogNonDefaultSchema.$commonTblName")))
-    validateForNameTableId(s"$nonSessionCatalogNonDefaultSchema.$nonDefaultSchemaUniqueTbl",
-      Some(
-        tableNameToId(s"$catalogName.$nonSessionCatalogNonDefaultSchema.$nonDefaultSchemaUniqueTbl")
-      ))
-  }
-
   for (table <- Seq(commonTblName, nonDefaultSchemaUniqueTbl))
   test(s"forName fails for partially " +
     s"qualified tables in non session catalog with table=$table") {
@@ -155,6 +140,17 @@ class DeltaTableForNameSuite extends QueryTest
     }
     checkError(exception = e, "DELTA_MISSING_DELTA_TABLE",
       parameters = Map("tableName" -> s"`$nonSessionCatalogNonDefaultSchema`.`$table`"))
+  }
+
+  // forName currently doesn't resolve unqualified tables correctly for non session catalogs.
+  // in this test, it resolves to the table `spark_catalog.default.tbl` but it adds an incorrect
+  // identifier on top.
+  test(s"forName resolves partially qualified tables in non session catalog incorrectly") {
+    sql(s"SET CATALOG $catalogName")
+    validateForNameTableId(s"$defaultSchema.$commonTblName",
+      Some(tableNameToId(s"$catalogName.$defaultSchema.$commonTblName")))
+    validateForNameTableId(s"$defaultSchema.$defaultSchemaUniqueTbl",
+      Some(tableNameToId(s"$catalogName.$defaultSchema.$defaultSchemaUniqueTbl")))
   }
 
   test("forName with invalid non session catalog") {

--- a/spark/src/test/scala/io/delta/tables/DeltaTableForNameSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableForNameSuite.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables
+
+import scala.collection.mutable
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DummyCatalogWithNamespace}
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.catalog.CatalogNotFoundException
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DeltaTableForNameSuite extends QueryTest
+  with DeltaSQLCommandTest
+  with SharedSparkSession {
+  private val sparkCatalog = "spark_catalog"
+  private val catalogName = "test_catalog"
+  private val defaultSchema = "default"
+  private val nonDefaultSchema = "non_default"
+  private val commonTblName = "tbl"
+  private val defaultSchemaUniqueTbl = "default_tbl"
+  private val nonDefaultSchemaUniqueTbl = "non_default_tbl"
+  private val nonSessionCatalogNonDefaultSchema = "non_default_session_schema"
+  private val tableNameToId = mutable.Map.empty[String, String]
+
+  override def sparkConf: SparkConf =
+    super.sparkConf
+      .set(s"spark.sql.catalog.$catalogName", classOf[DummyCatalogWithNamespace].getName)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // General Test setup
+    sql(s"CREATE SCHEMA $nonDefaultSchema;")
+    sql(s"CREATE SCHEMA $catalogName.$defaultSchema;")
+    sql(s"CREATE SCHEMA $catalogName.$nonSessionCatalogNonDefaultSchema;")
+    // Setup custom catalog default schema tables
+    sql(s"SET CATALOG $catalogName")
+    setUpTable(catalogName, defaultSchema, commonTblName)
+    setUpTable(catalogName, defaultSchema, defaultSchemaUniqueTbl)
+    // Setup custom catalog non default schema tables
+    setUpTable(catalogName, nonSessionCatalogNonDefaultSchema, commonTblName)
+    setUpTable(catalogName, nonSessionCatalogNonDefaultSchema, nonDefaultSchemaUniqueTbl)
+    // Setup session catalog default schema tables
+    sql(s"SET CATALOG $sparkCatalog")
+    setUpTable(sparkCatalog, defaultSchema, commonTblName)
+    setUpTable(sparkCatalog, defaultSchema, defaultSchemaUniqueTbl)
+    // Setup session catalog non default schema tables
+    setUpTable(sparkCatalog, nonDefaultSchema, commonTblName)
+    setUpTable(sparkCatalog, nonDefaultSchema, nonDefaultSchemaUniqueTbl)
+  }
+
+  override def afterAll(): Unit = {
+    sql(s"DROP SCHEMA $sparkCatalog.$nonDefaultSchema CASCADE;")
+    sql(s"DROP SCHEMA $catalogName.$defaultSchema CASCADE;")
+    sql(s"DROP SCHEMA $catalogName.$nonSessionCatalogNonDefaultSchema CASCADE;")
+    super.afterAll()
+  }
+
+  protected override def beforeEach(): Unit = {
+    super.beforeEach()
+    sql(s"SET CATALOG $sparkCatalog")
+  }
+
+  private def getTablePath(tableName: String): Path = {
+    new Path(FileUtils.getTempDirectory.toString + "/DeltaTableForNameSuite/" + tableName)
+  }
+
+  private def setUpTable(catalog: String, schema: String, table: String): Unit = {
+    val tableName = s"$catalog.$schema.$table"
+    val path = getTablePath(tableName)
+    sql(s"CREATE OR REPLACE TABLE $tableName (id int) USING delta LOCATION '$path';")
+    tableNameToId += (tableName -> DeltaLog.forTable(spark,
+      getTablePath(tableName)).tableId)
+  }
+
+  private def validateForNameTableId(
+      tableName: String,
+      expectedResult: Option[String] = None): Unit = {
+    val table = DeltaTable.forName(spark, tableName)
+    checkAnswer(table.detail().select("id"), Seq(Row(expectedResult.getOrElse(
+      tableNameToId(tableName)
+    ))))
+  }
+
+  test(s"forName resolves fully qualified tables in session catalog correctly") {
+    validateForNameTableId(s"$sparkCatalog.$defaultSchema.$commonTblName")
+    validateForNameTableId(s"$sparkCatalog.$defaultSchema.$defaultSchemaUniqueTbl")
+
+    validateForNameTableId(s"$sparkCatalog.$nonDefaultSchema.$commonTblName")
+    validateForNameTableId(s"$sparkCatalog.$nonDefaultSchema.$nonDefaultSchemaUniqueTbl")
+  }
+
+  test(s"forName resolves partially qualified tables in session catalog correctly") {
+    validateForNameTableId(s"$defaultSchema.$commonTblName",
+      Some(tableNameToId(s"$sparkCatalog.$defaultSchema.$commonTblName")))
+    validateForNameTableId(s"$defaultSchema.$defaultSchemaUniqueTbl",
+      Some(tableNameToId(s"$sparkCatalog.$defaultSchema.$defaultSchemaUniqueTbl")))
+
+    validateForNameTableId(s"$nonDefaultSchema.$commonTblName",
+      Some(tableNameToId(s"$sparkCatalog.$nonDefaultSchema.$commonTblName")))
+    validateForNameTableId(s"$nonDefaultSchema.$nonDefaultSchemaUniqueTbl",
+      Some(tableNameToId(s"$sparkCatalog.$nonDefaultSchema.$nonDefaultSchemaUniqueTbl")))
+  }
+
+  test(s"forName resolves fully qualified tables in non session catalog correctly") {
+    validateForNameTableId(s"$catalogName.$defaultSchema.$commonTblName")
+    validateForNameTableId(s"$catalogName.$defaultSchema.$defaultSchemaUniqueTbl")
+
+    validateForNameTableId(s"$catalogName.$nonSessionCatalogNonDefaultSchema.$commonTblName")
+    validateForNameTableId(
+      s"$catalogName.$nonSessionCatalogNonDefaultSchema.$nonDefaultSchemaUniqueTbl")
+  }
+
+  ignore(s"forName resolves partially qualified tables in non session catalog correctly") {
+    sql(s"SET CATALOG $catalogName")
+    validateForNameTableId(s"$defaultSchema.$commonTblName",
+      Some(tableNameToId(s"$catalogName.$defaultSchema.$commonTblName")))
+    validateForNameTableId(s"$defaultSchema.$defaultSchemaUniqueTbl",
+      Some(tableNameToId(s"$catalogName.$defaultSchema.$defaultSchemaUniqueTbl")))
+
+    validateForNameTableId(s"$nonSessionCatalogNonDefaultSchema.$commonTblName",
+      Some(tableNameToId(s"$catalogName.$nonSessionCatalogNonDefaultSchema.$commonTblName")))
+    validateForNameTableId(s"$nonSessionCatalogNonDefaultSchema.$nonDefaultSchemaUniqueTbl",
+      Some(
+        tableNameToId(s"$catalogName.$nonSessionCatalogNonDefaultSchema.$nonDefaultSchemaUniqueTbl")
+      ))
+  }
+
+  for (table <- Seq(commonTblName, nonDefaultSchemaUniqueTbl))
+  test(s"forName fails for partially " +
+    s"qualified tables in non session catalog with table=$table") {
+    sql(s"SET CATALOG $catalogName")
+    val e = intercept[AnalysisException] {
+      DeltaTable.forName(spark, s"$nonSessionCatalogNonDefaultSchema.$table")
+    }
+    checkError(exception = e, "DELTA_MISSING_DELTA_TABLE",
+      parameters = Map("tableName" -> s"`$nonSessionCatalogNonDefaultSchema`.`$table`"))
+  }
+
+  test("forName with invalid non session catalog") {
+    intercept[CatalogNotFoundException] {
+      DeltaTable.forName(spark, "invalid_catalog.default.tbl")
+    }
+  }
+
+  test("forName with unqualified non session catalog") {
+    sql(s"SET CATALOG $sparkCatalog")
+    val e = intercept[AnalysisException] {
+      DeltaTable.forName(spark, s"$nonSessionCatalogNonDefaultSchema.$commonTblName")
+    }
+    checkError(exception = e, "DELTA_MISSING_DELTA_TABLE",
+      parameters = Map("tableName" -> s"`$nonSessionCatalogNonDefaultSchema`.`$commonTblName`"))
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/CustomCatalogs.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/CustomCatalogs.scala
@@ -1,0 +1,310 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import java.util
+
+import scala.collection.{immutable, mutable}
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.{NamespaceAlreadyExistsException, NoSuchTableException}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, NamespaceChange, SupportsNamespaces, Table, TableCatalog, TableChange, V1Table}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.Utils
+
+
+/**
+ * A Utils class for custom catalog implementations that could be used for testing.
+ */
+class DummyCatalog extends TableCatalog {
+  private val spark: SparkSession = SparkSession.active
+  protected lazy val tempDir: Path = new Path(Utils.createTempDir().getAbsolutePath)
+  // scalastyle:off deltahadoopconfiguration
+  protected lazy val fs: FileSystem =
+    tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+  // scalastyle:on deltahadoopconfiguration
+
+  override def name: String = "dummy"
+
+  def getTablePath(tableName: String): Path = {
+    new Path(tempDir.toString + "/" + tableName)
+  }
+  override def defaultNamespace(): Array[String] = Array("default")
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    val status = fs.listStatus(tempDir)
+    status.filter(_.isDirectory).map { dir =>
+      Identifier.of(namespace, dir.getPath.getName)
+    }
+  }
+
+  override def tableExists(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.name())
+    fs.exists(tablePath)
+  }
+
+  override def loadTable(ident: Identifier): Table = {
+    if (!tableExists(ident)) {
+      throw new NoSuchTableException(ident)
+    }
+    val tablePath = getTablePath(ident.name())
+    DeltaTableV2(spark = spark, path = tablePath, catalogTable = Some(createCatalogTable(ident)))
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: java.util.Map[String, String]): Table = {
+    val tablePath = getTablePath(ident.name())
+    // Create an empty Delta table on the tablePath
+    val part = partitions.map(_.arguments().head.toString)
+    spark.createDataFrame(List.empty[Row].asJava, schema)
+      .write.format("delta").partitionBy(part: _*).save(tablePath.toString)
+    DeltaTableV2(spark = spark, path = tablePath, catalogTable = Some(createCatalogTable(ident)))
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    // hack hack: no-op just for testing
+    loadTable(ident)
+  }
+
+  override def dropTable(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.name())
+    try {
+      fs.delete(tablePath, true)
+      true
+    } catch {
+      case _: Exception => false
+    }
+  }
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    throw new UnsupportedOperationException("Rename table operation is not supported.")
+  }
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    // Initialize tempDir here
+    if (!fs.exists(tempDir)) {
+      fs.mkdirs(tempDir)
+    }
+  }
+
+  private def createCatalogTable(ident: Identifier): CatalogTable = {
+    val tablePath = getTablePath(ident.name())
+    CatalogTable(
+      identifier = TableIdentifier(ident.name(), defaultNamespace.headOption, Some(name)),
+      tableType = CatalogTableType.MANAGED,
+      storage = CatalogStorageFormat(Some(tablePath.toUri), None, None, None, false, Map.empty),
+      schema = spark.range(0).schema
+    )
+  }
+}
+
+// A dummy catalog that adds additional table storage properties after the table is loaded.
+// It's only used inside `DummySessionCatalog`.
+class DummySessionCatalogInner extends DelegatingCatalogExtension {
+  override def loadTable(ident: Identifier): Table = {
+    val t = super.loadTable(ident).asInstanceOf[V1Table]
+    V1Table(t.v1Table.copy(
+      storage = t.v1Table.storage.copy(
+        properties = t.v1Table.storage.properties ++ Map("fs.myKey" -> "val")
+      )
+    ))
+  }
+}
+
+// A dummy catalog that adds a layer between DeltaCatalog and the Spark SessionCatalog,
+// to attach additional table storage properties after the table is loaded, and generates location
+// for managed tables.
+class DummySessionCatalog extends TableCatalog {
+  private var deltaCatalog: DeltaCatalog = null
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    val inner = new DummySessionCatalogInner()
+    inner.setDelegateCatalog(new V2SessionCatalog(
+      SparkSession.active.sessionState.catalogManager.v1SessionCatalog))
+    deltaCatalog = new DeltaCatalog()
+    deltaCatalog.setDelegateCatalog(inner)
+  }
+
+  override def name(): String = deltaCatalog.name()
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    deltaCatalog.listTables(namespace)
+  }
+
+  override def loadTable(ident: Identifier): Table = deltaCatalog.loadTable(ident)
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: java.util.Map[String, String]): Table = {
+    if (!properties.containsKey(TableCatalog.PROP_EXTERNAL) &&
+      !properties.containsKey(TableCatalog.PROP_LOCATION)) {
+      val newProps = new java.util.HashMap[String, String]
+      newProps.putAll(properties)
+      newProps.put(TableCatalog.PROP_LOCATION, properties.get("fakeLoc"))
+      newProps.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+      deltaCatalog.createTable(ident, schema, partitions, newProps)
+    } else {
+      deltaCatalog.createTable(ident, schema, partitions, properties)
+    }
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    deltaCatalog.alterTable(ident, changes: _*)
+  }
+
+  override def dropTable(ident: Identifier): Boolean = deltaCatalog.dropTable(ident)
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    deltaCatalog.renameTable(oldIdent, newIdent)
+  }
+}
+
+// This catalog always does a CASCADE on DROP SCHEMA ...
+class DummyCatalogWithNamespace extends DummyCatalog with SupportsNamespaces {
+  private val spark: SparkSession = SparkSession.active
+  // To load a catalog into spark CatalogPlugin calls the Catalog's no-arg constructor and
+  // then Catalog.initialize. To have a consistent state across different invocations
+  // in the same test, this catalog impl uses a hard coded path.
+  override lazy val tempDir: Path = new Path(
+    FileUtils.getTempDirectory.toString + "/DeltaTableForNameSuite")
+  // scalastyle:off deltahadoopconfiguration
+  override lazy val fs: FileSystem =
+    tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+  // scalastyle:on deltahadoopconfiguration
+
+  // Map each namespace to its metadata
+  protected val namespaces: util.Map[List[String], Map[String, String]] =
+    new util.HashMap[List[String], Map[String, String]]()
+
+  protected val tables: mutable.Map[Array[String], mutable.HashSet[Identifier]] =
+    new mutable.HashMap[Array[String], mutable.HashSet[Identifier]]()
+
+  override def name: String = "test_catalog"
+
+  override def getTablePath(tableName: String): Path = {
+    new Path(s"${tempDir.toString}/$name.$tableName")
+  }
+
+  override def tableExists(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.toString)
+    fs.exists(tablePath)
+  }
+
+  override def loadTable(ident: Identifier): Table = {
+    if (!tableExists(ident)) {
+      throw new NoSuchTableException(ident)
+    }
+    val tablePath = getTablePath(ident.toString)
+    DeltaTableV2(spark = spark, path = tablePath, catalogTable = Some(createCatalogTable(ident)))
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: java.util.Map[String, String]): Table = {
+    val tablePath = getTablePath(ident.toString)
+    // Create an empty Delta table on the tablePath
+    val part = partitions.map(_.arguments().head.toString)
+    spark.createDataFrame(List.empty[Row].asJava, schema)
+      .write.format("delta").partitionBy(part: _*).save(tablePath.toString)
+    val map = tables.getOrElseUpdate(ident.namespace(), new mutable.HashSet[Identifier]())
+    map.add(ident)
+    tables.put(ident.namespace(), map)
+    DeltaTableV2(spark = spark, path = tablePath, catalogTable = Some(createCatalogTable(ident)))
+  }
+
+  override def dropTable(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.toString)
+    try {
+      fs.delete(tablePath, true)
+      true
+    } catch {
+      case _: Exception => false
+    }
+  }
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    // Initialize tempDir here
+    if (!fs.exists(tempDir)) {
+      fs.mkdirs(tempDir)
+    }
+    fs.deleteOnExit(tempDir)
+  }
+
+  private def createCatalogTable(ident: Identifier): CatalogTable = {
+    val tablePath = getTablePath(ident.toString)
+    CatalogTable(
+      identifier = TableIdentifier(ident.toString, defaultNamespace.headOption, Some(name)),
+      tableType = CatalogTableType.MANAGED,
+      storage = CatalogStorageFormat(
+        Some(tablePath.toUri), None, None, None, false, immutable.Map.empty),
+      schema = spark.range(0).schema
+    )
+  }
+
+  override def createNamespace(
+      namespace: Array[String],
+      metadata: util.Map[String, String]): Unit = {
+    Option(namespaces.putIfAbsent(namespace.toList, metadata.asScala.toMap)) match {
+      case Some(_) =>
+        throw new NamespaceAlreadyExistsException(namespace)
+      case _ =>
+      // success
+    }
+  }
+
+  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = {
+    throw new UnsupportedOperationException("alter namespace metadata is not supported.")
+  }
+
+  override def dropNamespace(namespace: Array[String], cascade: Boolean): Boolean = {
+    tables.getOrElse(namespace, mutable.HashSet.empty[Identifier]).foreach(dropTable)
+    Option(namespaces.remove(namespace.toList)).isDefined
+  }
+
+  override def namespaceExists(namespace: Array[String]): Boolean = {
+    namespaces.containsKey(namespace.toList)
+  }
+
+  override def listNamespaces(): Array[Array[String]] = {
+    throw new UnsupportedOperationException("List namespaces operation is not supported.")
+  }
+
+  override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
+    throw new UnsupportedOperationException("List namespaces operation is not supported.")
+  }
+
+  override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
+    new util.HashMap[String, String]()
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Allow users to pass a fully qualified name (`catalog.schema.table`) to forName so they're able to use different catalogs than the default sessionCatalog. 
There are no changes in the behavior of input that's not fully qualified.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UTs

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
