### PR TITLE
Revert "[Kernel] Allow kernel to write Type Widening enable (#4517)"

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -175,6 +175,17 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
         }
       };
 
+  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPE_WIDENING =
+      (inputContext) -> {
+        if (inputContext.newProtocol.supportsFeature(TYPE_WIDENING_RW_FEATURE)) {
+          // TODO: Currently Kernel has no support for writing with type widening. When it is
+          //  supported extend this to allow a whitelist of supported type widening in Iceberg
+          throw DeltaErrors.unsupportedTableFeature(TYPE_WIDENING_RW_FEATURE.featureName());
+        } else if (inputContext.newProtocol.supportsFeature(TYPE_WIDENING_RW_PREVIEW_FEATURE)) {
+          throw DeltaErrors.unsupportedTableFeature(TYPE_WIDENING_RW_PREVIEW_FEATURE.featureName());
+        }
+      };
+
   @Override
   String compatFeatureName() {
     return "icebergCompatV2";
@@ -202,7 +213,8 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
             ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPES,
             ICEBERG_COMPAT_V2_CHECK_HAS_ALLOWED_PARTITION_TYPES,
             ICEBERG_COMPAT_V2_CHECK_HAS_NO_PARTITION_EVOLUTION,
-            ICEBERG_COMPAT_V2_CHECK_HAS_NO_DELETION_VECTORS)
+            ICEBERG_COMPAT_V2_CHECK_HAS_NO_DELETION_VECTORS,
+            ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPE_WIDENING)
         .collect(toList());
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -354,6 +354,11 @@ public class TableFeatures {
           // avoid possibly breaking old clients that only support the preview feature.
           !protocol.supportsFeature(TYPE_WIDENING_RW_PREVIEW_FEATURE);
     }
+
+    @Override
+    public boolean hasKernelWriteSupport(Metadata metadata) {
+      return false; // TODO: yet to support it.
+    }
   }
 
   public static final TableFeature TYPE_WIDENING_RW_FEATURE = new TypeWideningTableFeature();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -337,6 +337,10 @@ public class TableFeatures {
     TypeWideningTableFeatureBase(String featureName) {
       super(featureName, /* minReaderVersion = */ 3, /* minWriterVersion = */ 7);
     }
+    @Override
+    public boolean hasKernelWriteSupport(Metadata metadata) {
+      return false; // TODO: yet to support it.
+    }
   }
 
   private static class TypeWideningTableFeature extends TypeWideningTableFeatureBase
