### PR TITLE
[Delta] Migrate `DeltaSuite` and `DeltaSuiteEdge` to `CatalogOwned`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaSuiteShims._
-import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -21,8 +21,10 @@ import java.util.concurrent.atomic.AtomicInteger
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaSuiteShims._
+import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -53,7 +55,8 @@ class DeltaSuite extends QueryTest
   with SharedSparkSession
   with DeltaColumnMappingTestUtils
   with DeltaSQLTestUtils
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with CatalogOwnedTestBaseSuite {
 
   import testImplicits._
 
@@ -1686,6 +1689,10 @@ class DeltaSuite extends QueryTest
           Seq((2, 99), (5, 99)).toDF("key", "value")
         )
 
+        if (catalogOwnedDefaultCreationEnabledInTests) {
+          cancel("VACUUM is not supported on catalog owned managed tables")
+        }
+
         // VACUUM
         withSQLConf(DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false") {
           spark.sql(s"VACUUM delta.`${directory.getCanonicalPath}` RETAIN 0 HOURS")
@@ -2011,7 +2018,9 @@ class DeltaSuite extends QueryTest
     }
   }
 
-  test("An external write should be reflected during analysis of a path based query") {
+  // This test is only compatible w/ backfill batch size = 1.
+  testWithCatalogOwned(backfillBatchSize = 1)(
+      "An external write should be reflected during analysis of a path based query") {
     val tempDir = Utils.createTempDir().toString
     spark.range(10).coalesce(1).write.format("delta").mode("append").save(tempDir)
     spark.range(10, 20).coalesce(1).write.format("delta").mode("append").save(tempDir)
@@ -2211,24 +2220,31 @@ class DeltaSuite extends QueryTest
   }
 
   test("set metadata upon write") {
-    withTempDir { inputDir =>
-      val testPath = inputDir.getCanonicalPath
-      spark.range(10)
-        .map(_.toInt)
-        .withColumn("part", $"value" % 2)
-        .write
-        .format("delta")
-        .option("delta.logRetentionDuration", "123 days")
-        .option("mergeSchema", "true")
-        .partitionBy("part")
-        .mode("append")
-        .save(testPath)
+    withSQLConf(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "false") {
+      withTempDir { inputDir =>
+        val testPath = inputDir.getCanonicalPath
+        spark.range(10)
+          .map(_.toInt)
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .option("delta.logRetentionDuration", "123 days")
+          .option("mergeSchema", "true")
+          .partitionBy("part")
+          .mode("append")
+          .save(testPath)
 
-      val deltaLog = DeltaLog.forTable(spark, testPath)
-      // We need to drop default properties set by subclasses to make this test pass in them
-      assert(deltaLog.snapshot.metadata.configuration
-        .filterKeys(!_.startsWith("delta.columnMapping.")).toMap ===
-        Map("delta.logRetentionDuration" -> "123 days"))
+        val deltaLog = DeltaLog.forTable(spark, testPath)
+        val metadata = deltaLog.snapshot.metadata
+        // We need to drop default properties set by subclasses to make this test pass in them
+        // We need to drop `enableDeletionVectors` property b/c it is explicitly set to false.
+        assert(
+          metadata.configuration
+            .filter { case (k, _) => !k.startsWith("delta.columnMapping.") &&
+              !k.startsWith("delta.enableDeletionVectors")} ===
+          Map("delta.logRetentionDuration" -> "123 days") ++
+            extractCatalogOwnedSpecificPropertiesIfEnabled(metadata))
+      }
     }
   }
 
@@ -3221,4 +3237,19 @@ class DeltaNameColumnMappingSuite extends DeltaSuite
         insertedDF.filter(col("id") >= 6).union(otherDF))
     }
   }
+}
+
+class DeltaWithCatalogOwnedBatch1Suite
+    extends DeltaSuite {
+  override val catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class DeltaWithCatalogOwnedBatch2Suite
+    extends DeltaSuite {
+  override val catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class DeltaWithCatalogOwnedBatch100Suite
+    extends DeltaSuite {
+  override val catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR migrates `DeltaSuite` and `DeltaSuiteEdge` to `CatalogOwned`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
