### PR TITLE
[Spark] Optimize MERGE DELETE to avoid scanning unnecessary target columns when CDC is disabled

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -129,8 +129,12 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // unmatched source row when it should not be inserted. `target.output` will produce NULLs
     // which will get deleted eventually.
 
+    val deletedColsForUnmatchedTarget =
+      if (cdcEnabled) targetWriteCols
+      else targetWriteCols.map(e => Cast(Literal(null), e.dataType))
+
     val deleteSourceRowExprs =
-      (targetWriteCols ++
+      (deletedColsForUnmatchedTarget ++
         rowIdColumnExpressionOpt.map(_ => Literal(null)) ++
         rowCommitVersionColumnExpressionOpt.map(_ => Literal(null)) ++
         Seq(Literal(true))) ++
@@ -291,7 +295,15 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
             }
           }
           // Generate expressions to set the ROW_DROPPED_COL = true and mark as a DELETE
-          targetWriteCols ++
+          // Only read full target columns if CDC is enabled
+          val deletedDataExprs =
+            if (cdcEnabled) {
+              targetWriteCols
+            } else {
+              targetWriteCols.map(e => Cast(Literal(null), e.dataType))
+            }
+
+          deletedDataExprs ++
             rowIdColumnExpressionOpt ++
             rowCommitVersionColumnExpressionOpt ++
             Seq(incrCountExpr) ++


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When executing MERGE with DELETE actions, Delta’s write plan currently references all target payload columns even when CDC is off and we don’t need delete preimages. This happens in:

the matched DELETE branch, and

the target_is_null (source‑only) fallback used when no NOT MATCHED … INSERT applies.

Because those branches reference targetWriteCols, Spark cannot column‑prune the target payload; this inflates bytes scanned for delete‑only MERGEs (even with Deletion Vectors enabled).

With this PR, when CDC is disabled:
* In matched DELETE action vectors, replace targetWriteCols with typed NULLs
* In the target_is_null fallback vector, replace targetWriteCols with typed NULLs


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
tested against delete only merged and verified spark plans before and after, query similar to
```
MERGE INTO target_table t
                USING source_table i
                ON <condition>
                WHEN MATCHED THEN DELETE
```
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
