### PR TITLE
[SPARK] Block Time Travel beyond DeletedFileRetentionDuration

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3030,6 +3030,12 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_UNSUPPORTED_TIME_TRAVEL_BEYOND_DELETED_FILE_RETENTION_DURATION" : {
+    "message" : [
+      "Cannot time travel beyond delta.deletedFileRetentionDuration (<deletedFileRetention> HOURS) set on the table."
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_UNSUPPORTED_TIME_TRAVEL_MULTIPLE_FORMATS" : {
     "message" : [
       "Cannot specify time travel in multiple formats."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1589,6 +1589,14 @@ trait DeltaErrorsBase
     )
   }
 
+  def timeTravelBeyondDeletedFileRetentionDurationException(
+    deletedFileRetentionDurationHours: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_TIME_TRAVEL_BEYOND_DELETED_FILE_RETENTION_DURATION",
+      messageParameters = Array(deletedFileRetentionDurationHours)
+    )
+  }
+
   def nonExistentDeltaTable(tableId: DeltaTableIdentifier): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_TABLE_NOT_FOUND",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -183,7 +183,10 @@ class DeltaTableV2 private[delta](
         "queriedVersion" -> version,
         "accessType" -> accessType
       ))
-      deltaLog.getSnapshotAt(version, catalogTableOpt = catalogTable)
+      deltaLog.getSnapshotAt(
+        version,
+        catalogTableOpt = catalogTable,
+        enforceTimeTravelWithinDeletedFileRetention = true)
     }.getOrElse(
       deltaLog.update(
         stalenessAcceptable = true,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -118,7 +118,7 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
         val latestSnapshot = txn.snapshot
         val snapshotToRestore = deltaLog.getSnapshotAt(
           versionToRestore,
-          catalogTableOpt = txn.catalogTable)
+          catalogTableOpt = txn.catalogTable, enforceTimeTravelWithinDeletedFileRetention = true)
         val latestSnapshotFiles = latestSnapshot.allFiles
         val snapshotToRestoreFiles = snapshotToRestore.allFiles
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -342,7 +342,9 @@ trait CDCReaderImpl extends DeltaLogging {
       log"endingVersion: ${MDC(DeltaLogKeys.END_VERSION, endingVersionOpt.map(_.version))}")
 
     val startingSnapshot = snapshotToUse.deltaLog.getSnapshotAt(
-      startingVersion.version, catalogTableOpt = catalogTableOpt)
+      startingVersion.version,
+      catalogTableOpt = catalogTableOpt,
+      enforceTimeTravelWithinDeletedFileRetention = true)
     val columnMappingEnabledAtStartingVersion =
       startingSnapshot.metadata.columnMappingMode != NoMapping
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -34,7 +34,8 @@ object CheckpointHook extends PostCommitHook {
       txn.committedVersion,
       lastCheckpointHint = None,
       lastCheckpointProvider = Some(cp),
-      catalogTableOpt = txn.catalogTable)
+      catalogTableOpt = txn.catalogTable,
+      enforceTimeTravelWithinDeletedFileRetention = false)
     txn.deltaLog.checkpoint(snapshotToCheckpoint, txn.catalogTable)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -549,6 +549,13 @@ trait DeltaSQLConfBase {
       .checkValue(_ > 0, "history.threadPoolSize must be positive")
       .createWithDefault(10)
 
+  val ENFORCE_TIME_TRAVEL_WITHIN_DELETED_FILE_RETENTION_DURATION =
+    buildConf("vacuum.enforceTimeTravelWithinDeletedFileRetentionDuration")
+      .internal()
+      .doc("Enforces time travel within delta.deletedFileRetentionDuration.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_VACUUM_LOGGING_ENABLED =
     buildConf("vacuum.logging.enabled")
       .doc("Whether to log vacuum information into the Delta transaction log." +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta
 
+import java.time.LocalDate
+
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import org.apache.hadoop.fs.Path
 
@@ -80,8 +82,7 @@ class CloneTableScalaSuite extends CloneTableSuiteBase
     val sourceTbl = io.delta.tables.DeltaTable.forPath(source)
     assert(spark.read.format("delta").load(source).count() === 15)
 
-    val desiredTime = "1996-01-12"
-
+    val desiredTime = LocalDate.now().minusDays(5).toString // Date as of 5 days old
     val format = new java.text.SimpleDateFormat("yyyy-MM-dd")
     val time = format.parse(desiredTime).getTime
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
+import java.time.LocalDate
 
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, Metadata, Protocol, RemoveFile, SetTransaction, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
@@ -394,7 +395,7 @@ trait CloneTableSuiteBase extends QueryTest
     assert(spark.read.format("delta").load(source).count() === 15)
 
     // Get time corresponding to date
-    val desiredTime = "1996-01-12"
+    val desiredTime = LocalDate.now().minusDays(5).toString // Date as of 5 days old
     val format = new java.text.SimpleDateFormat("yyyy-MM-dd")
     val time = format.parse(desiredTime).getTime
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaTestUtils.{modifyCommitTimestamp, BOOLEAN_DOMAIN}
@@ -242,14 +243,15 @@ abstract class DeltaCDCSuiteBase
 
       // modify timestamps
       // version 0
-      modifyCommitTimestamp(deltaLog, 0, 0)
-      val tsAfterV0 = dateFormat.format(new Date(1))
+      val currentTime = System.currentTimeMillis() - 5.days.toMillis
+      modifyCommitTimestamp(deltaLog, 0, currentTime + 0)
+      val tsAfterV0 = dateFormat.format(new Date(currentTime + 1))
 
       // version 1
-      modifyCommitTimestamp(deltaLog, 1, 1000)
-      val tsAfterV1 = dateFormat.format(new Date(1001))
+      modifyCommitTimestamp(deltaLog, 1, currentTime + 1000)
+      val tsAfterV1 = dateFormat.format(new Date(currentTime + 2000))
 
-      modifyCommitTimestamp(deltaLog, 2, 2000)
+      modifyCommitTimestamp(deltaLog, 2, currentTime + 3000)
 
       val readDf = cdcRead(
         new TableName(tableName), StartingTimestamp(tsAfterV0), EndingTimestamp(tsAfterV1))
@@ -267,11 +269,12 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(tblName = Some(tableName))
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
 
-      modifyCommitTimestamp(deltaLog, 0, 0)
-      modifyCommitTimestamp(deltaLog, 1, 10000)
-      modifyCommitTimestamp(deltaLog, 2, 20000)
+      val currentTime = System.currentTimeMillis() - 5.days.toMillis
+      modifyCommitTimestamp(deltaLog, 0, currentTime + 0)
+      modifyCommitTimestamp(deltaLog, 1, currentTime + 10000)
+      modifyCommitTimestamp(deltaLog, 2, currentTime + 20000)
 
-      val ts0 = dateFormat.format(new Date(2000))
+      val ts0 = dateFormat.format(new Date(currentTime + 2000))
       val readDf = cdcRead(new TableName(tableName), StartingTimestamp(ts0), EndingVersion("1"))
       checkCDCAnswer(
         DeltaLog.forTable(spark, TableIdentifier(tableName)),
@@ -287,11 +290,12 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(tblName = Some(tableName))
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
 
-      modifyCommitTimestamp(deltaLog, 0, 0)
-      modifyCommitTimestamp(deltaLog, 1, 1000)
-      modifyCommitTimestamp(deltaLog, 2, 2000)
+      val currentTime = System.currentTimeMillis() - 5.days.toMillis
+      modifyCommitTimestamp(deltaLog, 0, currentTime + 0)
+      modifyCommitTimestamp(deltaLog, 1, currentTime + 1000)
+      modifyCommitTimestamp(deltaLog, 2, currentTime + 2000)
 
-      val ts0 = dateFormat.format(new Date(0))
+      val ts0 = dateFormat.format(new Date(currentTime + 0))
       val readDf = cdcRead(new TableName(tableName), StartingTimestamp(ts0), EndingVersion("1"))
       checkCDCAnswer(
         DeltaLog.forTable(spark, TableIdentifier(tableName)),
@@ -345,12 +349,13 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(tblName = Some(tableName))
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
 
-      modifyCommitTimestamp(deltaLog, 0, 0)
-      modifyCommitTimestamp(deltaLog, 1, 4000)
-      modifyCommitTimestamp(deltaLog, 2, 8000)
+      val currentTime = System.currentTimeMillis() - 5.days.toMillis
+      modifyCommitTimestamp(deltaLog, 0, currentTime + 0)
+      modifyCommitTimestamp(deltaLog, 1, currentTime + 4000)
+      modifyCommitTimestamp(deltaLog, 2, currentTime + 8000)
 
-      val ts0 = dateFormat.format(new Date(3000))
-      val ts1 = dateFormat.format(new Date(5000))
+      val ts0 = dateFormat.format(new Date(currentTime + 3000))
+      val ts1 = dateFormat.format(new Date(currentTime + 5000))
       val readDf = cdcRead(new TableName(tableName), StartingTimestamp(ts0), EndingTimestamp(ts1))
       checkCDCAnswer(
         DeltaLog.forTable(spark, TableIdentifier(tableName)),
@@ -421,6 +426,11 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(tblName = Some(tblName))
 
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tblName))
+      val largeRetentionHours = 2 * System.currentTimeMillis().millis.toHours
+      // Set the deletedFileRetentionDuration to a large value so that older versions
+      // can be accessed
+      spark.sql(s"ALTER TABLE $tblName SET TBLPROPERTIES" +
+        s" ('delta.deletedFileRetentionDuration' = 'interval $largeRetentionHours HOURS')")
 
       // Set commit time during Daylight savings time change.
       val restoreDate = "2022-11-06 01:42:44"
@@ -791,18 +801,19 @@ abstract class DeltaCDCSuiteBase
         createTblWithThreeVersions(tblName = Some(tableName))
         val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
 
+        val currentTime = System.currentTimeMillis() - 5.days.toMillis
         // modify timestamps
         // version 0
-        modifyCommitTimestamp(deltaLog, 0, 0)
+        modifyCommitTimestamp(deltaLog, 0, currentTime + 0)
 
         // version 1
-        modifyCommitTimestamp(deltaLog, 1, 1000)
+        modifyCommitTimestamp(deltaLog, 1, currentTime + 1000)
 
         // version 2
-        modifyCommitTimestamp(deltaLog, 2, 2000)
+        modifyCommitTimestamp(deltaLog, 2, currentTime + 2000)
 
-        val tsStart = dateFormat.format(new Date(0))
-        val tsEnd = dateFormat.format(new Date(4000))
+        val tsStart = dateFormat.format(new Date(currentTime + 0))
+        val tsEnd = dateFormat.format(new Date(currentTime + 4000))
 
         val readDf = cdcRead(
           new TableName(tableName), StartingTimestamp(tsStart), EndingTimestamp(tsEnd))
@@ -1038,6 +1049,7 @@ class DeltaCDCScalaSuite extends DeltaCDCSuiteBase {
   test("non-monotonic timestamps") {
     withTempTable(createTable = false) { tableName =>
       var deltaLog: DeltaLog = null
+      val currentTime = System.currentTimeMillis() - 5.days.toMillis
       (0 to 3).foreach { i =>
         spark.range(i * 10, (i + 1) * 10).write.format("delta").mode("append")
           .saveAsTable(tableName)
@@ -1045,7 +1057,7 @@ class DeltaCDCScalaSuite extends DeltaCDCSuiteBase {
           deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
         }
         val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, i).toUri)
-        file.setLastModified(300 - i)
+        file.setLastModified(currentTime + 300 - i)
       }
 
       checkCDCAnswer(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -242,7 +242,7 @@ trait DeltaTimeTravelTests extends QueryTest
     // scalastyle:off line.size.limit
     val tblName = "delta_table"
     withTable(tblName) {
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblName, start, start + 20.minutes, start + 40.minutes)
 
       verifyLogging(2L, 0L, "timestamp", "sql") {
@@ -272,7 +272,7 @@ trait DeltaTimeTravelTests extends QueryTest
   test("as of timestamp on exact timestamp") {
     val tblName = "delta_table"
     withTable(tblName) {
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblName, start, start + 20.minutes)
 
       // Simulate getting the timestamp directly from Spark SQL
@@ -306,7 +306,7 @@ trait DeltaTimeTravelTests extends QueryTest
     val tblName = s"delta_table"
     withTempDir { dir =>
       withTable(tblName, dir.toString) {
-        val start = 1540415658000L
+        val start = System.currentTimeMillis() - 5.days.toMillis
         generateCommitsAtPath(tblName, dir.toString, start, start + 20.minutes, start + 40.minutes)
         verifyLogging(2L, 0L, "version", "sql") {
           checkAnswer(
@@ -417,7 +417,7 @@ trait DeltaTimeTravelTests extends QueryTest
     }
     val tblName = "delta_table"
     withTable(tblName) {
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblName, start, start - 5.seconds, start + 3.minutes)
 
       checkAnswer(
@@ -469,7 +469,7 @@ trait DeltaTimeTravelTests extends QueryTest
   test("data skipping still works with time travel") {
     val tblName = "delta_table"
     withTable(tblName) {
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblName, start, start + 20.minutes)
 
       def testScan(df: DataFrame): Unit = {
@@ -580,7 +580,7 @@ abstract class DeltaHistoryManagerBase extends DeltaTimeTravelTests
     quietly {
       val tblName = "delta_table"
       withTable(tblName) {
-        val start = 1540415658000L
+        val start = System.currentTimeMillis() - 5.days.toMillis
         generateCommits(tblName, start, start + 20.minutes)
         sql(s"optimize $tblName")
 
@@ -604,7 +604,7 @@ abstract class DeltaHistoryManagerBase extends DeltaTimeTravelTests
   test("as of with table API") {
     val tblName = "delta_table"
     withTable(tblName) {
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblName, start, start + 20.minutes, start + 40.minutes)
 
       assert(spark.read.format("delta").option("versionAsOf", "0").table(tblName).count() == 10)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -98,12 +98,14 @@ class DeltaTimeTravelSuite extends QueryTest
       // backfilled them. This leads to the failure in certain UT where we manually modify/overwrite
       // the commit timestamps.
       // To correctly update the deltas in [[LogSegment]], we construct a fresh delta log.
+      DeltaLog.clearCache()
       deltaLog = DeltaLog.forTable(spark, dataPath = location)
       val filePath = DeltaCommitFileProvider
         .apply(snapshot = deltaLog.unsafeVolatileSnapshot)
         .deltaFile(version = startVersion)
       if (isICTEnabledForNewTablesCatalogOwned) {
         InCommitTimestampTestUtils.overwriteICTInDeltaFile(deltaLog, filePath, Some(ts))
+        InCommitTimestampTestUtils.overwriteICTInCrc(deltaLog, startVersion, Some(ts))
       } else {
         val file = new File(filePath.toUri)
         file.setLastModified(ts)
@@ -487,7 +489,7 @@ class DeltaTimeTravelSuite extends QueryTest
   test("as of timestamp in between commits should use commit before timestamp") {
     withTempDir { dir =>
       val tblLoc = dir.getCanonicalPath
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblLoc, start, start + 20.minutes, start + 40.minutes)
 
       val tablePathUri = identifierWithTimestamp(tblLoc, start + 10.minutes)
@@ -496,8 +498,9 @@ class DeltaTimeTravelSuite extends QueryTest
       checkAnswer(df1.groupBy().count(), Row(10L))
 
       // 2 minutes after start
-      val df2 = spark.read.format("delta").option("timestampAsOf", "2018-10-24 14:16:18")
-        .load(tblLoc)
+      val timeTwoMinutesAfterStart = new Timestamp(start + 2.minutes)
+      val df2 = spark.read.format("delta")
+        .option("timestampAsOf", timeTwoMinutesAfterStart.toString).load(tblLoc)
 
       checkAnswer(df2.groupBy().count(), Row(10L))
     }
@@ -506,7 +509,7 @@ class DeltaTimeTravelSuite extends QueryTest
   test("as of timestamp on exact timestamp") {
     withTempDir { dir =>
       val tblLoc = dir.getCanonicalPath
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblLoc, start, start + 20.minutes)
 
       // Simulate getting the timestamp directly from Spark SQL
@@ -598,7 +601,7 @@ class DeltaTimeTravelSuite extends QueryTest
   test("as of with versions") {
     withTempDir { dir =>
       val tblLoc = dir.getCanonicalPath
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblLoc, start, start + 20.minutes, start + 40.minutes)
 
       val df = spark.read.format("delta").load(identifierWithVersion(tblLoc, 0))
@@ -650,7 +653,7 @@ class DeltaTimeTravelSuite extends QueryTest
     }
     withTempDir { dir =>
       val tblLoc = dir.getCanonicalPath
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblLoc, start, start - 5.seconds, start + 3.minutes)
 
       val ts = getSparkFormattedTimestamps(
@@ -805,7 +808,7 @@ class DeltaTimeTravelSuite extends QueryTest
   test("time travel support in SQL") {
     withTempDir { dir =>
       val tblLoc = dir.getCanonicalPath
-      val start = 1540415658000L
+      val start = System.currentTimeMillis() - 5.days.toMillis
       generateCommits(tblLoc, start, start + 20.minutes)
       val tableName = "testTable"
 
@@ -826,16 +829,20 @@ class DeltaTimeTravelSuite extends QueryTest
         assert(ex.getMessage contains
           "Cannot time travel Delta table to version 2. Available versions: [0, 1]")
 
+        val timeAtVersion0 = new Timestamp(start).toString
+        val timeAtVersion1 = new Timestamp(start + 20.minutes).toString
+        val timeAfterVersion2 = new Timestamp(start + 6.hours).toString
+
         checkAnswer(
-          spark.sql(s"SELECT * from $tableName FOR TIMESTAMP AS OF '2018-10-24 14:14:18'"),
+          spark.sql(s"SELECT * from $tableName FOR TIMESTAMP AS OF '$timeAtVersion0'"),
           spark.read.option("versionAsOf", 0).format("delta").load(tblLoc))
 
         checkAnswer(
-          spark.sql(s"SELECT * from $tableName TIMESTAMP AS OF '2018-10-24 14:34:18'"),
+          spark.sql(s"SELECT * from $tableName TIMESTAMP AS OF '$timeAtVersion1'"),
           spark.read.option("versionAsOf", 1).format("delta").load(tblLoc))
 
         val ex2 = intercept[DeltaErrors.TemporallyUnstableInputException] {
-          spark.sql(s"SELECT * from $tableName FOR TIMESTAMP AS OF '2018-10-24 20:14:18'")
+          spark.sql(s"SELECT * from $tableName FOR TIMESTAMP AS OF '$timeAfterVersion2'")
         }
 
         checkError(
@@ -843,9 +850,9 @@ class DeltaTimeTravelSuite extends QueryTest
           "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
           sqlState = "42816",
           parameters = Map(
-            "providedTimestamp" -> "2018-10-24 20:14:18.0",
-            "tableName" -> "2018-10-24 14:34:18.0",
-            "maximumTimestamp" -> "2018-10-24 14:34:18")
+            "providedTimestamp" -> s"$timeAfterVersion2",
+            "tableName" -> s"$timeAtVersion1",
+            "maximumTimestamp" -> s"${timeAtVersion1.replaceFirst("\\.\\d+$", "")}") // exclude ms
         )
       }
     }
@@ -890,6 +897,133 @@ class DeltaTimeTravelSuite extends QueryTest
         .table(s"spark_catalog.default.$tblName"), Seq.empty)
       checkAnswer(spark.read.option("timestampAsOf", current_time_seconds)
         .table(s"spark_catalog.default.$tblName"), Seq.empty)
+    }
+  }
+
+  // Helper to generate a unique test table, commits, and timestamps for time travel blocking tests
+  def withTestTable(testBody: (String, String, String) => Unit): Unit = {
+    withTempDir { dir =>
+      val tblLoc = dir.getCanonicalPath
+      val tableName = "testTable"
+      withTable(tableName) {
+        // create six versions spaced 1 day apart
+        val start = System.currentTimeMillis() - 10.days.toMillis
+        generateCommits(
+          tblLoc,
+          start, // v0
+          start + 0.5.days, // v1
+          start + 1.days, // v2
+          start + 2.days, // v3
+          start + 2.5.days, // v4
+          start + 4.days, // v5
+          start + 5.days  // v6
+        )
+        // timestamps for v4 and v6
+        val t4 = new Timestamp(start + 2.5.days.toMillis).toString
+        val t6 = new Timestamp(start + 5.days.toMillis).toString
+
+        spark.sql(s"CREATE TABLE $tableName(id LONG) USING delta LOCATION '$tblLoc'")
+        spark.sql(s"ALTER TABLE $tableName" +
+          s" SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')")
+
+        testBody(tableName, t4, t6)
+      }
+    }
+  }
+
+  // Helper to assert whether a given SQL should or should not throw the retention exception
+  def assertBlocked(sql: String, shouldThrow: Boolean): Unit = {
+    val msg = "Cannot time travel beyond delta.deletedFileRetentionDuration"
+    if (shouldThrow) {
+      val ex = intercept[Exception]( spark.sql(sql) )
+      assert(ex.getMessage.contains(msg))
+    } else {
+      spark.sql(sql)  // must succeed
+    }
+  }
+
+  // 1) SELECT ... AS OF
+  test("Block time travel beyond deletedFileRetention") {
+    withTestTable { (tbl, t4, t6) =>
+      Seq(
+        s"SELECT * FROM $tbl VERSION AS OF 2" -> true,
+        s"SELECT * FROM $tbl TIMESTAMP AS OF '$t4'" -> true,
+        s"SELECT * FROM $tbl VERSION AS OF 5" -> false,
+        s"SELECT * FROM $tbl TIMESTAMP AS OF '$t6'" -> false
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
+
+      spark.sql(s"ALTER TABLE $tbl " +
+        s"SET TBLPROPERTIES ('delta.deletedFileRetentionDuration' = 'interval 0 HOURS')")
+      // Even after lowering retention to zero, a simple select * should still work
+      // which references the latest version
+      assertBlocked(s"SELECT * FROM $tbl", false)
+      // After setting it to zero, any time travel will fail
+      Seq(
+        s"SELECT * FROM $tbl VERSION AS OF 5" -> true,
+        s"SELECT * FROM $tbl TIMESTAMP AS OF '$t6'" -> true
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
+    }
+  }
+
+  // 2) SELECT ... CHANGES AS OF
+  test("Block CDC beyond deletedFileRetention") {
+    withTestTable { (tbl, t4, t6) =>
+      Seq(
+        s"SELECT * FROM table_changes('$tbl', 2)" -> true,
+        s"SELECT * FROM table_changes('$tbl', '$t4')" -> true,
+        s"SELECT * FROM table_changes('$tbl', 5)" -> false,
+        s"SELECT * FROM table_changes('$tbl', '$t6')" -> false
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
+
+      spark.sql(s"ALTER TABLE $tbl " +
+        s"SET TBLPROPERTIES ('delta.deletedFileRetentionDuration' = 'interval 0 HOURS')")
+      // After setting it to zero, any previous version will fail
+      Seq(
+        s"SELECT * FROM table_changes('$tbl', 5)" -> true,
+        s"SELECT * FROM table_changes('$tbl', '$t6')" -> true
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
+    }
+  }
+
+  // 3) RESTORE ... AS OF
+  test("Block restore table beyond deletedFileRetention") {
+    withTestTable { (tbl, t4, t6) =>
+      Seq(
+        s"RESTORE TABLE $tbl TO VERSION AS OF 2" -> true,
+        s"RESTORE TABLE $tbl TO TIMESTAMP AS OF '$t4'" -> true,
+        s"RESTORE TABLE $tbl TO VERSION AS OF 5" -> false,
+        s"RESTORE TABLE $tbl TO TIMESTAMP AS OF '$t6'" -> false
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
+
+      spark.sql(s"ALTER TABLE $tbl" +
+        s" SET TBLPROPERTIES ('delta.deletedFileRetentionDuration' = 'interval 0 HOURS')")
+      // After setting it to zero, any previous version will fail
+      Seq(
+        s"RESTORE TABLE $tbl TO VERSION AS OF 5" -> true,
+        s"RESTORE TABLE $tbl TO TIMESTAMP AS OF '$t6'" -> true
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
+    }
+  }
+
+  // 4) CLONE ... AS OF
+  test("Block clone table beyond deletedFileRetention") {
+    withTestTable { (tbl, t4, t6) =>
+      val targets = Seq("targetTable1", "targetTable2", "targetTable3")
+
+      Seq(
+        s"CREATE TABLE ${targets(0)} SHALLOW CLONE $tbl VERSION AS OF 2" -> true,
+        s"CREATE TABLE ${targets(0)} SHALLOW CLONE $tbl TIMESTAMP AS OF '$t4'" -> true,
+        s"CREATE TABLE ${targets(0)} SHALLOW CLONE $tbl VERSION AS OF 5" -> false,
+        s"CREATE TABLE ${targets(1)} SHALLOW CLONE $tbl TIMESTAMP AS OF '$t6'" -> false
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
+
+      spark.sql(s"ALTER TABLE $tbl" +
+        s" SET TBLPROPERTIES ('delta.deletedFileRetentionDuration' = 'interval 0 HOURS')")
+      // After setting it to zero, any previous version will fail
+      Seq(
+        s"CREATE TABLE ${targets(0)} SHALLOW CLONE $tbl VERSION AS OF 5" -> true,
+        s"CREATE TABLE ${targets(0)} SHALLOW CLONE $tbl TIMESTAMP AS OF '$t6'" -> true
+      ).foreach { case (sql, fail) => assertBlocked(sql, fail) }
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableScalaSuite.scala
@@ -16,6 +16,10 @@
 
 package org.apache.spark.sql.delta
 
+import java.sql.Date
+
+import scala.concurrent.duration._
+
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
@@ -121,14 +125,14 @@ class RestoreTableScalaDeletionVectorSuite
               restoreTableToVersion(path, args.versionToRestore, isTable = false)
             } else {
               // Set a custom timestamp for the commit
-              val desiredDateS = "1996-01-12"
+              val desiredDateS = new Date(System.currentTimeMillis() - 3.days.toMillis).toString
               setTimestampToCommitFileAtVersion(
                 deltaLog,
                 version = args.versionToRestore,
                 date = desiredDateS)
               // Set all previous versions to something lower, so we don't error out.
               for (version <- 0 until args.versionToRestore) {
-                val previousDateS = "1996-01-11"
+                val previousDateS = new Date(System.currentTimeMillis() - 5.days.toMillis).toString
                 setTimestampToCommitFileAtVersion(
                   deltaLog,
                   version = version,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -17,7 +17,11 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
+import java.sql.Date
+import java.sql.Timestamp
 import java.text.SimpleDateFormat
+
+import scala.concurrent.duration._
 
 import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
@@ -101,7 +105,6 @@ trait RestoreTableSuiteBase
   test("path based table") {
     withTempDir { tempDir =>
       val path = tempDir.getAbsolutePath
-
       val df1 = Seq(1, 2, 3, 4, 5).toDF("id")
       val df2 = Seq(6, 7).toDF("id")
       val df3 = Seq(8, 9, 10).toDF("id")
@@ -126,15 +129,15 @@ trait RestoreTableSuiteBase
       checkAnswer(spark.read.format("delta").load(path), df1.union(df2))
 
       // Set a custom timestamp for the commit
-      val desiredDate = "1996-01-12"
+      val desiredDate = new Date(System.currentTimeMillis() - 5.days.toMillis)
       overrideTimestampOfCommitFile(
         deltaLog,
         version = 0,
-        timestamp = dateStringToTimestamp(date = desiredDate)
+        timestamp = dateStringToTimestamp(date = desiredDate.toString)
       )
 
       // restore by timestamp to version 0
-      restoreTableToTimestamp(path, desiredDate, false)
+      restoreTableToTimestamp(path, desiredDate.toString, false)
       checkAnswer(spark.read.format("delta").load(path), df1)
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This change blocks time travel beyond deletedFileRetentionDuration. The affected commands are SELECT, RESTORE, CLONE and CDC which use the syntax AS OF.

## How was this patch tested?
Added new tests
Fixed existing tests to be compatible with the changes proposed.

## Does this PR introduce _any_ user-facing changes?

Yes. Previously, user could time travel to any delta version beyond deletedFileRetentionDuration. With this change, time travel is restricted to be within the deletedFileRetentionDuration.
