### PR TITLE
Use `TimestampAddInterval` instead of `TimeAdd`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -671,8 +671,8 @@ trait DataSkippingReaderBase
       // Date and time arithmetic.
       case _: AddMonthsBase | _: DateAdd | _: DateAddInterval | _: DateDiff | _: DateSub |
            _: DatetimeSub | _: LastDay | _: MonthsBetween | _: NextDay | _: SubtractDates |
-           _: SubtractTimestamps | _: TimeAdd | _: TimestampAdd | _: TimestampAddYMInterval |
-           _: TimestampDiff | _: TruncInstant => true
+           _: SubtractTimestamps | _: TimestampAddInterval | _: TimestampAdd |
+           _: TimestampAddYMInterval | _: TimestampDiff | _: TruncInstant => true
       // String expressions.
       case _: Base64 | _: BitLength | _: Chr | _: ConcatWs | _: Decode | _: Elt | _: Empty2Null |
            _: Encode | _: FormatNumber | _: FormatString | _: ILike | _: InitCap | _: Left |
@@ -978,11 +978,12 @@ trait DataSkippingReaderBase
           //
           // There is a longer term task SC-22825 to fix the serialization problem that caused this.
           // But we need the adjustment in any case to correctly read stats written by old versions.
-          Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampType))
+          Column(Cast(TimestampAddInterval(statCol.expr, oneMillisecondLiteralExpr), TimestampType))
         case (statCol, TimestampNTZType, _) if pathToStatType.head == MAX =>
           // We also apply the same adjustment of max stats that was applied to Timestamp
           // for TimestampNTZ because these 2 types have the same precision in terms of time.
-          Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampNTZType))
+          Column(Cast(TimestampAddInterval(statCol.expr, oneMillisecondLiteralExpr),
+            TimestampNTZType))
         case (statCol, _, _) =>
           statCol
       }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
In the PR, I propose to use `TimestampAddInterval` instead of `TimeAdd` in `DataSkippingReaderBase` because the internal expression was renamed in Spark by the PR: 

## How was this patch tested?
By compiling, and existing tests.

## Does this PR introduce _any_ user-facing changes?
No.