### PR TITLE
[Spark] Make DeltaDMLTestUtils agnostic to name/path-based access

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.StructType
 
 abstract class DeleteSuiteBase extends QueryTest
   with SharedSparkSession
-  with DeltaDMLTestUtils
+  with DeltaDMLByPathTestUtils
   with DeltaTestUtilsForTempViews
   with DeltaExcludedBySparkVersionTestMixinShims {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -37,7 +37,10 @@ import org.apache.spark.sql.types.StructType
  * Each take a unique path through analysis. The abstractions below captures these different
  * inserts to allow more easily running tests with all or a subset of them.
  */
-trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQLCommandTest {
+trait DeltaInsertIntoTest
+  extends QueryTest
+  with DeltaDMLByPathTestUtils
+  with DeltaSQLCommandTest {
 
   val catalogName = "spark_catalog"
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * either [[MergeIntoSQLTestUtils]] or [[MergeIntoScalaTestUtils]] to run merge tests using the SQL
  * or Scala API resp.
  */
-trait MergeIntoTestUtils extends DeltaDMLTestUtils with MergeHelpers {
+trait MergeIntoTestUtils extends DeltaDMLByPathTestUtils with MergeHelpers {
   self: SharedSparkSession =>
 
   protected def executeMerge(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types._
 abstract class UpdateSuiteBase
   extends QueryTest
   with SharedSparkSession
-  with DeltaDMLTestUtils
+  with DeltaDMLByPathTestUtils
   with DeltaSQLTestUtils
   with DeltaTestUtilsForTempViews
   with DeltaExcludedBySparkVersionTestMixinShims {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
@@ -35,7 +35,9 @@ import org.apache.spark.sql.types._
 /**
  * Test mixin that enables type widening by default for all tests in the suite.
  */
-trait TypeWideningTestMixin extends DeltaSQLCommandTest with DeltaDMLTestUtils { self: QueryTest =>
+trait TypeWideningTestMixin
+  extends DeltaSQLCommandTest
+  with DeltaDMLByPathTestUtils { self: QueryTest =>
 
   import testImplicits._
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR is one of a series of PRs aiming to refactor the DML suites such that we can extend the existing suites to test with name-based table access.

Currently, all DML suites are centered around the `DeltaDMLTestUtils` trait that creates a test table stored in `tempPath`. In this PR, all path-related elements in this trait will be abstracted out and put into a new specialized trait called `DeltaDMLByPathTestUtils`.

## How was this patch tested?

Existing UTs 

## Does this PR introduce _any_ user-facing changes?

No