### PR TITLE
[4.0][KERNEL] Check that variant type exists in the schema when requiring shredding table feature to be enabled

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -235,7 +235,8 @@ public class TableFeatures {
 
     @Override
     public boolean metadataRequiresFeatureToBeEnabled(Protocol protocol, Metadata metadata) {
-      return TableConfig.VARIANT_SHREDDING_ENABLED.fromMetadata(metadata);
+      return hasTypeColumn(metadata.getSchema(), VARIANT)
+          && TableConfig.VARIANT_SHREDDING_ENABLED.fromMetadata(metadata);
     }
 
     @Override

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -127,11 +127,27 @@ class TableFeaturesSuite extends AnyFunSuite {
     // ("rowTracking", testMetadata(tblProps = Map("delta.enableRowTracking" -> "true")), true),
     (
       "variantShredding-preview",
-      testMetadata(tblProps = Map("delta.enableVariantShredding" -> "true")),
+      testMetadata(
+        tblProps = Map("delta.enableVariantShredding" -> "true"),
+        includeVariantTypeCol = true),
       true),
     (
       "variantShredding-preview",
-      testMetadata(tblProps = Map("delta.enableVariantShredding" -> "false")),
+      testMetadata(
+        tblProps = Map("delta.enableVariantShredding" -> "true"),
+        includeVariantTypeCol = false),
+      false),
+    (
+      "variantShredding-preview",
+      testMetadata(
+        tblProps = Map("delta.enableVariantShredding" -> "false"),
+        includeVariantTypeCol = true),
+      false),
+    (
+      "variantShredding-preview",
+      testMetadata(
+        tblProps = Map("delta.enableVariantShredding" -> "false"),
+        includeVariantTypeCol = false),
       false),
     ("rowTracking", testMetadata(tblProps = Map("delta.enableRowTracking" -> "false")), false),
     (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

cherry pick of #4607

https://github.com/delta-io/delta/pull/4542 added support for kernel-java to recognize the variantShredding-preview table feature.

https://github.com/delta-io/delta/pull/4521 is adding a change to only require the variantShredding-preview table feature when a variant column is present in the schema, so we do the same in Kernel.

## How was this patch tested?

UT. Existing golden file and UTs pass.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
