### PR TITLE
[Kernel] [#5021] New FileSystemClient::getFileStatus API

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
@@ -85,4 +85,13 @@ public interface FileSystemClient {
    * @throws IOException for any IO error.
    */
   boolean delete(String path) throws IOException;
+
+  /**
+   * Get the metadata of the file at the given path.
+   *
+   * @param path Fully qualified path to the file.
+   * @return Metadata of the file.
+   * @throws IOException for any IO error.
+   */
+  FileStatus getFileStatus(String path) throws IOException;
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -160,6 +160,9 @@ trait BaseMockFileSystemClient extends FileSystemClient {
 
   override def delete(path: String): Boolean =
     throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def getFileStatus(path: String): FileStatus =
+    throw new UnsupportedOperationException("not supported in this test suite")
 }
 
 /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
@@ -91,6 +91,11 @@ public class DefaultFileSystemClient implements FileSystemClient {
     return fileIO.delete(path);
   }
 
+  @Override
+  public FileStatus getFileStatus(String path) throws IOException {
+    return fileIO.getFileStatus(path);
+  }
+
   private ByteArrayInputStream getStream(String filePath, int offset, int size) {
     InputFile inputFile = this.fileIO.newInputFile(filePath, /* fileSize */ -1);
     try (SeekableInputStream stream = inputFile.newStream()) {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
@@ -80,4 +80,19 @@ class DefaultFileSystemClientSuite extends AnyFunSuite with TestUtils {
       assert(!fs.exists(new Path(dir3)))
     }
   }
+
+  test("getFileStatus") {
+    val filePath = getTestResourceFilePath("json-files/1.json")
+    val fileStatus = fsClient.getFileStatus(filePath)
+
+    assert(fileStatus.getPath == fsClient.resolvePath(filePath))
+    assert(fileStatus.getSize > 0)
+    assert(fileStatus.getModificationTime > 0)
+  }
+
+  test("getFileStatus on non-existent file") {
+    intercept[FileNotFoundException] {
+      fsClient.getFileStatus("/non-existent-file.json")
+    }
+  }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5113/files) to review incremental changes.
- [**stack/5021_kernel_file_system_client_get_file_status**](https://github.com/delta-io/delta/pull/5113) [[Files changed](https://github.com/delta-io/delta/pull/5113/files)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Resolves #5021.

Adds a new Kernel FileSystemClient::getFileStatus API. This will be used by the Committers.

## How was this patch tested?

Trivial new UT.

## Does this PR introduce _any_ user-facing changes?

No.