### PR TITLE
[Spark] Fix CommitInfo Deserialization and retain legacy deserialization for legacy callsites

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -991,7 +991,7 @@ object DeltaHistory {
       userId = ci.userId,
       userName = ci.userName,
       operation = ci.operation,
-      operationParameters = ci.operationParameters,
+      operationParameters = ci.getLegacyPostDeserializationOperationParameters,
       job = ci.job,
       notebook = ci.notebook,
       clusterId = ci.clusterId,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -236,7 +236,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
 
     assert(operationParameters === expectedOperationParameters)
 
-    val expectedPrettyOperationParameters = Map(
+    val expectedLegacyOperationParameters = Map(
       "catalogTable" -> "t1",
       "numFiles" -> "23",
       "partitionedBy" -> "[\"a\",false]",
@@ -253,14 +253,14 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     assert(roundTrippedCommitInfo1.operationParameters === expectedOperationParameters)
     assert(
       roundTrippedCommitInfo1.getLegacyPostDeserializationOperationParameters ===
-        expectedPrettyOperationParameters)
+        expectedLegacyOperationParameters)
 
     val roundTrippedCommitInfo2 =
       JsonUtils.fromJson[CommitInfo](JsonUtils.toJson(roundTrippedCommitInfo1))
     assert(roundTrippedCommitInfo2.operationParameters === expectedOperationParameters)
     assert(
       roundTrippedCommitInfo2.getLegacyPostDeserializationOperationParameters ===
-        expectedPrettyOperationParameters)
+        expectedLegacyOperationParameters)
   }
 
   test("round trip of operation parameters: non-primitive types in operation parameters") {
@@ -279,7 +279,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
 
     assert(operationParameters === expectedOperationParameters)
 
-    val expectedPrettyOperationParameters = Map(
+    val expectedLegacyOperationParameters = Map(
       "k1" -> "[1,2]",
       "k2" -> "{\"a\":\"x\",\"b\":1,\"c\":{\"field1\":\"f1\",\"field2\":-1},\"d\":[3,\"e\"]}",
       "k3" -> "[]",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -26,9 +26,10 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.{QueryTest, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -211,6 +212,131 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123"}}""".stripMargin
     val ictOpt: Option[Long] = Action.fromJson(json1).asInstanceOf[CommitInfo].inCommitTimestamp
     assert(ictOpt.isEmpty)
+  }
+
+  test("round trip of operation parameters: primitive types in operation parameters") {
+    val rawOperationParameters: Map[String, Any] = Map(
+      "catalogTable" -> "t1",
+      "numFiles" -> 23L,
+      "partitionedBy" -> JsonUtils.toJson(Seq("a", false)),
+      "sourceFormat" -> "parquet",
+      "collectStats" -> false,
+      "k1" -> null,
+      "" -> null)
+    val operationParameters = rawOperationParameters.mapValues(JsonUtils.toJson(_)).toMap
+
+    val expectedOperationParameters = Map(
+      "catalogTable" -> "\"t1\"",
+      "numFiles" -> "23",
+      "partitionedBy" -> "\"[\\\"a\\\",false]\"",
+      "sourceFormat" -> "\"parquet\"",
+      "collectStats" -> "false",
+      "k1" -> "null",
+      "" -> "null")
+
+    assert(operationParameters === expectedOperationParameters)
+
+    val expectedPrettyOperationParameters = Map(
+      "catalogTable" -> "t1",
+      "numFiles" -> "23",
+      "partitionedBy" -> "[\"a\",false]",
+      "sourceFormat" -> "parquet",
+      "collectStats" -> "false",
+      "k1" -> null,
+      "" -> null)
+
+    val commitInfo = CommitInfo.empty().withTimestamp(1)
+      .copy(operationParameters = operationParameters)
+
+    // Try a couple rounds of round trips.
+    val roundTrippedCommitInfo1 = JsonUtils.fromJson[CommitInfo](JsonUtils.toJson(commitInfo))
+    assert(roundTrippedCommitInfo1.operationParameters === expectedOperationParameters)
+    assert(
+      roundTrippedCommitInfo1.getLegacyPostDeserializationOperationParameters ===
+        expectedPrettyOperationParameters)
+
+    val roundTrippedCommitInfo2 =
+      JsonUtils.fromJson[CommitInfo](JsonUtils.toJson(roundTrippedCommitInfo1))
+    assert(roundTrippedCommitInfo2.operationParameters === expectedOperationParameters)
+    assert(
+      roundTrippedCommitInfo2.getLegacyPostDeserializationOperationParameters ===
+        expectedPrettyOperationParameters)
+  }
+
+  test("round trip of operation parameters: non-primitive types in operation parameters") {
+    val rawOperationParameters: Map[String, Any] = Map(
+      "k1" -> Seq(1, 2),
+      "k2" -> Map("a" -> "x", "b" -> 1, "c" -> TestObject("f1", -1, None), "d" -> Seq(3, "e")),
+      "k3" -> Seq.empty,
+      "k4" -> TestObject("field1", 99, Some(Seq("v1", "v2"))))
+    val operationParameters = rawOperationParameters.mapValues(JsonUtils.toJson(_)).toMap
+
+    val expectedOperationParameters = Map(
+      "k1" -> "[1,2]",
+      "k2" -> "{\"a\":\"x\",\"b\":1,\"c\":{\"field1\":\"f1\",\"field2\":-1},\"d\":[3,\"e\"]}",
+      "k3" -> "[]",
+      "k4" -> "{\"field1\":\"field1\",\"field2\":99,\"field3\":[\"v1\",\"v2\"]}")
+
+    assert(operationParameters === expectedOperationParameters)
+
+    val expectedPrettyOperationParameters = Map(
+      "k1" -> "[1,2]",
+      "k2" -> "{\"a\":\"x\",\"b\":1,\"c\":{\"field1\":\"f1\",\"field2\":-1},\"d\":[3,\"e\"]}",
+      "k3" -> "[]",
+      "k4" -> "{\"field1\":\"field1\",\"field2\":99,\"field3\":[\"v1\",\"v2\"]}")
+
+    val commitInfo = CommitInfo.empty().withTimestamp(1)
+      .copy(operationParameters = operationParameters)
+
+    // Try a couple rounds of round trips.
+    val roundTrippedCommitInfo1 = JsonUtils.fromJson[CommitInfo](JsonUtils.toJson(commitInfo))
+    assert(roundTrippedCommitInfo1.operationParameters === expectedOperationParameters)
+    intercept[com.fasterxml.jackson.databind.exc.MismatchedInputException] {
+      // Non-primitive type values are not supported with legacy deserialization.
+      // Note that this is not a quirk specific to getLegacyPostDeserializationOperationParameters
+      // but rather a quirk of the legacy deserialization.
+      roundTrippedCommitInfo1.getLegacyPostDeserializationOperationParameters
+    }
+
+    val roundTrippedCommitInfo2 =
+      JsonUtils.fromJson[CommitInfo](JsonUtils.toJson(roundTrippedCommitInfo1))
+    assert(roundTrippedCommitInfo2.operationParameters === expectedOperationParameters)
+  }
+
+  test("getLegacyPostDeserializationOperationParameters is same as reading operation parameters  " +
+      "without custom deserialize") {
+    val rawOperationParameters: Map[String, Any] = Map(
+      "catalogTable" -> "t1",
+      "numFiles" -> 23L,
+      "partitionedBy" -> "[\"a\",\"b\"]",
+      "sourceFormat" -> "parquet",
+      "collectStats" -> false,
+      "k1" -> JsonUtils.toJson(Seq(1, 2)),
+      "k2" -> JsonUtils.toJson(Map("a" -> "x", "b" -> 1, "c" -> Seq(3, "e"))),
+      "k3" -> null,
+      "k4" -> JsonUtils.toJson(Seq.empty),
+      "" -> null)
+    val operationParameters = rawOperationParameters.mapValues(JsonUtils.toJson(_)).toMap
+
+    val commitInfo = CommitInfo
+      .empty()
+      .withTimestamp(1)
+      .copy(operationParameters = operationParameters)
+
+    val testRawDeserialization = TestRawDeserialization(
+      operationParameters = commitInfo.operationParameters)
+    val expectedLegacyOperationParameters = JsonUtils.fromJson[TestRawDeserialization](
+      JsonUtils.toJson(testRawDeserialization)).operationParameters
+
+    // Try a couple rounds of round trips.
+    val roundTrippedCommitInfo1 = JsonUtils.fromJson[CommitInfo](JsonUtils.toJson(commitInfo))
+    assert(roundTrippedCommitInfo1.getLegacyPostDeserializationOperationParameters ===
+      expectedLegacyOperationParameters)
+
+    val roundTrippedCommitInfo2 =
+      JsonUtils.fromJson[CommitInfo](JsonUtils.toJson(roundTrippedCommitInfo1))
+    assert(roundTrippedCommitInfo2.getLegacyPostDeserializationOperationParameters ===
+      expectedLegacyOperationParameters)
   }
 
   testActionSerDe(
@@ -622,10 +748,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         }
       assert(commitInfo1.json == expectedCommitInfoJson1)
       val newCommitInfo1 = Action.fromJson(expectedCommitInfoJson1).asInstanceOf[CommitInfo]
-      // TODO: operationParameters serialization/deserialization is broken as it uses a custom
-      //  serializer but a default deserializer and needs to be fixed.
-      assert(newCommitInfo1.copy(operationParameters = Map.empty) ==
-        commitInfo.copy(operationParameters = Map.empty))
+      assert(newCommitInfo1 == commitInfo1)
     }
 
     testActionSerDe(
@@ -638,6 +761,92 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
           """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123",""" +
           """"tags":{"k1":"v1"},"engineInfo":"Apache-Spark/3.1.1 Delta-Lake/10.1.0",""" +
           """"txnId":"123"}}""".stripMargin)
+  }
+
+  test("CommitInfo operationParameters deserialization with primitive types") {
+    // Test edge cases described in JsonMapDeserializer for primitive values
+    // This test verifies that the custom deserializer correctly handles mixed primitive types
+    // in operationParameters: strings, numbers, booleans, and null values
+    val operationParameters = Map(
+      "stringValue" -> "\"simpleString\"",
+      "numberValue" -> "123",
+      "booleanValue" -> "true",
+      "floatValue" -> "45.67",
+      "jsonEncodedString" -> "\"\\\"quoted string\\\"\""
+    )
+
+    val commitInfo = CommitInfo(
+      time = 1234567890L,
+      operation = "WRITE",
+      operationParameters = operationParameters,
+      commandContext = Map("clusterId" -> "test-cluster"),
+      readVersion = Some(5),
+      isolationLevel = Some("WriteSerializable"),
+      isBlindAppend = Some(false),
+      operationMetrics = Some(Map("numFiles" -> "10")),
+      userMetadata = Some("test metadata"),
+      tags = Some(Map("source" -> "test")),
+      txnId = Some("txn-123")
+    )
+
+    // Serialize and deserialize to test the JsonMapDeserializer
+    val serialized = commitInfo.json
+    val deserialized = Action.fromJson(serialized).asInstanceOf[CommitInfo]
+
+    // Verify that operationParameters are correctly preserved after round-trip
+    assert(deserialized.operationParameters == operationParameters)
+    assert(deserialized.operation == "WRITE")
+    assert(deserialized.readVersion == Some(5))
+
+    // Test that getLegacyPostDeserializationOperationParameters works correctly
+    val legacyParams = deserialized.getLegacyPostDeserializationOperationParameters
+    assert(legacyParams.nonEmpty)
+  }
+
+  test("CommitInfo operationParameters deserialization with complex operation") {
+    // Test with actual DeltaOperation parameters to verify real-world usage
+    // This focuses on the edge case where operation parameters contain JSON-encoded values
+    val operation = DeltaOperations.Write(
+      mode = SaveMode.Append,
+      partitionBy = Some(Seq("year", "month")),
+      predicate = Some("id > 100"),
+      userMetadata = Some("batch write operation")
+    )
+
+    val commitInfo = CommitInfo(
+      time = 9876543210L,
+      operation = operation.name,
+      operationParameters = operation.jsonEncodedValues,
+      commandContext = Map("clusterId" -> "prod-cluster"),
+      readVersion = Some(42),
+      isolationLevel = Some("WriteSerializable"),
+      isBlindAppend = Some(true),
+      operationMetrics = Some(Map("numFiles" -> "25", "numOutputRows" -> "1000")),
+      userMetadata = operation.userMetadata,
+      tags = Some(Map("environment" -> "production", "team" -> "data-eng")),
+      txnId = Some("txn-write-456")
+    )
+
+    // Test round-trip serialization/deserialization
+    val serialized = commitInfo.json
+    val deserialized = Action.fromJson(serialized).asInstanceOf[CommitInfo]
+
+    // Verify that complex operationParameters are correctly handled
+    assert(deserialized.operationParameters == operation.jsonEncodedValues)
+    assert(deserialized.operation == operation.name)
+    assert(deserialized.userMetadata == operation.userMetadata)
+
+    // Verify the specific operation parameters that should be preserved
+    val params = deserialized.operationParameters
+    assert(params.contains("mode"))
+    assert(params.contains("partitionBy"))
+    assert(params.contains("predicate"))
+
+    // Test legacy operation parameters for backward compatibility
+    val legacyParams = deserialized.getLegacyPostDeserializationOperationParameters
+    // Legacy parameters should be different due to the broken deserialization that the
+    // JsonMapDeserializer fixes
+    assert(legacyParams != deserialized.operationParameters)
   }
 
   private def roundTripCompare(name: String, actions: Action*) = {
@@ -691,3 +900,14 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     }
   }
 }
