### PR TITLE
[Spark] Add missing clock parameter

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -819,7 +819,7 @@ object DeltaLog extends DeltaLogging {
   /** Helper for creating a log for the table. */
   def forTable(spark: SparkSession, tableName: TableIdentifier, clock: Clock): DeltaLog = {
     if (DeltaTableIdentifier.isDeltaPath(spark, tableName)) {
-      forTable(spark, new Path(tableName.table))
+      forTable(spark, new Path(tableName.table), clock)
     } else {
       forTable(spark, spark.sessionState.catalog.getTableMetadata(tableName), clock)
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Fix a small bug where clock parameter is not sent to the overloaded method.

## How was this patch tested?
Existing unit tests

## Does this PR introduce _any_ user-facing changes?
No
