### PR TITLE
[Feature Request][Spark] Add test coverage for clustering on generate…

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -725,6 +725,25 @@ trait ClusteredTableDDLSuiteBase
     }
   }
 
+  test("create cluster with generated column") {
+    withTable(testTable) {
+      io.delta.tables.DeltaTable.create(spark)
+        .tableName(testTable)
+        .addColumn("c1", IntegerType)
+        .addColumn(
+          io.delta.tables.DeltaTable.columnBuilder(spark, "c2")
+            .dataType(IntegerType)
+            .generatedAlwaysAs("c1 + 10")
+            .build
+        )
+        .clusterBy("c2")
+        .execute()
+
+        val tableIdentifier = TableIdentifier(testTable)
+        verifyClusteringColumns(tableIdentifier, Seq("c2")) 
+    }
+  }
+
   test("optimize clustered table and trigger regular compaction") {
     withClusteredTable(testTable, "a INT, b STRING", "a, b") {
       val tableIdentifier = TableIdentifier(testTable)


### PR DESCRIPTION
Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Test case  clustering can applied to a generated.

<!--
- Describe what this PR changes.
- Describe why we need the change.

 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Testing done for test case only

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
:smiley:

