### PR TITLE
[3.3][Kernel] Bug fix: Missing Hadoop configuration parameter when creating parquet reader

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -129,7 +129,8 @@ public class ParquetFileReader {
                   protected ReadSupport<Object> getReadSupport() {
                     return readSupport;
                   }
-                }.withFilter(parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
+                }.withConf(confCopy)
+                    .withFilter(parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
                     // Disable the record level filtering as the `parquet-mr` evaluates
                     // the filter once the entire record has been materialized. Instead,
                     // we use the predicate to prune the row groups which is more efficient.

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/FakeFileSystem.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/FakeFileSystem.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import java.net.URI
+
+import org.apache.hadoop.fs.RawLocalFileSystem
+
+/** A fake file system to test whether session Hadoop configuration will be picked up. */
+class FakeFileSystem extends RawLocalFileSystem {
+  override def getScheme: String = FakeFileSystem.scheme
+  override def getUri: URI = FakeFileSystem.uri
+}
+
+object FakeFileSystem {
+  val scheme = "fake"
+  val uri = URI.create(s"$scheme:///")
+}
+


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description
When we fixed the IllegalAccessError we missed this parameter when creating the ParquetReader, we are only using it to read the footer.

Maybe also need fix to master and 4.0, I didn't have a chance to experiment the new version yet.

## How was this patch tested?
Manual tests.

## Does this PR introduce _any_ user-facing changes?
No