### PR TITLE
Revert "[Spark] Split Large Test Suites (#4957)", an attempt to fix the broken workflow

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -131,16 +131,11 @@ object SuiteGeneratorConfig {
       "MergeIntoTempViewsTests",
       "MergeIntoNestedDataTests",
       "MergeIntoUnlimitedMergeClausesTests",
-      "MergeIntoAnalysisExceptionTests",
-      "MergeIntoExtendedSyntaxTests",
       "MergeIntoSuiteBaseMiscTests",
       "MergeIntoNotMatchedBySourceSuite",
-      "MergeIntoNotMatchedBySourceWithCDCSuite",
       "MergeIntoSchemaEvolutionCoreTests",
       "MergeIntoSchemaEvolutionBaseTests",
-      "MergeIntoSchemaEvolutionStoreAssignmentPolicyTests",
       "MergeIntoSchemaEvolutionNotMatchedBySourceTests",
-      "MergeIntoNestedStructInMapEvolutionTests",
       "MergeIntoNestedStructEvolutionTests"
     )
     val MERGE_SQL = List(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
@@ -42,24 +42,12 @@ class MergeIntoUnlimitedMergeClausesTestsMergeIntoScalaSuite
   extends MergeIntoUnlimitedMergeClausesTests
   with MergeIntoScalaMixin
 
-class MergeIntoAnalysisExceptionTestsMergeIntoScalaSuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoScalaMixin
-
-class MergeIntoExtendedSyntaxTestsMergeIntoScalaSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoScalaMixin
-
 class MergeIntoSuiteBaseMiscTestsMergeIntoScalaSuite
   extends MergeIntoSuiteBaseMiscTests
   with MergeIntoScalaMixin
 
 class MergeIntoNotMatchedBySourceMergeIntoScalaSuite
   extends MergeIntoNotMatchedBySourceSuite
-  with MergeIntoScalaMixin
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoScalaSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
   with MergeIntoScalaMixin
 
 class MergeIntoSchemaEvolutionCoreTestsMergeIntoScalaSuite
@@ -70,16 +58,8 @@ class MergeIntoSchemaEvolutionBaseTestsMergeIntoScalaSuite
   extends MergeIntoSchemaEvolutionBaseTests
   with MergeIntoScalaMixin
 
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoScalaSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoScalaMixin
-
 class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoScalaSuite
   extends MergeIntoSchemaEvolutionNotMatchedBySourceTests
-  with MergeIntoScalaMixin
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoScalaSuite
-  extends MergeIntoNestedStructInMapEvolutionTests
   with MergeIntoScalaMixin
 
 class MergeIntoNestedStructEvolutionTestsMergeIntoScalaSuite
@@ -537,136 +517,6 @@ class MergeIntoUnlimitedMergeClausesTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedC
   with MergeCDCMixin
   with MergeCDCWithDVsMixin
 
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsNameBased
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMaOUEJP4QSuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableIdMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMaKF6BE5ISuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableNameMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPTSQDO3ISuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPMDDY5MISuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeCDCMixin
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMerLW4B7EYSuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoAnalysisExceptionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMerWY6KAEQSuite
-  extends MergeIntoAnalysisExceptionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsNameBased
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMappi6HIVMJQSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableIdMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumnMappiYEOF4FISuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableNameMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPredGI7G2IQSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDVsPredVYH2KWQSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeCDCMixin
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMergeIUM2FZ5ISuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoExtendedSyntaxTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMergeIRM5BF4QSuite
-  extends MergeIntoExtendedSyntaxTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
 class MergeIntoSuiteBaseMiscTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
   extends MergeIntoSuiteBaseMiscTests
   with MergeIntoSQLMixin
@@ -789,71 +639,6 @@ class MergeIntoNotMatchedBySourceMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnable
 
 class MergeIntoNotMatchedBySourceMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledMergeInFNSOPWQSuite
   extends MergeIntoNotMatchedBySourceSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsNameBased
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumCHJK75ASuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableIdMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltaColumZGORQEQSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableNameMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoD5GU4DXASuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedMergeIntoDFCCS47ISuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeCDCMixin
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledJSR4ACISuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoNotMatchedBySourceWithCDCMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledOXR24OASuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with CDCEnabled
@@ -992,71 +777,6 @@ class MergeIntoSchemaEvolutionBaseTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDC
   with MergeCDCMixin
   with MergeCDCWithDVsMixin
 
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsNameBased
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatEWFH7SYSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableIdMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatU6UMQEYSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableNameMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatXC5JFGYSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatBWA6HOQSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatV7A3XDISuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeCDCMixin
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatJAGZ2LASuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoSchemaEvolutionStoreAssignmentPolicyTestsMergeIntoSQLDeltaDMLTestUtilsPatNK6SWUYSuite
-  extends MergeIntoSchemaEvolutionStoreAssignmentPolicyTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
 class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
   extends MergeIntoSchemaEvolutionNotMatchedBySourceTests
   with MergeIntoSQLMixin
@@ -1114,71 +834,6 @@ class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoSQLDeltaDMLTestUti
 
 class MergeIntoSchemaEvolutionNotMatchedBySourceTestsMergeIntoSQLDeltaDMLTestUtilsPathBaYXEVIKQSuite
   extends MergeIntoSchemaEvolutionNotMatchedBySourceTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsNameBasedSuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsNameBased
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedSuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltJBCWZXISuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableIdMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedDeltJW3EETISuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with DeltaColumnMappingEnableNameMode
-  with MergeIntoSQLColumnMappingOverrides
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergSRCUATQSuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedMergKSC2XPASuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with MergeIntoDVsMixin
-  with PredicatePushdownEnabled
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeCDCMixin
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEKN3IGDASuite
-  extends MergeIntoNestedStructInMapEvolutionTests
-  with MergeIntoSQLMixin
-  with DeltaDMLTestUtilsPathBased
-  with CDCEnabled
-  with MergeIntoDVsMixin
-  with PredicatePushdownDisabled
-  with MergeCDCMixin
-  with MergeCDCWithDVsMixin
-
-class MergeIntoNestedStructInMapEvolutionTestsMergeIntoSQLDeltaDMLTestUtilsPathBasedCDCEDRQIUAISuite
-  extends MergeIntoNestedStructInMapEvolutionTests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with CDCEnabled


### PR DESCRIPTION
This reverts commit fda84ed4ec299a8d51875b03f810a006d8cd4097. Test starts consistent failing after the commit checked in

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
