### PR TITLE
[Spark] CDC, Row Tracking, and DV Test Dimensions; Split MergeIntoSuiteBase

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConverters._
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaTestUtils.{modifyCommitTimestamp, BOOLEAN_DOMAIN}
+import org.apache.spark.sql.delta.cdc.CDCEnabled
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -44,14 +45,12 @@ import org.apache.spark.sql.types.{LongType, StringType, StructType}
 
 abstract class DeltaCDCSuiteBase
   extends QueryTest
+  with CDCEnabled
   with SharedSparkSession
   with CheckCDCAnswer
   with DeltaSQLCommandTest {
 
   import testImplicits._
-
-  override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
 
   /** Represents path or metastore table name */
   abstract case class TblId(id: String)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.delta.deletionvectors.PersistentDVEnabled
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.hadoop.fs.Path
 import org.scalatest.concurrent.Eventually
@@ -410,9 +411,5 @@ trait DeltaSourceDeletionVectorTests extends StreamTest
 
 class DeltaSourceDeletionVectorsSuite extends DeltaSourceSuiteBase
   with DeltaSQLCommandTest
-  with DeltaSourceDeletionVectorTests {
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    enableDeletionVectorsInNewTables(spark.conf)
-  }
-}
+  with DeltaSourceDeletionVectorTests
+  with PersistentDVEnabled

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceFastDropFeatureSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.text.SimpleDateFormat
 
+import org.apache.spark.sql.delta.cdc.CDCEnabled
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -302,12 +303,7 @@ class DeltaSourceFastDropFeatureSuite
   }
 }
 
