### PR TITLE
[Spark] Push down IsNull through nullIntolerant exprs

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1596,6 +1596,14 @@ trait DeltaSQLConfBase {
       .stringConf
       .createOptional
 
+  val DELTA_DATASKIPPING_ISNULL_PUSHDOWN_EXPRS_ENABLED =
+    buildConf("skipping.enhancedIsNullPushdownExprs.enabled")
+      .doc("If true, support pushing down IsNull on additional null-intolerant expressions for " +
+        "data skipping.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * The below confs have a special prefix `spark.databricks.io` because this is the conf value
    * already used by Databricks' data skipping implementation. There's no benefit to making OSS

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -722,7 +722,10 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
       "TRUE",
       "FALSE",     // Ideally this should not hit, but its correct to not skip
       "NULL AND a = 1", // This is optimized to FALSE by ReplaceNullWithFalse, so it's same as above
-      "NOT a <=> 1"
+      "NOT a <=> 1",
+      "(a > 1) IS NULL", // This pushes down the IS NULL to both sides of GreaterThan.
+      "(a > 1 AND a > 0) IS NULL", // Pushdown of IS NULL on AND.
+      "(a > 1 OR a < 0) IS NULL" // Pushdown of IS NULL on OR.
     ),
     misses = Seq(
       // stats tell us a is always NULL, so any predicate that requires non-NULL a should skip
@@ -733,8 +736,40 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
       "a > 1",
       "a < 1",
       "a <> 1",
-      "a <=> 1"
+      "a <=> 1",
+      "NOT ((a > 1) IS NULL)"
     )
+  )
+
+  testSkipping(
+    "nulls - only non-null in file",
+    """
+      {"a": 1, "b": 2}
+    """,
+    schema = new StructType()
+      .add(new StructField("a", IntegerType))
+      .add(new StructField("b", IntegerType)),
+    hits = Seq(),
+    misses = Seq(
+      "(a > 0 AND b > 1) IS NULL",
+      "(a > 0 OR b > 1) IS NULL"
+    )
+  )
+
+  testSkipping(
+    "nulls - only non-null in file with enhanced pushdown disabled",
+    """
+      {"a": 1, "b": 2}
+    """,
+    schema = new StructType()
+      .add(new StructField("a", IntegerType))
+      .add(new StructField("b", IntegerType)),
+    hits = Seq(
+      "(a > 0 AND b > 1) IS NULL",
+      "(a > 0 OR b > 1) IS NULL"
+    ),
+    misses = Seq.empty,
+    sqlConfs = Seq((DeltaSQLConf.DELTA_DATASKIPPING_ISNULL_PUSHDOWN_EXPRS_ENABLED.key, "false"))
   )
 
   testSkipping(
@@ -756,7 +791,12 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
       "TRUE",
       "FALSE",    // Ideally this should not hit, but its correct to not skip
       "NULL AND a = 1", // This is optimized to FALSE by ReplaceNullWithFalse, so it's same as above
-      "NOT a <=> 1"
+      "NOT a <=> 1",
+      "(a > 0) IS NULL",
+      "(a < 0) IS NULL",
+      "(a > 1 AND a > 0) IS NULL", // Pushdown of IS NULL on AND.
+      "(a > 1 OR a < 0) IS NULL", // Pushdown of IS NULL on OR.
+      "NOT ((a > 0) IS NULL)"
     ),
     misses = Seq(
       "a <> 1",
@@ -764,6 +804,56 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
       "a < 1",
       "NOT a = 1"
     )
+  )
+
+  testSkipping(
+    "nulls - non-nulls only in file",
+    """
+      {"a": 1 }
+    """,
+    schema = new StructType().add(new StructField("a", IntegerType)),
+    hits = Seq(
+      "NOT ((a > 0) IS NULL)"
+    ),
+    misses = Seq(
+      "(a > 0) IS NULL",
+      "(a < 0) IS NULL",
+      "(a > 1 AND a > 0) IS NULL", // Pushdown of IS NULL on AND.
+      "(a > 1 OR a < 0) IS NULL" // Pushdown of IS NULL on OR.
+    )
+  )
+
+  testSkipping(
+    "nulls - non-nulls only in file with partial column stats",
+    """
+      {"a": 1, "b": 2}
+    """,
+    hits = Seq(
+      "NOT ((a > 0) IS NULL)",
+      "(b > 0) IS NULL",
+      "(b < 0) IS NULL",
+      "(b > 1 AND a > 0) IS NULL", // Pushdown of IS NULL on AND.
+      "(b > 1 OR a < 0) IS NULL" // Pushdown of IS NULL on OR.
+    ),
+    misses = Seq(
+      "(a > 0) IS NULL",
+      "(a < 0) IS NULL",
+      "(a > 1 AND a > 0) IS NULL", // Pushdown of IS NULL on AND.
+      "(a > 1 OR a < 0) IS NULL" // Pushdown of IS NULL on OR.
+    ),
+    indexedCols = 1
+  )
+
+  testSkipping(
+    "nulls - non-strict null-intolerant predicate returns hits for IS NULL",
+    """
+      {"a": [3, 4]}
+    """,
+    hits = Seq(
+      "NOT (element_at(a, 3) IS NULL)",
+      "element_at(a, 3) IS NULL"
+    ),
+    misses = Seq.empty
   )
 
   test("data skipping with missing stats") {
@@ -1345,7 +1435,8 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
         // b and c should have NULL_COUNT stats, but currently they're not SkippingEligibleColumn
         // (since they're not AtomicType), we couldn't skip for them
         "isnull(b)",
-        "c is null"
+        "c is null",
+        "ELEMENT_AT(c, 10) IS NULL" // Out-of-bounds access returns null.
       )
       val misses = Seq(
         // a has NULL_COUNT stats since it's missing from DataFrame schema


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Previously, we did not push down IsNull through AND/OR or other Null intolerant expressions when evaluating expressions for data skipping. This disabled more expressions for data skipping than we would otherwise desire.


## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?

No
