### PR TITLE
[Kernel] Refactor `ScanStateRow` and clean up schema representations

### DIFF
--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
@@ -238,7 +238,7 @@ public class MultiThreadedTableReader
                     FileStatus fileStatus =
                         InternalScanFileUtils.getAddFileStatus(scanFile);
                     StructType physicalReadSchema =
-                        ScanStateRow.getPhysicalDataReadSchema(engine, scanState);
+                        ScanStateRow.getPhysicalDataReadSchema(scanState);
 
                     CloseableIterator<ColumnarBatch> physicalDataIter =
                         engine.getParquetHandler().readParquetFiles(

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -103,7 +103,7 @@ public class SingleThreadedTableReader
         int readRecordCount = 0;
         try {
             StructType physicalReadSchema =
-                ScanStateRow.getPhysicalDataReadSchema(engine, scanState);
+                ScanStateRow.getPhysicalDataReadSchema(scanState);
             while (scanFileIter.hasNext()) {
                 FilteredColumnarBatch scanFilesBatch = scanFileIter.next();
                 try (CloseableIterator<Row> scanFileRows = scanFilesBatch.getRows()) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -147,7 +147,6 @@ public interface Scan {
       boolean inited = false;
 
       // initialized as part of init()
-      StructType physicalSchema = null; // TODO: This is unused and could be removed
       StructType logicalSchema = null;
       String tablePath = null;
 
@@ -158,7 +157,6 @@ public interface Scan {
         if (inited) {
           return;
         }
-        physicalSchema = ScanStateRow.getPhysicalDataReadSchema(scanState);
         logicalSchema = ScanStateRow.getLogicalSchema(scanState);
 
         tablePath = ScanStateRow.getTableRoot(scanState).toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -147,7 +147,7 @@ public interface Scan {
       boolean inited = false;
 
       // initialized as part of init()
-      StructType physicalSchema = null;  // TODO: This is unused and could be removed
+      StructType physicalSchema = null; // TODO: This is unused and could be removed
       StructType logicalSchema = null;
       String tablePath = null;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -463,6 +463,15 @@ public final class DeltaErrors {
         String.format("Required metadata key %s is not present in scan file %s.", entry, filePath));
   }
 
+  public static KernelException logicalPhysicalSchemaMismatch(
+      int logical_size, int physical_size, int num_partition_cols) {
+    return new KernelException(
+        String.format(
+            "Logical schema (%s) size does not equal physical schema size (%s) plus number of "
+                + "partition columns (%s).",
+            logical_size, physical_size, num_partition_cols));
+  }
+
   /* ------------------------ HELPER METHODS ----------------------------- */
   private static String formatTimestamp(long millisSinceEpochUTC) {
     return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -464,11 +464,11 @@ public final class DeltaErrors {
   }
 
   public static KernelException logicalPhysicalSchemaMismatch(
-      int logical_size, int physical_size, int num_partition_cols) {
+      int logical_size, int num_partition_cols, int physical_size) {
     return new KernelException(
         String.format(
-            "Logical schema (%s) size does not equal physical schema size (%s) plus number of "
-                + "partition columns (%s).",
+            "Logical schema (%s) size minus number of partition columns (%s) does not equal "
+                + "physical schema size (%s).",
             logical_size, physical_size, num_partition_cols));
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -350,6 +350,7 @@ public final class DeltaErrors {
     return new KernelException(
         String.format("Disabling %s on an existing table is not allowed.", key));
   }
+
   // End: icebergCompat exceptions
 
   public static KernelException partitionColumnMissingInData(
@@ -461,15 +462,6 @@ public final class DeltaErrors {
   public static KernelException rowTrackingMetadataMissingInFile(String entry, String filePath) {
     return new KernelException(
         String.format("Required metadata key %s is not present in scan file %s.", entry, filePath));
-  }
-
-  public static KernelException logicalPhysicalSchemaMismatch(
-      int logical_size, int num_partition_cols, int physical_size) {
-    return new KernelException(
-        String.format(
-            "Logical schema (%s) size minus number of partition columns (%s) does not equal "
-                + "physical schema size (%s).",
-            logical_size, physical_size, num_partition_cols));
   }
 
   /* ------------------------ HELPER METHODS ----------------------------- */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
@@ -48,11 +48,11 @@ public class DeltaErrorsInternal {
   }
 
   public static IllegalStateException logicalPhysicalSchemaMismatch(
-      int logical_size, int num_partition_cols, int physical_size) {
+      int num_partition_cols, int physical_size, int logical_size) {
     return new IllegalStateException(
         String.format(
-            "Logical schema (%s) size minus number of partition columns (%s) does not equal "
-                + "physical schema size (%s).",
-            logical_size, physical_size, num_partition_cols));
+            "The number of partition columns (%s) plus the physical schema size (%s) does not "
+                + "equal the logical schema size (%s).",
+            num_partition_cols, physical_size, logical_size));
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrorsInternal.java
@@ -46,4 +46,13 @@ public class DeltaErrorsInternal {
             + "not catalog-managed Delta tables. Since this table is catalog-managed, this "
             + "commit operation is unsupported.");
   }
+
+  public static IllegalStateException logicalPhysicalSchemaMismatch(
+      int logical_size, int num_partition_cols, int physical_size) {
+    return new IllegalStateException(
+        String.format(
+            "Logical schema (%s) size minus number of partition columns (%s) does not equal "
+                + "physical schema size (%s).",
+            logical_size, physical_size, num_partition_cols));
+  }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -42,7 +42,6 @@ import io.delta.kernel.internal.skipping.DataSkippingUtils;
 import io.delta.kernel.internal.util.*;
 import io.delta.kernel.metrics.ScanReport;
 import io.delta.kernel.metrics.SnapshotReport;
-import io.delta.kernel.types.FieldMetadata;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
@@ -218,16 +217,6 @@ public class ScanImpl implements Scan {
     return getDataFilters();
   }
 
-  /** Helper method to create a copy of a column that is marked as an internal column. */
-  public static StructField createInternalColumn(StructField field) {
-    FieldMetadata metadata =
-        FieldMetadata.builder()
-            .fromMetadata(field.getMetadata())
-            .putBoolean(StructField.IS_INTERNAL_COLUMN_KEY, true)
-            .build();
-    return field.withNewMetadata(metadata);
-  }
-
   /**
    * Transform the logical schema requested by the connector into a physical schema that is passed
    * to the engine's parquet reader.
@@ -263,7 +252,7 @@ public class ScanImpl implements Scan {
             .map(StructField::getName)
             .noneMatch(name -> name.equals(StructField.METADATA_ROW_INDEX_COLUMN_NAME))) {
       // If the row index column is not already present, add it to the physical read schema
-      physicalFields.add(createInternalColumn(StructField.METADATA_ROW_INDEX_COLUMN));
+      physicalFields.add(SchemaUtils.createInternalColumn(StructField.METADATA_ROW_INDEX_COLUMN));
     }
 
     return new StructType(physicalFields);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -39,7 +39,6 @@ public class ScanStateRow extends GenericRow {
           .add("configuration", new MapType(StringType.STRING, StringType.STRING, false))
           .add("logicalSchemaString", StringType.STRING)
           .add("physicalSchemaString", StringType.STRING)
-          .add("physicalDataReadSchemaString", StringType.STRING)
           .add("partitionColumns", new ArrayType(StringType.STRING, false))
           .add("minReaderVersion", IntegerType.INTEGER)
           .add("minWriterVersion", IntegerType.INTEGER)
@@ -53,16 +52,13 @@ public class ScanStateRow extends GenericRow {
   public static ScanStateRow of(
       Metadata metadata,
       Protocol protocol,
-      String readSchemaLogicalJson,
-      String readSchemaPhysicalJson,
-      String readPhysicalDataSchemaJson,
+      String logicalSchemaString,
+      String physicalSchemaString,
       String tablePath) {
     HashMap<Integer, Object> valueMap = new HashMap<>();
     valueMap.put(COL_NAME_TO_ORDINAL.get("configuration"), metadata.getConfigurationMapValue());
-    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), readSchemaLogicalJson);
-    valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaString"), readSchemaPhysicalJson);
-    valueMap.put(
-        COL_NAME_TO_ORDINAL.get("physicalDataReadSchemaString"), readPhysicalDataSchemaJson);
+    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), logicalSchemaString);
+    valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaString"), physicalSchemaString);
     valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumns());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minReaderVersion"), protocol.getMinReaderVersion());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minWriterVersion"), protocol.getMinWriterVersion());
@@ -99,28 +95,15 @@ public class ScanStateRow extends GenericRow {
 
   /**
    * Utility method to get the physical schema from the scan state {@link Row} returned by {@link
-   * Scan#getScanState(Engine)}.
+   * Scan#getScanState(Engine)}. This schema is used to request data from the scan files for the
+   * query.
    *
    * @param scanState Scan state {@link Row}
    * @return Physical schema to read from the data files.
    */
-  public static StructType getPhysicalSchema(Row scanState) {
+  public static StructType getPhysicalDataReadSchema(Row scanState) {
+    // TODO: This method should be deprecated in favor of getPhysicalSchema
     String serializedSchema = scanState.getString(COL_NAME_TO_ORDINAL.get("physicalSchemaString"));
-    return DataTypeJsonSerDe.deserializeStructType(serializedSchema);
-  }
-
-  /**
-   * Utility method to get the physical data read schema from the scan state {@link Row} returned by
-   * {@link Scan#getScanState(Engine)}. This schema is used to request data from the scan files for
-   * the query.
-   *
-   * @param engine instance of {@link Engine} to use.
-   * @param scanState Scan state {@link Row}
-   * @return Physical schema to read from the data files.
-   */
-  public static StructType getPhysicalDataReadSchema(Engine engine, Row scanState) {
-    String serializedSchema =
-        scanState.getString(COL_NAME_TO_ORDINAL.get("physicalDataReadSchemaString"));
     return DataTypeJsonSerDe.deserializeStructType(serializedSchema);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -102,7 +102,6 @@ public class ScanStateRow extends GenericRow {
    * @return Physical schema to read from the data files.
    */
   public static StructType getPhysicalDataReadSchema(Row scanState) {
-    // TODO: This method should be deprecated in favor of getPhysicalSchema
     String serializedSchema = scanState.getString(COL_NAME_TO_ORDINAL.get("physicalSchemaString"));
     return DataTypeJsonSerDe.deserializeStructType(serializedSchema);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -108,6 +108,21 @@ public class ScanStateRow extends GenericRow {
   }
 
   /**
+   * Utility method to get the physical schema from the scan state {@link Row} returned by {@link
+   * Scan#getScanState(Engine)}. This schema is used to request data from the scan files for the
+   * query.
+   *
+   * @deprecated The engine parameter is not needed and this method will be removed in a future
+   *     release. Use {@link #getPhysicalDataReadSchema(Row)} instead.
+   * @param scanState Scan state {@link Row}
+   * @return Physical schema to read from the data files.
+   */
+  @Deprecated
+  public static StructType getPhysicalDataReadSchema(Engine engine, Row scanState) {
+    return getPhysicalDataReadSchema(scanState);
+  }
+
+  /**
    * Get the list of partition column names from the scan state {@link Row} returned by {@link
    * Scan#getScanState(Engine)}.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -37,8 +37,8 @@ public class ScanStateRow extends GenericRow {
   private static final StructType SCHEMA =
       new StructType()
           .add("configuration", new MapType(StringType.STRING, StringType.STRING, false))
-          .add("logicalSchemaString", StringType.STRING)
-          .add("physicalSchemaString", StringType.STRING)
+          .add("logicalSchemaJson", StringType.STRING)
+          .add("physicalSchemaJson", StringType.STRING)
           .add("partitionColumns", new ArrayType(StringType.STRING, false))
           .add("minReaderVersion", IntegerType.INTEGER)
           .add("minWriterVersion", IntegerType.INTEGER)
@@ -52,13 +52,13 @@ public class ScanStateRow extends GenericRow {
   public static ScanStateRow of(
       Metadata metadata,
       Protocol protocol,
-      String logicalSchemaString,
-      String physicalSchemaString,
+      String logicalSchemaJson,
+      String physicalSchemaJson,
       String tablePath) {
     HashMap<Integer, Object> valueMap = new HashMap<>();
     valueMap.put(COL_NAME_TO_ORDINAL.get("configuration"), metadata.getConfigurationMapValue());
-    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), logicalSchemaString);
-    valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaString"), physicalSchemaString);
+    valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaJson"), logicalSchemaJson);
+    valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaJson"), physicalSchemaJson);
     valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumns());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minReaderVersion"), protocol.getMinReaderVersion());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minWriterVersion"), protocol.getMinWriterVersion());
@@ -89,7 +89,7 @@ public class ScanStateRow extends GenericRow {
    * @return Logical schema to read from the data files.
    */
   public static StructType getLogicalSchema(Row scanState) {
-    String serializedSchema = scanState.getString(COL_NAME_TO_ORDINAL.get("logicalSchemaString"));
+    String serializedSchema = scanState.getString(COL_NAME_TO_ORDINAL.get("logicalSchemaJson"));
     return DataTypeJsonSerDe.deserializeStructType(serializedSchema);
   }
 
@@ -102,23 +102,8 @@ public class ScanStateRow extends GenericRow {
    * @return Physical schema to read from the data files.
    */
   public static StructType getPhysicalDataReadSchema(Row scanState) {
-    String serializedSchema = scanState.getString(COL_NAME_TO_ORDINAL.get("physicalSchemaString"));
+    String serializedSchema = scanState.getString(COL_NAME_TO_ORDINAL.get("physicalSchemaJson"));
     return DataTypeJsonSerDe.deserializeStructType(serializedSchema);
-  }
-
-  /**
-   * Utility method to get the physical schema from the scan state {@link Row} returned by {@link
-   * Scan#getScanState(Engine)}. This schema is used to request data from the scan files for the
-   * query.
-   *
-   * @deprecated The engine parameter is not needed and this method will be removed in a future
-   *     release. Use {@link #getPhysicalDataReadSchema(Row)} instead.
-   * @param scanState Scan state {@link Row}
-   * @return Physical schema to read from the data files.
-   */
-  @Deprecated
-  public static StructType getPhysicalDataReadSchema(Engine engine, Row scanState) {
-    return getPhysicalDataReadSchema(scanState);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/MaterializedRowTrackingColumn.java
@@ -26,10 +26,10 @@ import io.delta.kernel.exceptions.InvalidTableException;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.InternalScanFileUtils;
-import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.SchemaUtils;
 import io.delta.kernel.types.*;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -183,7 +183,7 @@ public final class MaterializedRowTrackingColumn {
               LongType.LONG,
               true /* nullable */));
       if (logicalSchema.indexOf(StructField.METADATA_ROW_INDEX_COLUMN_NAME) == -1) {
-        physicalFields.add(ScanImpl.createInternalColumn(StructField.METADATA_ROW_INDEX_COLUMN));
+        physicalFields.add(SchemaUtils.createInternalColumn(StructField.METADATA_ROW_INDEX_COLUMN));
       }
       return physicalFields;
     } else if (logicalField.getName().equals(METADATA_ROW_COMMIT_VERSION_COLUMN_NAME)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -70,15 +70,19 @@ public class PartitionUtils {
       return dataBatch;
     }
 
+    // We verify that the number of partition columns in the logical schema plus the number of
+    // columns in the data batch schema is equal to the length of the logical schema.
+    // `partitionValues` contains all partition columns of the table (not just the requested ones),
+    // so we first need to count the number of partition columns in the logical schema.
     int numPartitionColumnsInSchema =
         (int)
             logicalSchema.fields().stream()
                 .map(ColumnMapping::getPhysicalName)
                 .filter(partitionValues::containsKey)
                 .count();
-    if (logicalSchema.length() - numPartitionColumnsInSchema != dataBatch.getSchema().length()) {
+    if (numPartitionColumnsInSchema + dataBatch.getSchema().length() != logicalSchema.length()) {
       throw DeltaErrorsInternal.logicalPhysicalSchemaMismatch(
-          logicalSchema.length(), partitionValues.size(), dataBatch.getSchema().length());
+          numPartitionColumnsInSchema, dataBatch.getSchema().length(), logicalSchema.length());
     }
 
     for (int colIdx = 0; colIdx < logicalSchema.length(); colIdx++) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -27,7 +27,6 @@ import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.engine.ExpressionHandler;
 import io.delta.kernel.expressions.*;
-import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.DeltaErrorsInternal;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.annotation.VisibleForTesting;
@@ -78,7 +77,7 @@ public class PartitionUtils {
                 .filter(partitionValues::containsKey)
                 .count();
     if (logicalSchema.length() - numPartitionColumnsInSchema != dataBatch.getSchema().length()) {
-      throw DeltaErrors.logicalPhysicalSchemaMismatch(
+      throw DeltaErrorsInternal.logicalPhysicalSchemaMismatch(
           logicalSchema.length(), partitionValues.size(), dataBatch.getSchema().length());
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -82,6 +82,8 @@ public class PartitionUtils {
     }
 
     for (int colIdx = 0; colIdx < logicalSchema.length(); colIdx++) {
+      // We must iterate the logical schema in order since we insert partition columns into the data
+      // batch according to their ordinal in the logical schema.
       StructField structField = logicalSchema.at(colIdx);
       String physicalName = ColumnMapping.getPhysicalName(structField);
       if (partitionValues.containsKey(physicalName)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -330,6 +330,16 @@ public class SchemaUtils {
     return columnPath.stream().map(SchemaUtils::escapeDots).collect(Collectors.joining("."));
   }
 
+  /** Helper method to create a copy of a column that is marked as an internal column. */
+  public static StructField createInternalColumn(StructField field) {
+    FieldMetadata metadata =
+        FieldMetadata.builder()
+            .fromMetadata(field.getMetadata())
+            .putBoolean(StructField.IS_INTERNAL_COLUMN_KEY, true)
+            .build();
+    return field.withNewMetadata(metadata);
+  }
+
   /////////////////////////////////////////////////////////////////////////////////////////////////
   /// Private methods                                                                           ///
   /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -370,7 +380,7 @@ public class SchemaUtils {
         // <a (id=1) : map<int,struct<b (id=2) : Int, c (id=3) : Int>>> )
         // This would eventually probe the currentFieldIdToField map for <"", 3> and
         // find it is an addition.
-        SchemaElementId rootId = new SchemaElementId(/* nestedPath =*/ "", id.getId());
+        SchemaElementId rootId = new SchemaElementId(/* nestedPath= */ "", id.getId());
         if (!currentFieldIdToField.containsKey(rootId)) {
           addedFieldIds.add(id.getId());
           schemaDiff.withAddedField(newElement.getNearestStructFieldAncestor());

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -266,7 +266,7 @@ trait AbstractTestUtils extends Assertions with SQLHelper {
     val scanState = scan.getScanState(engine);
     val fileIter = scan.getScanFiles(engine)
 
-    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(engine, scanState)
+    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(scanState)
     fileIter.forEach { fileColumnarBatch =>
       fileColumnarBatch.getRows().forEach { scanFileRow =>
         val fileStatus = InternalScanFileUtils.getAddFileStatus(scanFileRow)
@@ -320,7 +320,7 @@ trait AbstractTestUtils extends Assertions with SQLHelper {
       .build()
     val scanState = scan.getScanState(engine)
 
-    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(engine, scanState)
+    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(scanState)
     var result: Seq[FilteredColumnarBatch] = Nil
     scan.getScanFiles(engine).forEach { fileColumnarBatch =>
       fileColumnarBatch.getRows.forEach { scanFile =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR refactors the way kernel internally keeps track of logical and physical (read) schemas as well as intermediate versions thereof. The reason for this change is that the existing implementation is rather unintuitive and hard to maintain (especially for new developers).

In the context of this refactoring, I also modified the public API of `ScanStateRow`. Concretely, we do not serialize/expose the physical schema with partition columns anymore (formerly called `physicalSchema` although it is not the actual physical schema). Instead, we only expose the `logicalSchema` (sometimes also called `readSchema`) and the `physicalDataReadSchema` (which is the actual physical schema).

Internally, `physicalSchema` now refers to the actual physical schema (formerly `physicalDataReadSchema`). Ideally, we would also change the public API to reflect this, but this is up for discussion as it could be a potentially breaking change for query engines.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Existing tests - this PR does not add new functionality.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This PR cleans up (i.e., changes) the public interface of `ScanStateRow`. `ScanStateRow` is part of `kernel.internal` but still might be interacted with by query engines depending on how many defaults of Kernel they overwrite.

#### `ScanStateRow.getPhysicalSchema()`

Removed - the return value was not the actual physical schema but the physical schema plus partition columns. Since it does not represent anything that query engines should use, I removed this API to avoid confusion among developers.

#### `ScanStateRow.getPhysicalDataReadSchema()`

- Deprecated: `public static StructType getPhysicalDataReadSchema(Engine engine, Row scanState)`
- New: `public static StructType getPhysicalDataReadSchema(Row scanState)`

This method used to expect an `Engine` instance although it never used it. This behavior is inconsistent with the other public method in `ScanStateRow`, which do not expect an `Engine` instance. I therefore vote to deprecate/remove the `engine` parameter.

Furthermore, I vote to rename the method to `getPhysicalSchema` to more accurately and less verbosely describe its behavior, but I recognize that this might lead to migration issues for some users.

- Ideal (new) API: `public static StructType getPhysicalSchema(Row scanState)`
