### PR TITLE
[Spark] Safely log unresolved data skipping filters from DeltaScan

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.delta.stats
 
 // scalastyle:off import.ordering.noEmptyLine
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.stats.DeltaDataSkippingType.DeltaDataSkippingType
@@ -94,6 +96,20 @@ case class DeltaScan(
     val dataSkippingType: DeltaDataSkippingType) {
   assert(version == scannedSnapshot.version)
 
+  /**
+   * For unresolved expressions, converting the expression to SQL may throw an exception (if the
+   * conversion to SQL requires the child types to be resolved). This method safely handles these
+   * cases by returning a placeholder string for unresolved expressions.
+   */
+  def safeExprToSQL(expr: Expression): String = {
+    try {
+      expr.sql
+    } catch {
+      case NonFatal(_) => s"UNRESOLVED_EXPRESSION_(${expr.getClass.getSimpleName})"
+    }
+  }
+
+  lazy val rewrittenPartitionLikeFilterSQL = rewrittenPartitionLikeDataFilters.map(safeExprToSQL)
   lazy val filtersUsedForSkipping: ExpressionSet = partitionFilters ++ dataFilters
   lazy val allFilters: ExpressionSet = filtersUsedForSkipping ++ unusedFilters
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
@@ -83,7 +83,7 @@ trait ScanReportHelper extends SharedSparkSession with AdaptiveSparkPlanHelper {
                 partitionFilters = preparedScan.partitionFilters.map(_.sql).toSeq,
                 partitionLikeDataFilters = preparedScan.partitionLikeDataFilters.map(_.sql).toSeq,
                 rewrittenPartitionLikeDataFilters =
-                  preparedScan.rewrittenPartitionLikeDataFilters.map(_.sql).toSeq,
+                  preparedScan.rewrittenPartitionLikeFilterSQL.toSeq,
                 dataFilters = preparedScan.dataFilters.map(_.sql).toSeq,
                 unusedFilters = preparedScan.unusedFilters.map(_.sql).toSeq,
                 size = Map(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
When logging DeltaScans, we currently naively convert the rewritten partition-like data filters (which may be unresolved) to SQL. This is unsafe, as unresolved expressions might throw an error when converted to SQL (if the conversion to SQL accesses a child expression's data type). Wrap the SQL conversion to catch any potential errors to prevent this issue.

## How was this patch tested?
N/A.

## Does this PR introduce _any_ user-facing changes?
No.
