### PR TITLE
[Kernel][#2] IcebergCompatV3 - move IcebergCompatCheck to base class

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatMetadataValidatorAndUpdater.java
@@ -27,14 +27,15 @@ import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeature;
 import io.delta.kernel.internal.types.TypeWideningChecker;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.SchemaIterable;
 import io.delta.kernel.internal.util.SchemaUtils;
 import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.*;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Contains interfaces and common utility classes for defining the iceberg conversion compatibility
@@ -94,7 +95,7 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
    * is not set, we will set it to a default value. It will also update the metadata to make it
    * compatible with Iceberg compat version targeted.
    */
-  static class IcebergCompatRequiredTablePropertyEnforcer<T> {
+  protected static class IcebergCompatRequiredTablePropertyEnforcer<T> {
     public final TableConfig<T> property;
     public final Predicate<T> validator;
     public final String autoSetValue;
@@ -162,6 +163,17 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
     }
   }
 
+  /////////////////////////////////////////////////////////////////////////////////
+  /// Implementation of {@link IcebergCompatRequiredTablePropertyEnforcer}      ///
+  /////////////////////////////////////////////////////////////////////////////////
+  protected static final IcebergCompatRequiredTablePropertyEnforcer COLUMN_MAPPING_REQUIREMENT =
+      new IcebergCompatRequiredTablePropertyEnforcer<>(
+          TableConfig.COLUMN_MAPPING_MODE,
+          (value) ->
+              ColumnMapping.ColumnMappingMode.NAME == value
+                  || ColumnMapping.ColumnMappingMode.ID == value,
+          ColumnMapping.ColumnMappingMode.NAME.value);
+
   /**
    * Defines checks for compatibility with the targeted iceberg features (icebergCompatV1 or
    * icebergCompatV2 etc.)
@@ -173,52 +185,79 @@ public abstract class IcebergCompatMetadataValidatorAndUpdater {
   ///////////////////////////////////////////////////////////
   /// Implementation of {@link IcebergCompatCheck}        ///
   ///////////////////////////////////////////////////////////
-  protected static final IcebergCompatCheck CHECK_NO_COMPAT_V1_ENABLED =
-      (inputContext) -> {
-        if (Boolean.valueOf(
-            inputContext
-                .newMetadata
-                .getConfiguration()
-                .getOrDefault("delta.enableIcebergCompatV1", "false"))) {
+  protected static IcebergCompatCheck disallowOtherCompatVersions(List<String> incompatibleProps) {
+    return (inputContext) -> {
+      for (String prop : incompatibleProps) {
+        if (Boolean.parseBoolean(
+            inputContext.newMetadata.getConfiguration().getOrDefault(prop, "false"))) {
           throw DeltaErrors.icebergCompatIncompatibleVersionEnabled(
-              inputContext.compatFeatureName, "delta.enableIcebergCompatV1");
+              inputContext.compatFeatureName, prop);
         }
-      };
+      }
+    };
+  }
+
+  protected static final IcebergCompatCheck CHECK_ONLY_ICEBERG_COMPAT_V2_ENABLED =
+      disallowOtherCompatVersions(
+          Arrays.asList("delta.enableIcebergCompatV1", "delta.enableIcebergCompatV3"));
+
+  protected static final IcebergCompatCheck CHECK_ONLY_ICEBERG_COMPAT_V3_ENABLED =
+      disallowOtherCompatVersions(
+          Arrays.asList("delta.enableIcebergCompatV1", "delta.enableIcebergCompatV2"));
+
+  protected static IcebergCompatCheck hasOnlySupportedTypes(
+      Set<Class<? extends DataType>> supportedTypes) {
+    return (inputContext) -> {
+      List<Tuple2<List<String>, StructField>> matches =
+          SchemaUtils.filterRecursively(
+              inputContext.newMetadata.getSchema(),
+              /* recurseIntoMapAndArrayTypes= */ true,
+              /* stopOnFirstMatch = */ false,
+              field -> {
+                DataType dataType = field.getDataType();
+                for (Class<? extends DataType> clazz : supportedTypes) {
+                  if (clazz.isInstance(dataType)) return false;
+                }
+                return true;
+              });
+
+      if (!matches.isEmpty()) {
+        throw DeltaErrors.icebergCompatUnsupportedTypeColumns(
+            inputContext.compatFeatureName,
+            matches.stream().map(tuple -> tuple._2.getDataType()).collect(toList()));
+      }
+    };
+  }
+
+  private static final Set<Class<? extends DataType>> V2_SUPPORTED_TYPES =
+      new HashSet<>(
+          Arrays.asList(
+              ByteType.class,
+              ShortType.class,
+              IntegerType.class,
+              LongType.class,
+              FloatType.class,
+              DoubleType.class,
+              DecimalType.class,
+              StringType.class,
+              BinaryType.class,
+              BooleanType.class,
+              DateType.class,
+              TimestampType.class,
+              TimestampNTZType.class,
+              ArrayType.class,
+              MapType.class,
+              StructType.class));
 
   protected static final IcebergCompatCheck V2_CHECK_HAS_SUPPORTED_TYPES =
