### PR TITLE
[Delta] Migrate `DescribeDeltaDetailSuite` to `CatalogOwned`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -21,7 +21,7 @@ import java.io.FileNotFoundException
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsTestUtils
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
@@ -34,7 +34,7 @@ import org.apache.spark.util.Utils
 
 trait DescribeDeltaDetailSuiteBase extends QueryTest
   with SharedSparkSession
-  with CoordinatedCommitsTestUtils
+  with CatalogOwnedTestBaseSuite
   with DeltaTestUtilsForTempViews {
 
   import testImplicits._
@@ -213,8 +213,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     }
   }
 
-  testWithDifferentBackfillIntervalOptional(
-      "delta table: describe detail always run on the latest snapshot") { batchSizeOpt =>
+  test("delta table: describe detail always run on the latest snapshot") {
     val tableName = "tbl_name_on_latest_snapshot"
     withTable(tableName) {
         val tempDir = Utils.createTempDir().toString
@@ -232,17 +231,20 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
           metadata.configuration ++ Map("foo" -> "bar")
         )
         txn.commit(newMetadata :: Nil, DeltaOperations.ManualUpdate)
-        val coordinatedCommitsProperties = batchSizeOpt.map(_ =>
-          getCoordinatedCommitsDefaultProperties(withICT = true))
-          .getOrElse(Map.empty)
+        val catalogOwnedProperties = constructCatalogOwnedSpecificTableProperties(
+          spark, newMetadata)
         checkResult(sql(s"DESCRIBE DETAIL $tableName"),
-          Seq(Map("foo" -> "bar") ++ coordinatedCommitsProperties),
+          Seq(Map("foo" -> "bar") ++ catalogOwnedProperties),
           Seq("properties")
         )
       }
   }
 
   test("delta table: describe detail shows table features") {
+    if (catalogOwnedDefaultCreationEnabledInTests) {
+      cancel("CatalogOwned is not compatible w/ the test since protocol version would be " +
+        "set to (3, 7) by default for CC tables.")
+    }
     withTable("t1") {
       withSQLConf(
         DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION.key -> "1",
@@ -358,3 +360,15 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
 
 class DescribeDeltaDetailSuite
   extends DescribeDeltaDetailSuiteBase with DeltaSQLCommandTest
+
+class DescribeDeltaDetailWithCatalogOwnedBatch1Suite extends DescribeDeltaDetailSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class DescribeDeltaDetailWithCatalogOwnedBatch2Suite extends DescribeDeltaDetailSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class DescribeDeltaDetailWithCatalogOwnedBatch100Suite extends DescribeDeltaDetailSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -286,19 +286,6 @@ trait CoordinatedCommitsTestUtils
   protected val defaultCommitsCoordinatorName = "tracking-in-memory"
   protected val defaultCommitsCoordinatorConf = Map("randomConf" -> "randomConfValue")
 
-  def getCoordinatedCommitsDefaultProperties(withICT: Boolean = false): Map[String, String] = {
-    val coordinatedCommitsConfJson = JsonUtils.toJson(defaultCommitsCoordinatorConf)
-    val properties = Map(
-      DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.key -> defaultCommitsCoordinatorName,
-      DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_CONF.key -> coordinatedCommitsConfJson,
-      DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF.key -> "{}")
-    if (withICT) {
-      properties + (DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")
-    } else {
-      properties
-    }
-  }
-
   override def testWithDefaultCommitCoordinatorUnset(testName: String)(f: => Unit): Unit = {
     test(testName) {
       withoutDefaultCCTableFeature {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR migrates `DescribeDeltaDetailSuite` to `CatalogOwned`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
