### PR TITLE
[Kernel] Enable coalesced reads of row tracking metadata columns

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -21,6 +21,7 @@ import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.data.SelectionColumnVector;
@@ -185,9 +186,12 @@ public interface Scan {
                 physicalReadSchema);
 
         // Transform physical row tracking columns to logical row tracking columns
-        nextDataBatch =
-            MaterializedRowTrackingColumn.transformPhysicalData(
-                nextDataBatch, scanFile, scanState, engine);
+        if (TableConfig.ROW_TRACKING_ENABLED.fromMetadata(
+            ScanStateRow.getConfiguration(scanState))) {
+          nextDataBatch =
+              MaterializedRowTrackingColumn.transformPhysicalData(
+                  nextDataBatch, scanFile, scanState, engine);
+        }
 
         // Get the selectionVector if DV is present
         DeletionVectorDescriptor dv =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -176,7 +176,7 @@ public interface Scan {
 
         // Add partition columns
         // NOTE: Adding partition columns must be the first thing we do with the data batch because
-        // it is the last thing we remove from the physicalReadSchema.
+        // it is the last thing we remove from the physicalReadSchema when creating a ScanStateRow.
         nextDataBatch =
             PartitionUtils.withPartitionColumns(
                 engine.getExpressionHandler(),
@@ -196,8 +196,7 @@ public interface Scan {
           selectionVector = Optional.empty();
         } else {
           if (rowIndexOrdinal == -1) {
-            throw new InvalidTableException(
-                tablePath,
+            throw new IllegalArgumentException(
                 "Row index column is not present in the data read from the Parquet file.");
           }
           if (!dv.equals(currDV)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -19,7 +19,6 @@ package io.delta.kernel;
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.exceptions.InvalidTableException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
@@ -31,18 +31,24 @@ import java.util.stream.Collectors;
  * type scalar expressions are listed below.
  *
  * <ol>
- *   <li>Name: <code>element_at</code>
+ *   <li>Name: <code>ELEMENT_AT</code>
  *       <ul>
- *         <li>Semantic: <code>element_at(map, key)</code>. Return the value of given <i>key</i>
+ *         <li>Semantic: <code>ELEMENT_AT(map, key)</code>. Return the value of given <i>key</i>
  *             from the <i>map</i> type input. Returns <i>null</i> if the given <i>key</i> is not in
- *             the <i>map</i> Ex: `element_at(map(1, 'a', 2, 'b'), 2)` returns 'b'
+ *             the <i>map</i> Ex: `ELEMENT_AT(map(1, 'a', 2, 'b'), 2)` returns 'b'.
  *         <li>Since version: 3.0.0
  *       </ul>
  *   <li>Name: <code>COALESCE</code>
  *       <ul>
- *         <li>Semantic: <code>COALESCE(expr1, ..., exprN)</code> Return the first non-null
- *             argument. If all arguments are null returns null
+ *         <li>Semantic: <code>COALESCE(expr1, ..., exprN)</code>. Return the first non-null
+ *             argument. If all arguments are null, returns null.
  *         <li>Since version: 3.1.0
+ *       </ul>
+ *   <li>Name: <code>ADD</code>
+ *       <ul>
+ *         <li>Semantic: <code>ADD(expr1, expr2)</code>. Return the sum of two numeric expressions.
+ *             If either of the expressions is null, returns null.
+ *         <li>Since Version: 4.1.0
  *       </ul>
  *   <li>Name: <code>TIMEADD</code>
  *       <ul>

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -28,6 +28,7 @@ import io.delta.kernel.utils.DataFileStatus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -442,6 +443,19 @@ public final class DeltaErrors {
 
   public static KernelException cannotToggleRowTrackingOnExistingTable() {
     return new KernelException("Row tracking support cannot be changed once the table is created.");
+  }
+
+  public static KernelException missingRowTrackingColumnRequested(String columnName) {
+    return new KernelException(
+        String.format(
+            "Row tracking is not enabled, but row tracking column '%s' was requested.",
+            columnName));
+  }
+
+  public static KernelException missingMetadataConfigField(String key, Map<String, String> config) {
+    return new KernelException(
+        String.format(
+            "Missing required field '%s' in the metadata configuration: %s", key, config));
   }
 
   public static KernelException cannotModifyAppendOnlyTable(String tablePath) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -28,7 +28,6 @@ import io.delta.kernel.utils.DataFileStatus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -450,12 +449,6 @@ public final class DeltaErrors {
         String.format(
             "Row tracking is not enabled, but row tracking column '%s' was requested.",
             columnName));
-  }
-
-  public static KernelException missingMetadataConfigField(String key, Map<String, String> config) {
-    return new KernelException(
-        String.format(
-            "Missing required field '%s' in the metadata configuration: %s", key, config));
   }
 
   public static KernelException cannotModifyAppendOnlyTable(String tablePath) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -458,6 +458,12 @@ public final class DeltaErrors {
             tablePath, TableConfig.APPEND_ONLY_ENABLED.getKey()));
   }
 
+  public static KernelException missingRowTrackingEntryInFile(String filePath, String entry) {
+    return new KernelException(
+        String.format(
+            "%s is not present in scan file %s of table with row tracking.", entry, filePath));
+  }
+
   /* ------------------------ HELPER METHODS ----------------------------- */
   private static String formatTimestamp(long millisSinceEpochUTC) {
     return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -202,4 +202,9 @@ public class InternalScanFileUtils {
     Row addFileRow = getAddFileEntry(scanFile);
     return new AddFile(addFileRow).getDefaultRowCommitVersion();
   }
+
+  public static String getFilePath(Row scanFile) {
+    Row addFileRow = getAddFileEntry(scanFile);
+    return new AddFile(addFileRow).getPath();
+  }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
@@ -72,7 +72,8 @@ public class ScanBuilderImpl implements ScanBuilder {
 
   @Override
   public ScanBuilder withReadSchema(StructType readSchema) {
-    // TODO: validate the readSchema is a subset of the table schema
+    // TODO: Validate that readSchema is a subset of the table schema or that extra fields are
+    //  metadata columns.
     this.readSchema = readSchema;
     return this;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -201,20 +201,11 @@ public class ScanImpl implements Scan {
 
   @Override
   public Row getScanState(Engine engine) {
-    // Check for metadata columns in the read schema and convert them to physical columns
-    List<StructField> convertedFields = new ArrayList<>();
-    for (StructField field : readSchema.fields()) {
-      Optional<StructField> converted =
-          MaterializedRowTrackingColumn.convertToPhysicalColumn(field, metadata);
-      if (converted.isPresent()) {
-        convertedFields.add(converted.get());
-      } else {
-        convertedFields.add(field);
-      }
-    }
-    StructType convertedSchema = new StructType(convertedFields);
+    // Check for row tracking columns in the read schema and convert them to physical columns
+    StructType convertedSchema =
+        MaterializedRowTrackingColumn.convertToPhysicalSchema(readSchema, metadata);
 
-    // Physical equivalent of the logical read schema.
+    // Convert regular columns to physical columns if column mapping is enabled
     StructType physicalReadSchema =
         ColumnMapping.convertToPhysicalSchema(
             convertedSchema,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -218,7 +218,7 @@ public class ScanImpl implements Scan {
     List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumns());
     StructType physicalDataReadSchema =
         PartitionUtils.physicalSchemaWithoutPartitionColumns(
-            convertedSchema, /* logical read schema */
+            readSchema, /* logical read schema */
             physicalReadSchema,
             new HashSet<>(partitionColumns));
 
@@ -229,7 +229,7 @@ public class ScanImpl implements Scan {
     return ScanStateRow.of(
         metadata,
         protocol,
-        convertedSchema.toJson(),
+        readSchema.toJson(),
         physicalReadSchema.toJson(),
         physicalDataReadSchema.toJson(),
         dataPath.toUri().toString());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -202,12 +202,11 @@ public class ScanImpl implements Scan {
 
   @Override
   public Row getScanState(Engine engine) {
-    StructType physicalSchema = convertToPhysicalSchema();
+    StructType physicalSchema = getPhysicalSchema();
 
-    // Compute the physical data read schema, basically the list of columns to read
-    // from a Parquet data file. It should exclude partition columns and include
-    // row_index metadata columns (in case DVs are present)
-    // NOTE: Removing partition columns is the last thing we do with the read schema
+    // Compute the physical data read schema (i.e., the columns to read from a Parquet data file).
+    // The only difference to the physical schema is that we exclude partition columns. ALl other
+    // logic (e.g., row tracking columns, row index for DVs) is already handled before.
     List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumns());
     StructType physicalDataReadSchema =
         PartitionUtils.physicalSchemaWithoutPartitionColumns(
@@ -227,7 +226,7 @@ public class ScanImpl implements Scan {
     return getDataFilters();
   }
 
-  private StructType convertToPhysicalSchema() {
+  private StructType getPhysicalSchema() {
     StructType physicalSchema = new StructType();
 
     ColumnMapping.ColumnMappingMode mode =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -42,6 +42,8 @@ import io.delta.kernel.internal.skipping.DataSkippingUtils;
 import io.delta.kernel.internal.util.*;
 import io.delta.kernel.metrics.ScanReport;
 import io.delta.kernel.metrics.SnapshotReport;
+import io.delta.kernel.types.FieldMetadata;
+import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
@@ -249,11 +251,19 @@ public class ScanImpl implements Scan {
       }
     }
 
-    if (protocol.getReaderFeatures().contains("deletionVectors")) {
-      if (physicalSchema.indexOf(StructField.METADATA_ROW_INDEX_COLUMN_NAME) == -1) {
-        // If the row index column is not already present, add it to the physical read schema
-        physicalSchema = physicalSchema.add(StructField.METADATA_ROW_INDEX_COLUMN);
-      }
+    if (protocol.getReaderFeatures().contains("deletionVectors")
+        && physicalSchema.indexOf(StructField.METADATA_ROW_INDEX_COLUMN_NAME) == -1) {
+      // If the row index column is not already present, add it to the physical read schema
+      physicalSchema =
+          physicalSchema.add(
+              new StructField(
+                  StructField.METADATA_ROW_INDEX_COLUMN_NAME,
+                  LongType.LONG,
+                  false,
+                  FieldMetadata.builder()
+                      .putBoolean(StructField.IS_METADATA_COLUMN_KEY, true)
+                      .putBoolean(StructField.IS_INTERNAL_METADATA_COLUMN_KEY, true)
+                      .build()));
     }
 
     return physicalSchema;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -73,6 +73,17 @@ public class ScanStateRow extends GenericRow {
   }
 
   /**
+   * Utility method to get the configuration map from the scan state {@link Row} returned by {@link
+   * Scan#getScanState(Engine)}.
+   *
+   * @param scanState Scan state {@link Row}
+   * @return Map of configuration key-value pairs.
+   */
+  public static Map<String, String> getConfiguration(Row scanState) {
+    return VectorUtils.toJavaMap(scanState.getMap(COL_NAME_TO_ORDINAL.get("configuration")));
+  }
+
+  /**
    * Utility method to get the logical schema from the scan state {@link Row} returned by {@link
    * Scan#getScanState(Engine)}.
    *
@@ -127,9 +138,7 @@ public class ScanStateRow extends GenericRow {
    * Scan#getScanState(Engine)}.
    */
   public static ColumnMappingMode getColumnMappingMode(Row scanState) {
-    Map<String, String> configuration =
-        VectorUtils.toJavaMap(scanState.getMap(COL_NAME_TO_ORDINAL.get("configuration")));
-    return ColumnMapping.getColumnMappingMode(configuration);
+    return ColumnMapping.getColumnMappingMode(getConfiguration(scanState));
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -168,20 +168,19 @@ public final class MaterializedRowTrackingColumn {
       if (!rowTrackingEnabled
           && (field.getName().equals(METADATA_ROW_ID_COLUMN_NAME)
               || field.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME))) {
-        throw new InvalidTableException(
-            metadata.getId(),
-            String.format(
-                "Row tracking is not enabled, but row tracking column '%s' was requested.",
-                field.getName()));
+        throw DeltaErrors.missingRowTrackingColumnRequested(field.getName());
       }
 
       if (field.getName().equals(METADATA_ROW_ID_COLUMN_NAME)) {
         physicalFields.add(
-            new StructField(getPhysicalColumnName(ROW_ID, metadata), field.getDataType(), true));
+            new StructField(
+                getPhysicalColumnName(ROW_ID, metadata), field.getDataType(), true /* nullable */));
       } else if (field.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME)) {
         physicalFields.add(
             new StructField(
-                getPhysicalColumnName(ROW_COMMIT_VERSION, metadata), field.getDataType(), true));
+                getPhysicalColumnName(ROW_COMMIT_VERSION, metadata),
+                field.getDataType(),
+                true /* nullable */));
       } else {
         physicalFields.add(field);
       }
@@ -195,11 +194,8 @@ public final class MaterializedRowTrackingColumn {
             metadata.getConfiguration().get(column.getMaterializedColumnNameProperty()))
         .orElseThrow(
             () ->
-                new InvalidTableException(
-                    metadata.getId(),
-                    String.format(
-                        "Physical column name for %s does not exist in the metadata configuration.",
-                        column.getMaterializedColumnNameProperty())));
+                DeltaErrors.missingMetadataConfigField(
+                    column.getMaterializedColumnNameProperty(), metadata.getConfiguration()));
   }
 
   /** Generates a random name by concatenating the prefix with a random UUID. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -22,6 +22,7 @@ import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.util.*;
@@ -179,15 +180,13 @@ public final class MaterializedRowTrackingColumn {
       //  to the physical schema to compute non-materialized row IDs.
       return physicalSchema.add(
           new StructField(
-              getPhysicalColumnName(ROW_ID, metadata),
-              logicalField.getDataType(),
-              logicalField.isNullable()));
+              ROW_ID.getPhysicalColumnName(metadata), LongType.LONG, true /* nullable */));
     } else if (logicalField.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME)) {
       return physicalSchema.add(
           new StructField(
-              getPhysicalColumnName(ROW_COMMIT_VERSION, metadata),
-              logicalField.getDataType(),
-              logicalField.isNullable()));
+              ROW_COMMIT_VERSION.getPhysicalColumnName(metadata),
+              LongType.LONG,
+              true /* nullable */));
     } else {
       throw new IllegalArgumentException(
           String.format(
@@ -196,17 +195,15 @@ public final class MaterializedRowTrackingColumn {
     }
   }
 
-  private static String getPhysicalColumnName(
-      MaterializedRowTrackingColumn column, Metadata metadata) {
-    return Optional.ofNullable(
-            metadata.getConfiguration().get(column.getMaterializedColumnNameProperty()))
+  private String getPhysicalColumnName(Metadata metadata) {
+    return Optional.ofNullable(metadata.getConfiguration().get(getMaterializedColumnNameProperty()))
         .orElseThrow(
             () ->
                 new InvalidTableException(
                     metadata.getId(),
                     String.format(
                         "Materialized column name `%s` is missing in the metadata configuration.",
-                        column.getMaterializedColumnNameProperty())));
+                        getMaterializedColumnNameProperty())));
   }
 
   /** Generates a random name by concatenating the prefix with a random UUID. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -194,8 +194,11 @@ public final class MaterializedRowTrackingColumn {
             metadata.getConfiguration().get(column.getMaterializedColumnNameProperty()))
         .orElseThrow(
             () ->
-                DeltaErrors.missingMetadataConfigField(
-                    column.getMaterializedColumnNameProperty(), metadata.getConfiguration()));
+                new InvalidTableException(
+                    metadata.getId(),
+                    String.format(
+                        "Materialized column name `%s` is missing in the metadata configuration.",
+                        column.getMaterializedColumnNameProperty())));
   }
 
   /** Generates a random name by concatenating the prefix with a random UUID. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -23,6 +23,9 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.types.FieldMetadata;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.StructField;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.kernel.utils.CloseableIterator;
 import java.io.IOException;
@@ -33,6 +36,32 @@ import java.util.stream.Collectors;
 
 /** A collection of helper methods for working with row tracking. */
 public class RowTracking {
+  /**
+   * The name of the row ID metadata column. When present this column must be populated with the
+   * unique ID of each row.
+   */
+  public static String METADATA_ROW_ID_COLUMN_NAME = "_metadata.row_id";
+
+  public static StructField METADATA_ROW_ID_COLUMN =
+      new StructField(
+          METADATA_ROW_ID_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(StructField.IS_METADATA_COLUMN_KEY, true).build());
+
+  /**
+   * The name of the row commit version metadata column. When present this column must be populated
+   * with the commit version of each row.
+   */
+  public static String METADATA_ROW_COMMIT_VERSION_COLUMN_NAME = "_metadata.row_commit_version";
+
+  public static StructField METADATA_ROW_COMMIT_VERSION_COLUMN =
+      new StructField(
+          METADATA_ROW_COMMIT_VERSION_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(StructField.IS_METADATA_COLUMN_KEY, true).build());
+
   private RowTracking() {
     // Empty constructor to prevent instantiation of this class
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -68,6 +68,18 @@ public class RowTracking {
   }
 
   /**
+   * Checks if the provided field is a row tracking column, i.e., either the row ID or the row
+   * commit version column.
+   *
+   * @param field the field to check
+   * @return true if the field is a row tracking column, false otherwise
+   */
+  public static boolean isRowTrackingColumn(StructField field) {
+    return field.getName().equals(METADATA_ROW_ID_COLUMN_NAME)
+        || field.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME);
+  }
+
+  /**
    * Assigns or reassigns baseRowIds and defaultRowCommitVersions to {@link AddFile} actions in the
    * provided {@code dataActions}. This method should be invoked only when the 'rowTracking' feature
    * is supported and is used in two scenarios:

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 
 /** A collection of helper methods for working with row tracking. */
 public class RowTracking {
+  // TODO: Migrate this API to the unified metadata column API once it is available.
   /**
    * The name of the row ID metadata column. When present this column must be populated with the
    * unique ID of each row.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -251,6 +251,15 @@ public class ColumnMapping {
       StructType prunedSchema, StructType fullSchema, boolean includeFieldId) {
     StructType newSchema = new StructType();
     for (StructField prunedField : prunedSchema.fields()) {
+      if (fullSchema.indexOf(prunedField.getName()) == -1) {
+        // Metadata columns are not present in fullSchema by design, so we have to ignore them
+        // during column mapping.
+        // Note that we cannot use isMetadataColumn() here since logical metadata columns might
+        // have been converted to (regular) physical columns before column mapping is applied.
+        newSchema = newSchema.add(prunedField);
+        continue;
+      }
+
       StructField completeField = fullSchema.get(prunedField.getName());
       DataType physicalType =
           convertToPhysicalType(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -118,6 +118,33 @@ public class ColumnMapping {
     }
   }
 
+  /**
+   * Converts a logical column to a physical column based on the table's column mapping mode. The
+   * field-id metadata is preserved when cmMode = ID, all column metadata is otherwise removed.
+   *
+   * <p>We require {@code fullSchema} in addition to the logical field we want to convert since we
+   * need the complete field metadata as it is stored in the schema in the _delta_log. We cannot be
+   * sure (and do not enforce) that this metadata is preserved by the connector.
+   *
+   * @param logicalField the logical read column requested by the connector
+   * @param fullSchema the full delta schema (with complete metadata) as read from the _delta_log
+   * @param columnMappingMode Column mapping mode
+   */
+  public static StructField convertToPhysicalColumn(
+      StructField logicalField, StructType fullSchema, ColumnMappingMode columnMappingMode) {
+    switch (columnMappingMode) {
+      case NONE:
+        return logicalField;
+      case ID: // fall through
+      case NAME:
+        boolean includeFieldIds = columnMappingMode == ColumnMappingMode.ID;
+        return convertToPhysicalColumn(logicalField, fullSchema, includeFieldIds);
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported column mapping mode: " + columnMappingMode);
+    }
+  }
+
   /** Returns the physical name for a given {@link StructField} */
   public static String getPhysicalName(StructField field) {
     if (hasPhysicalName(field)) {
@@ -251,43 +278,44 @@ public class ColumnMapping {
       StructType prunedSchema, StructType fullSchema, boolean includeFieldId) {
     StructType newSchema = new StructType();
     for (StructField prunedField : prunedSchema.fields()) {
-      if (fullSchema.indexOf(prunedField.getName()) == -1) {
-        // Metadata columns are not present in fullSchema by design, so we have to ignore them
-        // during column mapping.
-        // Note that we cannot use isMetadataColumn() here since logical metadata columns might
-        // have been converted to (regular) physical columns before column mapping is applied.
-        newSchema = newSchema.add(prunedField);
-        continue;
-      }
-
-      StructField completeField = fullSchema.get(prunedField.getName());
-      DataType physicalType =
-          convertToPhysicalType(
-              prunedField.getDataType(), completeField.getDataType(), includeFieldId);
-      String physicalName = completeField.getMetadata().getString(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
-
-      if (includeFieldId) {
-        Long fieldId = completeField.getMetadata().getLong(COLUMN_MAPPING_ID_KEY);
-        FieldMetadata.Builder builder =
-            FieldMetadata.builder().putLong(PARQUET_FIELD_ID_KEY, fieldId);
-
-        // convertToPhysicalSchema(..) gets called when trying to find the read schema
-        // for the Parquet reader. This currently assumes that if the nested field IDs for
-        // the 'element' and 'key'/'value' fields of Arrays/Maps haven been written,
-        // then IcebergCompatV2 is enabled because the schema we are looking at is from
-        // the DeltaLog and has nested field IDs setup
-        if (hasNestedColumnIds(completeField)) {
-          builder.putFieldMetadata(
-              PARQUET_FIELD_NESTED_IDS_METADATA_KEY, getNestedColumnIds(completeField));
-        }
-
-        newSchema =
-            newSchema.add(physicalName, physicalType, prunedField.isNullable(), builder.build());
-      } else {
-        newSchema = newSchema.add(physicalName, physicalType, prunedField.isNullable());
-      }
+      newSchema = newSchema.add(convertToPhysicalColumn(prunedField, fullSchema, includeFieldId));
     }
     return newSchema;
+  }
+
+  /**
+   * Utility method to convert the given logical field to a physical field, recursively converting
+   * sub-types in case of complex types. When {@code includeFieldId} is true, converted physical
+   * schema will have field ids in the metadata. Column metadata is otherwise removed.
+   */
+  private static StructField convertToPhysicalColumn(
+      StructField logicalField, StructType fullSchema, boolean includeFieldId) {
+    StructField completeField = fullSchema.get(logicalField.getName());
+    DataType physicalType =
+        convertToPhysicalType(
+            logicalField.getDataType(), completeField.getDataType(), includeFieldId);
+    String physicalName = completeField.getMetadata().getString(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
+
+    if (includeFieldId) {
+      Long fieldId = completeField.getMetadata().getLong(COLUMN_MAPPING_ID_KEY);
+      FieldMetadata.Builder builder =
+          FieldMetadata.builder().putLong(PARQUET_FIELD_ID_KEY, fieldId);
+
+      // convertToPhysicalSchema(..) gets called when trying to find the read schema
+      // for the Parquet reader. This currently assumes that if the nested field IDs for
+      // the 'element' and 'key'/'value' fields of Arrays/Maps haven been written,
+      // then IcebergCompatV2 is enabled because the schema we are looking at is from
+      // the DeltaLog and has nested field IDs setup
+      if (hasNestedColumnIds(completeField)) {
+        builder.putFieldMetadata(
+            PARQUET_FIELD_NESTED_IDS_METADATA_KEY, getNestedColumnIds(completeField));
+      }
+
+      return new StructField(
+          physicalName, physicalType, logicalField.isNullable(), builder.build());
+    } else {
+      return new StructField(physicalName, physicalType, logicalField.isNullable());
+    }
   }
 
   private static DataType convertToPhysicalType(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -54,15 +54,17 @@ public class PartitionUtils {
    * Utility method to remove the given columns (as {@code columnsToRemove}) from the given {@code
    * physicalSchema}.
    *
-   * @param physicalSchema
-   * @param logicalSchema To create a logical name to physical name map. Partition column names are
-   *     in logical space and we need to identify the equivalent physical column name.
-   * @param columnsToRemove
-   * @return
+   * @param logicalSchema Logical schema used to map logical partition column names to physical
+   *     column names.
+   * @param physicalSchema Physical schema from which columns will be removed.
+   * @param columnsToRemove Set of partition column names (in logical space) to remove from the
+   *     physical schema.
+   * @return A new {@link StructType} representing the physical schema without the specified
+   *     partition columns.
    */
   public static StructType physicalSchemaWithoutPartitionColumns(
       StructType logicalSchema, StructType physicalSchema, Set<String> columnsToRemove) {
-    if (columnsToRemove == null || columnsToRemove.size() == 0) {
+    if (columnsToRemove == null || columnsToRemove.isEmpty()) {
       return physicalSchema;
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -34,7 +34,7 @@ public class StructField {
   ////////////////////////////////////////////////////////////////////////////////
 
   /** Indicates a metadata column when present in the field metadata and the value is true */
-  private static String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
+  private static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
   /**
    * The name of a row index metadata column. When present this column must be populated with row
@@ -42,9 +42,37 @@ public class StructField {
    */
   public static String METADATA_ROW_INDEX_COLUMN_NAME = "_metadata.row_index";
 
+  /**
+   * The name of a row ID metadata column. When present this column must be populated with the
+   * unique row ID of each column.
+   */
+  public static String METADATA_ROW_ID_COLUMN_NAME = "_metadata.row_id";
+
+  /**
+   * The name of a row commit version metadata column. When present this column must be populated
+   * with the commit version of each row.
+   */
+  public static String METADATA_ROW_COMMIT_VERSION_COLUMN_NAME = "_metadata.row_commit_version";
+
   public static StructField METADATA_ROW_INDEX_COLUMN =
       new StructField(
           METADATA_ROW_INDEX_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
+          Collections.emptyList());
+
+  public static StructField METADATA_ROW_ID_COLUMN =
+      new StructField(
+          METADATA_ROW_ID_COLUMN_NAME,
+          LongType.LONG,
+          false,
+          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
+          Collections.emptyList());
+
+  public static StructField METADATA_ROW_COMMIT_VERSION_COLUMN =
+      new StructField(
+          METADATA_ROW_COMMIT_VERSION_COLUMN_NAME,
           LongType.LONG,
           false,
           FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -34,7 +34,7 @@ public class StructField {
   ////////////////////////////////////////////////////////////////////////////////
 
   /** Indicates a metadata column when present in the field metadata and the value is true */
-  private static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
+  public static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
   /**
    * The name of a row index metadata column. When present this column must be populated with row
@@ -42,37 +42,9 @@ public class StructField {
    */
   public static String METADATA_ROW_INDEX_COLUMN_NAME = "_metadata.row_index";
 
-  /**
-   * The name of a row ID metadata column. When present this column must be populated with the
-   * unique row ID of each column.
-   */
-  public static String METADATA_ROW_ID_COLUMN_NAME = "_metadata.row_id";
-
-  /**
-   * The name of a row commit version metadata column. When present this column must be populated
-   * with the commit version of each row.
-   */
-  public static String METADATA_ROW_COMMIT_VERSION_COLUMN_NAME = "_metadata.row_commit_version";
-
   public static StructField METADATA_ROW_INDEX_COLUMN =
       new StructField(
           METADATA_ROW_INDEX_COLUMN_NAME,
-          LongType.LONG,
-          false,
-          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
-          Collections.emptyList());
-
-  public static StructField METADATA_ROW_ID_COLUMN =
-      new StructField(
-          METADATA_ROW_ID_COLUMN_NAME,
-          LongType.LONG,
-          false,
-          FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),
-          Collections.emptyList());
-
-  public static StructField METADATA_ROW_COMMIT_VERSION_COLUMN =
-      new StructField(
-          METADATA_ROW_COMMIT_VERSION_COLUMN_NAME,
           LongType.LONG,
           false,
           FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -37,6 +37,12 @@ public class StructField {
   public static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
   /**
+   * Indicates that a metadata column was requested for internal computations and should not be
+   * exposed to the user.
+   */
+  public static final String IS_INTERNAL_METADATA_COLUMN_KEY = "isInternalMetadataColumn";
+
+  /**
    * The name of a row index metadata column. When present this column must be populated with row
    * index of each row when reading from parquet.
    */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -242,7 +242,7 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
   def testBatch(includePartitionCols: Boolean): ColumnarBatch = {
     val testColumnVectors = Seq(
       stringVector(Seq("Alice", "Bob", "Charlie", "David", "Eve")), // name
-      longVector(20L, 30L, 40L, 50L, 60L), // id
+      longVector(Seq(20L, 30L, 40L, 50L, 60L)), // id
       stringVector(Seq("Campbell", "Roanoke", "Dallas", "Monte Sereno", "Minneapolis")) // city
     ) ++ {
       if (includePartitionCols) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/FilteredColumnarBatchSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/FilteredColumnarBatchSuite.scala
@@ -30,7 +30,7 @@ class FilteredColumnarBatchSuite extends AnyFunSuite with VectorTestUtils with M
   private val testSchema = new StructType().add("id", LongType.LONG)
 
   test("constructor should succeed when selectionVector is present and numSelectedRows is valid") {
-    val data = columnarBatch(testSchema, Seq(longVector(0L, 1L, 2L, 3L, 4L)))
+    val data = columnarBatch(testSchema, Seq(longVector(Seq(0L, 1L, 2L, 3L, 4L))))
     val selectionVector = Optional.of(booleanVector(Seq(true, false, true, false, true)))
     val batch = new FilteredColumnarBatch(data, selectionVector, "/test/path", 3)
 
@@ -43,7 +43,7 @@ class FilteredColumnarBatchSuite extends AnyFunSuite with VectorTestUtils with M
   test(
     "constructor should succeed when selectionVector is empty and numSelectedRows " +
       "equals batch size") {
-    val data = columnarBatch(testSchema, Seq(longVector(0L, 1L, 2L, 3L, 4L)))
+    val data = columnarBatch(testSchema, Seq(longVector(Seq(0L, 1L, 2L, 3L, 4L))))
     val selectionVector = Optional.empty[ColumnVector]()
     val batch = new FilteredColumnarBatch(data, selectionVector, "/test/path", 5)
 
@@ -55,7 +55,7 @@ class FilteredColumnarBatchSuite extends AnyFunSuite with VectorTestUtils with M
 
   test("constructor should throw IllegalArgumentException " +
     "when selectionVector is empty and numSelectedRows != batch size") {
-    val data = columnarBatch(testSchema, Seq(longVector(0L, 1L, 2L, 3L, 4L)))
+    val data = columnarBatch(testSchema, Seq(longVector(Seq(0L, 1L, 2L, 3L, 4L))))
     val selectionVector = Optional.empty[ColumnVector]()
     val exMsg = intercept[IllegalArgumentException] {
       new FilteredColumnarBatch(data, selectionVector, "/test/path", 3)
@@ -67,7 +67,7 @@ class FilteredColumnarBatchSuite extends AnyFunSuite with VectorTestUtils with M
 
   test("constructor should throw IllegalArgumentException " +
     "when selectionVector is present and numSelectedRows > batch size") {
-    val data = columnarBatch(testSchema, Seq(longVector(0L, 1L, 2L, 3L)))
+    val data = columnarBatch(testSchema, Seq(longVector(Seq(0L, 1L, 2L, 3L))))
     val selectionVector = Optional.of(booleanVector(Seq(true, false, true, false)))
 
     val exMsg = intercept[IllegalArgumentException] {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.internal
 
+import java.lang.{Long => JLong}
 import java.util.{Arrays, Collections, Optional}
 
 import scala.collection.JavaConverters._
@@ -787,8 +788,9 @@ trait SidecarIteratorProvider extends VectorTestUtils {
 
     override def getColumnVector(ordinal: Int): ColumnVector = ordinal match {
       case 0 => stringVector(sidecars.map(_.getPath)) // path
-      case 1 => longVector(sidecars.map(_.getSize): _*) // size
-      case 2 => longVector(sidecars.map(_.getModificationTime): _*) // modification time
+      case 1 => longVector(sidecars.map(_.getSize).map(JLong.valueOf)) // size
+      case 2 =>
+        longVector(sidecars.map(_.getModificationTime).map(JLong.valueOf)) // modification time
     }
 
     override def getSize: Int = sidecars.length
@@ -843,9 +845,9 @@ class MockReadLastCheckpointFileJsonHandler(
 
         override def getColumnVector(ordinal: Int): ColumnVector = {
           ordinal match {
-            case 0 => longVector(lastCheckpointVersion) /* version */
-            case 1 => longVector(100) /* size */
-            case 2 => longVector(1) /* parts */
+            case 0 => longVector(Seq(lastCheckpointVersion)) /* version */
+            case 1 => longVector(Seq(100)) /* size */
+            case 2 => longVector(Seq(1)) /* parts */
           }
         }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
@@ -248,7 +248,7 @@ object CheckpointerSuite extends VectorTestUtils {
     override def getSchema: StructType = CheckpointMetaData.READ_SCHEMA
 
     // empty vector for all columns
-    override def getColumnVector(ordinal: Int): ColumnVector = longVector(Seq())
+    override def getColumnVector(ordinal: Int): ColumnVector = longVector(Seq.empty)
 
     override def getSize: Int = 0
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
@@ -235,9 +235,9 @@ object CheckpointerSuite extends VectorTestUtils {
 
     override def getColumnVector(ordinal: Int): ColumnVector = {
       ordinal match {
-        case 0 => longVector(40) // version
-        case 1 => longVector(44) // size
-        case 2 => longVector(20); // parts
+        case 0 => longVector(Seq(40)) // version
+        case 1 => longVector(Seq(44)) // size
+        case 2 => longVector(Seq(20)); // parts
       }
     }
 
@@ -248,7 +248,7 @@ object CheckpointerSuite extends VectorTestUtils {
     override def getSchema: StructType = CheckpointMetaData.READ_SCHEMA
 
     // empty vector for all columns
-    override def getColumnVector(ordinal: Int): ColumnVector = longVector()
+    override def getColumnVector(ordinal: Int): ColumnVector = longVector(Seq())
 
     override def getSize: Int = 0
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -189,8 +189,8 @@ class MockReadICTFileJsonHandler(deltaVersionToICTMapping: Map[Long, Long])
 
         override def getColumnVector(ordinal: Int): ColumnVector = {
           val struct = Seq(
-            longVector(ict), /* inCommitTimestamp */
-            longVector(-1L), /* timestamp */
+            longVector(Seq(ict)), /* inCommitTimestamp */
+            longVector(Seq(-1L)), /* timestamp */
             stringVector(Seq("engine")), /* engineInfo */
             stringVector(Seq("operation")), /* operation */
             mapTypeVector(Seq(Map("operationParameter" -> ""))), /* operationParameters */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
@@ -15,7 +15,7 @@
  */
 package io.delta.kernel.test
 
-import java.lang.{Boolean => BooleanJ, Double => DoubleJ, Float => FloatJ}
+import java.lang.{Boolean => BooleanJ, Double => DoubleJ, Float => FloatJ, Long => LongJ}
 
 import scala.collection.JavaConverters._
 
@@ -97,7 +97,7 @@ trait VectorTestUtils {
 
       override def close(): Unit = {}
 
-      override def isNullAt(rowId: Int): Boolean = (values(rowId) == null)
+      override def isNullAt(rowId: Int): Boolean = values(rowId) == null
 
       override def getFloat(rowId: Int): Float = values(rowId)
     }
@@ -111,20 +111,20 @@ trait VectorTestUtils {
 
       override def close(): Unit = {}
 
-      override def isNullAt(rowId: Int): Boolean = (values(rowId) == null)
+      override def isNullAt(rowId: Int): Boolean = values(rowId) == null
 
       override def getDouble(rowId: Int): Double = values(rowId)
     }
   }
 
-  def longVector(values: Long*): ColumnVector = new ColumnVector {
+  def longVector(values: Seq[LongJ]): ColumnVector = new ColumnVector {
     override def getDataType: DataType = LongType.LONG
 
-    override def getSize: Int = values.size
+    override def getSize: Int = values.length
 
     override def close(): Unit = {}
 
-    override def isNullAt(rowId: Int): Boolean = false
+    override def isNullAt(rowId: Int): Boolean = values(rowId) == null
 
     override def getLong(rowId: Int): Long = values(rowId)
   }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -386,6 +386,94 @@ class DefaultExpressionUtils {
     };
   }
 
+  /** Represents an arithmetic operator that can be applied to two numeric values. */
+  public interface ArithmeticOperator {
+    byte apply(byte a, byte b);
+
+    short apply(short a, short b);
+
+    int apply(int a, int b);
+
+    long apply(long a, long b);
+
+    float apply(float a, float b);
+
+    double apply(double a, double b);
+
+    BigDecimal apply(BigDecimal a, BigDecimal b);
+  }
+
+  /**
+   * Creates a column vector that lazily evaluates an arithmetic operation between two column
+   * vectors.
+   *
+   * <p>Only numeric data types are supported.
+   *
+   * @param left the left operand column vector
+   * @param right the right operand column vector
+   * @param operator the arithmetic operator to apply
+   * @return a new column vector representing the result of the arithmetic operation
+   */
+  static ColumnVector arithmeticVector(
+      ColumnVector left, ColumnVector right, ArithmeticOperator operator) {
+    return new ColumnVector() {
+      @Override
+      public DataType getDataType() {
+        return left.getDataType();
+      }
+
+      @Override
+      public int getSize() {
+        return left.getSize();
+      }
+
+      @Override
+      public void close() {
+        Utils.closeCloseables(left, right);
+      }
+
+      @Override
+      public boolean isNullAt(int rowId) {
+        return left.isNullAt(rowId) || right.isNullAt(rowId);
+      }
+
+      @Override
+      public byte getByte(int rowId) {
+        return operator.apply(left.getByte(rowId), right.getByte(rowId));
+      }
+
+      @Override
+      public short getShort(int rowId) {
+        return operator.apply(left.getShort(rowId), right.getShort(rowId));
+      }
+
+      @Override
+      public int getInt(int rowId) {
+        return operator.apply(left.getInt(rowId), right.getInt(rowId));
+      }
+
+      @Override
+      public long getLong(int rowId) {
+        return operator.apply(left.getLong(rowId), right.getLong(rowId));
+      }
+
+      @Override
+      public float getFloat(int rowId) {
+        return operator.apply(left.getFloat(rowId), right.getFloat(rowId));
+      }
+
+      @Override
+      public double getDouble(int rowId) {
+        return operator.apply(left.getDouble(rowId), right.getDouble(rowId));
+      }
+
+      @Override
+      public BigDecimal getDecimal(int rowId) {
+        return operator.apply(left.getDecimal(rowId), right.getDecimal(rowId));
+      }
+    };
+  }
+
   /**
    * Checks if the specific expression is an integer literal, throws {@link
    * UnsupportedOperationException} if not.

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -399,8 +399,6 @@ class DefaultExpressionUtils {
     float apply(float a, float b);
 
     double apply(double a, double b);
-
-    BigDecimal apply(BigDecimal a, BigDecimal b);
   }
 
   /**
@@ -465,11 +463,6 @@ class DefaultExpressionUtils {
       @Override
       public double getDouble(int rowId) {
         return operator.apply(left.getDouble(rowId), right.getDouble(rowId));
-      }
-
-      @Override
-      public BigDecimal getDecimal(int rowId) {
-        return operator.apply(left.getDecimal(rowId), right.getDecimal(rowId));
       }
     };
   }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -63,6 +63,8 @@ abstract class ExpressionVisitor<R> {
 
   abstract R visitSubstring(ScalarExpression subString);
 
+  abstract R visitAdd(ScalarExpression add);
+
   abstract R visitLike(Predicate predicate);
 
   abstract R visitStartsWith(Predicate predicate);
@@ -113,6 +115,8 @@ abstract class ExpressionVisitor<R> {
         return visitIsNull(new Predicate(name, children));
       case "COALESCE":
         return visitCoalesce(expression);
+      case "ADD":
+        return visitAdd(expression);
       case "TIMEADD":
         return visitTimeAdd(expression);
       case "SUBSTRING":

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -428,8 +428,6 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
   }
 
   /* -------- Test reading from tables with row tracking -------- */
-  // TODO: For now, we only read the materialized column values so the metadata column content will
-  //  be null for a new table without materialized row id/row commit version.
   test("Error when reading row tracking columns from a non-row-tracking table") {
     withTempDirAndEngine { (tablePath, engine) =>
       // Create a new table without row tracking
@@ -461,10 +459,10 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
         val expectedAnswer = Seq(
           TestRow(1, "A", 0L, 1L),
           TestRow(2, "B", 1L, 1L),
-          TestRow(3, "C_updated", 2L, null),
+          TestRow(3, "C_updated", 2L, 2L),
           TestRow(4, "D", 3L, 1L),
           TestRow(5, "E", 4L, 1L),
-          TestRow(6, "F", null, null))
+          TestRow(6, "F", 10L, 2L))
 
         // We only check whether the delta-spark table schema is inferred correctly if column
         // mapping is disabled
@@ -494,7 +492,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
         TestRow("C_updated", 2L),
         TestRow("D", 3L),
         TestRow("E", 4L),
-        TestRow("F", null))
+        TestRow("F", 10L))
 
       checkTable(
         path = tablePath,
@@ -511,10 +509,10 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
       val expectedAnswer = Seq(
         TestRow(1L, 0L),
         TestRow(1L, 1L),
-        TestRow(null, 2L),
+        TestRow(2L, 2L),
         TestRow(1L, 3L),
         TestRow(1L, 4L),
-        TestRow(null, null))
+        TestRow(2L, 10L))
 
       // This test also checks a different ordering of the metadata columns
       checkTable(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -448,7 +448,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Read row tracking columns from golden table") {
+  test("Read row tracking columns from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 
@@ -460,7 +460,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
         TestRow(5, "E", 4L, 1L),
         TestRow(6, "F", null, null))
 
-      // This tests also checks that the golden table schema is inferred correctly
+      // This tests also checks that the delta-spark table schema is inferred correctly
       checkTable(
         path = tablePath,
         expectedAnswer,
@@ -472,7 +472,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Read subset of row tracking columns from golden table") {
+  test("Read subset of row tracking columns from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 
@@ -492,7 +492,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Only read row tracking columns from golden table") {
+  test("Only read row tracking columns from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 
@@ -514,7 +514,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     }
   }
 
-  test("Metadata columns are not read by default from golden table") {
+  test("Metadata columns are not read by default from delta-spark table") {
     withTempDirAndEngine { (tablePath, _) =>
       createRowTrackingTableWithSpark(tablePath)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -21,7 +21,6 @@ import java.util.Optional
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 
-import io.delta.kernel.Table
 import io.delta.kernel.data.{FilteredColumnarBatch, Row}
 import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
 import io.delta.kernel.defaults.utils.TestRow

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -435,7 +435,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
       createEmptyTable(engine, tablePath, wrongSchema)
 
       // Try to read row tracking columns
-      val e = intercept[InvalidTableException] {
+      val e = intercept[KernelException] {
         checkTable(
           tablePath,
           expectedAnswer = Seq(),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -81,6 +81,18 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
     }
   }
 
+  protected def checkLongVectors(actual: ColumnVector, expected: ColumnVector): Unit = {
+    assert(actual.getDataType === expected.getDataType)
+    assert(actual.getSize === expected.getSize)
+    Seq.range(0, actual.getSize).foreach { rowId =>
+      if (expected.isNullAt(rowId)) {
+        assert(actual.isNullAt(rowId), s"Expected null at row $rowId")
+      } else {
+        assert(actual.getLong(rowId) === expected.getLong(rowId), s"Unexpected value at row $rowId")
+      }
+    }
+  }
+
   protected def checkTimestampVectors(actual: ColumnVector, expected: ColumnVector): Unit = {
     assert(actual.getSize === expected.getSize)
     for (rowId <- 0 until actual.getSize) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR builds upon #4943 and #4953 to enable fully functioning reads of row tracking metadata columns. Concretely, it adds functionality to compute non-materialized row IDs and row commit versions on the fly.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

I modified the tests that I added in #4943 to now expect the fully correct result (instead of `null` for non-materialized values).

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
This PR turns the work started in #4943 into a usable new feature. Users/engines can now request row tracking metadata columns from Delta tables. At the moment, this PR still uses a preliminary API for requesting metadata columns until we agree on a stable metadata column API going forward.
