### PR TITLE
Clean up assigning default row commit version when type widening is enabled

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -818,9 +818,7 @@ private[delta] class ConflictChecker(
    *     to handle the row tracking feature being enabled by the winning transaction.
    */
   private def reassignRowCommitVersions(): Unit = {
-    if (!RowTracking.isSupported(currentTransactionInfo.protocol) &&
-      // Type widening relies on default row commit versions to be set.
-      !TypeWidening.isSupported(currentTransactionInfo.protocol)) {
+    if (!RowTracking.isSupported(currentTransactionInfo.protocol)) {
       return
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
@@ -28,8 +28,7 @@ object DefaultRowCommitVersion {
       protocol: Protocol,
       actions: Iterator[Action],
       version: Long): Iterator[Action] = {
-    // Type Widening relies on default row commit versions to be set.
-    if (!RowTracking.isSupported(protocol) && !TypeWidening.isSupported(protocol)) {
+    if (!RowTracking.isSupported(protocol)) {
       return actions
     }
     actions.map {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
@@ -153,6 +153,46 @@ trait TypeWideningCompatibilityTests {
     checkAnswer(readDeltaTable(tempPath),
       Seq(Row(1, "abc", "def"), Row(2, "ghi", "jkl"), Row(3, "longer string 1", "longer string 2")))
   }
+
+  test("type widening with row tracking") {
+    // Start with row tracking disabled.
+    sql(s"CREATE TABLE $tableSQLIdentifier (a TINYINT) USING DELTA " +
+        s"TBLPROPERTIES('${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = 'false')")
+
+    append(Seq(1).toDF("a").select($"a".cast(ByteType)))
+
+    sql(s"ALTER TABLE $tableSQLIdentifier SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = 'true')")
+
+    def readWithRowTracking(): DataFrame =
+      readDeltaTable(tempPath).select(
+        "a",
+        "_metadata.row_id",
+        "_metadata.base_row_id",
+        "_metadata.row_commit_version",
+        "_metadata.default_row_commit_version"
+      )
+
+    // [base_]row_id starting at 0, [default_]row_commit_version set to 3 when
+    // Row Tracking got enabled.
+    checkAnswer(readWithRowTracking(), Seq(Row(1, 0, 0, 3, 3)))
+
+    sql(s"UPDATE $tableSQLIdentifier SET a = 2 WHERE a = 1")
+    // Existing row moved to new file: base_row_id = 1. Version updated to 5
+    // (4 is internal row tracking backfill).
+    checkAnswer(readWithRowTracking(), Seq(Row(2, 0, 1, 5, 5)))
+
+    sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE INT")
+    // No changes when enabling Type Widening.
+    checkAnswer(readWithRowTracking(), Seq(Row(2, 0, 1, 5, 5)))
+
+    append(Seq(Int.MaxValue).toDF("a"))
+    // Adding new row in a new file [base_]row_id set to 2, [default_]row_commit_version set to 7.
+    checkAnswer(readWithRowTracking(), Seq(
+      Row(2, 0, 1, 5, 5),
+      Row(Int.MaxValue, 2, 2, 7, 7)
+    ))
+  }
 }
 
 /** Trait collecting tests covering type widening + column mapping. */


### PR DESCRIPTION
## Description
The preview of Type Widening used to store the table version in the type change metadata whenever a type change was applied.
This was removed in the stable version of the feature, but we kept assigning default row commit version when type widening is enabled even though we're not using this anymore.

This causes mismatches where rows present in the table before Row tracking is enabled have a row commit version that is older than the version where Row Tracking is enabled, as is usually the case.
This isn't a big issue in itself afaict, but it can be confusing and should be cleaned up.

## How was this patch tested?
Adding test covering the case where Row tracking is enabled on a table after type widening.