### PR TITLE
[Spark] Better exception for clones without stats that enable row tracking

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -433,6 +433,15 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_CLONE_WITH_ROW_TRACKING_WITHOUT_STATS" : {
+    "message" : [
+      "Cannot shallow clone a table without statistics and with row tracking enabled.",
+      "If you want to enable row tracking you need to first collect statistics on the source table by running:",
+      "ANALYZE TABLE table_name COMPUTE DELTA STATISTICS",
+      ""
+    ],
+    "sqlState" : "22000"
+  },
   "DELTA_CLUSTERING_COLUMNS_DATATYPE_NOT_SUPPORTED" : {
     "message" : [
       "CLUSTER BY is not supported because the following column(s): <columnsWithDataTypes> don't support data skipping."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -668,6 +668,13 @@ trait DeltaErrorsBase
     )
   }
 
+  def cloneWithRowTrackingWithoutStats(): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_CLONE_WITH_ROW_TRACKING_WITHOUT_STATS",
+      messageParameters = Array.empty
+    )
+  }
+
   def incorrectArrayAccess(): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_INCORRECT_ARRAY_ACCESS",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1728,7 +1728,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         deltaLog.protocolWrite(snapshot.protocol)
       }
 
-      allActions = RowId.assignFreshRowIds(protocol, snapshot, allActions)
+      allActions = RowId.assignFreshRowIds(protocol, snapshot, allActions, op)
       allActions = DefaultRowCommitVersion
         .assignIfMissing(protocol, allActions, getFirstAttemptVersion)
 
@@ -2122,7 +2122,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       deltaLog.protocolWrite(snapshot.protocol)
     }
 
-    finalActions = RowId.assignFreshRowIds(protocol, snapshot, finalActions.toIterator).toList
+    finalActions = RowId.assignFreshRowIds(protocol, snapshot, finalActions.toIterator, op).toList
     finalActions = DefaultRowCommitVersion
       .assignIfMissing(protocol, finalActions.toIterator, getFirstAttemptVersion).toList
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCloneSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCloneSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.rowid
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalStateException, DeltaLog, RowId}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalStateException, DeltaLog, DeltaUnsupportedOperationException, RowId}
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -182,10 +182,10 @@ class RowIdCloneSuite
           withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "true") {
             spark.range(0).write.format("delta").saveAsTable("target")
           }
-          val err = intercept[DeltaIllegalStateException] {
+          val err = intercept[DeltaUnsupportedOperationException] {
             cloneTable(targetTableName = "target", sourceTableName = "source")
           }
-          checkError(err, "DELTA_ROW_ID_ASSIGNMENT_WITHOUT_STATS")
+          checkError(err, "DELTA_CLONE_WITH_ROW_TRACKING_WITHOUT_STATS")
         }
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Improve exception message when customer attempt to clone a table without `numRecords` statistics and at the same time enable Row Tracking.

## How was this patch tested?

Updated existing test.

## Does this PR introduce _any_ user-facing changes?

No