### PR TITLE
[Spark] Migrate `IncrementalClusteringSuite` & `ClusteredTableDDLSuite` to `CatalogOwned`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -73,6 +73,9 @@ trait CommitCoordinatorUtilBase {
    * Returns false if this test is about CoordinatedCommits tabel feature.
    */
   def isCatalogOwnedTest: Boolean
+
+  /** Keeps track of the number of table names pointing to the location. */
+  protected val locRefCount: mutable.Map[String, Int] = mutable.Map.empty
 }
 
 trait CatalogOwnedTestBaseSuite
@@ -81,7 +84,7 @@ trait CatalogOwnedTestBaseSuite
   with CommitCoordinatorUtilBase
   with SharedSparkSession {
 
-  val defaultCatalogOwnedFeatureEnabledKey =
+  val defaultCatalogOwnedFeatureEnabledKey: String =
     TableFeatureProtocolUtils.defaultPropertyKey(CatalogOwnedTableFeature)
 
   // If this config is not overridden, newly created table is not CatalogOwned by default.
@@ -164,6 +167,48 @@ trait CatalogOwnedTestBaseSuite
   }
 
   override def isCatalogOwnedTest: Boolean = true
+
+  def deleteCatalogOwnedTableFromCommitCoordinator(tableName: String): Unit = {
+    val location = try {
+      spark.sql(s"describe detail $tableName")
+        .select("location")
+        .first()
+        .getAs[String](0)
+    } catch {
+      case NonFatal(_) =>
+        // Ignore if the table does not exist/broken.
+        return
+    }
+    deleteCatalogOwnedTableFromCommitCoordinator(path = new Path(location))
+  }
+
+  def deleteCatalogOwnedTableFromCommitCoordinator(path: Path): Unit = {
+    val catalogName = "spark_catalog"
+    val cc = CatalogOwnedCommitCoordinatorProvider.getBuilder(catalogName).getOrElse {
+      throw new IllegalStateException(
+        s"Unable to get CatalogOwnedCommitCoordinatorBuilder for table at path: ${path.toString}")
+    }.buildForCatalog(spark, catalogName)
+
+    assert(
+      cc.isInstanceOf[TrackingCommitCoordinatorClient],
+      s"Please implement delete/drop method for coordinator: ${cc.getClass.getName}")
+
+    val locKey = path.toString.stripPrefix("file:")
+    if (locRefCount.contains(locKey)) {
+      locRefCount(locKey) -= 1
+    }
+    // When we create an external table in a location where some table already existed, two table
+    // names could be pointing to the same location. We should only clean up the table data in the
+    // commit coordinator when the last table name pointing to the location is dropped.
+    if (locRefCount.getOrElse(locKey, 0) == 0) {
+      val logPath = new Path(path, "_delta_log")
+      cc.asInstanceOf[TrackingCommitCoordinatorClient]
+        .delegatingCommitCoordinatorClient
+        .asInstanceOf[InMemoryCommitCoordinator]
+        .dropTable(logPath)
+    }
+    DeltaLog.clearCache()
+  }
 
   protected def isICTEnabledForNewTables: Boolean = {
     catalogOwnedCoordinatorBackfillBatchSize.nonEmpty ||
@@ -477,9 +522,6 @@ trait CoordinatedCommitsBaseSuite
   def coordinatedCommitsBackfillBatchSize: Option[Int] = None
 
   final def coordinatedCommitsEnabledInTests: Boolean = coordinatedCommitsBackfillBatchSize.nonEmpty
-
-  // Keeps track of the number of table names pointing to the location.
-  protected val locRefCount: mutable.Map[String, Int] = mutable.Map.empty
 
   // In case some tests reuse the table path/name with DROP table, this method can be used to
   // clean the table data in the commit coordinator. Note that we should call this before

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.DeltaOperations
 import org.apache.spark.sql.delta.DeltaOperations.{CLUSTERING_PARAMETER_KEY, ZORDER_PARAMETER_KEY}
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite, CoordinatedCommitsBaseSuite}
 import org.apache.spark.sql.delta.hooks.UpdateCatalog
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
@@ -35,9 +35,10 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 trait ClusteredTableTestUtilsBase
-    extends SparkFunSuite
-    with SharedSparkSession
-    with CoordinatedCommitsBaseSuite {
+  extends SparkFunSuite
+  with SharedSparkSession
+  with CatalogOwnedTestBaseSuite {
+
   import testImplicits._
 
   /**
@@ -219,10 +220,11 @@ trait ClusteredTableTestUtilsBase
   }
 
   protected def deleteTableFromCommitCoordinatorIfNeeded(table: String): Unit = {
-    if (coordinatedCommitsEnabledInTests) {
-      // Clean up the table data in commit coordinator because DROP/REPLACE TABLE does not bother
-      // commit coordinator.
-      deleteTableFromCommitCoordinator(table)
+    // Clean up the table data in commit coordinator because DROP/REPLACE TABLE does not bother
+    // commit coordinator.
+    if (CatalogOwnedTableUtils.defaultCatalogOwnedEnabled(spark) &&
+        catalogOwnedDefaultCreationEnabledInTests) {
+      deleteCatalogOwnedTableFromCommitCoordinator(table)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -20,9 +20,10 @@ import java.io.File
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaConfigs, DeltaExcludedBySparkVersionTestMixinShims, DeltaLog, DeltaUnsupportedOperationException, NoMapping}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaAnalysisException, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaConfigs, DeltaExcludedBySparkVersionTestMixinShims, DeltaLog, DeltaUnsupportedOperationException, NoMapping}
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.hooks.UpdateCatalog
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.SkippingEligibleDataType
@@ -998,7 +999,7 @@ trait ClusteredTableDDLSuiteBase
 
 trait ClusteredTableDDLSuite
   extends ClusteredTableDDLSuiteBase
-    with CoordinatedCommitsBaseSuite
+  with CatalogOwnedTestBaseSuite
 
 trait ClusteredTableDDLWithNameColumnMapping
   extends ClusteredTableCreateOrReplaceDDLSuite with DeltaColumnMappingEnableNameMode
@@ -1209,6 +1210,9 @@ trait ClusteredTableDDLDataSourceV2SuiteBase
 
   test("create external clustered table: location has clustered table, schema specified, " +
     "cluster by specified with same clustering column") {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
+      cancel("CatalogOwned does not support external table creation.")
+    }
     val tableName = "clustered_table"
     withTempDir { dir =>
       // 1. Create a clustered table in the external location.
@@ -1226,6 +1230,9 @@ trait ClusteredTableDDLDataSourceV2SuiteBase
 
   test("create external clustered table: location has non-clustered table, schema specified, " +
     "cluster by specified") {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
+      cancel("CatalogOwned does not support external table creation.")
+    }
     val tableName = "clustered_table"
     withTempDir { dir =>
       // 1. Create a non-clustered table in the external location.
@@ -1264,7 +1271,7 @@ class ClusteredTableDDLDataSourceV2NameColumnMappingSuite
     with ClusteredTableDDLWithColumnMappingV2
     with ClusteredTableDDLSuite
 
-class ClusteredTableDDLDataSourceV2WithCoordinatedCommitsBatch100Suite
+class ClusteredTableDDLDataSourceV2WithCatalogOwnedBatch100Suite
     extends ClusteredTableDDLDataSourceV2Suite {
-  override val coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
+  override val catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR migrates `IncrementalClusteringSuite` & `ClusteredTableDDLSuite` to `CatalogOwned`.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through existing UTs.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
