### PR TITLE
[Spark] Emit `usage_log` for CC tables during Catalog discovery

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUsageLogs.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUsageLogs.scala
@@ -16,6 +16,20 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+/** Class containing usage logs emitted by Catalog Owned. */
+object CatalogOwnedUsageLogs {
+  /** Common prefix for all catalog-owned usage logs. */
+  val PREFIX = "delta.catalogOwned"
+
+  /**
+   * Usage log emitted when we populate the commit coordinator via invalid path-based access.
+   * I.e., No catalog table is present when trying to populate commit coordinator, which is
+   *       almost a bug case for CC tables.
+   */
+  val COMMIT_COORDINATOR_POPULATION_INVALID_PATH_BASED_ACCESS =
+    s"$PREFIX.commitCoordinatorPopulation.invalidPathBasedAccess"
+}
+
 /** Class containing usage logs emitted by Coordinated Commits. */
 object CoordinatedCommitsUsageLogs {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.util.Utils
 
-object CatalogOwnedTableUtils {
+object CatalogOwnedTableUtils extends DeltaLogging {
   /** The default catalog name only used for testing. */
   val DEFAULT_CATALOG_NAME_FOR_TESTING: String = "spark_catalog"
 
@@ -62,11 +62,11 @@ object CatalogOwnedTableUtils {
           "Couldn't locate commit coordinator for: " + catalogTable.identifier)
       }
       TableCommitCoordinatorClient(
-        cc,
-        snapshot.deltaLog.logPath,
-        snapshot.metadata.configuration,
-        snapshot.deltaLog.newDeltaHadoopConf(),
-        snapshot.deltaLog.store
+        commitCoordinatorClient = cc,
+        logPath = snapshot.deltaLog.logPath,
+        tableConf = snapshot.metadata.configuration,
+        hadoopConf = snapshot.deltaLog.newDeltaHadoopConf(),
+        logStore = snapshot.deltaLog.store
       )
     }
     .orElse {
@@ -82,16 +82,26 @@ object CatalogOwnedTableUtils {
           .map { cc =>
             return Some(TableCommitCoordinatorClient(
               cc,
-              snapshot.deltaLog.logPath,
-              snapshot.metadata.configuration,
-              snapshot.deltaLog.newDeltaHadoopConf(),
-              snapshot.deltaLog.store))
+              logPath = snapshot.deltaLog.logPath,
+              tableConf = snapshot.metadata.configuration,
+              hadoopConf = snapshot.deltaLog.newDeltaHadoopConf(),
+              logStore = snapshot.deltaLog.store)
+            )
           }
       }
       // This table is catalog owned table but catalogTableOpt is not defined. This means
       // that the caller is accessing this table by path-based or the calling code path is missing
       // the CatalogTable.
       // TODO: Better error message with proper error code.
+      recordCommitCoordinatorPopulationUsageLog(
+        deltaLog = snapshot.deltaLog,
+        opType = CatalogOwnedUsageLogs.COMMIT_COORDINATOR_POPULATION_INVALID_PATH_BASED_ACCESS,
+        snapshot = snapshot,
+        catalogTableOpt,
+        commitCoordinatorOpt = None,
+        includeStackTrace = true,
+        includeAdditionalDiagnostics = true
+      )
       throw new IllegalStateException(
         "Path based access is not supported for Catalog-Owned table: " + snapshot.path)
     }
