### PR TITLE
[Spark] Add more Unity Catalog integration tests

### DIFF
--- a/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
+++ b/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
@@ -14,17 +14,14 @@
 # limitations under the License.
 #
 
+import datetime
 import os
-import sys
-import threading
-import json
+import py4j
 import unittest
 
-import py4j.protocol
+from delta.tables import DeltaTable
+from pyspark.errors.exceptions.captured import AnalysisException, UnsupportedOperationException
 from pyspark.sql import SparkSession, DataFrame
-import datetime
-import uuid
-
 from pyspark.sql.functions import lit
 from pyspark.sql.types import IntegerType, StructType, StructField
 from pyspark.testing import assertDataFrameEqual
@@ -52,28 +49,27 @@ MANAGED_CC_TABLE = os.environ.get("MANAGED_CC_TABLE")
 SCHEMA = os.environ.get("SCHEMA")
 MANAGED_NON_CC_TABLE = os.environ.get("MANAGED_NON_CC_TABLE")
 
-
 spark = SparkSession \
     .builder \
     .appName("coordinated_commit_tester") \
     .master("local[*]") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("spark.sql.catalog.spark_catalog", "io.unitycatalog.spark.UCSingleCatalog") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
     .config(f"spark.sql.catalog.{CATALOG_NAME}", "io.unitycatalog.spark.UCSingleCatalog") \
     .config(f"spark.sql.catalog.{CATALOG_NAME}.token", CATALOG_TOKEN) \
     .config(f"spark.sql.catalog.{CATALOG_NAME}.uri", CATALOG_URI) \
-    .config(f"spark.sql.defaultCatalog", CATALOG_NAME) \
     .config("spark.databricks.delta.replaceWhere.constraintCheck.enabled", True) \
     .config("spark.hadoop.fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem") \
-    .config("spark.databricks.delta.commitcoordinator.unity-catalog.impl",
-            "org.delta.catalog.UCCoordinatedCommitClient") \
     .getOrCreate()
 
 MANAGED_CATALOG_OWNED_TABLE_FULL_NAME = f"{CATALOG_NAME}.{SCHEMA}.{MANAGED_CC_TABLE}"
 MANAGED_NON_CATALOG_OWNED_TABLE_FULL_NAME = f"{CATALOG_NAME}.{SCHEMA}.{MANAGED_NON_CC_TABLE}"
 
 
-class UnityCatalogManagedTableTestSuite(unittest.TestCase):
+class UnityCatalogManagedTableTestBase(unittest.TestCase):
+    """
+    Shared helpers and test setup for test suites below.
+    """
     setup_df = spark.createDataFrame([(1, ), (2, ), (3, )],
                                      schema=StructType([StructField("id", IntegerType(), True)]))
 
@@ -83,9 +79,6 @@ class UnityCatalogManagedTableTestSuite(unittest.TestCase):
     # Helper methods
     def read(self, table_name: str) -> DataFrame:
         return spark.read.table(table_name)
-
-    def read_with_timestamp(self, timestamp: str, table_name: str) -> DataFrame:
-        return spark.read.option("timestampAsOf", timestamp).table(table_name)
 
     def read_with_cdf_timestamp(self, timestamp: str, table_name: str) -> DataFrame:
         return spark.read.option('readChangeFeed', 'true').option(
@@ -107,18 +100,90 @@ class UnityCatalogManagedTableTestSuite(unittest.TestCase):
             [(4, ),  (5, )], schema=StructType([StructField("id", IntegerType(), True)]))
         single_col_df.writeTo(table_name).append()
 
