### PR TITLE
[Delta] Allow Clone Source to use absolutePath

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/NonSparkIcebergTestUtils.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/NonSparkIcebergTestUtils.scala
@@ -66,11 +66,13 @@ object NonSparkIcebergTestUtils {
    * @param table Iceberg table
    * @param rows  Data rows we write into the table
    * @param dataFileIdx index of the parquet file going to be written in the data folder
+   * @param dataPath Optional path to write the data file
    */
   def writeIntoIcebergTable(
       table: Table,
       rows: Seq[Map[String, Any]],
-      dataFileIdx: Int): Unit = {
+      dataFileIdx: Int,
+      dataPath: Option[String] = None): Unit = {
     val schema = table.schema()
     val records = rows.map { row =>
       val record = GenericRecord.create(schema)
@@ -80,7 +82,7 @@ object NonSparkIcebergTestUtils {
       record
     }
 
-    val parquetLocation = table.location() + s"/data/$dataFileIdx.parquet"
+    val parquetLocation = dataPath.getOrElse(table.location() + s"/data/$dataFileIdx.parquet")
 
     val fileAppender: FileAppender[GenericRecord] = Parquet
       .write(table.io().newOutputFile(parquetLocation))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
@@ -221,7 +221,7 @@ trait ConvertUtilsBase extends DeltaLogging {
         s"Fail to relativize path $path against base path $basePath.")
       relativePath.toUri.toString
     } else {
-      path.toUri.toString
+      fs.makeQualified(path).toUri.toString
     }
 
     AddFile(pathStrForAddFile, partition, file.length, file.modificationTime, dataChange = true,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR enables CloneSources to use absolutePath in data files
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UT
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
