### PR TITLE
Ensure deletion vector fileId-URL entries are preserved during cache refresh

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
@@ -295,13 +295,6 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
     }
   }
 
-  // Only absolute path (which is pre-signed url) need to be put in IdToUrl mapping.
-  // inline DV should be processed in place, and UUID should throw error.
-  private def requiresIdToUrlForDV(deletionVectorOpt: Option[DeletionVectorDescriptor]): Boolean = {
-    deletionVectorOpt.isDefined &&
-    deletionVectorOpt.get.storageType == DeletionVectorDescriptor.PATH_DV_MARKER
-  }
-
   /**
    * Convert DeltaSharingFileAction with delta sharing file path and serialize as json to store in
    * the delta log.
@@ -663,7 +656,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
 
           // 1. build it to url mapping
           idToUrl(fileAction.id) = fileAction.path
-          if (requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
+          if (DeltaSharingUtils.requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
             idToUrl(fileAction.deletionVectorFileId) =
               fileAction.getDeletionVectorOpt.get.pathOrInlineDv
           }
@@ -799,7 +792,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
 
       // 1. build id to url mapping
       idToUrl(fileAction.id) = fileAction.path
-      if (requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
+      if (DeltaSharingUtils.requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
         idToUrl(fileAction.deletionVectorFileId) =
           fileAction.getDeletionVectorOpt.get.pathOrInlineDv
       }

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -20,7 +20,6 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.text.SimpleDateFormat
 import java.util.{TimeZone, UUID}
 
-import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 
 import org.apache.spark.sql.delta._
@@ -33,13 +32,12 @@ import io.delta.sharing.client.util.JsonUtils
 import org.apache.spark.SparkEnv
 import org.apache.spark.delta.sharing.TableRefreshResult
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.storage.{BlockId, StorageLevel}
 
 object DeltaSharingUtils extends Logging {
-
-  import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 
   val STREAMING_SUPPORTED_READER_FEATURES: Seq[String] =
     Seq(

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
@@ -32,48 +32,74 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
 
   type RefresherFunction = Option[String] => TableRefreshResult
   class SimpleTestDeltaSharingClient extends DeltaSharingClient {
-    def getAddFileStr(): String = {
-        s"""{"file":{
-           |  "id":"add_file_id1",
-           |  "expirationTimestamp":1721350999999,
-           |  "deltaSingleAction":{
-           |    "add":{
-           |      "path":"70/part-00000-df2a2a20.c000.snappy.parquet",
-           |      "partitionValues":{"col-partition":"3"},
-           |      "size":1213,
-           |      "modificationTime":1721350059000,
-           |      "dataChange":true,
-           |      "stats":"{\\"numRecords\\":20,\\"minValues\\":{\\"col-a\\":0},\\"maxValues\\":{\\"col-a\\":19},\\"nullCount\\":{\\"col-a\\":0}}",
-           |      "tags":{"INSERTION_TIME":"1721350059000000"}
-           |    }
-           |  }
-           |}}""".stripMargin
+    def getStatsStr(): String = {
+      """{
+        |  "numRecords": 20,
+        |  "minValues": { "col-a": 0 },
+        |  "maxValues": { "col-a": 19 },
+        |  "nullCount": { "col-a": 0 }
+        |}""".stripMargin
+        .replace("\n", "")
+        .replace(" ", "")
+        .replace("\"", "\\\"")
     }
 
-    def getDeletionVectorStr(): String = {
-      s"""{"file":{
-         |  "id":"add_file_id2",
-         |  "expirationTimestamp":1721350999999,
-         |  "deletionVectorFileId":"dv_file_id",
-         |  "deltaSingleAction":{
-         |    "add":{
-         |      "path":"70/part-00000-df2a2a20.c000.snappy.parquet",
-         |      "partitionValues":{"col-partition":"3"},
-         |      "size":1213,
-         |      "modificationTime":1721350059000,
-         |      "dataChange":true,
-         |      "stats":"{\\"numRecords\\":20,\\"minValues\\":{\\"col-a\\":0},\\"maxValues\\":{\\"col-a\\":19},\\"nullCount\\":{\\"col-a\\":0}}",
-         |      "tags":{"INSERTION_TIME":"1721350059000000"},
-         |      "deletionVector":{
-         |        "storageType":"p",
-         |        "pathOrInlineDv":":encoded:placeholder:",
-         |        "offset":1,
-         |        "sizeInBytes":34,
-         |        "cardinality":1
+    def getAddFileStr(): String = {
+      val stats = getStatsStr()
+      s"""{
+         |  "file": {
+         |    "id": "add_file_id1",
+         |    "expirationTimestamp": 1721350999999,
+         |    "deltaSingleAction": {
+         |      "add": {
+         |        "path": "70/part-00000-df2a2a20.c000.snappy.parquet",
+         |        "partitionValues": {
+         |          "col-partition": "3"
+         |        },
+         |        "size": 1213,
+         |        "modificationTime": 1721350059000,
+         |        "dataChange": true,
+         |        "stats": "$stats",
+         |        "tags": {
+         |          "INSERTION_TIME": "1721350059000000"
+         |        }
          |      }
          |    }
          |  }
-         |}}""".stripMargin
+         |}""".stripMargin
+    }
+
+    def getDeletionVectorStr(): String = {
+      val stats = getStatsStr()
+      s"""{
+         |  "file": {
+         |    "id": "add_file_id2",
+         |    "expirationTimestamp": 1721350999999,
+         |    "deletionVectorFileId": "dv_file_id",
+         |    "deltaSingleAction": {
+         |      "add": {
+         |        "path": "70/part-00000-df2a2a20.c000.snappy.parquet",
+         |        "partitionValues": {
+         |          "col-partition": "3"
+         |        },
+         |        "size": 1213,
+         |        "modificationTime": 1721350059000,
+         |        "dataChange": true,
+         |        "stats": "$stats",
+         |        "tags": {
+         |          "INSERTION_TIME": "1721350059000000"
+         |        },
+         |        "deletionVector": {
+         |          "storageType": "p",
+         |          "pathOrInlineDv": ":encoded:placeholder:",
+         |          "offset": 1,
+         |          "sizeInBytes": 34,
+         |          "cardinality": 1
+         |        }
+         |      }
+         |    }
+         |  }
+         |}""".stripMargin
     }
 
     def getCdcStr(): String = {

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
@@ -122,19 +122,21 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     override def getTableVersion(table: Table, startingTimestamp: Option[String] = None): Long = 0
 
     override def getMetadata(
-                     table: Table,
-                     versionAsOf: Option[Long] = None,
-                     timestampAsOf: Option[String] = None): DeltaTableMetadata
-    = throw new UnsupportedOperationException
+      table: Table,
+      versionAsOf: Option[Long] = None,
+      timestampAsOf: Option[String] = None
+    ): DeltaTableMetadata =
+      throw new UnsupportedOperationException
 
     override def getFiles(
-                  table: Table,
-                  predicates: Seq[String],
-                  limit: Option[Long],
-                  versionAsOf: Option[Long],
-                  timestampAsOf: Option[String],
-                  jsonPredicateHints: Option[String],
-                  refreshToken: Option[String]): DeltaTableFiles = {
+      table: Table,
+      predicates: Seq[String],
+      limit: Option[Long],
+      versionAsOf: Option[Long],
+      timestampAsOf: Option[String],
+      jsonPredicateHints: Option[String],
+      refreshToken: Option[String]
+    ): DeltaTableFiles = {
       val file = getAddFileStr()
       val dv = getDeletionVectorStr()
       DeltaTableFiles(
@@ -156,9 +158,9 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     }
 
     override def getCDFFiles(
-                     table: Table,
-                     cdfOptions: Map[String, String],
-                     includeHistoricalMetadata: Boolean): DeltaTableFiles = {
+      table: Table,
+      cdfOptions: Map[String, String],
+      includeHistoricalMetadata: Boolean): DeltaTableFiles = {
       val file = getAddFileStr()
       val dv = getDeletionVectorStr()
       val cdc = getCdcStr()

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
@@ -52,7 +52,7 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
          |    "expirationTimestamp": 1721350999999,
          |    "deltaSingleAction": {
          |      "add": {
-         |        "path": "70/part-00000-df2a2a20.c000.snappy.parquet",
+         |        "path": "c000.snappy.parquet",
          |        "partitionValues": {
          |          "col-partition": "3"
          |        },
@@ -78,7 +78,7 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
          |    "deletionVectorFileId": "dv_file_id",
          |    "deltaSingleAction": {
          |      "add": {
-         |        "path": "70/part-00000-df2a2a20.c000.snappy.parquet",
+         |        "path": "c001.snappy.parquet",
          |        "partitionValues": {
          |          "col-partition": "3"
          |        },
@@ -91,7 +91,7 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
          |        },
          |        "deletionVector": {
          |          "storageType": "p",
-         |          "pathOrInlineDv": ":encoded:placeholder:",
+         |          "pathOrInlineDv": "fakeurl",
          |          "offset": 1,
          |          "sizeInBytes": 34,
          |          "cardinality": 1
@@ -218,8 +218,11 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     val idToUrls = func(None).idToUrl
     assert(idToUrls.size == 3)
     assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.get("add_file_id1") == Some("c000.snappy.parquet"))
     assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.get("add_file_id2") == Some("c001.snappy.parquet"))
     assert(idToUrls.contains("dv_file_id"))
+    assert(idToUrls.get("dv_file_id") == Some("fakeurl"))
   }
 
   test("getRefresherForGetFilesWithStartingVersion with deletion vector") {
@@ -234,8 +237,11 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     val idToUrls = func(None).idToUrl
     assert(idToUrls.size == 3)
     assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.get("add_file_id1") == Some("c000.snappy.parquet"))
     assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.get("add_file_id2") == Some("c001.snappy.parquet"))
     assert(idToUrls.contains("dv_file_id"))
+    assert(idToUrls.get("dv_file_id") == Some("fakeurl"))
   }
 
   test("getRefresherForGetCDFFiles with deletion vector") {
@@ -249,8 +255,12 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     val idToUrls = func(None).idToUrl
     assert(idToUrls.size == 4)
     assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.get("add_file_id1") == Some("c000.snappy.parquet"))
     assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.get("add_file_id2") == Some("c001.snappy.parquet"))
     assert(idToUrls.contains("dv_file_id"))
+    assert(idToUrls.get("dv_file_id") == Some("fakeurl"))
     assert(idToUrls.contains("cdc_file_id"))
+    assert(idToUrls.get("cdc_file_id") == Some("_change_data/cdc.c000.snappy.parquet"))
   }
 }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
@@ -20,9 +20,130 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.{SharedSparkContext, SparkEnv, SparkFunSuite}
 import org.apache.spark.storage.BlockId
+import org.apache.spark.delta.sharing.TableRefreshResult
+
+import io.delta.sharing.client.model.Table
+import DeltaSharingUtils._
+import io.delta.sharing.client.DeltaSharingClient
+import io.delta.sharing.client.model.{DeltaTableFiles, DeltaTableMetadata}
+import io.delta.sharing.client.DeltaSharingRestClient
 
 class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
-  import DeltaSharingUtils._
+
+  type RefresherFunction = Option[String] => TableRefreshResult
+  class SimpleTestDeltaSharingClient extends DeltaSharingClient {
+    def getAddFileStr(): String = {
+        s"""{"file":{
+           |  "id":"add_file_id1",
+           |  "expirationTimestamp":1721350999999,
+           |  "deltaSingleAction":{
+           |    "add":{
+           |      "path":"70/part-00000-df2a2a20.c000.snappy.parquet",
+           |      "partitionValues":{"col-partition":"3"},
+           |      "size":1213,
+           |      "modificationTime":1721350059000,
+           |      "dataChange":true,
+           |      "stats":"{\\"numRecords\\":20,\\"minValues\\":{\\"col-a\\":0},\\"maxValues\\":{\\"col-a\\":19},\\"nullCount\\":{\\"col-a\\":0}}",
+           |      "tags":{"INSERTION_TIME":"1721350059000000"}
+           |    }
+           |  }
+           |}}""".stripMargin
+    }
+
+    def getDeletionVectorStr(): String = {
+      s"""{"file":{
+         |  "id":"add_file_id2",
+         |  "expirationTimestamp":1721350999999,
+         |  "deletionVectorFileId":"dv_file_id",
+         |  "deltaSingleAction":{
+         |    "add":{
+         |      "path":"70/part-00000-df2a2a20.c000.snappy.parquet",
+         |      "partitionValues":{"col-partition":"3"},
+         |      "size":1213,
+         |      "modificationTime":1721350059000,
+         |      "dataChange":true,
+         |      "stats":"{\\"numRecords\\":20,\\"minValues\\":{\\"col-a\\":0},\\"maxValues\\":{\\"col-a\\":19},\\"nullCount\\":{\\"col-a\\":0}}",
+         |      "tags":{"INSERTION_TIME":"1721350059000000"},
+         |      "deletionVector":{
+         |        "storageType":"p",
+         |        "pathOrInlineDv":":encoded:placeholder:",
+         |        "offset":1,
+         |        "sizeInBytes":34,
+         |        "cardinality":1
+         |      }
+         |    }
+         |  }
+         |}}""".stripMargin
+    }
+
+    def getCdcStr(): String = {
+      s"""{"file":{
+         |  "id":"cdc_file_id",
+         |  "expirationTimestamp":1721350999999,
+         |  "deltaSingleAction":{
+         |    "cdc":{
+         |      "path":"_change_data/cdc.c000.snappy.parquet",
+         |      "partitionValues":{},
+         |      "size":1213,
+         |      "modificationTime":1721350059000,
+         |      "dataChange":false
+         |    }
+         |  }
+         |}}""".stripMargin
+    }
+    override def listAllTables(): Seq[Table] = Seq.empty
+
+    override def getTableVersion(table: Table, startingTimestamp: Option[String] = None): Long = 0
+
+    override def getMetadata(
+                     table: Table,
+                     versionAsOf: Option[Long] = None,
+                     timestampAsOf: Option[String] = None): DeltaTableMetadata
+    = throw new UnsupportedOperationException
+
+    override def getFiles(
+                  table: Table,
+                  predicates: Seq[String],
+                  limit: Option[Long],
+                  versionAsOf: Option[Long],
+                  timestampAsOf: Option[String],
+                  jsonPredicateHints: Option[String],
+                  refreshToken: Option[String]): DeltaTableFiles = {
+      val file = getAddFileStr()
+      val dv = getDeletionVectorStr()
+      DeltaTableFiles(
+        version = 0L,
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
+        lines = Seq(file, dv)
+      )
+    }
+
+    override def getFiles(table: Table, startingVersion: Long, endingVersion: Option[Long])
+    : DeltaTableFiles = {
+      val file = getAddFileStr()
+      val dv = getDeletionVectorStr()
+      DeltaTableFiles(
+        version = 0L,
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
+        lines = Seq(file, dv)
+      )
+    }
+
+    override def getCDFFiles(
+                     table: Table,
+                     cdfOptions: Map[String, String],
+                     includeHistoricalMetadata: Boolean): DeltaTableFiles = {
+      val file = getAddFileStr()
+      val dv = getDeletionVectorStr()
+      val cdc = getCdcStr()
+      DeltaTableFiles(
+        version = 0L,
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
+        lines = Seq(file, dv, cdc)
+      )
+    }
+  }
+
 
   test("override single block in blockmanager works") {
     val blockId = BlockId(s"${DeltaSharingUtils.DELTA_SHARING_BLOCK_ID_PREFIX}_1")
@@ -54,5 +175,56 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     assert(getSeqFromBlockManager[Int](blockId) == Seq(1, 2))
     overrideIteratorBlock[String](blockId, values = Seq("3", "4").toIterator)
     assert(getSeqFromBlockManager[String](blockId) == Seq("3", "4"))
+  }
+
+  test("getRefresherForGetFiles with deletion vector") {
+    val client = new SimpleTestDeltaSharingClient()
+    val table = Table(name = "table", schema = "schema", share = "share")
+    val func: RefresherFunction = getRefresherForGetFiles(
+      client,
+      table,
+      Seq.empty,
+      None,
+      None,
+      None,
+      None
+    )
+    val idToUrls = func(None).idToUrl
+    assert(idToUrls.size == 3)
+    assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.contains("dv_file_id"))
+  }
+
+  test("getRefresherForGetFilesWithStartingVersion with deletion vector") {
+    val client = new SimpleTestDeltaSharingClient()
+    val table = Table(name = "table", schema = "schema", share = "share")
+    val func: RefresherFunction = getRefresherForGetFilesWithStartingVersion(
+      client,
+      table,
+      0L,
+      None
+    )
+    val idToUrls = func(None).idToUrl
+    assert(idToUrls.size == 3)
+    assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.contains("dv_file_id"))
+  }
+
+  test("getRefresherForGetCDFFiles with deletion vector") {
+    val client = new SimpleTestDeltaSharingClient()
+    val table = Table(name = "table", schema = "schema", share = "share")
+    val func: RefresherFunction = getRefresherForGetCDFFiles(
+      client,
+      table,
+      Map[String, String]("startingVersion" -> "0")
+    )
+    val idToUrls = func(None).idToUrl
+    assert(idToUrls.size == 4)
+    assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.contains("dv_file_id"))
+    assert(idToUrls.contains("cdc_file_id"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (delta-sharing)

## Description

[During cache registration](https://sourcegraph.prod.databricks-corp.com/databricks-eng/runtime/-/blob/sql/core/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala?L676-679), we store more fileId-URL entries than what the refresh logic stores. The additional entries come from files associated with deletion vectors. However, [the refresh logic does not include these deletion vector entries](https://sourcegraph.prod.databricks-corp.com/databricks-eng/runtime/-/blob/sql/core/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala?L142-155). As a result, if we query a Delta table in Delta format and the table contains deletion vectors, the refresh operation will drop the corresponding fileId-URL entries for those files.

This causes long running queries seeing file id not found errors.

## How was this patch tested?

Adding new test cases on refresh functions.

## Does this PR introduce _any_ user-facing changes?

No
