### PR TITLE
[Spark] Improve Suite Generator

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuitesWriter.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuitesWriter.scala
@@ -61,15 +61,6 @@ object SuitesWriter {
   private lazy val PACKAGE_NAME =
     ModularSuiteGenerator.GENERATED_PACKAGE.parse[Term].get.asInstanceOf[Term.Ref]
 
-  private val IMPORT_PACKAGES = List(
-    importer"org.apache.spark.sql.delta._",
-    importer"org.apache.spark.sql.delta.cdc._",
-    importer"org.apache.spark.sql.delta.deletionvectors._",
-    importer"org.apache.spark.sql.delta.rowid._",
-    importer"org.apache.spark.sql.delta.rowtracking._",
-    importer"org.apache.spark.sql.delta.stats._"
-  )
-
   private lazy val SRC_HEADERS =
     s"""/*
        |${LEGAL_HEADER.linesWithSeparators.map(" *" + _).mkString}
@@ -100,12 +91,12 @@ class SuitesWriter(val outputDir: Path) {
 
   protected val allFiles: ListBuffer[Path] = ListBuffer.empty[Path]
 
-  def writeGeneratedSuitesOfGroup(suites: List[TestSuite], group: String): Unit = {
+  def writeGeneratedSuitesOfGroup(suites: List[TestSuite], testGroup: TestGroup): Unit = {
     val src = SRC_HEADERS +
       source"""package $PACKAGE_NAME
-               import ..$IMPORT_PACKAGES
+               import ..${testGroup.imports}
                ..${suites.map(_.classDefinition)}"""
-    val srcFile = outputDir.resolve(group + ".scala")
+    val srcFile = outputDir.resolve(testGroup.name + ".scala")
     val formattedSrc = Scalafmt.format(src, SCALAFMT_CONFIG).get
     writeFile(srcFile, formattedSrc)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuites.scala
@@ -29,10 +29,7 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
-import org.apache.spark.sql.delta.deletionvectors._
 import org.apache.spark.sql.delta.rowid._
-import org.apache.spark.sql.delta.rowtracking._
-import org.apache.spark.sql.delta.stats._
 
 class DeleteScalaTestsDeleteScalaSuite extends DeleteScalaTests with DeleteScalaMixin
 class DeleteBaseTestsDeleteScalaSuite extends DeleteBaseTests with DeleteScalaMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
@@ -29,10 +29,7 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
-import org.apache.spark.sql.delta.deletionvectors._
 import org.apache.spark.sql.delta.rowid._
-import org.apache.spark.sql.delta.rowtracking._
-import org.apache.spark.sql.delta.stats._
 
 class MergeIntoScalaTestsMergeIntoScalaSuite extends MergeIntoScalaTests with MergeIntoScalaMixin
 class MergeIntoBasicTestsMergeIntoScalaSuite extends MergeIntoBasicTests with MergeIntoScalaMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuites.scala
@@ -29,10 +29,8 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
-import org.apache.spark.sql.delta.deletionvectors._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
-import org.apache.spark.sql.delta.stats._
 
 class UpdateScalaTestsUpdateScalaSuite extends UpdateScalaTests with UpdateScalaMixin
 class UpdateBaseMiscTestsUpdateScalaSuite extends UpdateBaseMiscTests with UpdateScalaMixin


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR makes some improvements to the suite generator and its configuration. Namely:
- Instead of global imports, each test group now has its own import list
- Added a new utility method to easily create `DimensionMixin` from a `DimensionWithMultipleValues`

## How was this patch tested?

NA

## Does this PR introduce _any_ user-facing changes?

No