### PR TITLE
[PROTOCOL RFC][FOLLOW-UP] Variant Shredding

### DIFF
--- a/protocol_rfcs/variant-shredding.md
+++ b/protocol_rfcs/variant-shredding.md
@@ -36,7 +36,8 @@ typed_value | * | (optional) This can be any Parquet type, representing the data
 ## Writer Requirements for Variant Shredding
 
 When Variant Shredding is supported (`writerFeatures` field of a table's `protocol` action contains `variantShredding`), writers:
-- must respect the `delta.enableVariantShredding` table property configuration. If `delta.enableVariantShredding=false`, a column of type `variant` must not be written as a shredded Variant, but as an unshredded Variant. If `delta.enableVariantShredding=true`, the writer can choose to shred a Variant column according to the [Parquet Variant Shredding specification](https://github.com/apache/parquet-format/blob/master/VariantShredding.md)
+- must respect the `delta.enableVariantShredding` table property configuration. If `delta.enableVariantShredding=false`, a column of type `variant` must not be written as a shredded Variant, but as an unshredded Variant. If `delta.enableVariantShredding=true`, the writer can choose to shred a Variant column according to the [Parquet Variant Shredding specification](https://github.com/apache/parquet-format/blob/master/VariantShredding.md).
+- must ensure the `variantType` table feature is present in the table protocol's `writerFeatures`  and `readerFeatures` when enabling the `delta.enableVariantShredding` table property, i.e. setting `delta.enableVariantShredding=true`.
 
 ## Reader Requirements for Variant Shredding
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR adds a requirement to the [Variant Shredding Protocol RFC](https://github.com/delta-io/delta/pull/4033) for writers to add the `variantShredding` table feature when enabling the `enableVariantShredding` table property. This way, writers can assume that the enablement of the table property implies the existence of the table feature, and can safely write shredded data.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

N/A
