### PR TITLE
[Kernel] UCCatalogManagedCommitter: finish the lightweight WRITE (not CREATE) implementation

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
@@ -24,6 +24,7 @@ import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.internal.util.Tuple2;
 import java.util.Optional;
 
@@ -175,6 +176,32 @@ public class CommitMetadata {
     } else {
       return CommitType.FILESYSTEM_WRITE;
     }
+  }
+
+  /**
+   * Returns the corresponding published Delta log file path for this commit, which is in the form
+   * of {@code <table_path>/_delta_log/0000000000000000000<version>.json}.
+   *
+   * <p>Usages:
+   *
+   * <ul>
+   *   <li>Filesystem-managed committers must write to this file path.
+   *   <li>Catalog-managed committers must backfill to this file path, if/when they so choose.
+   * </ul>
+   */
+  public String getPublishedDeltaFilePath() {
+    return FileNames.deltaFile(logPath, version);
+  }
+
+  /**
+   * Returns a new staged commit file path with a unique UUID for this commit. Each invocation
+   * returns a new, unique value, in the form of {@code
+   * <table_path>/_delta_log/_staged_commits/0000000000000000000<version>.<uuid>.json}
+   *
+   * <p>Catalog-managed committers may use this path to write new staged commits.
+   */
+  public String generateNewStagedCommitFilePath() {
+    return FileNames.stagedCommitFile(logPath, version);
   }
 
   private void checkReadStateAbsentIfAndOnlyIfVersion0() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
