### PR TITLE
[Delta] Migrate `DataSkippingDeltaV1Suite` to `CatalogOwned`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -20,10 +20,11 @@ import java.io.File
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.metering.ScanReport
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.test.ScanReportHelper
 import org.apache.commons.io.FileUtils
@@ -48,7 +49,9 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
     with DeltaSQLCommandTest
     with DataSkippingDeltaTestsUtils
     with GivenWhenThen
-    with ScanReportHelper {
+    with ScanReportHelper
+    with CatalogOwnedTestBaseSuite
+    with DeltaSQLTestUtils {
 
   val defaultNumIndexedCols = DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.fromString(
     DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.defaultValue)
@@ -1180,9 +1183,10 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
 
   test("data skipping with missing columns in DataFrame", tableSchemaOnlyTag) {
     // case-1: dataframe schema has less columns than the dataSkippingNumIndexedCols
-    withTable("table") {
-      sql("CREATE TABLE table (a Int, b Int, c Int, d Int, e Int) USING delta PARTITIONED BY(b)")
-      val r = DeltaLog.forTable(spark, new TableIdentifier("table"))
+    withTempTable(createTable = false) { tableName =>
+      sql(s"CREATE TABLE $tableName (a Int, b Int, c Int, d Int, e Int) " +
+        "USING delta PARTITIONED BY(b)")
+      val r = DeltaLog.forTable(spark, new TableIdentifier(tableName))
       // Only index the first three columns, excluding partition column b
       setNumIndexedColumns(r.dataPath.toString, 3)
       val dataSeq = Seq((1, 2, 3, 4, 5))
@@ -1214,9 +1218,10 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
 
     // case-2: dataframe schema lacks columns that are supposed to be part of the stats schema,
     // but has an additional column that should not collect stats on
-    withTable("table") {
-      sql("CREATE TABLE table (a Int, b Int, c Int, d Int, e Int) USING delta PARTITIONED BY(b)")
-      val r = DeltaLog.forTable(spark, new TableIdentifier("table"))
+    withTempTable(createTable = false) { tableName =>
+      sql(s"CREATE TABLE $tableName (a Int, b Int, c Int, d Int, e Int) " +
+        "USING delta PARTITIONED BY(b)")
+      val r = DeltaLog.forTable(spark, new TableIdentifier(tableName))
       // Only index the first three columns, excluding partition column b
       setNumIndexedColumns(r.dataPath.toString, 3)
       val dataSeq = Seq((1, 2, 3, 4, 5))
@@ -1296,9 +1301,9 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
 
     // case-4: dataframe schema does not have any columns within the first
     // dataSkippingNumIndexedCols columns of the table schema
-    withTable("table") {
-      sql("CREATE TABLE table (a Int, b Int, c Int, d Int, e Int) USING delta")
-      val r = DeltaLog.forTable(spark, new TableIdentifier("table"))
+    withTempTable(createTable = false) { tableName =>
+      sql(s"CREATE TABLE $tableName (a Int, b Int, c Int, d Int, e Int) USING delta")
+      val r = DeltaLog.forTable(spark, new TableIdentifier(tableName))
       // Only index the first three columns
       setNumIndexedColumns(r.dataPath.toString, 3)
       val dataSeq = Seq((1, 2, 3, 4, 5))
@@ -1323,10 +1328,10 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
 
     // case-5: The first dataSkippingNumIndexedCols columns of the table schema has map or array
     // types, which we only collect NULL_COUNT
-    withTable("table") {
-      sql("CREATE TABLE table (a Int, b Map<String, Int>, c Array<Int>, d Int, e Int)" +
+    withTempTable(createTable = false) { tableName =>
+      sql(s"CREATE TABLE $tableName (a Int, b Map<String, Int>, c Array<Int>, d Int, e Int)" +
         " USING delta")
-      val r = DeltaLog.forTable(spark, new TableIdentifier("table"))
+      val r = DeltaLog.forTable(spark, new TableIdentifier(tableName))
       // Only index the first three columns
       setNumIndexedColumns(r.dataPath.toString, 3)
       val dataSeq = Seq((1, Map("key" -> 2), Seq(3, 3, 3), 4, 5))
@@ -2225,7 +2230,9 @@ class DataSkippingDeltaV1Suite
     val data = spark.range(10).repartition(2)
 
     Given("appending data without collecting stats")
-    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+    withSQLConf(
+        DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false",
+        DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "false") {
       data.write.format("delta").save(r.dataPath.toString)
       checkAnswer(rStats, Seq(Row(null, null, null), Row(null, null, null)))
     }
@@ -2310,4 +2317,16 @@ class DataSkippingDeltaV1ParquetCheckpointV2Suite extends DataSkippingDeltaV1Sui
       )
     )
   }
+}
+
+class DataSkippingDeltaV1WithCatalogOwnedBatch1Suite extends DataSkippingDeltaV1Suite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class DataSkippingDeltaV1WithCatalogOwnedBatch2Suite extends DataSkippingDeltaV1Suite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class DataSkippingDeltaV1WithCatalogOwnedBatch100Suite extends DataSkippingDeltaV1Suite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR migrates `DataSkippingDeltaV1Suite` to `CatalogOwned`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
