### PR TITLE
[Kernel] Fix CRC listing to correctly terminate at the readVersion

### DIFF
--- a/.github/workflows/connectors_test.yaml
+++ b/.github/workflows/connectors_test.yaml
@@ -16,7 +16,7 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
       - name: Cache Scala, SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.sbt

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ChecksumReader.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ChecksumReader.java
@@ -17,6 +17,7 @@ package io.delta.kernel.internal.replay;
 
 import static io.delta.kernel.internal.replay.VersionStats.fromColumnarBatch;
 import static io.delta.kernel.internal.util.FileNames.checksumFile;
+import static io.delta.kernel.internal.util.FileNames.checksumVersion;
 import static io.delta.kernel.internal.util.FileNames.isChecksumFile;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 
@@ -71,6 +72,7 @@ public class ChecksumReader {
       List<FileStatus> crcFilesList = new ArrayList<>();
       crcFiles
           .filter(file -> isChecksumFile(new Path(file.getPath())))
+          .takeWhile(file -> checksumVersion(new Path(file.getPath())) <= readVersion)
           .forEachRemaining(crcFilesList::add);
 
       // pick the last file which is the latest version that has the CRC file

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/CloseableIteratorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/CloseableIteratorSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.internal.util.Utils
+import io.delta.kernel.utils.CloseableIterator
+import io.delta.kernel.utils.CloseableIterator.BreakableFilterResult
+import org.scalatest.funsuite.AnyFunSuite
+
+class CloseableIteratorSuite extends AnyFunSuite {
+
+  private def toCloseableIter[T](elems: Seq[T]): CloseableIterator[T] = {
+    Utils.toCloseableIterator(elems.iterator.asJava)
+  }
+
+  private def toList[T](iter: CloseableIterator[T]): List[T] = {
+    iter.toInMemoryList.asScala.toList
+  }
+
+  private def normalDataIter = toCloseableIter(Seq(1, 2, 3, 4, 5))
+
+  private def throwingDataIter = toCloseableIter(Seq(1, 2, 3, 4, 5)).map { x =>
+    if (x > 4) {
+      throw new RuntimeException("Underlying data evaluated at element > 4")
+    }
+    x
+  }
+
+  test("CloseableIterator::filter -- returns filtered result") {
+    val result = normalDataIter.filter(x => x <= 3 || x == 5)
+    assert(toList(result) === List(1, 2, 3, 5))
+  }
+
+  test("CloseableIterator::filter -- iterates over all elements") {
+    intercept[RuntimeException] {
+      toList(throwingDataIter.filter(x => x <= 3))
+    }
+  }
+
+  test("CloseableIterator::takeWhile -- stops iteration at first false condition") {
+    // we expect it to evaluate 1, 2, 3, 4; break when it sees x == 4; and only return 1, 2, 3
+    val result = throwingDataIter.takeWhile(x => x <= 3)
+    assert(toList(result) === List(1, 2, 3))
+  }
+
+  test("CloseableIterator::breakableFilter -- correctly filters and breaks iteration") {
+    val result = throwingDataIter.breakableFilter { x =>
+      if (x <= 1 || x == 3) {
+        BreakableFilterResult.INCLUDE
+      } else if (x == 2) {
+        BreakableFilterResult.EXCLUDE
+      } else if (x == 4) {
+        BreakableFilterResult.BREAK
+      } else {
+        throw new RuntimeException("This should never be reached")
+      }
+    }
+    // we except it to include 1; exclude 2; include 3; and break at 4, thus never seeing 5
+    assert(toList(result) === List(1, 3))
+  }
+
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
@@ -446,15 +446,14 @@ class LogReplayEngineMetricsSuite extends AnyFunSuite with TestUtils {
   }
 
   test("checksum not found at the read version, but found at a previous version; " +
-    "crc exists after version queried") {
+    "checksum exists after version queried") {
     withTempDirAndMetricsEngine { (path, engine) =>
       // copy the golden table with crc files to the temp dir delete the checksum files
       // for version 5
       copyTable(getTestResourceFilePath("stream_table_optimize"), path)
-      Seq(5L).foreach { version =>
-        val crcFile = new File(path, f"_delta_log/$version%020d.crc")
-        assert(Files.deleteIfExists(crcFile.toPath))
-      }
+      val crcFile = new File(path, f"_delta_log/${5L}%020d.crc")
+      assert(Files.deleteIfExists(crcFile.toPath))
+      // Now table has CRC present for versions 0, 1, 2, 3, 4, 6 (missing for version 5)
 
       loadPandMCheckMetrics(
         Table.forPath(engine, path)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
@@ -445,6 +445,32 @@ class LogReplayEngineMetricsSuite extends AnyFunSuite with TestUtils {
     }
   }
 
+  test("checksum not found at the read version, but found at a previous version; " +
+    "crc exists after version queried") {
+    withTempDirAndMetricsEngine { (path, engine) =>
+      // copy the golden table with crc files to the temp dir delete the checksum files
+      // for version 5
+      copyTable(getTestResourceFilePath("stream_table_optimize"), path)
+      Seq(5L).foreach { version =>
+        val crcFile = new File(path, f"_delta_log/$version%020d.crc")
+        assert(Files.deleteIfExists(crcFile.toPath))
+      }
+
+      loadPandMCheckMetrics(
+        Table.forPath(engine, path)
+          .getSnapshotAsOfVersion(engine, 5 /* versionId */).getSchema(engine),
+        engine,
+        // We find the checksum from crc at version 4, but still read commit file 5
+        // to find the P&M which could have been updated in version 5
+        expJsonVersionsRead = Seq(5),
+        expParquetVersionsRead = Nil,
+        expParquetReadSetSizes = Nil,
+        // First attempted to read checksum for version 5, then we do a listing of
+        // last 100 crc files and read the latest one which is version 4 (as version 5 is deleted)
+        expChecksumReadSet = Seq(5, 4))
+    }
+  }
+
   test("checksum not found at the read version, but uses snapshot hint lower bound") {
     withTempDirAndMetricsEngine { (path, engine) =>
       // copy the golden table with crc files to the temp dir delete the checksum files


### PR DESCRIPTION
Adds a test (mirrors the other tests in the suite just ensures a later CRC does exist). Confirmed that the test fails without the fix.

Also cherry-picked https://github.com/delta-io/delta/commit/ab1fa99f78631ff4e6592445d9d5d8b3e650674c as it's needed for the CI.