+
+// Both of these are used for CommitInfo serde tests
+case class TestObject(field1: String, field2: Int, field3: Option[Seq[String]])
+
+/**
+ * Test class to deserialize operation parameters without using custom
+ * JsonMapDeserializer.
+ */
+private final case class TestRawDeserialization(
+    @JsonSerialize(using = classOf[JsonMapSerializer])
+    operationParameters: Map[String, String])

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.reflect.runtime.universe._
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.sql.{QueryTest, SaveMode}
+import org.apache.spark.sql.catalyst.expressions.{EqualTo, Literal}
+import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+/**
+ * Tests for the correct serialization and deserialization of CommitInfo.
+ * The main focus is on the correct deserialization of operation parameters.
+ * See [[JsonMapDeserializer]] for more details about how operation
+ * parameter deserialization was broken before.
+ */
+class CommitInfoSerializerSuite extends QueryTest with SharedSparkSession {
+
+  def testOperationSerialization(operation: DeltaOperations.Operation): Unit = {
+    val commitInfo = CommitInfo(
+      time = 123L,
+      operation = operation.name,
+      inCommitTimestamp = Some(123L),
+      operationParameters = Map.empty,
+      commandContext = Map("clusterId" -> "23"),
+      readVersion = Some(23),
+      isolationLevel = Some("SnapshotIsolation"),
+      isBlindAppend = Some(true),
+      operationMetrics = Some(Map("m1" -> "v1", "m2" -> "v2")),
+      userMetadata = Some("123"),
+      tags = Some(Map("k1" -> "v1")),
+      txnId = Some("123")
+    ).copy(engineInfo = None)
+
+    val inMemoryCommitInfo = commitInfo.copy(operationParameters = operation.jsonEncodedValues)
+    val commitInfoSerialized = inMemoryCommitInfo.json
+    val roundTrippedCommitInfo = Action.fromJson(commitInfoSerialized).asInstanceOf[CommitInfo]
+    assert(roundTrippedCommitInfo.operationParameters == inMemoryCommitInfo.operationParameters)
+    assert(roundTrippedCommitInfo == inMemoryCommitInfo)
+
+    // Also ensure that CommitInfo.getLegacyOperationParameters is correct
+    val legacyPostDeserializationCommitInfo =
+      JsonUtils.mapper.readValue[ActionWrapper](commitInfoSerialized).commitInfo
+    val legacyOperationParametersActual =
+      roundTrippedCommitInfo.getLegacyPostDeserializationOperationParameters
+    assert(
+      legacyOperationParametersActual == legacyPostDeserializationCommitInfo.operationParameters)
+  }
+
+  val testMetadata = Metadata(
+    id = "test-id",
+    name = "test_table",
+    description = "Test table",
+    format = Format(),
+    schemaString = StructType(Seq(
+      StructField("col1", StringType),
+      StructField("col2", IntegerType)
+    )).json,
+    partitionColumns = Seq("col1"),
+    configuration = Map("property1" -> "value1")
+  )
+
+  val oldSchema = StructType(Seq(StructField("col1", StringType)))
+  val newSchema = StructType(Seq(StructField("col1", StringType), StructField("col2", IntegerType)))
+
+  val trackedOperationClasses = Map(
+    "Convert" -> (() => DeltaOperations.Convert(
+      numFiles = 23L,
+      partitionBy = Seq("a", "b"),
+      collectStats = false,
+      catalogTable = Some("t1"),
+      sourceFormat = Some("parquet"))),
+    "DomainMetadataCleanup" -> (() => DeltaOperations.DomainMetadataCleanup(1)),
+    "Write" -> (() => DeltaOperations.Write(
+      mode = SaveMode.Append,
+      partitionBy = Some(Seq("col1", "col2")),
+      predicate = Some("col1 > 10"),
+      userMetadata = Some("test metadata")
+    )),
+    "StreamingUpdate" -> (() => DeltaOperations.StreamingUpdate(
+      outputMode = OutputMode.Append(),
+      queryId = "query-123",
+      epochId = 42L,
+      userMetadata = Some("streaming metadata")
+    )),
+    "Delete" -> (() => DeltaOperations.Delete(Seq(EqualTo(Literal("col1"), Literal("value1"))))),
+    "Truncate" -> (() => DeltaOperations.Truncate()),
+    "Merge" -> (() => DeltaOperations.Merge(
+      predicate = Some(EqualTo(Literal("source.id"), Literal("target.id"))),
+      updatePredicate = Some("source.value > target.value"),
+      deletePredicate = Some("source.flag = 'delete'"),
+      insertPredicate = Some("source.id IS NOT NULL"),
+      matchedPredicates = Seq(DeltaOperations.MergePredicate(Some("matched"), "update")),
+      notMatchedPredicates = Seq(DeltaOperations.MergePredicate(Some("not matched"), "insert")),
+      notMatchedBySourcePredicates = Seq(
+        DeltaOperations.MergePredicate(Some("not matched by source"), "delete"))
+    )),
+    "Update" -> (() => DeltaOperations.Update(Some(EqualTo(Literal("col1"), Literal("value1"))))),
+    "CreateTable" -> (() => DeltaOperations.CreateTable(
+      metadata = testMetadata,
+      isManaged = true,
+      asSelect = true,
+      clusterBy = Some(Seq("col1"))
+    )),
+    "ReplaceTable" -> (() => DeltaOperations.ReplaceTable(
+      metadata = testMetadata,
+      isManaged = true,
+      orCreate = true,
+      asSelect = true,
+      userMetadata = Some("replace metadata"),
+      clusterBy = Some(Seq("col2")))),
+    "SetTableProperties" ->
+      (() => DeltaOperations.SetTableProperties(Map("key1" -> "value1", "key2" -> "value2"))),
+    "UnsetTableProperties" ->
+      (() => DeltaOperations.UnsetTableProperties(Seq("key1", "key2"), ifExists = true)),
+    "DropTableFeature" ->
+      (() => DeltaOperations.DropTableFeature("testFeature", truncateHistory = true)),
+    "AddColumns" -> (() => DeltaOperations.AddColumns(Seq(
+      DeltaOperations.QualifiedColTypeWithPositionForLog(
+        Seq("newCol"),
+        StructField("newCol", StringType),
+        Some("AFTER col1"))))),
+    "DropColumns" -> (() => DeltaOperations.DropColumns(Seq(Seq("col1"), Seq("col2")))),
+    "RenameColumn" -> (() => DeltaOperations.RenameColumn(Seq("oldCol"), Seq("newCol"))),
+    "ChangeColumn" -> (() => DeltaOperations.ChangeColumn(
+      columnPath = Seq("col1"),
+      columnName = "col1",
+      newColumn = StructField("col1", StringType),
+      colPosition = Some("FIRST"))),
+    "ChangeColumns" -> (() => DeltaOperations.ChangeColumns(Seq(
+      DeltaOperations.ChangeColumn(
+        columnPath = Seq("col1"),
+        columnName = "col1",
+        newColumn = StructField("col1", StringType),
+        colPosition = Some("FIRST"))))),
+    "ReplaceColumns" -> (() => DeltaOperations.ReplaceColumns(Seq(
+      StructField("newCol1", StringType),
+      StructField("newCol2", IntegerType)))),
+    "UpgradeProtocol" ->
+      (() => DeltaOperations.UpgradeProtocol(Protocol(minReaderVersion = 1, minWriterVersion = 2))),
+    "UpdateColumnMetadata" -> (() => DeltaOperations.UpdateColumnMetadata(
+      "UPDATE COLUMN METADATA",
+      Seq((Seq("col1"), StructField("col1", StringType))))),
+    "UpdateSchema" -> (() => DeltaOperations.UpdateSchema(oldSchema, newSchema)),
+    "AddConstraint" -> (() => DeltaOperations.AddConstraint("check_positive", "col1 > 0")),
+    "DropConstraint" -> (() => DeltaOperations.DropConstraint("check_positive", Some("col1 > 0"))),
+    "ComputeStats" ->
+      (() => DeltaOperations.ComputeStats(Seq(EqualTo(Literal("col1"), Literal("value1"))))),
+    "Restore" -> (() => DeltaOperations.Restore(Some(5L), Some("2023-01-01T00:00:00Z"))),
+    "Optimize" -> (() => DeltaOperations.Optimize(
+      predicate = Seq(EqualTo(Literal("col1"), Literal("value1"))),
+      zOrderBy = Seq("col1", "col2"),
+      auto = true,
+      clusterBy = Some(Seq("col3")),
+      isFull = false)),
+    "Clone" -> (() => DeltaOperations.Clone(
+      source = "s3://bucket/path/to/table",
+      sourceVersion = 10L)),
+    "VacuumStart" -> (() => DeltaOperations.VacuumStart(
+      retentionCheckEnabled = true,
+      specifiedRetentionMillis = Some(604800000L),
+      defaultRetentionMillis = 604800000L)),
+    "VacuumEnd" -> (() => DeltaOperations.VacuumEnd("COMPLETED")),
+    "Reorg" -> (() => DeltaOperations.Reorg(
+      predicate = Seq(EqualTo(Literal("col1"), Literal("value1"))),
+      applyPurge = true)),
+    "ClusterBy" -> (() => DeltaOperations.ClusterBy(
+      oldClusteringColumns = JsonUtils.toJson(Seq("oldCol1", "oldCol2")),
+      newClusteringColumns = JsonUtils.toJson(Seq("newCol1", "newCol2")))),
+    "RowTrackingBackfill" -> (() => DeltaOperations.RowTrackingBackfill(batchId = 3)),
+    "RowTrackingUnBackfill" -> (() => DeltaOperations.RowTrackingUnBackfill(batchId = 4)),
+    "UpgradeUniformProperties" ->
+      (() => DeltaOperations.UpgradeUniformProperties(Map("uniform.property1" -> "value1"))),
+    "RemoveColumnMapping" ->
+      (() => DeltaOperations.RemoveColumnMapping(Some("remove column mapping metadata"))),
+    "AddDeletionVectorsTombstones" -> (() => DeltaOperations.AddDeletionVectorsTombstones),
+    "ManualUpdate" -> (() => DeltaOperations.ManualUpdate),
+    "EmptyCommit" -> (() => DeltaOperations.EmptyCommit)
+  )
+
+  trackedOperationClasses.foreach { case (operationName, operationGenerator) =>
+    test(s"$operationName operation serialization") {
+      testOperationSerialization(operationGenerator())
+    }
+  }
+
+  val ignoredOperationClasses = Set(
+    "TestOperation"
+  )
+
+  test("all operations should be tested in this suite") {
+    val mirror = runtimeMirror(getClass.getClassLoader)
+    val moduleSymbol =
+      mirror.staticModule("org.apache.spark.sql.delta.DeltaOperations")
+    val moduleMirror = mirror.reflectModule(moduleSymbol)
+    val instance = moduleMirror.instance
+
+    val instanceMirror = mirror.reflect(instance)
+    val symbol = instanceMirror.symbol
+    val traitOperation =
+      typeOf[org.apache.spark.sql.delta.DeltaOperations.Operation].typeSymbol
+
+    val allOperations = symbol.typeSignature.members.flatMap {
+      case cls: ClassSymbol
+          if cls.isCaseClass && cls.isPublic && cls.toType.baseClasses.contains(traitOperation) =>
+        Some(cls.name.toString)
+      case obj: ModuleSymbol
+          if obj.isPublic && obj.moduleClass.asType.toType.baseClasses.contains(traitOperation) =>
+        Some(obj.name.toString)
+      case _ => None
+    }.toSet
+    assert(
+      (allOperations -- ignoredOperationClasses) == trackedOperationClasses.keySet,
+      s"if you add a new operation, please add a new test case in this suite " +
+        "for that operation and then add the operation name to the `trackedOperationClasses` " +
+        "Map in this test. Missing operations: " +
+        s"${allOperations -- ignoredOperationClasses -- trackedOperationClasses.keySet}"
+    )
+  }
+}
+
+/**
+ * A minimal CommitInfo with only operation parameters. This one
+ * does not use the custom JsonMapDeserializer so we can
+ * use it to test our ability to generate the legacy operation parameters.
+ */
+case class LegacyCommitInfoWithOperationParametersOnly(
+  operationParameters: Map[String, String]
+)
+
+case class ActionWrapper(commitInfo: LegacyCommitInfoWithOperationParametersOnly = null)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -465,14 +465,6 @@ class DeltaLogMinorCompactionSuite extends QueryTest
               .map {
                 case r: RemoveFile if r.deletionTimestamp.isDefined =>
                   r.copy(deletionTimestamp = None)
-                case ci: CommitInfo =>
-                  // The operationParameters were serialized with JsonMapSerializer but there
-                  // were no corresponding JsonMapDeserializer when reading them back,
-                  // so need to do this step to ensure they can be serialized again.
-                  val parameters = Option(ci.operationParameters)
-                    .map(_.mapValues(JsonUtils.toJson(_)).toMap)
-                    .orNull
-                  ci.copy(operationParameters = parameters)
                 case other => other
               }
               .map(_.json)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR completely fixes `CommitInfo`.operationParameters deserialization. A new method `getLegacyPostDeserializationOperationParameters` has been added to retain the legacy behaviour for old callsites. This PR, by itself, should be a no-op in terms of behaviour changes as the legacy callsites will use `getLegacyPostDeserializationOperationParameters` for now.



