### PR TITLE
[Spark] 2 minor variable naming changes in the REPLACE WHERE codebase

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -184,11 +184,11 @@ trait WriteIntoDeltaLike {
 
   protected def extractConstraints(
       sparkSession: SparkSession,
-      expr: Seq[Expression]): Seq[Constraint] = {
+      exprs: Seq[Expression]): Seq[Constraint] = {
     if (!sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_CONSTRAINT_CHECK_ENABLED)) {
       Seq.empty
     } else {
-      expr.flatMap { e =>
+      exprs.flatMap { e =>
         // While writing out the new data, we only want to enforce constraint on expressions
         // with UnresolvedAttribute, that is, containing column name. Because we parse a
         // predicate string without analyzing it, if there's a column name, it has to be


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
1. Given that the `condition` here is `Seq[Expression]`, I think it makes more sense to have it in plural form.

It should be singular, like `processedCondition`, when it is an AND-sum of `condition`s.

2. `replaceOnDataColsEnabled` should be `replaceWhereOnDataColsEnabled` to make it more clearer that this is REPLACE WHERE.

Variable name changing for code clarity.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Just a variable name change.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
