### PR TITLE
[Kernel]support RowTrackingDomainMetadata in Transaction.addDomainMetadata

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -431,6 +431,15 @@ public final class DeltaErrors {
             + " but 'domainMetadata' is unsupported");
   }
 
+  public static KernelException rowTrackingRequiredForRowIdHighWatermark(
+      String tablePath, String rowIdHighWatermark) {
+    return new KernelException(
+        String.format(
+            "Cannot assign a rowId high water mark ('%s') to a table `%s` that does not support "
+                + "row tracking. Please enable the rowTracking table feature.",
+            rowIdHighWatermark, tablePath));
+  }
+
   public static KernelException cannotToggleRowTrackingOnExistingTable() {
     return new KernelException("Row tracking support cannot be changed once the table is created.");
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/DomainMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/DomainMetadata.java
@@ -22,12 +22,11 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.data.GenericRow;
+import io.delta.kernel.internal.rowtracking.RowTrackingMetadataDomain;
 import io.delta.kernel.types.BooleanType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 /** Delta log action representing an `DomainMetadata` action */
 public class DomainMetadata {
@@ -37,6 +36,21 @@ public class DomainMetadata {
     // Domain identifiers are case-sensitive, but we don't want to allow users to set domains
     // with prefixes like `DELTA.` either, so perform case-insensitive check for this purpose
     return !domain.toLowerCase(Locale.ROOT).startsWith("delta.");
+  }
+
+  /**
+   * Checks whether the provided {@code domain} is a system domain that is supported for set in a
+   * Delta transaction via addDomainMetadata.
+   *
+   * <p>By default, system domains are not allowed to be set through transaction-level domain
+   * metadata due to their reserved nature. However, there are specific system domains—such as
+   * {@link RowTrackingMetadataDomain#DOMAIN_NAME}—that are explicitly allowed to be set in this
+   * context. This method defines the allowlist of such supported domains and checks against it.
+   */
+  public static boolean isSystemDomainSupportedSetFromTxn(String domain) {
+    Set<String> SUPPORTED_SYSTEM_DOMAINS = new HashSet<>();
+    SUPPORTED_SYSTEM_DOMAINS.add(RowTrackingMetadataDomain.DOMAIN_NAME);
+    return SUPPORTED_SYSTEM_DOMAINS.contains(domain);
   }
 
   /** Full schema of the {@link DomainMetadata} action in the Delta Log. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -146,6 +146,8 @@ public class RowTracking {
    *     transaction. Should be empty for initial assignment and present for conflict resolution.
    * @param txnDataActions a {@link CloseableIterable} of data actions this txn is trying to commit
    * @param txnDomainMetadatas a list of domain metadata actions this txn is trying to commit
+   * @param providedRowIdHighWatermark Optional row ID high watermark explicitly provided by the
+   *     transaction builder.
    * @return Updated list of domain metadata actions for commit
    */
   public static List<DomainMetadata> updateRowIdHighWatermarkIfNeeded(
@@ -153,7 +155,8 @@ public class RowTracking {
       Protocol txnProtocol,
       Optional<Long> winningTxnRowIdHighWatermark,
       CloseableIterable<Row> txnDataActions,
-      List<DomainMetadata> txnDomainMetadatas) {
+      List<DomainMetadata> txnDomainMetadatas,
+      Optional<Long> providedRowIdHighWatermark) {
     checkArgument(
         TableFeatures.isRowTrackingSupported(txnProtocol),
         "Row ID high watermark is updated only when feature 'rowTracking' is supported.");
@@ -170,14 +173,14 @@ public class RowTracking {
 
     // Tracks the new row ID high watermark as we iterate through data actions and counting new rows
     // added in this transaction.
-    final AtomicLong currRowIdHighWatermark =
+    final AtomicLong currCalculatedRowIdHighWatermark =
         new AtomicLong(winningTxnRowIdHighWatermark.orElse(prevRowIdHighWatermark));
 
     // The row ID high watermark must increase monotonically, so the winning transaction's high
     // watermark (if present) must be greater than or equal to the high watermark from the
     // current transaction's read snapshot.
     checkArgument(
-        currRowIdHighWatermark.get() >= prevRowIdHighWatermark,
+        currCalculatedRowIdHighWatermark.get() >= prevRowIdHighWatermark,
         "The current row ID high watermark must be greater than or equal to "
             + "the high watermark from the transaction's read snapshot");
 
@@ -187,14 +190,32 @@ public class RowTracking {
             AddFile addFile = new AddFile(row.getStruct(SingleAction.ADD_FILE_ORDINAL));
             if (!addFile.getBaseRowId().isPresent()
                 || addFile.getBaseRowId().get() > prevRowIdHighWatermark) {
-              currRowIdHighWatermark.addAndGet(getNumRecordsOrThrow(addFile));
+              currCalculatedRowIdHighWatermark.addAndGet(getNumRecordsOrThrow(addFile));
             }
           }
         });
 
-    if (currRowIdHighWatermark.get() != prevRowIdHighWatermark) {
+    // If the txn builder has explicitly provided a row ID high watermark, we should use that value
+    // instead of the one calculated from the current row ID high watermark and uncommitted data
+    // actions. Validate that the provided value is greater than or equal to the calculated
+    // watermark to
+    // ensure consistency.
+    providedRowIdHighWatermark.ifPresent(
+        providedHighWatermark ->
+            checkArgument(
+                providedHighWatermark >= currCalculatedRowIdHighWatermark.get(),
+                String.format(
+                    "The provided row ID high watermark (%d) must be greater than or equal to "
+                        + "the calculated row ID high watermark (%d) based on the transaction's "
+                        + "data actions.",
+                    providedHighWatermark, currCalculatedRowIdHighWatermark.get())));
+
+    final long finalRowIdHighWatermark =
+        providedRowIdHighWatermark.orElse(currCalculatedRowIdHighWatermark.get());
+
+    if (finalRowIdHighWatermark != prevRowIdHighWatermark) {
       nonRowTrackingDomainMetadatas.add(
-          new RowTrackingMetadataDomain(currRowIdHighWatermark.get()).toDomainMetadata());
+          new RowTrackingMetadataDomain(finalRowIdHighWatermark).toDomainMetadata());
     }
 
     return nonRowTrackingDomainMetadatas;

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -33,8 +33,8 @@ import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.{Column, Literal}
 import io.delta.kernel.expressions.Literal.ofInt
 import io.delta.kernel.hook.PostCommitHook.PostCommitHookType
-import io.delta.kernel.internal.{ScanImpl, SnapshotImpl, TableConfig, TableImpl}
-import io.delta.kernel.internal.actions.{Metadata, Protocol, SingleAction}
+import io.delta.kernel.internal.{ScanImpl, SnapshotImpl, TableConfig, TableImpl, TransactionImpl}
+import io.delta.kernel.internal.actions.{DomainMetadata, Metadata, Protocol, SingleAction}
 import io.delta.kernel.internal.fs.{Path => DeltaPath}
 import io.delta.kernel.internal.util.{Clock, FileNames, VectorUtils}
 import io.delta.kernel.internal.util.SchemaUtils.casePreservingPartitionColNames
@@ -354,6 +354,36 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
     txnBuilder = txnBuilder.withLogCompactionInverval(logCompactionInterval)
 
     txnBuilder.build(engine)
+  }
+
+  def createTxnWithDomainMetadatas(
+      engine: Engine,
+      tablePath: String,
+      domainMetadatas: Seq[DomainMetadata],
+      useInternalApi: Boolean = false): Transaction = {
+
+    val txnBuilder = createWriteTxnBuilder(TableImpl.forPath(engine, tablePath))
+    if (domainMetadatas.nonEmpty && !useInternalApi) {
+      txnBuilder.withDomainMetadataSupported()
+    }
+    val txn = txnBuilder.build(engine).asInstanceOf[TransactionImpl]
+
+    domainMetadatas.foreach { dm =>
+      if (dm.isRemoved) {
+        if (useInternalApi) {
+          txn.removeDomainMetadataInternal(dm.getDomain)
+        } else {
+          txn.removeDomainMetadata(dm.getDomain)
+        }
+      } else {
+        if (useInternalApi) {
+          txn.addDomainMetadataInternal(dm.getDomain, dm.getConfiguration)
+        } else {
+          txn.addDomainMetadata(dm.getDomain, dm.getConfiguration)
+        }
+      }
+    }
+    txn
   }
 
   def getAppendActions(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
@@ -78,36 +78,6 @@ class DomainMetadataSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase
     table.checksum(engine, snapshot.getVersion)
   }
 
-  private def createTxnWithDomainMetadatas(
-      engine: Engine,
-      tablePath: String,
-      domainMetadatas: Seq[DomainMetadata],
-      useInternalApi: Boolean = false): Transaction = {
-
-    val txnBuilder = createWriteTxnBuilder(TableImpl.forPath(engine, tablePath))
-    if (domainMetadatas.nonEmpty && !useInternalApi) {
-      txnBuilder.withDomainMetadataSupported()
-    }
-    val txn = txnBuilder.build(engine).asInstanceOf[TransactionImpl]
-
-    domainMetadatas.foreach { dm =>
-      if (dm.isRemoved) {
-        if (useInternalApi) {
-          txn.removeDomainMetadataInternal(dm.getDomain)
-        } else {
-          txn.removeDomainMetadata(dm.getDomain)
-        }
-      } else {
-        if (useInternalApi) {
-          txn.addDomainMetadataInternal(dm.getDomain, dm.getConfiguration)
-        } else {
-          txn.addDomainMetadata(dm.getDomain, dm.getConfiguration)
-        }
-      }
-    }
-    txn
-  }
-
   private def commitDomainMetadataAndVerify(
       engine: Engine,
       tablePath: String,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Support the pass the system domain metadata `RowTrackingDomainMetadata` in the Transaction.addDomianMetadata API, which would be used to set the highWaterMark of row tracking feature. This provided high water mark must be larger or same as the current largest row id, otherwise we would throw the exception.

This is required for supporting IcebergCompatV3 table as we need to keep the Iceberg nextRowId and Delta highWaterMark in sync.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
