### PR TITLE
[VARIANT] Add enableVariantShredding Table Property and VariantShredding-preview table feature in Delta-Spark

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2303,7 +2303,7 @@
   },
   "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED" : {
     "message" : [
-      "Attempted to write shredded Variants but the table does not support shredded writes. Consider setting the table property delta.enableVariantShredding to true."
+      "Attempted to write shredded Variants but the table does not support shredded writes. Consider setting the table property enableVariantShredding to true."
     ],
     "sqlState" : "0A000"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2301,6 +2301,12 @@
     ],
     "sqlState" : "42809"
   },
+  "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED" : {
+    "message" : [
+      "Attempted to write shredded Variants but the table does not support shredded writes. Consider setting the table property enableVariantShredding to true."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_SOURCE_IGNORE_DELETE" : {
     "message" : [
       "Detected deleted data (for example <removedFile>) from streaming source at version <version>. This is currently not supported. If you'd like to ignore deletes, set the option 'ignoreDeletes' to 'true'. The source table can be found at path <dataPath>."
@@ -2973,12 +2979,6 @@
       "Subquery is not supported in partition predicates."
     ],
     "sqlState" : "0AKDC"
-  },
-  "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED" : {
-    "message" : [
-      "Attempted to write shredded Variants but the table does not support shredded writes. Consider setting the table property enableVariantShredding to true."
-    ],
-    "sqlState" : "0A000"
   },
   "DELTA_UNSUPPORTED_TIME_TRAVEL_MULTIPLE_FORMATS" : {
     "message" : [

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2303,7 +2303,7 @@
   },
   "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED" : {
     "message" : [
-      "Attempted to write shredded Variants but the table does not support shredded writes. Consider setting the table property enableVariantShredding to true."
+      "Attempted to write shredded Variants but the table does not support shredded writes. Consider setting the table property delta.enableVariantShredding to true."
     ],
     "sqlState" : "0A000"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2974,6 +2974,12 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED" : {
+    "message" : [
+      "Attempted to write shredded Variants but the table does not support shredded writes. Consider setting the table property enableVariantShredding to true."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_UNSUPPORTED_TIME_TRAVEL_MULTIPLE_FORMATS" : {
     "message" : [
       "Cannot specify time travel in multiple formats."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -549,6 +549,13 @@ trait DeltaConfigsBase extends DeltaLogging {
     validationFunction = _ => true,
     helpMessage = "needs to be a boolean.")
 
+  val ENABLE_VARIANT_SHREDDING = buildConfig[Boolean](
+    key = "enableVariantShredding",
+    defaultValue = "false",
+    fromString = _.toBoolean,
+    validationFunction = _ => true,
+    helpMessage = "needs to be a boolean.")
+
   /**
    * Whether this table will automatically optimize the layout of files during writes.
    */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2827,6 +2827,13 @@ trait DeltaErrorsBase
     )
   }
 
+  def variantShreddingUnsupported(): Throwable = {
+    new DeltaSparkException(
+      errorClass = "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED",
+      messageParameters = Array.empty
+    )
+  }
+
   def unsupportSubqueryInPartitionPredicates(): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_SUBQUERY_IN_PARTITION_PREDICATES",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -27,7 +27,6 @@ import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.util.control.NonFatal
 
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
-
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
@@ -944,6 +943,7 @@ trait OptimisticTransactionImpl extends DeltaTransaction
     }
   }
 
+  // Make sure shredded writes are only performed if the shredding table property was set.
   private def assertShreddingStateConsistent() = {
     if (!DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)) {
       val isVariantShreddingSchemaForced =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -947,7 +947,8 @@ trait OptimisticTransactionImpl extends DeltaTransaction
   private def assertShreddingStateConsistent() = {
     if (!DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)) {
       val isVariantShreddingSchemaForced =
-        spark.sessionState.conf.getConf(SQLConf.VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST).nonEmpty
+        spark.sessionState.conf
+          .getConfString("spark.sql.variant.forceShreddingSchemaForTest", "").nonEmpty
       if (isVariantShreddingSchemaForced) {
         throw DeltaErrors.variantShreddingUnsupported()
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -946,8 +946,6 @@ trait OptimisticTransactionImpl extends DeltaTransaction
   // Make sure shredded writes are only performed if the shredding table property was set.
   private def assertShreddingStateConsistent() = {
     if (!DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)) {
-      // TODO: Point to the VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST config instead of hard-coding
-      // the config name when connected to Spark versions that contain this config.
       val isVariantShreddingSchemaForced =
         spark.sessionState.conf
           .getConfString("spark.sql.variant.forceShreddingSchemaForTest", "").nonEmpty

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -946,6 +946,8 @@ trait OptimisticTransactionImpl extends DeltaTransaction
   // Make sure shredded writes are only performed if the shredding table property was set.
   private def assertShreddingStateConsistent() = {
     if (!DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)) {
+      // TODO: Point to the VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST config instead of hard-coding
+      // the config name when connected to Spark versions that contain this config.
       val isVariantShreddingSchemaForced =
         spark.sessionState.conf
           .getConfString("spark.sql.variant.forceShreddingSchemaForTest", "").nonEmpty

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -370,7 +370,7 @@ object TableFeature {
       InCommitTimestampTableFeature,
       VariantTypePreviewTableFeature,
       VariantTypeTableFeature,
-      VariantShreddingTableFeature,
+      VariantShreddingPreviewTableFeature,
       CatalogOwnedTableFeature,
       CoordinatedCommitsTableFeature,
       CheckpointProtectionTableFeature)
@@ -714,8 +714,9 @@ object VariantTypeTableFeature extends ReaderWriterFeature(name = "variantType")
   }
 }
 
-object VariantShreddingTableFeature extends ReaderWriterFeature(name = "variantShredding-preview")
-  with FeatureAutomaticallyEnabledByMetadata {
+object VariantShreddingPreviewTableFeature
+    extends ReaderWriterFeature(name = "variantShredding-preview")
+    with FeatureAutomaticallyEnabledByMetadata {
   override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
 
   override def metadataRequiresFeatureToBeEnabled(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -721,7 +721,8 @@ object VariantShreddingPreviewTableFeature
 
   override def metadataRequiresFeatureToBeEnabled(
       protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
-    DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)
+    DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata) &&
+      SchemaUtils.checkForVariantTypeColumnsRecursively(metadata.schema)
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -370,6 +370,7 @@ object TableFeature {
       InCommitTimestampTableFeature,
       VariantTypePreviewTableFeature,
       VariantTypeTableFeature,
+      VariantShreddingTableFeature,
       CatalogOwnedTableFeature,
       CoordinatedCommitsTableFeature,
       CheckpointProtectionTableFeature)
@@ -710,6 +711,16 @@ object VariantTypeTableFeature extends ReaderWriterFeature(name = "variantType")
       // feature is enabled so old tables with only the preview table feature can be read.
       !protocol.isFeatureSupported(VariantTypePreviewTableFeature)
     }
+  }
+}
+
+object VariantShreddingTableFeature extends ReaderWriterFeature(name = "variantShredding-preview")
+  with FeatureAutomaticallyEnabledByMetadata {
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
+
+  override def metadataRequiresFeatureToBeEnabled(
+      protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
+    DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -721,8 +721,7 @@ object VariantShreddingPreviewTableFeature
 
   override def metadataRequiresFeatureToBeEnabled(
       protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
-    DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata) &&
-      SchemaUtils.checkForVariantTypeColumnsRecursively(metadata.schema)
+    DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)
   }
 }
 

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -81,7 +81,6 @@ class DeltaVariantShreddingSuite
       val footer: ParquetMetadata = reader.getFooter
       val isShredded =
         hasStructWithFieldNames(footer.getFileMetaData().getSchema, requiredFieldNames)
-        hasStructWithFieldNames(footer.getFileMetaData().getSchema, requiredFieldNames)
       reader.close()
       isShredded
     }

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -92,7 +92,8 @@ class DeltaVariantShreddingSuite
     // 2. Drop the variant column (currently the variantTy)
     // 3. Add the shredding property - shredding feature should be absent
     // 4. Add the variant column - shredding feature should be present
-    Seq("v variant", "v struct<v1 variant>").foreach { variantColumn =>
+    Seq("v variant", "v struct<v1 variant>", "v array<variant>", "v map<string, variant>")
+      .foreach { variantColumn =>
       withTable("tbl") {
         sql("CREATE TABLE tbl(s STRING, i INTEGER, v VARIANT) USING DELTA")
         val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("tbl"))

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -16,6 +16,12 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils, TestsStatistics}
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
 class DeltaVariantShreddingSuite
   extends QueryTest
     with SharedSparkSession

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -197,6 +197,9 @@ class DeltaVariantShreddingSuite
               df.write.format("delta").mode("append").saveAsTable("tbl")
             }
             checkError(e, "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED", parameters = Map())
+            assert(e.getMessage.contains(
+              "Attempted to write shredded Variants but the table does not support shredded " +
+                "writes. Consider setting the table property enableVariantShredding to true."))
             assert(numShreddedFiles(dir.getAbsolutePath, validation = { field: GroupType =>
               field.getName == "v" && (field.getType("typed_value") match {
                 case t: GroupType =>

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-class DeltaVariantSuite
+package org.apache.spark.sql.delta
+
+class DeltaVariantShreddingSuite
   extends QueryTest
     with SharedSparkSession
     with DeltaSQLCommandTest

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -92,8 +92,7 @@ class DeltaVariantShreddingSuite
     // 2. Drop the variant column (currently the variantTy)
     // 3. Add the shredding property - shredding feature should be absent
     // 4. Add the variant column - shredding feature should be present
-    Seq("v variant", "v struct<v1 variant>", "v array<variant>", "v map<string, variant>")
-      .foreach { variantColumn =>
+    Seq("v variant", "v struct<v1 variant>").foreach { variantColumn =>
       withTable("tbl") {
         sql("CREATE TABLE tbl(s STRING, i INTEGER, v VARIANT) USING DELTA")
         val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("tbl"))

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -92,24 +92,26 @@ class DeltaVariantShreddingSuite
     // 2. Drop the variant column (currently the variantTy)
     // 3. Add the shredding property - shredding feature should be absent
     // 4. Add the variant column - shredding feature should be present
-    withTable("tbl") {
-      sql("CREATE TABLE tbl(s STRING, i INTEGER, v VARIANT) USING DELTA")
-      val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("tbl"))
-      assert(!snapshot.protocol
-        .isFeatureSupported(VariantShreddingPreviewTableFeature),
-        s"Table tbl contains ShreddedVariantTableFeature descriptor when its not supposed to")
-      // Add column mapping so drop column can be supported
-      sql("""ALTER TABLE tbl SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name')""")
-      sql("ALTER TABLE tbl DROP COLUMN v")
-      assert(!getProtocolForTable("tbl")
-        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
-      sql(s"ALTER TABLE tbl " +
-        s"SET TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
-      assert(!getProtocolForTable("tbl")
-        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
-      sql(s"ALTER TABLE tbl ADD COLUMN (v VARIANT)")
-      assert(getProtocolForTable("tbl")
-        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
+    Seq("v variant", "v struct<v1 variant>").foreach { variantColumn =>
+      withTable("tbl") {
+        sql("CREATE TABLE tbl(s STRING, i INTEGER, v VARIANT) USING DELTA")
+        val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("tbl"))
+        assert(!snapshot.protocol
+          .isFeatureSupported(VariantShreddingPreviewTableFeature),
+          s"Table tbl contains ShreddedVariantTableFeature descriptor when its not supposed to")
+        // Add column mapping so drop column can be supported
+        sql("""ALTER TABLE tbl SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name')""")
+        sql("ALTER TABLE tbl DROP COLUMN v")
+        assert(!getProtocolForTable("tbl")
+          .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
+        sql(s"ALTER TABLE tbl " +
+          s"SET TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
+        assert(!getProtocolForTable("tbl")
+          .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
+        sql(s"ALTER TABLE tbl ADD COLUMN ($variantColumn)")
+        assert(getProtocolForTable("tbl")
+          .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
+      }
     }
     // Create table with variant and config - feature should be present
     withTable("tbl") {

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -88,41 +88,21 @@ class DeltaVariantShreddingSuite
   }
 
   test("variant shredding table property") {
-    // 1. Create table with variant but no shredding property so variantType feature is added.
-    // 2. Drop the variant column (currently the variantTy)
-    // 3. Add the shredding property - shredding feature should be absent
-    // 4. Add the variant column - shredding feature should be present
     withTable("tbl") {
-      sql("CREATE TABLE tbl(s STRING, i INTEGER, v VARIANT) USING DELTA")
+      sql("CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA")
       val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("tbl"))
       assert(!snapshot.protocol
         .isFeatureSupported(VariantShreddingPreviewTableFeature),
-        s"Table tbl contains ShreddedVariantTableFeature descriptor when its not supposed to")
-      // Add column mapping so drop column can be supported
-      sql("""ALTER TABLE tbl SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name')""")
-      sql("ALTER TABLE tbl DROP COLUMN v")
-      assert(!getProtocolForTable("tbl")
-        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
+        s"Table tbl contains ShreddedVariantTableFeature descriptor when its not supposed to"
+      )
       sql(s"ALTER TABLE tbl " +
         s"SET TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
-      assert(!getProtocolForTable("tbl")
-        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
-      sql(s"ALTER TABLE tbl ADD COLUMN (v VARIANT)")
       assert(getProtocolForTable("tbl")
         .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
     }
-    // Create table with variant and config - feature should be present
     withTable("tbl") {
-      sql(s"CREATE TABLE tbl(s STRING, i INTEGER, v VARIANT) USING DELTA " +
+      sql(s"CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA " +
         s"TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
-      assert(getProtocolForTable("tbl")
-        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
-    }
-    // CTAS variant and config - feature should be present
-    withTable("tbl") {
-      sql(s"CREATE TABLE tbl USING DELTA " +
-        s"TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true') " +
-        s"""AS SELECT 1 AS i, parse_json('{"a": 1, "b": "2", "c": 3.3}') AS v from range(10)""")
       assert(getProtocolForTable("tbl")
         .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
     }

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class DeltaVariantSuite
+  extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest
+    with DeltaSQLTestUtils
+    with TestsStatistics {
+
+  import testImplicits._
+
+  test("variant shredding table property") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA")
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      assert(!deltaLog.unsafeVolatileSnapshot.protocol
+        .isFeatureSupported(VariantShreddingPreviewTableFeature),
+        s"Table tbl contains ShreddedVariantTableFeature descriptor when its not supposed to"
+      )
+      sql(s"ALTER TABLE tbl " +
+        s"SET TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
+      assert(getProtocolForTable("tbl")
+        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
+    }
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA " +
+        s"TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
+      assert(getProtocolForTable("tbl")
+        .readerAndWriterFeatures.contains(VariantShreddingPreviewTableFeature))
+    }
+    assert(DeltaConfigs.ENABLE_VARIANT_SHREDDING.key == "delta.enableVariantShredding")
+  }
+}

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -197,9 +197,6 @@ class DeltaVariantShreddingSuite
               df.write.format("delta").mode("append").saveAsTable("tbl")
             }
             checkError(e, "DELTA_SHREDDING_TABLE_PROPERTY_DISABLED", parameters = Map())
-            assert(e.getMessage.contains(
-              "Attempted to write shredded Variants but the table does not support shredded " +
-                "writes. Consider setting the table property enableVariantShredding to true."))
             assert(numShreddedFiles(dir.getAbsolutePath, validation = { field: GroupType =>
               field.getName == "v" && (field.getType("typed_value") match {
                 case t: GroupType =>

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantShreddingSuite.scala
@@ -90,8 +90,8 @@ class DeltaVariantShreddingSuite
   test("variant shredding table property") {
     withTable("tbl") {
       sql("CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA")
-      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
-      assert(!deltaLog.unsafeVolatileSnapshot.protocol
+      val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("tbl"))
+      assert(!snapshot.protocol
         .isFeatureSupported(VariantShreddingPreviewTableFeature),
         s"Table tbl contains ShreddedVariantTableFeature descriptor when its not supposed to"
       )
@@ -197,8 +197,8 @@ class DeltaVariantShreddingSuite
   test("Set table property to invalid value") {
     withTable("tbl") {
       sql("CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA")
-      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
-      assert(!deltaLog.unsafeVolatileSnapshot.protocol
+      val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("tbl"))
+      assert(!snapshot.protocol
         .isFeatureSupported(VariantShreddingPreviewTableFeature),
         s"Table tbl contains ShreddedVariantTableFeature descriptor when its not supposed to"
       )

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2024) The Delta Lake Project Authors.
+ * Copyright (2025) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -725,4 +725,33 @@ class DeltaVariantSuite
       assert(newLessThanZeroCount == 0)
     }
   }
+
+  test("variant shredding table property") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA")
+      assert(getProtocolForTable("tbl") == Protocol(1, 2))
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      assert(
+        !deltaLog.unsafeVolatileSnapshot.protocol.isFeatureSupported(VariantShreddingTableFeature),
+        s"Table tbl contains ShreddedVariantTableFeature descriptor when it is not supposed to"
+      )
+      sql(s"ALTER TABLE tbl " +
+        s"SET TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
+      assert(
+        getProtocolForTable("tbl") == VariantShreddingTableFeature.minProtocolVersion
+          .withFeatures(
+            Seq(VariantShreddingTableFeature, InvariantsTableFeature, AppendOnlyTableFeature))
+      )
+    }
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA " +
+        s"TBLPROPERTIES('${DeltaConfigs.ENABLE_VARIANT_SHREDDING.key}' = 'true')")
+      assert(
+        getProtocolForTable("tbl") == VariantShreddingTableFeature.minProtocolVersion
+          .withFeatures(
+            Seq(VariantShreddingTableFeature, InvariantsTableFeature, AppendOnlyTableFeature))
+      )
+    }
+    assert(DeltaConfigs.ENABLE_VARIANT_SHREDDING.key == "delta.enableVariantShredding")
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add the preview table feature for Variant Shredding (see https://github.com/delta-io/delta/pull/4033) enabled by the new enableVariantShredding table property. Spark will check if the `enableVariantShredding` table property is enabled before writing shredded data to Delta tables, when support for shredded writes is implemented in Spark.

## How was this patch tested?

Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No