### PR TITLE
[Spark] Emit `usage_log` for CC tables during Catalog discovery

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUsageLogs.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUsageLogs.scala
@@ -16,6 +16,20 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+/** Class containing usage logs emitted by Catalog Owned. */
+object CatalogOwnedUsageLogs {
+  /** Common prefix for all catalog-owned usage logs. */
+  val PREFIX = "delta.catalogOwned"
+
+  /**
+   * Usage log emitted when we populate the commit coordinator via invalid path-based access.
+   * I.e., No catalog table is present when trying to populate commit coordinator, which is
+   *       almost a bug case for CC tables.
+   */
+  val COMMIT_COORDINATOR_POPULATION_INVALID_PATH_BASED_ACCESS =
+    s"$PREFIX.commitCoordinatorPopulation.invalidPathBasedAccess"
+}
+
 /** Class containing usage logs emitted by Coordinated Commits. */
 object CoordinatedCommitsUsageLogs {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -302,9 +302,7 @@ object CatalogOwnedTableUtils extends DeltaLogging {
     // Base data that's common to *all* usage logs for tccc population.
     val baseData = Map(
       "version" -> snapshot.version.toString,
-      "path" -> snapshot.path.toString,
-      "ucTableId" -> snapshot.getProperties
-        .getOrElse(UCCommitCoordinatorClient.UC_TABLE_ID_KEY, "UC_TABLE_ID_MISSING")
+      "path" -> snapshot.path.toString
     )
 
     val catalogData = catalogTableOpt.map { catalogTable =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.commons.lang3.NotImplementedException
 
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 
 class CatalogOwnedEnablementSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.delta.DeltaOperations._
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.JsonUtils
-import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.commons.lang3.NotImplementedException
 
 import org.apache.spark.sql.catalyst.TableIdentifier

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -293,7 +293,7 @@ class CatalogOwnedEnablementSuite
       val usageLogBlob = JsonUtils.fromJson[Map[String, Any]](usageLog.head.blob)
 
       val logStore =
-        "org.apache.spark.sql.delta.storage.LocalLogStore"
+        "org.apache.spark.sql.delta.storage.DelegatingLogStore"
 
       validateUsageLogBlob(
         usageLogBlob,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -329,10 +329,8 @@ class CatalogOwnedEnablementSuite
           ),
           "properties" -> Map(
             "delta.feature.appendOnly" -> "supported",
-            "delta.enableDeletionVectors" -> "true",
             // To avoid potential naming change in the future.
             s"delta.feature.${CatalogOwnedTableFeature.name}" -> "supported",
-            "delta.checkpointPolicy" -> "v2",
             "delta.feature.vacuumProtocolCheck" -> "supported",
             "delta.feature.domainMetadata" -> "supported"
           ),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR emits `usage_log` for CC tables during Catalog discovery for invalid path-based access.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through newly added UT in `CatalogOwnedEnablementSuite`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
