### PR TITLE
[Spark] Make MergeIntoSuiteBase agnostic to name/path-based access

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -38,16 +38,16 @@ trait MergeIntoDVsMixin extends MergeIntoSQLMixin with DeletionVectorsTestUtils 
 
   override def excluded: Seq[String] = {
     val miscFailures = Seq(
-      "basic case - merge to view on a Delta table by path, " +
+      "basic case - merge to view on a Delta table, " +
         "partitioned: true skippingEnabled: false useSqlView: true",
-      "basic case - merge to view on a Delta table by path, " +
+      "basic case - merge to view on a Delta table, " +
         "partitioned: true skippingEnabled: false useSqlView: false",
-      "basic case - merge to view on a Delta table by path, " +
+      "basic case - merge to view on a Delta table, " +
         "partitioned: false skippingEnabled: false useSqlView: true",
-      "basic case - merge to view on a Delta table by path, " +
+      "basic case - merge to view on a Delta table, " +
         "partitioned: false skippingEnabled: false useSqlView: false",
-      "basic case - merge to Delta table by name, isPartitioned: false skippingEnabled: false",
-      "basic case - merge to Delta table by name, isPartitioned: true skippingEnabled: false",
+      "basic case - merge to Delta table, isPartitioned: false skippingEnabled: false",
+      "basic case - merge to Delta table, isPartitioned: true skippingEnabled: false",
       "not matched by source - all 3 clauses - no changes - " +
         "isPartitioned: true - cdcEnabled: true",
       "not matched by source - all 3 clauses - no changes - " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 trait MergeIntoSQLMixin extends MergeIntoSuiteBaseMixin
   with MergeIntoSQLTestUtils
   with DeltaSQLCommandTest
+  with DeltaDMLByPathTestUtils
   with DeltaTestUtilsForTempViews {
 
   override def excluded: Seq[String] = super.excluded ++ Seq(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.types.StructType
 trait MergeIntoScalaMixin extends MergeIntoSuiteBaseMixin
   with MergeIntoScalaTestUtils
   with DeltaSQLCommandTest
+  with DeltaDMLByPathTestUtils
   with DeltaTestUtilsForTempViews
   with DeltaExcludedTestMixin {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -77,14 +77,14 @@ trait MergeIntoSchemaEvolutionMixin {
           errorContains(Utils.exceptionString(ex), error)
         } else {
           executeMerge(s"$tableSQLIdentifier t", "source s", cond, clauses: _*)
-          checkAnswer(readDeltaTableByIdentifier(tableSQLIdentifier), df.collect())
+          checkAnswer(readDeltaTableByIdentifier(), df.collect())
           if (schema != null) {
-            assert(readDeltaTableByIdentifier(tableSQLIdentifier).schema === schema)
+            assert(readDeltaTableByIdentifier().schema === schema)
           } else {
             // Check against the schema of the expected result df if no explicit schema was
             // provided. Nullability of fields will vary depending on the actual data in the df so
             // we ignore it.
-            assert(readDeltaTableByIdentifier(tableSQLIdentifier).schema.asNullable ===
+            assert(readDeltaTableByIdentifier().schema.asNullable ===
               df.schema.asNullable)
           }
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR is a continuation of https://github.com/delta-io/delta/pull/4808. Here, we continue pushing the `DeltaDMLByPathTestUtils` trait down closer to the MergeInto suites. In the process, we need to change all explicit path-based accesses to more generic constructs such as `tableSQLIdentifier` and `readDeltaTableByIdentifier`, which can be overrode with either `DeltaDMLByPathTestUtils` or `DeltaDMLByNameTestUtils` (to be added later) traits.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No