@@ -268,6 +278,68 @@ object CatalogOwnedTableUtils {
     spark.conf
       .getOption(TableFeatureProtocolUtils.defaultPropertyKey(CatalogOwnedTableFeature))
       .contains("supported")
+  }
+
+  /**
+   * Records usage logs for commit coordinator population with common fields.
+   *
+   * @param deltaLog The delta log instance
+   * @param opType The operation type for the usage log
+   * @param snapshot The table snapshot
+   * @param catalogTableOpt Optional catalog table information
+   * @param commitCoordinatorOpt Optional commit coordinator instance
+   * @param includeStackTrace Whether to include stack trace in the log
+   * @param includeAdditionalDiagnostics Whether to include additional diagnostic information
+   */
+  private def recordCommitCoordinatorPopulationUsageLog(
+      deltaLog: DeltaLog,
+      opType: String,
+      snapshot: Snapshot,
+      catalogTableOpt: Option[CatalogTable],
+      commitCoordinatorOpt: Option[CommitCoordinatorClient] = None,
+      includeStackTrace: Boolean = false,
+      includeAdditionalDiagnostics: Boolean = false): Unit = {
+    // Base data that's common to *all* usage logs for tccc population.
+    val baseData = Map(
+      "version" -> snapshot.version.toString,
+      "path" -> snapshot.path.toString
+    )
+
+    val catalogData = catalogTableOpt.map { catalogTable =>
+      Map(
+        "catalogTable.identifier" -> catalogTable.identifier.toString,
+        "catalogTable.tableType" -> catalogTable.tableType.toString
+      )
+    }.getOrElse(Map.empty[String, String])
+
+    val coordinatorData = commitCoordinatorOpt.map { cc =>
+      Map("commitCoordinator.getClass" -> cc.getClass.getName)
+    }.getOrElse(Map.empty[String, String])
+
+    val stackTraceData = if (includeStackTrace) {
+      Map("stackTrace" -> Thread.currentThread().getStackTrace.tail.mkString("\n\t"))
+    } else {
+      Map.empty[String, String]
+    }
+
+    val diagnosticData = if (includeAdditionalDiagnostics) {
+      Map(
+        "latestCheckpointVersion" -> snapshot.checkpointProvider.version,
+        "checksumOpt" -> snapshot.checksumOpt,
+        "properties" -> snapshot.getProperties,
+        "logStore" -> snapshot.deltaLog.store.getClass.getName
+      )
+    } else {
+      Map.empty[String, Any]
+    }
+
+    val allData = baseData ++ catalogData ++ coordinatorData ++ stackTraceData ++ diagnosticData
+
+    recordDeltaEvent(
+      deltaLog = deltaLog,
+      opType = opType,
+      data = allData
+    )
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -20,14 +20,19 @@ import java.util.UUID
 
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaOperations._
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.commons.lang3.NotImplementedException
 
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 
 class CatalogOwnedEnablementSuite
-  extends DeltaSQLTestUtils
+  extends QueryTest
+  with CatalogOwnedTestBaseSuite
+  with DeltaSQLTestUtils
   with DeltaSQLCommandTest
   with DeltaTestUtilsBase
   with DeltaExceptionTestUtils {
@@ -101,6 +106,52 @@ class CatalogOwnedEnablementSuite
     withTable(randomTableName) {
       testCatalogOwnedAlterTableSetup(randomTableName, createCatalogOwnedTableAtInit)
       f(randomTableName)
+    }
+  }
+
+  /**
+   * Validate the usage log blob.
+   *
+   * @param usageLogBlob The usage log blob to validate.
+   * @param expectedPresentFields The fields that should be present in the usage log blob.
+   * @param expectedAbsentFields The fields that should not be present in the usage log blob.
+   * @param expectedValues The expected values for the fields.
+   */
+  private def validateUsageLogBlob(
+      usageLogBlob: Map[String, Any],
+      expectedPresentFields: Seq[String] = Seq.empty,
+      expectedAbsentFields: Seq[String] = Seq.empty,
+      expectedValues: Map[String, Any] = Map.empty): Unit = {
+    expectedPresentFields.foreach { field =>
+      assert(usageLogBlob.contains(field), s"Field '$field' should be present in usage log blob")
+    }
+    expectedAbsentFields.foreach { field =>
+      assert(!usageLogBlob.contains(field),
+        s"Field '$field' should not be present in usage log blob")
+    }
+    assert(expectedValues.size === expectedPresentFields.size,
+      "The size of `expectedValues` should match the size of `expectedPresentFields`.")
+    expectedValues.foreach { case (field, expectedValue) =>
+      if (field == "stackTrace") {
+        // Only validate the start of the stack trace.
+        assert(
+          usageLogBlob(field).asInstanceOf[String].startsWith(expectedValue.asInstanceOf[String]),
+          s"Field '$field' should start with '$expectedValue' but was '${usageLogBlob(field)}'"
+        )
+      } else if (field == "checksumOpt" || field == "properties") {
+        // Validate a portion of the entire `checksumOpt` or `properties` map.
+        val properties = expectedValue.asInstanceOf[Map[String, Any]]
+        properties.foreach { case (key, value) =>
+          assert(
+            usageLogBlob(field).asInstanceOf[Map[String, Any]].get(key).contains(value),
+            s"Field '$field' should contain '$key' with value '$value' " +
+              s"but was '${usageLogBlob(field)}'"
+          )
+        }
+      } else {
+        assert(usageLogBlob(field) === expectedValue,
+          s"Field '$field' should have value '$expectedValue' but was '${usageLogBlob(field)}'")
+      }
     }
   }
 
@@ -212,6 +263,83 @@ class CatalogOwnedEnablementSuite
           // catalogTable is not available for FS_TO_CO_UPGRADE_COMMIT
           commitCoordinatorName = "CATALOG_MISSING",
           commitCoordinatorConf = Map.empty))