@@ -353,11 +357,6 @@ public class TableFeatures {
           // supported, to
           // avoid possibly breaking old clients that only support the preview feature.
           !protocol.supportsFeature(TYPE_WIDENING_RW_PREVIEW_FEATURE);
-    }
-
-    @Override
-    public boolean hasKernelWriteSupport(Metadata metadata) {
-      return false; // TODO: yet to support it.
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -337,6 +337,7 @@ public class TableFeatures {
     TypeWideningTableFeatureBase(String featureName) {
       super(featureName, /* minReaderVersion = */ 3, /* minWriterVersion = */ 7);
     }
+
     @Override
     public boolean hasKernelWriteSupport(Metadata metadata) {
       return false; // TODO: yet to support it.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdaterSuite.scala
@@ -120,6 +120,26 @@ trait IcebergCompatV2MetadataValidatorAndUpdaterSuiteBase extends AnyFunSuite
   }
 
   Seq(true, false).foreach { isNewTable =>
+    Seq(TYPE_WIDENING_RW_FEATURE, TYPE_WIDENING_RW_PREVIEW_FEATURE).foreach {
+      typeWideningFeature =>
+        test(s"can't enable icebergCompatV2 on a table with $typeWideningFeature supported, " +
+          s"isNewTable = $isNewTable") {
+          val schema = new StructType().add("col", BooleanType.BOOLEAN)
+          val metadata = getCompatEnabledMetadata(schema)
+          val protocol = getCompatEnabledProtocol(typeWideningFeature)
+
+          val ex = intercept[KernelException] {
+            runValidateAndUpdateIcebergCompatV2Metadata(isNewTable, metadata, protocol)
+          }
+          assert(ex.getMessage.contains(
+            s"Unsupported Delta table feature: table requires feature " +
+              s""""${typeWideningFeature.featureName()}" which is unsupported by this version """ +
+              s"of Delta Kernel."))
+        }
+    }
+  }
+
+  Seq(true, false).foreach { isNewTable =>
     test(s"can't enable icebergCompatV2 on a table with icebergCompatv1 enabled, " +
       s"isNewTable = $isNewTable") {
       val schema = new StructType().add("col", BooleanType.BOOLEAN)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -265,8 +265,8 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
       "v2Checkpoint",
       "inCommitTimestamp",
       "clustering",
-      "typeWidening",
-      "typeWidening-preview",
+      // "typeWidening", add this to this test once we support typeWidening
+      // "typeWidening-preview", add this to this test once we support typeWidening
       "timestampNtz")
     val protocol = new Protocol(3, 7, readerFeatures.asJava, writerFeatures.asJava)
     val metadata = getCompatEnabledMetadata(cmTestSchema())
@@ -293,6 +293,19 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
       }
       assert(e.getMessage.contains(expectedErrorMessageContains))
     }
+  }
+
+  Seq("typeWidening", "typeWidening-preview").foreach {
+    unsupportedCompatibleFeature =>
+      test(s"cannot enable with compatible UNSUPPORTED feature $unsupportedCompatibleFeature") {
+        // We add this test here so that it will fail when we add Kernel support for these features
+        // When this happens -> add the feature to the test above
+        checkUnsupportedOrIncompatibleFeature(
+          unsupportedCompatibleFeature,
+          "Unsupported Delta table feature: table requires feature " +
+            s""""$unsupportedCompatibleFeature" which is unsupported by this version of """ +
+            "Delta Kernel")
+      }
   }
 
   Seq(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -258,8 +258,6 @@ class TableFeaturesSuite extends AnyFunSuite {
       "changeDataFeed",
       "timestampNtz",
       "identityColumns",
-      "typeWidening-preview",
-      "typeWidening",
       "icebergWriterCompatV1",
       "clustering")
 
@@ -527,13 +525,13 @@ class TableFeaturesSuite extends AnyFunSuite {
     testMetadata(includeTimestampNtzTypeCol = true))
 
   Seq("typeWidening", "typeWidening-preview").foreach { feature =>
-    checkWriteSupported(
+    checkWriteUnsupported(
       s"validateKernelCanWriteToTable: protocol 7 with $feature, " +
         s"metadata doesn't contains $feature",
       new Protocol(3, 7, singleton(feature), singleton(feature)),
       testMetadata())
 
-    checkWriteSupported(
+    checkWriteUnsupported(
       s"validateKernelCanWriteToTable: protocol 7 with $feature, " +
         s"metadata contains $feature",
       new Protocol(3, 7, singleton(feature), singleton(feature)),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -183,6 +183,17 @@ class DeltaIcebergCompatV2Suite extends DeltaTableWriteSuiteBase with ColumnMapp
     }
   }
 
+  test("can't enable icebergCompatV2 on a table with type widening supported also enabled") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      checkError[KernelException]("Unsupported Delta writer feature") {
+        val tblProps = Map(
+          TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true",
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true")
+        createEmptyTable(engine, tablePath, testSchema, tableProperties = tblProps)
+      }
+    }
+  }
+
   ignore("can't enable icebergCompatV2 on a table with icebergCompatv1 enabled") {
     // We can't test this as Kernel throws error when enabling icebergCompatV1
     // as there is no support it in the current version.

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -347,68 +347,6 @@ class DeltaTableFeaturesSuite extends DeltaTableWriteSuiteBase {
     }
   }
 
-  /* ---- Start: type widening tests ---- */
-  test("only typeWidening feature is enabled when metadata supports it: new table") {
-    withTempDirAndEngine { (tablePath, engine) =>
-      createEmptyTable(
-        engine,
-        tablePath = tablePath,
-        schema = testSchema,
-        tableProperties = Map("delta.enableTypeWidening" -> "true"))
-
-      val protocolV0 = getProtocol(engine, tablePath)
-      assert(!protocolV0.supportsFeature(TableFeatures.TYPE_WIDENING_RW_PREVIEW_FEATURE))
-      assert(protocolV0.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
-
-      // try enabling type widening again and expect no change in protocol
-      updateTableMetadata(
-        engine = engine,
-        tablePath = tablePath,
-        tableProperties = Map("delta.enableTypeWidening" -> "true"))
-      val protocolV1 = getProtocol(engine, tablePath)
-      assert(protocolV1 === protocolV0)
-    }
-  }
-
-  test("only typeWidening feature is enabled when new metadata supports it: existing table") {
-    withTempDirAndEngine { (tablePath, engine) =>
-      createEmptyTable(engine, tablePath = tablePath, schema = testSchema)
-      val protocolV0 = getProtocol(engine, tablePath)
-      assert(!protocolV0.supportsFeature(TableFeatures.TYPE_WIDENING_RW_PREVIEW_FEATURE))
-      assert(!protocolV0.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
-
-      // try enabling type widening  and expect change in protocol
-      updateTableMetadata(
-        engine = engine,
-        tablePath = tablePath,
-        tableProperties = Map("delta.enableTypeWidening" -> "true"))
-      val protocolV1 = getProtocol(engine, tablePath)
-      assert(!protocolV1.supportsFeature(TableFeatures.TYPE_WIDENING_RW_PREVIEW_FEATURE))
-      assert(protocolV1.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
-    }
-  }
-
-  test("typeWidening-preview in existing table is respected") {
-    withTempDirAndEngine { (tablePath, engine) =>
-      spark.sql(s"CREATE TABLE delta.`$tablePath`(id INT) USING delta " +
-        s"TBLPROPERTIES ('delta.feature.typeWidening-preview' = 'supported')")
-
-      val protocolV0 = getProtocol(engine, tablePath)
-      require(protocolV0.supportsFeature(TableFeatures.TYPE_WIDENING_RW_PREVIEW_FEATURE))
-      require(!protocolV0.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
-
-      // now through Kernel type enabling the type widening through table property
-      updateTableMetadata(
-        engine = engine,
-        tablePath = tablePath,
-        tableProperties = Map("delta.enableTypeWidening" -> "true"))
-      val protocolV1 = getProtocol(engine, tablePath)
-      assert(protocolV1.supportsFeature(TableFeatures.TYPE_WIDENING_RW_PREVIEW_FEATURE))
-      assert(!protocolV1.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
-    }
-  }
-  /* ---- End: type widening tests ---- */
-
   ///////////////////////////////////////////////////////////////////////////
   // Helper methods
   ///////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -558,14 +558,7 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
 
   test("legacy table features allowed with icebergWriterCompatV1 if inactive") {
     val tblProperties =
-      Seq(
-        "invariants",
-        "changeDataFeed",
-        "checkConstraints",
-        "identityColumns",
-        "generatedColumns",
-        "typeWidening",
-        "typeWidening-preview")
+      Seq("invariants", "changeDataFeed", "checkConstraints", "identityColumns", "generatedColumns")
         .map(tableFeature => s"delta.feature.$tableFeature" -> "supported")
         .toMap
 
@@ -606,7 +599,6 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
       assert(protocol.supportsFeature(TableFeatures.CONSTRAINTS_W_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.CHANGE_DATA_FEED_W_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.INVARIANTS_W_FEATURE))
-      assert(protocol.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
     }
   }
 
@@ -618,8 +610,7 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
       TableConfig.APPEND_ONLY_ENABLED.getKey -> "true", // appendOnly
       TableConfig.CHECKPOINT_POLICY.getKey -> "v2", // checkpointV2
       TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true", // inCommitTimestamp
-      TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.getKey -> "true",
-      TableConfig.TYPE_WIDENING_ENABLED.getKey -> "true")
+      TableConfig.ICEBERG_WRITER_COMPAT_V1_ENABLED.getKey -> "true")
     val schema = new StructType()
       .add("c1", IntegerType.INTEGER)
       .add("c2", TimestampNTZType.TIMESTAMP_NTZ) // timestampNtz
@@ -669,13 +660,24 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
       // assert(protocol.supportsFeature(TableFeatures.TIMESTAMP_NTZ_RW_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.DOMAIN_METADATA_W_FEATURE))
       assert(protocol.supportsFeature(TableFeatures.INVARIANTS_W_FEATURE))
-      assert(protocol.supportsFeature(TableFeatures.TYPE_WIDENING_RW_FEATURE))
-      // TODO in the future add clustering once they are supported
+      // TODO in the future add typeWidening and clustering once they are supported
     }
   }
 
   /* -------------------- Enforcements blocked by icebergCompatV2 -------------------- */
   // We test the deletionVector checks above as part of blocked table feature tests
+
+  // We don't support typeWidening yet in Kernel or for icebergCompatV2; when we add support update
+  // these tests (only certain transforms allowed) and add to the above test for compatible table
+  // features
+
+  testIncompatibleUnsupportedTableFeature(
+    "typeWidening",
+    tablePropertiesToEnable = Map("delta.enableTypeWidening" -> "true"))
+
+  testIncompatibleUnsupportedTableFeature(
+    "typeWidening inactive",
+    tablePropertiesToEnable = Map("delta.feature.typeWidening" -> "supported"))
 
   // We cannot test enabling icebergCompatV1 since it is not a table feature in Kernel; This is
   // tested in the unit tests in IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite


### PR DESCRIPTION
This reverts commit df114f1e597e8532f9d231d12ca232e580fbcb9b.

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This reverts a commit that should not be shipped without follow-up feature work.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

Not from a previous release.
