### PR TITLE
[Kernel] [CatalogManaged] Implement default commiter & refactor TransactionImpl to use it

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentWriteException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentWriteException.java
@@ -24,13 +24,19 @@ import io.delta.kernel.annotation.Evolving;
  */
 @Evolving
 public class ConcurrentWriteException extends KernelException {
+  static final String msg =
+      "Transaction has encountered a conflict and can not be committed. "
+          + "Query needs to be re-executed using the latest version of the table.";
+
   public ConcurrentWriteException() {
-    super(
-        "Transaction has encountered a conflict and can not be committed. "
-            + "Query needs to be re-executed using the latest version of the table.");
+    super(msg);
   }
 
   public ConcurrentWriteException(String message) {
     super(message);
+  }
+
+  public ConcurrentWriteException(Throwable cause) {
+    super(msg, cause);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentWriteException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentWriteException.java
@@ -24,12 +24,12 @@ import io.delta.kernel.annotation.Evolving;
  */
 @Evolving
 public class ConcurrentWriteException extends KernelException {
-  static final String msg =
-      "Transaction has encountered a conflict and can not be committed. "
+  private static final String ERROR_MESSAGE =
+      "Transaction has encountered a conflict and cannot be committed. "
           + "Query needs to be re-executed using the latest version of the table.";
 
   public ConcurrentWriteException() {
-    super(msg);
+    super(ERROR_MESSAGE);
   }
 
   public ConcurrentWriteException(String message) {
@@ -37,6 +37,6 @@ public class ConcurrentWriteException extends KernelException {
   }
 
   public ConcurrentWriteException(Throwable cause) {
-    super(msg, cause);
+    super(ERROR_MESSAGE, cause);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/MaxCommitRetriesReachedException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/MaxCommitRetriesReachedException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.exceptions;
+
+import io.delta.kernel.annotation.Evolving;
+
+@Evolving
+public class MaxCommitRetriesReachedException extends KernelException {
+  public MaxCommitRetriesReachedException(long commitVersion, int maxRetries, Exception cause) {
+    super(
+        String.format(
+            "Commit attempt for version %d failed with a retryable exception but will not be "
+                + "retried because the maximum number of retries (%d) has been reached.",
+            commitVersion, maxRetries),
+        cause);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -512,12 +512,8 @@ public class TransactionImpl implements Transaction {
               commitAsVersion,
               logPath.toString(),
               attemptCommitInfo,
-              readSnapshot.getVersion() >= 0
-                  ? Optional.of(readSnapshot.getProtocol())
-                  : Optional.empty(),
-              readSnapshot.getVersion() >= 0
-                  ? Optional.of(readSnapshot.getMetadata())
-                  : Optional.empty(),
+              readSnapshotOpt.map(SnapshotImpl::getProtocol),
+              readSnapshotOpt.map(SnapshotImpl::getMetadata),
               shouldUpdateProtocol ? Optional.of(protocol) : Optional.empty(),
               shouldUpdateMetadata ? Optional.of(metadata) : Optional.empty());
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
@@ -71,7 +71,7 @@ public class DefaultFileSystemManagedTableOnlyCommitter implements Committer {
           false /* conflict */,
           "Failed to write commit file due to I/O error: " + e.getMessage(),
           e);
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       throw new CommitFailedException(
           false /* retryable */,
           false /* conflict */,
@@ -79,6 +79,7 @@ public class DefaultFileSystemManagedTableOnlyCommitter implements Committer {
           e);
     }
 
+    // TODO: [delta-io/delta#5021] Use FileSystemClient::getFileStatus API instead
     return new CommitResponse(ParsedLogData.forFileStatus(FileStatus.of(jsonCommitFile)));
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -185,6 +185,11 @@ public final class FileNames {
     return String.format("%s/%020d.json", path, version);
   }
 
+  /** Returns the delta (json format) path for a given delta file. */
+  public static String deltaFile(String path, long version) {
+    return deltaFile(new Path(path), version);
+  }
+
   public static String stagedCommitFile(Path logPath, long version) {
     final Path stagedCommitPath = new Path(logPath, STAGED_COMMIT_DIRECTORY);
     return String.format("%s/%020d.%s.json", stagedCommitPath, version, UUID.randomUUID());

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaReplaceTableSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaReplaceTableSuite.scala
@@ -22,7 +22,7 @@ import io.delta.kernel.{Operation, Table, Transaction, TransactionBuilder, Trans
 import io.delta.kernel.data.FilteredColumnarBatch
 import io.delta.kernel.defaults.utils.TestRow
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.exceptions.{ConcurrentTransactionException, ConcurrentWriteException, KernelException, TableNotFoundException}
+import io.delta.kernel.exceptions.{ConcurrentTransactionException, ConcurrentWriteException, KernelException, MaxCommitRetriesReachedException, TableNotFoundException}
 import io.delta.kernel.expressions.{Column, Literal}
 import io.delta.kernel.expressions.Literal.{ofInt, ofString}
 import io.delta.kernel.internal.{SnapshotImpl, TableConfig, TableImpl}
@@ -318,7 +318,7 @@ class DeltaReplaceTableSuite extends DeltaReplaceTableSuiteBase {
         tablePath,
         data = Seq(Map.empty[String, Literal] -> (dataBatches2)))
       // Try to commit replace table and intercept conflicting txn (no conflict resolution)
-      intercept[ConcurrentWriteException] {
+      intercept[MaxCommitRetriesReachedException] {
         commitTransaction(txn, engine, emptyIterable())
       }
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5010/files) to review incremental changes.
- [**stack/kernel_catalog_managed_transaction_impl_invoke_committer**](https://github.com/delta-io/delta/pull/5010) [[Files changed](https://github.com/delta-io/delta/pull/5010/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR implements the default committer and updates our transaction class to use it to perform the commit. Consequently, we have to change how our TransactionImpl decides when/if to retry the commit, based on the type of CommitFailedException thrown by the committer.

## How was this patch tested?

New unit and e2e tests.

## Does this PR introduce _any_ user-facing changes?

No.
