### PR TITLE
[Spark] Fix tests to run with both path-based and name-based

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -86,15 +86,14 @@ trait UpdateBaseMixin
       targetDF: DataFrame,
       set: Seq[String],
       where: String = null,
-      errMsgs: Seq[String] = Nil) = {
-    withTempDir { dir =>
-      targetDF.write.format("delta").save(dir.toString)
-      val e = intercept[AnalysisException] {
-        executeUpdate(target = s"delta.`$dir`", set, where)
-      }
-      errMsgs.foreach { msg =>
-        assert(e.getMessage.toLowerCase(Locale.ROOT).contains(msg.toLowerCase(Locale.ROOT)))
-      }
+      errMsgs: Seq[String] = Nil): Unit = {
+    dropTable()
+    append(targetDF)
+    val e = intercept[AnalysisException] {
+      executeUpdate(target = tableSQLIdentifier, set, where)
+    }
+    errMsgs.foreach { msg =>
+      assert(e.getMessage.toLowerCase(Locale.ROOT).contains(msg.toLowerCase(Locale.ROOT)))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This is part of the effort to convert DML tests to run with both name-based and path-based access. This PR fixes a few tests that we missed.

## How was this patch tested?

UT

## Does this PR introduce _any_ user-facing changes?

No