### PR TITLE
[Spark] Fix MinorCompaction not including RemoveFile

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -518,7 +518,7 @@ trait RecordChecksum extends DeltaLogging {
     // `minSetTransactionRetentionTimestamp` is set. So passing this as None here explicitly.
     // We can also ignore file retention because that only affects [[RemoveFile]] actions.
     val logReplay = new InMemoryLogReplay(
-      minFileRetentionTimestamp = 0,
+      minFileRetentionTimestamp = None,
       minSetTransactionRetentionTimestamp = None)
 
     logReplay.append(attemptVersion - 1, oldSetTransactions.toIterator)
@@ -547,7 +547,7 @@ trait RecordChecksum extends DeltaLogging {
 
     // We only work with DomainMetadata, so RemoveFile and SetTransaction retention don't matter.
     val logReplay = new InMemoryLogReplay(
-      minFileRetentionTimestamp = 0,
+      minFileRetentionTimestamp = None,
       minSetTransactionRetentionTimestamp = None)
 
     val threshold = spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_MAX_DOMAIN_METADATAS_IN_CRC)
@@ -612,7 +612,7 @@ trait RecordChecksum extends DeltaLogging {
 
     // We only work with AddFile, so RemoveFile and SetTransaction retention don't matter.
     val logReplay = new InMemoryLogReplay(
-      minFileRetentionTimestamp = 0,
+      minFileRetentionTimestamp = None,
       minSetTransactionRetentionTimestamp = None)
 
     logReplay.append(attemptVersion - 1, oldAllFiles.map(normalizePath).toIterator)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -511,7 +511,7 @@ class Snapshot(
         .mapPartitions { iter =>
           val state: LogReplay =
             new InMemoryLogReplay(
-              localMinFileRetentionTimestamp,
+              Some(localMinFileRetentionTimestamp),
               localMinSetTransactionRetentionTimestamp)
           state.append(0, iter.map(_.unwrap))
           state.checkpoint.map(_.wrap)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames}
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
@@ -44,14 +44,8 @@ class DeltaLogMinorCompactionSuite extends QueryTest
       startVersion: Long,
       endVersion: Long): Unit = {
     val deltaLog = DeltaLog.forTable(spark, tablePath)
-    CatalogOwnedTableUtils.populateTableCommitCoordinatorFromCatalog(
-      spark,
-      catalogTableOpt = None,
-      snapshot = deltaLog.unsafeVolatileSnapshot).foreach { tcc =>
-      tcc.backfillToVersion(endVersion)
-    }
     val logReplay = new InMemoryLogReplay(
-      minFileRetentionTimestamp = 0,
+      minFileRetentionTimestamp = None,
       minSetTransactionRetentionTimestamp = None)
     val hadoopConf = deltaLog.newDeltaHadoopConf()
 
@@ -187,7 +181,8 @@ class DeltaLogMinorCompactionSuite extends QueryTest
   def testSnapshotCreation(
       compactionWindows: Seq[(Long, Long)],
       checkpoints: Set[Int] = Set.empty,
-      postSetupFunc: Option[(DeltaLog => Unit)] = None,
+      postDataGenerationFunc: Option[DeltaLog => Unit] = None,
+      postSetupFunc: Option[DeltaLog => Unit] = None,
       expectedCompactedDeltas: Seq[CompactedDelta],
       expectedDeltas: Seq[Long],
       expectedCheckpoint: Long = -1L,
@@ -206,7 +201,19 @@ class DeltaLogMinorCompactionSuite extends QueryTest
       withTempDir { tmpDir =>
         val tableDir = tmpDir.getAbsolutePath
         generateData(tableDir, checkpoints)
-        val deltaLog = DeltaLog.forTable(spark, tableDir)
+
+        val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, tableDir)
+        // Ensure all commits are backfilled after data generation.
+        CatalogOwnedTableUtils.populateTableCommitCoordinatorFromCatalog(
+            spark,
+            catalogTableOpt = None,
+            snapshot = snapshot).foreach { tcc =>
+          tcc.backfillToVersion(snapshot.version)
+        }
+
+        // Data generation complete - run post data generation function
+        postDataGenerationFunc.foreach(_.apply(deltaLog))
+
         compactionWindows.foreach { case (startV, endV) =>
           minorCompactDeltaLog(tableDir, startV, endV)
         }
@@ -421,7 +428,6 @@ class DeltaLogMinorCompactionSuite extends QueryTest
     )
   }
 
-
   test("compacted deltas should not be used when there are holes in deltas") {
     testSnapshotCreation(
       compactionWindows = Seq((0, 2), (3, 5), (3, 6)),
@@ -441,6 +447,52 @@ class DeltaLogMinorCompactionSuite extends QueryTest
       // commit version 8 where we change `delta.dataSkippingNumIndexedCols` to 0.
       additionalConfs =
         Seq(DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.defaultTablePropertyKey -> "false")
+    )
+  }
+
+  test("compacted deltas should include RemoveFiles that do not have deletionTimestamp") {
+    testSnapshotCreation(
+      compactionWindows = Seq((1, 3), (4, 6), (7, 10)),
+      checkpoints = Set.empty,
+      postDataGenerationFunc = Some(
+        (deltaLog: DeltaLog) => {
+          val hadoopConf = deltaLog.newDeltaHadoopConf()
+          // Remove deletionTimestamp from RemoveFile in versions 1 to 10.
+          (1 to 10).foreach { versionToRead =>
+            val file = FileNames.unsafeDeltaFile(deltaLog.logPath, versionToRead)
+            val actions = deltaLog.store.readAsIterator(file, hadoopConf).map(Action.fromJson)
+            val actionsWithoutDeletionTimestamp = actions
+              .map {
+                case r: RemoveFile if r.deletionTimestamp.isDefined =>
+                  r.copy(deletionTimestamp = None)
+                case ci: CommitInfo =>
+                  // The operationParameters were serialized with JsonMapSerializer but there
+                  // were no corresponding JsonMapDeserializer when reading them back,
+                  // so need to do this step to ensure they can be serialized again.
+                  val parameters = Option(ci.operationParameters)
+                    .map(_.mapValues(JsonUtils.toJson(_)).toMap)
+                    .orNull
+                  ci.copy(operationParameters = parameters)
+                case other => other
+              }
+              .map(_.json)
+              .toSeq
+            // The iterator is already consumed above so that we don't run into the issue of
+            // overwriting the file while reading it.
+            deltaLog.store.write(
+              path = file,
+              actions = actionsWithoutDeletionTimestamp.toIterator,
+              overwrite = true,
+              hadoopConf = hadoopConf)
+          }
+        }
+      ),
+      expectedCompactedDeltas = Seq(
+        CompactedDelta((1, 3), numAdds = 1, numRemoves = 1, numMetadata = 0),
+        CompactedDelta((4, 6), numAdds = 11, numRemoves = 5, numMetadata = 0),
+        CompactedDelta((7, 10), numAdds = 8, numRemoves = 6, numMetadata = 1)
+      ),
+      expectedDeltas = Seq(0)
     )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Currently, if the RemoveFile in a table did not have the `deletionTimestamp` field for whatever reason, these actions would not be included in the compaction file, causing state constructed from the compaction file to include the removed files. This is because we default the `deletionTimestamp` to 0 when this happens, and the log replay only keeps the `RemoveFile` with `deletionTimestamp` larger than 0.

In PR fixes this issue by changing the type of `minFileRetentionTimestamp` in `InMemoryLogReplay` to an `Option[Long]`, so that we can specify `None` to include all `RemoveFiles`, regardless of whether they have a `deletionTimestamp` or not.

The main call site change is in `MinorCompactionHook`, all other call sites can safely change from 0 to None since they don't care about tombstones.

## How was this patch tested?

New unit test

## Does this PR introduce _any_ user-facing changes?

No