### PR TITLE
done first pass

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
@@ -16,6 +16,8 @@
 
 package io.delta.kernel.internal.commit;
 
+import static io.delta.kernel.internal.DeltaErrors.wrapEngineExceptionThrowsIO;
+
 import io.delta.kernel.commit.CommitFailedException;
 import io.delta.kernel.commit.CommitMetadata;
 import io.delta.kernel.commit.CommitResponse;
@@ -24,10 +26,21 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaErrorsInternal;
 import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultFileSystemManagedTableOnlyCommitter implements Committer {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(DefaultFileSystemManagedTableOnlyCommitter.class);
+
   public static final DefaultFileSystemManagedTableOnlyCommitter INSTANCE =
       new DefaultFileSystemManagedTableOnlyCommitter();
 
@@ -39,7 +52,37 @@ public class DefaultFileSystemManagedTableOnlyCommitter implements Committer {
       throws CommitFailedException {
     commitMetadata.getReadProtocolOpt().ifPresent(this::validateProtocol);
     commitMetadata.getNewProtocolOpt().ifPresent(this::validateProtocol);
-    throw new UnsupportedOperationException("Default Committer not yet implemented");
+
+    final String jsonCommitFile =
+        FileNames.deltaFile(commitMetadata.getDeltaLogDirPath(), commitMetadata.getVersion());
+
+    logger.info("Attempting to commit {}", jsonCommitFile);
+
+    try {
+      wrapEngineExceptionThrowsIO(
+          () -> {
+            engine
+                .getJsonHandler()
+                .writeJsonFileAtomically(jsonCommitFile, finalizedActions, false /* overwrite */);
+            return null;
+          },
+          String.format("Write file actions to JSON log file `%s`", jsonCommitFile));
+    } catch (FileAlreadyExistsException e) {
+      throw new CommitFailedException(
+          true /* retryable */,
+          true /* conflict */,
+          "Concurrent write detected for version " + commitMetadata.getVersion(),
+          e);
+    } catch (IOException e) {
+      throw new CommitFailedException(
+          true /* retryable */,
+          false /* conflict */,
+          "Failed to write commit file due to I/O error: " + e.getMessage(),
+          e);
+    }
+
+    // TODO: [delta-io/delta#5021] Use FileSystemClient::getFileStatus API instead
+    return new CommitResponse(ParsedLogData.forFileStatus(FileStatus.of(jsonCommitFile)));
   }
 
   private void validateProtocol(Protocol protocol) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -185,6 +185,11 @@ public final class FileNames {
     return String.format("%s/%020d.json", path, version);
   }
 
+  /** Returns the delta (json format) path for a given delta file. */
+  public static String deltaFile(String path, long version) {
+    return deltaFile(new Path(path), version);
+  }
+
   public static String stagedCommitFile(Path logPath, long version) {
     final Path stagedCommitPath = new Path(logPath, STAGED_COMMIT_DIRECTORY);
     return String.format("%s/%020d.%s.json", stagedCommitPath, version, UUID.randomUUID());

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/DefaultCommitterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/DefaultCommitterSuite.scala
@@ -16,13 +16,18 @@
 
 package io.delta.kernel.internal.commit
 
+import java.io.IOException
+import java.nio.file.FileAlreadyExistsException
 import java.util.Optional
 
 import io.delta.kernel.TableManager
-import io.delta.kernel.commit.CommitMetadata
+import io.delta.kernel.commit.{CommitFailedException, CommitMetadata}
+import io.delta.kernel.data.Row
+import io.delta.kernel.exceptions.KernelEngineException
 import io.delta.kernel.internal.actions.Protocol
-import io.delta.kernel.test.{ActionUtils, MockFileSystemClientUtils, VectorTestUtils}
+import io.delta.kernel.test.{ActionUtils, BaseMockJsonHandler, MockFileSystemClientUtils, VectorTestUtils}
 import io.delta.kernel.types.{IntegerType, StructType}
+import io.delta.kernel.utils.CloseableIterator
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -32,6 +37,15 @@ class DefaultCommitterSuite extends AnyFunSuite
     with VectorTestUtils {
 
   private val protocol12 = new Protocol(1, 2)
+
+  private val basicFileSystemCommitMetadataNoPMChange = new CommitMetadata(
+    1L,
+    "/fake/_delta_log",
+    testCommitInfo,
+    Optional.of(protocol12),
+    Optional.of(basicPartitionedMetadata),
+    Optional.empty(),
+    Optional.empty())
 
   Seq(
     (protocol12, protocolWithCatalogManagedSupport, "Upgrade"),
@@ -71,6 +85,102 @@ class DefaultCommitterSuite extends AnyFunSuite
         "filesystem-managed Delta tables, not catalog-managed Delta tables. Since this table " +
         "is catalog-managed, this commit operation is unsupported"))
     }
+  }
+
+  ////////////////////////////////////////////////////////
+  // DefaultCommitter exception handling tests -- START //
+  ////////////////////////////////////////////////////////
+
+  case class ExceptionTestCase(
+      description: String,
+      exceptionToThrow: Exception,
+      expectedRetryableOpt: Option[Boolean],
+      expectedConflictOpt: Option[Boolean],
+      expectedThrownType: Class[_],
+      expectedCauseType: Class[_])
+
+  private val exceptionTestCases = Seq(
+    ExceptionTestCase(
+      description = "FileAlreadyExistsException -> CFE(true, true)",
+      exceptionToThrow = new FileAlreadyExistsException("_delta_log/001.json"),
+      expectedRetryableOpt = Some(true),
+      expectedConflictOpt = Some(true),
+      expectedThrownType = classOf[CommitFailedException],
+      expectedCauseType = classOf[FileAlreadyExistsException]),
+    ExceptionTestCase(
+      description = "IOException -> CFE(true, false)",
+      exceptionToThrow = new IOException("Network timeout writing to _delta_log/001.json"),
+      expectedRetryableOpt = Some(true),
+      expectedConflictOpt = Some(false),
+      expectedThrownType = classOf[CommitFailedException],
+      expectedCauseType = classOf[IOException]),
+    ExceptionTestCase(
+      description = "RuntimeException wrapped and thrown as KernelEngineException",
+      exceptionToThrow = new RuntimeException("Some runtime error"),
+      expectedRetryableOpt = None,
+      expectedConflictOpt = None,
+      expectedThrownType = classOf[KernelEngineException],
+      expectedCauseType = classOf[RuntimeException]))
+
+  exceptionTestCases.foreach { testCase =>
+    test(s"default committer handles ${testCase.description} correctly") {
+
+      val throwingEngine = mockEngine(jsonHandler = new BaseMockJsonHandler {
+        override def writeJsonFileAtomically(
+            filePath: String,
+            data: CloseableIterator[Row],
+            overwrite: Boolean): Unit = {
+          throw testCase.exceptionToThrow
+        }
+      })
+
+      val ex = intercept[Exception] {
+        DefaultFileSystemManagedTableOnlyCommitter.INSTANCE.commit(
+          throwingEngine,
+          emptyActionsIterator,
+          basicFileSystemCommitMetadataNoPMChange)
+      }
+
+      assert(ex.getClass == testCase.expectedThrownType)
+      assert(ex.getCause.getClass == testCase.expectedCauseType)
+
+      testCase.expectedRetryableOpt.foreach { expectedRetryable =>
+        assert(ex.isInstanceOf[CommitFailedException])
+        val commitEx = ex.asInstanceOf[CommitFailedException]
+        assert(commitEx.isRetryable == expectedRetryable)
+      }
+
+      testCase.expectedConflictOpt.foreach { expectedConflict =>
+        assert(ex.isInstanceOf[CommitFailedException])
+        val commitEx = ex.asInstanceOf[CommitFailedException]
+        assert(commitEx.isConflict == expectedConflict)
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////////
+  // DefaultCommitter exception handling tests -- END //
+  //////////////////////////////////////////////////////
+
+  test("success commit returns ParsedLogData containing FileStatus for that commit file") {
+    val noOpEngine = mockEngine(jsonHandler = new BaseMockJsonHandler {
+      override def writeJsonFileAtomically(
+          filePath: String,
+          data: CloseableIterator[Row],
+          overwrite: Boolean): Unit = {
+        // what's important is that we do *not* throw here
+      }
+    })
+
+    val commitResult = DefaultFileSystemManagedTableOnlyCommitter.INSTANCE.commit(
+      noOpEngine,
+      emptyActionsIterator,
+      basicFileSystemCommitMetadataNoPMChange)
+
+    val commitParsedLogData = commitResult.getCommitLogData
+
+    assert(commitParsedLogData.isMaterialized)
+    assert(commitParsedLogData.version == basicFileSystemCommitMetadataNoPMChange.getVersion)
   }
 
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5040/files) to review incremental changes.
- [**stack/kernel_default_file_system_managed_committer**](https://github.com/delta-io/delta/pull/5040) [[Files changed](https://github.com/delta-io/delta/pull/5040/files)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
