### PR TITLE
[Kernel] Remove `schemaString` from `Metadata` action constructor

### DIFF
--- a/connectors/flink/src/test/java/io/delta/flink/source/internal/KernelMetadataUtils.java
+++ b/connectors/flink/src/test/java/io/delta/flink/source/internal/KernelMetadataUtils.java
@@ -55,9 +55,8 @@ public class KernelMetadataUtils {
             Optional.ofNullable("name"),
             Optional.ofNullable("description"),
             new io.delta.kernel.internal.actions.Format("parquet", new HashMap<String, String>()),
-            "schemaString",
             schema,
-            new ArrayValue() { // paritionColumns
+            new ArrayValue() { // partitionColumns
                 @Override
                 public int getSize() {
                     return 2;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -805,7 +805,6 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         Optional.empty(), /* name */
         Optional.empty(), /* description */
         new Format(), /* format */
-        schema.get().toJson(), /* schemaString */
         schema.get(), /* schema */
         buildArrayValue(partitionColumnsCasePreserving, StringType.STRING), /* partitionColumns */
         Optional.of(currentTimeMillis), /* createdTime */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -54,7 +54,6 @@ public class Metadata {
         Optional.ofNullable(
             vector.getChild(2).isNullAt(rowId) ? null : vector.getChild(2).getString(rowId)),
         Format.fromColumnVector(requireNonNull(vector.getChild(3), rowId, "format"), rowId),
-        schemaJson,
         schema,
         vector.getChild(5).getArray(rowId),
         Optional.ofNullable(
@@ -83,7 +82,6 @@ public class Metadata {
   private final Optional<String> name;
   private final Optional<String> description;
   private final Format format;
-  private final String schemaString;
   private final StructType schema;
   private final ArrayValue partitionColumns;
   private final Optional<Long> createdTime;
@@ -99,7 +97,6 @@ public class Metadata {
       Optional<String> name,
       Optional<String> description,
       Format format,
-      String schemaString,
       StructType schema,
       ArrayValue partitionColumns,
       Optional<Long> createdTime,
@@ -108,8 +105,7 @@ public class Metadata {
     this.name = name;
     this.description = requireNonNull(description, "description is null");
     this.format = requireNonNull(format, "format is null");
-    this.schemaString = requireNonNull(schemaString, "schemaString is null");
-    this.schema = schema;
+    this.schema = requireNonNull(schema, "schema is null");
     this.partitionColumns = requireNonNull(partitionColumns, "partitionColumns is null");
     this.createdTime = createdTime;
     this.configurationMapValue = requireNonNull(configurationMapValue, "configuration is null");
@@ -160,7 +156,6 @@ public class Metadata {
         this.name,
         this.description,
         this.format,
-        this.schemaString,
         this.schema,
         this.partitionColumns,
         this.createdTime,
@@ -173,7 +168,6 @@ public class Metadata {
         this.name,
         this.description,
         this.format,
-        schema.toJson(),
         schema,
         this.partitionColumns,
         this.createdTime,
@@ -203,7 +197,7 @@ public class Metadata {
         + ", format="
         + format
         + ", schemaString='"
-        + schemaString
+        + schema.toJson()
         + '\''
         + ", partitionColumns="
         + sb
@@ -212,10 +206,6 @@ public class Metadata {
         + ", configuration="
         + configuration.get()
         + '}';
-  }
-
-  public String getSchemaString() {
-    return schemaString;
   }
 
   public StructType getSchema() {
@@ -303,7 +293,7 @@ public class Metadata {
     metadataMap.put(1, name.orElse(null));
     metadataMap.put(2, description.orElse(null));
     metadataMap.put(3, format.toRow());
-    metadataMap.put(4, schemaString);
+    metadataMap.put(4, schema.toJson());
     metadataMap.put(5, partitionColumns);
     metadataMap.put(6, createdTime.orElse(null));
     metadataMap.put(7, configurationMapValue);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
@@ -50,7 +50,7 @@ public class TransactionStateRow extends GenericRow {
 
   public static TransactionStateRow of(Metadata metadata, String tablePath, int maxRetries) {
     HashMap<Integer, Object> valueMap = new HashMap<>();
-    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), metadata.getSchemaString());
+    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), metadata.getSchema().toJson());
     valueMap.put(
         COL_NAME_TO_ORDINAL.get("physicalSchemaString"), metadata.getPhysicalSchema().toJson());
     valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumns());

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -162,7 +162,6 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
         Optional.empty(),
         Optional.empty(),
         new Format(),
-        DataTypeJsonSerDe.serializeDataType(schema),
         schema,
         VectorUtils.buildArrayValue(Seq.empty.asJava, StringType.STRING),
         Optional.empty(),
@@ -306,7 +305,6 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
       Optional.empty(), /* name */
       Optional.empty(), /* description */
       new Format(),
-      DataTypeJsonSerDe.serializeDataType(schema),
       schema,
       VectorUtils.buildArrayValue(partitionCols.asJava, StringType.STRING), // partitionColumns
       Optional.empty(), // createdTime

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
@@ -1014,7 +1014,6 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       Optional.empty(),
       Optional.empty(),
       new Format(),
-      testSchema.toJson,
       testSchema,
       buildArrayValue(java.util.Arrays.asList("c3"), StringType.STRING),
       Optional.of(123),

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtilsSuite.scala
@@ -45,7 +45,6 @@ class GenerateIcebergCompatActionUtilsSuite extends AnyFunSuite {
       Optional.empty(), /* name */
       Optional.empty(), /* description */
       new Format(),
-      testSchema.toJson,
       testSchema,
       VectorUtils.buildArrayValue(partitionColumns.asJava, StringType.STRING),
       Optional.empty(), /* createdTime */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/MetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/MetadataSuite.scala
@@ -53,7 +53,6 @@ class MetadataSuite extends AnyFunSuite {
       Optional.of("name"),
       Optional.of("description"),
       new Format("parquet", Collections.emptyMap()),
-      testSchema.toJson,
       testSchema,
       new ArrayValue() { // partitionColumns
         override def getSize = 1

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumWriterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumWriterSuite.scala
@@ -158,7 +158,6 @@ class ChecksumWriterSuite extends AnyFunSuite with MockEngineUtils {
       Optional.of("name"),
       Optional.of("description"),
       new Format("parquet", Collections.emptyMap()),
-      DataTypeJsonSerDe.serializeDataType(new StructType()),
       new StructType(),
       buildArrayValue(util.Arrays.asList("c3"), StringType.STRING),
       Optional.of(123),

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -1212,7 +1212,6 @@ class TableFeaturesSuite extends AnyFunSuite {
       Optional.of("name"),
       Optional.of("description"),
       new Format("parquet", Collections.emptyMap()),
-      testSchema.toJson,
       testSchema,
       new ArrayValue() { // partitionColumns
         override def getSize = 1

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -1202,7 +1202,6 @@ class SchemaUtilsSuite extends AnyFunSuite {
       Optional.empty(), /* name */
       Optional.empty(), /* description */
       new Format(),
-      DataTypeJsonSerDe.serializeDataType(schema),
       schema,
       VectorUtils.buildArrayValue(util.Arrays.asList(), StringType.STRING), // partitionColumns
       Optional.empty(), // createdTime

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -63,7 +63,6 @@ trait ActionUtils extends VectorTestUtils {
       Optional.of("name"),
       Optional.of("description"),
       new Format("parquet", Collections.emptyMap()),
-      schema.toJson,
       schema,
       new ArrayValue() { // partitionColumns
         override def getSize: Int = partitionCols.size

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockSnapshotUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockSnapshotUtils.scala
@@ -55,7 +55,6 @@ object MockSnapshotUtils {
       Optional.empty(), /* name */
       Optional.empty(), /* description */
       new Format(),
-      testSchema.toJson,
       testSchema,
       buildArrayValue(java.util.Arrays.asList("c3"), StringType.STRING),
       Optional.of(123),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
@@ -112,7 +112,6 @@ trait ChecksumComparisonSuiteBase extends DeltaTableWriteSuiteBase with TestUtil
         metadata.getName,
         metadata.getDescription,
         metadata.getFormat,
-        metadata.getSchemaString,
         metadata.getSchema,
         metadata.getPartitionColumns,
         Optional.empty(),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The current `Metadata` action constructor requires both a schema `StructType` and a string representation of the schema. This introduces a possible danger of data inconsistency.

This PR therefore removes `schemaString` from the `Metadata` constructor and adjusts all affected methods & tests.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Existing tests. This PR contains a refactoring without new functionality.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No - action implementations are part of `kernel.internal`.
