### PR TITLE
[Spark] Add support for Row Tracking removal

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2243,17 +2243,13 @@
   },
   "DELTA_ROW_TRACKING_BACKFILL_RUNNING_CONCURRENTLY_WITH_UNBACKFILL" : {
     "message" : [
-      "A Row Tracking enablement operation was detected running concurrently with a Row Tracking disablement.",
-      "Aborting the disablement operation.",
-      "Please retry the disablement operation if necessary when the enablement operation is complete."
+      "A Row Tracking enablement operation was detected running concurrently with a Row Tracking disablement. Aborting the disablement operation. Please retry the disablement operation if necessary when the enablement operation is complete."
     ],
     "sqlState" : "22KD0"
   },
   "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION" : {
     "message" : [
-      "Illegal table state was detected.",
-      "Table properties `<property1>` and `<property2>` are both set to true.",
-      "The issue can be resolved by disabling any of the two table properties."
+      "Illegal table state was detected. Table properties `<property1>` and `<property2>` are both set to true. The issue can be resolved by disabling any of the two table properties."
     ],
     "sqlState" : "55000"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2253,7 +2253,7 @@
     "message" : [
       "Illegal table state was detected.",
       "Table properties `<property1>` and `<property2>` are both set to true.",
-      "The issue can be resolved by disabling any of the two table properties.",
+      "The issue can be resolved by disabling any of the two table properties."
     ],
     "sqlState" : "55000"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2241,6 +2241,22 @@
     ],
     "sqlState" : "22000"
   },
