### PR TITLE
[Spark] Replace DELTA_EMPTY_DIRECTORY error with DELTA_LOG_FILE_NOT_FOUND

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1631,6 +1631,12 @@
     ],
     "sqlState" : "42K04"
   },
+  "DELTA_LOG_FILE_NOT_FOUND" : {
+    "message" : [
+      "Unable to retrieve the delta log files to construct table version <version> starting from checkpoint version <checkpointVersion> at <logPath>."
+    ],
+    "sqlState" : "42K03"
+  },
   "DELTA_LOG_FILE_NOT_FOUND_FOR_STREAMING_SOURCE" : {
     "message" : [
       "If you never deleted it, it's likely your query is lagging behind. Please delete its checkpoint to restart from scratch. To avoid this happening again, you can update your retention policy of your Delta table"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -940,7 +940,7 @@ trait DeltaErrorsBase
     )
   }
 
-  def logFileNotFoundException(
+  def truncatedTransactionLogException(
       path: Path,
       version: Long,
       metadata: Metadata): Throwable = {
@@ -955,6 +955,19 @@ trait DeltaErrorsBase
         logRetention.toString,
         DeltaConfigs.CHECKPOINT_RETENTION_DURATION.key,
         checkpointRetention.toString)
+    )
+  }
+
+  def logFileNotFoundException(
+      path: Path,
+      version: Option[Long],
+      checkpointVersion: Long): Throwable = {
+    new DeltaFileNotFoundException(
+      errorClass = "DELTA_LOG_FILE_NOT_FOUND",
+      messageParameters = Array(
+        version.map(_.toString).getOrElse("LATEST"),
+        checkpointVersion.toString,
+        path.toString)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -449,7 +449,7 @@ trait SnapshotManagement { self: DeltaLog =>
       }
 
       if (headDeltaVersion != checkpointVersion + 1) {
-        throw DeltaErrors.logFileNotFoundException(
+        throw DeltaErrors.truncatedTransactionLogException(
           unsafeDeltaFile(logPath, checkpointVersion + 1),
           lastDeltaVersion,
           unsafeVolatileMetadata) // metadata is best-effort only
@@ -500,7 +500,7 @@ trait SnapshotManagement { self: DeltaLog =>
       if (newFiles.isEmpty && lastCheckpointVersion < 0) {
         // We can't construct a snapshot because the directory contained no usable commit
         // files... but we can't return None either, because it was not truly empty.
-        throw DeltaErrors.emptyDirectoryException(logPath.toString)
+        throw DeltaErrors.logFileNotFoundException(logPath, versionToLoad, lastCheckpointVersion)
       } else if (newFiles.isEmpty) {
         // The directory may be deleted and recreated and we may have stale state in our DeltaLog
         // singleton, so try listing from the first version
@@ -911,7 +911,10 @@ trait SnapshotManagement { self: DeltaLog =>
     ).getOrElse {
       // This shouldn't be possible right after a commit
       logError(log"No delta log found for the Delta table at ${MDC(DeltaLogKeys.PATH, logPath)}")
-      throw DeltaErrors.emptyDirectoryException(logPath.toString)
+      throw DeltaErrors.logFileNotFoundException(
+        logPath,
+        version = None,
+        checkpointVersion = getCheckpointVersion(None, Some(oldCheckpointProvider)))
     }
   }
 
@@ -1462,7 +1465,10 @@ trait SnapshotManagement { self: DeltaLog =>
       lastCheckpointInfo = lastCheckpointInfoOpt)
     val logSegment = logSegmentOpt.getOrElse {
       // We can't return InitialSnapshot because our caller asked for a specific snapshot version.
-      throw DeltaErrors.emptyDirectoryException(logPath.toString)
+      throw DeltaErrors.logFileNotFoundException(
+        logPath,
+        Some(version),
+        getCheckpointVersion(lastCheckpointInfoOpt, lastCheckpointProviderOpt))
     }
     createSnapshot(
       initSegment = logSegment,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -679,6 +679,16 @@ trait DeltaErrorsSuiteBase
       ))
     }
     {
+      val e = intercept[DeltaFileNotFoundException] {
+        throw DeltaErrors.logFileNotFoundException(new Path("file://table"), None, 10)
+      }
+      checkError(e, "DELTA_LOG_FILE_NOT_FOUND", "42K03", Map(
+        "version" -> "LATEST",
+        "checkpointVersion" -> "10",
+        "logPath" -> "file://table"
+      ))
+    }
+    {
       val ex = new FileNotFoundException("reason")
       val e = intercept[DeltaFileNotFoundException] {
         throw DeltaErrors.logFileNotFoundExceptionForStreamingSource(ex)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

In some instances of DELTA_EMPTY_DIRECTORY, the actual cause may not be because the directory is completely empty but because the log files listing return empty. This PR replaces these instances with DELTA_LOG_FILE_NOT_FOUND and provide more info to help with debugging.

## How was this patch tested?

UT

## Does this PR introduce _any_ user-facing changes?

No