### PR TITLE
[Kernel][Metric]Add metric for fs listing during logsegment construction

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/DelegateEngine.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/DelegateEngine.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.engine;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+public class DelegateEngine implements Engine {
+
+  private final Engine delegate;
+
+  public DelegateEngine(Engine delegate) {
+    this.delegate = requireNonNull(delegate);
+  }
+
+  @Override
+  public ExpressionHandler getExpressionHandler() {
+    return delegate.getExpressionHandler();
+  }
+
+  @Override
+  public JsonHandler getJsonHandler() {
+    return delegate.getJsonHandler();
+  }
+
+  @Override
+  public FileSystemClient getFileSystemClient() {
+    return delegate.getFileSystemClient();
+  }
+
+  @Override
+  public ParquetHandler getParquetHandler() {
+    return delegate.getParquetHandler();
+  }
+
+  @Override
+  public List<MetricsReporter> getMetricsReporters() {
+    return delegate.getMetricsReporters();
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/DelegateFileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/DelegateFileSystemClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.engine;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class DelegateFileSystemClient implements FileSystemClient {
+
+  private final FileSystemClient delegate;
+
+  public DelegateFileSystemClient(FileSystemClient delegate) {
+    this.delegate = requireNonNull(delegate);
+  }
+
+  @Override
+  public CloseableIterator<FileStatus> listFrom(String filePath) throws IOException {
+    return delegate.listFrom(filePath);
+  }
+
+  @Override
+  public String resolvePath(String path) throws IOException {
+    return delegate.resolvePath(path);
+  }
+
+  @Override
+  public CloseableIterator<ByteArrayInputStream> readFiles(
+      CloseableIterator<FileReadRequest> readRequests) throws IOException {
+    return delegate.readFiles(readRequests);
+  }
+
+  @Override
+  public boolean mkdirs(String path) throws IOException {
+    return delegate.mkdirs(path);
+  }
+
+  @Override
+  public boolean delete(String path) throws IOException {
+    return delegate.delete(path);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotMetrics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotMetrics.java
@@ -34,6 +34,8 @@ public class SnapshotMetrics {
 
   public final Timer timeToBuildLogSegmentForVersionTimer = new Timer();
 
+  public final Timer logSegmentListCallDurationTimer = new Timer();
+
   public SnapshotMetricsResult captureSnapshotMetricsResult() {
     return new SnapshotMetricsResult() {
 
@@ -43,6 +45,8 @@ public class SnapshotMetrics {
           loadInitialDeltaActionsTimer.totalDurationNs();
       final long timeToBuildLogSegmentForVersionDurationResult =
           timeToBuildLogSegmentForVersionTimer.totalDurationNs();
+      final long logSegmentListCallDuration = logSegmentListCallDurationTimer.totalDurationNs();
+      final long numLogSegmentListCalls = logSegmentListCallDurationTimer.count();
 
       @Override
       public Optional<Long> getTimestampToVersionResolutionDurationNs() {
@@ -58,6 +62,16 @@ public class SnapshotMetrics {
       public long getTimeToBuildLogSegmentForVersionNs() {
         return timeToBuildLogSegmentForVersionDurationResult;
       }
+
+      @Override
+      public long getLogSegmentListCallDurationNs() {
+        return logSegmentListCallDuration;
+      }
+
+      @Override
+      public long getNumLogSegmentListCalls() {
+        return numLogSegmentListCalls;
+      }
     };
   }
 
@@ -66,9 +80,11 @@ public class SnapshotMetrics {
     return String.format(
         "SnapshotMetrics(timestampToVersionResolutionTimer=%s, "
             + "loadInitialDeltaActionsTimer=%s, "
-            + "timeToBuildLogSegmentForVersionTimer=%s)",
+            + "timeToBuildLogSegmentForVersionTimer=%s, "
+            + "logSegmentListCallDurationTimer=%s)",
         timestampToVersionResolutionTimer,
         loadInitialDeltaActionsTimer,
-        timeToBuildLogSegmentForVersionTimer);
+        timeToBuildLogSegmentForVersionTimer,
+        logSegmentListCallDurationTimer);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/SnapshotMetricsResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/SnapshotMetricsResult.java
@@ -22,7 +22,9 @@ import java.util.Optional;
 @JsonPropertyOrder({
   "timestampToVersionResolutionDurationNs",
   "loadInitialDeltaActionsDurationNs",
-  "timeToBuildLogSegmentForVersionDurationNs"
+  "timeToBuildLogSegmentForVersionNs",
+  "logSegmentListCallDurationNs",
+  "numLogSegmentListCalls"
 })
 public interface SnapshotMetricsResult {
 
@@ -43,4 +45,17 @@ public interface SnapshotMetricsResult {
    *     construction. 0 if snapshot construction fails before this step.
    */
   long getTimeToBuildLogSegmentForVersionNs();
+
+  /**
+   * @return the total duration (ns) of all log segment list calls made during snapshot
+   *     construction. 0 if no list calls were made or if snapshot construction fails before this
+   *     step.
+   */
+  long getLogSegmentListCallDurationNs();
+
+  /**
+   * @return the total number of log segment list calls made during snapshot construction. 0 if no
+   *     list calls were made or if snapshot construction fails before this step.
+   */
+  long getNumLogSegmentListCalls();
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -44,6 +44,10 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       snapshotReport.getSnapshotMetrics().getLoadInitialDeltaActionsDurationNs()
     val buildLogSegmentDuration =
       snapshotReport.getSnapshotMetrics().getTimeToBuildLogSegmentForVersionNs()
+    val logSegmentListCallDuration =
+      snapshotReport.getSnapshotMetrics().getLogSegmentListCallDurationNs()
+    val numLogSegmentListCalls =
+      snapshotReport.getSnapshotMetrics().getNumLogSegmentListCalls()
     val exception: Optional[String] = snapshotReport.getException().map(_.toString)
     val expectedJson =
       s"""
@@ -57,7 +61,9 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"snapshotMetrics":{
          |"timestampToVersionResolutionDurationNs":${timestampToVersionResolutionDuration},
          |"loadInitialDeltaActionsDurationNs":${loadProtocolAndMetadataDuration},
-         |"timeToBuildLogSegmentForVersionNs":${buildLogSegmentDuration}
+         |"timeToBuildLogSegmentForVersionNs":${buildLogSegmentDuration},
+         |"logSegmentListCallDurationNs":${logSegmentListCallDuration},
+         |"numLogSegmentListCalls":${numLogSegmentListCalls}
          |}
          |}
          |""".stripMargin.replaceAll("\n", "")
@@ -69,6 +75,9 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
     snapshotContext1.getSnapshotMetrics.timestampToVersionResolutionTimer.record(10)
     snapshotContext1.getSnapshotMetrics.loadInitialDeltaActionsTimer.record(1000)
     snapshotContext1.getSnapshotMetrics.timeToBuildLogSegmentForVersionTimer.record(500)
+    // Record some log segment list call metrics
+    snapshotContext1.getSnapshotMetrics.logSegmentListCallDurationTimer.record(250)
+    snapshotContext1.getSnapshotMetrics.logSegmentListCallDurationTimer.record(150)
     snapshotContext1.setVersion(25)
     snapshotContext1.setCheckpointVersion(Optional.of(20))
     val exception = new RuntimeException("something something failed")
@@ -90,7 +99,9 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
         |"snapshotMetrics":{
         |"timestampToVersionResolutionDurationNs":10,
         |"loadInitialDeltaActionsDurationNs":1000,
-        |"timeToBuildLogSegmentForVersionNs":500
+        |"timeToBuildLogSegmentForVersionNs":500,
+        |"logSegmentListCallDurationNs":400,
+        |"numLogSegmentListCalls":2
         |}
         |}
         |""".stripMargin.replaceAll("\n", "")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR add 2nd/3rd metric in https://github.com/delta-io/delta/issues/4701, also did refactor for test code
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No