### PR TITLE
[Spark] Run UpdateSQLSuite with both path-based and name-based access

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -228,15 +228,21 @@ object SuiteGeneratorConfig {
           )
         ),
         TestConfig(
+          "UpdateSQLTests" :: Tests.UPDATE_BASE,
+          List(
+            List(Dims.UPDATE_SQL, Dims.NAME_BASED),
+          )
+        ),
+        TestConfig(
           "UpdateCDCWithDeletionVectorsTests" ::
             "UpdateCDCTests" ::
             "UpdateSQLWithDeletionVectorsTests" ::
             "UpdateSQLTests" ::
             Tests.UPDATE_BASE,
           List(
-            List(Dims.UPDATE_SQL, Dims.CDC.asOptional, Dims.ROW_TRACKING.asOptional),
-            List(Dims.UPDATE_SQL, Dims.CDC, Dims.UPDATE_DVS),
-            List(Dims.UPDATE_SQL, Dims.UPDATE_DVS, Dims.PREDPUSH)
+            List(Dims.UPDATE_SQL, Dims.PATH_BASED, Dims.CDC.asOptional, Dims.ROW_TRACKING.asOptional),
+            List(Dims.UPDATE_SQL, Dims.PATH_BASED, Dims.CDC, Dims.UPDATE_DVS),
+            List(Dims.UPDATE_SQL, Dims.PATH_BASED, Dims.UPDATE_DVS, Dims.PREDPUSH)
           )
         ),
         TestConfig(
@@ -281,6 +287,7 @@ object SuiteGeneratorConfig {
         )
       )
     )
