### PR TITLE
[Spark] Rename StatsProvider.getPredicateWithStatType to StatsProvider.getPredicateWithStatTypeIfExists

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingPredicateBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingPredicateBuilder.scala
@@ -80,32 +80,32 @@ object DataSkippingPredicateBuilder {
 private [stats] class ColumnPredicateBuilder extends DataSkippingPredicateBuilder {
   def equalTo(statsProvider: StatsProvider, colPath: Seq[String], value: Column)
     : Option[DataSkippingPredicate] = {
-    statsProvider.getPredicateWithStatTypes(colPath, value.expr.dataType, MIN, MAX) { (min, max) =>
-      min <= value && value <= max
+    statsProvider.getPredicateWithStatTypesIfExists(colPath, value.expr.dataType, MIN, MAX) {
+      (min, max) => min <= value && value <= max
     }
   }
 
   def notEqualTo(statsProvider: StatsProvider, colPath: Seq[String], value: Column)
     : Option[DataSkippingPredicate] = {
-    statsProvider.getPredicateWithStatTypes(colPath, value.expr.dataType, MIN, MAX) { (min, max) =>
-      min < value || value < max
+    statsProvider.getPredicateWithStatTypesIfExists(colPath, value.expr.dataType, MIN, MAX) {
+      (min, max) => min < value || value < max
     }
   }
 
   def lessThan(statsProvider: StatsProvider, colPath: Seq[String], value: Column)
     : Option[DataSkippingPredicate] =
-    statsProvider.getPredicateWithStatType(colPath, value.expr.dataType, MIN)(_ < value)
+    statsProvider.getPredicateWithStatTypeIfExists(colPath, value.expr.dataType, MIN)(_ < value)
 
   def lessThanOrEqual(statsProvider: StatsProvider, colPath: Seq[String], value: Column)
     : Option[DataSkippingPredicate] =
-    statsProvider.getPredicateWithStatType(colPath, value.expr.dataType, MIN)(_ <= value)
+    statsProvider.getPredicateWithStatTypeIfExists(colPath, value.expr.dataType, MIN)(_ <= value)
 
   def greaterThan(statsProvider: StatsProvider, colPath: Seq[String], value: Column)
     : Option[DataSkippingPredicate] =
-    statsProvider.getPredicateWithStatType(colPath, value.expr.dataType, MAX)(_ > value)
+    statsProvider.getPredicateWithStatTypeIfExists(colPath, value.expr.dataType, MAX)(_ > value)
 
   def greaterThanOrEqual(statsProvider: StatsProvider, colPath: Seq[String], value: Column)
     : Option[DataSkippingPredicate] =
-    statsProvider.getPredicateWithStatType(colPath, value.expr.dataType, MAX)(_ >= value)
+    statsProvider.getPredicateWithStatTypeIfExists(colPath, value.expr.dataType, MAX)(_ >= value)
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -278,7 +278,7 @@ trait DataSkippingReaderBase
       pathToColumn: Seq[String]): Option[DataSkippingPredicate] = {
     val nullCountCol = StatsColumn(NULL_COUNT, pathToColumn, LongType)
     val numRecordsCol = StatsColumn(NUM_RECORDS, pathToColumn = Nil, LongType)
-    statsProvider.getPredicateWithStatsColumns(nullCountCol, numRecordsCol) {
+    statsProvider.getPredicateWithStatsColumnsIfExists(nullCountCol, numRecordsCol) {
       (nullCount, numRecords) => nullCount < numRecords
     }
   }
@@ -514,7 +514,7 @@ trait DataSkippingReaderBase
       // Note DVs might result in a redundant read of a file.
       // However, they cannot lead to a correctness issue.
       case IsNull(SkippingEligibleColumn(a, dt)) =>
-        statsProvider.getPredicateWithStatType(a, dt, NULL_COUNT) { nullCount =>
+        statsProvider.getPredicateWithStatTypeIfExists(a, dt, NULL_COUNT) { nullCount =>
           nullCount > Literal(0L)
         }
       case Not(IsNull(e)) =>
@@ -589,7 +589,7 @@ trait DataSkippingReaderBase
       // Similar to an equality test, except comparing against a prefix of the min/max stats, and
       // neither commutative nor invertible.
       case StartsWith(SkippingEligibleColumn(a, _), v @ Literal(s: UTF8String, dt: StringType)) =>
-        statsProvider.getPredicateWithStatTypes(a, dt, MIN, MAX) { (min, max) =>
+        statsProvider.getPredicateWithStatTypesIfExists(a, dt, MIN, MAX) { (min, max) =>
           val sLen = s.numChars()
           substring(min, 0, sLen) <= v && substring(max, 0, sLen) >= v
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatsProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatsProvider.scala
@@ -41,21 +41,21 @@ private [stats] class StatsProvider(getStat: StatsColumn => Option[Column]) {
    * @return A [[DataSkippingPredicate]] with a data skipping expression, or None if the given
    *         stats column does not exist.
    */
-  def getPredicateWithStatsColumn(statCol: StatsColumn)
+  def getPredicateWithStatsColumnIfExists(statCol: StatsColumn)
     (f: Column => Column): Option[DataSkippingPredicate] = {
     for (stat <- getStat(statCol))
       yield DataSkippingPredicate(f(stat), statCol)
   }
 
-  /** A variant of [[getPredicateWithStatsColumn]] with two stats columns. */
-  def getPredicateWithStatsColumns(statCol1: StatsColumn, statCol2: StatsColumn)
+  /** A variant of [[getPredicateWithStatsColumnIfExists]] with two stats columns. */
+  def getPredicateWithStatsColumnsIfExists(statCol1: StatsColumn, statCol2: StatsColumn)
     (f: (Column, Column) => Column): Option[DataSkippingPredicate] = {
     for (stat1 <- getStat(statCol1); stat2 <- getStat(statCol2))
       yield DataSkippingPredicate(f(stat1, stat2), statCol1, statCol2)
   }
 
-  /** A variant of [[getPredicateWithStatsColumn]] with three stats columns. */
-  def getPredicateWithStatsColumns(
+  /** A variant of [[getPredicateWithStatsColumnIfExists]] with three stats columns. */
+  def getPredicateWithStatsColumnsIfExists(
       statCol1: StatsColumn,
       statCol2: StatsColumn,
       statCol3: StatsColumn)
@@ -77,30 +77,30 @@ private [stats] class StatsProvider(getStat: StatsColumn => Option[Column]) {
    * @return A [[DataSkippingPredicate]] with a data skipping expression, or None if the given
    *         stats column does not exist.
    */
-  def getPredicateWithStatType(
+  def getPredicateWithStatTypeIfExists(
       pathToColumn: Seq[String], columnDataType: DataType, statType: String)
     (f: Column => Column): Option[DataSkippingPredicate] = {
-    getPredicateWithStatsColumn(StatsColumn(statType, pathToColumn, columnDataType))(f)
+    getPredicateWithStatsColumnIfExists(StatsColumn(statType, pathToColumn, columnDataType))(f)
   }
 
-  /** A variant of [[getPredicateWithStatType]] with two stat types. */
-  def getPredicateWithStatTypes(
+  /** A variant of [[getPredicateWithStatTypeIfExists]] with two stat types. */
+  def getPredicateWithStatTypesIfExists(
       pathToColumn: Seq[String], columnDataType: DataType, statType1: String, statType2: String)
     (f: (Column, Column) => Column): Option[DataSkippingPredicate] = {
-    getPredicateWithStatsColumns(
+    getPredicateWithStatsColumnsIfExists(
       StatsColumn(statType1, pathToColumn, columnDataType),
       StatsColumn(statType2, pathToColumn, columnDataType))(f)
   }
 
-  /** A variant of [[getPredicateWithStatType]] with three stat types. */
-  def getPredicateWithStatTypes(
+  /** A variant of [[getPredicateWithStatTypeIfExists]] with three stat types. */
+  def getPredicateWithStatTypesIfExists(
       pathToColumn: Seq[String],
       columnDataType: DataType,
       statType1: String,
       statType2: String,
       statType3: String)
     (f: (Column, Column, Column) => Column): Option[DataSkippingPredicate] = {
-    getPredicateWithStatsColumns(
+    getPredicateWithStatsColumnsIfExists(
       StatsColumn(statType1, pathToColumn, columnDataType),
       StatsColumn(statType2, pathToColumn, columnDataType),
       StatsColumn(statType3, pathToColumn, columnDataType))(f)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Change the name of `StatsProvider.getPredicateWithStatType` to be more clearer, to make it clear that when the column does not have stats, the return value is None.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs, just a naming change.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
