### PR TITLE
[Spark] Remove parallelism in Row Tracking Backfill

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillCommandStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillCommandStats.scala
@@ -23,7 +23,6 @@ package org.apache.spark.sql.delta.commands.backfill
  *                       is the parent transaction for BackfillBatch commits.
  * @param nameOfTriggeringOperation: The name of the operation that triggered backfill. For now,
  *                                   this can be ALTER TABLE SET TBLPROPERTIES
- * @param maxNumBatchesInParallel The maximum number of batches that could have run in parallel.
  * @param totalExecutionTimeMs The total execution time in milliseconds.
  * @param numSuccessfulBatches The number of BackfillBatch's that was successfully committed.
  * @param numFailedBatches The number of BackfillBatch's that failed.
@@ -32,7 +31,6 @@ package org.apache.spark.sql.delta.commands.backfill
 case class BackfillCommandStats(
     transactionId: String,
     nameOfTriggeringOperation: String,
-    maxNumBatchesInParallel: Int,
     var totalExecutionTimeMs: Long = 0,
     var numSuccessfulBatches: Int = 0,
     var numFailedBatches: Int = 0,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutionObserver.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import org.apache.spark.sql.delta.{ChainableExecutionObserver, NoOpTransactionExecutionObserver, ThreadStorageExecutionObserver, TransactionExecutionObserver}
+
+trait BackfillExecutionObserver extends ChainableExecutionObserver[BackfillExecutionObserver] {
+  def executeBatch[T](f: => T): T
+
+  override def advanceToNextThreadObserver(): Unit = {
+    BackfillExecutionObserver.setObserver(nextObserver.getOrElse(NoOpBackfillExecutionObserver))
+  }
+}
+
+object BackfillExecutionObserver
+  extends ThreadStorageExecutionObserver[BackfillExecutionObserver] {
+
+  override protected val threadObserver: ThreadLocal[BackfillExecutionObserver] =
+    new InheritableThreadLocal[BackfillExecutionObserver] {
+      override def initialValue(): BackfillExecutionObserver = NoOpBackfillExecutionObserver
+    }
+
+  override protected def initialValue: BackfillExecutionObserver = NoOpBackfillExecutionObserver
+}
+
+object NoOpBackfillExecutionObserver extends BackfillExecutionObserver {
+  def executeBatch[T](f: => T): T = {
+    TransactionExecutionObserver.withObserver(NoOpTransactionExecutionObserver)(f)
+  }
+}
+

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
@@ -47,10 +47,8 @@ case class RowTrackingBackfillCommand(
       spark: SparkSession,
       txn: OptimisticTransaction,
       fileMaterializationTracker: FileMetadataMaterializationTracker,
-      maxNumBatchesInParallel: Int,
       backfillStats: BackfillCommandStats): BackfillExecutor = {
-    new RowTrackingBackfillExecutor(
-      spark, txn, fileMaterializationTracker, maxNumBatchesInParallel, backfillStats)
+    new RowTrackingBackfillExecutor(spark, txn, fileMaterializationTracker, backfillStats)
   }
 
   override def filesToBackfill(txn: OptimisticTransaction): Dataset[AddFile] =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillExecutor.scala
@@ -26,7 +26,6 @@ class RowTrackingBackfillExecutor(
     override val spark: SparkSession,
     override val origTxn: OptimisticTransaction,
     override val tracker: FileMetadataMaterializationTracker,
-    override val maxBatchesInParallel: Int,
     override val backfillStats: BackfillCommandStats) extends BackfillExecutor {
   override val backFillBatchOpType = "delta.rowTracking.backfill.batch"
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1061,22 +1061,6 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
-  val DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL =
-    buildConf("rowTracking.backfill.maxNumBatchesInParallel")
-      .internal()
-      .doc("The maximum number of backfill batches (commits) that can run at the same time " +
-        "from a single RowTrackingBackfillCommand.")
-      .intConf
-      .checkValue(_ > 0, "'backfill.maxNumBatchesInParallel' must be positive.")
-      .createWithDefault(1)
-
-  val DELTA_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL =
-    buildConf("backfill.maxNumBatchesInParallel")
-      .internal()
-      .doc("The maximum number of backfill batches (commits) that can run at the same time " +
-        "from a single BackfillCommand.")
-      .fallbackConf(DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL)
-
   val DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_FILES_PER_COMMIT =
     buildConf("rowTracking.backfill.maxNumFiles")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBackfillConflictsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBackfillConflictsSuite.scala
@@ -84,28 +84,4 @@ class RowTrackingBackfillBackfillConflictsSuite extends RowTrackingBackfillConfl
       }
     }
   }
