### PR TITLE
[Kernel] [UC] UCatalogManagedCommitter CREATE support

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
@@ -108,7 +108,8 @@ public interface JsonHandler {
    *
    * @param filePath Fully qualified destination file path
    * @param data Iterator of {@link Row} objects where each row should be serialized as JSON and
-   *     written as separate line in the destination file.
+   *     written as separate line in the destination file. It is the responsibility of the
+   *     implementation to close this iterator.
    * @param overwrite If {@code true}, the file is overwritten if it already exists. If {@code
    *     false} and a file exists {@link FileAlreadyExistsException} is thrown.
    * @throws FileAlreadyExistsException if the file already exists and {@code overwrite} is false.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -345,13 +345,6 @@ public class TransactionImpl implements Transaction {
           return doCommit(
               engine, commitAsVersion, attemptCommitInfo, dataActions, transactionMetrics);
         } catch (CommitFailedException cfe) {
-          // TODO: When catalog-managed CREATE conflicts on 00.json, yielding CFE(retryable=false,
-          //       conflict=true), we can't retry with 001.json since CREATE must be version 0.
-          //       However, we might be conflicting with our own previous attempt that succeeded but
-          //       the client didn't learn about it. Similar to Case 4 below, we need detection to
-          //       distinguish between genuine conflict and conflict with our own previous commit
-          //       attempt. For now, we just fail.
-
           if (!cfe.isRetryable()) {
             // Case 1: Non-retryable exception. We must throw this. We don't expect connectors to
             //         be able to recover from this.

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
@@ -35,6 +35,7 @@ import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.util.Optional;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -75,11 +76,33 @@ public class UCCatalogManagedCommitter implements Committer {
 
     final CommitMetadata.CommitType commitType = commitMetadata.getCommitType();
 
-    if (commitType != CommitMetadata.CommitType.CATALOG_WRITE) {
-      // TODO: Support CATALOG_CREATE in the future, too
-      throw new UnsupportedOperationException("Unsupported commit type: " + commitType);
+    if (commitType == CommitMetadata.CommitType.CATALOG_CREATE) {
+      return createImpl(engine, finalizedActions, commitMetadata);
+    }
+    if (commitType == CommitMetadata.CommitType.CATALOG_WRITE) {
+      return writeImpl(engine, finalizedActions, commitMetadata);
     }
 
+    throw new UnsupportedOperationException("Unsupported commit type: " + commitType);
+  }
+
+  /** Handles CATALOG_CREATE by writing the published delta file for version 0. */
+  private CommitResponse createImpl(
+      Engine engine, CloseableIterator<Row> finalizedActions, CommitMetadata commitMetadata)
+      throws CommitFailedException {
+    final FileStatus kernelPublishedDeltaFileStatus =
+        writePublishedDeltaFileForVersion0(engine, finalizedActions, commitMetadata);
+
+    return new CommitResponse(ParsedLogData.forFileStatus(kernelPublishedDeltaFileStatus));
+  }
+
+  /**
+   * Handles CATALOG_WRITE by writing the staged commit file and then committing (e.g. REST or RPC
+   * call) to UC server.
+   */
+  private CommitResponse writeImpl(
+      Engine engine, CloseableIterator<Row> finalizedActions, CommitMetadata commitMetadata)
+      throws CommitFailedException {
     if (commitMetadata.getNewProtocolOpt().isPresent()) {
       // TODO: support this
       throw new UnsupportedOperationException("Protocol change is not yet implemented");
@@ -120,34 +143,70 @@ public class UCCatalogManagedCommitter implements Committer {
       throws CommitFailedException {
     checkArgument(
         commitMetadata.getVersion() > 0, "Can only write staged commit files for versions > 0");
-    final String stagedCommitFilePath = commitMetadata.generateNewStagedCommitFilePath();
+    try {
+      // Do not use Put-If-Absent for staged commit files since we assume that UUID-based
+      // commit files are globally unique, and so we will never have concurrent writers
+      // attempting to write the same commit file.
+      return writeDeltaFile(
+          engine,
+          finalizedActions,
+          commitMetadata.generateNewStagedCommitFilePath(),
+          true /* overwrite */);
+    } catch (IOException ex) {
+      throw new CommitFailedException(
+          true /* retryable */,
+          false /* conflict */,
+          "Failed to write staged commit file due to: " + ex.getMessage(),
+          ex);
+    }
+  }
 
+  private FileStatus writePublishedDeltaFileForVersion0(
+      Engine engine, CloseableIterator<Row> finalizedActions, CommitMetadata commitMetadata)
+      throws CommitFailedException {
+    checkArgument(
+        commitMetadata.getVersion() == 0,
+        "Expected version 0, but got %s",
+        commitMetadata.getVersion());
+    try {
+      return writeDeltaFile(
+          engine,
+          finalizedActions,
+          commitMetadata.getPublishedDeltaFilePath(),
+          false /* overwrite */);
+    } catch (FileAlreadyExistsException ex) {
+      // We are either conflicting with (a) another writer concurrently writing to the same staging
+      // table location (which should be impossible) or (b) a previous commit attempt from this
+      // writer that succeeded in writing 00.json but failed to notify the client (e.g. due to
+      // network issues).
+      throw new CommitFailedException(
+          false /* retryable */,
+          true /* conflict */,
+          "Failed to write published delta file due to: " + ex.getMessage(),
+          ex);
+    } catch (IOException ex) {
+      throw new CommitFailedException(
+          true /* retryable */,
+          false /* conflict */,
+          "Failed to write published delta file due to: " + ex.getMessage(),
+          ex);
+    }
+  }
+
+  private FileStatus writeDeltaFile(
+      Engine engine, CloseableIterator<Row> finalizedActions, String filePath, boolean overwrite)
+      throws IOException {
     return timeCheckedOperation(
         logger,
-        "Write staged commit file: " + stagedCommitFilePath,
+        "Write file: " + filePath,
         ucTableId,
         () -> {
-          try {
-            // Do not use Put-If-Absent for staged commit files since we assume that UUID-based
-            // commit files are globally unique, and so we will never have concurrent writers
-            // attempting to write the same commit file.
+          // Note: the engine is responsible for closing the actions iterator once it has been
+          //       fully consumed.
+          engine.getJsonHandler().writeJsonFileAtomically(filePath, finalizedActions, overwrite);
 
-            // Note: the engine is responsible for closing the actions iterator once it has been
-            //       fully consumed.
-            engine
-                .getJsonHandler()
-                .writeJsonFileAtomically(
-                    stagedCommitFilePath, finalizedActions, true /* overwrite */);
-
-            // TODO: [delta-io/delta#5021] Use FileSystemClient::getFileStatus API instead
-            return FileStatus.of(stagedCommitFilePath);
-          } catch (IOException ex) {
-            throw new CommitFailedException(
-                true /* retryable */,
-                false /* conflict */,
-                "Failed to write staged commit file due to: " + ex.getMessage(),
-                ex);
-          }
+          // TODO: [delta-io/delta#5021] Use FileSystemClient::getFileStatus API instead
+          return FileStatus.of(filePath);
         });
   }
 

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
@@ -181,6 +181,10 @@ public class UCCatalogManagedCommitter implements Committer {
           commitMetadata.getPublishedDeltaFilePath(),
           false /* overwrite */);
     } catch (FileAlreadyExistsException ex) {
+      logger.warn(
+          "[{}] File already exists for version 0, treating as successful commit: {}",
+          ucTableId,
+          commitMetadata.getPublishedDeltaFilePath());
       // This can happen if a previous commit attempt from this writer succeeded in writing 00.json,
       // but the client was not successfully notified of that write (e.g. due to network
       // issues).


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5121/files) to review incremental changes.
- [**stack/kernel_uc_catalog_managed_committer_create**](https://github.com/delta-io/delta/pull/5121) [[Files changed](https://github.com/delta-io/delta/pull/5121/files)]

---------
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Enable the UCCatalogManagedCommiter to be invoked for v0 at to thus CREATE the delta table. Note that UC still needs to be contacted about 00.json in a post-commit RPC hook. This is outside the purview of Kernel.

## How was this patch tested?

Simple UTs. More complex integration tests will come soon.

## Does this PR introduce _any_ user-facing changes?

No.