-    # DML Operations #
+
+class UnityCatalogManagedTableBasicSuite(UnityCatalogManagedTableTestBase):
+    """
+    Suite covering basic functionality of catalog owned tables.
+    """
+
+    def test_read_from_managed_table_without_catalog_owned(self) -> None:
+        self.read(MANAGED_NON_CATALOG_OWNED_TABLE_FULL_NAME)
+
+    def test_write_to_managed_catalog_owned_table(self) -> None:
+        self.append(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl,
+                             self.create_df_with_rows([(1, ), (2, ), (3, ), (4, ), (5, )]))
+
+    def test_read_from_managed_catalog_owned_table(self) -> None:
+        self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl, self.setup_df)
+
+    # Writing to tables that are not catalog owned is not supported.
+    def test_write_to_managed_table_without_catalog_owned(self) -> None:
+        try:
+            self.append(MANAGED_NON_CATALOG_OWNED_TABLE_FULL_NAME)
+        except py4j.protocol.Py4JJavaError as error:
+            assert("[TASK_WRITE_FAILED] Task failed while writing rows to s3" in str(error))
+
+    def test_unset_catalog_owned_feature(self) -> None:
+        try:
+            spark.sql(f"ALTER TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                      f"UNSET TBLPROPERTIES ('delta.feature.catalogOwned-preview')")
+        except UnsupportedOperationException as error:
+            assert("Altering a table is not supported yet" in str(error))
+
+    def test_drop_catalog_owned_property(self) -> None:
+        try:
+            spark.sql(f"ALTER TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                      f"DROP FEATURE 'catalogOwned-preview'")
+        except UnsupportedOperationException as error:
+            assert("Altering a table is not supported yet" in str(error))
+
+
+class UnityCatalogManagedTableDMLSuite(UnityCatalogManagedTableTestBase):
+    """
+    Suite covering DMLs (INSERT, MERGE, UPDATE, DELETE) on catalog owned tables.
+    """
+
     def test_update(self) -> None:
+        dt = DeltaTable.forName(spark, MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        dt.update(condition="id = 1", set={"id": "4"})
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(4, ), (2, ), (3, )]))
+
+    def test_sql_update(self) -> None:
         spark.sql(f"UPDATE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} SET id=4 WHERE id=1")
         updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
         assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(4, ), (2, ), (3, )]))
 
     def test_delete(self) -> None:
+        dt = DeltaTable.forName(spark, MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        dt.delete(condition="id = 1")
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(2, ), (3, )]))
+
+    def test_sql_delete(self) -> None:
         spark.sql(f"DELETE FROM {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} where id=1")
         updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
         assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(2, ), (3, )]))
 
     def test_merge(self) -> None:
+        dt = DeltaTable.forName(spark, MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        src = self.create_df_with_rows([(1, ), (2, ), (3, ), (4, ), (5, )])
+        dt.alias("target") \
+            .merge(
+                source=src.alias("src"),
+                condition="src.id = target.id") \
+            .whenNotMatchedInsertAll() \
+            .execute()
+
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl,
+                             self.create_df_with_rows([(1, ), (2, ), (3, ), (4, ), (5, )]))
+
+    def test_sql_merge(self) -> None:
         spark.sql(f"MERGE INTO {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} AS target "
                   f"USING (VALUES 2, 3, 4, 5 AS src(id)) AS src "
                   f"ON src.id = target.id WHEN NOT MATCHED THEN INSERT *;")
@@ -126,52 +191,69 @@ class UnityCatalogManagedTableTestSuite(unittest.TestCase):
         assertDataFrameEqual(updated_tbl,
                              self.create_df_with_rows([(1, ), (2, ), (3, ), (4, ), (5, )]))
 
-    # Utility Functions #
-    def test_optimize(self) -> None:
-        spark.sql(f"OPTIMIZE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}")
-        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
-        assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(1, ), (2, ), (3, )]))
-
-    # DESCRIBE HISTORY is currently unsupported on catalog owned tables.
-    def test_history(self) -> None:
+    def test_merge_schema_evolution(self) -> None:
+        spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", "true")
         try:
