### PR TITLE
[Kernel][Dsv2]Setup test catalog to create spark table using the kernel backed table

### DIFF
--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
@@ -71,14 +71,14 @@ public class Dsv2BasicTest {
   }
 
   @Test
-  public void testQueryTable() {
+  public void testBatchRead() {
     spark.sql(
         String.format(
-            "CREATE TABLE dsv2.%s.query_test (id INT, name STRING, value DOUBLE)", nameSpace));
+            "CREATE TABLE dsv2.%s.batch_read_test (id INT, name STRING, value DOUBLE)", nameSpace));
     AnalysisException e =
         assertThrows(
             AnalysisException.class,
-            () -> spark.sql(String.format("SELECT * FROM dsv2.%s.query_test", nameSpace)));
+            () -> spark.sql(String.format("SELECT * FROM dsv2.%s.batch_read_test", nameSpace)));
     // TODO: update when implementing SupportReads
     assertTrue(e.getMessage().contains("does not support batch scan"));
   }

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
@@ -54,11 +54,12 @@ public class Dsv2BasicTest {
   @Test
   void testCreateTable() {
     spark.sql(
-        "CREATE TABLE dsv2."
-            + nameSpace
-            + ".create_table_test (id INT, name STRING, value DOUBLE)");
+        String.format(
+            "CREATE TABLE dsv2.%s.create_table_test (id INT, name STRING, value DOUBLE)",
+            nameSpace));
 
-    Dataset<Row> actual = spark.sql("DESCRIBE TABLE dsv2." + nameSpace + ".create_table_test");
+    Dataset<Row> actual =
+        spark.sql(String.format("DESCRIBE TABLE dsv2.%s.create_table_test", nameSpace));
 
     List<Row> expectedRows =
         Arrays.asList(
@@ -70,11 +71,13 @@ public class Dsv2BasicTest {
 
   @Test
   void testQueryTable() {
-    spark.sql("CREATE TABLE dsv2." + nameSpace + ".query_test (id INT, name STRING, value DOUBLE)");
+    spark.sql(
+        String.format(
+            "CREATE TABLE dsv2.%s.query_test (id INT, name STRING, value DOUBLE)", nameSpace));
     AnalysisException e =
         assertThrows(
             AnalysisException.class,
-            () -> spark.sql("SELECT * FROM dsv2." + nameSpace + ".query_test"));
+            () -> spark.sql(String.format("SELECT * FROM dsv2.%s.query_test", nameSpace)));
     // TODO: update when implementing SupportReads
     assertTrue(e.getMessage().contains("does not support batch scan"));
   }
@@ -84,7 +87,7 @@ public class Dsv2BasicTest {
     AnalysisException e =
         assertThrows(
             AnalysisException.class,
-            () -> spark.sql("SELECT * FROM dsv2." + nameSpace + ".not_found_test"));
+            () -> spark.sql(String.format("SELECT * FROM dsv2.%s.not_found_test", nameSpace)));
     assertEquals(
         "TABLE_OR_VIEW_NOT_FOUND",
         e.getErrorClass(),
@@ -96,7 +99,6 @@ public class Dsv2BasicTest {
   /////////////////////
   private void assertDatasetEquals(Dataset<Row> actual, List<Row> expectedRows) {
     List<Row> actualRows = actual.collectAsList();
-    ;
     assertEquals(
         expectedRows,
         actualRows,

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
@@ -33,7 +33,7 @@ public class Dsv2BasicTest {
   private String nameSpace;
 
   @BeforeAll
-  void setUp(@TempDir File tempDir) {
+  public void setUp(@TempDir File tempDir) {
     // Spark doesn't allow '-'
     nameSpace = "ns_" + UUID.randomUUID().toString().replace('-', '_');
     SparkConf conf =
@@ -46,14 +46,14 @@ public class Dsv2BasicTest {
   }
 
   @AfterAll
-  void tearDown() {
+  public void tearDown() {
     if (spark != null) {
       spark.stop();
     }
   }
 
   @Test
-  void testCreateTable() {
+  public void testCreateTable() {
     spark.sql(
         String.format(
             "CREATE TABLE dsv2.%s.create_table_test (id INT, name STRING, value DOUBLE)",
@@ -71,7 +71,7 @@ public class Dsv2BasicTest {
   }
 
   @Test
-  void testQueryTable() {
+  public void testQueryTable() {
     spark.sql(
         String.format(
             "CREATE TABLE dsv2.%s.query_test (id INT, name STRING, value DOUBLE)", nameSpace));
@@ -84,7 +84,7 @@ public class Dsv2BasicTest {
   }
 
   @Test
-  void testQueryTableNotExist() {
+  public void testQueryTableNotExist() {
     AnalysisException e =
         assertThrows(
             AnalysisException.class,

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
@@ -34,6 +34,7 @@ public class Dsv2BasicTest {
 
   @BeforeAll
   void setUp(@TempDir File tempDir) {
+    // Spark doesn't allow '-'
     nameSpace = "ns_" + UUID.randomUUID().toString().replace('-', '_');
     SparkConf conf =
         new SparkConf()

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
@@ -16,6 +16,10 @@
 package io.delta.spark.dsv2.catalog;
 
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.delta.kernel.defaults.engine.DefaultEngine;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -23,29 +27,69 @@ import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import io.delta.kernel.TableManager;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.dsv2.table.DeltaKernelTable;
+import io.delta.kernel.internal.SnapshotImpl;
+import org.apache.hadoop.conf.Configuration;
 
 /**
- * A {@link TableCatalog} implementation that is only used for facilitating testing for spark-dsv2
- * code path.
+ * A {@link TableCatalog} implementation that uses Delta Kernel for table operations.
+ * This catalog is used for facilitating testing for spark-dsv2 code path.
  */
 public class TestCatalog implements TableCatalog {
 
   private String catalogName;
+  private String basePath;
+  // TODO: Support catalog owned commit.
+  private final Map<String, String> tablePaths = new ConcurrentHashMap<>();
+  private final Engine engine = DefaultEngine.create(new Configuration());
 
   @Override
   public Identifier[] listTables(String[] namespace) {
-    throw new UnsupportedOperationException("listTables method is not implemented");
+    // Return all registered tables for the given namespace
+    return tablePaths.entrySet().stream()
+        .filter(entry -> {
+          String tableName = entry.getKey();
+          // Simple namespace matching - in a real implementation, you'd want more sophisticated logic
+          return namespace.length == 0 || tableName.startsWith(String.join(".", namespace) + ".");
+        })
+        .map(entry -> {
+          String tableName = entry.getKey();
+          String[] nameParts = tableName.split("\\.");
+          String[] tableNamespace = nameParts.length > 1 ? 
+              java.util.Arrays.copyOf(nameParts, nameParts.length - 1) : new String[0];
+          String tableIdentifier = nameParts[nameParts.length - 1];
+          return Identifier.of(tableNamespace, tableIdentifier);
+        })
+        .toArray(Identifier[]::new);
   }
 
   @Override
   public Table loadTable(Identifier ident) {
-    throw new UnsupportedOperationException("loadTable method is not implemented");
+    String tableKey = getTableKey(ident);
+    String tablePath = tablePaths.get(tableKey);
+    
+    if (tablePath == null) {
+      throw new RuntimeException("Table not found: " + ident);
+    }
+    
+    try {
+      // Use TableManager.loadTable to load the table
+      SnapshotImpl snapshot = (SnapshotImpl) TableManager.loadSnapshot(tablePath).build(engine);
+      return new DeltaKernelTable(ident, snapshot);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load table: " + ident, e);
+    }
   }
 
   @Override
   public Table createTable(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties) {
-    throw new UnsupportedOperationException("createTable method is not implemented");
+    String tableKey = getTableKey(ident);
+    String tablePath = basePath + UUID.randomUUID() + "/";
+    tablePaths.put(tableKey, tablePath);
+    
   }
 
   @Override
@@ -55,7 +99,8 @@ public class TestCatalog implements TableCatalog {
 
   @Override
   public boolean dropTable(Identifier ident) {
-    throw new UnsupportedOperationException("dropTable method is not implemented");
+    String tableKey = getTableKey(ident);
+    return tablePaths.remove(tableKey) != null;
   }
 
   @Override
@@ -65,11 +110,23 @@ public class TestCatalog implements TableCatalog {
 
   @Override
   public void initialize(String name, CaseInsensitiveStringMap options) {
+    this.basePath = options.get("base_path");
     this.catalogName = name;
   }
 
   @Override
   public String name() {
     return catalogName;
+  }
+
+  /**
+   * Helper method to get the table key from identifier.
+   */
+  private String getTableKey(Identifier ident) {
+    if (ident.namespace().length == 0) {
+      return ident.name();
+    } else {
+      return String.join(".", ident.namespace()) + "." + ident.name();
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

This PR setup test catalog and add a e2e test for `DESCRIBE TABLE` using new kernel table implementation. Currently we just use path based legacy kernel api to write and create table for unblocking current or future e2e testing.

When CCv2's commiter lands, we will migrate to the new api

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
