### PR TITLE
[KERNEL] Add clustering columns to `SnapshotImpl`

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -76,8 +76,11 @@ public class SnapshotImpl implements Snapshot {
     // io.delta.kernel.metrics.SnapshotMetricsResult#getLoadSnapshotTotalDurationNs}, are only
     // completed *after* the Snapshot has been constructed.
     this.lazySnapshotReport = new Lazy<>(() -> SnapshotReportImpl.forSuccess(snapshotContext));
-    this.lazyClusteringColumns = new Lazy<>(() -> ClusteringMetadataDomain.fromSnapshot(this)
-        .map(ClusteringMetadataDomain::getClusteringColumns));
+    this.lazyClusteringColumns =
+        new Lazy<>(
+            () ->
+                ClusteringMetadataDomain.fromSnapshot(this)
+                    .map(ClusteringMetadataDomain::getClusteringColumns));
   }
 
   /////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -160,7 +160,7 @@ public class SnapshotImpl implements Snapshot {
     return lazySnapshotReport.get();
   }
 
-  // TODO: put this on the public Snapshot API? (need to convert to logical?)
+  /** @returns the physical clustering columns in this snapshot */
   public Optional<List<Column>> getClusteringColumns() {
     return lazyClusteringColumns.get();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -309,11 +309,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
 
     Tuple2<Optional<Protocol>, Optional<Metadata>> updatedProtocolAndMetadata =
         validateAndUpdateProtocolAndMetadata(
-            engine,
-            baseMetadata,
-            baseProtocol,
-            isCreateOrReplace,
-            latestSnapshot);
+            engine, baseMetadata, baseProtocol, isCreateOrReplace, latestSnapshot);
     Optional<Protocol> newProtocol = updatedProtocolAndMetadata._1;
     Optional<Metadata> newMetadata = updatedProtocolAndMetadata._2;
 
@@ -346,7 +342,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         operation,
         newProtocol.orElse(baseProtocol),
         newMetadata.orElse(baseMetadata),
-        setTxnOpt, newResolvedClusteringColumns, /* new clustering columns only */
+        setTxnOpt,
+        newResolvedClusteringColumns, /* new clustering columns only */
         newMetadata.isPresent() || isCreateOrReplace /* shouldUpdateMetadata */,
         newProtocol.isPresent() || isCreateOrReplace /* shouldUpdateProtocol */,
         maxRetries,
@@ -499,8 +496,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     // This is only done if clustering columns are explicitly set in this transaction.
     StructType updatedSchema = newMetadata.orElse(baseMetadata).getSchema();
     this.newResolvedClusteringColumns =
-        initialClusteringColumns.map(cols ->
-            SchemaUtils.casePreservingEligibleClusterColumns(updatedSchema, cols));
+        initialClusteringColumns.map(
+            cols -> SchemaUtils.casePreservingEligibleClusterColumns(updatedSchema, cols));
 
     /* ----- 6: Update the METADATA with materialized row tracking column name if applicable----- */
     Optional<Metadata> rowTrackingMetadata =
@@ -516,8 +513,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       // Use physicalClusteringColumns if clustering column is set in this txn,
       // otherwise fallback to existingClusteringCols
       Optional<List<Column>> effectiveClusteringCols =
