### PR TITLE
[Kernel] Enable fresh & materialized reads of row tracking metadata columns

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -21,6 +21,7 @@ import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.data.SelectionColumnVector;
@@ -185,9 +186,12 @@ public interface Scan {
                 physicalReadSchema);
 
         // Transform physical row tracking columns to logical row tracking columns
-        nextDataBatch =
-            MaterializedRowTrackingColumn.transformPhysicalData(
-                nextDataBatch, scanFile, scanState, engine);
+        if (TableConfig.ROW_TRACKING_ENABLED.fromMetadata(
+            ScanStateRow.getConfiguration(scanState))) {
+          nextDataBatch =
+              MaterializedRowTrackingColumn.transformPhysicalData(
+                  nextDataBatch, scanFile, scanState, engine);
+        }
 
         // Get the selectionVector if DV is present
         DeletionVectorDescriptor dv =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -219,8 +219,7 @@ public interface Scan {
 
         // If a column was only requested to compute other columns, we remove it
         for (StructField field : nextDataBatch.getSchema().fields()) {
-          if (field.getMetadata().contains(StructField.IS_INTERNAL_COLUMN_KEY)
-              && field.getMetadata().getBoolean(StructField.IS_INTERNAL_COLUMN_KEY)) {
+          if (field.isInternalColumn()) {
             int columnOrdinal = nextDataBatch.getSchema().indexOf(field.getName());
             if (columnOrdinal == -1) {
               // This should never happen since we only interact with a single schema

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -460,8 +460,7 @@ public final class DeltaErrors {
 
   public static KernelException rowTrackingMetadataMissingInFile(String entry, String filePath) {
     return new KernelException(
-        String.format(
-            "Required metadata key %s is not present in scan file %s.", entry, filePath));
+        String.format("Required metadata key %s is not present in scan file %s.", entry, filePath));
   }
 
   /* ------------------------ HELPER METHODS ----------------------------- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -458,10 +458,10 @@ public final class DeltaErrors {
             tablePath, TableConfig.APPEND_ONLY_ENABLED.getKey()));
   }
 
-  public static KernelException missingRowTrackingEntryInFile(String filePath, String entry) {
+  public static KernelException rowTrackingMetadataMissingInFile(String entry, String filePath) {
     return new KernelException(
         String.format(
-            "%s is not present in scan file %s of table with row tracking.", entry, filePath));
+            "Required metadata key %s is not present in scan file %s.", entry, filePath));
   }
 
   /* ------------------------ HELPER METHODS ----------------------------- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -458,6 +458,12 @@ public final class DeltaErrors {
             tablePath, TableConfig.APPEND_ONLY_ENABLED.getKey()));
   }
 
+  public static KernelException missingRowTrackingEntryInFile(String filePath, String entry) {
+    return new KernelException(
+        String.format(
+            "%s is not present in scan file %s of table with row tracking.", entry, filePath));
+  }
+
   /* ------------------------ HELPER METHODS ----------------------------- */
   private static String formatTimestamp(long millisSinceEpochUTC) {
     return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -202,4 +202,9 @@ public class InternalScanFileUtils {
     Row addFileRow = getAddFileEntry(scanFile);
     return new AddFile(addFileRow).getDefaultRowCommitVersion();
   }
+
+  public static String getFilePath(Row scanFile) {
+    Row addFileRow = getAddFileEntry(scanFile);
+    return new AddFile(addFileRow).getPath();
+  }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -270,7 +270,7 @@ public class ScanImpl implements Scan {
               false,
               FieldMetadata.builder()
                   .putBoolean(StructField.IS_METADATA_COLUMN_KEY, true)
-                  .putBoolean(StructField.IS_INTERNAL_METADATA_COLUMN_KEY, true)
+                  .putBoolean(StructField.IS_INTERNAL_COLUMN_KEY, true)
                   .build()));
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -42,8 +42,6 @@ import io.delta.kernel.internal.skipping.DataSkippingUtils;
 import io.delta.kernel.internal.util.*;
 import io.delta.kernel.metrics.ScanReport;
 import io.delta.kernel.metrics.SnapshotReport;
-import io.delta.kernel.types.FieldMetadata;
-import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -227,8 +227,12 @@ public class ScanImpl implements Scan {
   }
 
   /**
-   * Create a physical schema that is used to read data from files based on the scan's logical
-   * schema.
+   * Transform the logical schema requested by the connector into a physical schema that is passed
+   * to the engine's parquet reader.
+   *
+   * <p>The logical-to-physical conversion is reversed in {@link Scan#transformPhysicalData(Engine,
+   * Row, Row, CloseableIterator)} when physical data batches returned by the parquet reader are
+   * converted into logical data batches requested by the connector.
    *
    * <p>The logical-to-physical conversion follows these high-level steps:
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -146,10 +146,8 @@ public class ScanImpl implements Scan {
     boolean shouldReadStats = hasDataSkippingFilter || includeStats;
 
     Timer.Timed planningDuration = scanMetrics.totalPlanningTimer.start();
-    // ScanReportReporter stores the current context and can be invoked (in the
-    // future) with
-    // `reportError` or `reportSuccess` to stop the planning duration timer and push
-    // a report to
+    // ScanReportReporter stores the current context and can be invoked (in the  future) with
+    // `reportError` or `reportSuccess` to stop the planning duration timer and push a report to
     // the engine
     ScanReportReporter reportReporter =
         (exceptionOpt, isFullyConsumed) -> {
@@ -172,8 +170,7 @@ public class ScanImpl implements Scan {
 
     try {
       // Get active AddFiles via log replay
-      // If there is a partition predicate, construct a predicate to prune checkpoint
-      // files
+      // If there is a partition predicate, construct a predicate to prune checkpoint files
       // while constructing the table state.
       CloseableIterator<FilteredColumnarBatch> scanFileIter =
           logReplay.getAddFilesAsColumnarBatches(
@@ -209,12 +206,9 @@ public class ScanImpl implements Scan {
   public Row getScanState(Engine engine) {
     StructType physicalSchema = createPhysicalSchema();
 
-    // Compute the physical data read schema (i.e., the columns to read from a
-    // Parquet data file).
-    // The only difference to the physical schema is that we exclude partition
-    // columns. All other
-    // logic (e.g., row tracking columns, row index for DVs) is already handled
-    // before.
+    // Compute the physical data read schema (i.e., the columns to read from a Parquet data file).
+    // The only difference to the physical schema is that we exclude partition columns. All other
+    // logic (e.g., row tracking columns, row index for DVs) is already handled before.
     List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumns());
     StructType physicalDataReadSchema =
         PartitionUtils.physicalSchemaWithoutPartitionColumns(
@@ -261,8 +255,7 @@ public class ScanImpl implements Scan {
         && physicalFields.stream()
             .map(StructField::getName)
             .noneMatch(name -> name.equals(StructField.METADATA_ROW_INDEX_COLUMN_NAME))) {
-      // If the row index column is not already present, add it to the physical read
-      // schema
+      // If the row index column is not already present, add it to the physical read schema
       physicalFields.add(
           new StructField(
               StructField.METADATA_ROW_INDEX_COLUMN_NAME,
@@ -289,8 +282,7 @@ public class ScanImpl implements Scan {
           logicalField, readSchema, metadata);
     }
 
-    // As of now, metadata columns other than row tracking columns do not require
-    // any special
+    // As of now, metadata columns other than row tracking columns do not require any special
     // handling, so we can just add them to the physical schema as is.
     return Collections.singletonList(logicalField);
   }
@@ -379,20 +371,16 @@ public class ScanImpl implements Scan {
       CloseableIterator<FilteredColumnarBatch> scanFileIter,
       DataSkippingPredicate dataSkippingFilter) {
     // Get the stats schema
-    // It's possible to instead provide the referenced columns when building the
-    // schema but
+    // It's possible to instead provide the referenced columns when building the schema but
     // pruning it after is much simpler
     StructType prunedStatsSchema =
         DataSkippingUtils.pruneStatsSchema(
             getStatsSchema(metadata.getDataSchema()), dataSkippingFilter.getReferencedCols());
 
     // Skipping happens in two steps:
-    // 1. The predicate produces false for any file whose stats prove we can safely
-    // skip it. A
-    // value of true means the stats say we must keep the file, and null means we
-    // could not
-    // determine whether the file is safe to skip, because its stats were
-    // missing/null.
+    // 1. The predicate produces false for any file whose stats prove we can safely skip it. A
+    //    value of true means the stats say we must keep the file, and null means we could not
+    //    determine whether the file is safe to skip, because its stats were missing/null.
     // 2. The coalesce(skip, true) converts null (= keep) to true
     Predicate filterToEval =
         new Predicate(
@@ -452,17 +440,14 @@ public class ScanImpl implements Scan {
       @Override
       public void close() throws IOException {
         try {
-          // If a ScanReport has already been pushed in the case of an exception don't
-          // double report
+          // If a ScanReport has already been pushed in the case of an exception don't double report
           if (!errorReported) {
             if (!scanIter.hasNext()) {
-              // The entire scan file iterator has been successfully consumed report a
-              // complete Scan
+              // The entire scan file iterator has been successfully consumed report a complete Scan
               reporter.reportCompleteScan();
             } else {
               // The scan file iterator has NOT been fully consumed before being closed
-              // We have no way of knowing the reason why, this could be due to an exception
-              // in the
+              // We have no way of knowing the reason why, this could be due to an exception in the
               // connector code, or intentional early termination such as for a LIMIT query
               reporter.reportIncompleteScan();
             }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -256,15 +256,7 @@ public class ScanImpl implements Scan {
             .map(StructField::getName)
             .noneMatch(name -> name.equals(StructField.METADATA_ROW_INDEX_COLUMN_NAME))) {
       // If the row index column is not already present, add it to the physical read schema
-      physicalFields.add(
-          new StructField(
-              StructField.METADATA_ROW_INDEX_COLUMN_NAME,
-              LongType.LONG,
-              false,
-              FieldMetadata.builder()
-                  .putBoolean(StructField.IS_METADATA_COLUMN_KEY, true)
-                  .putBoolean(StructField.IS_INTERNAL_COLUMN_KEY, true)
-                  .build()));
+      physicalFields.add(StructField.createInternalColumn(StructField.METADATA_ROW_INDEX_COLUMN));
     }
 
     return new StructType(physicalFields);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -146,7 +146,7 @@ public class ScanImpl implements Scan {
     boolean shouldReadStats = hasDataSkippingFilter || includeStats;
 
     Timer.Timed planningDuration = scanMetrics.totalPlanningTimer.start();
-    // ScanReportReporter stores the current context and can be invoked (in the  future) with
+    // ScanReportReporter stores the current context and can be invoked (in the future) with
     // `reportError` or `reportSuccess` to stop the planning duration timer and push a report to
     // the engine
     ScanReportReporter reportReporter =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -73,6 +73,17 @@ public class ScanStateRow extends GenericRow {
   }
 
   /**
+   * Utility method to get the configuration map from the scan state {@link Row} returned by {@link
+   * Scan#getScanState(Engine)}.
+   *
+   * @param scanState Scan state {@link Row}
+   * @return Map of configuration key-value pairs.
+   */
+  public static Map<String, String> getConfiguration(Row scanState) {
+    return VectorUtils.toJavaMap(scanState.getMap(COL_NAME_TO_ORDINAL.get("configuration")));
+  }
+
+  /**
    * Utility method to get the logical schema from the scan state {@link Row} returned by {@link
    * Scan#getScanState(Engine)}.
    *
@@ -127,9 +138,7 @@ public class ScanStateRow extends GenericRow {
    * Scan#getScanState(Engine)}.
    */
   public static ColumnMappingMode getColumnMappingMode(Row scanState) {
-    Map<String, String> configuration =
-        VectorUtils.toJavaMap(scanState.getMap(COL_NAME_TO_ORDINAL.get("configuration")));
-    return ColumnMapping.getColumnMappingMode(configuration);
+    return ColumnMapping.getColumnMappingMode(getConfiguration(scanState));
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -104,8 +104,7 @@ public final class MaterializedRowTrackingColumn {
       return;
     }
 
-    // Check that both materialized column name configs are present when row
-    // tracking is enabled
+    // Check that both materialized column name configs are present when row tracking is enabled
     Stream.of(ROW_ID, ROW_COMMIT_VERSION)
         .forEach(
             column -> {
@@ -260,8 +259,8 @@ public final class MaterializedRowTrackingColumn {
         InternalScanFileUtils.getBaseRowId(scanFile)
             .orElseThrow(
                 () ->
-                    DeltaErrors.missingRowTrackingEntryInFile(
-                        InternalScanFileUtils.getFilePath(scanFile), "Base row ID"));
+                    DeltaErrors.rowTrackingMetadataMissingInFile(
+                        "Base row ID", InternalScanFileUtils.getFilePath(scanFile)));
     Expression rowIdExpr =
         new ScalarExpression(
             "COALESCE",
@@ -294,8 +293,8 @@ public final class MaterializedRowTrackingColumn {
         InternalScanFileUtils.getDefaultRowCommitVersion(scanFile)
             .orElseThrow(
                 () ->
-                    DeltaErrors.missingRowTrackingEntryInFile(
-                        InternalScanFileUtils.getFilePath(scanFile), "Default row commit version"));
+                    DeltaErrors.rowTrackingMetadataMissingInFile(
+                        "Default row commit version", InternalScanFileUtils.getFilePath(scanFile)));
     Expression commitVersionExpr =
         new ScalarExpression(
             "COALESCE",

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -26,6 +26,7 @@ import io.delta.kernel.exceptions.InvalidTableException;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.ColumnMapping;
@@ -182,7 +183,7 @@ public final class MaterializedRowTrackingColumn {
               LongType.LONG,
               true /* nullable */));
       if (logicalSchema.indexOf(StructField.METADATA_ROW_INDEX_COLUMN_NAME) == -1) {
-        physicalFields.add(StructField.createInternalColumn(StructField.METADATA_ROW_INDEX_COLUMN));
+        physicalFields.add(ScanImpl.createInternalColumn(StructField.METADATA_ROW_INDEX_COLUMN));
       }
       return physicalFields;
     } else if (logicalField.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -17,14 +17,21 @@ package io.delta.kernel.internal.rowtracking;
 
 import static io.delta.kernel.internal.rowtracking.RowTracking.*;
 
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.engine.ExpressionHandler;
 import io.delta.kernel.exceptions.InvalidTableException;
+import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.DeltaErrors;
+import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.types.*;
 import io.delta.kernel.types.LongType;
-import io.delta.kernel.types.StructField;
-import io.delta.kernel.types.StructType;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -98,7 +105,8 @@ public final class MaterializedRowTrackingColumn {
       return;
     }
 
-    // Check that both materialized column name configs are present when row tracking is enabled
+    // Check that both materialized column name configs are present when row
+    // tracking is enabled
     Stream.of(ROW_ID, ROW_COMMIT_VERSION)
         .forEach(
             column -> {
@@ -173,17 +181,27 @@ public final class MaterializedRowTrackingColumn {
     }
 
     if (logicalField.getName().equals(METADATA_ROW_ID_COLUMN_NAME)) {
-      // TODO: Use logicalSchema here to determine whether we also need to add row index
-      //  to the physical schema to compute non-materialized row IDs.
-      // We return a list of StructFields here because we may need to add both the row ID and the
-      // row index columns to the physical schema (in scope for a follow-up PR).
-      return Collections.singletonList(
+      List<StructField> physicalFields = new ArrayList<>(2);
+      physicalFields.add(
           new StructField(
               ROW_ID.getPhysicalColumnName(metadata), LongType.LONG, true /* nullable */));
+      if (logicalSchema.indexOf(StructField.METADATA_ROW_INDEX_COLUMN_NAME) == -1) {
+        physicalFields.add(
+            new StructField(
+                StructField.METADATA_ROW_INDEX_COLUMN_NAME,
+                LongType.LONG,
+                false,
+                FieldMetadata.builder()
+                    .putBoolean(StructField.IS_METADATA_COLUMN_KEY, true)
+                    .putBoolean(StructField.IS_INTERNAL_METADATA_COLUMN_KEY, true)
+                    .build()));
+      }
+      return physicalFields;
     } else if (logicalField.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME)) {
       return Collections.singletonList(
           new StructField(
-              ROW_COMMIT_VERSION.getPhysicalColumnName(metadata),
+              ROW_COMMIT_VERSION.getPhysicalColumnName(
+                  metadata.getId(), metadata.getConfiguration()),
               LongType.LONG,
               true /* nullable */));
     }
@@ -193,8 +211,90 @@ public final class MaterializedRowTrackingColumn {
             logicalField.getName()));
   }
 
-  private String getPhysicalColumnName(Metadata metadata) {
-    return Optional.ofNullable(metadata.getConfiguration().get(getMaterializedColumnNameProperty()))
+  /**
+   * Transforms physical data related to row tracking to the logical metadata requested by the user.
+   *
+   * @param dataBatch a batch of physical data read from the table.
+   * @param scanFile the {@link Row} representing the scan file metadata.
+   * @param scanState the {@link Row} representing the scan state metadata.
+   * @param engine the {@link Engine} to use for expression evaluation.
+   * @return a new {@link ColumnarBatch} with logical row tracking columns
+   */
+  public static ColumnarBatch transformPhysicalData(
+      ColumnarBatch dataBatch, Row scanFile, Row scanState, Engine engine) {
+    StructType readSchema = dataBatch.getSchema();
+    ExpressionHandler exprHandler = engine.getExpressionHandler();
+
+    // NOTE: We assume that each column is requested at most once in the read
+    // schema. This is
+    // consistent with other parts of the codebase.
+    // TODO: Change the indexOf() check once we migrate to the new metadata API
+    String rowIdColumnName =
+        ROW_ID.getPhysicalColumnName(
+            ScanStateRow.getTableRoot(scanState), ScanStateRow.getConfiguration(scanState));
+    int rowIdOrdinal = readSchema.indexOf(rowIdColumnName);
+    if (rowIdOrdinal != -1) {
+      long baseRowId =
+          InternalScanFileUtils.getBaseRowId(scanFile)
+              .orElseThrow(
+                  () ->
+                      DeltaErrors.missingRowTrackingEntryInFile(
+                          InternalScanFileUtils.getFilePath(scanFile), "Base row ID"));
+      Expression rowIdExpr =
+          new ScalarExpression(
+              "COALESCE",
+              Arrays.asList(
+                  new Column(rowIdColumnName),
+                  new ScalarExpression(
+                      "ADD",
+                      Arrays.asList(
+                          new Column(StructField.METADATA_ROW_INDEX_COLUMN_NAME),
+                          Literal.ofLong(baseRowId)))));
+      ColumnVector rowIdVector =
+          exprHandler.getEvaluator(readSchema, rowIdExpr, LongType.LONG).eval(dataBatch);
+
+      // Remove the materialized row ID column and replace it with the coalesced row
+      // ID vector
+      dataBatch =
+          dataBatch
+              .withDeletedColumnAt(rowIdOrdinal)
+              .withNewColumn(rowIdOrdinal, METADATA_ROW_ID_COLUMN, rowIdVector);
+    }
+
+    String commitVersionColumnName =
+        ROW_COMMIT_VERSION.getPhysicalColumnName(
+            ScanStateRow.getTableRoot(scanState), ScanStateRow.getConfiguration(scanState));
+    int commitVersionOrdinal = readSchema.indexOf(commitVersionColumnName);
+    if (commitVersionOrdinal != -1) {
+      long defaultRowCommitVersion =
+          InternalScanFileUtils.getDefaultRowCommitVersion(scanFile)
+              .orElseThrow(
+                  () ->
+                      DeltaErrors.missingRowTrackingEntryInFile(
+                          InternalScanFileUtils.getFilePath(scanFile),
+                          "Default row commit version"));
+      Expression commitVersionExpr =
+          new ScalarExpression(
+              "COALESCE",
+              Arrays.asList(
+                  new Column(commitVersionColumnName), Literal.ofLong(defaultRowCommitVersion)));
+      ColumnVector commitVersionVector =
+          exprHandler.getEvaluator(readSchema, commitVersionExpr, LongType.LONG).eval(dataBatch);
+
+      // Remove the materialized row commit version column and replace it with the
+      // coalesced vector
+      dataBatch =
+          dataBatch
+              .withDeletedColumnAt(commitVersionOrdinal)
+              .withNewColumn(
+                  commitVersionOrdinal, METADATA_ROW_COMMIT_VERSION_COLUMN, commitVersionVector);
+    }
+
+    return dataBatch;
+  }
+
+  private String getPhysicalColumnName(String tablePath, Map<String, String> configuration) {
+    return Optional.ofNullable(configuration.get(getMaterializedColumnNameProperty()))
         .orElseThrow(
             () ->
                 new IllegalArgumentException(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -34,13 +34,14 @@ public class StructField {
   ////////////////////////////////////////////////////////////////////////////////
 
   /** Indicates a metadata column when present in the field metadata and the value is true */
+  // TODO: Make this private once we migrate to the new metadata column API.
   public static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
   /**
-   * Indicates that a metadata column was requested for internal computations and should not be
-   * exposed to the user.
+   * Indicates that a column was requested for internal computations and should not be returned to
+   * the user.
    */
-  public static final String IS_INTERNAL_COLUMN_KEY = "isInternalColumn";
+  private static final String IS_INTERNAL_COLUMN_KEY = "isInternalColumn";
 
   /**
    * The name of a row index metadata column. When present this column must be populated with row
@@ -147,6 +148,10 @@ public class StructField {
     return !isMetadataColumn();
   }
 
+  public boolean isInternalColumn() {
+    return Optional.ofNullable(metadata.getBoolean(IS_INTERNAL_COLUMN_KEY)).orElse(false);
+  }
+
   @Override
   public String toString() {
     return String.format(
@@ -202,6 +207,19 @@ public class StructField {
    */
   public StructField withDataType(DataType newType) {
     return new StructField(name, newType, nullable, metadata, typeChanges);
+  }
+
+  public static StructField createInternalColumn(StructField field) {
+    FieldMetadata.Builder metadataBuilder =
+        FieldMetadata.builder()
+            .fromMetadata(field.metadata)
+            .putBoolean(IS_INTERNAL_COLUMN_KEY, true);
+    return new StructField(
+        field.getName(),
+        field.getDataType(),
+        field.isNullable(),
+        metadataBuilder.build(),
+        field.getTypeChanges());
   }
 
   /** Fetches collation and type changes metadata from nested fields. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -37,6 +37,12 @@ public class StructField {
   public static final String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
   /**
+   * Indicates that a metadata column was requested for internal computations and should not be
+   * exposed to the user.
+   */
+  public static final String IS_INTERNAL_METADATA_COLUMN_KEY = "isInternalMetadataColumn";
+
+  /**
    * The name of a row index metadata column. When present this column must be populated with row
    * index of each row when reading from parquet.
    */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -40,7 +40,7 @@ public class StructField {
    * Indicates that a metadata column was requested for internal computations and should not be
    * exposed to the user.
    */
-  public static final String IS_INTERNAL_METADATA_COLUMN_KEY = "isInternalMetadataColumn";
+  public static final String IS_INTERNAL_COLUMN_KEY = "isInternalColumn";
 
   /**
    * The name of a row index metadata column. When present this column must be populated with row

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -41,7 +41,7 @@ public class StructField {
    * Indicates that a column was requested for internal computations and should not be returned to
    * the user.
    */
-  private static final String IS_INTERNAL_COLUMN_KEY = "isInternalColumn";
+  public static final String IS_INTERNAL_COLUMN_KEY = "isInternalColumn";
 
   /**
    * The name of a row index metadata column. When present this column must be populated with row
@@ -207,19 +207,6 @@ public class StructField {
    */
   public StructField withDataType(DataType newType) {
     return new StructField(name, newType, nullable, metadata, typeChanges);
-  }
-
-  public static StructField createInternalColumn(StructField field) {
-    FieldMetadata.Builder metadataBuilder =
-        FieldMetadata.builder()
-            .fromMetadata(field.metadata)
-            .putBoolean(IS_INTERNAL_COLUMN_KEY, true);
-    return new StructField(
-        field.getName(),
-        field.getDataType(),
-        field.isNullable(),
-        metadataBuilder.build(),
-        field.getTypeChanges());
   }
 
   /** Fetches collation and type changes metadata from nested fields. */

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -429,8 +429,6 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
   }
 
   /* -------- Test reading from tables with row tracking -------- */
-  // TODO: For now, we only read the materialized column values so the metadata column content will
-  //  be null for a new table without materialized row id/row commit version.
   test("Error when reading row tracking columns from a non-row-tracking table") {
     withTempDirAndEngine { (tablePath, engine) =>
       // Create a new table without row tracking
@@ -462,10 +460,10 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
         val expectedAnswer = Seq(
           TestRow(1, "A", 0L, 1L),
           TestRow(2, "B", 1L, 1L),
-          TestRow(3, "C_updated", 2L, null),
+          TestRow(3, "C_updated", 2L, 2L),
           TestRow(4, "D", 3L, 1L),
           TestRow(5, "E", 4L, 1L),
-          TestRow(6, "F", null, null))
+          TestRow(6, "F", 10L, 2L))
 
         // We only check whether the delta-spark table schema is inferred correctly if column
         // mapping is disabled
@@ -495,7 +493,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
         TestRow("C_updated", 2L),
         TestRow("D", 3L),
         TestRow("E", 4L),
-        TestRow("F", null))
+        TestRow("F", 10L))
 
       checkTable(
         path = tablePath,
@@ -512,10 +510,10 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
       val expectedAnswer = Seq(
         TestRow(1L, 0L),
         TestRow(1L, 1L),
-        TestRow(null, 2L),
+        TestRow(2L, 2L),
         TestRow(1L, 3L),
         TestRow(1L, 4L),
-        TestRow(null, null))
+        TestRow(2L, 10L))
 
       // This test also checks a different ordering of the metadata columns
       checkTable(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR builds upon #4943 and #4953 to enable fully functioning reads of row tracking metadata columns. Concretely, it adds functionality to compute non-materialized row IDs and row commit versions on the fly.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

I modified the tests that I added in #4943 to now expect the fully correct result (instead of `null` for non-materialized values).

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This PR turns the work started in #4943 into a usable new feature. Users/engines can now request row tracking metadata columns from Delta tables. At the moment, this PR still uses a preliminary API for requesting metadata columns until we agree on a stable metadata column API going forward.
