### PR TITLE
[Spark] Move parseDeltaStatsColumnNames to a general helper class

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.hooks.AutoCompactType
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.{DataSkippingReader, StatisticsCollection}
-import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.spark.sql.delta.util.{DeltaSqlParserUtils, JsonUtils}
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.{DateTimeConstants, IntervalUtils}
@@ -600,7 +600,7 @@ trait DeltaConfigsBase extends DeltaLogging {
     "dataSkippingStatsColumns",
     null,
     v => Option(v),
-    vOpt => vOpt.forall(v => StatisticsCollection.parseDeltaStatsColumnNames(v).isDefined),
+    vOpt => vOpt.forall(v => DeltaSqlParserUtils.parseMultipartColumnList(v).isDefined),
     """
       |The dataSkippingStatsColumns parameter is a comma-separated list of case-insensitive column
       |identifiers. Each column identifier can consist of letters, digits, and underscores.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.delta.schema.SchemaUtils.transformSchema
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DeltaStatistics._
 import org.apache.spark.sql.delta.stats.StatisticsCollection.getIndexedColumns
+import org.apache.spark.sql.delta.util.DeltaSqlParserUtils
 import org.apache.spark.sql.util.ScalaExtensions._
 
 import org.apache.spark.sql._
@@ -414,37 +415,6 @@ object StatisticsCollection extends DeltaCommand {
   val UTF8_MAX_CHARACTER = new String(Character.toChars(Character.MAX_CODE_POINT))
 
   /**
-   * The SQL grammar already includes a `multipartIdentifierList` rule for parsing a string into a
-   * list of multi-part identifiers. We just expose it here, with a custom parser and AstBuilder.
-   */
-  private class SqlParser extends AbstractSqlParser {
-    override val astBuilder = new AstBuilder {
-      override def visitMultipartIdentifierList(ctx: MultipartIdentifierListContext)
-      : Seq[UnresolvedAttribute] = ParserUtils.withOrigin(ctx) {
-        ctx.multipartIdentifier.asScala.toSeq.map(typedVisit[Seq[String]])
-          .map(new UnresolvedAttribute(_))
-      }
-    }
-    def parseMultipartIdentifierList(sqlText: String): Seq[UnresolvedAttribute] = {
-      parse(sqlText) { parser =>
-        astBuilder.visitMultipartIdentifierList(parser.multipartIdentifierList())
-      }
-    }
-  }
-  private val parser = new SqlParser
-
-  /** Parses a comma-separated list of column names; returns None if parsing fails. */
-  def parseDeltaStatsColumnNames(deltaStatsColNames: String): Option[Seq[UnresolvedAttribute]] = {
-    // The parser rejects empty lists, so handle that specially here.
-    if (deltaStatsColNames.trim.isEmpty) return Some(Nil)
-    try {
-      Some(parser.parseMultipartIdentifierList(deltaStatsColNames))
-    } catch {
-      case _: ParseException => None
-    }
-  }
-
-  /**
    * This method is the wrapper method to validates the DATA_SKIPPING_STATS_COLUMNS value of
    * metadata.
    */
@@ -510,7 +480,7 @@ object StatisticsCollection extends DeltaCommand {
       schema: StructType, partitionColumns: Seq[String], deltaStatsColumnsConfigs: String): Unit = {
     val partitionColumnSet = partitionColumns.map(_.toLowerCase(Locale.ROOT)).toSet
     val visitedColumns = ArrayBuffer.empty[String]
-    parseDeltaStatsColumnNames(deltaStatsColumnsConfigs).foreach { columns =>
+    DeltaSqlParserUtils.parseMultipartColumnList(deltaStatsColumnsConfigs).foreach { columns =>
       columns.foreach { columnAttribute =>
         val columnFullPath = columnAttribute.nameParts
         // Delta statistics columns must not be partitioned column.
@@ -618,7 +588,7 @@ object StatisticsCollection extends DeltaCommand {
     val indexedColNamesOpt = DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.fromMetaData(metadata)
     val numIndexedCols = DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.fromMetaData(metadata)
     indexedColNamesOpt.map { indexedColNames =>
-      DeltaStatsColumnSpec(parseDeltaStatsColumnNames(indexedColNames), None)
+      DeltaStatsColumnSpec(DeltaSqlParserUtils.parseMultipartColumnList(indexedColNames), None)
     }.getOrElse {
       DeltaStatsColumnSpec(None, Some(numIndexedCols))
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSqlParserUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSqlParserUtils.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.parser.{AbstractSqlParser, AstBuilder, ParseException, ParserUtils, SqlBaseParser}
+
+/**
+ * Utility functions for SQL parsing operations.
+ */
+object DeltaSqlParserUtils {
+  /**
+   * The SQL grammar already includes a `multipartIdentifierList` rule for parsing a string into a
+   * list of multi-part identifiers. We just expose it here, with a custom parser and AstBuilder.
+   */
+  private class MultipartIdentifierSqlParser extends AbstractSqlParser {
+    override val astBuilder = new AstBuilder {
+      override def visitMultipartIdentifierList(ctx: SqlBaseParser.MultipartIdentifierListContext)
+      : Seq[UnresolvedAttribute] = ParserUtils.withOrigin(ctx) {
+        ctx.multipartIdentifier.asScala.toSeq.map(typedVisit[Seq[String]])
+          .map(new UnresolvedAttribute(_))
+      }
+    }
+    def parseMultipartIdentifierList(sqlText: String): Seq[UnresolvedAttribute] = {
+      parse(sqlText) { parser =>
+        astBuilder.visitMultipartIdentifierList(parser.multipartIdentifierList())
+      }
+    }
+  }
+
+  private val multipartIdentifierSqlParser = new MultipartIdentifierSqlParser
+
+  /** Parses a comma-separated list of column names; returns None if parsing fails. */
+  def parseMultipartColumnList(columns: String): Option[Seq[UnresolvedAttribute]] = {
+    // The parser rejects empty lists, so handle that specially here.
+    if (columns.trim.isEmpty) return Some(Nil)
+    try {
+      Some(multipartIdentifierSqlParser.parseMultipartIdentifierList(columns))
+    } catch {
+      case _: ParseException => None
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Move parseDeltaStatsColumnNames to a general helper class.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through existing tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
