### PR TITLE
[Kernel] Validate row tracking configs are not missing on existing tables

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -491,9 +491,24 @@ public class TransactionBuilderImpl implements TransactionBuilder {
             cols -> SchemaUtils.casePreservingEligibleClusterColumns(updatedSchema, cols));
 
     /* ----- 6: Update the METADATA with materialized row tracking column name if applicable----- */
-    Optional<Metadata> rowTrackingMetadata =
-        MaterializedRowTrackingColumn.assignMaterializedColumnNamesIfNeeded(
-            newMetadata.orElse(baseMetadata));
+    Optional<Metadata> rowTrackingMetadata = Optional.empty();
+    if (isCreateOrReplace) {
+      // For new tables, assign materialized column names if row tracking is enabled
+      rowTrackingMetadata =
+          MaterializedRowTrackingColumn.assignMaterializedColumnNamesIfNeeded(
+              newMetadata.orElse(baseMetadata));
+    } else {
+      // For existing tables, we block enabling/disabling row tracking because:
+      // 1. Enabling requires backfilling row IDs/commit versions, which is not supported in Kernel
+      // 2. Disabling is irreversible in Kernel (re-enabling not supported)
+      newMetadata.ifPresent(
+          metadata -> RowTracking.throwIfRowTrackingToggled(baseMetadata, metadata));
+
+      // For existing tables, validate that row tracking configs are present when row tracking
+      // is enabled
+      MaterializedRowTrackingColumn.validateRowTrackingConfigsNotMissing(
+          newMetadata.orElse(baseMetadata));
+    }
     if (rowTrackingMetadata.isPresent()) {
       newMetadata = rowTrackingMetadata;
     }
@@ -610,7 +625,6 @@ public class TransactionBuilderImpl implements TransactionBuilder {
    *         <li>the schema change is a valid schema change given the tables partition and
    *             clustering columns
    *       </ul>
-   *   <li>Enabling/disabling row tracking on existing tables is blocked
    *   <li>Materialized row tracking column names do not conflict with schema
    * </ul>
    */
@@ -688,13 +702,6 @@ public class TransactionBuilderImpl implements TransactionBuilder {
             // We allow new non-null fields in REPLACE since we know all existing data is removed
             true /* allowNewRequiredFields */);
       }
-    }
-
-    // Block enabling/disabling row tracking on existing tables because:
-    // 1. Enabling requires backfilling row IDs/commit versions, which is not supported in Kernel
-    // 2. Disabling is irreversible in Kernel (re-enabling not supported)
-    if (!isCreateOrReplace) {
-      RowTracking.throwIfRowTrackingToggled(oldMetadata, newMetadata);
     }
 
     MaterializedRowTrackingColumn.throwIfColumnNamesConflictWithSchema(newMetadata);

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -24,7 +24,7 @@ import scala.collection.immutable.Seq
 import io.delta.kernel.data.{FilteredColumnarBatch, Row}
 import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.exceptions.{InvalidTableException, KernelException}
 import io.delta.kernel.expressions.Literal
 import io.delta.kernel.internal.{InternalScanFileUtils, SnapshotImpl, TableConfig, TableImpl}
 import io.delta.kernel.internal.actions.{AddFile, SingleAction}
@@ -640,7 +640,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
 
       // Now try to perform an append operation on this existing table with missing configs
       // This should trigger the validation and throw the expected exception
-      val e = intercept[IllegalStateException] {
+      val e = intercept[InvalidTableException] {
         val dataBatch = generateData(testSchema, Seq.empty, Map.empty, 10, 1)
         appendData(engine, tablePath, data = prepareDataForCommit(dataBatch))
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR cherry-picks #4670.

This PR improves row tracking materialized column name assignment by:

- Making it explicit that row tracking column names are assigned only when creating new tables
- Adding validation to ensure row tracking column names already exist on existing tables when row tracking enabled.
If the configs are missing in this case (which should not happen), we now throw an error instead of silently assigning them.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

New unit tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.