### PR TITLE
Only build sharing for spark 4.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -570,6 +570,24 @@ lazy val sharing = (project in file("sharing"))
     scalaStyleSettings,
     releaseSettings,
     crossSparkSettings(),
+    Compile / compile := runTaskOnlyOnSparkMaster(
+      task = Compile / compile,
+      taskName = "compile",
+      projectName = "delta-sharing-spark",
+      emptyValue = Analysis.empty.asInstanceOf[CompileAnalysis]
+    ).value,
+    Test / test := runTaskOnlyOnSparkMaster(
+      task = Test / test,
+      taskName = "test",
+      projectName = "delta-sharing-spark",
+      emptyValue = ()
+    ).value,
+    publish := runTaskOnlyOnSparkMaster(
+      task = publish,
+      taskName = "publish",
+      projectName = "delta-sharing-spark",
+      emptyValue = ()
+    ).value,
     Test / javaOptions ++= Seq("-ea"),
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (delta sharing)

## Description
Due to the Spark 4.0 upgrade, Delta Sharing now only publishes Scala 2.13 builds with Spark 4.0. However, Delta OSS still builds both Scala 2.12 and 2.13 with Spark 3.x. This mismatch leads to build errors when attempting to use the latest Delta Sharing release in the Delta OSS master branch, blocking further development.

To unblock this, we propose skipping Spark 3.x builds for Delta Sharing in the Delta OSS master branch and only keeping Spark 4.x builds for Delta Sharing.

When Delta cuts a new 3.4 release branch (which will depend on Spark 3.x), we will use Delta Sharing version 1.2.4 and revert any incompatible commits as needed in Delta 3.4 branch.

## How was this patch tested?

CI pipeline

## Does this PR introduce _any_ user-facing changes?

No
