### PR TITLE
Fix misuse of structured logging in MergeIntoMaterializeSource

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -180,7 +180,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
           mergeMaterializedSourceRddBlockLostErrorRegex(materializedSourceRDD.get.id)) =>
       logWarning(log"Materialized ${MDC(DeltaLogKeys.OPERATION, operation)} source RDD block " +
         log"lost. ${MDC(DeltaLogKeys.OPERATION, operation)} needs to be restarted. " +
-        s"This was attempt number $attempt.")
+        log"This was attempt number ${MDC(DeltaLogKeys.ATTEMPT, attempt)}.")
       if (!isLastAttempt) {
         RetryHandling.Retry
       } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -178,8 +178,8 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
       if materializedSourceRDD.nonEmpty &&
         s.getMessage.matches(
           mergeMaterializedSourceRddBlockLostErrorRegex(materializedSourceRDD.get.id)) =>
-      log.warn(log"Materialized ${MDC(DeltaLogKeys.OPERATION, operation)} source RDD block lost. " +
-        log"${MDC(DeltaLogKeys.OPERATION, operation)} needs to be restarted. " +
+      logWarning(log"Materialized ${MDC(DeltaLogKeys.OPERATION, operation)} source RDD block " +
+        log"lost. ${MDC(DeltaLogKeys.OPERATION, operation)} needs to be restarted. " +
         s"This was attempt number $attempt.")
       if (!isLastAttempt) {
         RetryHandling.Retry

--- a/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
@@ -46,6 +46,7 @@ import org.apache.spark.internal.LogKeyShims
  */
 trait DeltaLogKeysBase {
   case object APP_ID extends LogKeyShims
+  case object ATTEMPT extends LogKeyShims
   case object BATCH_ID extends LogKeyShims
   case object BATCH_SIZE extends LogKeyShims
   case object CATALOG extends LogKeyShims


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Convert `log.warn` to `logWarning` to add support for logging `MessageWithContext` objects.

The operation `log"..." + s"..."` currently produces an object of type `String`, which is compatible with `log.warn` but which is not consistent with the goals of Spark Structured Logging.  This converts the message fully to `MessageWithContext` and logs via `logWarning` to log in the Structured Logging format.

## How was this patch tested?

Confirmed it compiles

## Does this PR introduce _any_ user-facing changes?

Changes the format of this warning.
