### PR TITLE
[Spark] Add row_index metadata column only for DV read

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableWithDVs.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableWithDVs.scala
@@ -147,7 +147,12 @@ object ScanWithDeletionVectors {
           case o => o
         }
       } else {
-        inputScan.output :+ fileFormat.createFileMetadataCol()
+        val metadataAttr = fileFormat.createFileMetadataCol()
+        val rowIndexOnlyDataType =
+          metadataAttr.dataType.asInstanceOf[StructType].apply(Set(ParquetFileFormat.ROW_INDEX))
+        inputScan.output :+ metadataAttr.copy(
+          dataType = rowIndexOnlyDataType)(
+            exprId = metadataAttr.exprId, qualifier = metadataAttr.qualifier)
       }
     } else {
       inputScan.output


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Minor improvement that when dv read using Spark metadata column, add row_index column only instead of adding all metadata columns.
 
## How was this patch tested?
Existing test suites

## Does this PR introduce _any_ user-facing changes?
No
