### PR TITLE
[Spark] Split some merge suites

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -159,7 +159,8 @@ object SuiteGeneratorConfig {
       "MergeIntoExtendedSyntaxTests",
       "MergeIntoSuiteBaseMiscTests",
       "MergeIntoNotMatchedBySourceSuite",
-      "MergeIntoNotMatchedBySourceWithCDCSuite",
+      "MergeIntoNotMatchedBySourceCDCPart1Tests",
+      "MergeIntoNotMatchedBySourceCDCPart2Tests",
       "MergeIntoSchemaEvolutionCoreTests",
       "MergeIntoSchemaEvolutionBaseTests",
       "MergeIntoSchemaEvolutionStoreAssignmentPolicyTests",
@@ -229,7 +230,7 @@ object SuiteGeneratorConfig {
           )
         ),
         TestConfig(
-          List("MergeIntoMaterializeSourceTests"),
+          List("MergeIntoMaterializeSourceTests", "MergeIntoMaterializeSourceErrorTests"),
           List(
             List(Dims.MERGE_PERSISTENT_DV_OFF)
           )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
@@ -161,8 +161,7 @@ trait MergeIntoMaterializeSourceMixin
   }
 }
 
-trait MergeIntoMaterializeSourceTests extends MergeIntoMaterializeSourceMixin {
-
+trait MergeIntoMaterializeSourceErrorTests extends MergeIntoMaterializeSourceMixin {
   import testImplicits._
 
   // Test error message that we check if blocks of materialized source RDD were evicted.
@@ -307,6 +306,10 @@ trait MergeIntoMaterializeSourceTests extends MergeIntoMaterializeSourceMixin {
     }
   }
   testMergeMaterializeSourceUnpersistRetries
+}
+
+trait MergeIntoMaterializeSourceTests extends MergeIntoMaterializeSourceMixin {
+  import testImplicits._
 
   private def getHints(df: => DataFrame): Seq[(Seq[ResolvedHint], JoinHint)] = {
     val plans = withAllPlansCaptured(spark) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
@@ -21,14 +21,14 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.Row
 
-trait MergeIntoNotMatchedBySourceWithCDCSuite extends MergeIntoSuiteBaseMixin {
+trait MergeIntoNotMatchedBySourceWithCDCMixin extends MergeIntoSuiteBaseMixin {
   import testImplicits._
 
   /**
    * Variant of `testExtendedMerge` that runs a MERGE INTO command, checks the expected result and
    * additionally validate that the CDC produced is correct.
    */
-  private def testExtendedMergeWithCDC(
+  protected def testExtendedMergeWithCDC(
       name: String,
       namePrefix: String = "not matched by source")(
       source: Seq[(Int, Int)],
@@ -59,7 +59,9 @@ trait MergeIntoNotMatchedBySourceWithCDCSuite extends MergeIntoSuiteBaseMixin {
       }
     }
   }
+}
 
+trait MergeIntoNotMatchedBySourceCDCPart1Tests extends MergeIntoNotMatchedBySourceWithCDCMixin {
   // Test correctness with NOT MATCHED BY SOURCE clauses.
   testExtendedMergeWithCDC("all 3 types of match clauses without conditions")(
     source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
@@ -217,7 +219,9 @@ trait MergeIntoNotMatchedBySourceWithCDCSuite extends MergeIntoSuiteBaseMixin {
       (1, 10, "update_preimage"),
       (1, 11, "update_postimage"),
       (5, 50, "delete")))
+}
 
+trait MergeIntoNotMatchedBySourceCDCPart2Tests extends MergeIntoNotMatchedBySourceWithCDCMixin {
   testExtendedMergeWithCDC("not matched by source update + delete clauses")(
     source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
     target = (1, 10) :: (2, 20) :: (7, 70) :: Nil,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuites.scala
@@ -54,8 +54,12 @@ class MergeIntoNotMatchedBySourceScalaSuite
   extends MergeIntoNotMatchedBySourceSuite
   with MergeIntoScalaMixin
 
-class MergeIntoNotMatchedBySourceWithCDCScalaSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1ScalaSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
+  with MergeIntoScalaMixin
+
+class MergeIntoNotMatchedBySourceCDCPart2ScalaSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
   with MergeIntoScalaMixin
 
 class MergeIntoSchemaEvolutionCoreScalaSuite
@@ -793,53 +797,53 @@ class MergeIntoNotMatchedBySourceSQLPathBasedCDCOnDVsPredPushOnSuite
   with MergeCDCMixin
   with MergeCDCWithDVsMixin
 
-class MergeIntoNotMatchedBySourceWithCDCSQLNameBasedSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLNameBasedSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsNameBased
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedColMapIdModeSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedColMapIdModeSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with DeltaColumnMappingEnableIdMode
   with MergeIntoSQLColumnMappingOverrides
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedColMapNameModeSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedColMapNameModeSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with DeltaColumnMappingEnableNameMode
   with MergeIntoSQLColumnMappingOverrides
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedDVsPredPushOffSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedDVsPredPushOffSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with MergeIntoDVsMixin
   with PredicatePushdownDisabled
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedDVsPredPushOnSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedDVsPredPushOnSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with MergeIntoDVsMixin
   with PredicatePushdownEnabled
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedCDCOnSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedCDCOnSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with CDCEnabled
   with MergeCDCMixin
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedCDCOnDVsPredPushOffSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedCDCOnDVsPredPushOffSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with CDCEnabled
@@ -848,8 +852,73 @@ class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedCDCOnDVsPredPushOffSuite
   with MergeCDCMixin
   with MergeCDCWithDVsMixin
 
-class MergeIntoNotMatchedBySourceWithCDCSQLPathBasedCDCOnDVsPredPushOnSuite
-  extends MergeIntoNotMatchedBySourceWithCDCSuite
+class MergeIntoNotMatchedBySourceCDCPart1SQLPathBasedCDCOnDVsPredPushOnSuite
+  extends MergeIntoNotMatchedBySourceCDCPart1Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLNameBasedSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsNameBased
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedColMapIdModeSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableIdMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedColMapNameModeSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with DeltaColumnMappingEnableNameMode
+  with MergeIntoSQLColumnMappingOverrides
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedDVsPredPushOffSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedDVsPredPushOnSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with MergeIntoDVsMixin
+  with PredicatePushdownEnabled
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedCDCOnSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeCDCMixin
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedCDCOnDVsPredPushOffSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
+  with MergeIntoSQLMixin
+  with DeltaDMLTestUtilsPathBased
+  with CDCEnabled
+  with MergeIntoDVsMixin
+  with PredicatePushdownDisabled
+  with MergeCDCMixin
+  with MergeCDCWithDVsMixin
+
+class MergeIntoNotMatchedBySourceCDCPart2SQLPathBasedCDCOnDVsPredPushOnSuite
+  extends MergeIntoNotMatchedBySourceCDCPart2Tests
   with MergeIntoSQLMixin
   with DeltaDMLTestUtilsPathBased
   with CDCEnabled
@@ -1250,6 +1319,10 @@ class MergeIntoNestedStructEvolutionSQLPathBasedCDCOnDVsPredPushOnSuite
 
 class MergeIntoMaterializeSourceMergePersistentDVOffSuite
   extends MergeIntoMaterializeSourceTests
+  with MergePersistentDVDisabled
+
+class MergeIntoMaterializeSourceErrorMergePersistentDVOffSuite
+  extends MergeIntoMaterializeSourceErrorTests
   with MergePersistentDVDisabled
 
 class RowTrackingMergeCommonNameBasedSuite


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR splits the following large Merge test suites:

- `MergeIntoNotMatchedBySourceWithCDCSuite`
- `MergeIntoMaterializeSourceTests`

## How was this patch tested?

NA

## Does this PR introduce _any_ user-facing changes?

No