### PR TITLE
[Kernel] Block writing data into column mapping enable table as it is not yet implemented

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -19,6 +19,7 @@ import static io.delta.kernel.internal.DeltaErrors.dataSchemaMismatch;
 import static io.delta.kernel.internal.DeltaErrors.partitionColumnMissingInData;
 import static io.delta.kernel.internal.TransactionImpl.getStatisticsColumns;
 import static io.delta.kernel.internal.data.TransactionStateRow.*;
+import static io.delta.kernel.internal.util.ColumnMapping.blockIfColumnMappingEnabled;
 import static io.delta.kernel.internal.util.PartitionUtils.getTargetDirectory;
 import static io.delta.kernel.internal.util.PartitionUtils.validateAndSanitizePartitionValues;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -36,7 +37,6 @@ import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.internal.data.TransactionStateRow;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdater;
-import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.*;
@@ -165,12 +165,7 @@ public interface Transaction {
     // - generating the generated columns
 
     boolean isIcebergCompatV2Enabled = isIcebergCompatV2Enabled(transactionState);
-    ColumnMapping.ColumnMappingMode columnMappingMode = getColumnMappingMode(transactionState);
-
-    if (columnMappingMode != ColumnMapping.ColumnMappingMode.NONE) {
-      throw new UnsupportedOperationException(
-          "Writing into column mapping enabled table is not supported yet.");
-    }
+    blockIfColumnMappingEnabled(transactionState);
 
     // TODO: set the correct schema once writing into column mapping enabled table is supported.
     String tablePath = getTablePath(transactionState);
@@ -211,6 +206,7 @@ public interface Transaction {
    */
   static DataWriteContext getWriteContext(
       Engine engine, Row transactionState, Map<String, Literal> partitionValues) {
+    blockIfColumnMappingEnabled(transactionState);
     StructType tableSchema = getLogicalSchema(transactionState);
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -36,6 +36,7 @@ import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.internal.data.TransactionStateRow;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdater;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.*;
@@ -164,6 +165,12 @@ public interface Transaction {
     // - generating the generated columns
 
     boolean isIcebergCompatV2Enabled = isIcebergCompatV2Enabled(transactionState);
+    ColumnMapping.ColumnMappingMode columnMappingMode = getColumnMappingMode(transactionState);
+
+    if (columnMappingMode != ColumnMapping.ColumnMappingMode.NONE) {
+      throw new UnsupportedOperationException(
+          "Writing into column mapping enabled table is not supported yet.");
+    }
 
     // TODO: set the correct schema once writing into column mapping enabled table is supported.
     String tablePath = getTablePath(transactionState);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
@@ -23,6 +23,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.*;
 import java.util.HashMap;
@@ -111,6 +112,20 @@ public class TransactionStateRow extends GenericRow {
     return Boolean.parseBoolean(
         getConfiguration(transactionState)
             .getOrDefault(TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey(), "false"));
+  }
+
+  /**
+   * Get the column mapping mode from the transaction state {@link Row} returned by {@link
+   * Transaction#getTransactionState(Engine)}
+   *
+   * @param transactionState
+   * @return ColumnMapping mode as {@link ColumnMapping.ColumnMappingMode}
+   */
+  public static ColumnMapping.ColumnMappingMode getColumnMappingMode(Row transactionState) {
+    String columnMappingModeStr =
+        getConfiguration(transactionState)
+            .getOrDefault(TableConfig.COLUMN_MAPPING_MODE.getKey(), "none");
+    return ColumnMapping.ColumnMappingMode.fromTableConfig(columnMappingModeStr);
   }
 
   /**


### PR DESCRIPTION
Currently the support is just for the metadata updates to column mapping enabled tables. Data path is not yet implemented. Block it so that the connectors won't write invalid data files.