-          (isCreateOrReplace || initialClusteringColumns.isPresent()) ?
-          newResolvedClusteringColumns : latestSnapshot.get().getClusteringColumns();
+          (isCreateOrReplace || initialClusteringColumns.isPresent())
+              ? newResolvedClusteringColumns
+              : latestSnapshot.get().getClusteringColumns();
 
       Optional<Metadata> schemaUpdatedMetadata =
           validateMetadataChangeAndUpdateMetadata(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -113,7 +113,6 @@ public class TransactionImpl implements Transaction {
       int maxRetries,
       int logCompactionInterval,
       Clock clock) {
-    // checkArgument(isCreateOrReplace || readSnapshot.isPresent());
     this.isCreateOrReplace = isCreateOrReplace;
     this.dataPath = dataPath;
     this.logPath = logPath;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -202,8 +202,9 @@ public class TransactionImpl implements Transaction {
     if (isCreateOrReplace) {
       return newClusteringColumnsOpt;
     } else {
-      return newClusteringColumnsOpt.isPresent() ? newClusteringColumnsOpt :
-          readSnapshot.getClusteringColumns();
+      return newClusteringColumnsOpt.isPresent()
+          ? newClusteringColumnsOpt
+          : readSnapshot.getClusteringColumns();
     }
   }
 
@@ -225,7 +226,8 @@ public class TransactionImpl implements Transaction {
       TransactionReport transactionReport =
           recordTransactionReport(
               engine,
-              Optional.of(committedVersion), getEffectiveClusteringColumns(),
+              Optional.of(committedVersion),
+              getEffectiveClusteringColumns(),
               transactionMetrics,
               Optional.empty() /* exception */);
       TransactionMetricsResult txnMetricsCaptured =
@@ -237,7 +239,8 @@ public class TransactionImpl implements Transaction {
     } catch (Exception e) {
       recordTransactionReport(
           engine,
-          Optional.empty() /* committedVersion */, getEffectiveClusteringColumns(),
+          Optional.empty() /* committedVersion */,
+          getEffectiveClusteringColumns(),
           transactionMetrics,
           Optional.of(e) /* exception */);
       throw e;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringUtils.java
@@ -17,10 +17,8 @@
 package io.delta.kernel.internal.clustering;
 
 import io.delta.kernel.expressions.Column;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.DomainMetadata;
 import java.util.List;
-import java.util.Optional;
 
 public class ClusteringUtils {
 
@@ -36,14 +34,5 @@ public class ClusteringUtils {
     ClusteringMetadataDomain clusteringMetadataDomain =
         ClusteringMetadataDomain.fromClusteringColumns(clusteringColumns);
     return clusteringMetadataDomain.toDomainMetadata();
-  }
-
-  /**
-   * Extract ClusteringColumns from a given snapshot. Return None if the clustering domain metadata
-   * is missing.
-   */
-  public static Optional<List<Column>> getClusteringColumnsOptional(SnapshotImpl snapshot) {
-    return ClusteringMetadataDomain.fromSnapshot(snapshot)
-        .map(ClusteringMetadataDomain::getClusteringColumns);
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaReplaceTableSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaReplaceTableSuite.scala
@@ -265,14 +265,14 @@ trait DeltaReplaceTableSuiteBase extends DeltaTableWriteSuiteBase {
         assertHasWriterFeature(snapshot, "domainMetadata")
         // Validate clustering columns are correct
         // TODO when we support column mapping we will need to convert to physical-name here
-        assert(ClusteringUtils.getClusteringColumnsOptional(snapshot).toScala
+        assert(snapshot.getClusteringColumns.toScala
           .exists(_.asScala == clusteringCols))
       case None =>
         if (wasClusteredTable) {
           // If the table was previously clustered we expect the table feature to remain and for
           // there to be a clustering domain metadata with clusteringColumns=[]
           assertHasWriterFeature(snapshot, "clustering")
-          assert(ClusteringUtils.getClusteringColumnsOptional(snapshot).toScala
+          assert(snapshot.getClusteringColumns.toScala
             .exists(_.isEmpty))
         } else {
           // Otherwise there should be no table feature and no clustering domain metadata


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Currently we have a method in ClusteringUtils that takes in a snapshot and returns the clustering columns. Since this requires parsing the domain metadata we try to avoid doing this more than once and instead pass around a `resolvedClusteringColumns` from txn building to txn implementation. This makes the fields in both much more confusing as we need to differentiate between newClusteringCols (set in the builder for a new or update table) vs existingClusteringCols for an existing table. Instead, we should lazily parse the clustering columns on SnapshotImpl and store it on that class.

## How was this patch tested?

Just a refactor existing tests should suffice.

## Does this PR introduce _any_ user-facing changes?

No.