### PR TITLE
[Kernel] Create adapters from Kernel protocol & metadata to io.delta.storage.commit types

### DIFF
--- a/unity/src/main/java/io/delta/unity/adapters/MetadataAdapter.java
+++ b/unity/src/main/java/io/delta/unity/adapters/MetadataAdapter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.unity.adapters;
+
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import java.util.*;
+
+/**
+ * Adapter from {@link io.delta.kernel.internal.actions.Metadata} to {@link
+ * io.delta.storage.commit.actions.AbstractMetadata}.
+ */
+public class MetadataAdapter implements AbstractMetadata {
+
+  private final Metadata kernelMetadata;
+
+  public MetadataAdapter(Metadata kernelMetadata) {
+    this.kernelMetadata = Objects.requireNonNull(kernelMetadata, "kernelMetadata is null");
+  }
+
+  @Override
+  public String getId() {
+    return kernelMetadata.getId();
+  }
+
+  @Override
+  public String getName() {
+    return kernelMetadata.getName().orElse(null);
+  }
+
+  @Override
+  public String getDescription() {
+    return kernelMetadata.getDescription().orElse(null);
+  }
+
+  @Override
+  public String getProvider() {
+    return kernelMetadata.getFormat().getProvider();
+  }
+
+  @Override
+  public Map<String, String> getFormatOptions() {
+    return Collections.unmodifiableMap(kernelMetadata.getFormat().getOptions());
+  }
+
+  @Override
+  public String getSchemaString() {
+    return kernelMetadata.getSchemaString();
+  }
+
+  @Override
+  public List<String> getPartitionColumns() {
+    return Collections.unmodifiableList(
+        VectorUtils.toJavaList(kernelMetadata.getPartitionColumns()));
+  }
+
+  @Override
+  public Map<String, String> getConfiguration() {
+    return Collections.unmodifiableMap(kernelMetadata.getConfiguration());
+  }
+
+  @Override
+  public Long getCreatedTime() {
+    return kernelMetadata.getCreatedTime().orElse(null);
+  }
+}

--- a/unity/src/main/java/io/delta/unity/adapters/ProtocolAdapter.java
+++ b/unity/src/main/java/io/delta/unity/adapters/ProtocolAdapter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.unity.adapters;
+
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Adapter from {@link io.delta.kernel.internal.actions.Protocol} to {@link
+ * io.delta.storage.commit.actions.AbstractProtocol}.
+ */
+public class ProtocolAdapter implements AbstractProtocol {
+
+  private final Protocol kernelProtocol;
+
+  public ProtocolAdapter(Protocol kernelProtocol) {
+    this.kernelProtocol = Objects.requireNonNull(kernelProtocol, "kernelProtocol is null");
+  }
+
+  @Override
+  public int getMinReaderVersion() {
+    return kernelProtocol.getMinReaderVersion();
+  }
+
+  @Override
+  public int getMinWriterVersion() {
+    return kernelProtocol.getMinWriterVersion();
+  }
+
+  @Override
+  public Set<String> getReaderFeatures() {
+    return Collections.unmodifiableSet(kernelProtocol.getReaderFeatures());
+  }
+
+  @Override
+  public Set<String> getWriterFeatures() {
+    return Collections.unmodifiableSet(kernelProtocol.getWriterFeatures());
+  }
+}

--- a/unity/src/test/scala/io/delta/unity/adapters/ActionAdaptersSuite.scala
+++ b/unity/src/test/scala/io/delta/unity/adapters/ActionAdaptersSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.unity.adapters
+
+import scala.jdk.CollectionConverters._
+
+import io.delta.kernel.data.{ArrayValue, ColumnVector}
+import io.delta.kernel.internal.actions.{Format, Metadata => KernelMetadata, Protocol => KernelProtocol}
+import io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector
+import io.delta.kernel.internal.util.VectorUtils
+import io.delta.kernel.types.{IntegerType, StructType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ActionAdaptersSuite extends AnyFunSuite {
+
+  test("ProtocolAdapter") {
+    // ===== GIVEN =====
+    val readerFeatures = Set("v2Checkpoint").asJava
+    val writerFeatures = Set("v2Checkpoint", "rowTracking").asJava
+    val kernelProtocol = new KernelProtocol(3, 7, readerFeatures, writerFeatures)
+
+    // ===== WHEN =====
+    val adapterProtocol = new ProtocolAdapter(kernelProtocol)
+
+    // ===== THEN =====
+    assert(adapterProtocol.getMinReaderVersion === 3)
+    assert(adapterProtocol.getMinWriterVersion === 7)
+    assert(adapterProtocol.getReaderFeatures.asScala == Set("v2Checkpoint"))
+    assert(adapterProtocol.getWriterFeatures.asScala == Set("v2Checkpoint", "rowTracking"))
+  }
+
+  test("MetadataAdapter") {
+    // ===== GIVEN =====
+    val partCols = new ArrayValue() {
+      override def getSize = 1
+      override def getElements: ColumnVector = singletonStringColumnVector("part1")
+    }
+    val formatOptions = Map("foo" -> "bar").asJava
+    val format = new Format("parquet", formatOptions)
+    val configuration = Map("zip" -> "zap").asJava
+
+    val kernelMetadata = new KernelMetadata(
+      "id",
+      java.util.Optional.of("name"),
+      java.util.Optional.of("description"),
+      format,
+      "schemaStringJson",
+      new StructType().add("part1", IntegerType.INTEGER).add("col1", IntegerType.INTEGER),
+      partCols,
+      java.util.Optional.of(42L), // createdTime
+      VectorUtils.stringStringMapValue(configuration))
+
+    // ===== WHEN =====
+    val adapter = new MetadataAdapter(kernelMetadata)
+
+    // ===== THEN =====
+    assert(adapter.getId === "id")
+    assert(adapter.getName === "name")
+    assert(adapter.getDescription === "description")
+    assert(adapter.getProvider === "parquet")
+    assert(adapter.getFormatOptions.asScala == Map("foo" -> "bar"))
+    assert(adapter.getSchemaString === "schemaStringJson")
+    assert(adapter.getPartitionColumns.asScala == Seq("part1"))
+    assert(adapter.getConfiguration.asScala == Map("zip" -> "zap"))
+    assert(adapter.getCreatedTime === 42L)
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5097/files) to review incremental changes.
- [**stack/kernel_uc_committer_convert_p_and_m**](https://github.com/delta-io/delta/pull/5097) [[Files changed](https://github.com/delta-io/delta/pull/5097/files)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Title. Pretty trivial.

In the future, everything should be standardized on Kernel and Kernel only. e.g. delta-unity should NOT depend on delta-storage. the UCClient should be defined in delta-unity, and should depend on Kernel Abstract P&M types (yet to be defined).

## How was this patch tested?

Trivial new UTs.

## Does this PR introduce _any_ user-facing changes?

No.