-class DeltaSourceFastDropFeatureCDCSuite extends DeltaSourceFastDropFeatureSuite {
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    spark.conf.set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
-  }
-
+class DeltaSourceFastDropFeatureCDCSuite extends DeltaSourceFastDropFeatureSuite with CDCEnabled {
   override protected def excluded: Seq[String] =
     super.excluded ++ Seq(
       // Excluded because in CDC streaming the current behaviour is to always check the protocol at

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.Row
 
-trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBase {
+trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBaseMixin {
   import testImplicits._
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -32,7 +32,11 @@ import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class MergeIntoSQLSuite extends MergeIntoSuiteBase
+class MergeIntoSQLSuite extends MergeIntoBasicTests
+  with MergeIntoTempViewsTests
+  with MergeIntoNestedDataTests
+  with MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSuiteBaseMiscTests
   with MergeIntoSQLTestUtils
   with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
@@ -185,7 +189,7 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase
     }
   }
 
-  def testNondeterministicOrder(insertOnly: Boolean): Unit = {
+  private def testNondeterministicOrder(insertOnly: Boolean): Unit = {
     withTable("target") {
       // For the spark sql random() function the seed is fixed for both invocations
       val trueRandom = () => Math.random()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -28,7 +28,10 @@ import org.apache.spark.sql.catalyst.plans.logical.{Assignment, DeltaMergeIntoCl
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 
-class MergeIntoScalaSuite extends MergeIntoSuiteBase
+class MergeIntoScalaSuite extends MergeIntoBasicTests
+  with MergeIntoNestedDataTests
+  with MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSuiteBaseMiscTests
   with MergeIntoScalaTestUtils
   with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
@@ -36,38 +39,6 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase
   with DeltaExcludedTestMixin {
 
   import testImplicits._
-
-  override def excluded: Seq[String] = super.excluded ++ Seq(
-    // Exclude tempViews, because DeltaTable.forName does not resolve them correctly, so no one can
-    // use them anyway with the Scala API.
-    // scalastyle:off line.size.limit
-    "basic case - merge to view on a Delta table by path, partitioned: true skippingEnabled: true useSqlView: true",
-    "basic case - merge to view on a Delta table by path, partitioned: true skippingEnabled: true useSqlView: false",
-    "basic case - merge to view on a Delta table by path, partitioned: false skippingEnabled: true useSqlView: true",
-    "basic case - merge to view on a Delta table by path, partitioned: false skippingEnabled: true useSqlView: false",
-    "basic case - merge to view on a Delta table by path, partitioned: true skippingEnabled: false useSqlView: true",
-    "basic case - merge to view on a Delta table by path, partitioned: true skippingEnabled: false useSqlView: false",
-    "basic case - merge to view on a Delta table by path, partitioned: false skippingEnabled: false useSqlView: true",
-    "basic case - merge to view on a Delta table by path, partitioned: false skippingEnabled: false useSqlView: false",
-    "Negative case - more operations between merge and delta target",
-    "test merge on temp view - basic - SQL TempView",
-    "test merge on temp view - basic - Dataset TempView",
-    "test merge on temp view - basic - merge condition references subset of target cols - SQL TempView",
-    "test merge on temp view - basic - merge condition references subset of target cols - Dataset TempView",
-    "test merge on temp view - subset cols - SQL TempView",
-    "test merge on temp view - subset cols - Dataset TempView",
-    "test merge on temp view - superset cols - SQL TempView",
-    "test merge on temp view - superset cols - Dataset TempView",
-    "test merge on temp view - nontrivial projection - SQL TempView",
-    "test merge on temp view - nontrivial projection - Dataset TempView",
-    "test merge on temp view - view with too many internal aliases - SQL TempView",
-    "test merge on temp view - view with too many internal aliases - Dataset TempView",
-    "test merge on temp view - view with too many internal aliases - merge condition references subset of target cols - SQL TempView",
-    "test merge on temp view - view with too many internal aliases - merge condition references subset of target cols - Dataset TempView",
-    "Update specific column works fine in temp views - SQL TempView",
-    "Update specific column works fine in temp views - Dataset TempView"
-    // scalastyle:on line.size.limit
-    )
 
   // Maps expected error classes to actual error classes. Used to handle error classes that are
   // different when running using SQL vs. Scala.
@@ -696,6 +667,9 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase
     }
   }
 
+  /* Exclude tempViews, because DeltaTable.forName does not resolve them correctly, so no one can
+   * use them anyway with the Scala API.
+
   // Scala API won't hit the resolution exception.
   testWithTempView("Update specific column works fine in temp views") { isSQLTempView =>
     withJsonData(
@@ -718,6 +692,7 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase
       )
     }
   }
+   */
 
   test("delta merge into clause with invalid data type.") {
     import org.apache.spark.sql.catalyst.dsl.expressions._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
@@ -29,11 +29,8 @@ import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.lit
 
-class DeleteCDCSuite extends DeleteSQLSuite {
+class DeleteCDCSuite extends DeleteSQLSuite with CDCEnabled {
   import testImplicits._
-
-  override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
 
   protected def testCDCDelete(name: String)(
       initialData: => Dataset[_],

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 /**
@@ -38,18 +39,23 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 class MergeCDCCoreSuite extends MergeCDCTests
 class MergeCDCSuite extends MergeIntoSQLSuite with MergeCDCTests
 
+trait CDCEnabled extends SharedSparkSession {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
+}
+
 /**
  * Tests for MERGE INTO in CDC output mode.
  *
  */
 trait MergeCDCTests extends QueryTest
+  with CDCEnabled
   with MergeIntoSQLTestUtils
   with DeltaColumnMappingTestUtils
   with DeltaSQLCommandTest {
   import testImplicits._
 
   override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
     .set(DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS.key, "false")
 
   // scalastyle:off argcount

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
@@ -24,15 +24,11 @@ import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.test.DeltaExcludedTestMixin
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 
-class UpdateCDCSuite extends UpdateSQLSuite with DeltaColumnMappingTestUtils {
+class UpdateCDCSuite extends UpdateSQLSuite with CDCEnabled with DeltaColumnMappingTestUtils {
   import testImplicits._
-
-  override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
 
   test("CDC for unconditional update") {
     append(Seq((1, 1), (2, 2), (3, 3), (4, 4)).toDF("key", "value"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
 
+import org.apache.spark.SparkConf
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -44,6 +45,18 @@ import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+
+trait PersistentDVDisabled extends SharedSparkSession {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey, "false")
+}
+
+trait PersistentDVEnabled extends DeletionVectorsTestUtils {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    enableDeletionVectorsInNewTables(spark.conf)
+  }
+}
 
 class DeletionVectorsSuite extends QueryTest
   with SharedSparkSession

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingCompactionSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
+import org.apache.spark.sql.delta.deletionvectors.PersistentDVEnabled
 import org.apache.spark.sql.delta.hooks.AutoCompact
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -240,16 +241,11 @@ trait RowTrackingAutoCompactionTests extends RowTrackingCompactionTests {
   }
 }
 
-trait RowTrackingPurgeTests extends RowTrackingCompactionTests with DeletionVectorsTestUtils {
+trait RowTrackingPurgeTests extends RowTrackingCompactionTests with PersistentDVEnabled {
 
   override protected val numSoftDeletedRows: Int = 3
 
   override protected def commandName: String = "purge"
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    enableDeletionVectorsInNewTables(spark.conf)
-  }
 
   override protected def createTable(
       dir: File,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingDeleteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingDeleteSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.rowid
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.deletionvectors.PersistentDVEnabled
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf
@@ -243,12 +244,7 @@ trait RowTrackingDeleteSuiteBase extends RowTrackingDeleteTestDimension {
 
 trait RowTrackingDeleteDvBase
   extends RowTrackingDeleteTestDimension
-  with DeletionVectorsTestUtils {
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    enableDeletionVectorsInNewTables(spark.conf)
-  }
+  with PersistentDVEnabled {
 
   override protected def deletionVectorEnabled = true
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingTestUtils.scala
@@ -26,6 +26,17 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.test.SharedSparkSession
 
+trait RowTrackingDisabled extends RowTrackingTestUtils {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey, "false")
+    .set(defaultRowTrackingFeatureProperty, "supported")
+}
+
+trait RowTrackingEnabled extends RowTrackingTestUtils {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey, "true")
+}
+
 trait RowTrackingTestUtils
   extends QueryTest
   with SharedSparkSession


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR extracts delta test dimensions for CDC, Row Tracking, and DV to traits. These will be useful when splitting test suites and using the new test generation script.

Additionally, `MergeIntoSuiteBase` is split into a mixin that contains the setup and overridden methods and multiple smaller base suites. `MergeIntoTempViewsTests` is not added to `MergeIntoScalaSuite` as they were previously being excluded. This PR shouldn't affect any functionality of the tests.

Old `MergeIntoSuiteBase` is split into the following:
- `trait MergeIntoSuiteBaseMixin`
- `trait MergeIntoBasicTests`
- `trait MergeIntoTempViewsTests`
- `trait MergeIntoNestedDataTests`
- `trait MergeIntoUnlimitedMergeClausesTests`
- `trait MergeIntoSuiteBaseMiscTests`

## How was this patch tested?

Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

No
