### PR TITLE
[Kernel]  Add isNested method to DataType class

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
@@ -282,7 +282,7 @@ public class DataTypeJsonSerDe {
         }
         List<TypeChange> changes = pathToTypeChanges.get(pathFromAncestor);
         if (changes != null) {
-          if (isNested(element.getField().getDataType())) {
+          if (element.getField().getDataType().isNested()) {
             throw new KernelException(
                 format("Invalid data type for type change: \"%s\"", element.getField()));
           }
@@ -302,12 +302,6 @@ public class DataTypeJsonSerDe {
                       .build());
     }
     return structField;
-  }
-
-  private static boolean isNested(DataType dataType) {
-    return dataType instanceof StructType
-        || dataType instanceof MapType
-        || dataType instanceof ArrayType;
   }
 
   private static void updateCollation(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -516,8 +516,8 @@ public class SchemaUtils {
       }
 
       if (!existingField.equals(newField)) {
-        if (!isNestedType(existingField)
-            && !isNestedType(newField)
+        if (!existingField.getDataType().isNested()
+            && !newField.getDataType().isNested()
             && !existingField.getDataType().equivalent(newField.getDataType())) {
           // Type changes only apply to non-nested types.  This loop evaluates both
           // nested and non-nested, so we narrow down updates here. Actual type differences
@@ -536,12 +536,6 @@ public class SchemaUtils {
       schemaDiff.withUpdatedSchema(newSchemaIterable.getSchema());
     }
     return schemaDiff.build();
-  }
-
-  private static boolean isNestedType(StructField existingField) {
-    // TODO: Make is nested a centralized concept
-    DataType d = existingField.getDataType();
-    return d instanceof StructType || d instanceof ArrayType || d instanceof MapType;
   }
 
   private static Map<SchemaElementId, StructField> fieldsByElementId(StructType schema) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/ArrayType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/ArrayType.java
@@ -56,6 +56,11 @@ public class ArrayType extends DataType {
   }
 
   @Override
+  public boolean isNested() {
+    return true;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
@@ -83,6 +83,11 @@ public abstract class BasePrimitiveType extends DataType {
   }
 
   @Override
+  public boolean isNested() {
+    return false;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(primitiveTypeName);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/DataType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/DataType.java
@@ -36,6 +36,13 @@ public abstract class DataType {
     return equals(dataType);
   }
 
+  /**
+   * Returns true iff this data is a nested data type (it logically parameterized by other types).
+   *
+   * <p>For example StructType, ArrayType, MapType are nested data types.
+   */
+  public abstract boolean isNested();
+
   @Override
   public abstract int hashCode();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/DecimalType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/DecimalType.java
@@ -58,6 +58,11 @@ public final class DecimalType extends DataType {
   }
 
   @Override
+  public boolean isNested() {
+    return false;
+  }
+
+  @Override
   public String toString() {
     return String.format("Decimal(%d, %d)", precision, scale);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/MapType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/MapType.java
@@ -84,6 +84,11 @@ public class MapType extends DataType {
   }
 
   @Override
+  public boolean isNested() {
+    return true;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(keyField, valueField);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
@@ -135,6 +135,11 @@ public final class StructType extends DataType {
   }
 
   @Override
+  public boolean isNested() {
+    return true;
+  }
+
+  @Override
   public String toString() {
     return String.format(
         "struct(%s)", fields.stream().map(StructField::toString).collect(Collectors.joining(", ")));

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/types/TypesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/types/TypesSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.types
+
+import java.util.Arrays
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class TypesSuite extends AnyFunSuite {
+  test("isNested - false") {
+    // All primitive types should return false for isNested
+    val primitiveTypes = Seq(
+      BinaryType.BINARY,
+      BooleanType.BOOLEAN,
+      ByteType.BYTE,
+      DateType.DATE,
+      new DecimalType(10, 2),
+      DoubleType.DOUBLE,
+      FloatType.FLOAT,
+      IntegerType.INTEGER,
+      LongType.LONG,
+      ShortType.SHORT,
+      StringType.STRING,
+      TimestampType.TIMESTAMP,
+      TimestampNTZType.TIMESTAMP_NTZ,
+      VariantType.VARIANT
+    )
+    
+    primitiveTypes.foreach { dataType =>
+      assert(!dataType.isNested(), s"Expected $dataType to not be nested")
+    }
+  }
+  
+  test("isNested - nested types") {
+    // Create instances of nested types
+    val structFields = Arrays.asList(
+      new StructField("field1", IntegerType.INTEGER, true),
+      new StructField("field2", StringType.STRING, true)
+    )
+    val structType = new StructType(structFields)
+    
+    val arrayType = new ArrayType(
+      new StructField("element", IntegerType.INTEGER, true)
+    )
+    
+    val mapType = new MapType(
+      new StructField("key", StringType.STRING, false),
+      new StructField("value", IntegerType.INTEGER, true)
+    )
+    
+    // All nested types should return true for isNested
+    val nestedTypes = Seq(structType, arrayType, mapType)
+    
+    nestedTypes.foreach { dataType =>
+      assert(dataType.isNested(), s"Expected $dataType to be nested")
+    }
+  }
+}


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This method centralizes the concept of isNested to the DataType class instead of individual helper methods.

## How was this patch tested?

Unit tests.

## Does this PR introduce _any_ user-facing changes?

Yes, it adds a new API method isNested.
