### PR TITLE
[Spark][ICT] Bug Fix: Avoid accidentally dropping enablement info during REPLACE on ICT tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -870,6 +870,7 @@ private[delta] class ConflictChecker(
     val nextAvailableVersion = winningCommitVersion + 1L
     val updatedMetadata =
       InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
+        spark,
         updatedCommitTimestamp,
         currentTransactionInfo.readSnapshot,
         currentTransactionInfo.metadata,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1532,7 +1532,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val metadataWithIctInfo = commitInfo.inCommitTimestamp
       .flatMap { inCommitTimestamp =>
         InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
-          inCommitTimestamp, snapshot, metadata, firstAttemptVersion)
+          spark, inCommitTimestamp, snapshot, metadata, firstAttemptVersion)
       }.getOrElse { return false }
     newMetadata = Some(metadataWithIctInfo)
     true

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -704,6 +704,16 @@ trait DeltaSQLConfBase {
   // DynamoDB Commit Coordinator-specific configs end
   /////////////////////////////////////////////
 
+  val IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED =
+    buildConf("inCommitTimestamp.retainEnablementInfoFix.enabled")
+      .internal()
+      .doc("When disabled, Delta can end up dropping " +
+        s"inCommitTimestampEnablementVersion and inCommitTimestampEnablementTimestamp " +
+        s"during a REPLACE or CLONE command. This accidental removal of these " +
+        s"properties can result in failures on time travel queries.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_UPDATE_CATALOG_LONG_FIELD_TRUNCATION_THRESHOLD =
     buildConf("catalog.update.longFieldTruncationThreshold")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -1212,6 +1212,7 @@ class InCommitTimestampSuite
         "AS SELECT * FROM range(3, 4)")
     }
   }
+
   testWithDefaultCommitCoordinatorUnset(
     "ICT enablement properties are dropped after a REPLACE with explicit enablement " +
       s"when the ${DeltaSQLConf.IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED.key} " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, Json
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.test.SharedSparkSession
@@ -1144,6 +1145,103 @@ class InCommitTimestampSuite
             row.getAs[Timestamp]("source_commit_timestamp").getTime == expectedTimestamp)
         }
       }}}
+    }
+  }
+
+  private def testICTEnablementPropertyRetention(
+      expectRetention: Boolean,
+      expectICTEnabled: Option[Boolean] = None)(runCommand: (String) => Unit): Unit = {
+    val ictConfOpt =
+      spark.conf.getOption(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey)
+    try {
+      spark.conf.unset(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey)
+      withTempDir { tempDir =>
+        spark.range(1).write.format("delta").save(tempDir.getAbsolutePath)
+        val deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        // Enable ICT at version 1 instead of 0 so that we can test the retention of
+        // enablement provenance properties as well.
+        spark.sql(
+          s"ALTER TABLE delta.`${tempDir.getAbsolutePath}` " +
+            s"SET TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+        val enablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(
+            deltaLog.snapshot.metadata)
+        val enablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(
+            deltaLog.snapshot.metadata)
+        assert(enablementVersion.contains(1))
+        assert(enablementTimestamp.isDefined)
+
+        spark.range(2, 3).write.format("delta").mode("overwrite").save(tempDir.getAbsolutePath)
+
+        // Run the REPLACE/CLONE command.
+        runCommand(tempDir.getAbsolutePath)
+
+        val metadataAfterReplace = deltaLog.update().metadata
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(
+            metadataAfterReplace) == expectICTEnabled.getOrElse(expectRetention))
+        if (expectRetention) {
+          assert(
+            DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(
+              metadataAfterReplace) == enablementTimestamp)
+          assert(
+            DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(
+              metadataAfterReplace) == enablementVersion)
+        } else {
+          Seq(
+            DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key,
+            DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key
+          ).foreach { key =>
+            assert(!metadataAfterReplace.configuration.contains(key))
+          }
+        }
+      }
+    } finally {
+      ictConfOpt.foreach { ictConf =>
+        spark.conf.set(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey, ictConf)
+      }
+    }
+  }
+
+  testWithDefaultCommitCoordinatorUnset(
+    "ICT enablement properties remain unchanged after a REPLACE with explicit enablement") {
+    testICTEnablementPropertyRetention(expectRetention = true) { tableDir =>
+      sql(s"REPLACE TABLE delta.`$tableDir` USING delta " +
+        s"TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true') " +
+        "AS SELECT * FROM range(3, 4)")
+    }
+  }
+  testWithDefaultCommitCoordinatorUnset(
+    "ICT enablement properties are dropped after a REPLACE with explicit enablement " +
+      s"when the ${DeltaSQLConf.IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED.key} " +
+      s"is disabled") {
+    withSQLConf(
+      DeltaSQLConf.IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED.key -> "false"
+    ) {
+      testICTEnablementPropertyRetention(
+        expectRetention = false, expectICTEnabled = Some(true)) { tableDir =>
+          sql(
+            s"REPLACE TABLE delta.`$tableDir` USING delta " +
+              s"TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true') " +
+              "AS SELECT * FROM range(3, 4)")
+      }
+    }
+  }
+
+  testWithDefaultCommitCoordinatorUnset(
+    "ICT enablement properties are dropped after a REPLACE with explicit disablement") {
+    testICTEnablementPropertyRetention(expectRetention = false) { tableDir =>
+      sql(s"REPLACE TABLE delta.`$tableDir` USING delta " +
+        s"TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'false') " +
+        "AS SELECT * FROM range(3, 4)")
+    }
+  }
+
+  testWithDefaultCommitCoordinatorUnset(
+    "ICT is completely dropped after a REPLACE with no explicit disablement") {
+    testICTEnablementPropertyRetention(expectRetention = false) { tableDir =>
+      sql(s"REPLACE TABLE delta.`$tableDir` USING delta AS SELECT * FROM range(3, 4)")
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR fixes ICT so that we don't end up accidentally dropping enablement info (ICT enablement timestamp and version) when REPLACE is run on an ICT table.

Note that this PR does not change the behaviour of when ICT remains enabled/disabled after a REPLACE. It just makes sure that if ICT remains enabled, we don't drop the enablement info.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New tests in InCommitTimestampSuite.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No