+  "DELTA_ROW_TRACKING_BACKFILL_RUNNING_CONCURRENTLY_WITH_UNBACKFILL" : {
+    "message" : [
+      "A Row Tracking enablement operation was detected running concurrently with a Row Tracking disablement.",
+      "Aborting the disablement operation.",
+      "Please retry the disablement operation if necessary when the enablement operation is complete."
+    ],
+    "sqlState" : "22KD0"
+  },
+  "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION" : {
+    "message" : [
+      "Illegal table state was detected.",
+      "Table properties `<property1>` and `<property2>` are both set to true.",
+      "The issue can be resolved by disabling any of the two table properties.",
+    ],
+    "sqlState" : "55000"
+  },
   "DELTA_SCHEMA_CHANGED" : {
     "message" : [
       "Detected schema change:",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -629,7 +629,11 @@ object RecordChecksum {
     DeltaOperations.ComputeStats(Seq.empty).name,
     // Backfill/Tagging re-adds existing AddFiles without changing the underlying data files.
     // Incremental commits should ignore backfill commits.
-    DeltaOperations.RowTrackingBackfill().name
+    DeltaOperations.RowTrackingBackfill().name,
+    // Same as Backfill.
+    DeltaOperations.RowTrackingUnBackfill().name,
+    // Dropping a feature may re-add existing AddFiles without changing the underlying data files.
+    DeltaOperations.OP_DROP_FEATURE
   )
 
   // Operations where we should ignore RemoveFiles in the incremental checksum computation.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.DeltaOperations.ROW_TRACKING_BACKFILL_OPERATION_NAME
+import org.apache.spark.sql.delta.DeltaOperations.{ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -103,6 +103,7 @@ private[delta] case class CurrentTransactionInfo(
 
   // Whether this is a row tracking backfill transaction or not.
   val isRowTrackingBackfillTxn = op.name == ROW_TRACKING_BACKFILL_OPERATION_NAME
+  val isRowTrackingUnBackfillTxn = op.name == ROW_TRACKING_UNBACKFILL_OPERATION_NAME
 
   def isConflict(winningTxn: SetTransaction): Boolean = readAppIds.contains(winningTxn.appId)
 }
@@ -122,6 +123,8 @@ private[delta] class WinningCommitSummary(val actions: Seq[Action], val commitVe
   // Whether this is a row tracking backfill transaction or not.
   val isRowTrackingBackfillTxn =
     commitInfo.exists(_.operation == ROW_TRACKING_BACKFILL_OPERATION_NAME)
+  val isRowTrackingUnBackfillTxn =
+    commitInfo.exists(_.operation == ROW_TRACKING_UNBACKFILL_OPERATION_NAME)
   val removedFiles: Seq[RemoveFile] = actions.collect { case a: RemoveFile => a }
   val addedFiles: Seq[AddFile] = actions.collect { case a: AddFile => a }
   // This is used in resolveRowTrackingBackfillConflicts.
@@ -183,6 +186,7 @@ private[delta] class ConflictChecker(
     checkForUpdatedApplicationTransactionIdsThatCurrentTxnDependsOn()
 
     resolveRowTrackingBackfillConflicts()
+    resolveRowTrackingUnBackfillConflicts()
     // Row Tracking reconciliation. We perform this before the file checks to ensure that
     // no files have duplicate row IDs and avoid interacting with files that don't comply with
     // the protocol.
@@ -252,16 +256,22 @@ private[delta] class ConflictChecker(
     val newProtocol = currentTransactionInfo.protocol
     val readProtocol = currentTransactionInfo.readSnapshot.protocol
     if (TableFeature.isProtocolRemovingFeatures(newProtocol, readProtocol)) {
-      val winningSnapshot = deltaLog.getSnapshotAt(
-        winningCommitSummary.commitVersion,
-        catalogTableOpt = currentTransactionInfo.catalogTable)
-      val isDowngradeCommitValid = TableFeature.validateFeatureRemovalAtSnapshot(
-        newProtocol = newProtocol,
-        oldProtocol = readProtocol,
-        snapshot = winningSnapshot)
-      if (!isDowngradeCommitValid) {
-        throw DeltaErrors.dropTableFeatureConflictRevalidationFailed(
-          winningCommitSummary.commitInfo)
+      // Feature specific conflict resolution logic.
+      if (TableFeature.isFeatureDropped(newProtocol, readProtocol, RowTrackingFeature)) {
+        currentTransactionInfo = resolveRowTrackingUnBackfillConflicts(
+          currentTransactionInfo, winningCommitSummary)
+      } else {
+        val winningSnapshot = deltaLog.getSnapshotAt(
+          winningCommitSummary.commitVersion,
+          catalogTableOpt = currentTransactionInfo.catalogTable)
+        val isDowngradeCommitValid = TableFeature.validateFeatureRemovalAtSnapshot(
+          newProtocol = newProtocol,
+          oldProtocol = readProtocol,
+          snapshot = winningSnapshot)
+        if (!isDowngradeCommitValid) {
+          throw DeltaErrors.dropTableFeatureConflictRevalidationFailed(
+            winningCommitSummary.commitInfo)
+        }
       }
       // When the current transaction is removing a feature and CheckpointProtectionTableFeature
       // is enabled, the current transaction will set the requireCheckpointProtectionBeforeVersion
@@ -378,6 +388,80 @@ private[delta] class ConflictChecker(
         currentTransactionInfo = currentTransactionInfo.copy(actions = newActions)
       }
     }
+  }
+
+  /**
+   * Row tracking unbackfill is an operation that removes row tracking metadata from the table.
+   * This is achieved by recommiting existing add files without base row ID and default
+   * row commit version. The operation is invoked as part of the cleanup process when dropping
+   * the row tracking feature from the table.
+   *
+   * In general, Delta writers should never generate baseRowIds while
+   * `delta.rowTrackingSuspended` is enabled. However, the delta protocol does not enforce
+   * the config and as a result third party writers may not respect it. The unbackfill conflict
+   * resolver unbackfills the addFiles of the winning commits to compensate for this.
+   */
+  private def resolveRowTrackingUnBackfillConflicts(): Unit = {
+    // If row tracking is not supported, there can be no unbackfill commit.
+    if (!RowTracking.isSupported(currentTransactionInfo.protocol)) {
+      assert(!currentTransactionInfo.isRowTrackingUnBackfillTxn)
+      assert(!winningCommitSummary.isRowTrackingUnBackfillTxn)
+      return
+    }
+
+    if (!currentTransactionInfo.isRowTrackingUnBackfillTxn) {
+      return
+    }
+    // Third party writers might not use the same operation name for backfill.
+    // In that case we will proceed to conflict resolution.
+    if (winningCommitSummary.isRowTrackingBackfillTxn) {
+      throw DeltaErrors.rowTrackingBackfillRunningConcurrentlyWithUnbackfill()
+    }
+
+    val timerPhaseName = "checked-row-tracking-unbackfill"
+    recordTime(timerPhaseName) {
+      currentTransactionInfo = resolveRowTrackingUnBackfillConflicts(
+        currentTransactionInfo,
+        winningCommitSummary)
+    }
+  }
+
+  /**
+   * Resolve conflicts by cleaning up addFiles of winning commits. Furthermore, make sure
+   * sure that removed files are not resurrected.
+   */
+  private def resolveRowTrackingUnBackfillConflicts(
+      currentTransactionInfo: CurrentTransactionInfo,
+      winningCommitSummary: WinningCommitSummary): CurrentTransactionInfo = {
+
+    // Unbackfill new AddFiles. This has the advantage that will cleanup commits
+    // from third party writers that do not respect `delta.rowTrackingSuspended`.
+    val (pathsToRemoveFromUnBackfill, filesToAddToUnBackfill) =
+      winningCommitSummary.actions.collect {
+        case a: AddFile =>
+          val fileToAdd = if (a.baseRowId.nonEmpty || a.defaultRowCommitVersion.nonEmpty) {
+            Some(a.copy(dataChange = false, baseRowId = None, defaultRowCommitVersion = None))
+          } else {
+            None
+          }
+          (a.path, fileToAdd)
+        case r: RemoveFile => (r.path, None)
+      }.unzip
+    val pathsToRemoveFromUnBackfillSet = pathsToRemoveFromUnBackfill.toSet
+    val filesToAddToUnBackfillSet = filesToAddToUnBackfill.flatten.toSet
+
+    val newActions = currentTransactionInfo.actions.filterNot {
+      case a: AddFile => pathsToRemoveFromUnBackfillSet.contains(a.path)
+      case _ => false
+    } ++ filesToAddToUnBackfillSet
+
+    // We can remove pruned files from the read list. However, we should not add
+    // the new AddFiles because that would cause a conflict, albeit, we already
+    // resolved it.
+    val newReadFiles = currentTransactionInfo.readFiles.filterNot(
+      a => pathsToRemoveFromUnBackfillSet.contains(a.path))
+
+    currentTransactionInfo.copy(actions = newActions, readFiles = newReadFiles)
   }
 
   /**
@@ -783,7 +867,10 @@ private[delta] class ConflictChecker(
    */
   private def reassignOverlappingRowIds(): Unit = {
     // The current transaction should only assign Row Ids if they are supported.
-    if (!RowId.isSupported(currentTransactionInfo.protocol)) return
+    val currentProtocol = currentTransactionInfo.protocol
+    val currentMetadata = currentTransactionInfo.metadata
+    if (!RowId.isSupported(currentProtocol)) return
+    if (RowTracking.isSuspended(spark, currentMetadata)) return
 
     val readHighWaterMark = currentTransactionInfo.readRowIdHighWatermark
 
@@ -825,9 +912,8 @@ private[delta] class ConflictChecker(
    *     to handle the row tracking feature being enabled by the winning transaction.
    */
   private def reassignRowCommitVersions(): Unit = {
-    if (!RowTracking.isSupported(currentTransactionInfo.protocol)) {
-      return
-    }
+    if (!RowId.isSupported(currentTransactionInfo.protocol)) return
+    if (RowTracking.isSuspended(spark, currentTransactionInfo.metadata)) return
 
     val newActions = currentTransactionInfo.actions.map {
       case a: AddFile if a.defaultRowCommitVersion.contains(winningCommitVersion) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
@@ -19,23 +19,35 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.util.ScalaExtensions._
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.FileSourceConstantMetadataStructField
 import org.apache.spark.sql.types
 import org.apache.spark.sql.types.{LongType, MetadataBuilder, StructField}
 
 object DefaultRowCommitVersion {
   def assignIfMissing(
+      spark: SparkSession,
       protocol: Protocol,
+      snapshot: Snapshot,
       actions: Iterator[Action],
       version: Long): Iterator[Action] = {
     if (!RowTracking.isSupported(protocol)) {
       return actions
     }
-    actions.map {
-      case a: AddFile if a.defaultRowCommitVersion.isEmpty =>
-        a.copy(defaultRowCommitVersion = Some(version))
-      case a =>
-        a
+    // Do not propagate defaultRowCommitVersions if generation is suspended.
+    if (RowTracking.isSuspended(spark, snapshot.metadata)) {
+      actions.map {
+        case a: AddFile if a.defaultRowCommitVersion.isDefined =>
+          a.copy(defaultRowCommitVersion = None)
+        case a => a
+      }
+    } else {
+      actions.map {
+        case a: AddFile if a.defaultRowCommitVersion.isEmpty =>
+          a.copy(defaultRowCommitVersion = Some(version))
+        case a =>
+          a
+      }
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -749,6 +749,22 @@ trait DeltaConfigsBase extends DeltaLogging {
     helpMessage = "needs to be a boolean.")
 
   /**
+   * Controls whether row tracking operations should be suspended. It blocks the assignment of new
+   * baseRowIds as well as copying existing baseRowIds. It is intended to be used when dropping
+   * row tracking. It can be enabled after setting `delta.enableRowTracking` to false.
+   *
+   * WARNING 1: Should never be enabled when `delta.enableRowTracking` is set to true.
+   * WARNING 2: It should never be manually set. It is only safe to be used in the context of
+   *            DROP FEATURE.
+   */
+  val ROW_TRACKING_SUSPENDED = buildConfig[Boolean](
+    key = "rowTrackingSuspended",
+    defaultValue = false.toString,
+    fromString = _.toBoolean,
+    validationFunction = _ => true,
+    helpMessage = "needs to be a boolean.")
+
+  /**
    * Convert the table's metadata into other storage formats after each Delta commit.
    * Only Iceberg is supported for now
    */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2749,6 +2749,19 @@ trait DeltaErrorsBase
         rowTrackingDefaultPropertyKey))
   }
 
+  def rowTrackingBackfillRunningConcurrentlyWithUnbackfill(): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_ROW_TRACKING_BACKFILL_RUNNING_CONCURRENTLY_WITH_UNBACKFILL")
+  }
+
+  def rowTrackingIllegalPropertyCombination(): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION",
+      messageParameters = Array(
+        DeltaConfigs.ROW_TRACKING_ENABLED.key,
+        DeltaConfigs.ROW_TRACKING_SUSPENDED.key))
+  }
+
   /** This is a method only used for testing Py4J exception handling. */
   def throwDeltaIllegalArgumentException(): Throwable = {
     new DeltaIllegalArgumentException(errorClass = "DELTA_UNRECOGNIZED_INVARIANT")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1727,9 +1727,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
         deltaLog.protocolWrite(snapshot.protocol)
       }
 
-      allActions = RowId.assignFreshRowIds(protocol, snapshot, allActions, op)
-      allActions = DefaultRowCommitVersion
-        .assignIfMissing(protocol, allActions, getFirstAttemptVersion)
+      allActions = RowId.assignFreshRowIds(spark, protocol, snapshot, allActions, op)
+      allActions = DefaultRowCommitVersion.assignIfMissing(
+        spark, protocol, snapshot, allActions, getFirstAttemptVersion)
 
       val commitStatsComputer = new CommitStatsComputer()
       allActions = commitStatsComputer.addToCommitStats(allActions)
@@ -2117,9 +2117,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
       deltaLog.protocolWrite(snapshot.protocol)
     }
 
-    finalActions = RowId.assignFreshRowIds(protocol, snapshot, finalActions.toIterator, op).toList
-    finalActions = DefaultRowCommitVersion
-      .assignIfMissing(protocol, finalActions.toIterator, getFirstAttemptVersion).toList
+    finalActions = RowId.assignFreshRowIds(
+      spark, protocol, snapshot, finalActions.toIterator, op).toList
+    finalActions = DefaultRowCommitVersion.assignIfMissing(
+      spark, protocol, snapshot, finalActions.toIterator, getFirstAttemptVersion).toList
 
     // We make sure that this isn't an appendOnly table as we check if we need to delete
     // files.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -18,9 +18,11 @@ package org.apache.spark.sql.delta
 
 import java.util.Locale
 
+import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.commands.backfill.RowTrackingBackfillCommand
 import org.apache.spark.sql.delta.constraints.{Constraints, Invariants}
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
 import org.apache.spark.sql.delta.redirect.{RedirectReaderWriter, RedirectWriterOnly}
@@ -31,6 +33,7 @@ import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.FileNames
 
 import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.TimestampNTZType
 
 /* --------------------------------------- *
@@ -198,12 +201,20 @@ sealed trait FeatureAutomaticallyEnabledByMetadata { this: TableFeature =>
  *    unnecessary failure during the history validation of the next DROP FEATURE call. Note,
  *    while the feature-to-remove is supported in the protocol we cannot generate a legit protocol
  *    action that adds support for that feature since it is already supported.
+ *
+ *    Furthermore, methods `tablePropertiesToRemoveAtDowngradeCommit` and
+ *    `actionsToIncludeAtDowngradeCommit` can be optionally implemented. They can be used for
+ *    defining properties/actions that need to be removed/included at the protocol downgrade
+ *    commit.
  */
 sealed trait RemovableFeature { self: TableFeature =>
   def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand
   def validateRemoval(snapshot: Snapshot): Boolean
   def requiresHistoryProtection: Boolean = isReaderWriterFeature
   def actionUsesFeature(action: Action): Boolean
+  def tablePropertiesToRemoveAtDowngradeCommit: Seq[String] = Seq.empty
+  def actionsToIncludeAtDowngradeCommit(snapshot: Snapshot): Seq[Action] = Seq.empty
+
 
   /**
    * Examines all historical commits for traces of the removableFeature.
@@ -435,14 +446,22 @@ object TableFeature {
   protected def getDroppedFeatures(
       newProtocol: Protocol,
       oldProtocol: Protocol): Set[TableFeature] = {
-    val newFeatureNames = newProtocol.implicitlyAndExplicitlySupportedFeatures
-    val oldFeatureNames = oldProtocol.implicitlyAndExplicitlySupportedFeatures
-    oldFeatureNames -- newFeatureNames
+    val newFeatures = newProtocol.implicitlyAndExplicitlySupportedFeatures
+    val oldFeatures = oldProtocol.implicitlyAndExplicitlySupportedFeatures
+    oldFeatures -- newFeatures
   }
 
   /** Identifies whether there was any feature removal between two protocols. */
   def isProtocolRemovingFeatures(newProtocol: Protocol, oldProtocol: Protocol): Boolean = {
     getDroppedFeatures(newProtocol = newProtocol, oldProtocol = oldProtocol).nonEmpty
+  }
+
+  /** Returns true when `newProtocol` drops `feature`. */
+  def isFeatureDropped(
+      newProtocol: Protocol,
+      oldProtocol: Protocol,
+      feature: TableFeature): Boolean = {
+    getDroppedFeatures(newProtocol = newProtocol, oldProtocol = oldProtocol).contains(feature)
   }
 
   /**
@@ -773,6 +792,7 @@ object DeletionVectorsTableFeature
 }
 
 object RowTrackingFeature extends WriterFeature(name = "rowTracking")
+  with RemovableFeature
   with FeatureAutomaticallyEnabledByMetadata {
   override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
 
@@ -783,6 +803,104 @@ object RowTrackingFeature extends WriterFeature(name = "rowTracking")
     DeltaConfigs.ROW_TRACKING_ENABLED.fromMetaData(metadata)
 
   override def requiredFeatures: Set[TableFeature] = Set(DomainMetadataTableFeature)
+
+  /**
+   * When dropping row tracking we remove all relevant properties at downgrade commit.
+   * This is because concurrent transactions may still use them while the feature exists in the
+   * protocol.
+   */
+  override def tablePropertiesToRemoveAtDowngradeCommit: Seq[String] = {
+    Seq(
+      DeltaConfigs.ROW_TRACKING_ENABLED.key,
+      DeltaConfigs.ROW_TRACKING_SUSPENDED.key,
+      MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP,
+      MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP)
+  }
+
+  /** Remove rowTracking domain metadata at downgrade commit. */
+  override def actionsToIncludeAtDowngradeCommit(snapshot: Snapshot): Seq[Action] = {
+    val domainOpt = RowTrackingMetadataDomain.fromSnapshot(snapshot)
+    Seq.empty ++ domainOpt.map(_.toDomainMetadata.copy(removed = true))
+  }
+
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand = {
+    RowTrackingPreDowngradeCommand(table)
+  }
+
+  private[delta] def validateConfigurations(configurations: Map[String, String]): Unit = {
+    val enabled = configurations.getOrElse(
+      DeltaConfigs.ROW_TRACKING_ENABLED.key, "false").toBoolean
+    val suspended = configurations.getOrElse(
+      DeltaConfigs.ROW_TRACKING_SUSPENDED.key, "false").toBoolean
+
+    if (enabled && suspended) {
+      throw DeltaErrors.rowTrackingIllegalPropertyCombination()
+    }
+  }
+
+  private[delta] def validateAndBackfill(
+      spark: SparkSession,
+      table: DeltaTableV2,
+      newConfiguration: Map[String, String]): Unit = {
+
+    // If there is no relevant configuration change, we do not need to do anything.
+    if (!newConfiguration.contains(DeltaConfigs.ROW_TRACKING_ENABLED.key) &&
+        !newConfiguration.contains(DeltaConfigs.ROW_TRACKING_SUSPENDED.key)) {
+      return
+    }
+
+    val snapshot = table.deltaLog.update(catalogTableOpt = table.catalogTable)
+
+    // For overlapping configs, we keep the values of new configuration.
+    validateConfigurations(snapshot.metadata.configuration ++ newConfiguration)
+
+    val justEnabled = newConfiguration.getOrElse(
+      DeltaConfigs.ROW_TRACKING_ENABLED.key, "false").toBoolean
+
+    // If we're enabling row tracking on an existing table, we need to complete a backfill process
+    // prior to updating the table metadata.
+    if (justEnabled) {
+      RowTrackingBackfillCommand(
+        table.deltaLog,
+        nameOfTriggeringOperation = DeltaOperations.OP_SET_TBLPROPERTIES,
+        table.catalogTable).run(spark)
+    }
+  }
+
+  /**
+   * Returns true if no relevant row tracking metadata exist on the table. This excludes
+   * properties/domain metadata that are only removed at the downgrade commit.
+   *
+   * Returns false otherwise.
+   */
+  override def validateRemoval(snapshot: Snapshot): Boolean = {
+    val rowTrackingEnabled = DeltaConfigs.ROW_TRACKING_ENABLED.fromMetaData(snapshot.metadata)
+    val rowTrackingSuspended =
+      DeltaConfigs.ROW_TRACKING_SUSPENDED.fromMetaData(snapshot.metadata)
+
+    if (rowTrackingEnabled || !rowTrackingSuspended) return false
+
+    // In most cases, we should only reach this expensive check only at the protocol downgrade
+    // commit validation.
+    snapshot
+      .allFiles
+      .filter(col("baseRowId").isNotNull || col("defaultRowCommitVersion").isNotNull)
+      .isEmpty
+  }
+
+  /**
+   * Even though Row tracking is a writer-only feature it could benefit from history protection.
+   * Without history protection, oblivious writers could replace past checkpoints that contain
+   * Row Tracking metadata. That could break time travel, i.e. row tracking might appear enabled
+   * in a past version but metadata might be missing.
+   *
+   * On the other hand, history protection dictates the addition of the checkpointProtection
+   * feature when dropping row tracking. For this reason, we choose not to protect history. There
+   * should be no (or very limited) uses cases where row tracking is expected to work for past
+   * versions.
+   */
+  override def requiresHistoryProtection: Boolean = false
+  override def actionUsesFeature(action: Action): Boolean = false
 }
 
 object DomainMetadataTableFeature extends WriterFeature(name = "domainMetadata")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -602,4 +602,18 @@ object DropTableFeatureUtils extends DeltaLogging {
 
     DeltaConfigs.getMilliSeconds(truncateHistoryLogRetention)
   }
+
+  /**
+   * Returns new metadata without `tablePropertiesToRemoveAtDowngradeCommit` table properties.
+   */
+  def getDowngradedProtocolMetadata(
+      feature: RemovableFeature,
+      metadata: Metadata): Metadata = {
+    val propKeys = feature.tablePropertiesToRemoveAtDowngradeCommit
+    val normalizedKeys = DeltaConfigs.normalizeConfigKeys(propKeys)
+    val newConfiguration = metadata.configuration.filterNot {
+      case (key, _) => normalizedKeys.contains(key)
+    }
+    metadata.copy(configuration = newConfiguration)
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillBatch.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillBatch.scala
@@ -25,18 +25,23 @@ import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 
 import org.apache.spark.internal.MDC
+import org.apache.spark.sql.SparkSession
 
 trait BackfillBatch extends DeltaLogging {
   /** The files in this batch. */
   def filesInBatch: Seq[AddFile]
   def backfillBatchStatsOpType: String
 
-  protected def prepareFilesAndCommit(txn: OptimisticTransaction, batchId: Int): Unit
+  protected def prepareFilesAndCommit(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      batchId: Int): Unit
 
   /**
    * The main method of this trait. This method commits the backfill batch, records metrics and
    * updates the two atomic counters passed in.
    *
+   * @param spark The Spark session.
    * @param backfillTxnId the transaction id associated with the parent command.
    * @param batchId an integer identifier of the batch within a parent [[BackfillCommand]].
    * @param txn transaction used to construct the current batch.
@@ -46,6 +51,7 @@ trait BackfillBatch extends DeltaLogging {
    *                       batches that failed.
    */
   def execute(
+      spark: SparkSession,
       backfillTxnId: String,
       batchId: Int,
       txn: OptimisticTransaction,
@@ -73,7 +79,7 @@ trait BackfillBatch extends DeltaLogging {
       log"${MDC(DeltaLogKeys.NUM_FILES, filesInBatch.size.toLong)} candidate files")
     val txnId = txn.txnId
     try {
-      prepareFilesAndCommit(txn, batchId)
+      prepareFilesAndCommit(spark, txn, batchId)
       recordBackfillBatchStats(txnId, wasSuccessful = true)
     } catch {
       case t: Throwable =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutor.scala
@@ -62,7 +62,7 @@ trait BackfillExecutor extends DeltaLogging {
           val txn = deltaLog.startTransaction(catalogTableOpt, Some(snapshot))
           txn.trackFilesRead(filesInBatch)
           recordDeltaOperation(deltaLog, backFillBatchOpType) {
-            batch.execute(backfillTxnId, batchId, txn, numSuccessfulBatch, numFailedBatch)
+            batch.execute(spark, backfillTxnId, batchId, txn, numSuccessfulBatch, numFailedBatch)
           }
         }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBatch.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBatch.scala
@@ -16,8 +16,12 @@
 
 package org.apache.spark.sql.delta.commands.backfill
 
-import org.apache.spark.sql.delta.{DeltaOperations, OptimisticTransaction}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaOperations, OptimisticTransaction, RowTrackingFeature}
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
+
+import org.apache.spark.sql.SparkSession
 
 case class RowTrackingBackfillBatch(filesInBatch: Seq[AddFile]) extends BackfillBatch {
 
@@ -25,8 +29,23 @@ case class RowTrackingBackfillBatch(filesInBatch: Seq[AddFile]) extends Backfill
 
   /** Mark all files as dataChange = false and commit. */
   override protected def prepareFilesAndCommit(
+      spark: SparkSession,
       txn: OptimisticTransaction,
       batchId: Int): Unit = {
+    val protocol = txn.snapshot.protocol
+    val metadata = txn.snapshot.metadata
+    val isRowTrackingSupported = protocol.isFeatureSupported(RowTrackingFeature)
+    val ignoreProperty = DeltaSQLConf.DELTA_ROW_TRACKING_IGNORE_SUSPENSION.key
+    val ignoreSuspension = DeltaUtils.isTesting && spark.conf.get(ignoreProperty).toBoolean
+    val suspendRowTracking =
+      DeltaConfigs.ROW_TRACKING_SUSPENDED.fromMetaData(metadata) && !ignoreSuspension
+    if (!isRowTrackingSupported || suspendRowTracking) {
+      throw new IllegalStateException(
+        """
+          |Cannot run backfill command if row tracking is not supported or
+          |row ID generation is suspended.""".stripMargin)
+    }
+
     val filesToCommit = filesInBatch.map(_.copy(dataChange = false))
     // Base Row IDs are added as part of the OptimisticTransaction.prepareCommit(), so we don't
     // need to do anything here other than recommit the files.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.commands.backfill
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddFile, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingUnBackfillBatch.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingUnBackfillBatch.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaOperations, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.AddFile
+
+import org.apache.spark.sql.SparkSession
+
+case class RowTrackingUnBackfillBatch(filesInBatch: Seq[AddFile]) extends BackfillBatch {
+  override val backfillBatchStatsOpType = "delta.rowTracking.unbackfill.batch.stats"
+
+  /** Remove relevant metadata from addFiles. */
+  override protected def prepareFilesAndCommit(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      batchId: Int): Unit = {
+    val metadata = txn.snapshot.metadata
+    val isEnabled = DeltaConfigs.ROW_TRACKING_ENABLED.fromMetaData(metadata)
+    val suspendIdGeneration = DeltaConfigs.ROW_TRACKING_SUSPENDED.fromMetaData(metadata)
+    if (isEnabled || !suspendIdGeneration) {
+      throw new IllegalStateException(
+        "Cannot run unbackfill when row tracking is enabled or not suspended.")
+    }
+
+    val filesToCommit = filesInBatch.map(_.copy(
+      baseRowId = None,
+      defaultRowCommitVersion = None,
+      dataChange = false))
+    txn.commit(filesToCommit, DeltaOperations.RowTrackingUnBackfill(batchId))
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingUnBackfillCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingUnBackfillCommand.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.{AddFile, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * This command cleans up tracking metadata from a delta table. In particular, it removes
+ * `baseRowId` and `defaultRowCommitVersion`. This is achieved by re-commiting addFiles with
+ * `dataChance = false`. This requires to commit the AddFiles of the entire table.
+ *
+ * Similarly to all backfilling operations, the relevant files are commited in multiple batches.
+ * Each batch contains [[DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT]]. This is to avoid
+ * generating large commits in big tables.
+ */
+case class RowTrackingUnBackfillCommand(
+    override val deltaLog: DeltaLog,
+    override val nameOfTriggeringOperation: String,
+    override val catalogTableOpt: Option[CatalogTable])
+  extends BackfillCommand {
+
+  override def getBackfillExecutor(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      catalogTableOpt: Option[CatalogTable],
+      backfillId: String,
+      backfillStats: BackfillCommandStats): BackfillExecutor = {
+    new RowTrackingUnBackfillExecutor(spark, deltaLog, catalogTableOpt, backfillId, backfillStats)
+  }
+
+  override def opType: String = "delta.rowTracking.unbackfill"
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingUnBackfillExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingUnBackfillExecutor.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+class RowTrackingUnBackfillExecutor(
+    override val spark: SparkSession,
+    override val deltaLog: DeltaLog,
+    override val catalogTableOpt: Option[CatalogTable],
+    override val backfillTxnId: String,
+    override val backfillStats: BackfillCommandStats) extends BackfillExecutor {
+  override val backFillBatchOpType = "delta.rowTracking.unbackfill.batch"
+
+  override def filesToBackfill(snapshot: Snapshot): Dataset[AddFile] = {
+    RowTrackingUnBackfillExecutor.getCandidateFilesToUnBackfill(snapshot)
+  }
+
+  override def constructBatch(files: Seq[AddFile]): BackfillBatch =
+    RowTrackingUnBackfillBatch(files)
+}
+
+private[delta] object RowTrackingUnBackfillExecutor extends DeltaLogging {
+  /** Returns the dataset with the list of candidate files to unbackfill. */
+  def getCandidateFilesToUnBackfill(
+      snapshot: Snapshot): Dataset[AddFile] = {
+    // Note: We can't use txn.filterFiles() because it drops the file statistics.
+    snapshot
+      .allFiles
+      .filter(a => a.baseRowId.nonEmpty || a.defaultRowCommitVersion.nonEmpty)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1079,6 +1079,15 @@ trait DeltaSQLConfBase {
         "delta log entry below 100mb.")
       .fallbackConf(DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_FILES_PER_COMMIT)
 
+  val DELTA_ROW_TRACKING_IGNORE_SUSPENSION =
+    buildConf("rowTracking.ignoreSuspension")
+      .internal()
+      .doc(
+        """Controls whether to ignore `delta.rowTrackingSuspended` property.
+          |This is a testing only config.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   ////////////////////////////////////
   // Checkpoint V2 Specific Configs
   ////////////////////////////////////

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingRemovalSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingRemovalSuite.scala
@@ -1,0 +1,311 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowid
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalStateException, DeltaLog, DeltaOperations, MaterializedRowCommitVersion, MaterializedRowId, RowId, RowTrackingFeature}
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.AlterTableSetPropertiesDeltaCommand
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.tables.DeltaTable
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.functions.{expr, lit}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ManualClock
+
+trait RowTrackingRemovalSuiteBase
+    extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest {
+
+  protected override def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey, "true")
+
+  def validateRowTrackingState(deltaLog: DeltaLog, isPresent: Boolean): Unit = {
+    val snapshot = deltaLog.update()
+    val configuration = snapshot.metadata.configuration
+    val allFiles = snapshot.allFiles.collect()
+
+    assert(RowId.isSupported(snapshot.protocol) === isPresent)
+    assert(!configuration.contains(DeltaConfigs.ROW_TRACKING_SUSPENDED.key))
+
+    if (isPresent) {
+      assert(DeltaConfigs.ROW_TRACKING_ENABLED.fromMetaData(snapshot.metadata))
+      assert(configuration.contains(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP))
+      assert(configuration.contains(MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP))
+      assert(RowTrackingMetadataDomain
+        .fromSnapshot(snapshot)
+        .forall(_.rowIdHighWaterMark > RowId.MISSING_HIGH_WATER_MARK))
+      assert(allFiles.forall(a => a.baseRowId.isDefined && a.defaultRowCommitVersion.isDefined))
+    } else {
+      assert(!configuration.contains(DeltaConfigs.ROW_TRACKING_ENABLED.key))
+      assert(!configuration.contains(DeltaConfigs.ROW_TRACKING_SUSPENDED.key))
+      assert(!configuration.contains(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP))
+      assert(!configuration.contains(MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP))
+      assert(RowTrackingMetadataDomain.fromSnapshot(snapshot).isEmpty)
+      assert(allFiles.forall(a => a.baseRowId.isEmpty && a.defaultRowCommitVersion.isEmpty))
+    }
+  }
+
+  def dropRowTracking(deltaLog: DeltaLog, truncateHistory: Boolean = false): Unit = {
+    val sqlText =
+      s"""
+         |ALTER TABLE delta.`${deltaLog.dataPath}`
+         |DROP FEATURE ${RowTrackingFeature.name}
+         |${if (truncateHistory) "TRUNCATE HISTORY" else ""}
+         |""".stripMargin
+
+    sql(sqlText)
+  }
+
+  def addData(path: String, start: Long, end: Long): Unit = {
+    spark.range(start, end, step = 1, numPartitions = 2)
+      .write
+      .format("delta")
+      .mode("append")
+      .save(path)
+  }
+}
+
+class RowTrackingRemovalSuite extends RowTrackingRemovalSuiteBase {
+
+  test("Basic row tracking removal") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath)
+
+      addData(dir.getAbsolutePath, 0, 10)
+      assert(RowId.isSupported(deltaLog.update().protocol))
+
+      dropRowTracking(deltaLog)
+      validateRowTrackingState(deltaLog, isPresent = false)
+    }
+  }
+
+  test("Remove row tracking and then re-enable it") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath)
+
+      addData(dir.getAbsolutePath, 0, 10)
+      addData(dir.getAbsolutePath, 10, 20)
+
+      val table = DeltaTable.forPath(spark, dir.getAbsolutePath)
+      table.update(expr("id == 2"), Map("id" -> lit(200)))
+
+      // Store the old materialized column names.
+      val configuration = deltaLog.update().metadata.configuration
+      val oldMaterializedRowIdName = configuration(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)
+      val oldMaterializedRowCommitVersionName =
+        configuration(MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP)
+
+      dropRowTracking(deltaLog)
+      addData(dir.getAbsolutePath, 20, 30)
+      validateRowTrackingState(deltaLog, isPresent = false)
+
+      // Re-enable row tracking.
+      sql(
+        s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
+           |SET TBLPROPERTIES(
+           |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'
+           |)""".stripMargin)
+
+      addData(dir.getAbsolutePath, 30, 40)
+
+      validateRowTrackingState(deltaLog, isPresent = true)
+
+      // Make sure the materialized column names are different.
+      val newConfiguration = deltaLog.update().metadata.configuration
+      val newMaterializedRowIdName =
+        newConfiguration(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)
+      val newMaterializedRowCommitVersionName =
+        newConfiguration(MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP)
+      assert(newMaterializedRowIdName != oldMaterializedRowIdName)
+      assert(newMaterializedRowCommitVersionName != oldMaterializedRowCommitVersionName)
+    }
+  }
+
+  // This test verifies we can recover a drop feature failure. this is for the scenario
+  // the user decides to re-enable row tracking instead of retrying drop feature.
+  test("Row tracking can recover from suspension") {
+    import org.apache.spark.sql.delta.implicits._
+
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath)
+
+      def getMaterializedRowId(df: DataFrame, id: Long): Long = {
+         df
+          .filter(s"id == $id")
+          .select(RowId.QUALIFIED_COLUMN_NAME)
+          .as[Long]
+          .collect()
+          .head
+      }
+
+      def getHighWatermark(): Long = {
+        RowId.extractHighWatermark(deltaLog.update()).getOrElse {
+          throw new IllegalStateException("High watermark is missing")
+        }
+      }
+
+      addData(dir.getAbsolutePath, 0, 10)
+
+      val table = DeltaTable.forPath(spark, dir.getAbsolutePath)
+
+      // These operations should materialize row IDs.
+      table.update(expr("id == 2"), Map("id" -> lit(200)))
+      table.delete("id == 4")
+
+      val watermarkPreDisablement = getHighWatermark()
+      val materializedRowIdPreDisablement = getMaterializedRowId(table.toDF, 200)
+
+      AlterTableSetPropertiesDeltaCommand(
+        table = DeltaTableV2(spark, deltaLog.dataPath),
+        configuration = Map(
+          DeltaConfigs.ROW_TRACKING_ENABLED.key -> "false",
+          DeltaConfigs.ROW_TRACKING_SUSPENDED.key -> "true"))
+        .run(spark)
+
+      // Should not generate row IDs.
+      addData(dir.getAbsolutePath, 10, 15)
+      table.update(expr("id == 200"), Map("id" -> lit(300)))
+      assert(getHighWatermark() === watermarkPreDisablement)
+
+      // Lift row identity generation suspension.
+      AlterTableSetPropertiesDeltaCommand(
+        table = DeltaTableV2(spark, deltaLog.dataPath),
+        configuration = Map(DeltaConfigs.ROW_TRACKING_SUSPENDED.key -> "false"))
+        .run(spark)
+
+      // Backfill.
+      AlterTableSetPropertiesDeltaCommand(
+        table = DeltaTableV2(spark, deltaLog.dataPath),
+        configuration = Map(DeltaConfigs.ROW_TRACKING_ENABLED.key -> "true"))
+        .run(spark)
+
+      // Row tracking continued from previous high watermark.
+      assert(getHighWatermark() > watermarkPreDisablement)
+
+      // Row tracking does not guarantee the materialized row ID will be the same after
+      // re-enablement.
+      assert(getMaterializedRowId(table.toDF, 300) != materializedRowIdPreDisablement)
+
+      // All add files should have row IDs.
+      assert(deltaLog.update().allFiles.where("baseRowId IS NULL").count() === 0)
+    }
+  }
+
+  for (dvsEnabled <- BOOLEAN_DOMAIN)
+  test(s"Property `delta.rowTrackingSuspended` is respected - dvsEnabled: $dvsEnabled") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      addData(dir.getAbsolutePath, 0, 10)
+
+      sql(
+        s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
+           |SET TBLPROPERTIES(
+           |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'false',
+           |${DeltaConfigs.ROW_TRACKING_SUSPENDED.key} = 'true',
+           |${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key} = '$dvsEnabled'
+           |)""".stripMargin)
+
+      val filesWithRowIds = deltaLog.update().allFiles.collect().toSet
+
+      addData(dir.getAbsolutePath, 10, 15)
+
+      val targetTable = DeltaTable.forPath(dir.getAbsolutePath)
+      targetTable.update(expr("id IN (2, 12)"), Map("id" -> lit(200)))
+      targetTable.delete("id == 3")
+
+      val allFiles = deltaLog.update()
+        .allFiles
+        .collect()
+        .filterNot(filesWithRowIds.contains)
+
+      assert(allFiles.forall(a => a.baseRowId.isEmpty && a.defaultRowCommitVersion.isEmpty))
+    }
+  }
+
+  test(s"Cannot enable both configurations at the same time") {
+    withTempDir { dir =>
+      addData(dir.getAbsolutePath, 0, 10)
+
+      sql(
+        s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
+           |SET TBLPROPERTIES(
+           |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'
+           |)""".stripMargin)
+
+      assertThrows[IllegalStateException] {
+        sql(
+          s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
+             |SET TBLPROPERTIES(
+             |${DeltaConfigs.ROW_TRACKING_SUSPENDED.key} = 'true'
+             |)""".stripMargin)
+      }
+
+      sql(
+        s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
+           |SET TBLPROPERTIES(
+           |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'false',
+           |${DeltaConfigs.ROW_TRACKING_SUSPENDED.key} = 'true'
+           |)""".stripMargin)
+
+
+      assertThrows[IllegalStateException] {
+        sql(
+          s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
+             |SET TBLPROPERTIES(
+             |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'
+             |)""".stripMargin)
+      }
+    }
+  }
+
+  test("Third party writer enables row tracking without disabling suspension property") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath)
+
+      addData(dir.getAbsolutePath, 0, 10)
+
+      // Third party writer messes up the configs.
+      val txn = deltaLog.startTransaction(catalogTableOpt = None)
+      val newConfiguration = txn.metadata.configuration ++ Map(
+        DeltaConfigs.ROW_TRACKING_ENABLED.key -> "true",
+        DeltaConfigs.ROW_TRACKING_SUSPENDED.key -> "true"
+      )
+      txn.updateMetadata(txn.metadata.copy(configuration = newConfiguration))
+      txn.commit(Seq.empty, DeltaOperations.ManualUpdate)
+
+
+      val e = intercept[DeltaIllegalStateException] {
+        addData(dir.getAbsolutePath, 10, 20)
+      }
+      checkError(
+        e,
+        "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION",
+        parameters = Map(
+          "property1" -> DeltaConfigs.ROW_TRACKING_ENABLED.key,
+          "property2" -> DeltaConfigs.ROW_TRACKING_SUSPENDED.key))
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds support for row tracking removal. The main complexity is that row tracking cannot be disabled. The feature property, `delta.enableRowTracking`, only controls whether clients should expect all rows to contain row IDs. This means that concurrent transactions may continue generating row IDs while we clean up metadata.

Furthermore, the feature can be dropped and then re-enabled multiple times. Once the feature is dropped, there are no guarantees writers will preserve past metadata (either by copying action metadata or preserving them in the checkpoints). Therefore, we need to ensure that re-enablement is safe and it does not mix up (potentially incomplete) metadata from past enablements.

This can be aided with the introduction of an optional new configuration, `delta.suspendRowTracking`, that allows to suspend any row ID generation. This should help reduce the concurrent conflicting transactions. However, we cannot rely on this being respected by all clients. Thus, we need to design a solution that tolerates concurrent transactions.

We drop Row Tracking as follows:

a) Flip `delta.enableRowTracking` property. Readers/writers do not long expect all rows to be assigned with an ID.
b) Flip `delta.suspendRowTracking` property.
c) Unbackfill. This should only remove baseRowId and defaultRowCommitVersion from all actions. Note, in the meantime concurrent transactions can still produce row IDs. These should continue from the latest high watermark.
d) In a single commit, downgrade the protocol and remove all relevant properties (High watermark, materialized column names). Removing the materialized column names results in ignoring the columns in any future re-enablement of the feature.
e) Resolve any conflicting transactions by cleaning relevant metadata from add/remove actions. The conflict resolution should take place in both unbackfill commits as well as the drop feature commit.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added new suite.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Now users can drop row tracking.