+    }
+  }
+
+  test("Testing usage log for commit coordinator population for invalid path-based access") {
+    // Clear all potential CC builders so that we are not entering the UT-only path when
+    // populating the commit coordinator.
+    clearBuilders()
+    withTempDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.getCanonicalPath)
+      // Create a path-based table so that we can simulate the scenario
+      // where catalog table is not available.
+      sql(s"CREATE TABLE delta.`$tempDir` (id INT) USING delta TBLPROPERTIES " +
+        s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
+      val usageLog = Log4jUsageLogger.track {
+        val error = intercept[IllegalStateException] {
+          // Hence, we simply ignore the exception and focus on the usage log validation.
+          sql(s"INSERT INTO TABLE delta.`$tempDir` VALUES (1), (2), (3)")
+        }
+        assert(error.getMessage.contains(
+          "Path based access is not supported for Catalog-Owned table"))
+      }.filter { log =>
+        log.metric == "tahoeEvent" &&
+          log.tags.getOrElse("opType", null) ==
+            CatalogOwnedUsageLogs.COMMIT_COORDINATOR_POPULATION_INVALID_PATH_BASED_ACCESS
+      }
+
+      assert(usageLog.nonEmpty, "Should have usage log for INVALID_PATH_BASED_ACCESS scenario")
+      val usageLogBlob = JsonUtils.fromJson[Map[String, Any]](usageLog.head.blob)
+
+      val logStore =
+        "org.apache.spark.sql.delta.storage.DelegatingLogStore"
+
+      validateUsageLogBlob(
+        usageLogBlob,
+        expectedPresentFields = Seq(
+          "path",
+          "version",
+          "stackTrace",
+          "latestCheckpointVersion",
+          "checksumOpt",
+          "properties",
+          "logStore"
+        ),
+        expectedAbsentFields = Seq(
+          "catalogTable.identifier",
+          "catalogTable.tableType",
+          "commitCoordinator.getClass"
+        ),
+        expectedValues = Map(
+          "path" -> log.logPath.toString,
+          "version" -> "0",
+          "stackTrace" ->
+            ("org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTableUtils$" +
+             ".recordCommitCoordinatorPopulationUsageLog"),
+          "latestCheckpointVersion" -> -1,
+          // Only check for certain fields of `checksumOpt` since the entire map
+          // is too large to validate.
+          "checksumOpt" -> Map(
+            "tableSizeBytes" -> 0,
+            "numFiles" -> 0,
+            "numMetadata" -> 1,
+            "allFiles" -> List.empty
+          ),
+          "properties" -> Map(
+            "delta.minReaderVersion" -> "3",
+            "delta.minWriterVersion" -> "7",
+            "delta.feature.appendOnly" -> "supported",
+            "delta.feature.invariants" -> "supported",
+            // To avoid potential naming change in the future.
+            s"delta.feature.${CatalogOwnedTableFeature.name}" -> "supported",
+            "delta.feature.inCommitTimestamp" -> "supported",
+            "delta.feature.vacuumProtocolCheck" -> "supported",
+            "delta.enableInCommitTimestamps" -> "true"
+          ),
+          "logStore" -> logStore
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR emits `usage_log` for CC tables during Catalog discovery for invalid path-based access.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through newly added UT in `CatalogOwnedEnablementSuite`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
