### PR TITLE
[Spark] Make UpdateSuiteBase agnostic to name/path-based access

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 
 trait UpdateSQLMixin extends UpdateBaseMixin
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with DeltaDMLTestUtilsPathBased {
 
   override protected def executeUpdate(
       target: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -22,7 +22,8 @@ import org.apache.spark.sql.{functions, Row}
 
 trait UpdateScalaMixin extends UpdateBaseMixin
   with DeltaSQLCommandTest
-  with DeltaExcludedTestMixin {
+  with DeltaExcludedTestMixin
+  with DeltaDMLTestUtilsPathBased {
 
   override protected def executeUpdate(
       target: String,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR refactor the existing UPDATE tests to use abstract methods in DeltaDMLTestUtils, so that the tests can later be run with name-based or path-based access, depending on whether the DeltaDMLTestUtilsPathBased or DeltaDMLTestUtilsNameBased is mixed in.

## How was this patch tested?
Existing UTs

## Does this PR introduce _any_ user-facing changes?

No