### PR TITLE
[Kernel] [CatalogManaged] Create ScanBuilder from ResolvedTable; Run E2E read tests using new TableManager APIs

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableFactory.java
@@ -76,7 +76,14 @@ class ResolvedTableFactory {
     final Metadata metadata = getMetadata(logReplay);
 
     return new ResolvedTableInternalImpl(
-        resolvedPath, version, protocol, metadata, lazyLogSegment, logReplay, ctx.clock);
+        resolvedPath,
+        version,
+        protocol,
+        metadata,
+        lazyLogSegment,
+        logReplay,
+        ctx.clock,
+        snapshotCtx);
   }
 
   private SnapshotQueryContext getSnapshotQueryContext() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableInternal.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableInternal.java
@@ -17,12 +17,14 @@
 package io.delta.kernel.internal.table;
 
 import io.delta.kernel.ResolvedTable;
+import io.delta.kernel.internal.actions.DomainMetadata;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.lang.Lazy;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.util.Clock;
+import java.util.Map;
 
 /**
  * Internal extension of {@link ResolvedTable} that exposes additional interfaces to provides access
@@ -37,6 +39,8 @@ public interface ResolvedTableInternal extends ResolvedTable {
   Metadata getMetadata();
 
   Clock getClock();
+
+  Map<String, DomainMetadata> getActiveDomainMetadataMap();
 
   @VisibleForTesting
   LogSegment getLogSegment();

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/test/AbstractTableManagerAdapter.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/test/AbstractTableManagerAdapter.scala
@@ -34,6 +34,10 @@ import io.delta.kernel.engine.Engine
  * [[io.delta.kernel.defaults.utils.TestUtilsWithTableManagerAPIs]].
  */
 trait AbstractTableManagerAdapter {
+
+  /** Does this adapter support resolving a timestamp to a version? */
+  def supportsTimestampResolution: Boolean
+
   def getResolvedTableAdapterAtLatest(engine: Engine, path: String): AbstractResolvedTableAdapter
 
   def getResolvedTableAdapterAtVersion(
@@ -51,6 +55,8 @@ trait AbstractTableManagerAdapter {
  * Legacy implementation using the [[Table.forPath]] API which then wraps a [[Snapshot]].
  */
 class LegacyTableManagerAdapter extends AbstractTableManagerAdapter {
+  override def supportsTimestampResolution: Boolean = true
+
   override def getResolvedTableAdapterAtLatest(
       engine: Engine,
       path: String): AbstractResolvedTableAdapter = {
@@ -77,6 +83,8 @@ class LegacyTableManagerAdapter extends AbstractTableManagerAdapter {
  * [[ResolvedTable]].
  */
 class TableManagerAdapter extends AbstractTableManagerAdapter {
+  override def supportsTimestampResolution: Boolean = false
+
   override def getResolvedTableAdapterAtLatest(
       engine: Engine,
       path: String): AbstractResolvedTableAdapter = {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4663/files) to review incremental changes.
- [**stack/kernel_catalog_managed_4**](https://github.com/delta-io/delta/pull/4663) [[Files changed](https://github.com/delta-io/delta/pull/4663/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR adds the minimal code to `ResolvedTable` to support creating `ScanBuilder`s

This PR also refactors `AbstractDeltaTableReadsSuite` to fully support, for all applicable tests, the `TableManagerAdapter` test APIs (that let us test with both (a) `TableManager` and `ResolvedTable` and (b) `Table` and `Snapshot` APIs

## How was this patch tested?

New child class implementation of `AbstractDeltaTableReadsSuite` for the new `TableManager` APIs.

## Does this PR introduce _any_ user-facing changes?

No.
