### PR TITLE
[Spark] Change readPredicates from Seq to Vector

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.types.StructType
  */
 private[delta] case class CurrentTransactionInfo(
     val txnId: String,
-    val readPredicates: Seq[DeltaTableReadPredicate],
+    val readPredicates: Vector[DeltaTableReadPredicate],
     val readFiles: Set[AddFile],
     val readWholeTable: Boolean,
     val readAppIds: Set[String],

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1465,7 +1465,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       }
       val currentTransactionInfo = CurrentTransactionInfo(
         txnId = txnId,
-        readPredicates = readPredicates.asScala.toSeq,
+        readPredicates = readPredicates.asScala.toVector,
         readFiles = readFiles.toSet,
         readWholeTable = readTheWholeTable,
         readAppIds = readTxn.toSet,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Change the type of `readPredicates` in `OptimisticTransaction` class from generic `Seq` to `Vector`.

## How was this patch tested?

No behaviour change. Existing tests are suficient.

## Does this PR introduce _any_ user-facing changes?

No
