### PR TITLE
[spark] assign reserved row tracking field id for uniform tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
@@ -74,11 +74,16 @@ object RowTracking {
       metadata: Metadata,
       nullableConstantFields: Boolean,
       nullableGeneratedFields: Boolean): Iterable[StructField] = {
-    RowId.createRowIdField(protocol, metadata, nullableGeneratedFields) ++
+    val needSetRowTrackingFieldIdForUniform =
+      IcebergCompat.isGeqEnabled(metadata, requiredVersion = 3)
+
+    RowId.createRowIdField(
+      protocol, metadata, nullableGeneratedFields, needSetRowTrackingFieldIdForUniform) ++
       RowId.createBaseRowIdField(protocol, metadata, nullableConstantFields) ++
       DefaultRowCommitVersion.createDefaultRowCommitVersionField(
         protocol, metadata, nullableConstantFields) ++
-      RowCommitVersion.createMetadataStructField(protocol, metadata, nullableGeneratedFields)
+      RowCommitVersion.createMetadataStructField(
+        protocol, metadata, nullableGeneratedFields, needSetRowTrackingFieldIdForUniform)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -338,6 +338,12 @@ object IcebergConstants {
   val ICEBERG_TBLPROP_METADATA_LOCATION = "metadata_location"
   val ICEBERG_PROVIDER = "iceberg"
   val ICEBERG_NAME_MAPPING_PROPERTY = "schema.name-mapping.default"
+
+  // Reserved field ID for the `_row_id` column
+  // Iceberg spec: https://iceberg.apache.org/spec/?h=row#reserved-field-ids
+  val ICEBERG_ROW_TRACKING_ROW_ID_FIELD_ID = 2147483540L
+  // Reserved field ID for the `_last_updated_sequence_number` column
+  val ICEBERG_ROW_TRACKING_LAST_UPDATED_SEQUENCE_NUMBER_FIELD_ID = 2147483539L
 }
 
 object HudiConstants {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -432,6 +432,7 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
         (if (cdcEnabled) Seq(CDC_TYPE_NOT_CDC) else Seq())
 
     // Generate output columns.
+    val needSetRowTrackingFieldIdForUniform = IcebergCompat.isGeqEnabled(deltaTxn.metadata, 3)
     val outputCols = generateWriteAllChangesOutputCols(
       targetWriteCols,
       rowIdColumnExpressionOpt,
@@ -439,7 +440,8 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
       outputColNames,
       noopCopyExprs,
       clausesWithPrecompConditions,
-      cdcEnabled
+      cdcEnabled,
+      needSetRowTrackingFieldIdForUniform = needSetRowTrackingFieldIdForUniform
     )
 
     val preOutputDF = if (cdcEnabled) {
@@ -450,7 +452,9 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
           noopCopyExprs,
           rowIdColumnExpressionOpt.map(_.name),
           rowCommitVersionColumnExpressionOpt.map(_.name),
-          deduplicateCDFDeletes)
+          deduplicateCDFDeletes,
+          needSetRowTrackingFieldIdForUniform = needSetRowTrackingFieldIdForUniform
+      )
     } else {
       // change data capture is off, just output the normal data
       joinedAndPrecomputedConditionsDF

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
@@ -133,12 +133,13 @@ trait RowIdTestUtils extends RowTrackingTestUtils with DeltaSQLCommandTest {
   implicit class DataFrameRowIdColumn(df: DataFrame) {
     def withMaterializedRowIdColumn(
         materializedColumnName: String, rowIdColumn: Column): DataFrame =
-      RowId.preserveRowIdsUnsafe(df, materializedColumnName, rowIdColumn)
+      RowId.preserveRowIdsUnsafe(
+        df, materializedColumnName, rowIdColumn, shouldSetIcebergReservedFieldId = false)
 
     def withMaterializedRowCommitVersionColumn(
         materializedColumnName: String, rowCommitVersionColumn: Column): DataFrame =
       RowCommitVersion.preserveRowCommitVersionsUnsafe(
-        df, materializedColumnName, rowCommitVersionColumn)
+        df, materializedColumnName, rowCommitVersionColumn, shouldSetIcebergReservedFieldId = false)
   }
 
   def extractMaterializedRowCommitVersionColumnName(log: DeltaLog): Option[String] = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -2118,7 +2118,10 @@ class SchemaUtilsSuite extends QueryTest
           col("*"),
           col("_metadata.row_id").as("row_id")
         )
-        .withMetadata("row_id", RowId.RowIdMetadataStructField.metadata("name"))
+        .withMetadata(
+          "row_id",
+          RowId.RowIdMetadataStructField.metadata("name", shouldSetIcebergReservedFieldId = false)
+        )
 
       val tableSchema = new StructType().add("id", LongType)
       val normalized =
@@ -2141,8 +2144,14 @@ class SchemaUtilsSuite extends QueryTest
           col("_metadata.row_id").as("row_id"),
           col("_metadata.row_commit_version").as("row_commit_version")
         )
-        .withMetadata("row_id", RowId.RowIdMetadataStructField.metadata("name"))
-        .withMetadata("row_commit_version", RowCommitVersion.MetadataStructField.metadata("name"))
+        .withMetadata(
+          "row_id",
+          RowId.RowIdMetadataStructField.metadata("name", shouldSetIcebergReservedFieldId = false))
+        .withMetadata(
+          "row_commit_version",
+          RowCommitVersion.MetadataStructField.metadata(
+            "name", shouldSetIcebergReservedFieldId = false)
+        )
 
       val tableSchema = new StructType().add("id", LongType)
         val normalized =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->



#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For uniform tables, to make the materialized row id column and row commit version column is understandable by Iceberg, we need to assign the corresponding parquet field id to these two columns.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
