### PR TITLE
[Spark] Fix DeltaDataFrameWriterV2Suite.Replace: fail if table does not exist

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -403,11 +403,12 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Replace: fail if table does not exist") {
-    val exc = intercept[CannotReplaceMissingTableException] {
+    val exc = intercept[AnalysisException] {
       spark.table("source").writeTo("table_name").using("delta").replace()
     }
 
-    assert(exc.getMessage.contains("table_name"))
+    checkError(exc, "TABLE_OR_VIEW_NOT_FOUND", Some("42P01"),
+      Map("relationName" -> "`default`.`table_name`"))
   }
 
   test("CreateOrReplace: table does not exist") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

CannotReplaceMissingTableException extends AnalysisException.
Spark has rewrites that sometimes change AnalysisException into ExtendedAnalysisException to add more context.
For some reason, it started happening here. Rewriting it into ExtendedAnalysisException makes it lose the CannotReplaceMissingTableException, but it retains the correct error class and SQL state. Make the test check the error class and SQL state instead.

## How was this patch tested?

Test runs.

## Does this PR introduce _any_ user-facing changes?

No.
