### PR TITLE
[Spark] Materialize cached Delta sources in MERGE

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1683,6 +1683,12 @@
     ],
     "sqlState" : "42601"
   },
+  "DELTA_MERGE_SOURCE_CACHED_DURING_EXECUTION" : {
+    "message" : [
+      "The MERGE operation failed because (part of) the source plan was cached while the MERGE operation was running."
+    ],
+    "sqlState" : "25000"
+  },
   "DELTA_MERGE_UNEXPECTED_ASSIGNMENT_KEY" : {
     "message" : [
       "Unexpected assignment key: <unexpectedKeyClass> - <unexpectedKeyObject>"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1325,6 +1325,9 @@ trait DeltaErrorsBase
     )
   }
 
+  def mergeConcurrentOperationCachedSourceException(): Throwable =
+    new DeltaRuntimeException(errorClass = "DELTA_MERGE_SOURCE_CACHED_DURING_EXECUTION")
+
   def columnOfTargetTableNotFoundInMergeException(targetCol: String,
       colNames: String): Throwable = {
     new DeltaAnalysisException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -165,6 +165,8 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
       .collect()
       .head
 
+    checkSourcePlanIsNotCached(spark, getMergeSource.df.queryExecution.logical)
+
     val hasMultipleMatches = multipleMatchCount > 0
     throwErrorOnMultipleMatches(hasMultipleMatches, spark)
     if (hasMultipleMatches) {
@@ -464,6 +466,8 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
 
     // Write to Delta
     val newFiles = writeFiles(spark, deltaTxn, outputDF)
+
+    checkSourcePlanIsNotCached(spark, getMergeSource.df.queryExecution.logical)
 
     // Update metrics
     val (addedBytes, addedPartitions) = totalBytesAndDistinctPartitionValues(newFiles)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -272,7 +272,8 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
           // the user defined function is marked as deterministic, as it is often incorrectly marked
           // as such.
           (true, MergeIntoMaterializeSourceReason.NON_DETERMINISTIC_SOURCE_WITH_DETERMINISTIC_UDF)
-        } else if (materializeCachedSource && planIsCached(spark, source)) {
+        } else if (materializeCachedSource &&
+            planContainsCachedRelation(DataFrameUtils.ofRows(spark, source))) {
           // The query cache doesn't pin the version of cached Delta tables, we materialize the
           // source in that case to avoid this issue.
           (true, MergeIntoMaterializeSourceReason.SOURCE_CACHED)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -274,8 +274,9 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
           (true, MergeIntoMaterializeSourceReason.NON_DETERMINISTIC_SOURCE_WITH_DETERMINISTIC_UDF)
         } else if (materializeCachedSource &&
             planContainsCachedRelation(DataFrameUtils.ofRows(spark, source))) {
-          // The query cache doesn't pin the version of cached Delta tables, we materialize the
-          // source in that case to avoid this issue.
+          // The query cache doesn't pin the version of cached Delta tables, cache can get
+          // concurrently updated in the middle of MERGE execution. We materialize the source in
+          // that case to avoid this issue.
           (true, MergeIntoMaterializeSourceReason.SOURCE_CACHED)
         } else {
           (false, MergeIntoMaterializeSourceReason.NOT_MATERIALIZED_AUTO)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -873,6 +873,20 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val MERGE_FAIL_SOURCE_CACHED_AFTER_MATERIALIZATION =
+    buildConf("merge.failSourceCachedAfterMaterialization")
+      .internal()
+      .doc(
+        """
+          |Enables a check that fails the MERGE operation if the source was cached (using
+          |df.cache()) after the source materialization phase. Query caching doesn't pin the version
+          |of Delta tables and we should materialize cached source plans. In rare cases, the source
+          |might get cached after the decision to materialize, which could lead to incorrect results
+          |if we let the operation succeed.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL =
     buildConf("merge.materializeSource.rddStorageLevel")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -861,6 +861,18 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val MERGE_MATERIALIZE_CACHED_SOURCE =
+    buildConf("merge.materializeCachedSource")
+      .internal()
+      .doc(
+        """
+          |When enabled, materialize the source in MERGE if it is cached (e.g. via df.cache()). This
+          |prevents incorrect results due to query caching not pinning the version of cached Delta
+          |tables.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL =
     buildConf("merge.materializeSource.rddStorageLevel")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSparkPlanUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSparkPlanUtils.scala
@@ -51,7 +51,6 @@ trait DeltaSparkPlanUtils {
   protected def planContainsCachedRelation(df: DataFrame): Boolean =
     df.queryExecution.withCachedData.exists(_.isInstanceOf[InMemoryRelation])
 
-
   /**
    * Returns `true` if `plan` has a safe level of determinism. This is a conservative
    * approximation of `plan` being a truly deterministic query.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSparkPlanUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSparkPlanUtils.scala
@@ -16,8 +16,9 @@
 
 package org.apache.spark.sql.delta.util
 
-import org.apache.spark.sql.delta.{DeltaTable, DeltaTableReadPredicate}
+import org.apache.spark.sql.delta.{DataFrameUtils, DeltaTable, DeltaTableReadPredicate}
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Exists, Expression, InSubquery, LateralSubquery, ScalarSubquery, SubqueryExpression => SparkSubqueryExpression, UserDefinedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{Distinct, Filter, LeafNode, LogicalPlan, OneRowRelation, Project, SubqueryAlias, Union}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -43,6 +44,12 @@ trait DeltaSparkPlanUtils {
       // If not found in main plan, look into subqueries.
       collectFirst(source.subqueries, findFirstNonDeltaScan)
     )
+  }
+
+  /** Returns whether the given plan was cached using df.cache() or similar. */
+  protected def planIsCached(spark: SparkSession, plan: LogicalPlan): Boolean = {
+    import org.apache.spark.sql.delta.ClassicColumnConversions._
+    spark.sharedState.cacheManager.lookupCachedData(DataFrameUtils.ofRows(spark, plan)).nonEmpty
   }
 
   /**


### PR DESCRIPTION
## Description


Fixes a source of non-determinism in MERGE due to query caching. Query caching doesn't pin the version of Delta tables, a source cached using `df.cache()` can then return different results between the two internal MERGE jobs if it is updated in the meantime.

Guarded by flag `spark.databricks.delta.merge.materializeCachedSource`.

## How was this patch tested?
This is tough to cover with a test since it requires precise timing to update the source while the MERGE operation is running.
I did validate that the fix works manually, running with a debugger.

## Does this PR introduce _any_ user-facing changes?
No
