### PR TITLE
[Spark] Small refactor for the Source Materialization Framework

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -71,6 +71,16 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
 
   import MergeIntoMaterializeSource._
 
+  protected def operation: String = "MERGE"
+
+  protected def enableColumnPruningBeforeMaterialize: Boolean = true
+
+  protected def materializeSourceErrorOpType: String =
+    MergeIntoMaterializeSourceError.OP_TYPE
+
+  protected def getMaterializeSourceMode(spark: SparkSession): String =
+    spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE)
+
   /**
    * Prepared Dataframe with source data.
    * If needed, it is materialized, @see prepareMergeSource
@@ -97,7 +107,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       spark: SparkSession,
       deltaLog: DeltaLog,
       metrics: Map[String, SQLMetric],
-      runMergeFunc: SparkSession => Seq[Row]): Seq[Row] = {
+      runOperationFunc: SparkSession => Seq[Row]): Seq[Row] = {
     var doRetry = false
     var runResult: Seq[Row] = null
     attempt = 1
@@ -105,23 +115,26 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       doRetry = false
       metrics.values.foreach(_.reset())
       try {
-        runResult = runMergeFunc(spark)
+        runResult = runOperationFunc(spark)
       } catch {
         case NonFatal(ex) =>
           val isLastAttempt =
             attempt == spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_MAX_ATTEMPTS)
           handleExceptionDuringAttempt(ex, isLastAttempt, deltaLog) match {
             case RetryHandling.Retry =>
-              logInfo(log"Retrying MERGE with materialized source. Attempt " +
-                log"${MDC(DeltaLogKeys.NUM_ATTEMPT, attempt)} failed.")
+              logInfo(log"Retrying ${MDC(DeltaLogKeys.OPERATION, operation)} " +
+                log"with materialized source." +
+                log"Attempt ${MDC(DeltaLogKeys.NUM_ATTEMPT, attempt)} failed.")
               doRetry = true
               attempt += 1
             case RetryHandling.ExhaustedRetries =>
               logError(log"Exhausted retries after ${MDC(DeltaLogKeys.NUM_ATTEMPT, attempt)}" +
-                log" attempts in MERGE with materialized source. Logging latest exception.", ex)
+                log" attempts in ${MDC(DeltaLogKeys.OPERATION, operation)} " +
+                log"with materialized source. Logging latest exception.", ex)
               throw DeltaErrors.sourceMaterializationFailedRepeatedlyInMerge
             case RetryHandling.RethrowException =>
-              logError(log"Fatal error in MERGE with materialized source in " +
+              logError(log"Fatal error in ${MDC(DeltaLogKeys.OPERATION, operation)} " +
+                log"with materialized source in " +
                 log"attempt ${MDC(DeltaLogKeys.NUM_ATTEMPT, attempt)}", ex)
               throw ex
           }
@@ -165,7 +178,8 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       if materializedSourceRDD.nonEmpty &&
         s.getMessage.matches(
           mergeMaterializedSourceRddBlockLostErrorRegex(materializedSourceRDD.get.id)) =>
-      log.warn("Materialized Merge source RDD block lost. Merge needs to be restarted. " +
+      log.warn(log"Materialized ${MDC(DeltaLogKeys.OPERATION, operation)} source RDD block lost. " +
+        log"${MDC(DeltaLogKeys.OPERATION, operation)} needs to be restarted. " +
         s"This was attempt number $attempt.")
       if (!isLastAttempt) {
         RetryHandling.Retry
@@ -173,7 +187,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
         // Record situations where we lost RDD materialized source blocks, despite retries.
         recordDeltaEvent(
           deltaLog,
-          MergeIntoMaterializeSourceError.OP_TYPE,
+          materializeSourceErrorOpType,
           data = MergeIntoMaterializeSourceError(
             errorType = MergeIntoMaterializeSourceErrorType.RDD_BLOCK_LOST.toString,
             attempt = attempt,
@@ -192,7 +206,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       // by the materialized RDD.
       recordDeltaEvent(
         deltaLog,
-        MergeIntoMaterializeSourceError.OP_TYPE,
+        materializeSourceErrorOpType,
         data = MergeIntoMaterializeSourceError(
           errorType = MergeIntoMaterializeSourceErrorType.OUT_OF_DISK.toString,
           attempt = attempt,
@@ -240,7 +254,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
   protected def shouldMaterializeSource(
     spark: SparkSession, source: LogicalPlan, isInsertOnly: Boolean
   ): (Boolean, MergeIntoMaterializeSourceReason.MergeIntoMaterializeSourceReason) = {
-    val materializeType = spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE)
+    val materializeType = getMaterializeSourceMode(spark)
     val forceMaterializationWithUnreadableFiles =
       spark.conf.get(DeltaSQLConf.MERGE_FORCE_SOURCE_MATERIALIZATION_WITH_UNREADABLE_FILES)
     import DeltaSQLConf.MergeMaterializeSource._
@@ -312,11 +326,24 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       return
     }
 
-    val referencedSourceColumns =
+    val referencedSourceColumns = if (enableColumnPruningBeforeMaterialize) {
       getReferencedSourceColumns(source, condition, matchedClauses, notMatchedClauses)
-    // When we materialize the source, we want to make sure that columns got pruned before caching.
-    val sourceWithSelectedColumns = Project(referencedSourceColumns, source)
-    val baseSourcePlanDF = DataFrameUtils.ofRows(spark, sourceWithSelectedColumns)
+    } else {
+      assert(matchedClauses.isEmpty && notMatchedClauses.isEmpty,
+        "If column pruning is disabled, then there should be no MERGE clauses.")
+      assert(operation != "MERGE",
+        "Column pruning before materialization must be done for MERGE.")
+      source.output
+    }
+
+    val baseSourcePlanDF = if (enableColumnPruningBeforeMaterialize) {
+      // When we materialize the source, we want to make sure that columns got pruned
+      // before caching.
+      val sourceWithSelectedColumns = Project(referencedSourceColumns, source)
+      DataFrameUtils.ofRows(spark, sourceWithSelectedColumns)
+    } else {
+      DataFrameUtils.ofRows(spark, source)
+    }
 
     // Caches the source in RDD cache using localCheckpoint, which cuts away the RDD lineage,
     // which shall ensure that the source cannot be recomputed and thus become inconsistent.
@@ -372,8 +399,8 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       assert(rdd.isCheckpointed)
     }
 
-    logDebug(s"Materializing MERGE with pruned columns $referencedSourceColumns.")
-    logDebug(s"Materialized MERGE source plan:\n${getMergeSource.df.queryExecution}")
+    logDebug(s"Materializing $operation with pruned columns $referencedSourceColumns.")
+    logDebug(s"Materialized $operation source plan:\n${getMergeSource.df.queryExecution}")
   }
 
   /** Returns the prepared merge source. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
In the future, we will need the materialization framework for other commands than MERGE, for now we do some small refactoring in advance for the sake of small PRs.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs, just a refactor.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
