### PR TITLE
[Kernel][Dsv2][Test only]Support path based table in TestCatalog

### DIFF
--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
@@ -122,7 +122,7 @@ public class Dsv2BasicTest {
 
     testData.write().format("delta").save(tablePath);
 
-    // Test path-based table using DESCRIBE TABLE
+    // TODO: [delta-io/delta#5001] change to select query after batch read is supported for dsv2 path.
     Dataset<Row> actual = spark.sql(String.format("DESCRIBE TABLE dsv2.delta.`%s`", tablePath));
 
     List<Row> expectedRows =

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
@@ -122,7 +122,8 @@ public class Dsv2BasicTest {
 
     testData.write().format("delta").save(tablePath);
 
-    // TODO: [delta-io/delta#5001] change to select query after batch read is supported for dsv2 path.
+    // TODO: [delta-io/delta#5001] change to select query after batch read is supported for dsv2
+    // path.
     Dataset<Row> actual = spark.sql(String.format("DESCRIBE TABLE dsv2.delta.`%s`", tablePath));
 
     List<Row> expectedRows =

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/Dsv2BasicTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -40,6 +41,10 @@ public class Dsv2BasicTest {
         new SparkConf()
             .set("spark.sql.catalog.dsv2", "io.delta.spark.dsv2.catalog.TestCatalog")
             .set("spark.sql.catalog.dsv2.base_path", tempDir.getAbsolutePath())
+            .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .set(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog")
             .setMaster("local[*]")
             .setAppName("Dsv2BasicTest");
     spark = SparkSession.builder().config(conf).getOrCreate();
@@ -96,6 +101,37 @@ public class Dsv2BasicTest {
         "TABLE_OR_VIEW_NOT_FOUND",
         e.getErrorClass(),
         "Missing table should raise TABLE_OR_VIEW_NOT_FOUND");
+  }
+
+  @Test
+  public void testPathBasedTable(@TempDir File deltaTablePath) {
+    String tablePath = deltaTablePath.getAbsolutePath();
+
+    // Create test data and write as Delta table
+    Dataset<Row> testData =
+        spark.createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1, "Alice", 100.0),
+                RowFactory.create(2, "Bob", 200.0),
+                RowFactory.create(3, "Charlie", 300.0)),
+            DataTypes.createStructType(
+                Arrays.asList(
+                    DataTypes.createStructField("id", DataTypes.IntegerType, false),
+                    DataTypes.createStructField("name", DataTypes.StringType, false),
+                    DataTypes.createStructField("value", DataTypes.DoubleType, false))));
+
+    testData.write().format("delta").save(tablePath);
+
+    // Test path-based table using DESCRIBE TABLE
+    Dataset<Row> actual = spark.sql(String.format("DESCRIBE TABLE dsv2.delta.`%s`", tablePath));
+
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create("id", "int", null),
+            RowFactory.create("name", "string", null),
+            RowFactory.create("value", "double", null));
+
+    assertDatasetEquals(actual, expectedRows);
   }
 
   //////////////////////

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
@@ -159,7 +159,8 @@ public class TestCatalog implements TableCatalog {
 
   /**
    * Check if the given identifier represents a path-based table. Path-based tables are identified
-   * by having a delta namespace. This follows the same logic as Delta Spark's SupportsPathIdentifier.
+   * by having a delta namespace. This follows the same logic as Delta Spark's
+   * SupportsPathIdentifier.
    *
    * @param ident the table identifier to check
    * @return true if this is a path-based table identifier, false otherwise

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
@@ -161,9 +161,6 @@ public class TestCatalog implements TableCatalog {
    * Check if the given identifier represents a path-based table. Path-based tables are identified
    * by having a delta namespace. This follows the same logic as Delta Spark's
    * SupportsPathIdentifier.
-   *
-   * @param ident the table identifier to check
-   * @return true if this is a path-based table identifier, false otherwise
    */
   private boolean isPathIdentifier(Identifier ident) {
     // For testing, simply check if it has a delta namespace

--- a/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
+++ b/spark-kernel-dsv2/src/test/java/io/delta/spark/dsv2/catalog/TestCatalog.java
@@ -159,28 +159,14 @@ public class TestCatalog implements TableCatalog {
 
   /**
    * Check if the given identifier represents a path-based table. Path-based tables are identified
-   * by having a delta namespace (delta/tahoe) and an absolute path. This follows the same logic as
-   * DeltaCatalog's SupportsPathIdentifier.
+   * by having a delta namespace. This follows the same logic as Delta Spark's SupportsPathIdentifier.
    *
    * @param ident the table identifier to check
    * @return true if this is a path-based table identifier, false otherwise
    */
   private boolean isPathIdentifier(Identifier ident) {
-    try {
-      // Check if it has a delta namespace (should be length 1 and named "delta")
-      boolean hasDeltaNamespace =
-          ident.namespace().length == 1 && ident.namespace()[0].toLowerCase().equals("delta");
-
-      if (!hasDeltaNamespace) {
-        return false;
-      }
-
-      // Use Hadoop Path to properly check if it's an absolute path
-      return new org.apache.hadoop.fs.Path(ident.name()).isAbsolute();
-    } catch (IllegalArgumentException e) {
-      // Handle malformed path strings gracefully
-      return false;
-    }
+    // For testing, simply check if it has a delta namespace
+    return ident.namespace().length == 1 && ident.namespace()[0].toLowerCase().equals("delta");
   }
 
   /** Helper method to get the table key from identifier. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Support path based table in TestCatalog so that we could test the connector more easily before dsv2 connector support writes. (we could insert using existing delta-spark connector and read using new connector then)

Sample testing idea is in the early poc for reference https://github.com/delta-io/delta/pull/5105

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Add unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No