### PR TITLE
[Kernel] Update max id to use SchemaIterable

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -220,11 +220,17 @@ public class ColumnMapping {
 
   /** Visible for testing */
   static int findMaxColumnId(StructType schema) {
-    int maxColumnId = 0;
-    for (StructField field : schema.fields()) {
-      maxColumnId = findMaxColumnId(field, maxColumnId);
-    }
-    return maxColumnId;
+    return new SchemaIterable(schema).
+            stream()
+            .mapToInt(e -> {
+                int columnId = hasColumnId(e.getField()) ? getColumnId(e.getField()) : 0;
+                int nestedMaxId = hasNestedColumnIds(e.getField())
+                    ? getMaxNestedColumnId(e.getField())
+                    : 0;
+                return Math.max(columnId, nestedMaxId);
+              }
+            )
+            .max().orElse(0);
   }
 
   static boolean hasColumnId(StructField field) {
@@ -233,33 +239,6 @@ public class ColumnMapping {
 
   static boolean hasPhysicalName(StructField field) {
     return field.getMetadata().contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
-  }
-
-  private static int findMaxColumnId(StructField field, int maxColumnId) {
-    if (hasColumnId(field)) {
-      maxColumnId = Math.max(maxColumnId, getColumnId(field));
-
-      if (hasNestedColumnIds(field)) {
-        maxColumnId = Math.max(maxColumnId, getMaxNestedColumnId(field));
-      }
-    }
-
-    if (field.getDataType() instanceof StructType) {
-      StructType structType = (StructType) field.getDataType();
-      for (StructField structField : structType.fields()) {
-        maxColumnId = findMaxColumnId(structField, maxColumnId);
-      }
-      return maxColumnId;
-    } else if (field.getDataType() instanceof ArrayType) {
-      ArrayType arrayType = (ArrayType) field.getDataType();
-      return findMaxColumnId(arrayType.getElementField(), maxColumnId);
-    } else if (field.getDataType() instanceof MapType) {
-      MapType mapType = (MapType) field.getDataType();
-      return Math.max(
-          findMaxColumnId(mapType.getKeyField(), maxColumnId),
-          findMaxColumnId(mapType.getValueField(), maxColumnId));
-    }
-    return maxColumnId;
   }
 
   /**
@@ -385,7 +364,7 @@ public class ColumnMapping {
     }
 
     // The maxColumnId in the metadata may be out-of-date either due to field-id assignment
-    // performed in this fx, or due to connector adding new fields
+    // performed in this function, or due to connector adding new fields
     boolean shouldUpdateMaxId =
         TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.fromMetadata(metadata) != maxColumnId.get();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -220,17 +220,17 @@ public class ColumnMapping {
 
   /** Visible for testing */
   static int findMaxColumnId(StructType schema) {
-    return new SchemaIterable(schema).
-            stream()
-            .mapToInt(e -> {
-                int columnId = hasColumnId(e.getField()) ? getColumnId(e.getField()) : 0;
-                int nestedMaxId = hasNestedColumnIds(e.getField())
-                    ? getMaxNestedColumnId(e.getField())
-                    : 0;
-                return Math.max(columnId, nestedMaxId);
-              }
-            )
-            .max().orElse(0);
+    return new SchemaIterable(schema)
+        .stream()
+            .mapToInt(
+                e -> {
+                  int columnId = hasColumnId(e.getField()) ? getColumnId(e.getField()) : 0;
+                  int nestedMaxId =
+                      hasNestedColumnIds(e.getField()) ? getMaxNestedColumnId(e.getField()) : 0;
+                  return Math.max(columnId, nestedMaxId);
+                })
+            .max()
+            .orElse(0);
   }
 
   static boolean hasColumnId(StructField field) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaIterable.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaIterable.java
@@ -19,6 +19,8 @@ import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.types.*;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Utility class for iterating over schema structures and modifying them.
@@ -108,6 +110,14 @@ public class SchemaIterable implements Iterable<SchemaIterable.SchemaElement> {
         return iterator.next();
       }
     };
+  }
+
+  Stream<SchemaElement> stream() {
+    return StreamSupport.stream(spliterator(), /* parallel = */false);
+  }
+
+  Stream<MutableSchemaElement> mutableStream() {
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(newMutableIterator(), /*characteristics = */0), /* parallel = */false);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaIterable.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaIterable.java
@@ -112,12 +112,14 @@ public class SchemaIterable implements Iterable<SchemaIterable.SchemaElement> {
     };
   }
 
-  Stream<SchemaElement> stream() {
-    return StreamSupport.stream(spliterator(), /* parallel = */false);
+  public Stream<SchemaElement> stream() {
+    return StreamSupport.stream(spliterator(), /* parallel = */ false);
   }
 
-  Stream<MutableSchemaElement> mutableStream() {
-    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(newMutableIterator(), /*characteristics = */0), /* parallel = */false);
+  public Stream<MutableSchemaElement> mutableStream() {
+    return StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(newMutableIterator(), /*characteristics = */ 0),
+        /* parallel = */ false);
   }
 
   /**


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4742/files) to review incremental changes.
- [**stack/schemaIdToSchemaIterable**](https://github.com/delta-io/delta/pull/4742) [[Files changed](https://github.com/delta-io/delta/pull/4742/files)]
  - [stack/update_table_features](https://github.com/delta-io/delta/pull/4752) [[Files changed](https://github.com/delta-io/delta/pull/4752/files/4631f204cf59016d876a0c3bd408e7c67112b22b..19c2fe51f33bba7e4e584874238884d04bef514e)]
    - [stack/update_validators](https://github.com/delta-io/delta/pull/4753) [[Files changed](https://github.com/delta-io/delta/pull/4753/files/19c2fe51f33bba7e4e584874238884d04bef514e..378a8eda53800bcbfffc648459f5b0af69fdfffc)]
      - [stack/remove_recurse_from_schema_utils](https://github.com/delta-io/delta/pull/4754) [[Files changed](https://github.com/delta-io/delta/pull/4754/files/378a8eda53800bcbfffc648459f5b0af69fdfffc..c4c744aa0f7e6601da7b2d12254eeb0360d9ca13)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR refactors findMaxId to use schema iterable. 

Relates to https://github.com/delta-io/delta/issues/4744

## How was this patch tested?

Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

No.
