### PR TITLE
[Kernel] [Refactor] Move `testMetadata` creation helper to separate test trait

### DIFF
--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuiteBase.scala
@@ -15,16 +15,13 @@
  */
 package io.delta.kernel.internal.util
 
-import java.util.{Collections, Optional}
-
 import scala.collection.JavaConverters._
 
-import io.delta.kernel.data.{ArrayValue, ColumnVector, MapValue}
 import io.delta.kernel.internal.TableConfig
-import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
+import io.delta.kernel.internal.actions.{Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.TableFeature
 import io.delta.kernel.internal.util.ColumnMapping.{COLUMN_MAPPING_ID_KEY, COLUMN_MAPPING_NESTED_IDS_KEY}
-import io.delta.kernel.test.VectorTestUtils
+import io.delta.kernel.test.ActionUtils
 import io.delta.kernel.types.{ArrayType, FieldMetadata, IntegerType, MapType, StringType, StructField, StructType}
 
 import org.assertj.core.api.Assertions.assertThat
@@ -34,7 +31,7 @@ import org.assertj.core.util.Maps
  * Common utilities for column mapping and iceberg compat v2 related nested column mapping
  * functionality
  */
-trait ColumnMappingSuiteBase extends VectorTestUtils {
+trait ColumnMappingSuiteBase extends ActionUtils {
 
   /* Asserts that the given field has the expected column mapping info */
   def assertColumnMapping(
@@ -229,30 +226,6 @@ trait ColumnMappingSuiteBase extends VectorTestUtils {
 
     assertThat(metadata.getConfiguration)
       .containsEntry(ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY, fieldId.toString)
-  }
-
-  /** create test metadata object */
-  def testMetadata(
-      schema: StructType,
-      partitionCols: Seq[String] = Seq.empty,
-      tblProps: Map[String, String] = Map.empty): Metadata = {
-    new Metadata(
-      "id",
-      Optional.of("name"),
-      Optional.of("description"),
-      new Format("parquet", Collections.emptyMap()),
-      schema.toJson,
-      schema,
-      new ArrayValue() { // partitionColumns
-        override def getSize: Int = partitionCols.size
-        override def getElements: ColumnVector = stringVector(partitionCols)
-      },
-      Optional.empty(),
-      new MapValue() { // conf
-        override def getSize: Int = tblProps.size
-        override def getKeys: ColumnVector = stringVector(tblProps.toSeq.map(_._1))
-        override def getValues: ColumnVector = stringVector(tblProps.toSeq.map(_._2))
-      })
   }
 
   def testProtocol(tableFeatures: TableFeature*): Protocol = {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.test
+
+import java.util.{Collections, Optional}
+
+import io.delta.kernel.data.{ArrayValue, ColumnVector, MapValue}
+import io.delta.kernel.internal.actions.{Format, Metadata}
+import io.delta.kernel.types.StructType
+
+trait ActionUtils extends VectorTestUtils {
+  def testMetadata(
+      schema: StructType,
+      partitionCols: Seq[String] = Seq.empty,
+      tblProps: Map[String, String] = Map.empty): Metadata = {
+    new Metadata(
+      "id",
+      Optional.of("name"),
+      Optional.of("description"),
+      new Format("parquet", Collections.emptyMap()),
+      schema.toJson,
+      schema,
+      new ArrayValue() { // partitionColumns
+        override def getSize: Int = partitionCols.size
+        override def getElements: ColumnVector = stringVector(partitionCols)
+      },
+      Optional.empty(),
+      new MapValue() { // conf
+        override def getSize: Int = tblProps.size
+        override def getKeys: ColumnVector = stringVector(tblProps.toSeq.map(_._1))
+        override def getValues: ColumnVector = stringVector(tblProps.toSeq.map(_._2))
+      })
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4657/files) to review incremental changes.
- [**stack/kernel_test_refactor_metadata_creation**](https://github.com/delta-io/delta/pull/4657) [[Files changed](https://github.com/delta-io/delta/pull/4657/files)]

---------

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

In kernel tests, we should easily and succinctly be able to create a new Metadata object.

This PR moves such a helper method to a reusable trait.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No
