### PR TITLE
[Spark] Avoid full table scan when MATCHED, NOT MATCHED predicates have conditionals 

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -136,7 +136,7 @@ This file is divided into 3 sections:
   </check>
 
   <check customId="argcount" level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-    <parameters><parameter name="maxParameters"><![CDATA[11]]></parameter></parameters>
+    <parameters><parameter name="maxParameters"><![CDATA[10]]></parameter></parameters>
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -136,7 +136,7 @@ This file is divided into 3 sections:
   </check>
 
   <check customId="argcount" level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-    <parameters><parameter name="maxParameters"><![CDATA[10]]></parameter></parameters>
+    <parameters><parameter name="maxParameters"><![CDATA[11]]></parameter></parameters>
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -442,7 +442,6 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
       writeUnmodifiedRows,
       clausesWithPrecompConditions,
       cdcEnabled,
-      joinType,
       needSetRowTrackingFieldIdForUniform
     )
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -439,9 +439,11 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
       rowCommitVersionColumnExpressionOpt,
       outputColNames,
       noopCopyExprs,
+      writeUnmodifiedRows,
       clausesWithPrecompConditions,
       cdcEnabled,
-      needSetRowTrackingFieldIdForUniform = needSetRowTrackingFieldIdForUniform
+      joinType,
+      needSetRowTrackingFieldIdForUniform
     )
 
     val preOutputDF = if (cdcEnabled) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -212,11 +212,9 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
         case "inner" => matchedExprs(i)
         case "leftOuter" =>
           // The source row is never null, so we only need to check if the target row is null.
-          assert(notMatchedBySourceExprs.isEmpty)
           If(ifTargetRowNull, notMatchedExprs(i), matchedExprs(i))
         case "rightOuter" =>
           // The target row is never null, so we only need to check if the source row is null.
-          assert(notMatchedExprs.isEmpty)
           If(ifSourceRowNull, notMatchedBySourceExprs(i), matchedExprs(i))
         case "fullOuter" =>
           CaseWhen(Seq(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.catalyst.expressions.RaiseError
 
 /**
  * Contains logic to transform the merge clauses into expressions that can be evaluated to obtain

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -152,7 +152,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       generateClauseOutputExprs(
         numOutputCols,
         processedNotMatchClauses,
-        noopCopyExprs,
+        deleteSourceRowExprs,
         writeUnmodifiedRows)
 
     // === Generate N + 2 (N + 4 with Row Tracking) expressions for NOT MATCHED BY SOURCE clause ===


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
Spark

## Description

Consider a MERGE INTO query as follows:

```
MERGE INTO target_table t
USING change_events c
on c.id = t.id
WHEN MATCHED and c.operation = 'Update' THEN UPDATE SET *
```

Originally, this would create projections like this which would reference the target table's columns, causing a full table scan:
```
If(update_condition) c.data else t.data
```


This PR changes the projection to be like this:
```
If(update_condition) c.data else RaiseError("unexpected row: this row should have been filtered out
```

The key question is: why can we do this? The basic answer is because we will never hit the else condition because in a previous step, we filtered to rows that will be modified and need to be rewritten. At this point, I will mention that we can optimize the projection by directly setting c.data instead of having the if-statement, but in the spirit of incremental, easy-to-read changes and for added safety, I decided to replace the fallbacks with RaiseErrors, since we want it to scream loudly that something is wrong. In a followup, we can implement the optimization.

Now let me try to explain more intuitively and with some code pointers. MERGE INTO is broken into two steps: rewriting modified rows, and writing delete vectors. Well let's think: why do we even need a fallback? If a row doesn't match any of the actions, we shouldn't even be processing it. And in fact, we don't, because there is an explicit filtering step in `ClassicMergeExecutor.scala` `def writeAllChanges` which is the method that constructs the overall plan/strategy for the rewriting phase. 

```

  /**
   * Write new files by reading the touched files and updating/inserting data using the source
   * query/table. This is implemented using a full-outer-join using the merge condition.
   *
   * Note that unlike the insert-only code paths with just one control column ROW_DROPPED_COL, this
   * method has a second control column CDC_TYPE_COL_NAME used for handling CDC when enabled.
   */
  protected def writeAllChanges(...) {
  ...
    val joinedDF =
      if (writeUnmodifiedRows) {
        joinedBaseDF
      } else {
        val filter = Or(generateFilterForModifiedRows(), generateFilterForNewRows())
        joinedBaseDF.filter(Column(filter))
      }
   ....
  }

  /**
   * Returns the expression that can be used for selecting the modified rows generated
   * by the merge operation. The expression is to designed to work irrespectively
   * of the join type used between the source and target tables.
   *
   * The expression consists of two parts, one for each of the action clause types that produce
   * row modifications: MATCHED, NOT MATCHED BY SOURCE. All actions of the same clause type form
   * a disjunctive clause. The result is then conjucted to an expression that filters the rows
   * of the particular action clause type. For example:
   *
   * MERGE INTO t
   * USING s
   * ON s.id = t.id
   * WHEN MATCHED AND id < 5 THEN ...
   * WHEN MATCHED AND id > 10 THEN ...
   * WHEN NOT MATCHED BY SOURCE AND id > 20 THEN ...
   *
   * Produces the following expression:
   *
   * ((as.id = t.id) AND (id < 5 OR id > 10))
   * OR
   * ((SOURCE TABLE IS NULL) AND (id > 20))
   */
  protected def generateFilterForModifiedRows(): Expression = {
    val matchedExpression = if (matchedClauses.nonEmpty) {
      And(Column(condition).expr, clauseDisjunction(matchedClauses))
    } else {
      Literal.FalseLiteral
    }

    val notMatchedBySourceExpression = if (notMatchedBySourceClauses.nonEmpty) {
      val combinedClauses = clauseDisjunction(notMatchedBySourceClauses)
      And(col(SOURCE_ROW_PRESENT_COL).isNull.expr, combinedClauses)
    } else {
      Literal.FalseLiteral
    }

    Or(matchedExpression, notMatchedBySourceExpression)
  }
```

We filter to rows that we *know* will land in one of the actions. With this invariant, we can safely remove the fallbacks and raise errors instead.
## How was this patch tested?


## Does this PR introduce _any_ user-facing changes?

No.