### PR TITLE
[Kernel]Fixing kernel resolving dv for a table with path containing space.

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -153,7 +153,7 @@ public interface Scan {
         physicalReadSchema = ScanStateRow.getPhysicalSchema(scanState);
         logicalReadSchema = ScanStateRow.getLogicalSchema(scanState);
 
-        tablePath = ScanStateRow.getTableRoot(scanState);
+        tablePath = ScanStateRow.getTableRoot(scanState).toString();
         inited = true;
       }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -140,8 +140,7 @@ public class ScanStateRow extends GenericRow {
    * @param scanState Scan state {@link Row}
    * @return Fully qualified path to the location of the table.
    */
-  public static String getTableRoot(Row scanState) {
-    return new Path(URI.create(scanState.getString(COL_NAME_TO_ORDINAL.get("tablePath"))))
-        .toString();
+  public static Path getTableRoot(Row scanState) {
+    return new Path(URI.create(scanState.getString(COL_NAME_TO_ORDINAL.get("tablePath"))));
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -22,11 +22,13 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.*;
+import java.net.URI;
 import java.util.*;
 import java.util.stream.IntStream;
 
@@ -139,6 +141,7 @@ public class ScanStateRow extends GenericRow {
    * @return Fully qualified path to the location of the table.
    */
   public static String getTableRoot(Row scanState) {
-    return scanState.getString(COL_NAME_TO_ORDINAL.get("tablePath"));
+    return new Path(URI.create(scanState.getString(COL_NAME_TO_ORDINAL.get("tablePath"))))
+        .toString();
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeletionVectorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeletionVectorSuite.scala
@@ -29,6 +29,21 @@ class DeletionVectorSuite extends AnyFunSuite with TestUtils {
       expectedAnswer = (2L until 10L).map(TestRow(_)))
   }
 
+  test("end-to-end usage: reading a table with dv with space in the root path") {
+    withTempDir { tempDir =>
+      val target = tempDir.getCanonicalPath + "spark test"
+      spark.sql(s"""CREATE TABLE tbl (
+          id int
+        ) USING delta LOCATION '$target'
+        TBLPROPERTIES ('delta.enableDeletionVectors' = true) """)
+      spark.sql("INSERT INTO tbl VALUES (1),(2),(3),(4),(5)")
+      spark.sql("DELETE FROM tbl WHERE id = 1")
+      checkTable(
+        path = target,
+        expectedAnswer = Seq(TestRow(2), TestRow(3), TestRow(4), TestRow(5)))
+    }
+  }
+
   test("end-to-end usage: reading a table with dv with checkpoint") {
     checkTable(
       path = getTestResourceFilePath("basic-dv-with-checkpoint"),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
See https://github.com/delta-io/delta/issues/4989
```
test("end-to-end usage: reading a table with dv with space in the root path") {
withTempDir { tempDir =>
val target = tempDir.getCanonicalPath + "spark test"
spark.sql(s"""CREATE TABLE tbl (
id int
) USING delta LOCATION '$target'
TBLPROPERTIES ('delta.enableDeletionVectors' = true) """)
spark.sql("INSERT INTO tbl VALUES (1),(2),(3),(4),(5)")
spark.sql("DELETE FROM tbl WHERE id = 1")
checkTable(
path = target,
expectedAnswer = Seq(TestRow(2), TestRow(3), TestRow(4), TestRow(5)))
}
}

IOException reading from file file:/private/var/folders/9k/rzsv_9697k53xcx101546y280000gp/T/109f478a-4f50-4e5a-80d2-216ba12669e81886802785450513247spark%20test/deletion_vector_bf2b7f39-cdc0-4289-945b-79f9829a4e97.bin at offset 1 size 42
java.io.UncheckedIOException: IOException reading from file file:/private/var/folders/9k/rzsv_9697k53xcx101546y280000gp/T/109f478a-4f50-4e5a-80d2-216ba12669e81886802785450513247spark%20test/deletion_vector_bf2b7f39-cdc0-4289-945b-79f9829a4e97.bin at offset 1 size 42
at io.delta.kernel.defaults.engine.DefaultFileSystemClient.getStream(DefaultFileSystemClient.java:103)
at io.delta.kernel.defaults.engine.DefaultFileSystemClient.lambda$readFiles$0(DefaultFileSystemClient.java:81)
at io.delta.kernel.utils.CloseableIterator$1.next(CloseableIterator.java:112)
at io.delta.kernel.internal.util.InternalUtils.getSingularElement(InternalUtils.java:77)
at io.delta.kernel.internal.deletionvectors.DeletionVectorStoredBitmap.load(DeletionVectorStoredBitmap.java:88)
at io.delta.kernel.internal.deletionvectors.DeletionVectorUtils.loadNewDvAndBitmap(DeletionVectorUtils.java:32)
at io.delta.kernel.Scan$1.next(Scan.java:193)
at io.delta.kernel.Scan$1.next(Scan.java:138)
at io.delta.kernel.defaults.utils.AbstractTestUtils$CloseableIteratorOps.forEach(TestUtils.scala:97)
at io.delta.kernel.defaults.utils.AbstractTestUtils.$anonfun$readResolvedTableAdapter$2(TestUtils.scala:286)
at io.delta.kernel.defaults.utils.AbstractTestUtils'
```

Root cause is we are calling tablePath.toUri().toString() when constructing the scan state, so when we get from scan state, we need to do it in the same way(toUri then toPath), otherwise we will put a wrong name when reading DV ("spark test" => "spark%20test")

follow how we handle addFIle in https://github.com/delta-io/delta/blob/5abc2961d9f45a959beeeb1a535479ba34d9ae8e/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java#L112

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added an unit test
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No