### PR TITLE
[Spark] Make DeleteSuiteBase agnostic to name/path-based access

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, Del
 import org.apache.spark.sql.Row
 
 trait DeleteSQLMixin extends DeleteBaseMixin
+  with DeltaDMLTestUtilsPathBased
   with DeltaSQLCommandTest {
 
   override protected def executeDelete(target: String, where: String = null): Unit = {
@@ -91,7 +92,7 @@ trait DeleteSQLNameColumnMappingMixin extends DeleteSQLMixin
   with DeltaColumnMappingSelectedTestMixin {
 
   protected override def runOnlyTests: Seq[String] = Seq(true, false).map { isPartitioned =>
-    s"basic case - delete from a Delta table by name - Partition=$isPartitioned"
+    s"basic case - delete from a Delta table - Partition=$isPartitioned"
   } ++ Seq(true, false).flatMap { isPartitioned =>
     Seq(
       s"where key columns - Partition=$isPartitioned",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.{functions, Row}
 trait DeleteScalaMixin
   extends DeleteBaseMixin
   with DeltaSQLCommandTest
+  with DeltaDMLTestUtilsPathBased
   with DeltaExcludedTestMixin {
 
   override protected def executeDelete(target: String, where: String = null): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR refactor the existing DELETE tests to use abstract methods in `DeltaDMLTestUtils`, so that the tests can later be run with name-based or path-based access, depending on whether the `DeltaDMLTestUtilsPathBased` or `DeltaDMLTestUtilsNameBased` is mixed in.

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No