### PR TITLE
[Spark] Fix DomainMetadata handling for REPLACE TABLE concurrent with a transaction that adds a new domain

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1686,6 +1686,16 @@ trait DeltaSQLConfBase {
       .checkValues(NonDeterministicPredicateWidening.list)
       .createWithDefault(NonDeterministicPredicateWidening.ON)
 
+  val DELTA_CONFLICT_DETECTION_ALLOW_REPLACE_TABLE_TO_REMOVE_NEW_DOMAIN_METADATA =
+    buildConf("conflictDetection.allowReplaceTableToRemoveNewDomainMetadata")
+      .doc("Whether to allow removing new domain metadatas from concurrent transactions during " +
+        "conflict resolution for a REPLACE TABLE operation. Note that this flag applies only " +
+        "to metadata domains where the table snapshot read by the REPLACE TABLE command did " +
+        "not contain a domain metadata of the same domain.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_UNIFORM_ICEBERG_SYNC_CONVERT_ENABLED =
     buildConf("uniform.iceberg.sync.convert.enabled")
       .doc("If enabled, iceberg conversion will be done synchronously. " +


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
If the winning transaction adds a new DomainMetadata for the first time in a table's history concurrent to a REPLACE TABLE operation, the REPLACE TABLE will incorrectly not mark this DomainMetadata as removed. This PR fixes this issue by marking any DomainMetadata added by the winning transaction as removed if they appear in the list of DomainMetadata to be removed and the domain does not appear in the DomainMetadata added by the REPLACE TABLE.

## How was this patch tested?
N/A - no DomainMetadata currently exist that fall into this category.