-      (inputContext) -> {
-        List<Tuple2<List<String>, StructField>> matches =
-            SchemaUtils.filterRecursively(
-                inputContext.newMetadata.getSchema(),
-                /* recurseIntoMapAndArrayTypes= */ true,
-                /* stopOnFirstMatch = */ false,
-                field -> {
-                  DataType dataType = field.getDataType();
-                  return !(dataType instanceof ByteType
-                      || dataType instanceof ShortType
-                      || dataType instanceof IntegerType
-                      || dataType instanceof LongType
-                      || dataType instanceof FloatType
-                      || dataType instanceof DoubleType
-                      || dataType instanceof DecimalType
-                      || dataType instanceof StringType
-                      || dataType instanceof BinaryType
-                      || dataType instanceof BooleanType
-                      || dataType instanceof DateType
-                      || dataType instanceof TimestampType
-                      || dataType instanceof TimestampNTZType
-                      || dataType instanceof ArrayType
-                      || dataType instanceof MapType
-                      || dataType instanceof StructType);
-                });
+      hasOnlySupportedTypes(V2_SUPPORTED_TYPES);
 
-        if (!matches.isEmpty()) {
-          throw DeltaErrors.icebergCompatUnsupportedTypeColumns(
-              inputContext.compatFeatureName,
-              matches.stream().map(tuple -> tuple._2.getDataType()).collect(toList()));
-        }
-      };
+  protected static final IcebergCompatCheck V3_CHECK_HAS_SUPPORTED_TYPES =
+      hasOnlySupportedTypes(
+          Stream.concat(V2_SUPPORTED_TYPES.stream(), Stream.of(VariantType.class))
+              .collect(Collectors.toSet()));
 
+  // These are the common supported partition types for both Iceberg compat V2 and V3
   protected static final IcebergCompatCheck CHECK_HAS_ALLOWED_PARTITION_TYPES =
       (inputContext) ->
           inputContext

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -24,7 +24,6 @@ import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeature;
-import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.DataFileStatus;
 import java.util.List;
@@ -71,12 +70,6 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
   private static final IcebergCompatV2MetadataValidatorAndUpdater INSTANCE =
       new IcebergCompatV2MetadataValidatorAndUpdater();
 
