### PR TITLE
[deprecated][Kernel]support with withRowIdHighWatermark in TransactionBuilder

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
@@ -167,6 +167,15 @@ public interface TransactionBuilder {
   TransactionBuilder withDomainMetadataSupported();
 
   /**
+   * Set the row ID high watermark for the table. This is used to track the highest row ID that has
+   * used for row tracking. This method should only be called when the 'rowTracking' feature is
+   * supported.
+   *
+   * @return updated {@link TransactionBuilder} instance
+   */
+  TransactionBuilder withRowIdHighWatermark(long rowIdHighWatermark);
+
+  /**
    * Build the transaction. Also validates the given info to ensure that a valid transaction can be
    * created.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -431,6 +431,15 @@ public final class DeltaErrors {
             + " but 'domainMetadata' is unsupported");
   }
 
+  public static KernelException rowTrackingRequiredForRowIdHighWatermark(
+      String tablePath, Long rowIdHighWatermark) {
+    return new KernelException(
+        String.format(
+            "Cannot assign a rowId high water mark ('%s') to a table `%s` that does not support "
+                + "row tracking. Please enable the rowTracking table feature.",
+            rowIdHighWatermark, tablePath));
+  }
+
   public static KernelException cannotToggleRowTrackingOnExistingTable() {
     return new KernelException("Row tracking support cannot be changed once the table is created.");
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -93,6 +93,7 @@ public class TransactionImpl implements Transaction {
   private int maxRetries;
   private int logCompactionInterval;
   private Optional<CRCInfo> currentCrcInfo;
+  private Optional<Long> providedRowIdHighWatermark;
 
   private boolean closed; // To avoid trying to commit the same transaction again.
 
@@ -112,7 +113,8 @@ public class TransactionImpl implements Transaction {
       boolean shouldUpdateProtocol,
       int maxRetries,
       int logCompactionInterval,
-      Clock clock) {
+      Clock clock,
+      Optional<Long> providedRowIdHighWatermark) {
     this.isCreateOrReplace = isCreateOrReplace;
     this.dataPath = dataPath;
     this.logPath = logPath;
@@ -130,6 +132,7 @@ public class TransactionImpl implements Transaction {
     this.logCompactionInterval = logCompactionInterval;
     this.clock = clock;
     this.currentCrcInfo = readSnapshot.getCurrentCrcInfo();
+    this.providedRowIdHighWatermark = providedRowIdHighWatermark;
   }
 
   @Override
@@ -252,7 +255,8 @@ public class TransactionImpl implements Transaction {
                 protocol,
                 Optional.empty() /* winningTxnRowIdHighWatermark */,
                 dataActions,
-                resolvedDomainMetadatas);
+                resolvedDomainMetadatas,
+                providedRowIdHighWatermark);
         domainMetadataState.setComputedDomainMetadatas(updatedDomainMetadata);
         dataActions =
             RowTracking.assignBaseRowIdAndDefaultRowCommitVersion(
@@ -317,7 +321,8 @@ public class TransactionImpl implements Transaction {
             commitAsVersion,
             this,
             domainMetadataState.getComputedDomainMetadatasToCommit(),
-            dataActions);
+            dataActions,
+            providedRowIdHighWatermark);
     long newCommitAsVersion = rebaseState.getLatestVersion() + 1;
     checkArgument(
         commitAsVersion < newCommitAsVersion,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -322,7 +322,8 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       withDomainMetadataSupported: Boolean = false,
       maxRetries: Int = -1,
       clusteringColsOpt: Option[List[Column]] = None,
-      logCompactionInterval: Int = 10): Transaction = {
+      logCompactionInterval: Int = 10,
+      rowIdHighWatermarkOpt: Option[Long] = None): Transaction = {
     // scalastyle:on argcount
 
     var txnBuilder = createWriteTxnBuilder(
@@ -349,6 +350,10 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
 
     if (maxRetries >= 0) {
       txnBuilder = txnBuilder.withMaxRetries(maxRetries)
+    }
+
+    if (rowIdHighWatermarkOpt.isDefined) {
+      txnBuilder = txnBuilder.withRowIdHighWatermark(rowIdHighWatermarkOpt.get)
     }
 
     txnBuilder = txnBuilder.withLogCompactionInverval(logCompactionInterval)
@@ -432,7 +437,8 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       data: Seq[(Map[String, Literal], Seq[FilteredColumnarBatch])],
       clock: Clock = () => System.currentTimeMillis,
       tableProperties: Map[String, String] = null,
-      clusteringColsOpt: Option[List[Column]] = None): TransactionCommitResult = {
+      clusteringColsOpt: Option[List[Column]] = None,
+      rowIdHighWatermarkOpt: Option[Long] = None): TransactionCommitResult = {
 
     val txn = createTxn(
       engine,
@@ -442,7 +448,8 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       partCols,
       tableProperties,
       clock,
-      clusteringColsOpt = clusteringColsOpt)
+      clusteringColsOpt = clusteringColsOpt,
+      rowIdHighWatermarkOpt = rowIdHighWatermarkOpt)
     commitAppendData(engine, txn, data)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Support the `withRowIdHighWatermark` API in the TransactionBuilder, which would be used to set the highWaterMark of row tracking feature. This provided high water mark must be larger or same as the current largest row id, otherwise we would throw the exception.

This is required for supporting IcebergCompatV3 table as we need to keep the Iceberg nextRowId and Delta highWaterMark in sync.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
tests.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
