### PR TITLE
[Spark] Fix Delta -> Iceberg stats translation when all min/max stats are null

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergStatsConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergStatsConverter.scala
@@ -94,6 +94,10 @@ case class IcebergStatsConverter(statsRow: InternalRow, statsSchema: StructType)
   private def generateIcebergByteBufferMetricMap(
       stats: InternalRow,
       statsSchema: StructType): Map[Integer, ByteBuffer] = {
+    // If the entire Delta stats struct is missing (for example, min or max values are missing for
+    // all columns), then the stats row may be null.
+    if (stats == null) return Map.empty
+
     statsSchema.fields.zipWithIndex.flatMap { case (field, idx) =>
       field.dataType match {
         // Iceberg statistics cannot be null.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Currently, when converting Delta stats to Iceberg, if MIN/MAX stats are missing, but are in the stats schema (meaning that all columns in the stats schema are entirely null for a file), we throw an error. This error is caught, but stats are not collected for that file. 

## How was this patch tested?
N/A.
