### PR TITLE
[Spark]Added table property `hierarchicalClusteringColumns`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSqlParserUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSqlParserUtils.scala
@@ -1,0 +1,63 @@
+/*
+ * DATABRICKS CONFIDENTIAL & PROPRIETARY
+ * __________________
+ *
+ * Copyright 2025-present Databricks, Inc.
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains the property of Databricks, Inc.
+ * and its suppliers, if any.  The intellectual and technical concepts contained herein are
+ * proprietary to Databricks, Inc. and its suppliers and may be covered by U.S. and foreign Patents,
+ * patents in process, and are protected by trade secret and/or copyright law. Dissemination, use,
+ * or reproduction of this information is strictly forbidden unless prior written permission is
+ * obtained from Databricks, Inc.
+ *
+ * If you view or obtain a copy of this information and believe Databricks, Inc. may not have
+ * intended it to be made available, please promptly report it to Databricks Legal Department
+ * @ legal@databricks.com.
+ */
+
+package com.databricks.sql.transaction.tahoe.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.parser.{AbstractSqlParser, AstBuilder, ParseException, ParserUtils, SqlBaseParser}
+
+/**
+ * Utility functions for SQL parsing operations.
+ */
+object DeltaSqlParserUtils {
+  /**
+   * The SQL grammar already includes a `multipartIdentifierList` rule for parsing a string into a
+   * list of multi-part identifiers. We just expose it here, with a custom parser and AstBuilder.
+   */
+  private class MultipartIdentifierSqlParser extends AbstractSqlParser {
+    override val astBuilder = new AstBuilder {
+      override def visitMultipartIdentifierList(ctx: SqlBaseParser.MultipartIdentifierListContext)
+      : Seq[UnresolvedAttribute] = ParserUtils.withOrigin(ctx) {
+        ctx.multipartIdentifier.asScala.toSeq.map(typedVisit[Seq[String]])
+          .map(new UnresolvedAttribute(_))
+      }
+    }
+    def parseMultipartIdentifierList(sqlText: String): Seq[UnresolvedAttribute] = {
+      parse(sqlText) { parser =>
+        astBuilder.visitMultipartIdentifierList(parser.multipartIdentifierList())
+      }
+    }
+  }
+
+  private val multipartIdentifierSqlParser = new MultipartIdentifierSqlParser
+
+  /** Parses a comma-separated list of column names; returns None if parsing fails. */
+  def parseMultipartColumnList(
+      hierarchicalClusteringColumns: String): Option[Seq[UnresolvedAttribute]] = {
+    // The parser rejects empty lists, so handle that specially here.
+    if (hierarchicalClusteringColumns.trim.isEmpty) return Some(Nil)
+    try {
+      Some(multipartIdentifierSqlParser.parseMultipartIdentifierList(hierarchicalClusteringColumns))
+    } catch {
+      case _: ParseException => None
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Added table property `hierarchicalClusteringColumns` and refactored column parser utils. 
The reason we need this is that we want to be able to specific columns to use for hierarchical clustering. We want Liquid to prioritize clustering the data files based on those columns if presented.

## How was this patch tested?

Through existing test suite.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No