### PR TITLE
[Kernel] Support reading materialized row tracking metadata columns

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -173,9 +173,9 @@ public interface Scan {
         initIfRequired();
         ColumnarBatch nextDataBatch = physicalDataIter.next();
 
-        // Add partition columns
-        // NOTE: Adding partition columns must be the first thing we do with the data batch because
-        // it is the last thing we remove from the physicalReadSchema when creating a ScanStateRow.
+        // Partition columns are the last thing we remove from the physicalReadSchema when creating
+        // a ScanStateRow. Therefore, we add them back first so that the data batch's schema matches
+        // the physicalReadSchema.
         nextDataBatch =
             PartitionUtils.withPartitionColumns(
                 engine.getExpressionHandler(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -176,7 +176,7 @@ public interface Scan {
 
         // Add partition columns
         // NOTE: Adding partition columns must be the first thing we do with the data batch because
-        // it is the last thing we remove from the physicalReadSchema.
+        // it is the last thing we remove from the physicalReadSchema when creating a ScanStateRow.
         nextDataBatch =
             PartitionUtils.withPartitionColumns(
                 engine.getExpressionHandler(),
@@ -196,8 +196,7 @@ public interface Scan {
           selectionVector = Optional.empty();
         } else {
           if (rowIndexOrdinal == -1) {
-            throw new InvalidTableException(
-                tablePath,
+            throw new IllegalArgumentException(
                 "Row index column is not present in the data read from the Parquet file.");
           }
           if (!dv.equals(currDV)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -19,7 +19,6 @@ package io.delta.kernel;
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.exceptions.InvalidTableException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -28,6 +28,7 @@ import io.delta.kernel.utils.DataFileStatus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -442,6 +443,19 @@ public final class DeltaErrors {
 
   public static KernelException cannotToggleRowTrackingOnExistingTable() {
     return new KernelException("Row tracking support cannot be changed once the table is created.");
+  }
+
+  public static KernelException missingRowTrackingColumnRequested(String columnName) {
+    return new KernelException(
+        String.format(
+            "Row tracking is not enabled, but row tracking column '%s' was requested.",
+            columnName));
+  }
+
+  public static KernelException missingMetadataConfigField(String key, Map<String, String> config) {
+    return new KernelException(
+        String.format(
+            "Missing required field '%s' in the metadata configuration: %s", key, config));
   }
 
   public static KernelException cannotModifyAppendOnlyTable(String tablePath) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -28,7 +28,6 @@ import io.delta.kernel.utils.DataFileStatus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -450,12 +449,6 @@ public final class DeltaErrors {
         String.format(
             "Row tracking is not enabled, but row tracking column '%s' was requested.",
             columnName));
-  }
-
-  public static KernelException missingMetadataConfigField(String key, Map<String, String> config) {
-    return new KernelException(
-        String.format(
-            "Missing required field '%s' in the metadata configuration: %s", key, config));
   }
 
   public static KernelException cannotModifyAppendOnlyTable(String tablePath) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
@@ -72,7 +72,8 @@ public class ScanBuilderImpl implements ScanBuilder {
 
   @Override
   public ScanBuilder withReadSchema(StructType readSchema) {
-    // TODO: validate the readSchema is a subset of the table schema
+    // TODO: Validate that readSchema is a subset of the table schema or that extra fields are
+    //  metadata columns.
     this.readSchema = readSchema;
     return this;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -201,20 +201,11 @@ public class ScanImpl implements Scan {
 
   @Override
   public Row getScanState(Engine engine) {
-    // Check for metadata columns in the read schema and convert them to physical columns
-    List<StructField> convertedFields = new ArrayList<>();
-    for (StructField field : readSchema.fields()) {
-      Optional<StructField> converted =
-          MaterializedRowTrackingColumn.convertToPhysicalColumn(field, metadata);
-      if (converted.isPresent()) {
-        convertedFields.add(converted.get());
-      } else {
-        convertedFields.add(field);
-      }
-    }
-    StructType convertedSchema = new StructType(convertedFields);
+    // Check for row tracking columns in the read schema and convert them to physical columns
+    StructType convertedSchema =
+        MaterializedRowTrackingColumn.convertToPhysicalSchema(readSchema, metadata);
 
-    // Physical equivalent of the logical read schema.
+    // Convert regular columns to physical columns if column mapping is enabled
     StructType physicalReadSchema =
         ColumnMapping.convertToPhysicalSchema(
             convertedSchema,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -218,7 +218,7 @@ public class ScanImpl implements Scan {
     List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumns());
     StructType physicalDataReadSchema =
         PartitionUtils.physicalSchemaWithoutPartitionColumns(
-            convertedSchema, /* logical read schema */
+            readSchema, /* logical read schema */
             physicalReadSchema,
             new HashSet<>(partitionColumns));
 
@@ -229,7 +229,7 @@ public class ScanImpl implements Scan {
     return ScanStateRow.of(
         metadata,
         protocol,
-        convertedSchema.toJson(),
+        readSchema.toJson(),
         physicalReadSchema.toJson(),
         physicalDataReadSchema.toJson(),
         dataPath.toUri().toString());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -202,12 +202,11 @@ public class ScanImpl implements Scan {
 
   @Override
   public Row getScanState(Engine engine) {
-    StructType physicalSchema = convertToPhysicalSchema();
+    StructType physicalSchema = getPhysicalSchema();
 
-    // Compute the physical data read schema, basically the list of columns to read
-    // from a Parquet data file. It should exclude partition columns and include
-    // row_index metadata columns (in case DVs are present)
-    // NOTE: Removing partition columns is the last thing we do with the read schema
+    // Compute the physical data read schema (i.e., the columns to read from a Parquet data file).
+    // The only difference to the physical schema is that we exclude partition columns. ALl other
+    // logic (e.g., row tracking columns, row index for DVs) is already handled before.
     List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumns());
     StructType physicalDataReadSchema =
         PartitionUtils.physicalSchemaWithoutPartitionColumns(
@@ -227,7 +226,7 @@ public class ScanImpl implements Scan {
     return getDataFilters();
   }
 
-  private StructType convertToPhysicalSchema() {
+  private StructType getPhysicalSchema() {
     StructType physicalSchema = new StructType();
 
     ColumnMapping.ColumnMappingMode mode =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -168,20 +168,19 @@ public final class MaterializedRowTrackingColumn {
       if (!rowTrackingEnabled
           && (field.getName().equals(METADATA_ROW_ID_COLUMN_NAME)
               || field.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME))) {
-        throw new InvalidTableException(
-            metadata.getId(),
-            String.format(
-                "Row tracking is not enabled, but row tracking column '%s' was requested.",
-                field.getName()));
+        throw DeltaErrors.missingRowTrackingColumnRequested(field.getName());
       }
 
       if (field.getName().equals(METADATA_ROW_ID_COLUMN_NAME)) {
         physicalFields.add(
-            new StructField(getPhysicalColumnName(ROW_ID, metadata), field.getDataType(), true));
+            new StructField(
+                getPhysicalColumnName(ROW_ID, metadata), field.getDataType(), true /* nullable */));
       } else if (field.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME)) {
         physicalFields.add(
             new StructField(
-                getPhysicalColumnName(ROW_COMMIT_VERSION, metadata), field.getDataType(), true));
+                getPhysicalColumnName(ROW_COMMIT_VERSION, metadata),
+                field.getDataType(),
+                true /* nullable */));
       } else {
         physicalFields.add(field);
       }
@@ -195,11 +194,8 @@ public final class MaterializedRowTrackingColumn {
             metadata.getConfiguration().get(column.getMaterializedColumnNameProperty()))
         .orElseThrow(
             () ->
-                new InvalidTableException(
-                    metadata.getId(),
-                    String.format(
-                        "Physical column name for %s does not exist in the metadata configuration.",
-                        column.getMaterializedColumnNameProperty())));
+                DeltaErrors.missingMetadataConfigField(
+                    column.getMaterializedColumnNameProperty(), metadata.getConfiguration()));
   }
 
   /** Generates a random name by concatenating the prefix with a random UUID. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -22,6 +22,7 @@ import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.util.*;
@@ -179,15 +180,13 @@ public final class MaterializedRowTrackingColumn {
       //  to the physical schema to compute non-materialized row IDs.
       return physicalSchema.add(
           new StructField(
-              getPhysicalColumnName(ROW_ID, metadata),
-              logicalField.getDataType(),
-              logicalField.isNullable()));
+              ROW_ID.getPhysicalColumnName(metadata), LongType.LONG, true /* nullable */));
     } else if (logicalField.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME)) {
       return physicalSchema.add(
           new StructField(
-              getPhysicalColumnName(ROW_COMMIT_VERSION, metadata),
-              logicalField.getDataType(),
-              logicalField.isNullable()));
+              ROW_COMMIT_VERSION.getPhysicalColumnName(metadata),
+              LongType.LONG,
+              true /* nullable */));
     } else {
       throw new IllegalArgumentException(
           String.format(
@@ -196,17 +195,15 @@ public final class MaterializedRowTrackingColumn {
     }
   }
 
-  private static String getPhysicalColumnName(
-      MaterializedRowTrackingColumn column, Metadata metadata) {
-    return Optional.ofNullable(
-            metadata.getConfiguration().get(column.getMaterializedColumnNameProperty()))
+  private String getPhysicalColumnName(Metadata metadata) {
+    return Optional.ofNullable(metadata.getConfiguration().get(getMaterializedColumnNameProperty()))
         .orElseThrow(
             () ->
                 new InvalidTableException(
                     metadata.getId(),
                     String.format(
                         "Materialized column name `%s` is missing in the metadata configuration.",
-                        column.getMaterializedColumnNameProperty())));
+                        getMaterializedColumnNameProperty())));
   }
 
   /** Generates a random name by concatenating the prefix with a random UUID. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -194,8 +194,11 @@ public final class MaterializedRowTrackingColumn {
             metadata.getConfiguration().get(column.getMaterializedColumnNameProperty()))
         .orElseThrow(
             () ->
-                DeltaErrors.missingMetadataConfigField(
-                    column.getMaterializedColumnNameProperty(), metadata.getConfiguration()));
+                new InvalidTableException(
+                    metadata.getId(),
+                    String.format(
+                        "Materialized column name `%s` is missing in the metadata configuration.",
+                        column.getMaterializedColumnNameProperty())));
   }
 
   /** Generates a random name by concatenating the prefix with a random UUID. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -187,12 +187,11 @@ public final class MaterializedRowTrackingColumn {
               ROW_COMMIT_VERSION.getPhysicalColumnName(metadata),
               LongType.LONG,
               true /* nullable */));
-    } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Logical field `%s` is not a recognized materialized row tracking column.",
-              logicalField.getName()));
     }
