### PR TITLE
[Kernel] [CatalogManaged] Add new builder .withCommitter API; Create DefaultCommitter skeleton

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/ResolvedTableBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/ResolvedTableBuilder.java
@@ -17,6 +17,7 @@
 package io.delta.kernel;
 
 import io.delta.kernel.annotation.Experimental;
+import io.delta.kernel.commit.Committer;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -46,6 +47,23 @@ public interface ResolvedTableBuilder {
   ResolvedTableBuilder atVersion(long version);
 
   // TODO: atTimestamp
+
+  /**
+   * Provides a custom committer to use at transaction commit time.
+   *
+   * <p>Catalog implementations that wish to support the catalogManaged Delta table feature should
+   * provide to engines their own catalog-specific Committer implementation which may, for example,
+   * send a commit RPC to the catalog service to finalize the commit.
+   *
+   * <p>If no committer is provided, a default committer will be created that only supports writing
+   * into filesystem-managed Delta tables.
+   *
+   * @param committer the committer to use
+   * @return a new builder instance with the provided committer
+   * @see io.delta.kernel.transaction.TransactionV2
+   * @see Committer
+   */
+  ResolvedTableBuilder withCommitter(Committer committer);
 
   /**
    * Provides parsed log data to optimize table resolution.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
@@ -38,4 +38,12 @@ public class DeltaErrorsInternal {
                 + "'yyyy-MM-dd HH:mm:ss[.SSSSSS]' or ISO-8601 (e.g. 2020-01-01T00:00:00Z)'",
             partitionValue));
   }
+
+  public static UnsupportedOperationException defaultCommitterDoesNotSupportCatalogManagedTables() {
+    return new UnsupportedOperationException(
+        "No io.delta.kernel.commit.Committer has been provided to Kernel, so Kernel is using a "
+            + "default Committer that only supports committing to filesystem-managed Delta tables, "
+            + "not catalog-managed Delta tables. Since this table is catalog-managed, this "
+            + "commit operation is unsupported.");
+  }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.commit;
+
+import io.delta.kernel.commit.CommitFailedException;
+import io.delta.kernel.commit.CommitMetadata;
+import io.delta.kernel.commit.CommitResponse;
+import io.delta.kernel.commit.Committer;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.DeltaErrorsInternal;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.utils.CloseableIterator;
+
+public class DefaultFileSystemManagedTableOnlyCommitter implements Committer {
+  public static final DefaultFileSystemManagedTableOnlyCommitter INSTANCE =
+      new DefaultFileSystemManagedTableOnlyCommitter();
+
+  private DefaultFileSystemManagedTableOnlyCommitter() {}
+
+  @Override
+  public CommitResponse commit(
+      Engine engine, CloseableIterator<Row> finalizedActions, CommitMetadata commitMetadata)
+      throws CommitFailedException {
+    commitMetadata.getReadProtocolOpt().ifPresent(this::validateProtocol);
+    commitMetadata.getNewProtocolOpt().ifPresent(this::validateProtocol);
+    throw new UnsupportedOperationException("Default Committer not yet implemented");
+  }
+
+  private void validateProtocol(Protocol protocol) {
+    if (TableFeatures.isCatalogManagedSupported(protocol)) {
+      throw DeltaErrorsInternal.defaultCommitterDoesNotSupportCatalogManagedTables();
+    }
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableBuilderImpl.java
@@ -20,6 +20,7 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.ResolvedTableBuilder;
+import io.delta.kernel.commit.Committer;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -44,6 +45,7 @@ public class ResolvedTableBuilderImpl implements ResolvedTableBuilder {
   public static class Context {
     public final String unresolvedPath;
     public Optional<Long> versionOpt;
+    public Optional<Committer> committerOpt;
     public List<ParsedLogData> logDatas;
     public Optional<Tuple2<Protocol, Metadata>> protocolAndMetadataOpt;
     public Clock clock;
@@ -51,6 +53,7 @@ public class ResolvedTableBuilderImpl implements ResolvedTableBuilder {
     public Context(String unresolvedPath) {
       this.unresolvedPath = requireNonNull(unresolvedPath, "unresolvedPath is null");
       this.versionOpt = Optional.empty();
+      this.committerOpt = Optional.empty();
       this.logDatas = Collections.emptyList();
       this.protocolAndMetadataOpt = Optional.empty();
       this.clock = System::currentTimeMillis;
@@ -79,6 +82,12 @@ public class ResolvedTableBuilderImpl implements ResolvedTableBuilder {
   @Override
   public ResolvedTableBuilderImpl atVersion(long version) {
     ctx.versionOpt = Optional.of(version);
+    return this;
+  }
+
+  @Override
+  public ResolvedTableBuilder withCommitter(Committer committer) {
+    ctx.committerOpt = Optional.of(requireNonNull(committer, "committer is null"));
     return this;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableInternalImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/ResolvedTableInternalImpl.java
@@ -50,6 +50,7 @@ public class ResolvedTableInternalImpl implements ResolvedTableInternal {
   private final Metadata metadata;
   private final Lazy<LogSegment> lazyLogSegment;
   private final LogReplay logReplay;
+  private final Committer committer;
   private final Clock clock;
   private final SnapshotReport snapshotReport;
 
@@ -60,6 +61,7 @@ public class ResolvedTableInternalImpl implements ResolvedTableInternal {
       Metadata metadata,
       Lazy<LogSegment> lazyLogSegment,
       LogReplay logReplay,
+      Committer committer,
       Clock clock,
       SnapshotQueryContext snapshotCtx) {
     this.path = requireNonNull(path, "path is null");
@@ -69,6 +71,7 @@ public class ResolvedTableInternalImpl implements ResolvedTableInternal {
     this.metadata = requireNonNull(metadata, "metadata is null");
     this.lazyLogSegment = requireNonNull(lazyLogSegment, "lazyLogSegment is null");
     this.logReplay = requireNonNull(logReplay, "logReplay is null");
+    this.committer = requireNonNull(committer, "committer is null");
     this.clock = requireNonNull(clock, "clock is null");
     this.snapshotReport = SnapshotReportImpl.forSuccess(snapshotCtx);
   }
@@ -124,7 +127,7 @@ public class ResolvedTableInternalImpl implements ResolvedTableInternal {
 
   @Override
   public Committer getCommitter() {
-    throw new UnsupportedOperationException("not implemented");
+    return committer;
   }
 
   ///////////////////////////////////////

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/DefaultCommitterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/DefaultCommitterSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.commit
+
+import java.util.Optional
+
+import io.delta.kernel.TableManager
+import io.delta.kernel.commit.CommitMetadata
+import io.delta.kernel.internal.actions.Protocol
+import io.delta.kernel.test.{ActionUtils, MockFileSystemClientUtils, VectorTestUtils}
+import io.delta.kernel.types.{IntegerType, StructType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class DefaultCommitterSuite extends AnyFunSuite
+    with MockFileSystemClientUtils
+    with ActionUtils
+    with VectorTestUtils {
+
+  private val protocol12 = new Protocol(1, 2)
+
+  Seq(
+    (protocol12, protocolWithCatalogManagedSupport, "Upgrade"),
+    (protocolWithCatalogManagedSupport, protocol12, "Downgrade"),
+    (
+      protocolWithCatalogManagedSupport,
+      protocolWithCatalogManagedSupport,
+      "CatalogManagedWrite")).foreach { case (readProtocol, newProtocol, testCase) =>
+    test(s"default committer does not support committing to catalog-managed tables -- $testCase") {
+      val emptyMockEngine = createMockFSListFromEngine(Nil)
+      val schema = new StructType().add("col1", IntegerType.INTEGER)
+      val metadata = testMetadata(schema, Seq[String]())
+      val committer = TableManager.loadTable(dataPath.toString)
+        .withProtocolAndMetadata(readProtocol, metadata)
+        .atVersion(1)
+        .build(emptyMockEngine)
+        .getCommitter
+
+      assert(committer.isInstanceOf[DefaultFileSystemManagedTableOnlyCommitter])
+
+      val exMsg = intercept[UnsupportedOperationException] {
+        committer.commit(
+          emptyMockEngine,
+          emptyActionsIterator,
+          new CommitMetadata(
+            3L,
+            "/fake/_delta_log",
+            testCommitInfo,
+            Optional.of(readProtocol),
+            Optional.of(metadata),
+            Optional.of(newProtocol),
+            Optional.of(metadata)))
+      }.getMessage
+
+      assert(exMsg.contains("No io.delta.kernel.commit.Committer has been provided to Kernel, so " +
+        "Kernel is using a default Committer that only supports committing to " +
+        "filesystem-managed Delta tables, not catalog-managed Delta tables. Since this table " +
+        "is catalog-managed, this commit operation is unsupported"))
+    }
+  }
+
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -16,12 +16,12 @@
 
 package io.delta.kernel.test
 
-import java.util.{Arrays, Collections, HashSet, Optional}
+import java.util.{Collections, Optional}
 
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.data.{ArrayValue, ColumnVector, MapValue}
-import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
+import io.delta.kernel.internal.actions.{CommitInfo, Format, Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.types.{IntegerType, StructType}
 
@@ -40,6 +40,19 @@ trait ActionUtils extends VectorTestUtils {
     schema = new StructType()
       .add("part1", IntegerType.INTEGER).add("col1", IntegerType.INTEGER),
     partitionCols = Seq("part1"))
+
+  def testCommitInfo: CommitInfo = {
+    new CommitInfo(
+      Optional.empty(),
+      -1,
+      "engineInfo",
+      "operation",
+      Collections.emptyMap(), // operationParameters
+      false, // isBlindAppend
+      "txnId",
+      Collections.emptyMap() // operationMetrics
+    )
+  }
 
   def testMetadata(
       schema: StructType,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
@@ -19,11 +19,18 @@ import java.lang.{Boolean => BooleanJ, Double => DoubleJ, Float => FloatJ, Long 
 
 import scala.collection.JavaConverters._
 
-import io.delta.kernel.data.{ColumnarBatch, ColumnVector, MapValue}
+import io.delta.kernel.data.{ColumnarBatch, ColumnVector, MapValue, Row}
 import io.delta.kernel.internal.util.VectorUtils
 import io.delta.kernel.types._
+import io.delta.kernel.utils.CloseableIterator
 
 trait VectorTestUtils {
+
+  protected def emptyActionsIterator = new CloseableIterator[Row] {
+    override def hasNext: Boolean = false
+    override def next(): Row = throw new NoSuchElementException("No more elements")
+    override def close(): Unit = {}
+  }
 
   protected def emptyColumnarBatch = new ColumnarBatch {
     override def getSchema: StructType = null


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/4936/files) to review incremental changes.
- [**stack/kernel_catalog_managed_writes_get_committer**](https://github.com/delta-io/delta/pull/4936) [[Files changed](https://github.com/delta-io/delta/pull/4936/files)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

https://github.com/delta-io/delta/pull/4814 introduced new TransactionV2, Committer, CommitContext, etc APIs.

This PR now adds the abilities for Engines to inject into Kernel the actual Committer.

This PR also includes a no-op Default committer implementation that validates that it is not interacting with catalog-managed tables. We do this because: ResolvedTable does not return an Optional committer, but rather just a committer. So we need to give it _something_ in the case that no committer was provided to the table builder.

## How was this patch tested?

New UTs.

## Does this PR introduce _any_ user-facing changes?

New .withCommitter API
