### PR TITLE
[Spark] Fix DomainMetadata handling for RESTORE/CLONE table

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -235,7 +235,7 @@ abstract class CloneTableBase(
         // Handle DomainMetadata for cloning a table.
         if (deltaOperation.name == DeltaOperations.OP_CLONE) {
           actions ++=
-            DomainMetadataUtils.handleDomainMetadataForCloneTable(sourceSnapshot.domainMetadata)
+            DomainMetadataUtils.handleDomainMetadataForCloneTable(sourceSnapshot, txn.snapshot)
         }
       }
       val sourceName = sourceTable.name


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
For RESTORE TABLE and the CLONE command, we currently don't mark a DomainMetadata as removed when target snapshot has the DomainMetadata, but the source snapshot does not have that DomainMetadata.

The fix is to mark a DomainMetadata as removed during a RESTORE or CLONE command if:
1. The DomainMetadata is included in the list of DomainMetadata to remove for REPLACE TABLE (thereby excluding the row ID high water mark).
2. The DomainMetadata is not present in the list of DomainMetadata that would anyways be committed by the CLONE command.

## How was this patch tested?
See test changes. 

## Does this PR introduce _any_ user-facing changes?
No.
