### PR TITLE
[Delta] Refactor & Migrate DeltaLog related suites to CatalogOwned

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -44,6 +44,9 @@ import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.util.Utils
 
 object CatalogOwnedTableUtils {
+  /** The default catalog name only used for testing. */
+  val DEFAULT_CATALOG_NAME_FOR_TESTING: String = "spark_catalog"
+
   // Populate table commit coordinator using table identifier inside CatalogTable.
   def populateTableCommitCoordinatorFromCatalog(
       spark: SparkSession,
@@ -72,8 +75,10 @@ object CatalogOwnedTableUtils {
         // in-memory commit coordinator. In this case, we return table commit coordinator
         // registered in the provider so that it can still test CatalogOwned table feature
         // capability.
-        CatalogOwnedCommitCoordinatorProvider.getBuilder("spark_catalog")
-          .flatMap(builder => Some(builder.buildForCatalog(spark, "spark_catalog")))
+        CatalogOwnedCommitCoordinatorProvider.getBuilder(DEFAULT_CATALOG_NAME_FOR_TESTING)
+          .flatMap{ builder =>
+            Some(builder.buildForCatalog(spark, DEFAULT_CATALOG_NAME_FOR_TESTING))
+          }
           .map { cc =>
             return Some(TableCommitCoordinatorClient(
               cc,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -93,6 +93,20 @@ trait CatalogOwnedTestBaseSuite
   def catalogOwnedDefaultCreationEnabledInTests: Boolean =
     catalogOwnedCoordinatorBackfillBatchSize.nonEmpty
 
+  /**
+   * Returns the commit coordinator client for the specified catalog.
+   *
+   * @param catalogName The name of the catalog to get the commit coordinator client for.
+   * @return The commit coordinator client for the specified catalog.
+   */
+  protected def getCatalogOwnedCommitCoordinatorClient(
+      catalogName: String): CommitCoordinatorClient = {
+    CatalogOwnedCommitCoordinatorProvider.getBuilder(catalogName).getOrElse {
+      throw new IllegalStateException(
+        s"Commit coordinator builder is not available for the specified catalog: $catalogName")
+    }.buildForCatalog(spark, catalogName)
+  }
+
   override protected def sparkConf: SparkConf = {
     if (catalogOwnedDefaultCreationEnabledInTests) {
       super.sparkConf.set(defaultCatalogOwnedFeatureEnabledKey, "supported")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR refactors and migrates DeltaLog-related suites to CatalogOwned.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through existing suites.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
