### PR TITLE
[Delta] Support absolute path in Clone

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
@@ -79,6 +79,8 @@ class IcebergFileManifest(
     _sizeInBytes.get
   }
 
+  override def supportAbsolutePath: Boolean = true
+
   def allFiles: Dataset[ConvertTargetFile] = {
     if (fileSparkResults.isEmpty) fileSparkResults = Some(getFileSparkResults())
     fileSparkResults.get

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -239,11 +239,14 @@ abstract class CloneConvertedSource(spark: SparkSession) extends CloneSource {
     val partitionSchema = convertTargetTable.partitionSchema
 
     {
-      convertTargetTable.fileManifest.allFiles.mapPartitions { targetFile =>
+      val fileManifest = convertTargetTable.fileManifest
+      val supportAbsolutePath = fileManifest.supportAbsolutePath
+      fileManifest.allFiles.mapPartitions { targetFile =>
         val basePath = new Path(baseDir)
         val fs = basePath.getFileSystem(conf.value.value)
         targetFile.map(ConvertUtils.createAddFile(
-          _, basePath, fs, SQLConf.get, Some(partitionSchema)))
+          _, basePath, fs, SQLConf.get, Some(partitionSchema),
+          supportAbsolutePath))
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -305,10 +305,13 @@ abstract class ConvertToDeltaCommandBase(
     val shouldCollectStats = collectStats && statsEnabled
     val statsBatchSize = conf.getConf(DeltaSQLConf.DELTA_IMPORT_BATCH_SIZE_STATS_COLLECTION)
     var numFiles = 0L
+    val useAbsolutePath = manifest.supportAbsolutePath
     manifest.getFiles.grouped(statsBatchSize).flatMap { batch =>
       val adds = batch.map(
         ConvertUtils.createAddFile(
-          _, txn.deltaLog.dataPath, fs, conf, Some(partitionSchema), deltaPath.isDefined))
+          _, txn.deltaLog.dataPath, fs, conf, Some(partitionSchema),
+          useAbsolutePath || deltaPath.isDefined
+        ))
       if (shouldCollectStats) {
         logInfo(
           log"Collecting stats for a batch of " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
@@ -221,7 +221,7 @@ trait ConvertUtilsBase extends DeltaLogging {
         s"Fail to relativize path $path against base path $basePath.")
       relativePath.toUri.toString
     } else {
-      path.toUri.toString
+      fs.makeQualified(path).toUri.toString
     }
 
     AddFile(pathStrForAddFile, partition, file.length, file.modificationTime, dataChange = true,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/interfaces.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/interfaces.scala
@@ -67,6 +67,8 @@ trait ConvertTargetFileManifest extends Closeable {
   /** Return the active files for a table in sequence */
   def getFiles: Iterator[ConvertTargetFile] = allFiles.toLocalIterator().asScala
 
+  /** All data file paths are required to be relative to table path when false */
+  def supportAbsolutePath: Boolean = false
   /** Return the number of files for the table */
   def numFiles: Long = allFiles.count()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This change allows CLONE Iceberg to accept Iceberg tables with data files not under the table path.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit test
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO