### PR TITLE
[Kernel] Optimize path construction 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -611,7 +611,12 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
       "junit" % "junit" % "4.13.2" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.slf4j" % "slf4j-log4j12" % "1.7.36" % "test",
-      "org.assertj" % "assertj-core" % "3.26.3" % "test"
+      "org.assertj" % "assertj-core" % "3.26.3" % "test",
+      // JMH dependencies allow writing micro-benchmarks for testing performance of components.
+      // JMH has framework to define benchmarks and takes care of many common functionalities
+      // such as warm runs, cold runs, defining benchmark parameter variables etc.
+      "org.openjdk.jmh" % "jmh-core" % "1.37" % "test",
+      "org.openjdk.jmh" % "jmh-generator-annprocess" % "1.37" % "test"
     ),
     // Shade jackson libraries so that connector developers don't have to worry
     // about jackson version conflicts.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/fs/Path.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/fs/Path.java
@@ -221,8 +221,7 @@ public class Path implements Comparable<Path>, Serializable, ObjectInputValidati
     // Validating this first before applying the regex saves ~40-50% of
     // Path construction time, with a potentially small overhead for
     // cases when paths need normalization.
-    boolean replace = containsRepeatedSlash(path);
-    if (replace) {
+    if (containsRepeatedSlash(path)) {
       // Remove duplicated slashes to ensure all equivalent Path's have
       // the same representation.
       path = SLASHES.matcher(path).replaceAll("/");
@@ -248,12 +247,11 @@ public class Path implements Comparable<Path>, Serializable, ObjectInputValidati
   }
 
   private static boolean containsRepeatedSlash(String path) {
-    for (int x = 0; x < path.length() - 1; x++) {
-      if (path.charAt(x) == '/' && path.charAt(x + 1) == '/') {
-        return true;
-      }
-    }
-    return false;
+    // Not inlining this method back into normalizePath() appears
+    // to be slightly faster (there is a high probability this is noise
+    // but keep out-of-line for now until there is definitive evidence
+    // one way or another).
+    return path.contains("//");
   }
 
   private static boolean hasWindowsDrive(String path) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/fs/Path.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/fs/Path.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
  * <p>Taken from https://github.com/apache/hadoop/blob/branch-3.3
  * .4/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Path.java
  */
-// TODO remove this class
 public class Path implements Comparable<Path>, Serializable, ObjectInputValidation {
 
   /** The directory separator, a slash. */
@@ -218,8 +217,16 @@ public class Path implements Comparable<Path>, Serializable, ObjectInputValidati
    * @return the normalized path string
    */
   private static String normalizePath(String scheme, String path) {
-    // Remove duplicated slashes.
-    path = SLASHES.matcher(path).replaceAll("/");
+    // In most cases the path is expected to not have repeated slashes.
+    // Validating this first before applying the regex saves ~40-50% of
+    // Path construction time, with a potentially small overhead for
+    // cases when paths need normalization.
+    boolean replace = containsRepeatedSlash(path);
+    if (replace) {
+      // Remove duplicated slashes to ensure all equivalent Path's have
+      // the same representation.
+      path = SLASHES.matcher(path).replaceAll("/");
+    }
 
     // Remove backslashes if this looks like a Windows path. Avoid
     // the substitution if it looks like a non-local URI.
@@ -238,6 +245,15 @@ public class Path implements Comparable<Path>, Serializable, ObjectInputValidati
     }
 
     return path;
+  }
+
+  private static boolean containsRepeatedSlash(String path) {
+    for (int x = 0; x < path.length() - 1; x++) {
+      if (path.charAt(x) == '/' && path.charAt(x + 1) == '/') {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static boolean hasWindowsDrive(String path) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/PathSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/PathSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2023) The Delta Lake Project Authors.
+ * Copyright (2025) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/PathSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/PathSuite.scala
@@ -1,0 +1,226 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.fs
+
+import java.net.URI
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PathSuite extends AnyFunSuite {
+
+  test("Path construction from String") {
+    // Basic path construction
+    val path1 = new Path("/user/data")
+    assert(path1.toString === "/user/data")
+
+    // Path with scheme
+    val path2 = new Path("file:/user/data")
+    assert(path2.toString === "file:/user/data")
+
+    // Path with authority
+    val path3 = new Path("hdfs://localhost:9000/user/data")
+    assert(path3.toString === "hdfs://localhost:9000/user/data")
+
+    // Relative path
+    val path4 = new Path("relative/path")
+    assert(path4.toString === "relative/path")
+
+    // Empty path should throw exception
+    val exception1 = intercept[IllegalArgumentException] {
+      new Path("")
+    }
+    assert(exception1.getMessage.contains("empty string"))
+
+    // Null path should throw exception
+    val exception2 = intercept[IllegalArgumentException] {
+      new Path(null: String)
+    }
+    assert(exception2.getMessage.contains("null string"))
+  }
+
+  test("Path construction from parent and child") {
+    // String parent, String child
+    val path1 = new Path("/user", "data")
+    assert(path1.toString === "/user/data")
+
+    // Path parent, String child
+    val path2 = new Path(new Path("/user"), "data")
+    assert(path2.toString === "/user/data")
+
+    // String parent, Path child
+    val path3 = new Path("/user", new Path("data"))
+    assert(path3.toString === "/user/data")
+
+    // Path parent, Path child
+    val path4 = new Path(new Path("/user"), new Path("data"))
+    assert(path4.toString === "/user/data")
+
+    // Parent with trailing slash
+    val path5 = new Path("/user/", "data")
+    assert(path5.toString === "/user/data")
+
+    // Parent is root
+    val path6 = new Path("/", "data")
+    assert(path6.toString === "/data")
+
+    // Parent with scheme
+    val path7 = new Path("file:/user", "data")
+    assert(path7.toString === "file:/user/data")
+  }
+
+  test("Path construction from URI") {
+    val uri1 = new URI("file:/user/data")
+    val path1 = new Path(uri1)
+    assert(path1.toString === "file:/user/data")
+
+    val uri2 = new URI("hdfs", "localhost:9000", "/user/data", null, null)
+    val path2 = new Path(uri2)
+    assert(path2.toString === "hdfs://localhost:9000/user/data")
+  }
+
+  test("Path construction from scheme, authority, path") {
+    val path1 = new Path("file", null, "/user/data")
+    assert(path1.toString === "file:/user/data")
+
+    val path2 = new Path("hdfs", "localhost:9000", "/user/data")
+    assert(path2.toString === "hdfs://localhost:9000/user/data")
+
+    val path3 = new Path(null, null, "/user/data")
+    assert(path3.toString === "/user/data")
+
+    // Skip the test for relative path with scheme as it's not supported
+  }
+
+  test("Path normalization") {
+    // Remove duplicate slashes
+    val path1 = new Path("/user//data///file")
+    assert(path1.toString === "/user/data/file")
+
+    // Remove trailing slash
+    val path2 = new Path("/user/data/")
+    assert(path2.toString === "/user/data")
+    val path3 = new Path("/user/data//")
+    assert(path3.toString === "/user/data")
+
+    // Don't remove trailing slash from root
+    val path4 = new Path("/")
+    assert(path4.toString === "/")
+  }
+
+  test("Path.getName") {
+    val path1 = new Path("/user/data/file.txt")
+    assert(path1.getName === "file.txt")
+
+    val path2 = new Path("/user/data/")
+    assert(path2.getName === "data")
+
+    val path3 = new Path("/")
+    assert(path3.getName === "")
+
+    val path4 = new Path("file.txt")
+    assert(path4.getName === "file.txt")
+  }
+
+  test("Path.getParent") {
+    val path1 = new Path("/user/data/file.txt")
+    assert(path1.getParent.toString === "/user/data")
+
+    val path2 = new Path("/user/data")
+    assert(path2.getParent.toString === "/user")
+
+    val path3 = new Path("/user")
+    assert(path3.getParent.toString === "/")
+
+    val path4 = new Path("/")
+    assert(path4.getParent === null)
+
+    val path5 = new Path("file.txt")
+    assert(path5.getParent.toString === "")
+
+    val path6 = new Path("dir/file.txt")
+    assert(path6.getParent.toString === "dir")
+  }
+
+  test("Path.isAbsolute and Path.isUriPathAbsolute") {
+    val path1 = new Path("/user/data")
+    assert(path1.isAbsolute === true)
+    assert(path1.isUriPathAbsolute === true)
+
+    val path2 = new Path("user/data")
+    assert(path2.isAbsolute === false)
+    assert(path2.isUriPathAbsolute === false)
+
+    // Skip the tests with scheme and relative paths as they cause exceptions
+  }
+
+  test("Path.isRoot") {
+    val path1 = new Path("/")
+    assert(path1.isRoot === true)
+
+    val path2 = new Path("/user")
+    assert(path2.isRoot === false)
+
+    val path3 = new Path("file:/")
+    assert(path3.isRoot === true)
+
+    val path4 = new Path("file:/user")
+    assert(path4.isRoot === false)
+  }
+
+  test("Path.toUri") {
+    val path1 = new Path("/user/data")
+    val uri1 = path1.toUri
+    assert(uri1.getScheme === null)
+    assert(uri1.getAuthority === null)
+    assert(uri1.getPath === "/user/data")
+
+    val path2 = new Path("file:/user/data")
+    val uri2 = path2.toUri
+    assert(uri2.getScheme === "file")
+    assert(uri2.getAuthority === null)
+    assert(uri2.getPath === "/user/data")
+
+    val path3 = new Path("hdfs://localhost:9000/user/data")
+    val uri3 = path3.toUri
+    assert(uri3.getScheme === "hdfs")
+    assert(uri3.getAuthority === "localhost:9000")
+    assert(uri3.getPath === "/user/data")
+  }
+
+  test("Path equality and comparison") {
+    val path1 = new Path("/user/data")
+    val path2 = new Path("/user/data")
+    val path3 = new Path("/user/other")
+
+    // Test equals
+    assert(path1 === path2)
+    assert(path1 !== path3)
+
+    // Test hashCode
+    assert(path1.hashCode === path2.hashCode)
+
+    // Test compareTo
+    assert(path1.compareTo(path2) === 0)
+    assert(path1.compareTo(path3) < 0) // "data" comes before "other" alphabetically
+    assert(path3.compareTo(path1) > 0)
+  }
+
+  test("Path.getName static method") {
+    assert(Path.getName("/user/data/file.txt") === "file.txt")
+    assert(Path.getName("file.txt") === "file.txt")
+    assert(Path.getName("/") === "")
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/benchmarks/PathNormalizationBenchmarks.java
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/benchmarks/PathNormalizationBenchmarks.java
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (2023) The Delta Lake Project Authors.
+ * Copyright (2025) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/benchmarks/PathNormalizationBenchmarks.java
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/fs/benchmarks/PathNormalizationBenchmarks.java
@@ -1,0 +1,63 @@
+
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.fs.benchmarks;
+
+import io.delta.kernel.internal.fs.Path;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark to measure the performance of initializing/normalizing path objects.
+ *
+ * <ul>
+ *   <li>
+ *       <pre>{@code
+ * build/sbt sbt:delta> project kernel
+ * sbt:delta> set fork in run := true sbt:delta>
+ * sbt:delta> test:runMain \
+ *   io.delta.kernel.internal.fs.benchmarks.PathNormalizationBenchmarks.
+ *
+ * }</pre>
+ * </ul>
+ *
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class PathNormalizationBenchmarks {
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void benchmarkNoNormalizationNeeded(Blackhole blackhole) throws Exception {
+        blackhole.consume(new Path("s3://bucket-name/table-path/metadata/data/some_file.parquet"));
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void benchmarkNormalizationNeeded(Blackhole blackhole) throws Exception {
+        blackhole.consume(new Path("s3://bucket-name/table-path/metadata/data//some_file.parquet"));
+    }
+
+    public static void main(String[] args) throws Exception {
+        org.openjdk.jmh.Main.main(args);
+    }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR attempts to optimize path normalization, assuming that most paths are already normalized (don't contain more then. 1 front-slash in a row).  It first does a check to see if this condition holds, and if it doesn't it applies the regex replace.

Regex.replace is fairly heavy weight and by making this change we see a 40-50% reduction in Path construction time when the path is already normalized.  The additional overhead for when normalization is needed is within measurement noise on the computer I'm running in (best estimate is someplace between 1-5%).

Also remove an outdated TODO for removing path.

## How was this patch tested?

- Add unit tests (mostly AI generated)
- Added a JMH benchmark for cases when normalization is needed and not needed.

## Does this PR introduce _any_ user-facing changes?

No.
