### PR TITLE
[Kernel][CatalogManaged] Refactor LogReplay to lazy-load P&M [Note: Snapshot still constructed with P&M eagerly]

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -188,6 +188,9 @@ public class SnapshotManager {
 
     long startTimeMillis = System.currentTimeMillis();
 
+    // Note: LogReplay now loads the protocol and metadata (P & M) lazily. Nonetheless, SnapshotImpl
+    //       is still constructed with an "eagerly"-loaded P & M.
+
     LogReplay logReplay =
         new LogReplay(
             logPath,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4641/files) to review incremental changes.
- [**stack/kernel_log_replay_refactor**](https://github.com/delta-io/delta/pull/4641) [[Files changed](https://github.com/delta-io/delta/pull/4641/files)]

---------
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

As part of the `catalogManaged` table support feature (#4573), we want our incoming `ResolvedTableBuilder` (#4614) to be able to receive from the Engine/Catalog the latest Protocol and Metadata for that pinned `ResolvedTable`.

Consequently, we won't always want replay the log to get the latest P & M -- we might just want to use what was given to us!

Thus, this PR makes `LogReplay` load the P & M lazily -- that is, not in the constructor.

This has no impact on existing call sites today:
- `SnapshotManager` -- will immediately then call `logReplay.getProtocol` to create the `SnapshotImpl`
- `TransactionBuilderImpl` -- just creates an `InitialSnapshot` with an `EmptyLogReplay` -- no changes needed

## How was this patch tested?

Just a refactor. Existing UTs

## Does this PR introduce _any_ user-facing changes?

No