-
-  test("Concurrent commits from one backfill command") {
-    val maxNumThreads = BackfillExecutor.getOrCreateThreadPool().getMaximumPoolSize
-    require(maxNumThreads >= numFiles,
-      s"Max thread pool size $maxNumThreads smaller than number of files $numFiles.")
-
-    withTestTable {
-      withTrackedBackfillCommits {
-        withSQLConf(
-          DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL.key ->
-            maxNumThreads.toString,
-          DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT.key -> "1"
-        ) {
-          val backfillFuture = launchBackFillAndBlockAfterFeatureIsCommitted()
-
-          commitBatchesSimultaneously(numFiles)
-
-          backfillFuture.get()
-        }
-
-        validateResult(() => tableCreationDF)
-      }
-    }
-  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillConflictsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillConflictsSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.commands.backfill
 
-import java.util.concurrent.{ConcurrentLinkedDeque, ExecutionException, Future, ThreadFactory, TimeUnit}
+import java.util.concurrent.{ConcurrentLinkedDeque, ExecutionException, Future, TimeUnit}
 
 import scala.annotation.tailrec
 
@@ -31,7 +31,7 @@ import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import io.delta.exceptions.MetadataChangedException
 
-import org.apache.spark.{SparkConf, SparkException, SparkThrowable}
+import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.col
@@ -121,18 +121,13 @@ trait RowTrackingBackfillConflictsTestBase extends RowIdTestUtils
   protected val backfillObservers =
     new ConcurrentLinkedDeque[PhaseLockingTransactionExecutionObserver]
 
-  // A Thread Factory that adds transaction observers to `backfillObservers` for all new threads.
-  private class BackfillObservingThreadFactory extends ThreadFactory {
-    override def newThread(r: Runnable): Thread = {
+  // An observer that adds transaction observers to `backfillObservers` for all batches.
+  object TrackingBackfillExecutionObserver extends BackfillExecutionObserver {
+    override def executeBatch[T](f: => T): T = {
       val observer = new PhaseLockingTransactionExecutionObserver(
         OptimisticTransactionPhases.forName("backfill-observer"))
       backfillObservers.addLast(observer)
-
-      val runnable: Runnable = () => {
-        TransactionExecutionObserver.withObserver(observer) { r.run() }
-      }
-
-      new Thread(runnable)
+      TransactionExecutionObserver.withObserver(observer)(f)
     }
   }
 
@@ -170,20 +165,6 @@ trait RowTrackingBackfillConflictsTestBase extends RowIdTestUtils
     waitForCommit(observer)
   }
 
-  protected def commitBatchesSimultaneously(numBatches: Int): Unit = {
-    // Wait for all backfill commit threads to be launched.
-    busyWaitFor(backfillObservers.size() == numBatches, timeout)
-
-    // Unblock all commits.
-    backfillObservers.forEach(unblockAllPhases(_))
-
-    // Wait for all commits to be finished.
-    while (!backfillObservers.isEmpty) {
-      val observer = backfillObservers.removeFirst()
-      waitForCommit(observer)
-    }
-  }
-
   // Launch the backfill command and wait until the table feature has been committed.
   protected def launchBackFillAndBlockAfterFeatureIsCommitted(): Future[_] = {
     val backfillFuture = launchBackfillInBackgroundThread()
@@ -199,19 +180,13 @@ trait RowTrackingBackfillConflictsTestBase extends RowIdTestUtils
   }
 
   protected def withTrackedBackfillCommits(testBlock: => Unit): Unit = {
-    // Use `BackfillObservingThreadFactory` on the backfill thread pool.
-    val oldThreadFactory = BackfillExecutor.getOrCreateThreadPool().getThreadFactory
-    assert(!oldThreadFactory.isInstanceOf[BackfillObservingThreadFactory])
-    BackfillExecutor.getOrCreateThreadPool()
-      .setThreadFactory(new BackfillObservingThreadFactory())
-
+    assert(backfillObservers.isEmpty)
     try {
-      withSQLConf(DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT.key ->
-          numFiles.toString) {
+      BackfillExecutionObserver.withObserver(TrackingBackfillExecutionObserver) {
         testBlock
       }
     } finally {
-      BackfillExecutor.getOrCreateThreadPool().setThreadFactory(oldThreadFactory)
+      backfillObservers.clear()
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
@@ -259,9 +259,6 @@ trait RowIdTestUtils extends RowTrackingTestUtils with DeltaSQLCommandTest {
     assert(backfillStats.wasSuccessful)
     assert(backfillStats.numFailedBatches === 0)
     assert(backfillStats.totalExecutionTimeMs > 0)
-    val expectedMaxNumBatchesInParallel =
-      spark.conf.get(DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL)
-    assert(backfillStats.maxNumBatchesInParallel === expectedMaxNumBatchesInParallel)
     assert(backfillStats.numSuccessfulBatches === expectedNumSuccessfulBatches)
     assert(backfillStats.nameOfTriggeringOperation === nameOfTriggeringOperation)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -201,16 +201,13 @@ class RowTrackingConflictResolutionSuite extends QueryTest
 
   /** Execute backfill on the table associated with the delta log passed in. */
   private def executeBackfill(log: DeltaLog, backfillTxn: OptimisticTransaction): Unit = {
-    val maxBatchesInParallel = 1
     val backfillStats = BackfillCommandStats(
       backfillTxn.txnId,
-      nameOfTriggeringOperation = DeltaOperations.OP_SET_TBLPROPERTIES,
-      maxNumBatchesInParallel = maxBatchesInParallel)
+      nameOfTriggeringOperation = DeltaOperations.OP_SET_TBLPROPERTIES)
     val backfillExecutor = new RowTrackingBackfillExecutor(
       spark,
       backfillTxn,
       FileMetadataMaterializationTracker.noopTracker,
-      maxBatchesInParallel,
       backfillStats
     )
     val filesToBackfill =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR removes the parallelism from the row tracking backfill. This parallelism is currently unused, and it makes it more difficult to add performance optimizations.

As part of this change an new backfill observer was added, as we can no longer rely on injecting a thread factory to inject transaction observers.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests to ensure that nothing breaks.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
