### PR TITLE
[Delta] Keep table protocol intact before and after REPLACE regardless of default CC enablement

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -394,9 +394,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
         TableFeatureProtocolUtils.defaultPropertyKey(CatalogOwnedTableFeature)
       // Isolate the spark conf to be used in the subsequent [[DeltaConfigs.mergeGlobalConfigs]]
       // by cloning the existing configuration.
-      val clonedConf = spark.synchronized {
-        spark.sessionState.conf.clone()
-      }
+      // Note: [[SQLConf.clone]] is already atomic so no extra synchronization is needed.
+      val clonedConf = spark.sessionState.conf.clone()
       // Unset default CC conf on the cloned spark conf.
       clonedConf.unsetConf(defaultCatalogOwnedFeatureEnabledKey)
       clonedConf


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR keeps table protocol intact before and after REPLACE commands.

Under the current implementation, we have the following scenario that may automatically/silently upgrade a normal delta table's Protocol when using REPLACE commands. It would be upgraded from `(x, x)` (i.e., any combinations of protocol versions) to `(3, 7)`, plus an additional (unintended) `VacuumProtocolCheckTableFeature`.

```sql
-- w/ protocol version (1, 2) if DV is turned off.
1. CREATE TABLE t (id LONG) USING delta;

-- Enable CO by default in the current SparkSession.
2. spark.conf.set("default CO conf", "supported")

-- The protocol would be automatically upgraded to (3, 7) w/ an extra VacuumProtocolCheckTableFeature.
3. REPLACE TABLE t (id LONG) USING delta;
```

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
N/A

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
