### PR TITLE
Add support for timestamp stats

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DataSkippingDeltaTestsUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DataSkippingDeltaTestsUtils.scala
@@ -1,0 +1,59 @@
+package io.delta.kernel.defaults
+
+import scala.collection.immutable.Seq
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.AddFile
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Expression, PredicateHelper}
+
+/**
+ * Encapsulates a few Delta-Spark DataSkipping Utils.
+ * E.g A helper to get files in a deltaScan after applying a predicate.
+ */
+trait DataSkippingDeltaTestsUtils extends PredicateHelper {
+  def parse(spark: SparkSession, deltaLog: DeltaLog, predicate: String): Seq[Expression] = {
+    if (predicate == "True") return Seq(
+      org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral)
+
+    val filtered = spark.read.format("delta").load(deltaLog.dataPath.toString).where(predicate)
+    filtered
+      .queryExecution
+      .optimizedPlan
+      .expressions
+      .flatMap(splitConjunctivePredicates).toList
+  }
+
+  def filesRead(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      predicate: String): Int = {
+    getFilesRead(spark, deltaLog, predicate, checkEmptyUnusedFilters = false).size
+  }
+
+  /**
+   * Returns the files that should be included in a scan after applying the given predicate on
+   * a snapshot of the Delta log.
+   *
+   * @param deltaLog                Delta log for a table.
+   * @param predicate               Predicate to run on the Delta table.
+   * @param checkEmptyUnusedFilters If true, check if there were no unused filters, meaning
+   *                                the given predicate was used as data or partition filters.
+   * @return The files that should be included in a scan after applying the predicate.
+   */
+  def getFilesRead(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      predicate: String,
+      checkEmptyUnusedFilters: Boolean): Seq[AddFile] = {
+    val parsed: Seq[Expression] = parse(spark, deltaLog, predicate)
+    val res = deltaLog.snapshot.filesForScan(parsed)
+    assert(res.total.files.get == deltaLog.snapshot.numOfFiles)
+    assert(res.total.bytesCompressed.get == deltaLog.snapshot.sizeInBytes)
+    assert(res.scanned.files.get == res.files.size)
+    assert(res.scanned.bytesCompressed.get == res.files.map(_.size).sum)
+    assert(!checkEmptyUnusedFilters || res.unusedFilters.isEmpty)
+    res.files.toList
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -33,7 +33,7 @@ import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.{Column, Literal}
 import io.delta.kernel.expressions.Literal.ofInt
 import io.delta.kernel.hook.PostCommitHook.PostCommitHookType
-import io.delta.kernel.internal.{SnapshotImpl, TableConfig, TableImpl}
+import io.delta.kernel.internal.{ScanImpl, SnapshotImpl, TableConfig, TableImpl}
 import io.delta.kernel.internal.actions.{Metadata, Protocol, SingleAction}
 import io.delta.kernel.internal.fs.{Path => DeltaPath}
 import io.delta.kernel.internal.util.{Clock, FileNames, VectorUtils}
@@ -574,6 +574,20 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       txnResult.getPostCommitHooks
         .stream()
         .anyMatch(hook => hook.getType == PostCommitHookType.CHECKPOINT) === isReadyForCheckpoint)
+  }
+
+  def collectStatsFromAddFiles(engine: Engine, path: String): Seq[String] = {
+    val snapshot = Table.forPath(engine, path).getLatestSnapshot(engine)
+    val scan = snapshot.getScanBuilder.build()
+    val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(engine, true)
+
+    scanFiles.asScala.toList.flatMap { scanFile =>
+      scanFile.getRows.asScala.toList.flatMap { row =>
+        val add = row.getStruct(row.getSchema.indexOf("add"))
+        val idx = add.getSchema.indexOf("stats")
+        if (idx >= 0 && !add.isNullAt(idx)) List(add.getString(idx)) else Nil
+      }
+    }
   }
 
   /**

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TimestampStatsAndDataSkippingTest.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TimestampStatsAndDataSkippingTest.scala
@@ -1,0 +1,280 @@
+package io.delta.kernel.defaults
+
+import java.io.File
+import java.time.{LocalDateTime, ZoneOffset}
+import java.util.Optional
+
+import scala.collection.immutable.Seq
+
+import io.delta.kernel.data.{ColumnarBatch, FilteredColumnarBatch}
+import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
+import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector
+import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
+import io.delta.kernel.expressions.Literal
+import io.delta.kernel.internal.util.JsonUtils
+import io.delta.kernel.types.{StructType, TimestampNTZType, TimestampType}
+
+import org.apache.spark.sql.delta.DeltaLog
+
+import org.apache.hadoop.fs.Path
+
+/**
+ * Tests timestamp statistics serialization and data skipping behavior
+ * for TIMESTAMP and TIMESTAMP_NTZ types.
+ */
+class TimestampStatsAndDataSkippingTest extends DeltaTableWriteSuiteBase
+    with DataSkippingDeltaTestsUtils
+    with ParquetSuiteBase {
+
+  test("verify on-disk TIMESTAMP stats format is equal when writing through spark and kernel") {
+    withTempDirAndEngine { (kernelPath, engine) =>
+      // Test with TIMESTAMP and TIMESTAMP_NTZ to verify serialization format
+      val schema = new StructType()
+        .add("timestampCol", TimestampType.TIMESTAMP)
+        .add("timestampNtzCol", TimestampNTZType.TIMESTAMP_NTZ)
+
+      // Create different batches with different timestamp ranges to test multiple boundaries
+      val timestampRanges = Seq(
+        ("2019-06-09 01:02:04.123456", "2019-09-09 01:02:04.123999"),
+        ("2019-06-09 01:02:04.123456", "2019-09-09 01:02:05.123999"),
+        // Microsecond boundary
+        ("2019-09-09 01:02:03.456789", "2019-09-09 01:02:03.456999"),
+        // End-of-millisecond boundary
+        ("2019-09-09 01:02:03.999000", "2019-09-09 01:02:03.999999"),
+        ("2019-09-09 01:02:04.123456", "2019-09-09 01:02:04.123999"))
+
+      // Write through Kernel
+      timestampRanges.zipWithIndex.foreach { case ((minTs, maxTs), fileIndex) =>
+        val batch = createMixedTimestampBatch(schema, minTs, maxTs, rowsPerFile = 10)
+        appendData(
+          engine,
+          kernelPath,
+          isNewTable = fileIndex == 0,
+          schema,
+          partCols = Seq.empty,
+          data = Seq(Map.empty[String, Literal] -> Seq(
+            new FilteredColumnarBatch(batch, Optional.empty()))))
+      }
+
+      // Read each file individually from Kernel location and write through Spark
+      val sparkTablePath = new File(kernelPath, "spark-copy").getAbsolutePath
+      val kernelDf = spark.read.format("delta").load(kernelPath)
+      val kernelFiles = kernelDf.inputFiles
+
+      log.info(s"Found ${kernelFiles.length} files from Kernel")
+
+      withSparkTimeZone("UTC") {
+        kernelFiles.zipWithIndex.foreach { case (filePath, fileIndex) =>
+          val singleFileDf = spark.read.parquet(filePath)
+          if (fileIndex == 0) {
+            // First file - create new table
+            singleFileDf.write.format("delta").mode("overwrite").save(sparkTablePath)
+          } else {
+            // Subsequent files - append to existing table
+            singleFileDf.write.format("delta").mode("append").save(sparkTablePath)
+          }
+        }
+      }
+
+      val mapper = JsonUtils.mapper()
+      val kernelStats = collectStatsFromAddFiles(engine, kernelPath).map(mapper.readTree)
+      val sparkStats = collectStatsFromAddFiles(engine, sparkTablePath).map(mapper.readTree)
+
+      require(
+        kernelStats.nonEmpty && sparkStats.nonEmpty,
+        "stats collected from AddFiles should be non-empty")
+      assert(
+        kernelStats.toSet == sparkStats.toSet,
+        s"\nKernel stats:\n${kernelStats.mkString("\n")}\n" +
+          s"Spark  stats:\n${sparkStats.mkString("\n")}")
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // Timestamp Data Skipping Tests that mirror those of Delta-Spark
+  //////////////////////////////////////////////////////////////////////////////////
+  for (timestampType <- Seq(TimestampType.TIMESTAMP, TimestampNTZType.TIMESTAMP_NTZ)) {
+    test(s"validate basic delta-spark data-skipping on ${timestampType.getClass.getSimpleName}") {
+      withTempDirAndEngine { (kernelPath, engine) =>
+        val schema = new StructType().add("ts", timestampType)
+
+        // Generate multiple files with different timestamp ranges.
+        val timestampRanges = Seq(
+          ("2019-01-01 12:00:00.123456", "2019-01-01 18:00:00.999999"),
+          ("2019-09-09 01:02:03.456789", "2019-09-09 01:02:03.456789"),
+          ("2019-12-31 20:00:00.100000", "2019-12-31 23:59:59.999999"),
+          ("2020-06-15 10:30:45.555555", "2020-06-15 15:45:30.888888"),
+          ("2021-03-20 08:15:22.777777", "2021-03-20 16:42:18.333333"))
+
+        timestampRanges.zipWithIndex.foreach { case ((minTs, maxTs), fileIndex) =>
+          val batch = createTimestampBatch(schema, minTs, maxTs, rowsPerFile = 10)
+
+          appendData(
+            engine,
+            kernelPath,
+            isNewTable = fileIndex == 0,
+            schema,
+            partCols = Seq.empty,
+            data = Seq(Map.empty[String, Literal] -> Seq(
+              new FilteredColumnarBatch(batch, Optional.empty()))))
+        }
+
+        // Query with all predicates in UTC for this test.
+        // We mainly want to validate that the scan results are correct.
+        withSparkTimeZone("UTC") {
+          val deltaLogPath = DeltaLog.forTable(spark, new Path(kernelPath))
+
+          val exactHits = Seq(
+            // Files 1,2,3,4
+            (s"ts >= ${createTimestampLiteral(timestampType, "2019-09-09 01:02:03.456789")}", 4),
+            // Files 1,2,3,4 (millisecond expansion)
+            (s"ts <= ${createTimestampLiteral(timestampType, "2019-09-09 01:02:03.456789")}", 2),
+            // Files 1,2,3,4 (tests millisecond expansion in MAX due to truncation)
+            (s"ts >= ${createTimestampLiteral(timestampType, "2019-09-09 01:02:03.456790")}", 4),
+            // File 1 only
+            (s"ts = ${createTimestampLiteral(timestampType, "2019-09-09 01:02:03.456789")}", 1))
+
+          exactHits.foreach { case (predicate, expectedFiles) =>
+            val filesHit = filesRead(spark, deltaLogPath, predicate)
+            assert(
+              filesHit == expectedFiles,
+              s"Expected exactly $expectedFiles files for: $predicate, but got $filesHit files")
+          }
+
+          // Test range queries (should hit multiple files)
+          val rangeHits = Seq(
+            (s"ts >= ${createTimestampLiteral(timestampType, "2019-01-01 00:00:00")}", 5),
+            (s"ts >= ${createTimestampLiteral(timestampType, "2020-01-01 00:00:00")}", 3),
+            (s"ts >= ${createTimestampLiteral(timestampType, "2019-06-01 00:00:00")}", 4),
+            (s"ts <= ${createTimestampLiteral(timestampType, "2019-06-01 00:00:00")}", 1),
+            (
+              s"ts BETWEEN ${createTimestampLiteral(timestampType, "2019-09-01 00:00:00")} " +
+                s"AND ${createTimestampLiteral(timestampType, "2019-09-30 23:59:59")}",
+              1),
+            (
+              s"ts BETWEEN ${createTimestampLiteral(timestampType, "2019-01-01 00:00:00")} " +
+                s"AND ${createTimestampLiteral(timestampType, "2019-12-31 23:59:59")}",
+              3))
+
+          rangeHits.foreach { case (predicate, expectedFiles) =>
+            val filesHit = filesRead(spark, deltaLogPath, predicate)
+            assert(
+              filesHit == expectedFiles,
+              s"Expected exactly $expectedFiles files for: $predicate, but got $filesHit files")
+          }
+
+          // Test precise misses (outside the millisecond range due to truncation )
+          val preciseCases = Seq(
+            // Files 1, 2, 3. Next millisecond
+            // ${createTimestampLiteral(timestampType, "2019-01-01 00:00:00")}
+            (s"ts > ${createTimestampLiteral(timestampType, "2019-09-09 01:02:03.457000")}", 3),
+            (s"ts < ${createTimestampLiteral(timestampType, "2019-09-09 01:02:03.456000")}", 1),
+            // Year boundary
+            (s"ts >= ${createTimestampLiteral(timestampType, "2020-01-01 00:00:00.000001")}", 2),
+            // True misses (0 files)
+            (s"ts >= ${createTimestampLiteral(timestampType, "2022-01-01 00:00:00")}", 0),
+            (s"ts <= ${createTimestampLiteral(timestampType, "2018-01-01 00:00:00")}", 0))
+
+          preciseCases.foreach { case (predicate, expectedFiles) =>
+            val filesHit = filesRead(spark, deltaLogPath, predicate)
+            assert(
+              filesHit == expectedFiles,
+              s"Expected exactly $expectedFiles files for: $predicate, but got $filesHit files")
+          }
+
+          // Test that we have the expected total number of files
+          val totalFiles = filesRead(spark, deltaLogPath, "TRUE")
+          assert(totalFiles == 5, s"Expected 5 total files, but got $totalFiles")
+        }
+      }
+    }
+  }
+
+  /**
+   * Create a mixed batch with various microsecond precision timestamps for fair Spark comparison
+   */
+  private def createMixedTimestampBatch(
+      schema: StructType,
+      minTimestampStr: String,
+      maxTimestampStr: String,
+      rowsPerFile: Int): ColumnarBatch = {
+
+    val minMicros = parseTimestampToMicros(minTimestampStr)
+    val maxMicros = parseTimestampToMicros(maxTimestampStr)
+
+    val timestampValues = (0 until rowsPerFile).map { rowIndex =>
+      if (rowIndex % 5 == 0) {
+        null // Some nulls for realistic data
+      } else {
+        // Distribute timestamps between min and max with microsecond precision
+        val fraction = rowIndex.toDouble / (rowsPerFile - 1)
+        val interpolatedMicros = minMicros + ((maxMicros - minMicros) * fraction).toLong
+        interpolatedMicros
+      }
+    }.toArray.asInstanceOf[Array[AnyRef]]
+
+    // TIMESTAMP column
+    val timestampVector = DefaultGenericVector.fromArray(
+      schema.fields().get(0).getDataType,
+      timestampValues)
+
+    // TIMESTAMP_NTZ column (same values)
+    val timestampNtzVector = DefaultGenericVector.fromArray(
+      schema.fields().get(1).getDataType,
+      timestampValues)
+
+    new DefaultColumnarBatch(rowsPerFile, schema, Array(timestampVector, timestampNtzVector))
+  }
+
+  /**
+   * Create a batch of timestamp data within a specific range
+   */
+  private def createTimestampBatch(
+      schema: StructType,
+      minTimestampStr: String,
+      maxTimestampStr: String,
+      rowsPerFile: Int): ColumnarBatch = {
+
+    val minMicros = parseTimestampToMicros(minTimestampStr)
+    val maxMicros = parseTimestampToMicros(maxTimestampStr)
+
+    // Generate timestamps distributed between min and max
+    val timestampValues = (0 until rowsPerFile).map { rowIndex =>
+      if (rowIndex != 0 && rowIndex % 4 == 0) {
+        null // Some nulls for realistic data
+      } else {
+        // Distribute timestamps across the range
+        val fraction = rowIndex.toDouble / (rowsPerFile - 1)
+        val interpolatedMicros = minMicros + ((maxMicros - minMicros) * fraction).toLong
+        interpolatedMicros
+      }
+    }.toArray.asInstanceOf[Array[AnyRef]]
+
+    val timestampVector = DefaultGenericVector.fromArray(
+      schema.fields().get(0).getDataType,
+      timestampValues)
+
+    new DefaultColumnarBatch(rowsPerFile, schema, Array(timestampVector))
+  }
+
+  /**
+   * Parse timestamp string to microseconds since epoch
+   */
+  private def parseTimestampToMicros(timestampStr: String): Long = {
+    // Parse "2019-09-09 01:02:03.456789" format
+    val localDateTime = LocalDateTime.parse(timestampStr.replace(" ", "T"))
+    val instant = localDateTime.toInstant(ZoneOffset.UTC)
+    instant.getEpochSecond * 1000000L + instant.getNano / 1000L
+  }
+
+  // Create type-appropriate literal function
+  def createTimestampLiteral(
+      timestampType: io.delta.kernel.types.DataType,
+      timestamp: String): String = {
+    timestampType match {
+      case _: TimestampType => s"TIMESTAMP'$timestamp'"
+      case _: TimestampNTZType => s"TIMESTAMP_NTZ'$timestamp'"
+      case _ => throw new IllegalArgumentException(s"Unsupported type: $timestampType")
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.4.0-SNAPSHOT"
+ThisBuild / version := "3.4.0-06022025-143ab3337-dbi"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Delta Kernel was incorrectly serializing TIMESTAMP_NTZ values in file stats with UTC zone suffix (Z), which differs from Delta Spark's format.
`TIMESTAMP_NTZ` now serializes as `2019-09-09T01:02:03.456 (no zone suffix)`
`TIMESTAMP` continues to serialize as `2019-09-09T01:02:03.456Z (with UTC zone)`

Both types truncate to millisecond precision to match Delta Spark behavior.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added `TimestampDataSkippingTest` with writes from the Kernel and reads from Delta-Spark and covers:
- Delta Spark parity testing (same predicates, boundaries (including adjustment of MAX by 1 millisecond, case-insensitive columns)
- Multi-file boundary testing across different timestamp ranges
- Timezone behavior validation with zone-aware queries
- On-disk Stats format verification (Kernel vs Spark comparison)

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
