### PR TITLE
[Kernel] Refactor parameter names in `ScanStateRow.of()`

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -51,16 +51,16 @@ public class ScanStateRow extends GenericRow {
   public static ScanStateRow of(
       Metadata metadata,
       Protocol protocol,
-      String readSchemaLogicalJson,
-      String readSchemaPhysicalJson,
-      String readPhysicalDataSchemaJson,
+      String logicalSchemaJson,
+      String physicalSchemaJson,
+      String physicalDataReadSchemaJson,
       String tablePath) {
     HashMap<Integer, Object> valueMap = new HashMap<>();
     valueMap.put(COL_NAME_TO_ORDINAL.get("configuration"), metadata.getConfigurationMapValue());
-    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), readSchemaLogicalJson);
-    valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaString"), readSchemaPhysicalJson);
+    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), logicalSchemaJson);
+    valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaString"), physicalSchemaJson);
     valueMap.put(
-        COL_NAME_TO_ORDINAL.get("physicalDataReadSchemaString"), readPhysicalDataSchemaJson);
+        COL_NAME_TO_ORDINAL.get("physicalDataReadSchemaString"), physicalDataReadSchemaJson);
     valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumns());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minReaderVersion"), protocol.getMinReaderVersion());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minWriterVersion"), protocol.getMinWriterVersion());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The current parameter names in `ScanStateRow.of()` are kind of confusing and not aligned with the field names of `ScanStateRow.SCHEMA` (e.g., `readSchemaLogicalJson` maps to `logicalSchemaString`) . I propose to simplify and align them. There is only one method using `of()` (`ScanImpl.getScanState`) so this change should be safe.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

`ScanStateRow.of()` is not directly used in any tests, so this change does not impact test behavior.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This is a user facing change for any user using named parameter access to `ScanStateRow.of()`. The order and functionality of the parameters remains unchanged.
