### PR TITLE
[Spark] Add Support for dropping Domain Metadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.DeltaOperations.{ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
@@ -267,6 +268,10 @@ private[delta] class ConflictChecker(
         val isDowngradeCommitValid = TableFeature.validateFeatureRemovalAtSnapshot(
           newProtocol = newProtocol,
           oldProtocol = readProtocol,
+          table = DeltaTableV2(
+            spark = spark,
+            path = deltaLog.dataPath,
+            catalogTable = currentTransactionInfo.catalogTable),
           snapshot = winningSnapshot)
         if (!isDowngradeCommitValid) {
           throw DeltaErrors.dropTableFeatureConflictRevalidationFailed(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -358,13 +358,6 @@ trait DeltaErrorsBase
     )
   }
 
-  def cannotDropDomainMetadataFeatureFromManagedIcebergTable(
-      name: String): DeltaTableFeatureException = {
-    new DeltaTableFeatureException(
-      errorClass = "DELTA_CANNOT_DROP_DOMAIN_METADATA_FEATURE_FROM_MANAGED_ICEBERG_TABLE",
-      messageParameters = Array(name))
-  }
-
   def deltaRelationPathMismatch(
       relationPath: Seq[String],
       targetType: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -358,6 +358,13 @@ trait DeltaErrorsBase
     )
   }
 
+  def cannotDropDomainMetadataFeatureFromManagedIcebergTable(
+      name: String): DeltaTableFeatureException = {
+    new DeltaTableFeatureException(
+      errorClass = "DELTA_CANNOT_DROP_DOMAIN_METADATA_FEATURE_FROM_MANAGED_ICEBERG_TABLE",
+      messageParameters = Array(name))
+  }
+
   def deltaRelationPathMismatch(
       relationPath: Seq[String],
       targetType: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -909,6 +909,22 @@ object DeltaOperations {
   }
 
   /**
+   * Recorded when cleaning up domain metadata. This process takes place when dropping
+   * the domainMetadata feature.
+   */
+  case class DomainMetadataCleanup(domainMetadataRemovedCount: Int)
+      extends Operation("DOMAIN METADATA CLEANUP") {
+    override val parameters: Map[String, Any] = Map(
+      "domainMetadataRemovedCount" -> domainMetadataRemovedCount)
+
+    // This operation shouldn't be introducing AddFile actions with DVs and tight bounds stats.
+    override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
+
+    // Only removes domain metadata.
+    override val isInPlaceFileMetadataUpdate: Option[Boolean] = Some(false)
+  }
+
+  /**
    * Qualified column type with position. We define a copy of the type here to avoid depending on
    * the parser output classes in our logging.
    */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorProvider, InMemoryCommitCoordinatorBuilder}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -490,7 +491,8 @@ class DeltaTableFeatureSuite
 
       val tableFeature =
         TableFeature.featureNameToFeature(featureName).get.asInstanceOf[RemovableFeature]
-      assert(tableFeature.historyContainsFeature(spark, log.update()))
+      assert(tableFeature.historyContainsFeature(
+        spark, DeltaTableV2(spark, log.dataPath), log.update()))
 
       // Dropping feature should fail because the feature still has traces in deltas.
       val e = intercept[DeltaTableFeatureException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataRemovalSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataRemovalSuite.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DomainMetadataRemovalSuite
+    extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest {
+
+  val testTableName = "test_domain_metadata_removal_table"
+
+  def addData(deltaLog: DeltaLog, start: Long, end: Long): Unit = {
+    spark.range(start, end, step = 1, numPartitions = 2)
+      .write
+      .format("delta")
+      .mode("append")
+      .save(deltaLog.dataPath.toString)
+  }
+
+  def createTableWithDomainMetadata(): DeltaLog = {
+    sql(s"DROP TABLE IF EXISTS $testTableName")
+    sql(
+      s"""CREATE TABLE $testTableName (id LONG)
+         |USING DELTA
+         |TBLPROPERTIES(
+         |'delta.feature.${DomainMetadataTableFeature.name}' = 'supported'
+         |)""".stripMargin)
+
+    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+    assert(deltaLog.update().protocol.isFeatureSupported(DomainMetadataTableFeature))
+    addData(deltaLog, 0, 100)
+    deltaLog
+  }
+
+  def dropFeature(
+      feature: TableFeature,
+      truncateHistory: Boolean = false): Unit = {
+    val sqlText =
+      s"""
+         |ALTER TABLE $testTableName
+         |DROP FEATURE ${feature.name}
+         |${if (truncateHistory) "TRUNCATE HISTORY" else ""}
+         |""".stripMargin
+    sql(sqlText)
+  }
+
+  def validateDomainMetadataRemoval(deltaLog: DeltaLog): Unit = {
+    val snapshot = deltaLog.update()
+    assert(!snapshot.protocol.isFeatureSupported(DomainMetadataTableFeature))
+    assert(snapshot.domainMetadata.isEmpty)
+  }
+
+  test("DomainMetadata can be dropped") {
+    val deltaLog = createTableWithDomainMetadata()
+    dropFeature(DomainMetadataTableFeature)
+    validateDomainMetadataRemoval(deltaLog)
+  }
+
+  test("Drop DomainMetadata feature when leaked domain metadata exist in the table") {
+    case class TestMetadataDomain() extends JsonMetadataDomain[TestMetadataDomain] {
+      override val domainName: String = "delta.test"
+    }
+
+    val deltaLog = createTableWithDomainMetadata()
+
+    // Add a domainMetadata action.
+    deltaLog
+      .startTransaction(catalogTableOpt = None)
+      .commit(Seq(TestMetadataDomain().toDomainMetadata), DeltaOperations.ManualUpdate)
+
+    dropFeature(DomainMetadataTableFeature)
+    validateDomainMetadataRemoval(deltaLog)
+  }
+
+  test("Cannot drop DomainMetadata if there is a dependent feature on the table") {
+    createTableWithDomainMetadata()
+
+    // Enable row tracking on the table.
+    sql(
+      s"""ALTER TABLE $testTableName
+         |SET TBLPROPERTIES(
+         |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'
+         |)""".stripMargin)
+
+    val e = intercept[DeltaTableFeatureException] {
+      dropFeature(DomainMetadataTableFeature)
+    }
+    checkError(
+      e,
+      "DELTA_FEATURE_DROP_DEPENDENT_FEATURE",
+      parameters = Map(
+        "feature" -> "domainMetadata",
+        "dependentFeatures" -> "rowTracking"))
+  }
+
+  test("Drop domainMetadata after dropping a dependent feature") {
+    val deltaLog = createTableWithDomainMetadata()
+    addData(deltaLog, 0, 100)
+
+    // Enable row tracking on the table. This also enables the domainMetadata feature.
+    sql(
+      s"""ALTER TABLE $testTableName
+         |SET TBLPROPERTIES(
+         |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'
+         |)""".stripMargin)
+
+    assert(deltaLog.update().protocol.isFeatureSupported(DomainMetadataTableFeature))
+
+    dropFeature(RowTrackingFeature)
+    dropFeature(DomainMetadataTableFeature)
+    validateDomainMetadataRemoval(deltaLog)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR adds support for dropping the domainMetadata table feature.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added a new suite.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.