-            self.get_table_history(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).collect()
+            spark.sql(f"MERGE INTO {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} AS target "
+                      f"USING (VALUES (2, 2), (3, 3), (4, 4), (5, 5) AS src(id, extra)) AS src "
+                      f"ON src.id = target.id WHEN NOT MATCHED THEN INSERT *;")
         except py4j.protocol.Py4JJavaError as error:
-            assert("Path based access is not supported for Catalog-Owned table" in str(error))
+            assert(
+                "A table's Delta metadata can only be changed from a cluster or warehouse"
+                in str(error)
+            )
+        finally:
+            spark.conf.unset("spark.databricks.delta.schema.autoMerge.enabled")
 
-    def test_time_travel_read(self) -> None:
-        current_timestamp = str(datetime.datetime.now())
-        self.append(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
-        updated_tbl = self.read_with_timestamp(current_timestamp,
-                                               MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
         assertDataFrameEqual(updated_tbl, self.setup_df)
 
-    # Restore is currenlty unsupported on catalog owned tables.
-    def test_restore(self) -> None:
+    def test_insert_schema_evolution(self) -> None:
+        two_cols_df = spark.createDataFrame([(4, 4), (5, 5)], schema=["id, extra"])
         try:
-            spark.sql(f"RESTORE TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} TO VERSION AS OF 0")
+            two_cols_df\
+                .write.mode("append").option("mergeSchema", "true")\
+                .insertInto(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
         except py4j.protocol.Py4JJavaError as error:
-            assert("A table's Delta metadata can only be changed from a cluster or warehouse"
-                   in str(error))
+            assert(
+                "A table's Delta metadata can only be changed from a cluster or warehouse"
+                in str(error)
+            )
 
-    # CDC (Timestamps, Versions) are currently unsupported for Catalog owned tables.
-    def test_change_data_feed_with_timestamp(self) -> None:
-        timestamp = str(datetime.datetime.now())
-        self.append(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
-        try:
-            self.read_with_cdf_timestamp(
-                timestamp, MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).select("id", "_change_type")
-        except py4j.protocol.Py4JJavaError as error:
-            assert("Path based access is not supported for Catalog-Owned table" in str(error))
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl, self.setup_df)
 
-    def test_change_data_feed_with_version(self) -> None:
-        self.append(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+    def test_sql_insert(self) -> None:
+        spark.sql(f"INSERT INTO {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                  f"VALUES (4), (5)")
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl,
+                             self.create_df_with_rows([(1,), (2,), (3,), (4,), (5,)]))
+
+    def test_sql_insert_overwrite(self) -> None:
+        spark.sql(f"INSERT OVERWRITE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                  f"VALUES (2), (3), (4), (5)")
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl,
+                             self.create_df_with_rows([(2,), (3,), (4,), (5,)]))
+
+    def test_sql_insert_replace_where(self) -> None:
+        spark.sql(f"INSERT INTO {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                  f"REPLACE WHERE id = 1 "
+                  f"VALUES (1)")
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl,
+                             self.create_df_with_rows([(1,), (2,), (3,)]))
+
+    def test_sql_insert_dynamic_partition_overwrite(self) -> None:
+        spark.conf.set("spark.databricks.delta.dynamicPartitionOverwrite.enabled", "true")
         try:
-            self.read_with_cdf_version(
-                0,
-                MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).select("id", "_change_type")
-        except py4j.protocol.Py4JJavaError as error:
-            assert("Path based access is not supported for Catalog-Owned table" in str(error))
+            spark.sql(f"INSERT INTO {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} VALUES (5)")
+            updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+            assertDataFrameEqual(updated_tbl,
+                                 self.create_df_with_rows([(1,), (2,), (3,), (5,)]))
+        finally:
+            spark.conf.unset("spark.databricks.delta.dynamicPartitionOverwrite.enabled")
 
     # Dataframe Writer V1 Tests #
     def test_insert_into_append(self) -> None:
@@ -221,9 +303,8 @@ class UnityCatalogManagedTableTestSuite(unittest.TestCase):
             f"DESCRIBE formatted {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}").collect()[5].data_type
         try:
             single_col_df.write.format("delta").save(mode="append", path=tbl_path)
-        except Exception as error:
-            assert("Forbidden (Service: Amazon S3; Status Code: 403; "
-                   "Error Code: 403 Forbidden;" in str(error))
+        except py4j.protocol.Py4JJavaError as error:
+            assert("AccessDeniedException" in str(error))
         updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
         assertDataFrameEqual(updated_tbl, self.setup_df)
 
@@ -248,35 +329,223 @@ class UnityCatalogManagedTableTestSuite(unittest.TestCase):
         updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
         assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(5,)]))
 
