### PR TITLE
[Kernel] [CatalogManaged] Add helpful APIs to CommitMetadata, useful for Committers

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
@@ -87,7 +87,7 @@ public class CommitMetadata {
         readMetadataOpt.isPresent() || newMetadataOpt.isPresent(),
         "At least one of readMetadataOpt or newMetadataOpt must be present");
 
-    checkICTPresentIfCatalogManaged();
+    checkInCommitTimestampPresentIfCatalogManaged();
   }
 
   /** The version of the Delta table this commit is targeting. */
@@ -143,7 +143,7 @@ public class CommitMetadata {
    * the protocol that was read at the beginning of the commit.
    */
   public Protocol getEffectiveProtocol() {
-    return newProtocolOpt.orElseGet(() -> readProtocolOpt.get());
+    return newProtocolOpt.orElseGet(readProtocolOpt::get);
   }
 
   /**
@@ -152,7 +152,7 @@ public class CommitMetadata {
    * metadata that was read at the beginning of the commit.
    */
   public Metadata getEffectiveMetadata() {
-    return newMetadataOpt.orElseGet(() -> readMetadataOpt.get());
+    return newMetadataOpt.orElseGet(readMetadataOpt::get);
   }
 
   /**
@@ -181,7 +181,7 @@ public class CommitMetadata {
     }
   }
 
-  private void checkICTPresentIfCatalogManaged() {
+  private void checkInCommitTimestampPresentIfCatalogManaged() {
     if (TableFeatures.isCatalogManagedSupported(getEffectiveProtocol())) {
       checkArgument(
           commitInfo.getInCommitTimestamp().isPresent(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
@@ -23,6 +23,7 @@ import io.delta.kernel.annotation.Experimental;
 import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import java.util.Optional;
 
 /**
@@ -31,6 +32,25 @@ import java.util.Optional;
  */
 @Experimental
 public class CommitMetadata {
+
+  /**
+   * Represents the different types of commits based on filesystem-managed and catalog-managed state
+   * transitions.
+   */
+  public enum CommitType {
+    /** Creating a new filesystem-managed table */
+    FILESYSTEM_CREATE,
+    /** Creating a new catalog-managed table */
+    CATALOG_CREATE,
+    /** Writing to an existing filesystem-managed table */
+    FILESYSTEM_WRITE,
+    /** Writing to an existing catalog-managed table */
+    CATALOG_WRITE,
+    /** Upgrading a filesystem-managed table to a catalog-managed table */
+    FILESYSTEM_UPGRADE_TO_CATALOG,
+    /** Downgrading a catalog-managed table to a filesystem-managed table */
+    CATALOG_DOWNGRADE_TO_FILESYSTEM
+  }
 
   private final long version;
   private final String logPath;
@@ -56,6 +76,18 @@ public class CommitMetadata {
     this.readMetadataOpt = requireNonNull(readMetadataOpt, "readMetadataOpt is null");
     this.newProtocolOpt = requireNonNull(newProtocolOpt, "newProtocolOpt is null");
     this.newMetadataOpt = requireNonNull(newMetadataOpt, "newMetadataOpt is null");
+
+    checkArgument(
+        readProtocolOpt.isPresent() == readMetadataOpt.isPresent(),
+        "readProtocolOpt and readMetadataOpt must either both be present or both be absent");
+    checkArgument(
+        readProtocolOpt.isPresent() || newProtocolOpt.isPresent(),
+        "At least one of readProtocolOpt or newProtocolOpt must be present");
+    checkArgument(
+        readMetadataOpt.isPresent() || newMetadataOpt.isPresent(),
+        "At least one of readMetadataOpt or newMetadataOpt must be present");
+
+    checkICTPresentIfCatalogManaged();
   }
 
   /** The version of the Delta table this commit is targeting. */
@@ -103,5 +135,57 @@ public class CommitMetadata {
    */
   public Optional<Metadata> getNewMetadataOpt() {
     return newMetadataOpt;
+  }
+
+  /**
+   * Returns the effective {@link Protocol} that will be in place after this commit. If a new
+   * protocol is being written as part of this commit, returns the new protocol. Otherwise, returns
+   * the protocol that was read at the beginning of the commit.
+   */
+  public Protocol getEffectiveProtocol() {
+    return newProtocolOpt.orElseGet(() -> readProtocolOpt.get());
+  }
+
+  /**
+   * Returns the effective {@link Metadata} that will be in place after this commit. If new metadata
+   * is being written as part of this commit, returns the new metadata. Otherwise, returns the
+   * metadata that was read at the beginning of the commit.
+   */
+  public Metadata getEffectiveMetadata() {
+    return newMetadataOpt.orElseGet(() -> readMetadataOpt.get());
+  }
+
+  /**
+   * Determines the type of commit based on whether this is a table creation and the catalog-managed
+   * status of the table before and after the commit.
+   */
+  public CommitType getCommitType() {
+    final boolean isCreate = !readProtocolOpt.isPresent() && !readMetadataOpt.isPresent();
+    final boolean readVersionCatalogManaged =
+        readProtocolOpt.map(TableFeatures::isCatalogManagedSupported).orElse(false);
+    final boolean writeVersionCatalogManaged =
+        TableFeatures.isCatalogManagedSupported(getEffectiveProtocol());
+
+    if (isCreate && writeVersionCatalogManaged) {
+      return CommitType.CATALOG_CREATE;
+    } else if (isCreate && !writeVersionCatalogManaged) {
+      return CommitType.FILESYSTEM_CREATE;
+    } else if (readVersionCatalogManaged && writeVersionCatalogManaged) {
+      return CommitType.CATALOG_WRITE;
+    } else if (readVersionCatalogManaged && !writeVersionCatalogManaged) {
+      return CommitType.CATALOG_DOWNGRADE_TO_FILESYSTEM;
+    } else if (!readVersionCatalogManaged && writeVersionCatalogManaged) {
+      return CommitType.FILESYSTEM_UPGRADE_TO_CATALOG;
+    } else {
+      return CommitType.FILESYSTEM_WRITE;
+    }
+  }
+
+  private void checkICTPresentIfCatalogManaged() {
+    if (TableFeatures.isCatalogManagedSupported(getEffectiveProtocol())) {
+      checkArgument(
+          commitInfo.getInCommitTimestamp().isPresent(),
+          "InCommitTimestamp must be present for commits to catalogManaged tables");
+    }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/CommitContextImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/CommitContextImpl.java
@@ -134,7 +134,7 @@ public class CommitContextImpl implements CommitContext {
 
   private CommitInfo getCommitInfo() {
     return new CommitInfo(
-        Optional.empty(), /* inCommitTimestampOpt */ // TODO: support ICT
+        Optional.of(commitAttemptTimestampMs), /* inCommitTimestampOpt */ // TODO: support ICT
         commitAttemptTimestampMs,
         "Kernel-" + Meta.KERNEL_VERSION + "/" + txnState.engineInfo, /* engineInfo */
         txnState.operation.getDescription(), /* description */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/CommitMetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/CommitMetadataSuite.scala
@@ -1,0 +1,258 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.commit
+
+import java.util.Optional
+
+import io.delta.kernel.commit.CommitMetadata
+import io.delta.kernel.commit.CommitMetadata.CommitType
+import io.delta.kernel.internal.actions.{Metadata, Protocol}
+import io.delta.kernel.test.{ActionUtils, VectorTestUtils}
+import io.delta.kernel.types.{IntegerType, StructType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class CommitMetadataSuite extends AnyFunSuite
+    with ActionUtils
+    with VectorTestUtils {
+
+  private val protocol12 = new Protocol(1, 2)
+  private val logPath = "/fake/_delta_log"
+  private val version = 5L
+
+  test("constructor validates non-negative version") {
+    val ex = intercept[IllegalArgumentException] {
+      new CommitMetadata(
+        -1L, // negative version
+        logPath,
+        testCommitInfo(),
+        Optional.of(protocol12),
+        Optional.of(basicPartitionedMetadata),
+        Optional.empty(),
+        Optional.empty())
+    }
+    assert(ex.getMessage.contains("version must be non-negative"))
+  }
+
+  test("constructor validates null parameters") {
+    intercept[NullPointerException] {
+      new CommitMetadata(
+        version,
+        null, // null logPath
+        testCommitInfo(),
+        Optional.of(protocol12),
+        Optional.of(basicPartitionedMetadata),
+        Optional.empty(),
+        Optional.empty())
+    }
+
+    intercept[NullPointerException] {
+      new CommitMetadata(
+        version,
+        logPath,
+        null, // null commitInfo
+        Optional.of(protocol12),
+        Optional.of(basicPartitionedMetadata),
+        Optional.empty(),
+        Optional.empty())
+    }
+  }
+
+  test("constructor validates readProtocol and readMetadata consistency") {
+    // Both present is valid
+    new CommitMetadata(
+      version,
+      logPath,
+      testCommitInfo(),
+      Optional.of(protocol12),
+      Optional.of(basicPartitionedMetadata),
+      Optional.empty(),
+      Optional.empty())
+
+    // Both absent is valid if new ones are present
+    new CommitMetadata(
+      version,
+      logPath,
+      testCommitInfo(),
+      Optional.empty(),
+      Optional.empty(),
+      Optional.of(protocol12),
+      Optional.of(basicPartitionedMetadata))
+
+    // One present, one absent should fail
+    intercept[IllegalArgumentException] {
+      new CommitMetadata(
+        version,
+        logPath,
+        testCommitInfo(),
+        Optional.of(protocol12),
+        Optional.empty(), // readMetadata absent but readProtocol present
+        Optional.empty(),
+        Optional.empty())
+    }
+  }
+
+  test("constructor validates at least one protocol must be present") {
+    intercept[IllegalArgumentException] {
+      new CommitMetadata(
+        version,
+        logPath,
+        testCommitInfo(),
+        Optional.empty(), // no read protocol
+        Optional.empty(),
+        Optional.empty(), // no new protocol
+        Optional.of(basicPartitionedMetadata))
+    }
+  }
+
+  test("constructor validates at least one metadata must be present") {
+    intercept[IllegalArgumentException] {
+      new CommitMetadata(
+        version,
+        logPath,
+        testCommitInfo(),
+        Optional.empty(),
+        Optional.empty(), // no read metadata
+        Optional.of(protocol12),
+        Optional.empty() // no new metadata
+      )
+    }
+  }
+
+  test("constructor validates ICT present if catalogManaged enabled") {
+    val exMsg = intercept[IllegalArgumentException] {
+      new CommitMetadata(
+        version,
+        logPath,
+        testCommitInfo(ictEnabled = false), // ICT not enabled!
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(protocolWithCatalogManagedSupport),
+        Optional.of(basicPartitionedMetadata))
+    }.getMessage
+
+    assert(exMsg.contains("InCommitTimestamp must be present for commits to catalogManaged tables"))
+  }
+
+  test("getEffectiveProtocol returns new protocol when present") {
+    val newProtocol = new Protocol(2, 3)
+    val commitMetadata = new CommitMetadata(
+      version,
+      logPath,
+      testCommitInfo(),
+      Optional.of(protocol12),
+      Optional.of(basicPartitionedMetadata),
+      Optional.of(newProtocol),
+      Optional.empty())
+
+    assert(commitMetadata.getEffectiveProtocol == newProtocol)
+  }
+
+  test("getEffectiveProtocol returns read protocol when new protocol absent") {
+    val commitMetadata = new CommitMetadata(
+      version,
+      logPath,
+      testCommitInfo(),
+      Optional.of(protocol12),
+      Optional.of(basicPartitionedMetadata),
+      Optional.empty(),
+      Optional.empty())
+
+    assert(commitMetadata.getEffectiveProtocol == protocol12)
+  }
+
+  test("getEffectiveMetadata returns new metadata when present") {
+    val newMetadata = testMetadata(new StructType().add("newCol", IntegerType.INTEGER))
+    val commitMetadata = new CommitMetadata(
+      version,
+      logPath,
+      testCommitInfo(),
+      Optional.of(protocol12),
+      Optional.of(basicPartitionedMetadata),
+      Optional.empty(),
+      Optional.of(newMetadata))
+
+    assert(commitMetadata.getEffectiveMetadata == newMetadata)
+  }
+
+  test("getEffectiveMetadata returns read metadata when new metadata absent") {
+    val commitMetadata = new CommitMetadata(
+      version,
+      logPath,
+      testCommitInfo(),
+      Optional.of(protocol12),
+      Optional.of(basicPartitionedMetadata),
+      Optional.empty(),
+      Optional.empty())
+
+    assert(commitMetadata.getEffectiveMetadata == basicPartitionedMetadata)
+  }
+
+  // ========== CommitType Tests START ==========
+
+  case class CommitTypeTestCase(
+      readProtocolOpt: Optional[Protocol] = Optional.empty(),
+      readMetadataOpt: Optional[Metadata] = Optional.empty(),
+      newProtocolOpt: Optional[Protocol] = Optional.empty(),
+      newMetadataOpt: Optional[Metadata] = Optional.empty(),
+      expectedCommitType: CommitType)
+
+  private val commitTypeTestCases = Seq(
+    CommitTypeTestCase(
+      newProtocolOpt = Optional.of(protocol12),
+      newMetadataOpt = Optional.of(basicPartitionedMetadata),
+      expectedCommitType = CommitType.FILESYSTEM_CREATE),
+    CommitTypeTestCase(
+      newProtocolOpt = Optional.of(protocolWithCatalogManagedSupport),
+      newMetadataOpt = Optional.of(basicPartitionedMetadata),
+      expectedCommitType = CommitType.CATALOG_CREATE),
+    CommitTypeTestCase(
+      readProtocolOpt = Optional.of(protocol12),
+      readMetadataOpt = Optional.of(basicPartitionedMetadata),
+      expectedCommitType = CommitType.FILESYSTEM_WRITE),
+    CommitTypeTestCase(
+      readProtocolOpt = Optional.of(protocolWithCatalogManagedSupport),
+      readMetadataOpt = Optional.of(basicPartitionedMetadata),
+      expectedCommitType = CommitType.CATALOG_WRITE),
+    CommitTypeTestCase(
+      readProtocolOpt = Optional.of(protocol12),
+      readMetadataOpt = Optional.of(basicPartitionedMetadata),
+      newProtocolOpt = Optional.of(protocolWithCatalogManagedSupport),
+      expectedCommitType = CommitType.FILESYSTEM_UPGRADE_TO_CATALOG),
+    CommitTypeTestCase(
+      readProtocolOpt = Optional.of(protocolWithCatalogManagedSupport),
+      readMetadataOpt = Optional.of(basicPartitionedMetadata),
+      newProtocolOpt = Optional.of(protocol12),
+      expectedCommitType = CommitType.CATALOG_DOWNGRADE_TO_FILESYSTEM))
+
+  commitTypeTestCases.foreach { testCase =>
+    test(s"getCommitType returns ${testCase.expectedCommitType}") {
+      val commitMetadata = new CommitMetadata(
+        version,
+        logPath,
+        testCommitInfo(),
+        testCase.readProtocolOpt,
+        testCase.readMetadataOpt,
+        testCase.newProtocolOpt,
+        testCase.newMetadataOpt)
+
+      assert(commitMetadata.getCommitType == testCase.expectedCommitType)
+    }
+  }
+
+  // ========== CommitType Tests END ==========
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/DefaultCommitterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/commit/DefaultCommitterSuite.scala
@@ -42,7 +42,7 @@ class DefaultCommitterSuite extends AnyFunSuite
   private val basicFileSystemCommitMetadataNoPMChange = new CommitMetadata(
     1L,
     "/fake/_delta_log",
-    testCommitInfo,
+    testCommitInfo(ictEnabled = false),
     Optional.of(protocol12),
     Optional.of(basicPartitionedMetadata),
     Optional.empty(), // newProtocolOpt
@@ -76,7 +76,7 @@ class DefaultCommitterSuite extends AnyFunSuite
           new CommitMetadata(
             3L,
             "/fake/_delta_log",
-            testCommitInfo,
+            testCommitInfo(),
             Optional.of(readProtocol),
             Optional.of(metadata),
             Optional.of(newProtocol),

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -41,10 +41,10 @@ trait ActionUtils extends VectorTestUtils {
       .add("part1", IntegerType.INTEGER).add("col1", IntegerType.INTEGER),
     partitionCols = Seq("part1"))
 
-  def testCommitInfo: CommitInfo = {
+  def testCommitInfo(ictEnabled: Boolean = true): CommitInfo = {
     new CommitInfo(
-      Optional.empty(),
-      -1,
+      if (ictEnabled) Optional.of(1L) else Optional.empty(), // ICT
+      1L, // timestamp
       "engineInfo",
       "operation",
       Collections.emptyMap(), // operationParameters


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5060/files) to review incremental changes.
- [**stack/kernel_commit_metadata_types**](https://github.com/delta-io/delta/pull/5060) [[Files changed](https://github.com/delta-io/delta/pull/5060/files)]

---------
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR adds some helpful APIs to CommitMetadata, which will be used by https://github.com/delta-io/delta/pull/5052 (see their usage there; I will rebase that 5052 PR after this PR is merged).

## How was this patch tested?

New UTs.

## Does this PR introduce _any_ user-facing changes?

No.
