### PR TITLE
[Kernel] Add `withCommitter` API to CreateTableTransactionBuilder

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/transaction/CreateTableTransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/transaction/CreateTableTransactionBuilder.java
@@ -17,6 +17,7 @@ package io.delta.kernel.transaction;
 
 import io.delta.kernel.Transaction;
 import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.commit.Committer;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.utils.CloseableIterable;
 import java.util.Map;
@@ -60,6 +61,22 @@ public interface CreateTableTransactionBuilder {
   CreateTableTransactionBuilder withMaxRetries(int maxRetries);
 
   /**
+   * Provides a custom committer to use at transaction commit time.
+   *
+   * <p>Catalog implementations that wish to support the catalogManaged Delta table feature should
+   * provide to engines their own catalog-specific Committer implementation which may, for example,
+   * send a commit RPC to the catalog service to finalize the commit.
+   *
+   * <p>If no committer is provided, a default committer will be created that only supports writing
+   * into filesystem-managed Delta tables.
+   *
+   * @param committer the committer to use
+   * @return a new builder instance with the provided committer
+   * @see Committer
+   */
+  CreateTableTransactionBuilder withCommitter(Committer committer);
+
+  /**
    * Build the transaction for creating the Delta table.
    *
    * <p>This validates all the configuration and creates a {@link Transaction} that can be used to
@@ -70,6 +87,4 @@ public interface CreateTableTransactionBuilder {
    * @return A configured {@link Transaction} for creating the table.
    */
   Transaction build(Engine engine);
-
-  // TODO: add withCommitter(Committer committer) method to pass to the transaction
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesTransactionBuilderV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesTransactionBuilderV2Suite.scala
@@ -287,6 +287,7 @@ class DeltaTableWritesTransactionBuilderV2Suite extends DeltaTableWritesSuite
 
       // Check the txn returns the correct committer
       assert(txn.getCommitter.isInstanceOf[FakeCommitter])
+
       // Check that the txn invokes the provided committer upon commit
       val e = intercept[RuntimeException] {
         txn.commit(engine, emptyIterable())

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesTransactionBuilderV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesTransactionBuilderV2Suite.scala
@@ -27,6 +27,7 @@ import io.delta.kernel.defaults.utils.WriteUtilsWithV2Builders
 import io.delta.kernel.engine.{Engine, JsonHandler}
 import io.delta.kernel.exceptions.{KernelException, MaxCommitRetryLimitReachedException, TableAlreadyExistsException}
 import io.delta.kernel.expressions.Column
+import io.delta.kernel.internal.commit.DefaultFileSystemManagedTableOnlyCommitter
 import io.delta.kernel.internal.table.SnapshotBuilderImpl
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.ColumnMapping
@@ -267,6 +268,39 @@ class DeltaTableWritesTransactionBuilderV2Suite extends DeltaTableWritesSuite
           schema = testSchema,
           maxRetries = 10).commit(transientErrorEngine, emptyIterable())
       }
+    }
+  }
+
+  test("CreateTableTransactionBuilder uses the committer when provided") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      class FakeCommitter extends Committer {
+        override def commit(
+            engine: Engine,
+            finalizedActions: CloseableIterator[Row],
+            commitMetadata: CommitMetadata): CommitResponse = {
+          throw new RuntimeException("This is a fake committer")
+        }
+      }
+      val txn = TableManager.buildCreateTableTransaction(tablePath, testSchema, testEngineInfo)
+        .withCommitter(new FakeCommitter())
+        .build(engine)
+
+      // Check the txn returns the correct committer
+      assert(txn.getCommitter.isInstanceOf[FakeCommitter])
+      // Check that the txn invokes the provided committer upon commit
+      val e = intercept[RuntimeException] {
+        txn.commit(engine, emptyIterable())
+      }
+      assert(e.getMessage.contains("This is a fake committer"))
+    }
+  }
+
+  test("CreateTableTransactionBuilder uses the default file system committer if none is provided") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val txn = TableManager.buildCreateTableTransaction(tablePath, testSchema, testEngineInfo)
+        .build(engine)
+      // Check the txn returns the correct committer
+      assert(txn.getCommitter == DefaultFileSystemManagedTableOnlyCommitter.INSTANCE)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

See title.

## How was this patch tested?

Adds tests.

## Does this PR introduce _any_ user-facing changes?

Yes, a custom committer can now be provided when creating new tables.