The newly introduced `JsonMapDeserializer` effectively performs an inverse of `JsonMapSerializer`. The original problem is explained in detail below:

The in-memory representation of operation params of any Delta Operation can be a combination of json encoded strings, simple strings, or primitives single-encoded as strings. The values can be any of:
- `"123"`
- `"true"`
- `"1.0"`
- `"\"true\""`
- `"\"1.0\""`
- or more complex json encoded strings

Due to how `JsonMapSerializer` strips one level of encoding for these values during serialization, these can end up being written out in this form:

- `"123"` → `123`
- `"true"` → `true`
- `"1.0"` → `1.0`
- `"\"true\""` → `"true"`
- `"\"1.0\""` → `"1.0"`

Since operationParameters is a `Map[String, String]`, during the deserialization phase, the deserializer intelligently converts primitive types from above to simple strings:

- `"123"` → `123` → `"123"`
- `"true"` → `true` → `"true"`
- `"1.0"` → `1.0` → `"1.0"`
- `"\"true\""` → `"true"` → `"true"`
- `"\"1.0\""` → `"1.0"` → `"1.0"`

Since we stripped one level of encoding during serialization, we need to add it back to get closer to the original in-memory representation:

- `"123"` → `123` → `"123"` → `"\"123\""`
- `"true"` → `true` → `"true"` → `"\"true\""`
- `"1.0"` → `1.0` → `"1.0"` → `"\"1.0\""`
- `"\"true\""` → `"true"` → `"true"` → `"\"true\""`
- `"\"1.0\""` → `"1.0"` → `"1.0"` → `"\"1.0\""`


Note how values that were single-encoded as strings originally are now double-encoded as strings (e.g., `"true"` → `true` → `"true"` → `"\"true\""`). This is because the deserializer converted the primitive values to strings as well as retained simple strings as strings. In this process, we lost some information about the original values.

Solution:

To fix this, we first deserialize the values as a `java.util.HashMap[String, Any]`:

- `"true"` → `true` → `true` (type: Boolean)
- `"\"true\""` → `"true"` → `"true"` (type: String)

And then JsonEncode them once to get the original in-memory representation:

- `"true"` → `true` → `true` → `"true"`
- `"\"true\""` → `"true"` → `"true"` → `"\"true\""`


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Adds a new suite that tests both the new deserialization as well as the legacy behaviour. Most DeltaOperations are covered by this suite.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No