### PR TITLE
[Spark] Unify AddCDCFile and AddFile stats handling

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -973,15 +973,15 @@ case class RemoveFile(
  *
  * [[path]] is URL-encoded.
  */
+@JsonIgnoreProperties(Array("stats"))
 case class AddCDCFile(
     override val path: String,
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    override val tags: Map[String, String] = null) extends FileAction {
+    override val tags: Map[String, String] = null,
+    override val stats: String = null) extends FileAction with HasNumRecords {
   override val dataChange = false
-  @JsonIgnore
-  override val stats: String = null
   @JsonIgnore
   override val deletionVector: DeletionVectorDescriptor = null
 
@@ -992,9 +992,6 @@ case class AddCDCFile(
 
   @JsonIgnore
   override def estLogicalFileSize: Option[Long] = None
-
-  @JsonIgnore
-  override def numLogicalRecords: Option[Long] = None
 }
 
 case class Format(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Refactor to simplify stats handling between AddFile and AddCDCFile (such that both now extend HasNumRecords to allow collecting record count stats for AddCDCFiles).

## How was this patch tested?
N/A.

## Does this PR introduce _any_ user-facing changes?
No.
