### PR TITLE
Aliases constraint imports to avoid name conflicts with Spark

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaConstraints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaConstraints.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.delta.constraints.{AddConstraint, DropConstraint}
+import org.apache.spark.sql.delta.constraints.{AddConstraint => AddDeltaConstraint, DropConstraint => DropDeltaConstraint} // Aliased to avoid conflicts with Spark's AddConstraint/DropConstraint
 
 import org.apache.spark.sql.connector.catalog.TableChange
 
@@ -25,7 +25,7 @@ import org.apache.spark.sql.connector.catalog.TableChange
  */
 case class AlterTableAddConstraint(
     table: LogicalPlan, constraintName: String, expr: String) extends AlterTableCommand {
-  override def changes: Seq[TableChange] = Seq(AddConstraint(constraintName, expr))
+  override def changes: Seq[TableChange] = Seq(AddDeltaConstraint(constraintName, expr))
 
   protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(table = newChild)
 }
@@ -35,7 +35,7 @@ case class AlterTableAddConstraint(
  */
 case class AlterTableDropConstraint(
     table: LogicalPlan, constraintName: String, ifExists: Boolean) extends AlterTableCommand {
-  override def changes: Seq[TableChange] = Seq(DropConstraint(constraintName, ifExists))
+  override def changes: Seq[TableChange] = Seq(DropDeltaConstraint(constraintName, ifExists))
 
   protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(table = newChild)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

As part of https://issues.apache.org/jira/browse/SPARK-51207, new `TableChange` [AddConstraint](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java#L839) and [DropConstraint](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java#L872) are introduced in the upcoming Spark 4.1. The names conflict with the exising `TableChange` in Delta.

To fix compiling failure, this PR aliases imports to avoid conflicts with Spark's AddConstraint/DropConstraint.

## How was this patch tested?

Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No