### PR TITLE
[SPARK] Throw exceptions when check constraint expression is unresolved in DeltaInvariantCheckerExec

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
@@ -199,19 +199,24 @@ object DeltaInvariantCheckerExec extends DeltaLogging {
           // Cap the maximum length when logging an unresolved expression to avoid issues. This is a
           // CHECK constraint expression and should be relatively simple.
           val MAX_OUTPUT_LENGTH = 10 * 1024
-          deltaAssert(
-            resolvedExpr.resolved,
-            name = "invariant.unresolvedExpression",
-            msg = s"CHECK constraint child expression was not properly resolved",
-            data = Map(
-              "name" -> name,
-              "checkExpr" -> expr.treeString.take(MAX_OUTPUT_LENGTH),
-              "attributesExtracted" -> attributesExtracted.treeString.take(MAX_OUTPUT_LENGTH),
-              "analyzedLogicalPlan" -> analyzedLogicalPlan.treeString.take(MAX_OUTPUT_LENGTH),
-              "optimizedLogicalPlan" -> optimizedLogicalPlan.treeString.take(MAX_OUTPUT_LENGTH),
-              "resolvedExpr" -> resolvedExpr.treeString.take(MAX_OUTPUT_LENGTH)
+          if (!resolvedExpr.resolved) {
+            // If the plan is not resolved, check the plan so that a user-facing exception is
+            // thrown.
+            spark.sessionState.analyzer.checkAnalysis(wrappedPlan)
+            deltaAssert(
+              check = false,
+              name = "invariant.unresolvedExpression",
+              msg = s"CHECK constraint child expression was not properly resolved",
+              data = Map(
+                "name" -> name,
+                "checkExpr" -> expr.treeString.take(MAX_OUTPUT_LENGTH),
+                "attributesExtracted" -> attributesExtracted.treeString.take(MAX_OUTPUT_LENGTH),
+                "analyzedLogicalPlan" -> analyzedLogicalPlan.treeString.take(MAX_OUTPUT_LENGTH),
+                "optimizedLogicalPlan" -> optimizedLogicalPlan.treeString.take(MAX_OUTPUT_LENGTH),
+                "resolvedExpr" -> resolvedExpr.treeString.take(MAX_OUTPUT_LENGTH)
+              )
             )
-          )
+          }
           resolvedExpr
       }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
In DeltaInvariantCheckerExec, if the check constraint expressions are unresolvable, we used to create an assertion log and not throw an exception. So in some cases an internal error is thrown in the subsequent steps.

The PR proposes to throw a proper user-facing error (AnalysisException) in DeltaInvariantCheckerExec to expose the problem to the user for better clarity, and avoid the issues in the downstream. It invokes checkAnalysis to throw a user-facing exception when the check constraint expression is unresolved.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
New UT.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

Previous behavior:

If the check constraint expressions are unresolvable, we used to create an assertion log and not throw an exception. So in some cases an internal error is thrown in the subsequent steps.

Proposed change: 

We throw a proper user-facing error (AnalysisException) when the check constraint expressions are unresolvable in DeltaInvariantCheckerExec to expose the problem to the user for better clarity, and avoid the issues in the downstream.