### PR TITLE
[Spark] Migrate `CloneTableSQLSuite` to CC

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import scala.collection.immutable.NumericRange
 
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
 import org.apache.hadoop.fs.Path
@@ -28,10 +29,11 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.util.Utils
 
-class CloneTableSQLSuite extends CloneTableSuiteBase
+class CloneTableSQLSuite
+  extends CloneTableSuiteBase
   with CloneTableSQLTestMixin
   with DeltaColumnMappingTestUtils
-{
+  with CatalogOwnedTestBaseSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -251,6 +253,24 @@ class CloneTableSQLSuite extends CloneTableSuiteBase
   }
 }
 
+
+class CloneTableSQLWithCatalogOwnedBatch1Suite
+  extends CloneTableSQLSuite
+{
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class CloneTableSQLWithCatalogOwnedBatch2Suite
+  extends CloneTableSQLSuite
+{
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class CloneTableSQLWithCatalogOwnedBatch100Suite
+  extends CloneTableSQLSuite
+{
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
+}
 
 class CloneTableSQLIdColumnMappingSuite
   extends CloneTableSQLSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
@@ -90,7 +90,7 @@ class CloneTableScalaSuite extends CloneTableSuiteBase
     val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
     // scalastyle:on deltahadoopconfiguration
     fs.setTimes(path, time, 0)
-    if (coordinatedCommitsEnabledInTests) {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
       InCommitTimestampTestUtils.overwriteICTInDeltaFile(
         DeltaLog.forTable(spark, source),
         path,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -21,11 +21,11 @@ import java.io.File
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, Metadata, Protocol, RemoveFile, SetTransaction, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
 import org.apache.spark.sql.delta.commands._
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
-import org.apache.spark.sql.delta.util.FileNames.unsafeDeltaFile
+import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.util.FileNames.{isCheckpointFile, unsafeDeltaFile}
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SparkSession}
@@ -40,7 +40,8 @@ trait CloneTableSuiteBase extends QueryTest
   with CloneTableTestMixin
   with DeltaColumnMappingTestUtils
   with DeltaSQLCommandTest
-  with CoordinatedCommitsBaseSuite
+  with DeltaSQLTestUtils
+  with CatalogOwnedTestBaseSuite
   with CoordinatedCommitsTestUtils
   with DeletionVectorsTestUtils {
 
@@ -355,8 +356,8 @@ trait CloneTableSuiteBase extends QueryTest
 
   cloneTest("CLONE ignores reader/writer session defaults", TAG_HAS_SHALLOW_CLONE) {
     (source, clone) =>
-      if (coordinatedCommitsEnabledInTests) {
-        cancel("Expects base protocol version")
+      if (catalogOwnedDefaultCreationEnabledInTests) {
+        cancel("Expects base protocol version.")
       }
       withSQLConf(
           DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION.key -> "1",
@@ -403,7 +404,7 @@ trait CloneTableSuiteBase extends QueryTest
     val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
     // scalastyle:on deltahadoopconfiguration
     fs.setTimes(path, time, 0)
-    if (coordinatedCommitsEnabledInTests) {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
       InCommitTimestampTestUtils.overwriteICTInDeltaFile(
         DeltaLog.forTable(spark, source),
         path,
@@ -419,6 +420,10 @@ trait CloneTableSuiteBase extends QueryTest
 
   cloneTest("clones take protocol from the source",
     TAG_HAS_SHALLOW_CLONE, TAG_MODIFY_PROTOCOL, TAG_CHANGE_COLUMN_MAPPING_MODE) { (source, clone) =>
+    if (catalogOwnedDefaultCreationEnabledInTests) {
+      cancel("table needs to start with custom protocol versions but enabling " +
+        "catalogOwned automatically upgrades table protocol version.")
+    }
     // Change protocol versions of (read, write) = (2, 5). We cannot initialize this to (0, 0)
     // because min reader and writer versions are at least 1.
     val defaultNewTableProtocol = Protocol.forNewTable(spark, metadataOpt = None)
@@ -523,9 +528,9 @@ trait CloneTableSuiteBase extends QueryTest
     testAllClones("Cloning a table with new table properties" +
       s" that force protocol version upgrade - ${featureWithProperty.property.key}"
     ) { (source, target, isShallow) =>
-      if (coordinatedCommitsEnabledInTests) {
+      if (catalogOwnedDefaultCreationEnabledInTests) {
         cancel("table needs to start with default protocol versions but enabling " +
-          "coordinatedCommits upgrades table protocol version.")
+          "catalogOwned upgrades table protocol version.")
       }
       import DeltaTestUtils.StrictProtocolOrdering
 
@@ -562,9 +567,9 @@ trait CloneTableSuiteBase extends QueryTest
 
   testAllClones("Cloning a table without DV property should not upgrade protocol version"
   ) { (source, target, isShallow) =>
-    if (coordinatedCommitsEnabledInTests) {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
       cancel("table needs to start with default protocol versions but enabling " +
-        "coordinatedCommits upgrades table protocol version.")
+        "catalogOwned upgrades table protocol version.")
     }
     import DeltaTestUtils.StrictProtocolOrdering
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
@@ -292,8 +292,27 @@ trait CloneTableTestMixin extends DeltaColumnMappingTestUtils
     val sourceMetadata = cloneSource.metadata
     val targetMetadata = targetLog.metadata
 
+    /**
+     * Filter out row tracking properties from the configuration map.
+     * These properties are not expected to be the same in source and target metadata.
+     *
+     * @param conf The configuration map to filter.
+     * @return Filtered configuration map without row tracking properties.
+     */
+    def filterOutRowTrackingProps(conf: Map[String, String]): Map[String, String] = {
+      conf.filterNot { case (k, _) =>
+        k == MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP ||
+          k == MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP
+      }
+    }
+
+    val sourceConfigsWithoutRowTrackingProps =
+      filterOutRowTrackingProps(conf = sourceMetadata.configuration)
+    val targetConfigsWithoutRowTrackingProps =
+      filterOutRowTrackingProps(conf = targetMetadata.configuration)
+
     assert(sourceMetadata.schema === targetMetadata.schema &&
-      sourceMetadata.configuration === targetMetadata.configuration &&
+      sourceConfigsWithoutRowTrackingProps === targetConfigsWithoutRowTrackingProps &&
       sourceMetadata.dataSchema === targetMetadata.dataSchema &&
       sourceMetadata.partitionColumns === targetMetadata.partitionColumns &&
       sourceMetadata.format === sourceMetadata.format)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -243,6 +243,23 @@ trait CatalogOwnedTestBaseSuite
   }
 
   /**
+   * Constructs the specific table properties for Catalog Owned tables.
+   *
+   * @param spark The Spark session.
+   * @param metadata The metadata of the CC table.
+   * @return A map of CC specific table properties.
+   */
+  def constructCatalogOwnedSpecificTableProperties(
+      spark: SparkSession,
+      metadata: Metadata): Map[String, String] = {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
+      Map(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")
+    } else {
+      Map.empty
+    }
+  }
+
+  /**
    * Returns the properties that are expected to show up in the table properties of a Delta table
    * when catalog owned is enabled in tests.
    */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR migrates `CloneTableSQLSuite` to CC.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Through existing and newly migrated suites.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