-  private static final IcebergCompatRequiredTablePropertyEnforcer ICEBERG_COMPAT_V2_CM_REQUIREMENT =
-      new IcebergCompatRequiredTablePropertyEnforcer<>(
-          TableConfig.COLUMN_MAPPING_MODE,
-          (value) -> ColumnMappingMode.NAME == value || ColumnMappingMode.ID == value,
-          ColumnMappingMode.NAME.value);
-
   @Override
   String compatFeatureName() {
     return "icebergCompatV2";
@@ -89,7 +82,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
 
   @Override
   List<IcebergCompatRequiredTablePropertyEnforcer> requiredDeltaTableProperties() {
-    return singletonList(ICEBERG_COMPAT_V2_CM_REQUIREMENT);
+    return singletonList(COLUMN_MAPPING_REQUIREMENT);
   }
 
   @Override
@@ -100,7 +93,7 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
   @Override
   List<IcebergCompatCheck> icebergCompatChecks() {
     return Stream.of(
-            CHECK_NO_COMPAT_V1_ENABLED,
+            CHECK_ONLY_ICEBERG_COMPAT_V2_ENABLED,
             V2_CHECK_HAS_SUPPORTED_TYPES,
             CHECK_HAS_ALLOWED_PARTITION_TYPES,
             CHECK_HAS_NO_PARTITION_EVOLUTION,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergCompatV2MetadataValidatorAndUpdater.java
@@ -16,7 +16,6 @@
 package io.delta.kernel.internal.icebergcompat;
 
 import static io.delta.kernel.internal.tablefeatures.TableFeatures.*;
-import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
@@ -25,14 +24,9 @@ import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeature;
-import io.delta.kernel.internal.types.TypeWideningChecker;
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
-import io.delta.kernel.internal.util.SchemaIterable;
-import io.delta.kernel.internal.util.SchemaUtils;
-import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.DataFileStatus;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -52,7 +46,8 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
   public static Optional<Metadata> validateAndUpdateIcebergCompatV2Metadata(
       boolean isCreatingNewTable, Metadata newMetadata, Protocol newProtocol) {
     return INSTANCE.validateAndUpdateMetadata(
-        new IcebergCompatInputContext(isCreatingNewTable, newMetadata, newProtocol));
+        new IcebergCompatInputContext(
+            INSTANCE.compatFeatureName(), isCreatingNewTable, newMetadata, newProtocol));
   }
 
   /**
@@ -82,120 +77,6 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
           (value) -> ColumnMappingMode.NAME == value || ColumnMappingMode.ID == value,
           ColumnMappingMode.NAME.value);
 
-  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_NO_COMPAT_V1_ENABLED =
-      (inputContext) -> {
-        if (Boolean.valueOf(
-            inputContext
-                .newMetadata
-                .getConfiguration()
-                .getOrDefault("delta.enableIcebergCompatV1", "false"))) {
-          throw DeltaErrors.icebergCompatIncompatibleVersionEnabled(
-              INSTANCE.compatFeatureName(), "delta.enableIcebergCompatV1");
-        }
-      };
-
-  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPES =
-      (inputContext) -> {
-        List<Tuple2<List<String>, StructField>> matches =
-            SchemaUtils.filterRecursively(
-                inputContext.newMetadata.getSchema(),
-                /* recurseIntoMapAndArrayTypes= */ true,
-                /* stopOnFirstMatch = */ false,
-                field -> {
-                  DataType dataType = field.getDataType();
-                  return !(dataType instanceof ByteType
-                      || dataType instanceof ShortType
-                      || dataType instanceof IntegerType
-                      || dataType instanceof LongType
-                      || dataType instanceof FloatType
-                      || dataType instanceof DoubleType
-                      || dataType instanceof DecimalType
-                      || dataType instanceof StringType
-                      || dataType instanceof BinaryType
-                      || dataType instanceof BooleanType
-                      || dataType instanceof DateType
-                      || dataType instanceof TimestampType
-                      || dataType instanceof TimestampNTZType
-                      || dataType instanceof ArrayType
-                      || dataType instanceof MapType
-                      || dataType instanceof StructType);
-                });
-
-        if (!matches.isEmpty()) {
-          throw DeltaErrors.icebergCompatUnsupportedTypeColumns(
-              INSTANCE.compatFeatureName(),
-              matches.stream().map(tuple -> tuple._2.getDataType()).collect(toList()));
-        }
-      };
-
-  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_ALLOWED_PARTITION_TYPES =
-      (inputContext) ->
-          inputContext
-              .newMetadata
-              .getPartitionColNames()
-              .forEach(
-                  partitionCol -> {
-                    int partitionFieldIndex =
-                        inputContext.newMetadata.getSchema().indexOf(partitionCol);
-                    checkArgument(
-                        partitionFieldIndex != -1,
-                        "Partition column %s not found in the schema",
-                        partitionCol);
-                    DataType dataType =
-                        inputContext.newMetadata.getSchema().at(partitionFieldIndex).getDataType();
-                    boolean validType =
-                        dataType instanceof ByteType
-                            || dataType instanceof ShortType
-                            || dataType instanceof IntegerType
-                            || dataType instanceof LongType
-                            || dataType instanceof FloatType
-                            || dataType instanceof DoubleType
-                            || dataType instanceof DecimalType
-                            || dataType instanceof StringType
-                            || dataType instanceof BinaryType
-                            || dataType instanceof BooleanType
-                            || dataType instanceof DateType
-                            || dataType instanceof TimestampType
-                            || dataType instanceof TimestampNTZType;
-                    if (!validType) {
-                      throw DeltaErrors.icebergCompatUnsupportedTypePartitionColumn(
-                          INSTANCE.compatFeatureName(), dataType);
-                    }
-                  });
-
-  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_NO_PARTITION_EVOLUTION =
-      (inputContext) -> {
-        // TODO: Kernel doesn't support replace table yet. When it is supported, extend
-        // this to allow checking the partition columns aren't changed
-      };
-
-  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_NO_DELETION_VECTORS =
-      (inputContext) -> {
-        if (inputContext.newProtocol.supportsFeature(DELETION_VECTORS_RW_FEATURE)) {
-          throw DeltaErrors.icebergCompatIncompatibleTableFeatures(
-              INSTANCE.compatFeatureName(), Collections.singleton(DELETION_VECTORS_RW_FEATURE));
-        }
-      };
-
-  private static final IcebergCompatCheck ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPE_WIDENING =
-      (inputContext) -> {
-        Protocol protocol = inputContext.newProtocol;
-        if (!protocol.supportsFeature(TYPE_WIDENING_RW_FEATURE)
-            && !protocol.supportsFeature(TYPE_WIDENING_RW_PREVIEW_FEATURE)) {
-          return;
-        }
-        for (SchemaIterable.SchemaElement element :
-            new SchemaIterable(inputContext.newMetadata.getSchema())) {
-          for (TypeChange typeChange : element.getField().getTypeChanges()) {
-            if (!TypeWideningChecker.isIcebergV2Compatible(
-                typeChange.getFrom(), typeChange.getTo())) {
-              throw DeltaErrors.icebergCompatUnsupportedTypeWidening(
-                  INSTANCE.compatFeatureName(), typeChange);
-            }
-          }
-        }
-      };
-
   @Override
   String compatFeatureName() {
     return "icebergCompatV2";
@@ -219,12 +100,12 @@ public class IcebergCompatV2MetadataValidatorAndUpdater
   @Override
   List<IcebergCompatCheck> icebergCompatChecks() {
     return Stream.of(
-            ICEBERG_COMPAT_V2_CHECK_NO_COMPAT_V1_ENABLED,
-            ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPES,
-            ICEBERG_COMPAT_V2_CHECK_HAS_ALLOWED_PARTITION_TYPES,
-            ICEBERG_COMPAT_V2_CHECK_HAS_NO_PARTITION_EVOLUTION,
-            ICEBERG_COMPAT_V2_CHECK_HAS_NO_DELETION_VECTORS,
-            ICEBERG_COMPAT_V2_CHECK_HAS_SUPPORTED_TYPE_WIDENING)
+            CHECK_NO_COMPAT_V1_ENABLED,
+            V2_CHECK_HAS_SUPPORTED_TYPES,
+            CHECK_HAS_ALLOWED_PARTITION_TYPES,
+            CHECK_HAS_NO_PARTITION_EVOLUTION,
+            CHECK_HAS_NO_DELETION_VECTORS,
+            CHECK_HAS_SUPPORTED_TYPE_WIDENING)
         .collect(toList());
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
@@ -112,7 +112,8 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
   public static Optional<Metadata> validateAndUpdateIcebergWriterCompatV1Metadata(
       boolean isCreatingNewTable, Metadata newMetadata, Protocol newProtocol) {
     return INSTANCE.validateAndUpdateMetadata(
-        new IcebergCompatInputContext(isCreatingNewTable, newMetadata, newProtocol));
+        new IcebergCompatInputContext(
+            INSTANCE.compatFeatureName(), isCreatingNewTable, newMetadata, newProtocol));
   }
 
   /// //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is refactoring only, move all the IcebergCompatChecks from `IcebergCompatV2MetadataValidatorAndUpdater.java` to its base class `IcebergCompatMetadataValidatorAndUpdater.java` so that later newly added `IcebergCompatV3MetadataValidatorAndUpdater.java` can use them.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing unit tests since it is only doing refactoring.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
