### PR TITLE
[WIP][KERNEL] Refactor `TransactionImpl` to make readSnapshot optional

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -17,6 +17,7 @@ package io.delta.kernel.internal;
 
 import static io.delta.kernel.internal.TableConfig.*;
 import static io.delta.kernel.internal.TableConfig.TOMBSTONE_RETENTION;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.ScanBuilder;
 import io.delta.kernel.Snapshot;
@@ -59,6 +60,7 @@ public class SnapshotImpl implements Snapshot {
       Protocol protocol,
       Metadata metadata,
       SnapshotQueryContext snapshotContext) {
+    checkArgument(logSegment.getVersion() >= 0, "A snapshot cannot have version < 0");
     this.logPath = new Path(dataPath, "_delta_log");
     this.dataPath = dataPath;
     this.version = logSegment.getVersion();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -262,7 +262,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
           false, // isCreateOrReplace
           table.getDataPath(),
           table.getLogPath(),
-          latestSnapshot.get(),
+          latestSnapshot,
           engineInfo,
           operation,
           latestSnapshot.get().getProtocol(), // reuse latest protocol
@@ -327,14 +327,6 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     Optional<Protocol> newProtocol = updatedProtocolAndMetadata._1;
     Optional<Metadata> newMetadata = updatedProtocolAndMetadata._2;
 
-    if (!latestSnapshot.isPresent()) {
-      // For now, we generate an empty snapshot (with version -1) for a new table. In the future,
-      // we should define an internal interface to expose just the information the transaction
-      // needs instead of the entire SnapshotImpl class. This should also let us avoid creating
-      // this fake empty initial snapshot.
-      latestSnapshot = Optional.of(getInitialEmptySnapshot(engine, baseMetadata, baseProtocol));
-    }
-
     // Block this for now - in a future PR we will enable this
     if (operation == Operation.REPLACE_TABLE) {
       if (newProtocol
@@ -351,7 +343,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         isCreateOrReplace,
         table.getDataPath(),
         table.getLogPath(),
-        latestSnapshot.get(),
+        latestSnapshot,
         engineInfo,
         operation,
         newProtocol.orElse(baseProtocol),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -119,8 +119,6 @@ public class TransactionImpl implements Transaction {
     this.isCreateOrReplace = isCreateOrReplace;
     this.dataPath = dataPath;
     this.logPath = logPath;
-    readSnapshot.ifPresent(snapshot ->
-        checkArgument(snapshot.getVersion() >= 0, "readSnapshot should be empty if the table does not exist"));
     this.readSnapshot = readSnapshot;
     this.engineInfo = engineInfo;
     this.operation = operation;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -119,6 +119,8 @@ public class TransactionImpl implements Transaction {
     this.isCreateOrReplace = isCreateOrReplace;
     this.dataPath = dataPath;
     this.logPath = logPath;
+    readSnapshot.ifPresent(snapshot ->
+        checkArgument(snapshot.getVersion() >= 0, "readSnapshot should be empty if the table does not exist"));
     this.readSnapshot = readSnapshot;
     this.engineInfo = engineInfo;
     this.operation = operation;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionReportImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionReportImpl.java
@@ -57,7 +57,7 @@ public class TransactionReportImpl extends DeltaOperationReportImpl implements T
       Optional<Long> committedVersion,
       Optional<List<Column>> clusteringColumns,
       TransactionMetrics transactionMetrics,
-      SnapshotReport snapshotReport,
+      Optional<SnapshotReport> snapshotReport,
       Optional<Exception> exception) {
     super(tablePath, exception);
     this.operation = requireNonNull(operation);
@@ -66,18 +66,18 @@ public class TransactionReportImpl extends DeltaOperationReportImpl implements T
     this.committedVersion = committedVersion;
     this.clusteringColumns = requireNonNull(clusteringColumns).orElse(Collections.emptyList());
     requireNonNull(snapshotReport);
-    checkArgument(
-        !snapshotReport.getException().isPresent(),
-        "Expected a successful SnapshotReport provided report has exception");
-    checkArgument(
-        snapshotReport.getVersion().isPresent(),
-        "Expected a successful SnapshotReport but missing version");
-    this.snapshotVersion = requireNonNull(snapshotReport).getVersion().get();
-    if (snapshotVersion < 0) {
-      // For a new table, no Snapshot is actually loaded and thus no SnapshotReport is emitted
-      this.snapshotReportUUID = Optional.empty();
+    if (snapshotReport.isPresent()) {
+      checkArgument(
+          !snapshotReport.get().getException().isPresent(),
+          "Expected a successful SnapshotReport provided report has exception");
+      checkArgument(
+          snapshotReport.get().getVersion().isPresent(),
+          "Expected a successful SnapshotReport but missing version");
+      this.snapshotVersion = snapshotReport.get().getVersion().get();
+      this.snapshotReportUUID = Optional.of(snapshotReport.get().getReportUUID());
     } else {
-      this.snapshotReportUUID = Optional.of(snapshotReport.getReportUUID());
+      this.snapshotVersion = -1;
+      this.snapshotReportUUID = Optional.empty();
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -178,7 +178,7 @@ public class ConflictChecker {
     Optional<CRCInfo> updatedCrcInfo =
         ChecksumReader.getCRCInfo(
             engine,
-            FileStatus.of(checksumFile(transaction.logPath, lastWinningVersion).toString()));
+            FileStatus.of(checksumFile(transaction.getLogPath(), lastWinningVersion).toString()));
 
     // if we get here, we have successfully rebased (i.e no logical conflicts)
     // against the winning transactions
@@ -368,7 +368,9 @@ public class ConflictChecker {
   }
 
   private List<FileStatus> getWinningCommitFiles(Engine engine) {
-    String firstWinningCommitFile = deltaFile(transaction.logPath, attemptVersion);
+    // TODO doesn't current impl mean we always try to resolve conflicts from readSnapshot version
+    //  again? instead of iteratively on only the newest commit
+    String firstWinningCommitFile = deltaFile(transaction.getLogPath(), attemptVersion);
 
     try (CloseableIterator<FileStatus> files =
         wrapEngineExceptionThrowsIO(
@@ -412,7 +414,7 @@ public class ConflictChecker {
       return lastWinningTxn.getModificationTime();
     } else {
       return CommitInfo.getRequiredInCommitTimestamp(
-          winningCommitInfoOpt, String.valueOf(lastWinningVersion), transaction.dataPath);
+          winningCommitInfoOpt, String.valueOf(lastWinningVersion), transaction.getDataPath());
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -105,7 +105,7 @@ public class RowTracking {
    *     defaultRowCommitVersions assigned or reassigned
    */
   public static CloseableIterable<Row> assignBaseRowIdAndDefaultRowCommitVersion(
-      SnapshotImpl txnReadSnapshot,
+      Optional<SnapshotImpl> txnReadSnapshot,
       Protocol txnProtocol,
       Optional<Long> winningTxnRowIdHighWatermark,
       Optional<Long> prevCommitVersion,
@@ -126,7 +126,8 @@ public class RowTracking {
       public CloseableIterator<Row> iterator() {
         // The row ID high watermark from the snapshot of the table that this transaction is reading
         // at. Any baseRowIds higher than this watermark are assigned by this transaction.
-        final long prevRowIdHighWatermark = readRowIdHighWaterMark(txnReadSnapshot);
+        final long prevRowIdHighWatermark =
+            txnReadSnapshot.map(RowTracking::readRowIdHighWaterMark).orElse(-1L);
 
         // Used to track the current high watermark as we iterate through the data actions and
         // assign baseRowIds. Use an AtomicLong to allow for updating in the lambda.
@@ -193,7 +194,7 @@ public class RowTracking {
    * @return Updated list of domain metadata actions for commit
    */
   public static List<DomainMetadata> updateRowIdHighWatermarkIfNeeded(
-      SnapshotImpl txnReadSnapshot,
+      Optional<SnapshotImpl> txnReadSnapshot,
       Protocol txnProtocol,
       Optional<Long> winningTxnRowIdHighWatermark,
       CloseableIterable<Row> txnDataActions,
@@ -215,7 +216,8 @@ public class RowTracking {
 
     // The row ID high watermark from the snapshot of the table that this transaction is reading at.
     // Any baseRowIds higher than this watermark are assigned by this transaction.
-    final long prevRowIdHighWatermark = readRowIdHighWaterMark(txnReadSnapshot);
+    final long prevRowIdHighWatermark =
+        txnReadSnapshot.map(RowTracking::readRowIdHighWaterMark).orElse(-1L);
 
     // Tracks the new row ID high watermark as we iterate through data actions and counting new rows
     // added in this transaction.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -41,9 +41,11 @@ public class InCommitTimestampUtils {
   public static Optional<Metadata> getUpdatedMetadataWithICTEnablementInfo(
       Engine engine,
       long inCommitTimestamp,
-      SnapshotImpl readSnapshot,
+      Optional<SnapshotImpl> readSnapshot,
       Metadata metadata,
       long commitVersion) {
+    // Instead of commitVersion this can use readSnapshot.isPresent? Make helper fx only for
+    // existing tables
     if (didCurrentTransactionEnableICT(engine, metadata, readSnapshot) && commitVersion != 0) {
       Map<String, String> enablementTrackingProperties = new HashMap<>();
       enablementTrackingProperties.put(
@@ -85,7 +87,7 @@ public class InCommitTimestampUtils {
 
   /** Returns true if the current transaction implicitly/explicitly enables ICT. */
   private static boolean didCurrentTransactionEnableICT(
-      Engine engine, Metadata currentTransactionMetadata, SnapshotImpl readSnapshot) {
+      Engine engine, Metadata currentTransactionMetadata, Optional<SnapshotImpl> readSnapshot) {
     // If ICT is currently enabled, and the read snapshot did not have ICT enabled,
     // then the current transaction must have enabled it.
     // In case of a conflict, any winning transaction that enabled it after
@@ -98,8 +100,8 @@ public class InCommitTimestampUtils {
     boolean isICTCurrentlyEnabled =
         IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(currentTransactionMetadata);
     boolean wasICTEnabledInReadSnapshot =
-        readSnapshot.getVersion() != -1
-            && IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(readSnapshot.getMetadata());
+        readSnapshot.isPresent()
+            && IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(readSnapshot.get().getMetadata());
     return isICTCurrentlyEnabled && !wasICTEnabledInReadSnapshot;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -44,9 +44,7 @@ public class InCommitTimestampUtils {
       Optional<SnapshotImpl> readSnapshot,
       Metadata metadata,
       long commitVersion) {
-    // Instead of commitVersion this can use readSnapshot.isPresent? Make helper fx only for
-    // existing tables
-    if (didCurrentTransactionEnableICT(engine, metadata, readSnapshot) && commitVersion != 0) {
+    if (readSnapshot.isPresent() && didCurrentTransactionEnableICT(engine, metadata, readSnapshot.get())) {
       Map<String, String> enablementTrackingProperties = new HashMap<>();
       enablementTrackingProperties.put(
           TableConfig.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.getKey(),
@@ -87,7 +85,7 @@ public class InCommitTimestampUtils {
 
   /** Returns true if the current transaction implicitly/explicitly enables ICT. */
   private static boolean didCurrentTransactionEnableICT(
-      Engine engine, Metadata currentTransactionMetadata, Optional<SnapshotImpl> readSnapshot) {
+      Engine engine, Metadata currentTransactionMetadata, SnapshotImpl readSnapshot) {
     // If ICT is currently enabled, and the read snapshot did not have ICT enabled,
     // then the current transaction must have enabled it.
     // In case of a conflict, any winning transaction that enabled it after
@@ -100,8 +98,7 @@ public class InCommitTimestampUtils {
     boolean isICTCurrentlyEnabled =
         IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(currentTransactionMetadata);
     boolean wasICTEnabledInReadSnapshot =
-        readSnapshot.isPresent()
-            && IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(readSnapshot.get().getMetadata());
+        IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(readSnapshot.getMetadata());
     return isICTCurrentlyEnabled && !wasICTEnabledInReadSnapshot;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -44,7 +44,8 @@ public class InCommitTimestampUtils {
       Optional<SnapshotImpl> readSnapshot,
       Metadata metadata,
       long commitVersion) {
-    if (readSnapshot.isPresent() && didCurrentTransactionEnableICT(engine, metadata, readSnapshot.get())) {
+    if (readSnapshot.isPresent()
+        && didCurrentTransactionEnableICT(engine, metadata, readSnapshot.get())) {
       Map<String, String> enablementTrackingProperties = new HashMap<>();
       enablementTrackingProperties.put(
           TableConfig.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.getKey(),

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -177,7 +177,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       Optional.of(Collections.singletonList(
         new Column(Array[String]("test-clustering-col1", "nested")))),
       transactionMetrics1,
-      snapshotReport1,
+      Optional.of(snapshotReport1),
       Optional.of(exception))
 
     // Manually check expected JSON
@@ -220,7 +220,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       Optional.of(Collections.singletonList(new Column("test-clustering-col1"))),
       // empty/un-incremented transaction metrics
       TransactionMetrics.withExistingTableFileSizeHistogram(Optional.empty()),
-      snapshotReport2,
+      Optional.of(snapshotReport2),
       Optional.empty() /* exception */
     )
     testTransactionReport(transactionReport2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Currently readSnapshot is a required input to TransactionImpl. For new tables, we create a fake empty snapshot to fulfill this requirement with version = -1 and a fake empty logsegment. This propagates bad semantics to other functions within TransactionImpl because they rely on this concept of an "empty snapshot" instead of correctly coding to the concept of no existing snapshot for the case of a new table.

This also leaves questionable results for a lot of the methods on SnapshotImpl for this fake empty snapshot like...
- what should getTimestamp return? (currently -1)
- empty log segment
- getSchema/partitionColumns (currently we initialize this to be the ones created in the new table but this doesn't really make sense since the snapshot doesn't exist)
- getScanBuilder (?!)
- getSnapshotReport
- etc, etc, etc

This refactor lets us get rid of this "non-existent snapshot" throughout our code.

## How was this patch tested?

Existing tests should suffice.

## Does this PR introduce _any_ user-facing changes?

No.