### PR TITLE
Stop supporting DELTA_CONVERT_ICEBERG_UNSAFE_MOR_TABLE_ENABLE

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -862,15 +862,6 @@ trait ConvertIcebergToDeltaSuiteBase
       spark.sql(s"DELETE FROM $table WHERE id = 1")
       // By default, conversion should fail because it is unsafe.
       assertConversionFailed()
-      // Force escape should work
-      withSQLConf(DeltaSQLConf.DELTA_CONVERT_ICEBERG_UNSAFE_MOR_TABLE_ENABLE.key -> "true") {
-        convert(s"iceberg.`$tablePath`")
-        // ... but with data duplication
-        checkAnswer(
-          spark.read.format("delta").load(tablePath),
-          (0 until 100).map(i => Row(i.toLong, s"name_$i"))
-        )
-      }
     }
 
     // --- UPDATE

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
@@ -224,9 +224,17 @@ trait ConvertUtilsBase extends DeltaLogging {
       fs.makeQualified(path).toUri.toString
     }
 
-    AddFile(pathStrForAddFile, partition, file.length, file.modificationTime, dataChange = true,
-      stats = targetFile.stats.orNull)
+
+    AddFile(
+      pathStrForAddFile,
+      partition,
+      file.length,
+      file.modificationTime,
+      dataChange = true,
+      stats = targetFile.stats.orNull
+    )
   }
+
 
   /**
    * A helper function to check whether a directory should be skipped during conversion.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/interfaces.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/interfaces.scala
@@ -20,7 +20,7 @@ import java.io.Closeable
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.{DeltaColumnMappingMode, NoMapping, SerializableFileStatus}
+import org.apache.spark.sql.delta.{DeltaColumnMappingMode, DeltaLog, NoMapping, SerializableFileStatus}
 
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.functions.sum
@@ -95,4 +95,5 @@ case class ConvertTargetFile(
   fileStatus: SerializableFileStatus,
   partitionValues: Option[Map[String, String]] = None,
   parquetSchemaDDL: Option[String] = None,
-  stats: Option[String] = None) extends Serializable
+  stats: Option[String] = None
+) extends Serializable

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1707,14 +1707,6 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
-  val DELTA_CONVERT_ICEBERG_UNSAFE_MOR_TABLE_ENABLE =
-    buildConf("convert.iceberg.unsafeConvertMorTable.enabled")
-      .doc("If enabled, iceberg merge-on-read tables can be unsafely converted by ignoring " +
-        "deletion files. This could cause data duplication and is strongly not recommended.")
-      .internal()
-      .booleanConf
-      .createWithDefault(false)
-
   val DELTA_CONVERT_ICEBERG_CAST_TIME_TYPE = {
     buildConf("convert.iceberg.castTimeType")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Stop supporting `DELTA_CONVERT_ICEBERG_UNSAFE_MOR_TABLE_ENABLE`. It's an extremely unsafe flag, which can lead to a corrupted table. As it is strongly not recommended, this PR proposes to stop its support

## How was this patch tested?
UTs