+    // scalastyle:on line.size.limit
   )
 
   /**

--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -169,6 +169,7 @@ object SuiteGeneratorConfig {
    * generation of a suite for it.
    */
   lazy val TEST_GROUPS: List[TestGroup] = List(
+    // scalastyle:off line.size.limit
     TestGroup(
       name = "MergeSuites",
       imports = List(

--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -230,7 +230,7 @@ object SuiteGeneratorConfig {
         TestConfig(
           "UpdateSQLTests" :: Tests.UPDATE_BASE,
           List(
-            List(Dims.UPDATE_SQL, Dims.NAME_BASED),
+            List(Dims.UPDATE_SQL, Dims.NAME_BASED)
           )
         ),
         TestConfig(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.errors.QueryExecutionErrors.toSQLType
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
@@ -30,7 +29,7 @@ import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 
 trait UpdateSQLMixin extends UpdateBaseMixin
   with DeltaSQLCommandTest
-  with DeltaDMLTestUtilsPathBased {
+  with DeltaDMLTestUtils {
 
   override protected def executeUpdate(
       target: String,
@@ -46,12 +45,12 @@ trait UpdateSQLTests extends UpdateSQLMixin {
 
   test("explain") {
     append(Seq((2, 2)).toDF("key", "value"))
-    val df = sql(s"EXPLAIN UPDATE delta.`$tempPath` SET key = 1, value = 2 WHERE key = 2")
+    val df = sql(s"EXPLAIN UPDATE $tableSQLIdentifier SET key = 1, value = 2 WHERE key = 2")
     val outputs = df.collect().map(_.mkString).mkString
     assert(outputs.contains("Delta"))
     assert(!outputs.contains("index") && !outputs.contains("ActionLog"))
     // no change should be made by explain
-    checkAnswer(readDeltaTable(tempPath), Row(2, 2))
+    checkAnswer(readDeltaTableByIdentifier(), Row(2, 2))
   }
 
   test("SC-11376: Update command should check target columns during analysis, same key") {
@@ -129,7 +128,7 @@ trait UpdateSQLTests extends UpdateSQLMixin {
       DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
     checkError(
       intercept[AnalysisException] {
-        executeUpdate(target = s"delta.`$tempPath`", set = "value = 'false'")
+        executeUpdate(target = tableSQLIdentifier, set = "value = 'false'")
       },
       "CANNOT_UP_CAST_DATATYPE",
       parameters = Map(
@@ -151,7 +150,7 @@ trait UpdateSQLTests extends UpdateSQLMixin {
         DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
     checkError(
       intercept[AnalysisException] {
-        executeUpdate(target = s"delta.`$tempPath`", set = "value = '5'")
+        executeUpdate(target = tableSQLIdentifier, set = "value = '5'")
       },
       "CANNOT_UP_CAST_DATATYPE",
       parameters = Map(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -24,6 +24,7 @@ import scala.language.implicitConversions
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 
+import org.apache.spark.{SparkThrowable, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.FileFormat
@@ -497,14 +498,25 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
   }
 
   test("Negative case - non-delta target") {
-    Seq((1, 1), (0, 3), (1, 5)).toDF("key1", "value")
-      .write.mode("overwrite").format("parquet").save(tableSQLIdentifier)
-    val e = intercept[DeltaAnalysisException] {
+    writeTable(
+      Seq((1, 1), (0, 3), (1, 5)).toDF("key1", "value").write.mode("overwrite").format("parquet"),
+      tableSQLIdentifier)
+    intercept[SparkThrowable] {
       executeUpdate(target = tableSQLIdentifier, set = "key1 = 3")
-    }.getMessage
-    assert(e.contains("UPDATE destination only supports Delta sources") ||
-      e.contains("is not a Delta table") || e.contains("doesn't exist") ||
-      e.contains("Incompatible format"))
+    } match {
+      // Thrown when running with path-based SQL
+      case e: DeltaAnalysisException if e.getCondition == "DELTA_MISSING_TRANSACTION_LOG" =>
+        checkErrorMatchPVals(e, "DELTA_MISSING_TRANSACTION_LOG",
+          parameters = Map("operation" -> "read from", "path" -> ".*", "docLink" -> "https://.*"))
+      // Thrown when running with path-based Scala API
+      case e: DeltaAnalysisException if e.getCondition == "DELTA_MISSING_DELTA_TABLE" =>
+        checkError(e, "DELTA_MISSING_DELTA_TABLE",
+          parameters = Map("tableName" -> tableSQLIdentifier.stripPrefix("delta.")))
+      // Thrown when running with name-based SQL
+      case e: SparkUnsupportedOperationException =>
+        checkError(e, "_LEGACY_ERROR_TEMP_2096",
+          parameters = Map("ddl" -> "UPDATE TABLE"))
+    }
   }
 
   test("Negative case - check target columns during analysis") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -505,6 +505,9 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
       executeUpdate(target = tableSQLIdentifier, set = "key1 = 3")
     } match {
       // Thrown when running with path-based SQL
+      case e: DeltaAnalysisException if e.getCondition == "DELTA_TABLE_NOT_FOUND" =>
+        checkError(e, "DELTA_TABLE_NOT_FOUND",
+          parameters = Map("tableName" -> tableSQLIdentifier.stripPrefix("delta.")))
       case e: DeltaAnalysisException if e.getCondition == "DELTA_MISSING_TRANSACTION_LOG" =>
         checkErrorMatchPVals(e, "DELTA_MISSING_TRANSACTION_LOG",
           parameters = Map("operation" -> "read from", "path" -> ".*", "docLink" -> "https://.*"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
@@ -26,7 +26,9 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 
-trait UpdateCDCTests extends UpdateSQLMixin with DeltaColumnMappingTestUtils {
+trait UpdateCDCTests  extends UpdateSQLMixin
+  with DeltaColumnMappingTestUtils
+  with DeltaDMLTestUtilsPathBased {
   import testImplicits._
 
   test("CDC for unconditional update") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuites.scala
@@ -35,198 +35,254 @@ import org.apache.spark.sql.delta.rowtracking._
 class UpdateScalaTestsUpdateScalaSuite extends UpdateScalaTests with UpdateScalaMixin
 class UpdateBaseMiscTestsUpdateScalaSuite extends UpdateBaseMiscTests with UpdateScalaMixin
 
-class UpdateCDCWithDeletionVectorsTestsUpdateSQLCDCEnabledUpdateSQLWithDeletionVectorsSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsNameBasedSuite
+  extends UpdateSQLTests
+  with UpdateSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsNameBasedSuite
+  extends UpdateBaseTempViewTests
+  with UpdateSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsNameBasedSuite
+  extends UpdateBaseMiscTests
+  with UpdateSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class UpdateCDCWithDeletionVectorsTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledUpda3PDSKEYSuite
   extends UpdateCDCWithDeletionVectorsTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with UpdateSQLWithDeletionVectorsMixin
 
-class UpdateCDCTestsUpdateSQLCDCEnabledSuite
+class UpdateCDCTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
   extends UpdateCDCTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
 
-class UpdateCDCTestsUpdateSQLCDCEnabledRowTrackingDisabledSuite
+class UpdateCDCTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingDisabledSuite
   extends UpdateCDCTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingDisabled
 
-class UpdateCDCTestsUpdateSQLCDCEnabledRowTrackingEnabledSuite
+class UpdateCDCTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingEnabledSuite
   extends UpdateCDCTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingEnabled
   with UpdateWithRowTrackingOverrides
 
-class UpdateCDCTestsUpdateSQLCDCEnabledUpdateSQLWithDeletionVectorsSuite
+class UpdateCDCTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledUpdateSQLWithDeletionVectorsSuite
   extends UpdateCDCTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with UpdateSQLWithDeletionVectorsMixin
 
-class UpdateSQLWithDeletionVectorsTestsUpdateSQLCDCEnabledUpdateSQLWithDeletionVectorsSuite
+class UpdateSQLWithDeletionVectorsTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledUpdaPVZZTXISuite
   extends UpdateSQLWithDeletionVectorsTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with UpdateSQLWithDeletionVectorsMixin
 
-class UpdateSQLWithDeletionVectorsTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePusPMYHPCISuite
+class UpdateSQLWithDeletionVectorsTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDB5H4F4QSuite
   extends UpdateSQLWithDeletionVectorsTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownDisabled
 
-class UpdateSQLWithDeletionVectorsTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePusBKLJDXQSuite
+class UpdateSQLWithDeletionVectorsTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDGYHUBZYSuite
   extends UpdateSQLWithDeletionVectorsTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownEnabled
 
-class UpdateSQLTestsUpdateSQLSuite extends UpdateSQLTests with UpdateSQLMixin
-
-class UpdateSQLTestsUpdateSQLCDCEnabledSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedSuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
+  extends UpdateSQLTests
+  with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
 
-class UpdateSQLTestsUpdateSQLRowTrackingDisabledSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedRowTrackingDisabledSuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with RowTrackingDisabled
 
-class UpdateSQLTestsUpdateSQLRowTrackingEnabledSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedRowTrackingEnabledSuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with RowTrackingEnabled
   with UpdateWithRowTrackingOverrides
 
-class UpdateSQLTestsUpdateSQLCDCEnabledRowTrackingDisabledSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingDisabledSuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingDisabled
 
-class UpdateSQLTestsUpdateSQLCDCEnabledRowTrackingEnabledSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingEnabledSuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingEnabled
   with UpdateWithRowTrackingOverrides
 
-class UpdateSQLTestsUpdateSQLCDCEnabledUpdateSQLWithDeletionVectorsSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledUpdateSQLWithDeletionVectorsSuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with UpdateSQLWithDeletionVectorsMixin
 
-class UpdateSQLTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePushdownDisabledSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDeletionVectorsPrediLZKT67ASuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownDisabled
 
-class UpdateSQLTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePushdownEnabledSuite
+class UpdateSQLTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDeletionVectorsPrediULIY7MYSuite
   extends UpdateSQLTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownEnabled
 
-class UpdateBaseTempViewTestsUpdateSQLSuite extends UpdateBaseTempViewTests with UpdateSQLMixin
-
-class UpdateBaseTempViewTestsUpdateSQLCDCEnabledSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedSuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
+  extends UpdateBaseTempViewTests
+  with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
 
-class UpdateBaseTempViewTestsUpdateSQLRowTrackingDisabledSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedRowTrackingDisabledSuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with RowTrackingDisabled
 
-class UpdateBaseTempViewTestsUpdateSQLRowTrackingEnabledSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedRowTrackingEnabledSuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with RowTrackingEnabled
   with UpdateWithRowTrackingOverrides
 
-class UpdateBaseTempViewTestsUpdateSQLCDCEnabledRowTrackingDisabledSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingDisabledSuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingDisabled
 
-class UpdateBaseTempViewTestsUpdateSQLCDCEnabledRowTrackingEnabledSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingEnabledSuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingEnabled
   with UpdateWithRowTrackingOverrides
 
-class UpdateBaseTempViewTestsUpdateSQLCDCEnabledUpdateSQLWithDeletionVectorsSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledUpdateSQLWithDLFJQJDASuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with UpdateSQLWithDeletionVectorsMixin
 
-class UpdateBaseTempViewTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePushdownDisabledSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDeletionVecIPXDUFQSuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownDisabled
 
-class UpdateBaseTempViewTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePushdownEnabledSuite
+class UpdateBaseTempViewTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDeletionVecUAPFF6YSuite
   extends UpdateBaseTempViewTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownEnabled
 
-class UpdateBaseMiscTestsUpdateSQLSuite extends UpdateBaseMiscTests with UpdateSQLMixin
-
-class UpdateBaseMiscTestsUpdateSQLCDCEnabledSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedSuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledSuite
+  extends UpdateBaseMiscTests
+  with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
 
-class UpdateBaseMiscTestsUpdateSQLRowTrackingDisabledSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedRowTrackingDisabledSuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with RowTrackingDisabled
 
-class UpdateBaseMiscTestsUpdateSQLRowTrackingEnabledSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedRowTrackingEnabledSuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with RowTrackingEnabled
   with UpdateWithRowTrackingOverrides
 
-class UpdateBaseMiscTestsUpdateSQLCDCEnabledRowTrackingDisabledSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingDisabledSuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingDisabled
 
-class UpdateBaseMiscTestsUpdateSQLCDCEnabledRowTrackingEnabledSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledRowTrackingEnabledSuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with RowTrackingEnabled
   with UpdateWithRowTrackingOverrides
 
-class UpdateBaseMiscTestsUpdateSQLCDCEnabledUpdateSQLWithDeletionVectorsSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedCDCEnabledUpdateSQLWithDeletQQ37XLISuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with UpdateSQLWithDeletionVectorsMixin
 
-class UpdateBaseMiscTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePushdownDisabledSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDeletionVectors7ZKMJHISuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownDisabled
 
-class UpdateBaseMiscTestsUpdateSQLUpdateSQLWithDeletionVectorsPredicatePushdownEnabledSuite
+class UpdateBaseMiscTestsUpdateSQLDeltaDMLTestUtilsPathBasedUpdateSQLWithDeletionVectorsAVHZNOASuite
   extends UpdateBaseMiscTests
   with UpdateSQLMixin
+  with DeltaDMLTestUtilsPathBased
   with UpdateSQLWithDeletionVectorsMixin
   with PredicatePushdownEnabled
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR makes UpdateSQLSuite an abstract suite and extends it to run with both path-based and name-based access

## How was this patch tested?

The updated UTs

## Does this PR introduce _any_ user-facing changes?

No