-    # CREATE TABLE is currently not supported by UC.
-    def test_create(self) -> None:
+
+class UnityCatalogManagedTableDDLSuite(UnityCatalogManagedTableTestBase):
+    """
+    Suite covering DDLs (CREATE, REPLACE, CLONE, ALTER) on catalog owned tables.
+    """
+
+    def test_create_non_delta(self) -> None:
         single_col_df = spark.createDataFrame(
             [(5,)], schema=StructType([StructField("id", IntegerType(), True)]))
         try:
+            # CREATE TABLE is currently not supported by UC.
             single_col_df.writeTo(f"{CATALOG_NAME}.{SCHEMA}.created_table").create()
         except py4j.protocol.Py4JJavaError as error:
             assert("io.unitycatalog.spark.UCProxy.createTable" in str(error))
 
-    # Writing to tables that are not catalog owned is not supported.
-    def test_write_to_managed_table_without_catalog_owned(self) -> None:
+    def test_create_delta(self) -> None:
+        single_col_df = spark.createDataFrame(
+            [(5,)], schema=StructType([StructField("id", IntegerType(), True)]))
         try:
-            self.append(MANAGED_NON_CATALOG_OWNED_TABLE_FULL_NAME)
+            # CREATE TABLE is currently not supported by UC.
+            single_col_df.writeTo(f"{CATALOG_NAME}.{SCHEMA}.created_table").using("delta").create()
+        except AnalysisException as error:
+            assert("[SCHEMA_NOT_FOUND] The schema `playground` cannot be found" in str(error))
+
+    def test_sql_create(self) -> None:
+        try:
+            # This ignores the catalog name passed and tries to create the table under
+            # 'spark_catalog'.
+            spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table (a int) USING DELTA")
+        except AnalysisException as error:
+            assert("[SCHEMA_NOT_FOUND] The schema `playground` cannot be found" in str(error))
+
+    def test_create_non_catalog_owned(self) -> None:
+        try:
+            # This ignores the catalog name passed and tries to create the table under
+            # 'spark_catalog'.
+            spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table (id int) USING DELTA")
+        except AnalysisException as error:
+            assert("[SCHEMA_NOT_FOUND] The schema `playground` cannot be found" in str(error))
+
+    def test_clone_into_catalog_owned(self) -> None:
+        try:
+            # CLONE fails with an assertion error in UCSingleCatalog
+            spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table" +
+                      f" SHALLOW CLONE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}")
         except py4j.protocol.Py4JJavaError as error:
-            assert("[TASK_WRITE_FAILED] Task failed while writing rows to s3" in str(error))
+            assert("java.lang.AssertionError: assertion failed" in str(error))
 
-    def test_read_from_managed_table_without_catalog_owned(self) -> None:
-        self.read(MANAGED_NON_CATALOG_OWNED_TABLE_FULL_NAME)
+    def test_clone_into_non_catalog_owned(self) -> None:
+        try:
+            # CLONE fails with an assertion error in UCSingleCatalog
+            spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table" +
+                      f" SHALLOW CLONE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                      f"TBLPROPERTIES ('delta.feature.catalogOwned-preview' = 'false')")
+        except py4j.protocol.Py4JJavaError as error:
+            assert("java.lang.AssertionError: assertion failed" in str(error))
 
