### PR TITLE
[Spark] Make CommittedTransaction NOT extend from DeltaTransaction

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -226,8 +226,8 @@ class HudiConverter(spark: SparkSession)
 
     // Get the most recently converted delta snapshot, if applicable
     val prevConvertedSnapshotOpt = (lastDeltaVersionConverted, txnOpt) match {
-      case (Some(version), Some(txn)) if version == txn.snapshot.version =>
-        Some(txn.snapshot)
+      case (Some(version), Some(txn)) if version == txn.readSnapshot.version =>
+        Some(txn.readSnapshot)
       // Check how long it has been since we last converted to Hudi. If outside the threshold,
       // fall back to state reconstruction to get the actions, to protect driver from OOMing.
       case (Some(version), _) if snapshotToConvert.version - version <= maxCommitsToConvert =>

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -308,8 +308,8 @@ class IcebergConverter(spark: SparkSession)
 
     // Get the most recently converted delta snapshot, if applicable
     val prevConvertedSnapshotOpt = (lastDeltaVersionConverted, txnOpt) match {
-      case (Some(version), Some(txn)) if version == txn.snapshot.version =>
-        Some(txn.snapshot)
+      case (Some(version), Some(txn)) if version == txn.readSnapshot.version =>
+        Some(txn.readSnapshot)
       // Check how long it has been since we last converted to Iceberg. If outside the threshold,
       // fall back to state reconstruction to get the actions, to protect driver from OOMing.
       case (Some(version), _) if snapshotToConvert.version - version <= maxCommitsToConvert =>
@@ -459,7 +459,7 @@ class IcebergConverter(spark: SparkSession)
       snapshotToConvert: Snapshot,
       txnOpt: Option[CommittedTransaction]): CatalogTable = {
     val disabledIceberg = txnOpt.map(txn =>
-      !UniversalFormat.icebergEnabled(txn.snapshot.metadata)
+      !UniversalFormat.icebergEnabled(txn.readSnapshot.metadata)
     ).getOrElse(!UniversalFormat.icebergEnabled(table.properties))
     val enablingUniform =
       disabledIceberg && UniversalFormat.icebergEnabled(snapshotToConvert.metadata)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo}
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
@@ -29,45 +29,34 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
  * This class encapsulates all relevant information about a transaction that has been successfully
  * committed. The main usage of this class is in running the post-commit hooks.
  *
- * @param txnId                     the unique identifier of the committed transaction.
- * @param deltaLog                  the [[DeltaLog]] instance for the table the transaction
- *                                  committed on.
- * @param catalogTable              the catalog table at the start of the transaction for the
- *                                  committed table.
- * @param snapshot                  the snapshot of the table at the time of the transaction's read.
- * @param metadata                  the metadata of the table after the txn committed.
- * @param protocol                  the protocol of the table after the txn committed.
- * @param committedVersion          the version of the table after the txn committed.
- * @param committedActions          the actions that were committed in this transaction.
- * @param postCommitSnapshot        the snapshot of the table after the txn successfully committed.
- *                                  NOTE: This may not match the committedVersion, if racing
- *                                  commits were written while the snapshot was computed.
- * @param postCommitHooks           the list of post-commit hooks to run after the commit.
- * @param finalTxnExecutionTimeMs   the time taken to execute the transaction.
- * @param finalNeedsCheckpoint      whether a checkpoint is needed after the commit.
- * @param finalPartitionsAddedToOpt the partitions that this txn added new files to.
- * @param finalIsBlindAppend        whether this transaction was a blind append.
+ * @param txnId                 the unique identifier of the committed transaction.
+ * @param deltaLog              the [[DeltaLog]] instance for the table the transaction
+ *                              committed on.
+ * @param catalogTable          the catalog table at the start of the transaction for the
+ *                              committed table.
+ * @param readSnapshot          the snapshot of the table at the time of the transaction's read.
+ * @param committedVersion      the version of the table after the txn committed.
+ * @param committedActions      the actions that were committed in this transaction.
+ * @param postCommitSnapshot    the snapshot of the table after the txn successfully committed.
+ *                              NOTE: This may not match the committedVersion, if racing
+ *                              commits were written while the snapshot was computed.
+ * @param postCommitHooks       the list of post-commit hooks to run after the commit.
+ * @param txnExecutionTimeMs    the time taken to execute the transaction.
+ * @param needsCheckpoint       whether a checkpoint is needed after the commit.
+ * @param partitionsAddedToOpt  the partitions that this txn added new files to.
+ * @param isBlindAppend         whether this transaction was a blind append.
  */
 case class CommittedTransaction(
     txnId: String,
     deltaLog: DeltaLog,
     catalogTable: Option[CatalogTable],
-    snapshot: Snapshot,
-    metadata: Metadata,
-    protocol: Protocol,
+    readSnapshot: Snapshot,
     committedVersion: Long,
     committedActions: Seq[Action],
     postCommitSnapshot: Snapshot,
     postCommitHooks: Seq[PostCommitHook],
-    finalTxnExecutionTimeMs: Long,
-    finalNeedsCheckpoint: Boolean,
-    finalPartitionsAddedToOpt: Option[mutable.HashSet[Map[String, String]]],
-    finalIsBlindAppend: Boolean
+    txnExecutionTimeMs: Long,
+    needsCheckpoint: Boolean,
+    partitionsAddedToOpt: Option[mutable.HashSet[Map[String, String]]],
+    isBlindAppend: Boolean
 )
-  extends DeltaTransaction
-{
-  override def txnExecutionTimeMs: Option[Long] = Some(finalTxnExecutionTimeMs)
-  needsCheckpoint = finalNeedsCheckpoint
-  partitionsAddedToOpt = finalPartitionsAddedToOpt
-  isBlindAppend = finalIsBlindAppend
-}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2775,17 +2775,15 @@ trait OptimisticTransactionImpl extends DeltaTransaction
       txnId = txnId,
       deltaLog = deltaLog,
       catalogTable = catalogTable,
-      snapshot = snapshot,
-      metadata = metadata,
-      protocol = protocol,
+      readSnapshot = snapshot,
       committedVersion = committedVersion,
       committedActions = committedActions,
       postCommitSnapshot = postCommitSnapshot,
       postCommitHooks = postCommitHooks.toSeq,
-      finalTxnExecutionTimeMs = txnExecutionTimeMs.get,
-      finalNeedsCheckpoint = needsCheckpoint,
-      finalPartitionsAddedToOpt = partitionsAddedToOpt,
-      finalIsBlindAppend = isBlindAppend
+      txnExecutionTimeMs = txnExecutionTimeMs.get,
+      needsCheckpoint = needsCheckpoint,
+      partitionsAddedToOpt = partitionsAddedToOpt,
+      isBlindAppend = isBlindAppend
     ))
 
   /** Register a hook that will be executed once a commit is successful. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompactUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompactUtils.scala
@@ -335,9 +335,7 @@ object AutoCompactUtils extends DeltaLogging {
    */
   def isQualifiedForAutoCompact(
       spark: SparkSession,
-      txn: DeltaTransaction): Boolean = {
-    // If txnExecutionTimeMs is empty, there is no transaction commit.
-    if (txn.txnExecutionTimeMs.isEmpty) return false
+      txn: CommittedTransaction): Boolean = {
     // If modified partitions only mode is not enabled, return true to avoid subsequent checking.
     if (!isModifiedPartitionsOnlyAutoCompactEnabled(spark)) return true
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -120,7 +120,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       val removedFileNames =
         spark.createDataset(removeFiles.collect { case r: RemoveFile => r.path }.toSeq).toDF("path")
       val partitionValuesOfRemovedFiles =
-        txn.snapshot.allFiles.join(removedFileNames, "path").select("partitionValues").persist()
+        txn.readSnapshot.allFiles.join(removedFileNames, "path").select("partitionValues").persist()
       try {
         val partitionsOfRemovedFiles = partitionValuesOfRemovedFiles
           .as[Map[String, String]](GenerateSymlinkManifestUtils.mapEncoder).collect().toSet

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
@@ -42,7 +42,7 @@ object IcebergConverterHook extends PostCommitHook with DeltaLogging {
 
     val converter = postCommitSnapshot.deltaLog.icebergConverter
     if (spark.sessionState.conf.getConf(DELTA_UNIFORM_ICEBERG_SYNC_CONVERT_ENABLED) ||
-         !UniversalFormat.icebergEnabled(txn.snapshot.metadata)) { // UniForm was not enabled
+         !UniversalFormat.icebergEnabled(txn.readSnapshot.metadata)) { // UniForm was not enabled
       converter.convertSnapshot(postCommitSnapshot, txn)
     } else {
       converter.enqueueSnapshotForConversion(postCommitSnapshot, txn)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.hooks
 
 import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.SparkSession


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Continuation of https://github.com/delta-io/delta/pull/4583

An OptimisticTransaction is currently used to keep track of in-progress transaction and also as a container for post-commit information about the transaction. This makes the semantics messy when it comes to post-commit usage. For example, it is possible for a post-commit hook to takes in an in-progress transaction, intentionally or not. A post-commit hook has access to mutable fields and may need to check whether a field is ready to be consumed or not.

Previously, we introduced DeltaTransaction to limit what can be accessed in a post-commit hook. However, that does not solve the in-progress vs. committed semantics problem and requires that if a new transaction implementation is introduced, it has to inherit all the var fields from the trait, so that it can be passed to the post-commit hooks.

This PR is part of a series of PRs to make the refactoring where:

- We introduce a new CommittedTransaction class, that is produced by every transaction implementation, to be passed to the post-commit hooks.
- We simplify the API of the post-commit hooks' run method so that it takes in only the CommittedTransaction struct.
- [This PR] We remove all var fields from DeltaTransaction and make CommittedTransaction not extend from DeltaTransaction.

## How was this patch tested?
Existing UTs

## Does this PR introduce _any_ user-facing changes?
 No
