### PR TITLE
[Spark] Refactor & Migrate `DeltaRetentionSuite` to CatalogOwned

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.DeltaOperations.Truncate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{CheckpointMetadata, Metadata, SidecarFile}
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames
@@ -41,7 +41,7 @@ import org.apache.spark.util.ManualClock
 
 trait DeltaRetentionSuiteBase extends QueryTest
   with SharedSparkSession
-  with CoordinatedCommitsBaseSuite {
+  with CatalogOwnedTestBaseSuite {
   protected val testOp = Truncate()
 
   protected override def sparkConf: SparkConf = super.sparkConf
@@ -102,7 +102,7 @@ trait DeltaRetentionSuiteBase extends QueryTest
   protected def getDeltaVersions(dir: File): Set[Long] = {
     val backfilledDeltaVersions = getFileVersions(getDeltaFiles(dir))
     val unbackfilledDeltaVersions = getUnbackfilledDeltaVersions(dir)
-    if (coordinatedCommitsEnabledInTests) {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
       // The unbackfilled commit files (except commit 0) should be a superset of the backfilled
       // commit files since they're always deleted together in this suite.
       assert(
@@ -195,7 +195,13 @@ trait DeltaRetentionSuiteBase extends QueryTest
   protected def day(startTime: Long, day: Int): Long =
     startTime + intervalStringToMillis(s"interval $day days")
 
-  // Create a sidecar file with given AddFiles inside it.
+  /**
+   * Creates a sidecar file with the given AddFiles.
+   *
+   * @param log The DeltaLog to which the sidecar file will be added.
+   * @param files A sequence of integers representing the AddFile indices.
+   * @return The name of the created sidecar file.
+   */
   protected def createSidecarFile(log: DeltaLog, files: Seq[Int]): String = {
     val sparkSession = spark
     // scalastyle:off sparkimplicits
@@ -203,7 +209,26 @@ trait DeltaRetentionSuiteBase extends QueryTest
     // scalastyle:on sparkimplicits
     var sidecarFileName: String = ""
     withTempDir { dir =>
-      val adds = files.map(i => createTestAddFile(i.toString))
+      val snapshot = log.unsafeVolatileSnapshot
+      val isRowTrackingEnabled = RowTracking.isEnabled(snapshot.protocol, snapshot.metadata)
+
+      val adds = files.map { i =>
+        val baseAddFile = createTestAddFile(i.toString)
+        if (isRowTrackingEnabled) {
+          // When [[RowTrackingFeature]] is enabled, assign `baseRowId` and
+          // `defaultRowCommitVersion` to match what would happen during actual commit.
+          // Otherwise, CRC validation will fail for subsequent commits after the first
+          // checkpoint, since the AddFiles from state reconstruction (checkpoint) differ
+          // from the incremental ones.
+          baseAddFile.copy(
+            baseRowId = Some((i - 1).toLong),
+            // Use 1L as the default row commit version for the mock AddFiles in the sidecar file.
+            defaultRowCommitVersion = Some(1L))
+        } else {
+          baseAddFile
+        }
+      }
+
       adds.map(_.wrap).toDF.repartition(1).write.mode("overwrite").parquet(dir.getAbsolutePath)
       val srcPath =
         new Path(dir.listFiles().filter(_.getName.endsWith("parquet")).head.getAbsolutePath)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR refactors and migrates `DeltaRetentionSuite` to CatalogOwned.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through existing UTs.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