-    def test_write_to_managed_catalog_owned_table(self) -> None:
+    def test_alter_table_comment(self) -> None:
+        try:
+            spark.sql(f"ALTER TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                      f"ALTER COLUMN id COMMENT 'comment'")
+        except UnsupportedOperationException as error:
+            assert("Altering a table is not supported yet" in str(error))
+
+    def test_alter_table_add_column(self) -> None:
+        try:
+            spark.sql(f"ALTER TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} ADD COLUMN extra INT")
+        except UnsupportedOperationException as error:
+            assert("Altering a table is not supported yet" in str(error))
+
+    def test_alter_table_set_tbl_properties(self) -> None:
+        try:
+            spark.sql(f"ALTER TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                      f"SET TBLPROPERTIES ('customProp' = 'customValue')")
+        except UnsupportedOperationException as error:
+            assert("Altering a table is not supported yet" in str(error))
+
+        description = spark.sql(f"DESCRIBE EXTENDED {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}")\
+            .filter("col_name = 'Table Properties'").collect()[0][1]
+        assert("customProp" not in description)
+
+
+class UnityCatalogManagedTableUtilitySuite(UnityCatalogManagedTableTestBase):
+    """
+    Suite covering utility operations on a managed table in Unity Catalog: OPTIMIZE, ANALYZE,
+    VACUUM, ...
+    """
+    def test_optimize(self) -> None:
+        spark.sql(f"OPTIMIZE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}")
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(1, ), (2, ), (3, )]))
+
+    def test_optimize_sql(self) -> None:
+        spark.sql(f"OPTIMIZE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}")
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(1, ), (2, ), (3, )]))
+
+    def test_zorder_by(self) -> None:
+        spark.sql(f"OPTIMIZE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} ZORDER BY (id)")
+        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
+        assertDataFrameEqual(updated_tbl, self.create_df_with_rows([(1, ), (2, ), (3, )]))
+
+    def test_analyze(self) -> None:
+        try:
+            spark.sql(f"ANALYZE TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} COMPUTE STATISTICS")
+        except AnalysisException as error:
+            assert(
+                "[NOT_SUPPORTED_COMMAND_FOR_V2_TABLE] ANALYZE TABLE is not supported for v2 tables."
+                in str(error)
+            )
+
+    def test_describe_table(self) -> None:
+        description = spark.sql(f"DESCRIBE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}").collect()
+        expected = spark.createDataFrame([("id", "int", None)],
+                                         "col_name string, data_type string, comment string")
+        assertDataFrameEqual(description, expected)
+
+    def test_history(self) -> None:
+        try:
+            # DESCRIBE HISTORY is currently unsupported on catalog owned tables.
+            self.get_table_history(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).collect()
+        except py4j.protocol.Py4JJavaError as error:
+            assert("Path based access is not supported for Catalog-Owned table" in str(error))
+
+    def test_vacuum(self) -> None:
+        try:
+            # VACUUM is currently unsupported on catalog owned tables.
+            spark.sql(f"VACUUM {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}")
+        except UnsupportedOperationException as error:
+            assert("DELTA_UNSUPPORTED_VACUUM_ON_MANAGED_TABLE" in str(error))
+
+    def test_restore(self) -> None:
+        try:
+            # Restore is currently unsupported on catalog owned tables.
+            spark.sql(f"RESTORE TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} TO VERSION AS OF 0")
+        except py4j.protocol.Py4JJavaError as error:
+            assert("A table's Delta metadata can only be changed from a cluster or warehouse"
+                   in str(error))
+
+
+class UnityCatalogManagedTableReadSuite(UnityCatalogManagedTableTestBase):
+    """
+    Suite covering reading from a managed table in Unity Catalog/
+    """
+
+    def test_time_travel_read(self) -> None:
+        dt = DeltaTable.forName(spark, MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        current_version = dt.history().selectExpr("max(version)").collect()[0][0]
+        current_timestamp = str(datetime.datetime.now())
         self.append(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
-        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
-        assertDataFrameEqual(updated_tbl,
-                             self.create_df_with_rows([(1, ), (2, ), (3, ), (4, ), (5, )]))
 
-    def test_read_from_managed_catalog_owned_table(self) -> None:
-        self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
-        updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
-        assertDataFrameEqual(updated_tbl, self.setup_df)
+        result = spark.read.option("timestampAsOf", current_timestamp)\
+            .table(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        assertDataFrameEqual(result, self.setup_df)
+
+        result = spark.read.option("versionAsOf", current_version)\
+            .table(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        assertDataFrameEqual(result, self.setup_df)
+
+        result = spark.sql(f"SELECT * FROM {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                           f"TIMESTAMP AS OF '{current_timestamp}'")
+        assertDataFrameEqual(result, self.setup_df)
+
+        result = spark.sql(f"SELECT * FROM {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} "
+                           f"VERSION AS OF {current_version}")
+        assertDataFrameEqual(result, self.setup_df)
+
+    # CDC (Timestamps, Versions) are currently unsupported for Catalog owned tables.
+    def test_change_data_feed_with_timestamp(self) -> None:
+        timestamp = str(datetime.datetime.now())
+        self.append(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        try:
+            self.read_with_cdf_timestamp(
+                timestamp, MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).select("id", "_change_type")
+        except py4j.protocol.Py4JJavaError as error:
+            assert("Path based access is not supported for Catalog-Owned table" in str(error))
+
+    def test_change_data_feed_with_version(self) -> None:
+        self.append(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
+        try:
+            self.read_with_cdf_version(
+                0,
+                MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).select("id", "_change_type")
+        except py4j.protocol.Py4JJavaError as error:
+            assert("Path based access is not supported for Catalog-Owned table" in str(error))
+
+    def test_delta_table_for_path(self) -> None:
+        tbl_path = spark.sql(
+            f"DESCRIBE formatted {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}").collect()[5].data_type
+        try:
+            DeltaTable.forPath(spark, tbl_path)
+        except py4j.protocol.Py4JJavaError as error:
+            # Path-based access isn't supported. This could throw a better error than just
+            # 'access denied' though.
+            assert("AccessDeniedException" in str(error))
+
+    def test_streaming_read(self) -> None:
+        try:
+            spark.readStream\
+                .table(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)\
+                .writeStream\
+                .option("checkpointLocation", "test")\
+                .toTable("output_table")
+        except py4j.protocol.Py4JJavaError as error:
+            # Streaming from a catalog owned table fails as it attempts to access the table by path.
+            # This could also throw a better error than jsut 'access denied'.
+            assert("AccessDeniedException" in str(error))
+
 
 if __name__ == "__main__":
-    unittest.main()
+    """
+    Change this to select tests to run, for example:
+    - '__main__': all tests in this file.
+    - '__main__.UnityCatalogManagedTableDMLSuite': all tests in that single suites.
+    - '__main__.UnityCatalogManagedTableDDLSuite.test_sql_create': only that single test.
+    """
+    test_name = "__main__"
+
+    suite = unittest.TestLoader().loadTestsFromName(test_name)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
+++ b/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
@@ -351,7 +351,10 @@ class UnityCatalogManagedTableDDLSuite(UnityCatalogManagedTableTestBase):
             # CREATE TABLE is currently not supported by UC.
             single_col_df.writeTo(f"{CATALOG_NAME}.{SCHEMA}.created_table").using("delta").create()
         except AnalysisException as error:
-            assert(f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found" in str(error))
+            assert(
+                f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found"
+                in str(error)
+            )
 
     def test_sql_create(self) -> None:
         try:
@@ -359,7 +362,10 @@ class UnityCatalogManagedTableDDLSuite(UnityCatalogManagedTableTestBase):
             # 'spark_catalog'.
             spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table (a int) USING DELTA")
         except AnalysisException as error:
-            assert(f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found" in str(error))
+            assert(
+                f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found"
+                in str(error)
+            )
 
     def test_create_non_catalog_owned(self) -> None:
         try:
@@ -367,7 +373,10 @@ class UnityCatalogManagedTableDDLSuite(UnityCatalogManagedTableTestBase):
             # 'spark_catalog'.
             spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table (id int) USING DELTA")
         except AnalysisException as error:
-            assert(f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found" in str(error))
+            assert(
+                f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found"
+                in str(error)
+            )
 
     def test_clone_into_catalog_owned(self) -> None:
         try:

--- a/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
+++ b/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
@@ -39,7 +39,7 @@ export MANAGED_NON_CC_TABLE=___
 
 ./run-integration-tests.py --use-local --unity-catalog-commit-coordinator-integration-tests \
     --packages \
-    io.unitycatalog:unitycatalog-spark_2.12:0.2.1,org.apache.spark:spark-hadoop-cloud_2.12:3.5.4
+    io.unitycatalog:unitycatalog-spark_2.13:0.3.0,org.apache.spark:spark-hadoop-cloud_2.13:4.0.0
 """
 
 CATALOG_NAME = os.environ.get("CATALOG_NAME")
@@ -351,7 +351,7 @@ class UnityCatalogManagedTableDDLSuite(UnityCatalogManagedTableTestBase):
             # CREATE TABLE is currently not supported by UC.
             single_col_df.writeTo(f"{CATALOG_NAME}.{SCHEMA}.created_table").using("delta").create()
         except AnalysisException as error:
-            assert("[SCHEMA_NOT_FOUND] The schema `playground` cannot be found" in str(error))
+            assert(f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found" in str(error))
 
     def test_sql_create(self) -> None:
         try:
@@ -359,7 +359,7 @@ class UnityCatalogManagedTableDDLSuite(UnityCatalogManagedTableTestBase):
             # 'spark_catalog'.
             spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table (a int) USING DELTA")
         except AnalysisException as error:
-            assert("[SCHEMA_NOT_FOUND] The schema `playground` cannot be found" in str(error))
+            assert(f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found" in str(error))
 
     def test_create_non_catalog_owned(self) -> None:
         try:
@@ -367,7 +367,7 @@ class UnityCatalogManagedTableDDLSuite(UnityCatalogManagedTableTestBase):
             # 'spark_catalog'.
             spark.sql(f"CREATE TABLE {CATALOG_NAME}.{SCHEMA}.created_table (id int) USING DELTA")
         except AnalysisException as error:
-            assert("[SCHEMA_NOT_FOUND] The schema `playground` cannot be found" in str(error))
+            assert(f"[SCHEMA_NOT_FOUND] The schema `spark_catalog`.`{SCHEMA}` cannot be found" in str(error))
 
     def test_clone_into_catalog_owned(self) -> None:
         try:

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -377,7 +377,7 @@ def run_unity_catalog_commit_coordinator_integration_tests(root_dir, version, te
 
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
-    packages = "io.delta:delta-%s_2.12:%s" % (get_artifact_name(version), version)
+    packages = "io.delta:delta-%s_2.13:%s" % (get_artifact_name(version), version)
     if extra_packages:
         packages += "," + extra_packages
 


### PR DESCRIPTION
## Description
This extends coverage for Unity Catalog integration tests:
- Split tests across multiple suites
- Add coverage for DMLs using SQL, time-travel, streaming, ALTER TABLE, utility functions, ...

## How was this patch tested?
Ran tests locally. These tests aren't executed automatically as part of PR validation as they require provisioning external resources.

## Does this PR introduce _any_ user-facing changes?
No
