### PR TITLE
[Kernel] Add new metric for total snapshot construction duration

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,12 +99,11 @@ public class TableImpl implements Table {
   @Override
   public Snapshot getLatestSnapshot(Engine engine) throws TableNotFoundException {
     SnapshotQueryContext snapshotContext = SnapshotQueryContext.forLatestSnapshot(tablePath);
-    try {
-      return snapshotManager.buildLatestSnapshot(engine, snapshotContext);
-    } catch (Exception e) {
-      snapshotContext.recordSnapshotErrorReport(engine, e);
-      throw e;
-    }
+    return loadSnapshotWithMetrics(
+        engine,
+        () -> snapshotManager.buildLatestSnapshot(engine, snapshotContext),
+        snapshotContext,
+        "AT LATEST");
   }
 
   @Override
@@ -111,12 +111,11 @@ public class TableImpl implements Table {
       throws TableNotFoundException {
     SnapshotQueryContext snapshotContext =
         SnapshotQueryContext.forVersionSnapshot(tablePath, versionId);
-    try {
-      return snapshotManager.getSnapshotAt(engine, versionId, snapshotContext);
-    } catch (Exception e) {
-      snapshotContext.recordSnapshotErrorReport(engine, e);
-      throw e;
-    }
+    return loadSnapshotWithMetrics(
+        engine,
+        () -> snapshotManager.getSnapshotAt(engine, versionId, snapshotContext),
+        snapshotContext,
+        String.format("AS OF VERSION %d", versionId));
   }
 
   @Override
@@ -125,13 +124,13 @@ public class TableImpl implements Table {
     SnapshotQueryContext snapshotContext =
         SnapshotQueryContext.forTimestampSnapshot(tablePath, millisSinceEpochUTC);
     SnapshotImpl latestSnapshot = (SnapshotImpl) getLatestSnapshot(engine);
-    try {
-      return snapshotManager.getSnapshotForTimestamp(
-          engine, latestSnapshot, millisSinceEpochUTC, snapshotContext);
-    } catch (Exception e) {
-      snapshotContext.recordSnapshotErrorReport(engine, e);
-      throw e;
-    }
+    return loadSnapshotWithMetrics(
+        engine,
+        () ->
+            snapshotManager.getSnapshotForTimestamp(
+                engine, latestSnapshot, millisSinceEpochUTC, snapshotContext),
+        snapshotContext,
+        String.format("AS OF TIMESTAMP %d", millisSinceEpochUTC));
   }
 
   @Override
@@ -322,6 +321,35 @@ public class TableImpl implements Table {
       // thrown an KernelException. So, clearly, this can't be the last commit, so we can safely
       // return commit.version + 1 as the version that is at or after the input timestamp.
       return commit.getVersion() + 1;
+    }
+  }
+
+  /** Helper method that loads a snapshot with proper metrics recording, logging, and reporting. */
+  private Snapshot loadSnapshotWithMetrics(
+      Engine engine,
+      Supplier<SnapshotImpl> loadSnapshot,
+      SnapshotQueryContext snapshotContext,
+      String queryString)
+      throws TableNotFoundException {
+    try {
+      final SnapshotImpl snapshot =
+          snapshotContext.getSnapshotMetrics().loadSnapshotTotalTimer.time(loadSnapshot);
+
+      logger.info(
+          "[{}] Took {}ms to load snapshot (version = {}) for snapshot query {}",
+          tablePath,
+          snapshotContext.getSnapshotMetrics().loadSnapshotTotalTimer.totalDurationMs(),
+          snapshot.getVersion(),
+          queryString);
+
+      engine
+          .getMetricsReporters()
+          .forEach(reporter -> reporter.report(snapshot.getSnapshotReport()));
+
+      return snapshot;
+    } catch (Exception e) {
+      snapshotContext.recordSnapshotErrorReport(engine, e);
+      throw e;
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotMetrics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotMetrics.java
@@ -28,6 +28,8 @@ import java.util.Optional;
  */
 public class SnapshotMetrics {
 
+  public final Timer loadSnapshotTotalTimer = new Timer();
+
   public final Timer timestampToVersionResolutionTimer = new Timer();
 
   public final Timer loadInitialDeltaActionsTimer = new Timer();
@@ -38,7 +40,7 @@ public class SnapshotMetrics {
 
   public SnapshotMetricsResult captureSnapshotMetricsResult() {
     return new SnapshotMetricsResult() {
-
+      final long loadSnapshotTotalDurationResult = loadSnapshotTotalTimer.totalDurationNs();
       final Optional<Long> timestampToVersionResolutionDurationResult =
           timestampToVersionResolutionTimer.totalDurationIfRecorded();
       final long loadInitialDeltaActionsDurationResult =
@@ -46,6 +48,11 @@ public class SnapshotMetrics {
       final long timeToBuildLogSegmentForVersionDurationResult =
           timeToBuildLogSegmentForVersionTimer.totalDurationNs();
       final long durationToGetCrcInfoDurationResult = durationToGetCrcInfoTimer.totalDurationNs();
+
+      @Override
+      public long getLoadSnapshotTotalDurationNs() {
+        return loadSnapshotTotalDurationResult;
+      }
 
       @Override
       public Optional<Long> getTimestampToVersionResolutionDurationNs() {
@@ -72,10 +79,13 @@ public class SnapshotMetrics {
   @Override
   public String toString() {
     return String.format(
-        "SnapshotMetrics(timestampToVersionResolutionTimer=%s, "
+        "SnapshotMetrics("
+            + "loadSnapshotTotalTimer=%s,"
+            + "timestampToVersionResolutionTimer=%s, "
             + "loadInitialDeltaActionsTimer=%s, "
             + "timeToBuildLogSegmentForVersionTimer=%s, "
             + "durationToGetCrcInfoTimer=%s)",
+        loadSnapshotTotalTimer,
         timestampToVersionResolutionTimer,
         loadInitialDeltaActionsTimer,
         timeToBuildLogSegmentForVersionTimer,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -256,30 +256,40 @@ public class LogReplay {
   private Lazy<Tuple2<Protocol, Metadata>> createLazyProtocolAndMetadata(
       Engine engine, Optional<SnapshotHint> hint, SnapshotMetrics snapshotMetrics) {
     return new Lazy<>(
-        () ->
-            snapshotMetrics.loadInitialDeltaActionsTimer.time(
-                () -> {
-                  final long targetVersion = getVersion();
+        () -> {
+          final Tuple2<Protocol, Metadata> result =
+              snapshotMetrics.loadInitialDeltaActionsTimer.time(
+                  () -> {
+                    final long targetVersion = getVersion();
 
-                  // Ignore the snapshot hint whose version is larger than the snapshot version.
-                  Optional<SnapshotHint> baseHint = hint;
-                  if (hint.isPresent() && hint.get().getVersion() > targetVersion) {
-                    baseHint = Optional.empty();
-                  }
+                    // Ignore the snapshot hint whose version is larger than the snapshot version.
+                    Optional<SnapshotHint> baseHint = hint;
+                    if (hint.isPresent() && hint.get().getVersion() > targetVersion) {
+                      baseHint = Optional.empty();
+                    }
 
-                  final Optional<SnapshotHint> newestHint =
-                      crcInfoContext.maybeGetNewerSnapshotHintAndUpdateCache(
-                          engine, getLogSegment(), baseHint, targetVersion);
+                    final Optional<SnapshotHint> newestHint =
+                        crcInfoContext.maybeGetNewerSnapshotHintAndUpdateCache(
+                            engine, getLogSegment(), baseHint, targetVersion);
 
-                  Tuple2<Protocol, Metadata> protocolAndMetadata =
-                      loadTableProtocolAndMetadata(
-                          engine, getLogSegment(), newestHint, targetVersion);
+                    Tuple2<Protocol, Metadata> protocolAndMetadata =
+                        loadTableProtocolAndMetadata(
+                            engine, getLogSegment(), newestHint, targetVersion);
 
-                  TableFeatures.validateKernelCanReadTheTable(
-                      protocolAndMetadata._1, dataPath.toString());
+                    TableFeatures.validateKernelCanReadTheTable(
+                        protocolAndMetadata._1, dataPath.toString());
 
-                  return protocolAndMetadata;
-                }));
+                    return protocolAndMetadata;
+                  });
+
+          logger.info(
+              "[{}] Took {}ms to load Protocol and Metadata at version {}",
+              dataPath.toString(),
+              snapshotMetrics.loadInitialDeltaActionsTimer.totalDurationMs(),
+              getVersion());
+
+          return result;
+        });
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/SnapshotMetricsResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/SnapshotMetricsResult.java
@@ -20,12 +20,20 @@ import java.util.Optional;
 
 /** Stores the metrics results for a {@link SnapshotReport} */
 @JsonPropertyOrder({
+  "loadSnapshotTotalDurationNs",
   "timestampToVersionResolutionDurationNs",
   "loadInitialDeltaActionsDurationNs",
   "timeToBuildLogSegmentForVersionNs",
   "durationToGetCrcInfoNs"
 })
 public interface SnapshotMetricsResult {
+
+  /**
+   * @return the total duration (ns) to load the snapshot, including all steps such as resolving
+   *     timestamp to version, LISTing the _delta_log, building the log segment, and determining the
+   *     latest protocol and metadata.
+   */
+  long getLoadSnapshotTotalDurationNs();
 
   /**
    * @return the duration (ns) to resolve the provided timestamp to a table version for timestamp

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -40,6 +40,8 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
   }
 
   private def testSnapshotReport(snapshotReport: SnapshotReport): Unit = {
+    val loadSnapshotTotalDuration =
+      snapshotReport.getSnapshotMetrics().getLoadSnapshotTotalDurationNs()
     val timestampToVersionResolutionDuration = optionToString(
       snapshotReport.getSnapshotMetrics().getTimestampToVersionResolutionDurationNs())
     val loadProtocolAndMetadataDuration =
@@ -59,6 +61,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"checkpointVersion":${optionToString(snapshotReport.getCheckpointVersion())},
          |"providedTimestamp":${optionToString(snapshotReport.getProvidedTimestamp())},
          |"snapshotMetrics":{
+         |"loadSnapshotTotalDurationNs":${loadSnapshotTotalDuration},
          |"timestampToVersionResolutionDurationNs":${timestampToVersionResolutionDuration},
          |"loadInitialDeltaActionsDurationNs":${loadProtocolAndMetadataDuration},
          |"timeToBuildLogSegmentForVersionNs":${buildLogSegmentDuration},
@@ -71,6 +74,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
 
   test("SnapshotReport serializer") {
     val snapshotContext1 = SnapshotQueryContext.forTimestampSnapshot("/table/path", 0)
+    snapshotContext1.getSnapshotMetrics.loadSnapshotTotalTimer.record(2000)
     snapshotContext1.getSnapshotMetrics.timestampToVersionResolutionTimer.record(10)
     snapshotContext1.getSnapshotMetrics.loadInitialDeltaActionsTimer.record(1000)
     snapshotContext1.getSnapshotMetrics.timeToBuildLogSegmentForVersionTimer.record(500)
@@ -94,6 +98,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
         |"checkpointVersion":20,
         |"providedTimestamp":0,
         |"snapshotMetrics":{
+        |"loadSnapshotTotalDurationNs":2000,
         |"timestampToVersionResolutionDurationNs":10,
         |"loadInitialDeltaActionsDurationNs":1000,
         |"timeToBuildLogSegmentForVersionNs":500,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/SnapshotReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/SnapshotReportSuite.scala
@@ -133,8 +133,9 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     if (expectations.expectNonEmptyTimestampToVersionResolutionDuration) {
       assert(metrics.getTimestampToVersionResolutionDurationNs.isPresent)
       assert(metrics.getTimestampToVersionResolutionDurationNs.get > 0)
-      assert(metrics.getTimestampToVersionResolutionDurationNs.get <
-        duration)
+      assert(metrics.getTimestampToVersionResolutionDurationNs.get < duration)
+      assert(metrics.getTimestampToVersionResolutionDurationNs.get <=
+        metrics.getLoadSnapshotTotalDurationNs)
     } else {
       assert(!metrics.getTimestampToVersionResolutionDurationNs.isPresent)
     }
@@ -143,6 +144,7 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     if (expectations.expectNonZeroLoadProtocolAndMetadataDuration) {
       assert(metrics.getLoadInitialDeltaActionsDurationNs > 0)
       assert(metrics.getLoadInitialDeltaActionsDurationNs < duration)
+      assert(metrics.getLoadInitialDeltaActionsDurationNs <= metrics.getLoadSnapshotTotalDurationNs)
     } else {
       assert(metrics.getLoadInitialDeltaActionsDurationNs == 0)
     }
@@ -151,6 +153,7 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     if (expectations.expectNonZeroBuildLogSegmentDuration) {
       assert(metrics.getTimeToBuildLogSegmentForVersionNs > 0)
       assert(metrics.getTimeToBuildLogSegmentForVersionNs < duration)
+      assert(metrics.getTimeToBuildLogSegmentForVersionNs <= metrics.getLoadSnapshotTotalDurationNs)
     } else {
       assert(metrics.getTimeToBuildLogSegmentForVersionNs == 0)
     }
@@ -159,6 +162,7 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     if (expectations.expectNonZeroDurationToGetCrcInfo) {
       assert(metrics.getDurationToGetCrcInfoNs > 0)
       assert(metrics.getDurationToGetCrcInfoNs < duration)
+      assert(metrics.getDurationToGetCrcInfoNs <= metrics.getLoadSnapshotTotalDurationNs)
     } else {
       assert(metrics.getDurationToGetCrcInfoNs == 0)
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/SnapshotReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/SnapshotReportSuite.scala
@@ -129,7 +129,7 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       assert(metrics.getLoadSnapshotTotalDurationNs >= 0)
     }
 
-    // ===== Metric: getTimestampToVersionResolutionDurationNs ends =====
+    // ===== Metric: getTimestampToVersionResolutionDurationNs =====
     if (expectations.expectNonEmptyTimestampToVersionResolutionDuration) {
       assert(metrics.getTimestampToVersionResolutionDurationNs.isPresent)
       assert(metrics.getTimestampToVersionResolutionDurationNs.get > 0)
@@ -139,7 +139,7 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       assert(!metrics.getTimestampToVersionResolutionDurationNs.isPresent)
     }
 
-    // ===== Metric: getLoadInitialDeltaActionsDurationNs ends =====
+    // ===== Metric: getLoadInitialDeltaActionsDurationNs =====
     if (expectations.expectNonZeroLoadProtocolAndMetadataDuration) {
       assert(metrics.getLoadInitialDeltaActionsDurationNs > 0)
       assert(metrics.getLoadInitialDeltaActionsDurationNs < duration)
@@ -147,7 +147,7 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       assert(metrics.getLoadInitialDeltaActionsDurationNs == 0)
     }
 
-    // ===== Metric: getTimeToBuildLogSegmentForVersionNs ends =====
+    // ===== Metric: getTimeToBuildLogSegmentForVersionNs =====
     if (expectations.expectNonZeroBuildLogSegmentDuration) {
       assert(metrics.getTimeToBuildLogSegmentForVersionNs > 0)
       assert(metrics.getTimeToBuildLogSegmentForVersionNs < duration)
@@ -155,7 +155,7 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       assert(metrics.getTimeToBuildLogSegmentForVersionNs == 0)
     }
 
-    // ===== Metric: getDurationToGetCrcInfoNs ends =====
+    // ===== Metric: getDurationToGetCrcInfoNs =====
     if (expectations.expectNonZeroDurationToGetCrcInfo) {
       assert(metrics.getDurationToGetCrcInfoNs > 0)
       assert(metrics.getDurationToGetCrcInfoNs < duration)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/SnapshotReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/SnapshotReportSuite.scala
@@ -118,31 +118,49 @@ class SnapshotReportSuite extends AnyFunSuite with MetricsReportTestUtils {
 
     // Since we cannot know the actual durations of these we sanity check that they are > 0 and
     // less than the total operation duration whenever they are expected to be non-zero/non-empty
+
+    val metrics = snapshotReport.getSnapshotMetrics
+
+    // ===== Metric: getLoadSnapshotTotalDurationNs =====
+    if (!expectations.expectException) {
+      assert(metrics.getLoadSnapshotTotalDurationNs > 0)
+      assert(metrics.getLoadSnapshotTotalDurationNs <= duration)
+    } else {
+      assert(metrics.getLoadSnapshotTotalDurationNs >= 0)
+    }
+
+    // ===== Metric: getTimestampToVersionResolutionDurationNs ends =====
     if (expectations.expectNonEmptyTimestampToVersionResolutionDuration) {
-      assert(snapshotReport.getSnapshotMetrics.getTimestampToVersionResolutionDurationNs.isPresent)
-      assert(snapshotReport.getSnapshotMetrics.getTimestampToVersionResolutionDurationNs.get > 0)
-      assert(snapshotReport.getSnapshotMetrics.getTimestampToVersionResolutionDurationNs.get <
+      assert(metrics.getTimestampToVersionResolutionDurationNs.isPresent)
+      assert(metrics.getTimestampToVersionResolutionDurationNs.get > 0)
+      assert(metrics.getTimestampToVersionResolutionDurationNs.get <
         duration)
     } else {
-      assert(!snapshotReport.getSnapshotMetrics.getTimestampToVersionResolutionDurationNs.isPresent)
+      assert(!metrics.getTimestampToVersionResolutionDurationNs.isPresent)
     }
+
+    // ===== Metric: getLoadInitialDeltaActionsDurationNs ends =====
     if (expectations.expectNonZeroLoadProtocolAndMetadataDuration) {
-      assert(snapshotReport.getSnapshotMetrics.getLoadInitialDeltaActionsDurationNs > 0)
-      assert(snapshotReport.getSnapshotMetrics.getLoadInitialDeltaActionsDurationNs < duration)
+      assert(metrics.getLoadInitialDeltaActionsDurationNs > 0)
+      assert(metrics.getLoadInitialDeltaActionsDurationNs < duration)
     } else {
-      assert(snapshotReport.getSnapshotMetrics.getLoadInitialDeltaActionsDurationNs == 0)
+      assert(metrics.getLoadInitialDeltaActionsDurationNs == 0)
     }
+
+    // ===== Metric: getTimeToBuildLogSegmentForVersionNs ends =====
     if (expectations.expectNonZeroBuildLogSegmentDuration) {
-      assert(snapshotReport.getSnapshotMetrics.getTimeToBuildLogSegmentForVersionNs > 0)
-      assert(snapshotReport.getSnapshotMetrics.getTimeToBuildLogSegmentForVersionNs < duration)
+      assert(metrics.getTimeToBuildLogSegmentForVersionNs > 0)
+      assert(metrics.getTimeToBuildLogSegmentForVersionNs < duration)
     } else {
-      assert(snapshotReport.getSnapshotMetrics.getTimeToBuildLogSegmentForVersionNs == 0)
+      assert(metrics.getTimeToBuildLogSegmentForVersionNs == 0)
     }
+
+    // ===== Metric: getDurationToGetCrcInfoNs ends =====
     if (expectations.expectNonZeroDurationToGetCrcInfo) {
-      assert(snapshotReport.getSnapshotMetrics.getDurationToGetCrcInfoNs > 0)
-      assert(snapshotReport.getSnapshotMetrics.getDurationToGetCrcInfoNs < duration)
+      assert(metrics.getDurationToGetCrcInfoNs > 0)
+      assert(metrics.getDurationToGetCrcInfoNs < duration)
     } else {
-      assert(snapshotReport.getSnapshotMetrics.getDurationToGetCrcInfoNs == 0)
+      assert(metrics.getDurationToGetCrcInfoNs == 0)
     }
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4800/files) to review incremental changes.
- [**stack/kernel_snapshot_construction_better_observability_1**](https://github.com/delta-io/delta/pull/4800) [[Files changed](https://github.com/delta-io/delta/pull/4800/files)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Add a new Snapshot metric `getLoadSnapshotTotalDurationNs` that records the total duration to load a Snapshot.

Includes minor refactors along the way.

## How was this patch tested?

Added new, minimal changes to existing UTs.

## Does this PR introduce _any_ user-facing changes?

New Kernel Snapshot metric.
