### PR TITLE
[Spark] Plumb catalog tables to `DeltaLog` API call sites in `LiquidMetadataCleanup`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -254,7 +254,9 @@ trait Checkpoints extends DeltaLogging {
   protected def store: LogStore
 
   /** Used to clean up stale log files. */
-  protected def doLogCleanup(snapshotToCleanup: Snapshot): Unit
+  protected def doLogCleanup(
+    snapshotToCleanup: Snapshot,
+    catalogTableOpt: Option[CatalogTable]): Unit
 
   /** Returns the checkpoint interval for this log. Not transactional. */
   def checkpointInterval(metadata: Metadata): Int =
@@ -330,11 +332,11 @@ trait Checkpoints extends DeltaLogging {
 
   def checkpointAndCleanUpDeltaLog(
       snapshotToCheckpoint: Snapshot,
-      catalogTableOpt: Option[CatalogTable] = None): Unit = {
+      catalogTableOpt: Option[CatalogTable]): Unit = {
     val lastCheckpointInfo = writeCheckpointFiles(snapshotToCheckpoint, catalogTableOpt)
     writeLastCheckpointFile(
       snapshotToCheckpoint.deltaLog, lastCheckpointInfo, LastCheckpointInfo.checksumEnabled(spark))
-    doLogCleanup(snapshotToCheckpoint)
+    doLogCleanup(snapshotToCheckpoint, catalogTableOpt)
   }
 
   protected[delta] def writeLastCheckpointFile(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -209,6 +209,7 @@ case class DeletionVectorsPreDowngradeCommand(table: DeltaTableV2)
 
     val startTimeNs = System.nanoTime()
     val snapshotToUse = table.deltaLog.update(
+      catalogTableOpt = table.catalogTable,
       checkIfUpdatedSinceTs = Some(checkIfSnapshotUpdatedSinceTs))
 
     val deletionVectorPath =
@@ -675,6 +676,7 @@ case class CheckpointProtectionPreDowngradeCommand(table: DeltaTableV2)
 
       table.deltaLog.cleanUpExpiredLogs(
         snapshot,
+        table.catalogTable,
         deltaRetentionMillisOpt = Some(truncateHistoryLogRetentionMillis(snapshot.metadata)),
         cutoffTruncationGranularity = TruncationGranularity.MINUTE)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -326,7 +326,7 @@ case class AlterTableDropFeatureDeltaCommand(
     // Check whether the protocol contains the feature in either the writer features list or
     // the reader+writer features list. Note, protocol needs to denormalized to allow dropping
     // features from legacy protocols.
-    val protocol = table.deltaLog.update(catalogTableOpt = table.catalogTable).protocol
+    val protocol = table.update().protocol
     val protocolContainsFeatureName =
       protocol.implicitlyAndExplicitlySupportedFeatures.map(_.name).contains(featureName)
     val featureInLowerCase = featureName.toLowerCase(Locale.ROOT)
@@ -443,6 +443,7 @@ case class AlterTableDropFeatureDeltaCommand(
         // cleanUpExpiredLogs call truncates the cutoff at a minute granularity.
         deltaLog.cleanUpExpiredLogs(
           snapshotToCleanup = snapshot,
+          catalogTableOpt = table.catalogTable,
           deltaRetentionMillisOpt =
             if (truncateHistory) Some(truncateHistoryLogRetentionMillis(txn.metadata)) else None,
           cutoffTruncationGranularity =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Plumb catalog tables to `DeltaLog` API call sites in `LiquidMetadataCleanup.scala`.

`DeltaLog` API call includes:
1. `DeltaLog.forTable`
2. `deltaLog.getSnapshotAt`
3. `deltaLog.update`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
