### PR TITLE
[Delta Core 2.4][Spark 3.4] Execute MERGE using Dataframe API in Scala to ensure merge command appears in the Logical Execution Plan and subsequently picked up by QueryExecutionListener

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -287,7 +287,7 @@ class DeltaMergeBuilder private(
       PreprocessTableMerge(sparkSession.sessionState.conf)(strippedMergeInto)
         .asInstanceOf[MergeIntoCommand]
     sparkSession.sessionState.analyzer.checkAnalysis(mergeIntoCommand)
-    mergeIntoCommand.run(sparkSession)
+    toDataset(sparkSession, mergeIntoCommand)
   }
 
   /**


### PR DESCRIPTION
(cherrypick of https://github.com/delta-io/delta/pull/3456) and (cherrypick of https://github.com/delta-io/delta/pull/3585)

This change ensures that the MERGE command executed via the Scala API is properly captured in the Logical Execution Plan and recognized by the QueryExecutionListener. While Spark 3.5.X and 4.x support lineage capture from the logical plan, earlier versions (3.1–3.4) do not, necessitating a backward-compatible solution.

This update manually resolves the plan, then executes it via the DataFrame API, allowing the command to flow through Spark’s standard analysis and execution pipeline. As a result, Spark data lineage can be captured using tools like Spline Spark Agent and etc.

Resolves (original issue: https://github.com/delta-io/delta/issues/1521) Covered by existing tests.

References:
(Cherrypick of https://github.com/delta-io/delta/pull/3456)
(Original issue: https://github.com/delta-io/delta/issues/1521)