@@ -186,7 +186,7 @@ public class CommitMetadata {
    *
    * <ul>
    *   <li>Filesystem-managed committers must write to this file path.
-   *   <li>Catalog-managed committers must backfill to this file path, if/when they so choose.
+   *   <li>Catalog-managed committers must publish to this file path, if/when they so choose.
    * </ul>
    */
   public String getPublishedDeltaFilePath() {

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
@@ -17,7 +17,7 @@
 package io.delta.unity;
 
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
-import static io.delta.unity.utils.OperationTimer.timeOperation;
+import static io.delta.unity.utils.OperationTimer.timeUncheckedOperation;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.SnapshotBuilder;
@@ -81,9 +81,9 @@ public class UCCatalogManagedClient {
     final List<ParsedLogData> logData =
         getSortedKernelLogDataFromRatifiedCommits(ucTableId, response.getCommits());
 
-    return timeOperation(
+    return timeUncheckedOperation(
         logger,
-        "TableManager.loadTable",
+        "TableManager.loadSnapshot",
         ucTableId,
         () -> {
           SnapshotBuilder snapshotBuilder = TableManager.loadSnapshot(tablePath);
@@ -111,7 +111,7 @@ public class UCCatalogManagedClient {
         getVersionString(versionOpt));
 
     final GetCommitsResponse response =
-        timeOperation(
+        timeUncheckedOperation(
             logger,
             "UCClient.getCommits",
             ucTableId,
@@ -170,7 +170,7 @@ public class UCCatalogManagedClient {
   static List<ParsedLogData> getSortedKernelLogDataFromRatifiedCommits(
       String ucTableId, List<Commit> commits) {
     final List<ParsedLogData> result =
-        timeOperation(
+        timeUncheckedOperation(
             logger,
             "Sort and convert UC ratified commits into Kernel ParsedLogData",
             ucTableId,

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
@@ -138,6 +138,7 @@ public class UCCatalogManagedClient {
     return response;
   }
 
+  // TODO: [delta-io/delta#5118] If UC changes CREATE semantics, update logic here.
   /**
    * As of this writing, UC catalog service is not informed when 0.json is successfully written
    * during table creation. Thus, when 0.json exists, the max ratified version returned by UC is -1.

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
@@ -17,6 +17,8 @@
 package io.delta.unity;
 
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static io.delta.kernel.internal.util.Preconditions.checkState;
+import static io.delta.unity.utils.OperationTimer.timeCheckedOperation;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.commit.CommitFailedException;
@@ -25,8 +27,15 @@ import io.delta.kernel.commit.CommitResponse;
 import io.delta.kernel.commit.Committer;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.annotation.VisibleForTesting;
+import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
+import java.io.IOException;
+import java.util.Optional;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,8 +80,6 @@ public class UCCatalogManagedCommitter implements Committer {
       throw new UnsupportedOperationException("Unsupported commit type: " + commitType);
     }
 
-    // TODO: lastKnownBackfilledVersion? Take that in as a hint.
-
     if (commitMetadata.getNewProtocolOpt().isPresent()) {
       // TODO: support this
       throw new UnsupportedOperationException("Protocol change is not yet implemented");
@@ -82,8 +89,12 @@ public class UCCatalogManagedCommitter implements Committer {
       throw new UnsupportedOperationException("Metadata change is not yet implemented");
     }
 
-    // TODO: support this
-    throw new UnsupportedOperationException("Commit logic is not yet implemented");
+    final FileStatus kernelStagedCommitFileStatus =
+        writeStagedCommitFile(engine, finalizedActions, commitMetadata);
+
+    commitToUC(commitMetadata, kernelStagedCommitFileStatus);
+
+    return new CommitResponse(ParsedLogData.forFileStatus(kernelStagedCommitFileStatus));
   }
 
   ////////////////////
@@ -102,5 +113,113 @@ public class UCCatalogManagedCommitter implements Committer {
         "Delta log path '%s' does not match expected '%s'",
         expectedDeltaLogPathNormalized,
         providedDeltaLogPathNormalized);
+  }
+
+  private FileStatus writeStagedCommitFile(
+      Engine engine, CloseableIterator<Row> finalizedActions, CommitMetadata commitMetadata)
+      throws CommitFailedException {
+    checkArgument(
+        commitMetadata.getVersion() > 0, "Can only write staged commit files for versions > 0");
+    final String stagedCommitFilePath = commitMetadata.generateNewStagedCommitFilePath();
+
+    return timeCheckedOperation(
+        logger,
+        "Write staged commit file: " + stagedCommitFilePath,
+        ucTableId,
+        () -> {
+          try {
+            // Do not use Put-If-Absent for staged commit files since we assume that UUID-based
+            // commit files are globally unique, and so we will never have concurrent writers
+            // attempting to write the same commit file.
+
+            engine
+                .getJsonHandler()
+                .writeJsonFileAtomically(
+                    stagedCommitFilePath, finalizedActions, true /* overwrite */);
+
+            // TODO: [delta-io/delta#5021] Use FileSystemClient::getFileStatus API instead
+            return FileStatus.of(stagedCommitFilePath);
+          } catch (IOException ex) {
+            throw new CommitFailedException(
+                true /* retryable */,
+                false /* conflict */,
+                "Failed to write staged commit file due to: " + ex.getMessage(),
+                ex);
+          }
+        });
+  }
+
+  private void commitToUC(CommitMetadata commitMetadata, FileStatus kernelStagedCommitFileStatus)
+      throws CommitFailedException {
+    timeCheckedOperation(
+        logger,
+        "Commit staged commit file to UC: " + kernelStagedCommitFileStatus.getPath(),
+        ucTableId,
+        () -> {
+          // commitToUc is only for normal catalog WRITES, not for CREATE, or UPGRADE, or DOWNGRADE,
+          // or anything filesystem related.
+          checkState(
+              commitMetadata.getCommitType() == CommitMetadata.CommitType.CATALOG_WRITE,
+              "Only supported commit type is CATALOG_WRITE, but got: %s");
+
+          try {
+            ucClient.commit(
+                ucTableId,
+                tablePath.toUri(),
+                Optional.of(getUcCommitPayload(commitMetadata, kernelStagedCommitFileStatus)),
+                Optional.empty() /* lastKnownBackfilledVersion */, // TODO: take this in as a hint
+                false /* isDisown */,
+                Optional.empty() /* newMetadata */, // TODO: support sending newProtocol
+                Optional.empty()); // TODO: support sending newProtocol
+            return null;
+          } catch (io.delta.storage.commit.CommitFailedException cfe) {
+            throw storageCFEtoKernelCFE(cfe);
+          } catch (IOException ex) {
+            throw new CommitFailedException(
+                true /* retryable */, false /* conflict */, ex.getMessage(), ex);
+          } catch (UCCommitCoordinatorException ucce) {
+            // For now, this catches all UC exceptions such as:
+            // - CommitLimitReachedException -> TODO: backfill in this case
+            // - InvalidTargetTableException
+            // - UpgradeNotAllowedException
+            // We can add specific catch statements for these exceptions if needed in the future.
+            throw new CommitFailedException(
+                false /* retryable */, false /* conflict */, ucce.getMessage(), ucce);
+          }
+        });
+  }
+
+  private Commit getUcCommitPayload(
+      CommitMetadata commitMetadata, FileStatus kernelStagedCommitFileStatus) {
+    return new Commit(
+        commitMetadata.getVersion(),
+        kernelFileStatusToHadoopFileStatus(kernelStagedCommitFileStatus),
+        // commitMetadata validates that the ICT is present if writing to a catalogManaged table
+        commitMetadata.getCommitInfo().getInCommitTimestamp().get());
+  }
+
+  @VisibleForTesting
+  public static org.apache.hadoop.fs.FileStatus kernelFileStatusToHadoopFileStatus(
+      io.delta.kernel.utils.FileStatus kernelFileStatus) {
+    return new org.apache.hadoop.fs.FileStatus(
+        kernelFileStatus.getSize() /* length */,
+        false /* isDirectory */,
+        1 /* blockReplication */,
+        128 * 1024 * 1024 /* blockSize (128MB) */,
+        kernelFileStatus.getModificationTime() /* modificationTime */,
+        kernelFileStatus.getModificationTime() /* accessTime */,
+        org.apache.hadoop.fs.permission.FsPermission.getFileDefault() /* permission */,
+        "unknown" /* owner */,
+        "unknown" /* group */,
+        new org.apache.hadoop.fs.Path(kernelFileStatus.getPath()) /* path */);
+  }
+
+  private static CommitFailedException storageCFEtoKernelCFE(
+      io.delta.storage.commit.CommitFailedException storageCFE) {
+    return new CommitFailedException(
+        storageCFE.getRetryable(),
+        storageCFE.getConflict(),
+        storageCFE.getMessage(),
+        storageCFE.getCause());
   }
 }

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
@@ -132,6 +132,8 @@ public class UCCatalogManagedCommitter implements Committer {
             // commit files are globally unique, and so we will never have concurrent writers
             // attempting to write the same commit file.
 
+            // Note: the engine is responsible for closing the actions iterator once it has been
+            //       fully consumed.
             engine
                 .getJsonHandler()
                 .writeJsonFileAtomically(
@@ -169,8 +171,8 @@ public class UCCatalogManagedCommitter implements Committer {
                 Optional.of(getUcCommitPayload(commitMetadata, kernelStagedCommitFileStatus)),
                 Optional.empty() /* lastKnownBackfilledVersion */, // TODO: take this in as a hint
                 false /* isDisown */,
-                Optional.empty() /* newMetadata */, // TODO: support sending newProtocol
-                Optional.empty()); // TODO: support sending newProtocol
+                Optional.empty() /* newMetadata */, // TODO: support sending newMetadata
+                Optional.empty()); /* newProtocol */ // TODO: support sending newProtocol
             return null;
           } catch (io.delta.storage.commit.CommitFailedException cfe) {
             throw storageCFEtoKernelCFE(cfe);
@@ -179,7 +181,7 @@ public class UCCatalogManagedCommitter implements Committer {
                 true /* retryable */, false /* conflict */, ex.getMessage(), ex);
           } catch (UCCommitCoordinatorException ucce) {
             // For now, this catches all UC exceptions such as:
-            // - CommitLimitReachedException -> TODO: backfill in this case
+            // - CommitLimitReachedException -> TODO: publish in this case
             // - InvalidTargetTableException
             // - UpgradeNotAllowedException
             // We can add specific catch statements for these exceptions if needed in the future.

--- a/unity/src/test/scala/io/delta/unity/InMemoryUCClient.scala
+++ b/unity/src/test/scala/io/delta/unity/InMemoryUCClient.scala
@@ -63,7 +63,9 @@ object InMemoryUCClient {
 
     /** Appends a new commit to this table. */
     def appendCommit(commit: Commit): Unit = synchronized {
-      val expectedCommitVersion = maxRatifiedVersion + 1
+      // TODO: [delta-io/delta#5118] If UC changes CREATE semantics, update logic here.
+      // For UC, commit 0 is expected to go through the filesystem
+      val expectedCommitVersion = if (maxRatifiedVersion == -1L) 1 else maxRatifiedVersion + 1
 
       if (commit.getVersion != expectedCommitVersion) {
         throw new CommitFailedException(
@@ -73,7 +75,7 @@ object InMemoryUCClient {
       }
 
       commits += commit
-      maxRatifiedVersion += 1
+      maxRatifiedVersion = commit.getVersion
     }
   }
 }

--- a/unity/src/test/scala/io/delta/unity/InMemoryUCClient.scala
+++ b/unity/src/test/scala/io/delta/unity/InMemoryUCClient.scala
@@ -125,6 +125,8 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       disown: Boolean,
       newMetadata: Optional[AbstractMetadata],
       newProtocol: Optional[AbstractProtocol]): Unit = {
+    forceThrowInCommitMethod()
+
     Seq(
       (lastKnownBackfilledVersion.isPresent, "lastKnownBackfilledVersion"),
       (disown, "disown"),
@@ -151,6 +153,9 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
   }
 
   override def close(): Unit = {}
+
+  /** Visible for testing. Can be overridden to force an exception in commit method. */
+  protected def forceThrowInCommitMethod(): Unit = {}
 
   private[unity] def createTableIfNotExistsOrThrow(
       ucTableId: String,

--- a/unity/src/test/scala/io/delta/unity/UCCatalogManagedClientSuite.scala
+++ b/unity/src/test/scala/io/delta/unity/UCCatalogManagedClientSuite.scala
@@ -37,7 +37,11 @@ import org.scalatest.funsuite.AnyFunSuite
 /** Unit tests for [[UCCatalogManagedClient]]. */
 class UCCatalogManagedClientSuite extends AnyFunSuite with UCCatalogManagedTestUtils {
 
-  private def createUCCatalogManagedClientForTableWithNoRatifiedCommits(
+  /**
+   * When a new UC table is created, it will have Delta version 0 but the max ratified verison in
+   * UC is -1. This is a special edge case.
+   */
+  private def createUCCatalogManagedClientForTableWithMaxRatifiedVersionNegativeOne(
       ucTableId: String = "ucTableId"): UCCatalogManagedClient = {
     val ucClient = new InMemoryUCClient("ucMetastoreId")
     val tableData = new TableData(-1, ArrayBuffer[Commit]())
@@ -136,7 +140,8 @@ class UCCatalogManagedClientSuite extends AnyFunSuite with UCCatalogManagedTestU
     case (versionToLoad, description) =>
       test(s"table version 0 is loaded when UC maxRatifiedVersion is -1 -- $description") {
         val tablePath = getTestResourceFilePath("catalog-owned-preview")
-        val ucCatalogManagedClient = createUCCatalogManagedClientForTableWithNoRatifiedCommits()
+        val ucCatalogManagedClient =
+          createUCCatalogManagedClientForTableWithMaxRatifiedVersionNegativeOne()
         val snapshot = ucCatalogManagedClient
           .loadSnapshot(defaultEngine, "ucTableId", tablePath, versionToLoad)
 
@@ -198,7 +203,8 @@ class UCCatalogManagedClientSuite extends AnyFunSuite with UCCatalogManagedTestU
 
   test("creates snapshot with UCCatalogManagedCommitter") {
     val tablePath = getTestResourceFilePath("catalog-owned-preview")
-    val ucCatalogManagedClient = createUCCatalogManagedClientForTableWithNoRatifiedCommits()
+    val ucCatalogManagedClient =
+      createUCCatalogManagedClientForTableWithMaxRatifiedVersionNegativeOne()
     val snapshot = ucCatalogManagedClient
       .loadSnapshot(defaultEngine, "ucTableId", tablePath, Optional.of(0L))
       .asInstanceOf[SnapshotImpl]

--- a/unity/src/test/scala/io/delta/unity/UCCatalogManagedClientSuite.scala
+++ b/unity/src/test/scala/io/delta/unity/UCCatalogManagedClientSuite.scala
@@ -37,6 +37,7 @@ import org.scalatest.funsuite.AnyFunSuite
 /** Unit tests for [[UCCatalogManagedClient]]. */
 class UCCatalogManagedClientSuite extends AnyFunSuite with UCCatalogManagedTestUtils {
 
+  // TODO: [delta-io/delta#5118] If UC changes CREATE semantics, update logic here.
   /**
    * When a new UC table is created, it will have Delta version 0 but the max ratified verison in
    * UC is -1. This is a special edge case.

--- a/unity/src/test/scala/io/delta/unity/UCCatalogManagedCommitterSuite.scala
+++ b/unity/src/test/scala/io/delta/unity/UCCatalogManagedCommitterSuite.scala
@@ -284,10 +284,9 @@ class UCCatalogManagedCommitterSuite
   test("CATALOG_WRITE: writes staged commit file and invokes UC client commit API") {
     withTempTableAndLogPathAndStagedCommitFolderCreated { case (tablePath, logPath) =>
       // ===== GIVEN =====
-      // Setup UC client with initial table with maxRatifiedVersion = 0, numCommits = 1
+      // Setup UC client with initial table with maxRatifiedVersion = -1, numCommits = 0
       val ucClient = new InMemoryUCClient("ucMetastoreId")
-      val initialCommit = createCommit(0)
-      val tableData = new TableData(0, ArrayBuffer(initialCommit))
+      val tableData = new TableData(-1, ArrayBuffer[Commit]())
       ucClient.createTableIfNotExistsOrThrow("ucTableId", tableData)
 
       val testValue = "TEST_COMMIT_DATA_12345"
@@ -316,10 +315,9 @@ class UCCatalogManagedCommitterSuite
       assert(stagedCommitFilePath.matches(expectedPattern))
 
       // Verify UC client was invoked and table was updated.
-      // We expect: maxRatifiedVersion = 1, numCommits = 2.
       val updatedTable = ucClient.getTablesCopy.get("ucTableId").get
       assert(updatedTable.getMaxRatifiedVersion == 1)
-      assert(updatedTable.getCommits.size == 2)
+      assert(updatedTable.getCommits.size == 1)
 
       // Verify the new commit in UC has correct version
       val lastCommit = updatedTable.getCommits.last

--- a/unity/src/test/scala/io/delta/unity/UCCatalogManagedCommitterSuite.scala
+++ b/unity/src/test/scala/io/delta/unity/UCCatalogManagedCommitterSuite.scala
@@ -430,6 +430,4 @@ class UCCatalogManagedCommitterSuite
     }
   }
 
-  // ========== Exception Handling Tests END ==========
-
 }

--- a/unity/src/test/scala/io/delta/unity/UCCatalogManagedCommitterSuite.scala
+++ b/unity/src/test/scala/io/delta/unity/UCCatalogManagedCommitterSuite.scala
@@ -16,23 +16,57 @@
 
 package io.delta.unity
 
-import java.util.Optional
+import java.io.{File, IOException}
+import java.nio.file.Files
+import java.util.{Optional, UUID}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
-import io.delta.kernel.commit.CommitMetadata
+import io.delta.kernel.commit.{CommitFailedException, CommitMetadata}
 import io.delta.kernel.commit.CommitMetadata.CommitType
+import io.delta.kernel.data.Row
 import io.delta.kernel.internal.actions.{Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.{Tuple2 => KernelTuple2}
-import io.delta.kernel.test.VectorTestUtils
+import io.delta.kernel.internal.util.Utils.singletonCloseableIterator
+import io.delta.kernel.test.{BaseMockJsonHandler, MockFileSystemClientUtils, VectorTestUtils}
+import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+import io.delta.storage.commit.Commit
+import io.delta.storage.commit.uccommitcoordinator.InvalidTargetTableException
+import io.delta.unity.InMemoryUCClient.TableData
 
+import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
 import org.scalatest.funsuite.AnyFunSuite
 
 class UCCatalogManagedCommitterSuite
     extends AnyFunSuite
     with UCCatalogManagedTestUtils
-    with VectorTestUtils {
+    with VectorTestUtils
+    with MockFileSystemClientUtils {
+
+  /**
+   * Utility to create a temp table directory as well as the _delta_log and
+   * _delta_log/_staged_commits subdirectories. Executes the provided function `f` with the table
+   * and delta log paths.
+   *
+   * Note: Normal Kernel txn execution will create the staged commits directory. This method should
+   * only be used for mock unit tests that don't perform a full txn execution.
+   */
+  private def withTempTableAndLogPathAndStagedCommitFolderCreated(
+      f: (String, String) => Unit): Unit = {
+    val tempDir = Files.createTempDirectory(UUID.randomUUID().toString).toFile
+    val tablePath = tempDir.getAbsolutePath
+    val logPath = s"$tablePath/_delta_log"
+
+    // This also creates the _delta_log directory
+    defaultEngine.getFileSystemClient.mkdirs(s"$logPath/_staged_commits")
+
+    try f(tablePath, logPath)
+    finally {
+      FileUtils.deleteDirectory(tempDir)
+    }
+  }
 
   private def createCommitMetadata(
       version: Long,
@@ -205,15 +239,190 @@ class UCCatalogManagedCommitterSuite
     assert(exMsg.contains("Metadata change is not yet implemented"))
   }
 
-  test("the remaining commit logic is not yet implemented") {
-    val ucClient = new InMemoryUCClient("ucMetastoreId")
-    val committer = new UCCatalogManagedCommitter(ucClient, "ucTableId", baseTestTablePath)
-    val commitMetadata = catalogManagedWriteCommitMetadata(version = 1)
+  test("commit writes staged commit file and invokes UC client commit API") {
+    withTempTableAndLogPathAndStagedCommitFolderCreated { case (tablePath, logPath) =>
+      // ===== GIVEN =====
+      // Setup UC client with initial table with maxRatifiedVersion = 0, numCommits = 1
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      val initialCommit = createCommit(0)
+      val tableData = new TableData(0, ArrayBuffer(initialCommit))
+      ucClient.createTableIfNotExistsOrThrow("ucTableId", tableData)
 
-    val exMsg = intercept[UnsupportedOperationException] {
-      committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
-    }.getMessage
-    assert(exMsg.contains("Commit logic is not yet implemented"))
+      val testValue = "TEST_COMMIT_DATA_12345"
+      val actionsIterator = getSingleElementRowIter(testValue)
+      val committer = new UCCatalogManagedCommitter(ucClient, "ucTableId", tablePath)
+      val commitMetadata = catalogManagedWriteCommitMetadata(version = 1, logPath = logPath)
+
+      // ===== WHEN =====
+      val response = committer.commit(defaultEngine, actionsIterator, commitMetadata)
+
+      // ===== THEN =====
+      val stagedCommitFilePath = response.getCommitLogData.getFileStatus.getPath
+
+      // Verify the staged commit file actually exists on disk
+      val file = new java.io.File(stagedCommitFilePath)
+      assert(file.exists())
+      assert(file.isFile())
+
+      // Read the file content and verify our test value was written
+      val fileContent = scala.io.Source.fromFile(file).getLines().mkString("\n")
+      assert(fileContent.contains(testValue))
+
+      // Verify the file is in the correct location
+      val expectedPattern =
+        s"^$tablePath/_delta_log/_staged_commits/00000000000000000001\\.[^.]+\\.json$$"
+      assert(stagedCommitFilePath.matches(expectedPattern))
+
+      // Verify UC client was invoked and table was updated.
+      // We expect: maxRatifiedVersion = 1, numCommits = 2.
+      val updatedTable = ucClient.getTablesCopy.get("ucTableId").get
+      assert(updatedTable.getMaxRatifiedVersion == 1)
+      assert(updatedTable.getCommits.size == 2)
+
+      // Verify the new commit in UC has correct version
+      val lastCommit = updatedTable.getCommits.last
+      assert(lastCommit.getVersion == 1)
+      assert(lastCommit.getFileStatus.getPath.toString == stagedCommitFilePath)
+    }
   }
+
+  private def getSingleElementRowIter(elem: String): CloseableIterator[Row] = {
+    import io.delta.kernel.defaults.integration.DataBuilderUtils
+    import io.delta.kernel.types.{StringType, StructField, StructType}
+
+    val schema = new StructType().add(new StructField("testColumn", StringType.STRING, true))
+    val simpleRow = DataBuilderUtils.row(schema, elem)
+    singletonCloseableIterator(simpleRow)
+  }
+
+  test("kernelFileStatusToHadoopFileStatus converts kernel FileStatus to Hadoop FileStatus") {
+    // ===== GIVEN =====
+    val kernelFileStatus = FileStatus.of("/path/to/file.json", 1024L, 1234567890L)
+
+    // ===== WHEN =====
+    val hadoopFileStatus =
+      UCCatalogManagedCommitter.kernelFileStatusToHadoopFileStatus(kernelFileStatus)
+
+    // ===== THEN =====
+    // These are the fields that we care about, taken from the Kernel FileStatus
+    assert(hadoopFileStatus.getPath.toString == "/path/to/file.json")
+    assert(hadoopFileStatus.getLen == 1024L)
+    assert(hadoopFileStatus.getModificationTime == 1234567890L)
+
+    // These are defaults that we set
+    assert(hadoopFileStatus.getAccessTime == 1234567890L) // same as modification time
+    assert(!hadoopFileStatus.isDirectory)
+    assert(hadoopFileStatus.getReplication == 1)
+    assert(hadoopFileStatus.getBlockSize == 128 * 1024 * 1024) // 128MB
+    assert(hadoopFileStatus.getOwner == "unknown")
+    assert(hadoopFileStatus.getGroup == "unknown")
+    assert(hadoopFileStatus.getPermission ==
+      org.apache.hadoop.fs.permission.FsPermission.getFileDefault)
+  }
+
+  // ========== Exception Handling Tests START ==========
+
+  test("IOException while writing staged commit => CFE(retryable=true, conflict=false)") {
+    withTempTableAndLogPathAndStagedCommitFolderCreated { case (tablePath, logPath) =>
+      // ===== GIVEN =====
+      val throwingEngine = mockEngine(jsonHandler = new BaseMockJsonHandler {
+        override def writeJsonFileAtomically(
+            path: String,
+            data: CloseableIterator[Row],
+            overwrite: Boolean): Unit =
+          throw new IOException("Network error")
+      })
+
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      val tableData = new TableData(maxRatifiedVersion = 1, commits = ArrayBuffer.empty[Commit])
+      ucClient.createTableIfNotExistsOrThrow("ucTableId", tableData)
+      val committer = new UCCatalogManagedCommitter(ucClient, "ucTableId", tablePath)
+      val commitMetadata = catalogManagedWriteCommitMetadata(2, logPath = logPath)
+
+      // ===== WHEN =====
+      val ex = intercept[CommitFailedException] {
+        committer.commit(throwingEngine, emptyActionsIterator, commitMetadata)
+      }
+
+      // ===== THEN =====
+      assert(ex.isRetryable && !ex.isConflict)
+      assert(ex.getMessage.contains("Failed to write staged commit file due to: Network error"))
+    }
+  }
+
+  test("io.delta.storage.commit.CommitFailedException during UC commit => kernel CFE") {
+    withTempTableAndLogPathAndStagedCommitFolderCreated { case (tablePath, logPath) =>
+      // ===== GIVEN =====
+      val ucClient = new InMemoryUCClient("ucMetastoreId") {
+        override def forceThrowInCommitMethod(): Unit =
+          throw new io.delta.storage.commit.CommitFailedException(
+            true, // retryable
+            true, // conflict
+            "Storage conflict",
+            null)
+      }
+      val tableData = new TableData(maxRatifiedVersion = 1, commits = ArrayBuffer.empty[Commit])
+      ucClient.createTableIfNotExistsOrThrow("ucTableId", tableData)
+      val committer = new UCCatalogManagedCommitter(ucClient, "ucTableId", tablePath)
+      val commitMetadata = catalogManagedWriteCommitMetadata(2, logPath = logPath)
+      // ===== WHEN =====
+      val ex = intercept[CommitFailedException] {
+        committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
+      }
+
+      // ===== THEN =====
+      assert(ex.isRetryable && ex.isConflict)
+      assert(ex.getMessage.contains("Storage conflict"))
+    }
+  }
+
+  test("IOException during UC commit => CFE(retryable=true, conflict=false)") {
+    withTempTableAndLogPathAndStagedCommitFolderCreated { case (tablePath, logPath) =>
+      // ===== GIVEN =====
+      val ucClient = new InMemoryUCClient("ucMetastoreId") {
+        override def forceThrowInCommitMethod(): Unit = throw new IOException("UC network error")
+      }
+      val tableData = new TableData(maxRatifiedVersion = 1, commits = ArrayBuffer.empty[Commit])
+      ucClient.createTableIfNotExistsOrThrow("ucTableId", tableData)
+      val committer = new UCCatalogManagedCommitter(ucClient, "ucTableId", tablePath)
+      val commitMetadata = catalogManagedWriteCommitMetadata(2, logPath = logPath)
+
+      // ===== WHEN =====
+      val ex = intercept[CommitFailedException] {
+        committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
+      }
+
+      // ===== THEN =====
+      assert(ex.isRetryable && !ex.isConflict)
+      assert(ex.getMessage.contains("UC network error"))
+    }
+  }
+
+  test("UCCommitCoordinatorException during UC commit => CFE(retryable=false, conflict=false)") {
+    withTempTableAndLogPathAndStagedCommitFolderCreated { case (tablePath, logPath) =>
+      // ===== GIVEN =====
+      val ucClient = new InMemoryUCClient("ucMetastoreId") {
+        override def forceThrowInCommitMethod(): Unit = {
+          throw new InvalidTargetTableException("Target table does not exist")
+        }
+      }
+      val tableData = new TableData(maxRatifiedVersion = 1, commits = ArrayBuffer.empty[Commit])
+      ucClient.createTableIfNotExistsOrThrow("ucTableId", tableData)
+      val committer = new UCCatalogManagedCommitter(ucClient, "unknownTableId", tablePath)
+      val commitMetadata = catalogManagedWriteCommitMetadata(2, logPath = logPath)
+
+      // ===== WHEN =====
+      val ex = intercept[CommitFailedException] {
+        committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
+      }
+
+      // ===== THEN =====
+      assert(ex.getCause.isInstanceOf[InvalidTargetTableException])
+      assert(!ex.isRetryable && !ex.isConflict)
+      assert(ex.getMessage.contains("Target table does not exist"))
+    }
+  }
+
+  // ========== Exception Handling Tests END ==========
 
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5074/files) to review incremental changes.
- [**stack/kernel_uc_catalog_managed_committer_2b**](https://github.com/delta-io/delta/pull/5074) [[Files changed](https://github.com/delta-io/delta/pull/5074/files)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR fleshes out the remaining WRITE (not CREATE) UCCatalogManagedCommitter implementation. e.g. write the staged commit file, and then send that info to UC.

## How was this patch tested?

Simple unit tests. E2E mock write tests will come later.

## Does this PR introduce _any_ user-facing changes?

No.