+    throw new IllegalArgumentException(
+        String.format(
+            "Logical field `%s` is not a recognized materialized row tracking column.",
+            logicalField.getName()));
   }
 
   private String getPhysicalColumnName(Metadata metadata) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -23,6 +23,9 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.types.FieldMetadata;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.StructField;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.kernel.utils.CloseableIterator;
 import java.io.IOException;
@@ -33,6 +36,32 @@ import java.util.stream.Collectors;
 
 /** A collection of helper methods for working with row tracking. */
 public class RowTracking {
+  /**
+   * The name of the row ID metadata column. When present this column must be populated with the
+   * unique ID of each row.
+   */
+  public static String METADATA_ROW_ID_COLUMN_NAME = "_metadata.row_id";
+
+  public static StructField METADATA_ROW_ID_COLUMN =
+      new StructField(
+          METADATA_ROW_ID_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(StructField.IS_METADATA_COLUMN_KEY, true).build());
+
+  /**
+   * The name of the row commit version metadata column. When present this column must be populated
+   * with the commit version of each row.
+   */
+  public static String METADATA_ROW_COMMIT_VERSION_COLUMN_NAME = "_metadata.row_commit_version";
+
+  public static StructField METADATA_ROW_COMMIT_VERSION_COLUMN =
+      new StructField(
+          METADATA_ROW_COMMIT_VERSION_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(StructField.IS_METADATA_COLUMN_KEY, true).build());
+
   private RowTracking() {
     // Empty constructor to prevent instantiation of this class
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -68,6 +68,18 @@ public class RowTracking {
   }
 
   /**
+   * Checks if the provided field is a row tracking column, i.e., either the row ID or the row
+   * commit version column.
+   *
+   * @param field the field to check
+   * @return true if the field is a row tracking column, false otherwise
+   */
+  public static boolean isRowTrackingColumn(StructField field) {
+    return field.getName().equals(METADATA_ROW_ID_COLUMN_NAME)
+        || field.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME);
+  }
+
+  /**
    * Assigns or reassigns baseRowIds and defaultRowCommitVersions to {@link AddFile} actions in the
    * provided {@code dataActions}. This method should be invoked only when the 'rowTracking' feature
    * is supported and is used in two scenarios:

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 
 /** A collection of helper methods for working with row tracking. */
 public class RowTracking {
+  // TODO: Migrate this API to the unified metadata column API once it is available.
   /**
    * The name of the row ID metadata column. When present this column must be populated with the
    * unique ID of each row.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -251,6 +251,15 @@ public class ColumnMapping {
       StructType prunedSchema, StructType fullSchema, boolean includeFieldId) {
     StructType newSchema = new StructType();
     for (StructField prunedField : prunedSchema.fields()) {
+      if (fullSchema.indexOf(prunedField.getName()) == -1) {
+        // Metadata columns are not present in fullSchema by design, so we have to ignore them
+        // during column mapping.
+        // Note that we cannot use isMetadataColumn() here since logical metadata columns might
+        // have been converted to (regular) physical columns before column mapping is applied.
+        newSchema = newSchema.add(prunedField);
+        continue;
+      }
+
       StructField completeField = fullSchema.get(prunedField.getName());
       DataType physicalType =
           convertToPhysicalType(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -296,26 +296,24 @@ public class ColumnMapping {
             logicalField.getDataType(), completeField.getDataType(), includeFieldId);
     String physicalName = completeField.getMetadata().getString(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
 
-    if (includeFieldId) {
-      Long fieldId = completeField.getMetadata().getLong(COLUMN_MAPPING_ID_KEY);
-      FieldMetadata.Builder builder =
-          FieldMetadata.builder().putLong(PARQUET_FIELD_ID_KEY, fieldId);
-
-      // convertToPhysicalSchema(..) gets called when trying to find the read schema
-      // for the Parquet reader. This currently assumes that if the nested field IDs for
-      // the 'element' and 'key'/'value' fields of Arrays/Maps haven been written,
-      // then IcebergCompatV2 is enabled because the schema we are looking at is from
-      // the DeltaLog and has nested field IDs setup
-      if (hasNestedColumnIds(completeField)) {
-        builder.putFieldMetadata(
-            PARQUET_FIELD_NESTED_IDS_METADATA_KEY, getNestedColumnIds(completeField));
-      }
-
-      return new StructField(
-          physicalName, physicalType, logicalField.isNullable(), builder.build());
-    } else {
+    if (!includeFieldId) {
       return new StructField(physicalName, physicalType, logicalField.isNullable());
     }
+
+    Long fieldId = completeField.getMetadata().getLong(COLUMN_MAPPING_ID_KEY);
+    FieldMetadata.Builder builder = FieldMetadata.builder().putLong(PARQUET_FIELD_ID_KEY, fieldId);
+
+    // convertToPhysicalSchema(..) gets called when trying to find the read schema
+    // for the Parquet reader. This currently assumes that if the nested field IDs for
+    // the 'element' and 'key'/'value' fields of Arrays/Maps haven been written,
+    // then IcebergCompatV2 is enabled because the schema we are looking at is from
+    // the DeltaLog and has nested field IDs setup
+    if (hasNestedColumnIds(completeField)) {
+      builder.putFieldMetadata(
+          PARQUET_FIELD_NESTED_IDS_METADATA_KEY, getNestedColumnIds(completeField));
+    }
+
+    return new StructField(physicalName, physicalType, logicalField.isNullable(), builder.build());
   }
 
   private static DataType convertToPhysicalType(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -118,6 +118,33 @@ public class ColumnMapping {
     }
   }
 
+  /**
+   * Converts a logical column to a physical column based on the table's column mapping mode. The
+   * field-id metadata is preserved when cmMode = ID, all column metadata is otherwise removed.
+   *
+   * <p>We require {@code fullSchema} in addition to the logical field we want to convert since we
+   * need the complete field metadata as it is stored in the schema in the _delta_log. We cannot be
+   * sure (and do not enforce) that this metadata is preserved by the connector.
+   *
+   * @param logicalField the logical read column requested by the connector
+   * @param fullSchema the full delta schema (with complete metadata) as read from the _delta_log
+   * @param columnMappingMode Column mapping mode
+   */
+  public static StructField convertToPhysicalColumn(
+      StructField logicalField, StructType fullSchema, ColumnMappingMode columnMappingMode) {
+    switch (columnMappingMode) {
+      case NONE:
+        return logicalField;
+      case ID: // fall through
+      case NAME:
+        boolean includeFieldIds = columnMappingMode == ColumnMappingMode.ID;
+        return convertToPhysicalColumn(logicalField, fullSchema, includeFieldIds);
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported column mapping mode: " + columnMappingMode);
+    }
+  }
+
   /** Returns the physical name for a given {@link StructField} */
   public static String getPhysicalName(StructField field) {
     if (hasPhysicalName(field)) {
@@ -251,43 +278,44 @@ public class ColumnMapping {
       StructType prunedSchema, StructType fullSchema, boolean includeFieldId) {
     StructType newSchema = new StructType();
     for (StructField prunedField : prunedSchema.fields()) {
-      if (fullSchema.indexOf(prunedField.getName()) == -1) {
-        // Metadata columns are not present in fullSchema by design, so we have to ignore them
-        // during column mapping.
-        // Note that we cannot use isMetadataColumn() here since logical metadata columns might
-        // have been converted to (regular) physical columns before column mapping is applied.
-        newSchema = newSchema.add(prunedField);
-        continue;
-      }
-
-      StructField completeField = fullSchema.get(prunedField.getName());
-      DataType physicalType =
-          convertToPhysicalType(
-              prunedField.getDataType(), completeField.getDataType(), includeFieldId);
-      String physicalName = completeField.getMetadata().getString(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
-
-      if (includeFieldId) {
-        Long fieldId = completeField.getMetadata().getLong(COLUMN_MAPPING_ID_KEY);
-        FieldMetadata.Builder builder =
-            FieldMetadata.builder().putLong(PARQUET_FIELD_ID_KEY, fieldId);
-
-        // convertToPhysicalSchema(..) gets called when trying to find the read schema
-        // for the Parquet reader. This currently assumes that if the nested field IDs for
-        // the 'element' and 'key'/'value' fields of Arrays/Maps haven been written,
-        // then IcebergCompatV2 is enabled because the schema we are looking at is from
-        // the DeltaLog and has nested field IDs setup
-        if (hasNestedColumnIds(completeField)) {
-          builder.putFieldMetadata(
-              PARQUET_FIELD_NESTED_IDS_METADATA_KEY, getNestedColumnIds(completeField));
-        }
-
-        newSchema =
-            newSchema.add(physicalName, physicalType, prunedField.isNullable(), builder.build());
-      } else {
-        newSchema = newSchema.add(physicalName, physicalType, prunedField.isNullable());
-      }
+      newSchema = newSchema.add(convertToPhysicalColumn(prunedField, fullSchema, includeFieldId));
     }
     return newSchema;
+  }
+
+  /**
+   * Utility method to convert the given logical field to a physical field, recursively converting
+   * sub-types in case of complex types. When {@code includeFieldId} is true, converted physical
+   * schema will have field ids in the metadata. Column metadata is otherwise removed.
+   */
+  private static StructField convertToPhysicalColumn(
+      StructField logicalField, StructType fullSchema, boolean includeFieldId) {
+    StructField completeField = fullSchema.get(logicalField.getName());
+    DataType physicalType =
+        convertToPhysicalType(
+            logicalField.getDataType(), completeField.getDataType(), includeFieldId);
+    String physicalName = completeField.getMetadata().getString(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
+
+    if (includeFieldId) {
+      Long fieldId = completeField.getMetadata().getLong(COLUMN_MAPPING_ID_KEY);
+      FieldMetadata.Builder builder =
+          FieldMetadata.builder().putLong(PARQUET_FIELD_ID_KEY, fieldId);
+
+      // convertToPhysicalSchema(..) gets called when trying to find the read schema
+      // for the Parquet reader. This currently assumes that if the nested field IDs for
+      // the 'element' and 'key'/'value' fields of Arrays/Maps haven been written,
+      // then IcebergCompatV2 is enabled because the schema we are looking at is from
+      // the DeltaLog and has nested field IDs setup
+      if (hasNestedColumnIds(completeField)) {
+        builder.putFieldMetadata(
+            PARQUET_FIELD_NESTED_IDS_METADATA_KEY, getNestedColumnIds(completeField));
+      }
+
+      return new StructField(
+          physicalName, physicalType, logicalField.isNullable(), builder.build());
+    } else {
+      return new StructField(physicalName, physicalType, logicalField.isNullable());
+    }
   }
 
   private static DataType convertToPhysicalType(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -54,15 +54,17 @@ public class PartitionUtils {
    * Utility method to remove the given columns (as {@code columnsToRemove}) from the given {@code
    * physicalSchema}.
    *
-   * @param physicalSchema
-   * @param logicalSchema To create a logical name to physical name map. Partition column names are
-   *     in logical space and we need to identify the equivalent physical column name.
-   * @param columnsToRemove
-   * @return
+   * @param logicalSchema Logical schema used to map logical partition column names to physical
+   *     column names.
+   * @param physicalSchema Physical schema from which columns will be removed.
+   * @param columnsToRemove Set of partition column names (in logical space) to remove from the
+   *     physical schema.
+   * @return A new {@link StructType} representing the physical schema without the specified
+   *     partition columns.
    */
   public static StructType physicalSchemaWithoutPartitionColumns(
       StructType logicalSchema, StructType physicalSchema, Set<String> columnsToRemove) {
-    if (columnsToRemove == null || columnsToRemove.size() == 0) {
+    if (columnsToRemove == null || columnsToRemove.isEmpty()) {
       return physicalSchema;
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -34,7 +34,7 @@ public class StructField {
   ////////////////////////////////////////////////////////////////////////////////
 
   /** Indicates a metadata column when present in the field metadata and the value is true */
-  private static String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
+  private static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
   /**
    * The name of a row index metadata column. When present this column must be populated with row
@@ -42,9 +42,37 @@ public class StructField {
    */
   public static String METADATA_ROW_INDEX_COLUMN_NAME = "_metadata.row_index";
 
+  /**
+   * The name of a row ID metadata column. When present this column must be populated with the
+   * unique row ID of each column.
+   */
+  public static String METADATA_ROW_ID_COLUMN_NAME = "_metadata.row_id";
+
+  /**
+   * The name of a row commit version metadata column. When present this column must be populated
+   * with the commit version of each row.
+   */
+  public static String METADATA_ROW_COMMIT_VERSION_COLUMN_NAME = "_metadata.row_commit_version";
+
   public static StructField METADATA_ROW_INDEX_COLUMN =
       new StructField(
           METADATA_ROW_INDEX_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
+          Collections.emptyList());
+
+  public static StructField METADATA_ROW_ID_COLUMN =
+      new StructField(
+          METADATA_ROW_ID_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
+          Collections.emptyList());
+
+  public static StructField METADATA_ROW_COMMIT_VERSION_COLUMN =
+      new StructField(
+          METADATA_ROW_COMMIT_VERSION_COLUMN_NAME,
           LongType.LONG,
           false,
           FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -34,7 +34,7 @@ public class StructField {
   ////////////////////////////////////////////////////////////////////////////////
 
   /** Indicates a metadata column when present in the field metadata and the value is true */
-  private static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
+  public static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
   /**
    * The name of a row index metadata column. When present this column must be populated with row
@@ -42,37 +42,9 @@ public class StructField {
    */
   public static String METADATA_ROW_INDEX_COLUMN_NAME = "_metadata.row_index";
 
-  /**
-   * The name of a row ID metadata column. When present this column must be populated with the
-   * unique row ID of each column.
-   */
-  public static String METADATA_ROW_ID_COLUMN_NAME = "_metadata.row_id";
-
-  /**
-   * The name of a row commit version metadata column. When present this column must be populated
-   * with the commit version of each row.
-   */
-  public static String METADATA_ROW_COMMIT_VERSION_COLUMN_NAME = "_metadata.row_commit_version";
-
   public static StructField METADATA_ROW_INDEX_COLUMN =
       new StructField(
           METADATA_ROW_INDEX_COLUMN_NAME,
-          LongType.LONG,
-          false,
-          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
-          Collections.emptyList());
-
-  public static StructField METADATA_ROW_ID_COLUMN =
-      new StructField(
-          METADATA_ROW_ID_COLUMN_NAME,
-          LongType.LONG,
-          false,
-          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
-          Collections.emptyList());
-
-  public static StructField METADATA_ROW_COMMIT_VERSION_COLUMN =
-      new StructField(
-          METADATA_ROW_COMMIT_VERSION_COLUMN_NAME,
           LongType.LONG,
           false,
           FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -448,7 +448,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Read row tracking columns from golden table") {
+  test("Read row tracking columns from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 
@@ -460,7 +460,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
         TestRow(5, "E", 4L, 1L),
         TestRow(6, "F", null, null))
 
-      // This tests also checks that the golden table schema is inferred correctly
+      // This tests also checks that the delta-spark table schema is inferred correctly
       checkTable(
         path = tablePath,
         expectedAnswer,
@@ -472,7 +472,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Read subset of row tracking columns from golden table") {
+  test("Read subset of row tracking columns from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 
@@ -492,7 +492,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Only read row tracking columns from golden table") {
+  test("Only read row tracking columns from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 
@@ -514,7 +514,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Metadata columns are not read by default from golden table") {
+  test("Metadata columns are not read by default from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -21,7 +21,6 @@ import java.util.Optional
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 
-import io.delta.kernel.Table
 import io.delta.kernel.data.{FilteredColumnarBatch, Row}
 import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
 import io.delta.kernel.defaults.utils.TestRow

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -435,7 +435,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
       createEmptyTable(engine, tablePath, wrongSchema)
 
       // Try to read row tracking columns
-      val e = intercept[InvalidTableException] {
+      val e = intercept[KernelException] {
         checkTable(
           tablePath,
           expectedAnswer = Seq(),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds initial support for reading row tracking metadata columns to kernel. Right now, this feature is limited to reading the materialized row ID and row commit version (i.e., values will be null if they were not materialized). Adding support for computing missing values on the fly will be added in a later PR.

The PR partially builds upon #4897 and #4924 and should be merged afterwards.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

The PR adds several tests to the `RowTrackingSuite`, both based on a newly generated Delta table and a golden table (see #4924) that was generated with delta-spark.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This PR introduces (incomplete) new features to kernel. It does not modify any existing features.
