### PR TITLE
[Spark] Refactor table configuration column rename function.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -1653,6 +1653,41 @@ def normalizeColumnNamesInDataType(
       case (_, other, _) => other
     }
   }
+
+  /**
+   * Renames a column in the metadata, given the old column path, new column path, and an optional
+   * list of column names. If the column names are provided, they will be updated to reflect the
+   * new path.
+   *
+   * @param oldColumnPath The original physical name path of the column to be renamed.
+   * @param newColumnPath The new physical name path for the column.
+   * @param columnNameOpt An optional sequence of unresolved attributes representing the column
+   *                      logical name.
+   * @param deltaConfig   The configuration key for columns that need to be renamed from metadata.
+   * @return              A map containing the updated Delta configuration with new column paths.
+   */
+  def renameColumnForConfig(
+      oldColumnPath: Seq[String],
+      newColumnPath: Seq[String],
+      columnNameOpt: Option[Seq[UnresolvedAttribute]],
+      deltaConfig: String): Map[String, String] = {
+    columnNameOpt.map { deltaColumnsNames =>
+      val deltaColumnsPath = deltaColumnsNames
+        .map(_.nameParts)
+        .map { attributeNameParts =>
+          val commonPrefix = oldColumnPath.zip(attributeNameParts)
+            .takeWhile { case (left, right) => left == right }
+            .size
+          if (commonPrefix == oldColumnPath.size) {
+            newColumnPath ++ attributeNameParts.takeRight(attributeNameParts.size - commonPrefix)
+          } else {
+            attributeNameParts
+          }
+        }
+        .map(columnParts => UnresolvedAttribute(columnParts).name)
+      Map(deltaConfig -> deltaColumnsPath.mkString(","))
+    }.getOrElse(Map.empty[String, String])
+  }
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -593,24 +593,11 @@ object StatisticsCollection extends DeltaCommand {
       newColumnPath: Seq[String]): Map[String, String] = {
     if (oldColumnPath == newColumnPath) return Map.empty[String, String]
     val deltaStatsColumnSpec = configuredDeltaStatsColumnSpec(metadata)
-    deltaStatsColumnSpec.deltaStatsColumnNamesOpt.map { deltaColumnsNames =>
-      val deltaStatsColumnsPath = deltaColumnsNames
-        .map(_.nameParts)
-        .map { attributeNameParts =>
-          val commonPrefix = oldColumnPath.zip(attributeNameParts)
-            .takeWhile { case (left, right) => left == right }
-            .size
-          if (commonPrefix == oldColumnPath.size) {
-            newColumnPath ++ attributeNameParts.takeRight(attributeNameParts.size - commonPrefix)
-          } else {
-            attributeNameParts
-          }
-        }
-        .map(columnParts => UnresolvedAttribute(columnParts).name)
-      Map(
-        DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.key -> deltaStatsColumnsPath.mkString(",")
-      )
-    }.getOrElse(Map.empty[String, String])
+    SchemaUtils.renameColumnForConfig(
+      oldColumnPath,
+      newColumnPath,
+      deltaStatsColumnSpec.deltaStatsColumnNamesOpt,
+      DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.key)
   }
 
   /** Returns the configured set of columns to be used for stats collection on a table */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Refactor table configuration column rename function.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through existing unit tests.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
