### PR TITLE
[Protocol] Fix typo in name of a row tracking domain metadata field in protocol spec

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1312,7 +1312,7 @@ Writers that do not implement VACUUM do not need to change anything and can safe
 For tables with Vacuum Protocol Check enabled, readers don’t need to understand or change anything new; they just need to acknowledge the feature exists.
 
 Making this feature a ReaderWriter feature (rather than solely a Writer feature) ensures that:
-- Older vacuum implementations, which only performed the Reader protocol check and lacked the Writer protocol check, will begin to fail if the table has `vacuumProtocolCheck` enabled.This change allows future writer features to have greater flexibility and safety in managing files within the table directory, eliminating the risk of older Vacuum implementations (that lack the Writer protocol check) accidentally deleting relevant files.
+- Older vacuum implementations, which only performed the Reader protocol check and lacked the Writer protocol check, will begin to fail if the table has `vacuumProtocolCheck` enabled. This change allows future writer features to have greater flexibility and safety in managing files within the table directory, eliminating the risk of older Vacuum implementations (that lack the Writer protocol check) accidentally deleting relevant files.
 
 # Clustered Table
 
@@ -1341,7 +1341,7 @@ When the Clustered Table is supported (when the `writerFeatures` field of a tabl
   - A clustering implementation is free to add additional information such as adding a new user-controlled metadata domain to keep track of its metadata.
 - Writers must not define clustered and partitioned table at the same time.
 
-The following is an example for the `domainMetadata` action defintion of a table that leverages column mapping.
+The following is an example for the `domainMetadata` action definition of a table that leverages column mapping.
 ```json
 {
   "domainMetadata": {
@@ -1511,7 +1511,7 @@ Field Name | optional/required | Description
 `fieldPath`| optional | When updating the type of a map key/value or array element only: the path from the struct field holding the metadata to the map key/value or array element that was updated.
 
 The `fieldPath` value is "key", "value" and "element"  when updating resp. the type of a map key, map value and array element.
-The `fieldPath` value for nested maps and nested arrays are prefixed by their parents's path, separated by dots.
+The `fieldPath` value for nested maps and nested arrays are prefixed by their parents' path, separated by dots.
 
 The following is an example for the definition of a column that went through two type changes:
 ```json
@@ -1614,7 +1614,7 @@ When Type Widening is supported (when the `readerFeatures` field of a table's `p
 This section documents additional requirements that writers must follow in order to preserve some of the higher level guarantees that Delta provides.
 
 ## Creation of New Log Entries
- - Writers MUST never overwrite an existing log entry. When ever possible they should use atomic primitives of the underlying filesystem to ensure concurrent writers do not overwrite each others entries.
+ - Writers MUST never overwrite an existing log entry. When ever possible they should use atomic primitives of the underlying filesystem to ensure concurrent writers do not overwrite each other's entries.
 
 ## Consistency Between Table Metadata and Data Files
  - Any column that exists in a data file present in the table MUST also be present in the metadata of the table.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -493,7 +493,7 @@ That means specifically that for any commit…
 
  - it is **legal** for the same `path` to occur in an `add` action and a `remove` action, but with two different `dvId`s.
  - it is **legal** for the same `path` to be added and/or removed and also occur in a `cdc` action.
- - it is **illegal** for the same `path` to be occur twice with different `dvId`s within each set of `add` or `remove` actions.
+ - it is **illegal** for the same `path` to occur twice with different `dvId`s within each set of `add` or `remove` actions.
  - it is **illegal** for a `path` to occur in an `add` action that already occurs with a different `dvId` in the list of `add` actions from the snapshot of the version immediately preceeding the commit, unless the commit also contains a remove for the later combination.
  - it is **legal** to commit an existing `path` and `dvId` combination again (this allows metadata updates).
 
@@ -1148,7 +1148,7 @@ To support this feature:
 
 When supported:
 - A table could use [uuid-named](#uuid-named-checkpoint) [V2 spec Checkpoints](#v2-spec) which must have [checkpoint metadata](#checkpoint-metadata) and may have [sidecar files](#sidecar-files) OR
-- A table could use [classic](#classic-checkpoint) checkpoints which can be follow [V1](#v1-spec) or [V2](#v2-spec) spec.
+- A table could use [classic](#classic-checkpoint) checkpoints which can follow [V1](#v1-spec) or [V2](#v2-spec) spec.
 - A table must not use [multi-part checkpoints](#multi-part-checkpoint)
 
 # Row Tracking
@@ -1254,9 +1254,9 @@ When Row Tracking is supported (when the `writerFeatures` field of a table's `pr
   - Writers must set the `baseRowId` field in recommitted and checkpointed `add` actions and `remove` actions to the `baseRowId` value (if present) of the last committed `add` action with the same `path`.
   - Writers must track the high water mark, i.e. the highest fresh row id assigned.
     - The high water mark must be stored in a `domainMetadata` action with `delta.rowTracking` as the `domain`
-      and a `configuration` containing a single key-value pair with `highWaterMark` as the key and the highest assigned fresh row id as the value.
-    - Writers must include a `domainMetadata` for `delta.rowTracking` whenever they assign new fresh Row IDs that are higher than `highWaterMark` value of the current `domainMetadata` for `delta.rowTracking`.
-      The `highWaterMark` value in the `configuration` of this `domainMetadata` action must always be equal to or greater than the highest fresh Row ID committed so far.
+      and a `configuration` containing a single key-value pair with `rowIdHighWaterMark` as the key and the highest assigned fresh row id as the value.
+    - Writers must include a `domainMetadata` for `delta.rowTracking` whenever they assign new fresh Row IDs that are higher than `rowIdHighWaterMark` value of the current `domainMetadata` for `delta.rowTracking`.
+      The `rowIdHighWaterMark` value in the `configuration` of this `domainMetadata` action must always be equal to or greater than the highest fresh Row ID committed so far.
       Writers can either commit this `domainMetadata` in the same commit, or they can reserve the fresh Row IDs in an earlier commit.
     - Writers must set the `baseRowId` field to a value that is higher than the row id high water mark.
 - Writer must assign fresh Row Commit Versions to all rows that they commit.
@@ -2020,7 +2020,7 @@ Bytes | Name | Description
 `<start of b>` – `<start of b> + 3` | key | The most significant 32-bit of all the values in this bucket.
 `<start of b> + 4` – `<end of b>` | bucketData | A serialized 32-bit RoaringBitmap with all the least signficant 32-bit entries in this bucket.
 
-The 32-bit serialization format then consists of a header that describes all the (least signficant) 16-bit containers, their types (s. above), and their their key (most significant 16-bits).
+The 32-bit serialization format then consists of a header that describes all the (least signficant) 16-bit containers, their types (s. above), and their key (most significant 16-bits).
 This is followed by the data for each individual container in a container-specific format.
 
 Reference Implementations of the Roaring format:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol spec)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The protocol spec has a typo in the row tracking metadata domain. [Kernel implements the high water mark as `rowIdHighWaterMark`](https://github.com/delta-io/delta/blob/master/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTrackingMetadataDomain.java#L60) but the spec defines it to be `highWaterMark`. Since the current implementation is already used in production (i.e., delta-spark has been using that name for years), I suggest to adapt that specification instead of opting for a breaking change in the code base.

Since this PR touches the spec anyways, I also fixed some non-critical typos along the way.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

No since no code was changed.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This PR introduces user-facing changes to anyone who wants to implement the row tracking feature as part of a Delta connector.
