### PR TITLE
[Kernel] Expose the clustering columns in txn report returned by the txn commit status

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionCommitResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionCommitResult.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.hook.PostCommitHook;
-import io.delta.kernel.metrics.TransactionMetricsResult;
+import io.delta.kernel.metrics.TransactionReport;
 import io.delta.kernel.utils.CloseableIterable;
 import java.util.List;
 
@@ -34,15 +34,13 @@ import java.util.List;
 public class TransactionCommitResult {
   private final long version;
   private final List<PostCommitHook> postCommitHooks;
-  private final TransactionMetricsResult transactionMetrics;
+  private final TransactionReport transactionReport;
 
   public TransactionCommitResult(
-      long version,
-      List<PostCommitHook> postCommitHooks,
-      TransactionMetricsResult transactionMetrics) {
+      long version, List<PostCommitHook> postCommitHooks, TransactionReport transactionReport) {
     this.version = version;
     this.postCommitHooks = requireNonNull(postCommitHooks);
-    this.transactionMetrics = requireNonNull(transactionMetrics);
+    this.transactionReport = requireNonNull(transactionReport);
   }
 
   /**
@@ -71,8 +69,8 @@ public class TransactionCommitResult {
     return postCommitHooks;
   }
 
-  /** @return the metrics for this transaction */
-  public TransactionMetricsResult getTransactionMetrics() {
-    return transactionMetrics;
+  /** @return the report and metrics for this transaction */
+  public TransactionReport getTransactionReport() {
+    return transactionReport;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -256,7 +256,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     if (!needsMetadataOrProtocolUpdate) {
       // TODO: fix this https://github.com/delta-io/delta/issues/4713
       // Return early if there is no metadata or protocol updates and isCreateOrReplace=false
-      return new TransactionImpl(
+      new TransactionImpl(
           false, // isCreateOrReplace
           table.getDataPath(),
           table.getLogPath(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -254,8 +254,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
             || enablesDomainMetadataSupport; // domain metadata support added
 
     if (!needsMetadataOrProtocolUpdate) {
+      // TODO: fix this https://github.com/delta-io/delta/issues/4713
       // Return early if there is no metadata or protocol updates and isCreateOrReplace=false
-      new TransactionImpl(
+      return new TransactionImpl(
           false, // isCreateOrReplace
           table.getDataPath(),
           table.getLogPath(),
@@ -265,7 +266,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
           latestSnapshot.get().getProtocol(), // reuse latest protocol
           latestSnapshot.get().getMetadata(), // reuse latest metadata
           setTxnOpt,
-          Optional.empty(), /* clustering cols=empty */
+          resolvedClusteringColumns, /* clustering cols=empty */
           false /* shouldUpdateClusteringDomainMetadata=false */,
           false /* shouldUpdateMetadata=false */,
           false /* shouldUpdateProtocol=false */,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -487,9 +487,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     // This is only done if clustering columns are explicitly set in this transaction.
     StructType updatedSchema = newMetadata.orElse(baseMetadata).getSchema();
     this.resolvedClusteringColumns =
-      initialClusteringColumns.isPresent() ?
-            initialClusteringColumns.map(
-                    cols -> SchemaUtils.casePreservingEligibleClusterColumns(updatedSchema, cols))
+        initialClusteringColumns.isPresent()
+            ? initialClusteringColumns.map(
+                cols -> SchemaUtils.casePreservingEligibleClusterColumns(updatedSchema, cols))
             : existingClusteringCols;
     shouldUpdateClusteringDomainMetadata = initialClusteringColumns.isPresent();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -266,6 +266,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
           latestSnapshot.get().getProtocol(), // reuse latest protocol
           latestSnapshot.get().getMetadata(), // reuse latest metadata
           setTxnOpt,
+          // TODO: not yet initialized, fix it as part of #4713
           resolvedClusteringColumns, /* clustering cols=empty */
           false /* shouldUpdateClusteringDomainMetadata=false */,
           false /* shouldUpdateMetadata=false */,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -791,8 +791,6 @@ public class TransactionImpl implements Transaction {
       } else if (TableFeatures.isClusteringTableFeatureSupported(protocol)
           && isReplaceTable()
           && !clusteringColumnsOpt.isPresent()) {
-        checkArgument(
-            shouldUpdateClusteringDomainMetadata, "Should update clustering domain metadata");
         // When clustering is in the writer features we require there to be a clustering domain
         // metadata present; when the table is no longer a clustered table this means we must have
         // a domain metadata with clusteringColumns=[]

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -791,7 +791,8 @@ public class TransactionImpl implements Transaction {
       } else if (TableFeatures.isClusteringTableFeatureSupported(protocol)
           && isReplaceTable()
           && !clusteringColumnsOpt.isPresent()) {
-        checkArgument(shouldUpdateClusteringDomainMetadata, "Should update clustering domain metadata");
+        checkArgument(
+            shouldUpdateClusteringDomainMetadata, "Should update clustering domain metadata");
         // When clustering is in the writer features we require there to be a clustering domain
         // metadata present; when the table is no longer a clustered table this means we must have
         // a domain metadata with clusteringColumns=[]

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -791,6 +791,7 @@ public class TransactionImpl implements Transaction {
       } else if (TableFeatures.isClusteringTableFeatureSupported(protocol)
           && isReplaceTable()
           && !clusteringColumnsOpt.isPresent()) {
+        checkArgument(shouldUpdateClusteringDomainMetadata, "Should update clustering domain metadata");
         // When clustering is in the writer features we require there to be a clustering domain
         // metadata present; when the table is no longer a clustered table this means we must have
         // a domain metadata with clusteringColumns=[]

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionReportImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionReportImpl.java
@@ -19,16 +19,13 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.expressions.Column;
-import io.delta.kernel.internal.util.SchemaUtils;
 import io.delta.kernel.metrics.SnapshotReport;
 import io.delta.kernel.metrics.TransactionMetricsResult;
 import io.delta.kernel.metrics.TransactionReport;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /** A basic POJO implementation of {@link TransactionReport} for creating them */
 public class TransactionReportImpl extends DeltaOperationReportImpl implements TransactionReport {
@@ -38,7 +35,7 @@ public class TransactionReportImpl extends DeltaOperationReportImpl implements T
   private final long snapshotVersion;
   private final Optional<UUID> snapshotReportUUID;
   private final Optional<Long> committedVersion;
-  private final List<String[]> clusteringColumns;
+  private final List<Column> clusteringColumns;
   private final TransactionMetricsResult transactionMetrics;
 
   /**
@@ -67,8 +64,7 @@ public class TransactionReportImpl extends DeltaOperationReportImpl implements T
     this.engineInfo = requireNonNull(engineInfo);
     this.transactionMetrics = requireNonNull(transactionMetrics).captureTransactionMetricsResult();
     this.committedVersion = committedVersion;
-    this.clusteringColumns = requireNonNull(clusteringColumns).orElse(Collections.emptyList())
-                    .stream().map(Column::getNames).collect(Collectors.toList());
+    this.clusteringColumns = requireNonNull(clusteringColumns).orElse(Collections.emptyList());
     requireNonNull(snapshotReport);
     checkArgument(
         !snapshotReport.getException().isPresent(),
@@ -101,8 +97,7 @@ public class TransactionReportImpl extends DeltaOperationReportImpl implements T
   }
 
   @Override
-  public List<String[]> getClusteringColumns()
-  {
+  public List<Column> getClusteringColumns() {
     return clusteringColumns;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionReport.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionReport.java
@@ -18,7 +18,6 @@ package io.delta.kernel.metrics;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.delta.kernel.expressions.Column;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -67,12 +66,11 @@ public interface TransactionReport extends DeltaOperationReport {
    * optional because clustering columns are not always defined for a table. Consumers of the
    * transaction report trigger clustering operations based on this list.
    *
-   * @return list of clustering columns for the table. The columns are physical
-   *  names of how the data is written in the data files. Each column is a array of strings
-   *  representing the column names, e.g. for a table with two clustering columns
-   *  "col1" and "col2.nestedCol2", the list will be [["col1"], ["col2", "nestedCol2"]].
+   * @return list of clustering columns for the table. The columns are physical names of how the
+   *     data is written in the data files. Each column can contain one or more elements
+   *     representing the hierarchy of the column names in case of nested columns.
    */
-  List<String[]> getClusteringColumns();
+  List<Column> getClusteringColumns();
 
   /**
    * @return the {@link SnapshotReport#getReportUUID} of the SnapshotReport for the transaction's

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionReport.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionReport.java
@@ -17,6 +17,9 @@ package io.delta.kernel.metrics;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.delta.kernel.expressions.Column;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,6 +35,7 @@ import java.util.UUID;
   "baseSnapshotVersion",
   "snapshotReportUUID",
   "committedVersion",
+  "clusteringColumns",
   "transactionMetrics"
 })
 public interface TransactionReport extends DeltaOperationReport {
@@ -57,6 +61,18 @@ public interface TransactionReport extends DeltaOperationReport {
    * @return the table version of the snapshot the transaction was started from
    */
   long getBaseSnapshotVersion();
+
+  /**
+   * Get the list of clustering columns the table data is expected to be clustered by. This is
+   * optional because clustering columns are not always defined for a table. Consumers of the
+   * transaction report trigger clustering operations based on this list.
+   *
+   * @return list of clustering columns for the table. The columns are physical
+   *  names of how the data is written in the data files. Each column is a array of strings
+   *  representing the column names, e.g. for a table with two clustering columns
+   *  "col1" and "col2.nestedCol2", the list will be [["col1"], ["col2", "nestedCol2"]].
+   */
+  List<String[]> getClusteringColumns();
 
   /**
    * @return the {@link SnapshotReport#getReportUUID} of the SnapshotReport for the transaction's

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -164,7 +164,8 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       "test-operation",
       "test-engine",
       Optional.of(2), /* committedVersion */
-      Optional.of(Collections.singletonList(new Column("test-clustering-col1"))),
+      Optional.of(Collections.singletonList(
+        new Column(Array[String]("test-clustering-col1", "nested")))),
       transactionMetrics1,
       snapshotReport1,
       Optional.of(exception))
@@ -181,7 +182,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"baseSnapshotVersion":1,
          |"snapshotReportUUID":"${snapshotReport1.getReportUUID}",
          |"committedVersion":2,
-         |"clusteringColumns":[["test-clustering-col1"]],
+         |"clusteringColumns":[["test-clustering-col1","nested"]],
          |"transactionMetrics":{
          |"totalCommitDurationNs":200,
          |"numCommitAttempts":2,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -16,9 +16,13 @@
 package io.delta.kernel.internal.metrics
 
 import java.util.{Collections, Optional, UUID}
+
+import scala.collection.JavaConverters._
+
 import io.delta.kernel.expressions.{Column, Literal, Predicate}
 import io.delta.kernel.metrics.{ScanReport, SnapshotReport, TransactionReport}
 import io.delta.kernel.types.{IntegerType, StructType}
+
 import org.scalatest.funsuite.AnyFunSuite
 
 class MetricsReportSerializerSuite extends AnyFunSuite {
@@ -109,6 +113,12 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       transactionReport.getSnapshotReportUUID().map(_.toString)
     val transactionMetrics = transactionReport.getTransactionMetrics
 
+    val clusterColString = transactionReport.getClusteringColumns
+      .asScala
+      .map(col =>
+        col.getNames.map(s => s""""$s"""").mkString("[", ",", "]"))
+      .mkString("[", ",", "]")
+
     val expectedJson =
       s"""
          |{"tablePath":"${transactionReport.getTablePath()}",
@@ -120,7 +130,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"baseSnapshotVersion":${transactionReport.getBaseSnapshotVersion()},
          |"snapshotReportUUID":${optionToString(snapshotReportUUID)},
          |"committedVersion":${optionToString(transactionReport.getCommittedVersion())},
-         |"clusteringColumns":${transactionReport.getClusteringColumns()},
+         |"clusteringColumns":$clusterColString,
          |"transactionMetrics":{
          |"totalCommitDurationNs":${transactionMetrics.getTotalCommitDurationNs},
          |"numCommitAttempts":${transactionMetrics.getNumCommitAttempts},

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -15,12 +15,10 @@
  */
 package io.delta.kernel.internal.metrics
 
-import java.util.{Optional, UUID}
-
+import java.util.{Collections, Optional, UUID}
 import io.delta.kernel.expressions.{Column, Literal, Predicate}
 import io.delta.kernel.metrics.{ScanReport, SnapshotReport, TransactionReport}
 import io.delta.kernel.types.{IntegerType, StructType}
-
 import org.scalatest.funsuite.AnyFunSuite
 
 class MetricsReportSerializerSuite extends AnyFunSuite {
@@ -122,6 +120,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"baseSnapshotVersion":${transactionReport.getBaseSnapshotVersion()},
          |"snapshotReportUUID":${optionToString(snapshotReportUUID)},
          |"committedVersion":${optionToString(transactionReport.getCommittedVersion())},
+         |"clusteringColumns":${transactionReport.getClusteringColumns()},
          |"transactionMetrics":{
          |"totalCommitDurationNs":${transactionMetrics.getTotalCommitDurationNs},
          |"numCommitAttempts":${transactionMetrics.getNumCommitAttempts},
@@ -155,6 +154,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       "test-operation",
       "test-engine",
       Optional.of(2), /* committedVersion */
+      Optional.of(Collections.singletonList(new Column("test-clustering-col1"))),
       transactionMetrics1,
       snapshotReport1,
       Optional.of(exception))
@@ -171,6 +171,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"baseSnapshotVersion":1,
          |"snapshotReportUUID":"${snapshotReport1.getReportUUID}",
          |"committedVersion":2,
+         |"clusteringColumns":[["test-clustering-col1"]],
          |"transactionMetrics":{
          |"totalCommitDurationNs":200,
          |"numCommitAttempts":2,
@@ -195,6 +196,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       "test-operation-2",
       "test-engine-2",
       Optional.empty(), /* committedVersion */
+      Optional.of(Collections.singletonList(new Column("test-clustering-col1"))),
       // empty/un-incremented transaction metrics
       TransactionMetrics.withExistingTableFileSizeHistogram(Optional.empty()),
       snapshotReport2,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
@@ -412,6 +412,8 @@ class DeltaTableClusteringSuite extends DeltaTableWriteSuiteBase {
         """{"clusteringColumns":[["id"],["part1"]]}""",
         false)
 
+      val newClusteringCols = List(new Column("id"), new Column("part1")) // will be updated in v1
+
       {
         val commitResult0 = appendData(
           engine,
@@ -420,6 +422,9 @@ class DeltaTableClusteringSuite extends DeltaTableWriteSuiteBase {
           testPartitionSchema,
           clusteringColsOpt = Some(testClusteringColumns),
           data = Seq(Map.empty[String, Literal] -> dataClusteringBatches1))
+        assertCommitResultHasClusteringCols(
+          commitResult0,
+          expectedClusteringCols = testClusteringColumns)
 
         val expData = dataClusteringBatches1.flatMap(_.toTestRows)
 
@@ -434,7 +439,10 @@ class DeltaTableClusteringSuite extends DeltaTableWriteSuiteBase {
         val commitResult1 = updateTableMetadata(
           engine,
           tablePath,
-          clusteringColsOpt = Some(List(new Column("id"), new Column("part1"))))
+          clusteringColsOpt = Some(newClusteringCols))
+        assertCommitResultHasClusteringCols(
+          commitResult1,
+          expectedClusteringCols = newClusteringCols)
 
         verifyCommitResult(commitResult1, expVersion = 1, expIsReadyForCheckpoint = false)
         verifyClusteringDMAndCRC(
@@ -446,6 +454,9 @@ class DeltaTableClusteringSuite extends DeltaTableWriteSuiteBase {
           engine,
           tablePath,
           data = Seq(Map.empty[String, Literal] -> dataClusteringBatches2))
+        assertCommitResultHasClusteringCols(
+          commitResult2,
+          expectedClusteringCols = newClusteringCols)
 
         val expData = dataClusteringBatches1.flatMap(_.toTestRows) ++
           dataClusteringBatches2.flatMap(_.toTestRows)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -619,4 +619,14 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
           emptyMap()))
       } else Optional.empty())
   }
+
+  protected def assertCommitResultHasClusteringCols(
+      commitResult: TransactionCommitResult,
+      expectedClusteringCols: Seq[Column]): Unit = {
+    val actualClusteringCols = commitResult.getTransactionReport.getClusteringColumns.asScala
+
+    assert(
+      actualClusteringCols === expectedClusteringCols,
+      s"Expected clustering columns: $expectedClusteringCols, but got: $actualClusteringCols")
+  }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -69,7 +69,9 @@ class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReport
         val txnCommitResult = timer.time(() =>
           transaction.commit(engine, actionsToCommit)) // Time the actual operation
         // Validate the txn metrics returned in txnCommitResult
-        validateTransactionMetrics(txnCommitResult.getTransactionMetrics, timer.totalDurationNs())
+        validateTransactionMetrics(
+          txnCommitResult.getTransactionReport.getTransactionMetrics,
+          timer.totalDurationNs())
       },
       expectException)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -590,7 +590,6 @@ class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReport
                 new Column(Array[String]("nested", "nestedName"))).asJava)
             .build(engine))
 
-
       // replace table (with no new clustering columns)
 
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -589,6 +589,10 @@ class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReport
                 new Column("name"),
                 new Column(Array[String]("nested", "nestedName"))).asJava)
             .build(engine))
+
+
+      // replace table (with no new clustering columns)
+
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -24,7 +24,7 @@ import io.delta.kernel._
 import io.delta.kernel.data.Row
 import io.delta.kernel.defaults.DeltaTableWriteSuiteBase
 import io.delta.kernel.engine._
-import io.delta.kernel.expressions.Literal
+import io.delta.kernel.expressions.{Column, Literal}
 import io.delta.kernel.internal.{TableConfig, TableImpl}
 import io.delta.kernel.internal.actions.{GenerateIcebergCompatActionUtils, SingleAction}
 import io.delta.kernel.internal.data.TransactionStateRow
@@ -95,6 +95,7 @@ class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReport
    * @param path table path to commit to
    * @param expectException whether we expect committing to throw an exception
    * @param expectedBaseSnapshotVersion expected snapshot version for the transaction
+   * @param expectedClusteringColumns expected clustering columns for the transaction
    * @param expectedNumAddFiles expected number of add files recorded in the metrics
    * @param expectedNumRemoveFiles expected number of remove files recorded in the metrics
    * @param expectedNumTotalActions expected number of total actions recorded in the metrics
@@ -110,6 +111,7 @@ class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReport
       path: String,
       expectException: Boolean,
       expectedBaseSnapshotVersion: Long,
+      expectedClusteringColumns: Seq[Column] = Seq.empty,
       expectedNumAddFiles: Long = 0,
       expectedNumRemoveFiles: Long = 0,
       expectedNumTotalActions: Long = 0,
@@ -190,6 +192,7 @@ class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReport
         transactionReport.getSnapshotReportUUID.toScala.contains(snapshotReport.getReportUUID)
       })
     }
+    assert(transactionReport.getClusteringColumns.asScala == expectedClusteringColumns)
     assert(transactionReport.getCommittedVersion.toScala == expectedCommitVersion)
     validateTransactionMetrics(transactionReport.getTransactionMetrics, duration)
   }
@@ -516,6 +519,76 @@ class TransactionReportSuite extends DeltaTableWriteSuiteBase with MetricsReport
           },
           operation = Operation.REPLACE_TABLE)
       }
+    }
+  }
+
+  test("TransactionReport: clustering columns are in transaction report") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val testSchema = new StructType()
+        .add("id", IntegerType.INTEGER)
+        .add("name", IntegerType.INTEGER)
+        .add(
+          "nested",
+          new StructType()
+            .add("nestedId", IntegerType.INTEGER)
+            .add("nestedName", IntegerType.INTEGER))
+
+      // create table
+      checkTransactionReport(
+        generateCommitActions = (_, _) => CloseableIterable.emptyIterable(),
+        tablePath,
+        expectException = false,
+        expectedBaseSnapshotVersion = -1,
+        expectedCommitVersion = Some(0),
+        expectedNumTotalActions = 4, // protocol, metadata, commitInfo, domainMetadata
+        expectedClusteringColumns = Seq(
+          new Column("id"),
+          new Column(Array[String]("nested", "nestedId"))),
+        expectedFileSizeHistogramResult = Some(
+          FileSizeHistogram.createDefaultHistogram().captureFileSizeHistogramResult()),
+        buildTransaction = (builder, engine) =>
+          builder
+            .withSchema(engine, testSchema)
+            .withClusteringColumns(
+              engine,
+              Seq(
+                new Column("id"),
+                new Column(Array[String]("nested", "nestedId"))).asJava)
+            .build(engine))
+
+      // update table (no clustering column change)
+      checkTransactionReport(
+        generateCommitActions = generateAppendActions(fileStatusIter1),
+        tablePath,
+        expectException = false,
+        expectedBaseSnapshotVersion = 0,
+        expectedCommitVersion = Some(1),
+        expectedNumTotalActions = 2, // commitInfo, one add file
+        expectedNumAddFiles = 1,
+        expectedTotalAddFilesSizeInBytes = 100,
+        expectedClusteringColumns = Seq(
+          new Column("id"),
+          new Column(Array[String]("nested", "nestedId"))))
+
+      // update clustering columns
+      checkTransactionReport(
+        generateCommitActions = (_, _) => CloseableIterable.emptyIterable(),
+        tablePath,
+        expectException = false,
+        expectedBaseSnapshotVersion = 1,
+        expectedCommitVersion = Some(2),
+        expectedNumTotalActions = 2, // commitInfo, domainMetadata
+        expectedClusteringColumns = Seq(
+          new Column("name"),
+          new Column(Array[String]("nested", "nestedName"))),
+        buildTransaction = (builder, engine) =>
+          builder
+            .withClusteringColumns(
+              engine,
+              Seq(
+                new Column("name"),
+                new Column(Array[String]("nested", "nestedName"))).asJava)
+            .build(engine))
     }
   }
 


### PR DESCRIPTION
## Description
Helps connectors decide on what further operations to trigger after the commit is done.

## How was this patch tested?
UTs and Integration tests