### PR TITLE
[Kernel] [Refactor] Move SnapshotQueryContext error reporting to instance method

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotQueryContext.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotQueryContext.java
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel.internal.metrics;
 
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.engine.MetricsReporter;
 import io.delta.kernel.metrics.SnapshotReport;
 import java.util.Optional;
 
@@ -86,6 +88,12 @@ public class SnapshotQueryContext {
    */
   public void setVersion(long updatedVersion) {
     version = Optional.of(updatedVersion);
+  }
+
+  /** Creates a {@link SnapshotReport} and pushes it to any {@link MetricsReporter}s. */
+  public void recordSnapshotErrorReport(Engine engine, Exception e) {
+    SnapshotReport snapshotReport = SnapshotReportImpl.forError(this, e);
+    engine.getMetricsReporters().forEach(reporter -> reporter.report(snapshotReport));
   }
 
   @Override


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4654/files) to review incremental changes.
- [**stack/kernel_refactor_snapshot_error_reporting**](https://github.com/delta-io/delta/pull/4654) [[Files changed](https://github.com/delta-io/delta/pull/4654/files)]

---------

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR moves the SnapshotQueryContext error reporting to an instance method. I want to be able to invoke the error reporting _on_ a SnnapshotQueryContext. This makes the error reporting logic re-usable, e.g. for our ResolvedTableBuilder that will want to do something similar.

## How was this patch tested?

Just a refactor. Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.