### PR TITLE
[Spark] Generate DV Tombstones with relative paths

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaUDF.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaUDF.scala
@@ -55,6 +55,10 @@ object DeltaUDF {
       f: DeletionVectorDescriptor => String): UserDefinedFunction =
     createUdfFromTemplateUnsafe(stringFromDeletionVectorDescriptorTemplate, f, udf(f))
 
+  def stringOptionFromDeletionVectorDescriptor(
+      f: DeletionVectorDescriptor => Option[String]): UserDefinedFunction =
+    createUdfFromTemplateUnsafe(stringOptionFromDeletionVectorDescriptorTemplate, f, udf(f))
+
   def booleanFromDeletionVectorDescriptor(
       f: DeletionVectorDescriptor => Boolean): UserDefinedFunction =
     createUdfFromTemplateUnsafe(booleanFromDeletionVectorDescriptorTemplate, f, udf(f))
@@ -91,6 +95,9 @@ object DeltaUDF {
 
   private lazy val stringFromDeletionVectorDescriptorTemplate =
     udf((_: DeletionVectorDescriptor) => "").asInstanceOf[SparkUserDefinedFunction]
+
+  private lazy val stringOptionFromDeletionVectorDescriptorTemplate =
+    udf((_: DeletionVectorDescriptor) => Some("")).asInstanceOf[SparkUserDefinedFunction]
 
   private lazy val booleanFromDeletionVectorDescriptorTemplate =
     udf((_: DeletionVectorDescriptor) => false).asInstanceOf[SparkUserDefinedFunction]

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
@@ -626,11 +626,14 @@ class DeltaFastDropFeatureSuite
       !protocol.readerFeatureNames.contains(DeletionVectorsTableFeature.name))
   }
 
-  private def validateTombstones(log: DeltaLog): Unit = {
+  private def validateTombstones(
+      log: DeltaLog,
+      expectedDVTombstoneCount: Option[Int] = None): Unit = {
     import org.apache.spark.sql.delta.implicits._
 
     val snapshot = log.update()
-    val dvPath = DeletionVectorDescriptor.urlEncodedPath(col("deletionVector"), log.dataPath)
+    val dvPath = DeletionVectorDescriptor
+      .urlEncodedRelativePathIfExists(col("deletionVector"), log.dataPath)
     val isDVTombstone = DeletionVectorDescriptor.isDeletionVectorPath(col("path"))
     val isInlineDeletionVector = DeletionVectorDescriptor.isInline(col("deletionVector"))
 
@@ -639,7 +642,8 @@ class DeltaFastDropFeatureSuite
       .filter("deletionVector IS NOT NULL")
       .filter(not(isInlineDeletionVector))
       .filter(not(isDVTombstone))
-      .select(dvPath)
+      .select(dvPath.as("path"))
+      .filter(col("path").isNotNull)
       .distinct()
       .as[String]
 
@@ -651,8 +655,10 @@ class DeltaFastDropFeatureSuite
 
     val dvTombstonesSet = dvTombstones.collect().toSet
 
-    assert(dvTombstonesSet.nonEmpty)
+    assert(dvTombstonesSet.nonEmpty || expectedDVTombstoneCount === Some(0))
+    assert(dvTombstonesSet.map(new Path(_)).forall(_.getParent.isRoot))
     assert(uniqueDvsFromParquetRemoveFiles.collect().toSet === dvTombstonesSet)
+    expectedDVTombstoneCount.foreach(expected => assert(dvTombstonesSet.size === expected))
   }
 
   for (withCommitLarge <- BOOLEAN_DOMAIN)
@@ -721,6 +727,48 @@ class DeltaFastDropFeatureSuite
       sql(s"ALTER TABLE delta.`${dir.getAbsolutePath}` DROP FEATURE deletionVectors")
 
       validateTombstones(deltaLog)
+    }
+  }
+  for (isShallowClone <- Seq(true))
+  test(s"We do not create redundant DV tombstones after cloning " +
+      s"isShallowClone: $isShallowClone") {
+    withTempPaths(2) { case Seq(sourceDir, targetDir) =>
+      val sourceLog = DeltaLog.forTable(spark, sourceDir.getAbsolutePath)
+      val targetLog = DeltaLog.forTable(spark, targetDir.getAbsolutePath)
+
+      createTableWithDeletionVectors(sourceLog)
+
+      io.delta.tables.DeltaTable.forPath(sourceLog.dataPath.toString).clone(
+        target = targetDir.getCanonicalPath,
+        isShallow = isShallowClone)
+
+      // We should not create any DV tombstones at this point since the shallow cloned table
+      // references the source table's data files.
+      val expectedDVTombstoneCount1 = Some(0)
+      dropDeletionVectors(targetLog)
+      validateTombstones(targetLog, expectedDVTombstoneCount1)
+
+      // Re-enable DVs in the target table.
+      sql(
+        s"""ALTER TABLE delta.`${targetDir.getAbsolutePath}`
+           |SET TBLPROPERTIES (
+           |delta.feature.${DeletionVectorsTableFeature.name} = 'enabled',
+           |${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key} = 'true'
+           |)""".stripMargin)
+
+      // Deleting rows causes shallow clone tables to create local files.
+      withSQLConf(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true") {
+        val targetTable = io.delta.tables.DeltaTable.forPath(targetDir.toString)
+        targetTable.delete("id > 20 and id <= 30")
+        assert(targetLog.update().numDeletionVectorsOpt === Some(2L))
+      }
+
+      sql(s"ALTER TABLE delta.`${targetDir.getAbsolutePath}` DROP FEATURE deletionVectors")
+
+      // Verify that the DV tombstones created exactly match the unique DV paths
+      // found in files with DVs.
+      val expectedDVTombstoneCount2 = Some(1)
+      validateTombstones(targetLog, expectedDVTombstoneCount2)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
When dropping Deletion Vectors with Fast Drop Feature we generate DV Tombstones. These are AddFiles that directly target all active DV files. There are operations in delta that may relativize the paths in the Actions of table. As a result, the DV tombstone paths created before such operation won't match anymore the DV descriptor paths. This PR resolves this issue by always creating DV tombstones with relative paths.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added new UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.