### PR TITLE
Update the comparision as it could be same but not not greater

### DIFF
--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaHistoryManager.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaHistoryManager.scala
@@ -225,7 +225,7 @@ private[internal] case class DeltaHistoryManager(deltaLog: DeltaLogImpl) extends
     while (i < length - 1) {
       val prevTimestamp = commits(i).getTimestamp
       assert(commits(i).getVersion < commits(i + 1).getVersion, "Unordered commits provided.")
-      if (prevTimestamp >= commits(i + 1).getTimestamp) {
+      if (prevTimestamp > commits(i + 1).getTimestamp) {
         logWarning(s"Found Delta commit ${commits(i).getVersion} with a timestamp $prevTimestamp " +
           s"which is greater than the next commit timestamp ${commits(i + 1).getTimestamp}.")
         commits(i + 1) = commits(i + 1).withTimestamp(prevTimestamp + 1).asInstanceOf[T]


### PR DESCRIPTION
fix the comparison, and the timestamp can be equal but not greater.

Here is one log entry from our system.
```
DeltaHistoryManager:324 - Found Delta commit 61281 with a timestamp 1735509899000 which is greater than the next commit timestamp 1735509899000.
```

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
