### PR TITLE
[UniForm] New Util function in IcebergCompat

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -259,6 +259,13 @@ case class IcebergCompatVersionBase(knownVersions: Set[IcebergCompatBase]) {
     )
 
   /**
+   * Get the IcebergCompat by Iceberg formatVersion.
+   * @return the IcebergCompatVx object, None if not supported.
+   */
+  def getForIcebergFormatVersion(formatVersion: Int): Option[IcebergCompatBase] =
+    knownVersions.find(_.icebergFormatVersion == formatVersion)
+
+  /**
    * @return any enabled IcebergCompat in the conf
    */
   def anyEnabled(conf: Map[String, String]): Option[IcebergCompatBase] =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -229,6 +229,7 @@ case class AlterTableUnsetPropertiesDeltaCommand(
       val txn = startTransaction()
       val metadata = txn.metadata
 
+
       val normalizedKeys = DeltaConfigs.normalizeConfigKeys(propKeys)
       if (!ifExists) {
         normalizedKeys.foreach { k =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.delta.commands.backfill
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddFile, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add a util function to IcebergCompat 
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Test
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No