### PR TITLE
[Kernel][4.0] Block schema evolution via withSchema for 4.0

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -233,6 +233,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     latestSnapshot.ifPresent(
         snapshot -> validateWriteToExistingTable(engine, snapshot, isCreateOrReplace));
     validateTransactionInputs(engine, isCreateOrReplace);
+    checkArgument(
+        isCreateOrReplace || !schema.isPresent(), "Schema evolution is not supported currently");
 
     boolean enablesDomainMetadataSupport =
         needDomainMetadataSupport

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -233,8 +233,10 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     latestSnapshot.ifPresent(
         snapshot -> validateWriteToExistingTable(engine, snapshot, isCreateOrReplace));
     validateTransactionInputs(engine, isCreateOrReplace);
-    checkArgument(
-        isCreateOrReplace || !schema.isPresent(), "Schema evolution is not supported currently");
+    if (!isCreateOrReplace && schema.isPresent()) {
+      throw new UnsupportedOperationException(
+          "Schema can only be provided for new tables. Evolution is not currently supported");
+    }
 
     boolean enablesDomainMetadataSupport =
         needDomainMetadataSupport

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -33,6 +33,7 @@ import io.delta.kernel.types.{ArrayType, FieldMetadata, IntegerType, LongType, M
 import io.delta.kernel.utils.CloseableIterable
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
 
+import org.scalatest.Ignore
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables
 
@@ -40,6 +41,7 @@ import org.scalatest.prop.Tables
  * ToDo: Clean this up by moving some common schemas to fixtures and abstracting
  * the setup/run schema evolution/assert loop
  */
+@Ignore
 class DeltaTableSchemaEvolutionSuite extends DeltaTableWriteSuiteBase with ColumnMappingSuiteBase {
 
   test("Add nullable column succeeds and correctly updates maxFieldId") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -155,7 +155,7 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
   }
 
   Seq(true, false).foreach { cmInfoPopulated =>
-    test(
+    ignore(
       s"Column mapping metadata set correctly when cmInfoPrePopulated=$cmInfoPopulated") {
       withTempDirAndEngine { (tablePath, engine) =>
         // Create new table and verify column mapping info set correctly
@@ -213,7 +213,8 @@ class IcebergWriterCompatV1Suite extends DeltaTableWriteSuiteBase with ColumnMap
   }
 
   Seq(true, false).foreach { isNewTable =>
-    test(s"Cannot set physicalName to something other than col-{fieldId}, isNewTable=$isNewTable") {
+    ignore(s"Cannot set physicalName to something other than col-{fieldId}, " +
+      s"isNewTable=$isNewTable") {
       withTempDirAndEngine { (tablePath, engine) =>
         if (!isNewTable) {
           createEmptyTable(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This change will block schema evolution support in 4.0. There's more work to be done to make sure this API is really safe to prevent invalid field reorderings. We aim to get this out and ready for the next release but for now to prevent users from potentially breaking their table due to lack of this validation we'll block the operation.

## How was this patch tested?
It's blocking a feature so I'm just disabling the tests which used to test this feature

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
