### PR TITLE
[Kernel] Introduce PeekableIterator class

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/PeekableIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/PeekableIterator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+public class PeekableIterator<T> implements Iterator<T> {
+  private final Iterator<T> iterator;
+  private Optional<T> peekedItem = Optional.empty();
+
+  public PeekableIterator(Iterator<T> iterator) {
+    this.iterator = iterator;
+  }
+
+  public T peek() {
+    if (!peekedItem.isPresent() && iterator.hasNext()) {
+      peekedItem = Optional.of(iterator.next());
+    }
+    if (!peekedItem.isPresent()) {
+      throw new NoSuchElementException("No element to peek");
+    }
+    return peekedItem.get();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return peekedItem.isPresent() || iterator.hasNext();
+  }
+
+  @Override
+  public T next() {
+    if (peekedItem.isPresent()) {
+      T result = peekedItem.get();
+      peekedItem = Optional.empty();
+      return result;
+    }
+    return iterator.next();
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/PeekableIteratorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/PeekableIteratorSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel
+import java.util.{Iterator => JIterator, NoSuchElementException}
+
+import scala.collection.JavaConverters.seqAsJavaListConverter
+
+import io.delta.kernel.utils.PeekableIterator
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PeekableIteratorSuite extends AnyFunSuite {
+
+  test("peek should return the next element without consuming it") {
+    val list = List(1, 2, 3).asJava
+    val peekable = new PeekableIterator(list.iterator())
+
+    assert(peekable.peek() === 1)
+    assert(peekable.peek() === 1) // Should return same element
+    assert(peekable.hasNext === true)
+    assert(peekable.next() === 1) // Should return the peeked element
+  }
+
+  test("peek should throw NoSuchElementException when no elements available") {
+    val emptyList = List.empty[Int].asJava
+    val peekable = new PeekableIterator(emptyList.iterator())
+
+    assertThrows[NoSuchElementException] {
+      peekable.peek()
+    }
+  }
+
+  test("peek and next should work correctly") {
+    val list = List(1, 2).asJava
+    val peekable = new PeekableIterator(list.iterator())
+
+    assert(peekable.hasNext === true)
+    assert(peekable.peek() === 1)
+    assert(peekable.next() === 1)
+
+    assert(peekable.hasNext === true)
+    assert(peekable.peek() === 2)
+    assert(peekable.next() === 2)
+
+    assert(peekable.hasNext === false)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Introduce PeekableIterator class, with this utils, we could check the head of a iterator without advancing.

It is prepared for some optimization like https://github.com/huan233usc/delta/pull/5

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit test
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No