### PR TITLE
[Spark] Split Merge Suites and Use Suite Generator Script

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/ModularSuiteGenerator.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/ModularSuiteGenerator.scala
@@ -103,14 +103,18 @@ object ModularSuiteGenerator {
 
   private lazy val BASE32 = new Base32()
 
-  private def generateCode(baseSuite: String, mixins: Seq[String]): TestSuite = {
+  private def generateCode(
+    baseSuite: String,
+    mixins: Seq[String]): TestSuite = {
     val allMixins = SuiteGeneratorConfig.applyCustomRulesAndGetAllMixins(baseSuite, mixins).toList
     val suiteParents = (baseSuite :: allMixins).map(_.parse[Init].get)
 
     // Generate suite name by combining the names of base suite, base mixins, and dimensions
     // Remove "Suite" / "Mixin" substrings for better readability
     val baseSuitePrefix = baseSuite.stripSuffix("Suite")
-    val mixinSuffix = mixins.map(_.replace("Mixin", "")).mkString("")
+    val mixinSuffix = mixins
+      .map(_.replace("Mixin", ""))
+      .mkString("")
     var suiteName = baseSuitePrefix + mixinSuffix
 
     // Truncate the name and replace with a consistent hash if line becomes longer than the limit

--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -50,7 +50,9 @@ case class DimensionWithMultipleValues(
 case class DimensionMixin(
     override val name: String,
     suffix: String = "Mixin"
-) extends Dimension(name, Seq(suffix))
+) extends Dimension(name, Seq(suffix)) {
+  lazy val traitName: String = name + suffix
+}
 
 /**
  * Main configuration class for the suite generator. It allows defining a set of base suites and the
@@ -66,13 +68,81 @@ case class TestConfig(
 )
 
 object SuiteGeneratorConfig {
+  private object Dims {
+    val MERGE_SQL = DimensionMixin("MergeIntoSQL")
+    val MERGE_SCALA = DimensionMixin("MergeIntoScala")
+    val MERGE_CDC = DimensionMixin("MergeCDC")
+    val MERGE_DVS = DimensionMixin("MergeIntoDVs")
+    val MERGE_CDC_DVS = DimensionMixin("MergeCDCWithDVs")
+    val MERGE_DVS_OVERRIDES = DimensionMixin("MergeIntoDVs", suffix = "Overrides")
+    val MERGE_DVS_PREDPUSH = DimensionMixin("MergeIntoDVsWithPredicatePushdown")
+    val CDC = DimensionMixin("CDC", suffix = "Enabled")
+    val COLUMN_MAPPING = DimensionWithMultipleValues(
+      "DeltaColumnMapping", Seq("EnableIdMode", "EnableNameMode"))
+    val MERGE_SQL_COLMAP = DimensionMixin("MergeIntoSQLColumnMapping", suffix = "Overrides")
+  }
+
+  private object Tests {
+    val MERGE_BASE = Seq(
+      "MergeIntoBasicTests",
+      "MergeIntoTempViewsTests",
+      "MergeIntoNestedDataTests",
+      "MergeIntoUnlimitedMergeClausesTests",
+      "MergeIntoSuiteBaseMiscTests",
+      "MergeIntoNotMatchedBySourceSuite",
+      "MergeIntoSchemaEvolutionAllTests"
+    )
+    val MERGE_SQL = Seq(
+      "MergeIntoSQLTests",
+      "MergeIntoSQLNondeterministicOrderTests"
+    )
+  }
+
   /**
    * All fileName, [[TestConfig]] list groupings. The generated suites of each group will be written
    * to a file named after the group name.
    */
+  // scalastyle:off line.size.limit
   lazy val GROUPS_WITH_TEST_CONFIGS: Seq[(String, Seq[TestConfig])] = Seq(
-    "GeneratedSuites" -> Seq()
+    "GeneratedSuites" -> Seq(
+      TestConfig(
+        // Exclude tempViews, because DeltaTable.forName does not resolve them correctly, so no one
+        // can use them anyway with the Scala API.
+        "MergeIntoScalaTests" +: Tests.MERGE_BASE.filterNot(_ == "MergeIntoTempViewsTests"),
+        Seq(
+          Seq(Dims.MERGE_SCALA)
+        )
+      ),
+      TestConfig(
+        Tests.MERGE_SQL ++: Tests.MERGE_BASE,
+        Seq(
+          Seq(Dims.MERGE_SQL),
+          Seq(Dims.MERGE_SQL, Dims.COLUMN_MAPPING, Dims.MERGE_SQL_COLMAP)
+        )
+      ),
+      TestConfig(
+        "MergeIntoDVsTests" +: Tests.MERGE_SQL ++: Tests.MERGE_BASE,
+        Seq(
+          Seq(Dims.MERGE_SQL, Dims.MERGE_DVS, Dims.MERGE_DVS_OVERRIDES),
+          Seq(Dims.MERGE_SQL, Dims.MERGE_DVS_PREDPUSH)
+        )
+      ),
+      TestConfig(
+        "MergeCDCTests" +: "MergeIntoDVsTests" +: Tests.MERGE_SQL ++: Tests.MERGE_BASE,
+        Seq(
+          Seq(Dims.MERGE_SQL, Dims.CDC, Dims.MERGE_CDC, Dims.MERGE_DVS, Dims.MERGE_CDC_DVS),
+          Seq(Dims.MERGE_SQL, Dims.CDC, Dims.MERGE_CDC, Dims.MERGE_DVS_PREDPUSH, Dims.MERGE_CDC_DVS)
+        )
+      ),
+      TestConfig(
+        "MergeCDCTests" +: Tests.MERGE_SQL ++: Tests.MERGE_BASE,
+        Seq(
+          Seq(Dims.MERGE_SQL, Dims.CDC, Dims.MERGE_CDC)
+        )
+      )
+    )
   )
+  // scalastyle:on line.size.limit
 
   /**
    * Used to add custom traits to some combinations of base suites and dimensions.

--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuitesWriter.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuitesWriter.scala
@@ -62,7 +62,11 @@ object SuitesWriter {
     ModularSuiteGenerator.GENERATED_PACKAGE.parse[Term].get.asInstanceOf[Term.Ref]
 
   private val IMPORT_PACKAGES = List(
-    importer"org.apache.spark.sql.delta._"
+    importer"org.apache.spark.sql.delta._",
+    importer"org.apache.spark.sql.delta.cdc._",
+    importer"org.apache.spark.sql.delta.deletionvectors._",
+    importer"org.apache.spark.sql.delta.rowid._",
+    importer"org.apache.spark.sql.delta.rowtracking._"
   )
 
   private lazy val SRC_HEADERS =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -53,10 +53,15 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.QueryExecutionListener
 import org.apache.spark.util.Utils
 
+object DeltaTestUtilsBase {
+  final val BOOLEAN_DOMAIN: Seq[Boolean] = Seq(true, false)
+}
+
 trait DeltaTestUtilsBase {
   import DeltaTestUtils.TableIdentifierOrPath
 
-  final val BOOLEAN_DOMAIN: Seq[Boolean] = Seq(true, false)
+  // Re-define here to avoid the need to import it before using
+  final def BOOLEAN_DOMAIN: Seq[Boolean] = DeltaTestUtilsBase.BOOLEAN_DOMAIN
 
   class PlanCapturingListener() extends QueryExecutionListener {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
@@ -28,7 +28,7 @@ trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBaseMixin {
    * Variant of `testExtendedMerge` that runs a MERGE INTO command, checks the expected result and
    * additionally validate that the CDC produced is correct.
    */
-  protected def testExtendedMergeWithCDC(
+  private def testExtendedMergeWithCDC(
       name: String,
       namePrefix: String = "not matched by source")(
       source: Seq[(Int, Int)],

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -32,22 +32,104 @@ import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class MergeIntoSQLSuite extends MergeIntoBasicTests
-  with MergeIntoTempViewsTests
-  with MergeIntoNestedDataTests
-  with MergeIntoUnlimitedMergeClausesTests
-  with MergeIntoSuiteBaseMiscTests
+trait MergeIntoSQLMixin extends MergeIntoSuiteBaseMixin
   with MergeIntoSQLTestUtils
-  with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {
-
-  import testImplicits._
 
   override def excluded: Seq[String] = super.excluded ++ Seq(
     // Schema evolution SQL syntax is not yet supported
     "schema evolution enabled for the current command"
   )
+}
+
+trait MergeIntoSQLNondeterministicOrderTests extends MergeIntoSQLMixin {
+  private def testNondeterministicOrder(insertOnly: Boolean): Unit = {
+    withTable("target") {
+      // For the spark sql random() function the seed is fixed for both invocations
+      val trueRandom = () => Math.random()
+      val trueRandomUdf = udf(trueRandom)
+      spark.udf.register("trueRandom", trueRandomUdf.asNondeterministic())
+
+      sql("CREATE TABLE target(`trgKey` INT, `trgValue` INT) using delta")
+      sql("INSERT INTO target VALUES (1,2), (3,4)")
+      // This generates different data sets on every execution
+      val sourceSql =
+        s"""
+           |(SELECT r.id AS srcKey, r.id AS srcValue
+           | FROM range(1, 100000) as r
+           |  JOIN (SELECT trueRandom() * 100000 AS bound) ON r.id < bound
+           |) AS source
+           |""".stripMargin
+
+      if (insertOnly) {
+        sql(s"""
+           |MERGE INTO target
+           |USING ${sourceSql}
+           |ON srcKey = trgKey
+           |WHEN NOT MATCHED THEN
+           |  INSERT (trgValue, trgKey) VALUES (srcValue, srcKey)
+           |""".stripMargin)
+      } else {
+        sql(s"""
+           |MERGE INTO target
+           |USING ${sourceSql}
+           |ON srcKey = trgKey
+           |WHEN MATCHED THEN
+           |  UPDATE SET trgValue = srcValue
+           |WHEN NOT MATCHED THEN
+           |  INSERT (trgValue, trgKey) VALUES (srcValue, srcKey)
+           |""".stripMargin)
+      }
+    }
+  }
+
+  test(s"detect nondeterministic source - flag on") {
+    withSQLConf(
+      // materializing source would fix determinism
+      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.NONE,
+      DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "true"
+    ) {
+      val e = intercept[UnsupportedOperationException](
+        testNondeterministicOrder(insertOnly = false)
+      )
+      assert(e.getMessage.contains("source dataset is not deterministic"))
+    }
+  }
+
+  test(s"detect nondeterministic source - flag on - insertOnly") {
+    withSQLConf(
+        // materializing source would fix determinism
+        DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.NONE,
+        DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "true") {
+      testNondeterministicOrder(insertOnly = true)
+    }
+  }
+
+  test("detect nondeterministic source - flag off") {
+    withSQLConf(
+      // materializing source would fix determinism
+      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.NONE,
+      DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "false"
+    ) {
+      testNondeterministicOrder(insertOnly = false)
+    }
+  }
+
+  test("detect nondeterministic source - flag on, materialized") {
+    withSQLConf(
+      // materializing source fixes determinism, so the source is no longer nondeterministic
+      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.ALL,
+      DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "true"
+    ) {
+      testNondeterministicOrder(insertOnly = false)
+    }
+  }
+}
+
+trait MergeIntoSQLTests extends MergeIntoSQLMixin {
+
+  import testImplicits._
 
   test("CTE as a source in MERGE") {
     withTable("source") {
@@ -186,88 +268,6 @@ class MergeIntoSQLSuite extends MergeIntoBasicTests
         """.stripMargin))
       assert(e.getMessage.contains(
         "only the last NOT MATCHED [BY TARGET] clause can omit the condition"))
-    }
-  }
-
-  private def testNondeterministicOrder(insertOnly: Boolean): Unit = {
-    withTable("target") {
-      // For the spark sql random() function the seed is fixed for both invocations
-      val trueRandom = () => Math.random()
-      val trueRandomUdf = udf(trueRandom)
-      spark.udf.register("trueRandom", trueRandomUdf.asNondeterministic())
-
-      sql("CREATE TABLE target(`trgKey` INT, `trgValue` INT) using delta")
-      sql("INSERT INTO target VALUES (1,2), (3,4)")
-      // This generates different data sets on every execution
-      val sourceSql =
-        s"""
-           |(SELECT r.id AS srcKey, r.id AS srcValue
-           | FROM range(1, 100000) as r
-           |  JOIN (SELECT trueRandom() * 100000 AS bound) ON r.id < bound
-           |) AS source
-           |""".stripMargin
-
-      if (insertOnly) {
-        sql(s"""
-           |MERGE INTO target
-           |USING ${sourceSql}
-           |ON srcKey = trgKey
-           |WHEN NOT MATCHED THEN
-           |  INSERT (trgValue, trgKey) VALUES (srcValue, srcKey)
-           |""".stripMargin)
-      } else {
-        sql(s"""
-           |MERGE INTO target
-           |USING ${sourceSql}
-           |ON srcKey = trgKey
-           |WHEN MATCHED THEN
-           |  UPDATE SET trgValue = srcValue
-           |WHEN NOT MATCHED THEN
-           |  INSERT (trgValue, trgKey) VALUES (srcValue, srcKey)
-           |""".stripMargin)
-      }
-    }
-  }
-
-  test(s"detect nondeterministic source - flag on") {
-    withSQLConf(
-      // materializing source would fix determinism
-      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.NONE,
-      DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "true"
-    ) {
-      val e = intercept[UnsupportedOperationException](
-        testNondeterministicOrder(insertOnly = false)
-      )
-      assert(e.getMessage.contains("source dataset is not deterministic"))
-    }
-  }
-
-  test(s"detect nondeterministic source - flag on - insertOnly") {
-    withSQLConf(
-        // materializing source would fix determinism
-        DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.NONE,
-        DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "true") {
-      testNondeterministicOrder(insertOnly = true)
-    }
-  }
-
-  test("detect nondeterministic source - flag off") {
-    withSQLConf(
-      // materializing source would fix determinism
-      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.NONE,
-      DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "false"
-    ) {
-      testNondeterministicOrder(insertOnly = false)
-    }
-  }
-
-  test("detect nondeterministic source - flag on, materialized") {
-    withSQLConf(
-      // materializing source fixes determinism, so the source is no longer nondeterministic
-      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> DeltaSQLConf.MergeMaterializeSource.ALL,
-      DeltaSQLConf.MERGE_FAIL_IF_SOURCE_CHANGED.key -> "true"
-    ) {
-      testNondeterministicOrder(insertOnly = false)
     }
   }
 
@@ -560,16 +560,8 @@ class MergeIntoSQLSuite extends MergeIntoBasicTests
   }
 }
 
-trait MergeIntoSQLColumnMappingSuiteBase extends DeltaColumnMappingSelectedTestMixin {
+trait MergeIntoSQLColumnMappingOverrides extends DeltaColumnMappingSelectedTestMixin {
   override protected def runOnlyTests: Seq[String] =
     Seq("schema evolution - new nested column with update non-* and insert * - " +
       "array of struct - longer target")
 }
-
-class MergeIntoSQLIdColumnMappingSuite extends MergeIntoSQLSuite
-  with DeltaColumnMappingEnableIdMode
-  with MergeIntoSQLColumnMappingSuiteBase
-
-class MergeIntoSQLNameColumnMappingSuite extends MergeIntoSQLSuite
-  with DeltaColumnMappingEnableNameMode
-  with MergeIntoSQLColumnMappingSuiteBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -157,9 +157,8 @@ trait MergeIntoSchemaEvolutionMixin {
  * in other suites to get basic test coverage for schema evolution in combination with other
  * features, e.g. CDF, DVs.
  */
-trait MergeIntoSchemaEvolutionCoreTests {
-  self: QueryTest with MergeIntoSchemaEvolutionMixin with MergeIntoTestUtils
-    with SharedSparkSession =>
+trait MergeIntoSchemaEvolutionCoreTests extends QueryTest {
+  self: MergeIntoSchemaEvolutionMixin with MergeIntoTestUtils with SharedSparkSession =>
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -48,7 +48,6 @@ trait MergeIntoSuiteBaseMixin
     with ScanReportHelper
     with MergeIntoTestUtils
     with MergeIntoSchemaEvolutionMixin
-    with MergeIntoSchemaEvolutionAllTests
     with DeltaExcludedBySparkVersionTestMixinShims {
   import testImplicits._
 
@@ -2495,7 +2494,7 @@ trait MergeIntoSuiteBaseMiscTests extends MergeIntoSuiteBaseMixin {
     expectedMessageParameters = Map("relationName" -> "`s`"))
 
 
-  protected def testMergeErrorOnMultipleMatches(
+  private def testMergeErrorOnMultipleMatches(
       name: String,
       confs: Seq[(String, String)] = Seq.empty)(
       source: Seq[(Int, Int)],

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
@@ -31,17 +31,19 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-/**
- * The MergeCDCCoreSuite suite only includes CDC tests defined in this file while MergeCDCSuite
- * runs exhaustive tests from MergeIntoSQLSuite to verify that CDC writing mode doesn't break
- * existing functionality.
- */
-class MergeCDCCoreSuite extends MergeCDCTests
-class MergeCDCSuite extends MergeIntoSQLSuite with MergeCDCTests
 
 trait CDCEnabled extends SharedSparkSession {
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
+}
+
+trait MergeCDCMixin extends SharedSparkSession
+  with MergeIntoSQLTestUtils
+  with DeltaColumnMappingTestUtils
+  with DeltaSQLCommandTest {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS.key, "false")
 }
 
 /**
@@ -50,13 +52,9 @@ trait CDCEnabled extends SharedSparkSession {
  */
 trait MergeCDCTests extends QueryTest
   with CDCEnabled
-  with MergeIntoSQLTestUtils
-  with DeltaColumnMappingTestUtils
-  with DeltaSQLCommandTest {
-  import testImplicits._
+  with MergeCDCMixin {
 
-  override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS.key, "false")
+  import testImplicits._
 
   // scalastyle:off argcount
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/GeneratedSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/GeneratedSuites.scala
@@ -28,3 +28,516 @@
 package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.rowid._
+import org.apache.spark.sql.delta.rowtracking._
+
+class MergeIntoScalaTestsMergeIntoScalaSuite extends MergeIntoScalaTests with MergeIntoScalaMixin
+class MergeIntoBasicTestsMergeIntoScalaSuite extends MergeIntoBasicTests with MergeIntoScalaMixin
+
+class MergeIntoNestedDataTestsMergeIntoScalaSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoScalaMixin
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoScalaSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoScalaMixin
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoScalaSuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoScalaMixin
+
+class MergeIntoNotMatchedBySourceMergeIntoScalaSuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoScalaMixin
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoScalaSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoScalaMixin
+
+class MergeIntoSQLTestsMergeIntoSQLSuite extends MergeIntoSQLTests with MergeIntoSQLMixin
+
+class MergeIntoSQLTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMergeIntoSQLColumnMappiE3VOO7QSuite
+  extends MergeIntoSQLTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSQLTestsMergeIntoSQLDeltaColumnMappingEnableNameModeMergeIntoSQLColumnMap63M5YPASuite
+  extends MergeIntoSQLTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLSuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMeET6765QSuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLDeltaColumnMappingEnableNameModeSK4YN4YSuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoBasicTestsMergeIntoSQLSuite extends MergeIntoBasicTests with MergeIntoSQLMixin
+
+class MergeIntoBasicTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMergeIntoSQLColumnMap3ITXYDASuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoBasicTestsMergeIntoSQLDeltaColumnMappingEnableNameModeMergeIntoSQLColumnMSUPDQJYSuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoTempViewsTestsMergeIntoSQLSuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+
+class MergeIntoTempViewsTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMergeIntoSQLColumSZ7YUIISuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoTempViewsTestsMergeIntoSQLDeltaColumnMappingEnableNameModeMergeIntoSQLColSNANUYYSuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNestedDataTestsMergeIntoSQLSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+
+class MergeIntoNestedDataTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMergeIntoSQLColu6YVXDZYSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNestedDataTestsMergeIntoSQLDeltaColumnMappingEnableNameModeMergeIntoSQLCoKJHCBWASuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMergePLXX5FASuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLDeltaColumnMappingEnableNameModeMerK7DXPDASuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLSuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMergeIntoSQLCK456OHASuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLDeltaColumnMappingEnableNameModeMergeIntoSQE3RKDNQSuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLSuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLDeltaColumnMappingEnableIdModeMergeIntoSQLCT2RJUIQSuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLDeltaColumnMappingEnableNameModeMergeIntoSQAWNMDZASuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLDeltaColumnMappingEnableIdModeMergeIntWGLAUBQSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLDeltaColumnMappingEnableNameModeMergeIUCCZW6YSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoDVsTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoDVsTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoDVsTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoDVsTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoSQLTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoSQLTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoSQLTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoSQLTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoBasicTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoBasicTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoTempViewsTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoTempViewsTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoNestedDataTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoNestedDataTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLMergeIntoDVsMergeIntoDVsOverridesSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsMixin
+  with MergeIntoDVsOverrides
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLMergeIntoDVsWithPredicatePushdownSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+
+class MergeCDCTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeCDCTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeCDCTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicatePushdownMergeCVGFIZMASuite
+  extends MergeCDCTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoDVsTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoDVsTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoDVsTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicatePushdownMe2GGR2YYSuite
+  extends MergeIntoDVsTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSQLTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoSQLTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSQLTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicatePushdownMe5JLWDRYSuite
+  extends MergeIntoSQLTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMeVMPBLEYSuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWiLH446PASuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoBasicTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoBasicTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicatePushdownVNW3HNQSuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoTempViewsTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoTempViewsTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicatePushTPKJJCISuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNestedDataTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNestedDataTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicatePus4O7YOPYSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeZ75HJ4QSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithP7GEKCBQSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicateVW425VASuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredicate4XPA7GISuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsMergeCDCWithDVsSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLCDCEnabledMergeCDCMergeIntoDVsWithPredEPXSK2YSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+  with MergeIntoDVsWithPredicatePushdownMixin
+  with MergeCDCWithDVsMixin
+
+class MergeCDCTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeCDCTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoSQLTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoSQLTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoSQLNondeterministicOrderTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoSQLNondeterministicOrderTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoBasicTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoTempViewsTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoTempViewsTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoNestedDataTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoNestedDataTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoSuiteBaseMiscTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoSuiteBaseMiscTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoNotMatchedBySourceMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoSchemaEvolutionAllTestsMergeIntoSQLCDCEnabledMergeCDCSuite
+  extends MergeIntoSchemaEvolutionAllTests
+  with MergeIntoSQLMixin
+  with CDCEnabled
+  with MergeCDCMixin


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR splits existing merge test suites for better parallelization of the tests. The suite generator script from #4810 is used to generate all suites with necessary configuration.

## How was this patch tested?

Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

No