### PR TITLE
[Spark] Deflake InvariantEnforcementSuite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
@@ -415,18 +415,20 @@ class InvariantEnforcementSuite extends QueryTest
         val e = intercept[InvariantViolationException] {
           spark.sql("INSERT INTO constraint VALUES (100, 50, null)")
         }
-        checkConstraintException(e,
-          s"""CHECK constraint mychk (valueA < valueB) violated by row with values:
-             | - valueA : 100
-             | - valueB : 50""".stripMargin)
+        checkConstraintException(
+          e,
+          "CHECK constraint mychk (valueA < valueB) violated by row with values:",
+          " - valueA : 100",
+          " - valueB : 50")
 
         val e2 = intercept[InvariantViolationException] {
           spark.sql("INSERT INTO constraint VALUES (100, null, null)")
         }
-        checkConstraintException(e2,
-          s"""CHECK constraint mychk (valueA < valueB) violated by row with values:
-             | - valueA : 100
-             | - valueB : null""".stripMargin)
+        checkConstraintException(
+          e2,
+          "CHECK constraint mychk (valueA < valueB) violated by row with values:",
+          " - valueA : 100",
+          " - valueB : null")
       }
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The values in error message could be printed in different order. `checkConstraintException` already handles that, just that the different substrings expected in the error messages need to be passed to it separately.

## How was this patch tested?

Deflaking existing test.

## Does this PR introduce _any_ user-facing changes?

No
