### PR TITLE
[Spark] Foundations for Conflict free feature enablement

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -548,6 +548,169 @@ private[delta] class ConflictChecker(
   }
 
   /**
+   * Attempts to resolve metadata conflicts between the current and winning transactions.
+   * Currently, we only support the resolution of configuration changes. This is achieved with
+   * the use of an allow-list that defines which configuration changes are allowed.
+   *
+   * We primarily focus on feature enablement. Features should be considered on a case-by-case
+   * basis whether they are eligible for white listing. The main consideration is whether
+   * transactions that produce the output before the feature enablement are safe to commit
+   * with the feature enabled. For some features the answer might be simply yes while some other
+   * features might require reconciliation logic at conflict resolution. Features that require
+   * data rewrite for reconciliation are not good candidates for white listing.
+   */
+  protected def attemptToResolveMetadataConflicts(): Unit = {
+    def throwMetadataChangedException(): Unit =
+      throw DeltaErrors.metadataChangedException(winningCommitSummary.commitInfo)
+
+    // If winning commit does not contain metadata update, no conflict.
+    if (winningCommitSummary.metadataUpdates.isEmpty) return
+
+    // Cannot resolve when both transactions have metadata updates.
+    if (currentTransactionInfo.metadataChanged) {
+      if (winningCommitSummary.identityOnlyMetadataUpdate) {
+        IdentityColumn.logTransactionAbort(deltaLog)
+      }
+      throwMetadataChangedException()
+    }
+
+    // Add all special cases here.
+    if (winningCommitSummary.identityOnlyMetadataUpdate) {
+      return
+    }
+
+    val currentMetadata = currentTransactionInfo.metadata
+    val winningCommitMetadata = winningCommitSummary.metadataUpdates.head
+    val propertyNamesDiff = currentMetadata.diff(winningCommitMetadata)
+
+    // We only support the resolution of configuration changes at the moment.
+    if (propertyNamesDiff != Seq("configuration")) {
+      throwMetadataChangedException()
+    }
+
+    val configurationChanges = validateConfigurationChanges(currentMetadata, winningCommitMetadata)
+    if (!configurationChanges.areValid) {
+      throwMetadataChangedException()
+    }
+
+    // Metadata changes are accepted. Consolidate them.
+    val rowTrackingEnabled = configurationChanges
+      .addedAndChanged
+      .getOrElse(DeltaConfigs.ROW_TRACKING_ENABLED.key, "false")
+      .toBoolean
+    if (rowTrackingEnabled) {
+      currentTransactionInfo = currentTransactionInfo.copy(
+        metadata = winningCommitMetadata,
+        commitInfo = currentTransactionInfo
+          .commitInfo
+          .map(RowTracking.addRowTrackingNotPreservedTag))
+    } else {
+      currentTransactionInfo.copy(metadata = winningCommitMetadata)
+    }
+  }
+
+  /**
+   * Return type of [[validateConfigurationChanges]]. It indicates whether the configuration
+   * changes are valid and provides the details of the changes.
+   */
+  private[delta] case class ConfigurationChanges(
+      areValid: Boolean,
+      removed: Set[String] = Set.empty,
+      added: Map[String, String] = Map.empty,
+      changed: Map[String, String] = Map.empty) {
+    def addedAndChanged : Map[String, String] = added ++ changed
+  }
+
+  /** Allow list for [[validateConfigurationChanges]]. */
+  private val metadataConfigurationChangeAllowList = Set(
+    MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP,
+    MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP,
+    DeltaConfigs.ROW_TRACKING_ENABLED.key)
+
+  /**
+   * Validates configuration changes between the current metadata and the winning metadata.
+   * Returns a [[ConfigurationChanges]] object that indicates whether the changes are valid.
+   */
+  protected[delta] def validateConfigurationChanges(
+      currentMetadata: Metadata,
+      winningMetadata: Metadata,
+      allowList: Set[String] = metadataConfigurationChangeAllowList): ConfigurationChanges = {
+
+    val currentConf = currentMetadata.configuration
+    val winningConf = winningMetadata.configuration
+    val currentConfKeys = currentConf.keySet
+    val winningConfKeys = winningConf.keySet
+
+    val removedKeys = currentConfKeys -- winningConfKeys
+    val addedKeys = winningConfKeys -- currentConfKeys
+    val changedKeys = currentConfKeys.intersect(winningConfKeys).filter { key =>
+      currentConf(key) != winningConf(key)
+    }
+    val addedAndChangedKeys = addedKeys ++ changedKeys
+
+    def configurationChanges(areValid: Boolean): ConfigurationChanges = {
+      ConfigurationChanges(
+        areValid = areValid,
+        removed = removedKeys,
+        added = addedKeys.map(key => key -> winningConf(key)).toMap,
+        changed = changedKeys.map(key => key -> winningConf(key)).toMap)
+    }
+
+    def INVALID_CONFIGURATION_CHANGES = configurationChanges(areValid = false)
+    def VALID_CONFIGURATION_CHANGES = configurationChanges(areValid = true)
+
+    // Unsetting a configuration is not supported at the moment.
+    if (removedKeys.nonEmpty) {
+      return INVALID_CONFIGURATION_CHANGES
+    }
+
+    // Every added or changed configuration must be in the allow list.
+    if (!addedAndChangedKeys.subsetOf(allowList)) {
+      return INVALID_CONFIGURATION_CHANGES
+    }
+
+    // Schema: Key, value, isNew.
+    val allChanges =
+      addedKeys.map(key => (key, winningConf(key), true)) ++
+      changedKeys.map(key => (key, winningConf(key), false))
+
+    val validChanges = allChanges.map { case (key, value, isNew) =>
+      key match {
+        // Row tracking related configurations.
+        case DeltaConfigs.ROW_TRACKING_ENABLED.key =>
+          isRowTrackingConfigChangeValid(value.toBoolean)
+        case MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP =>
+          areRowTrackingPropertyChangesValid(winningMetadata)
+        case MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP =>
+          areRowTrackingPropertyChangesValid(winningMetadata)
+
+        case _ => true
+      }
+    }
+
+    if (validChanges.contains(false)) {
+      return INVALID_CONFIGURATION_CHANGES
+    }
+
+    VALID_CONFIGURATION_CHANGES
+  }
+
+  protected def isRowTrackingConfigChangeValid(value: Boolean): Boolean = {
+    if (!currentTransactionInfo.protocol.isFeatureSupported(RowTrackingFeature)) {
+      return false
+    }
+    // Currently, we only allow enabling row tracking.
+    value
+  }
+
+  protected def areRowTrackingPropertyChangesValid(winningMetadata: Metadata): Boolean = {
+    winningMetadata
+      .configuration
+      .getOrElse(DeltaConfigs.ROW_TRACKING_ENABLED.key, "false")
+      .toBoolean
+  }
+
+  /**
    * Filters the [[files]] list with the partition predicates of the current transaction
    * and returns the first file that is matching.
    */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
@@ -132,7 +132,7 @@ object RowTracking {
   /**
    * Returns a copy of the CommitInfo passed in with the PreservedRowTrackingTag tag set to false.
    */
-  private def addRowTrackingNotPreservedTag(commitInfo: CommitInfo): CommitInfo = {
+  private[delta] def addRowTrackingNotPreservedTag(commitInfo: CommitInfo): CommitInfo = {
     val tagsMap = commitInfo.tags.getOrElse(Map.empty[String, String])
     val newCommitInfoTags = addPreservedRowTrackingTag(tagsMap, preserved = false)
     commitInfo.copy(tags = Some(newCommitInfoTags))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1034,6 +1034,24 @@ case class Metadata(
   // caused perf. problems here in the past:
 
   /**
+   * Compare this metadata with other.
+   * Returns a sequence of field names that differ between the two metadata objects.
+   * Returns an empty sequence then there are no differences.
+   */
+  def diff(other: Metadata): Seq[String] = {
+    import scala.reflect.runtime.universe._
+
+    // In scala 2.13, we can directly use productElementName(n: Int) along with productArity.
+    val fieldNames = typeOf[Metadata].members.sorted.collect {
+      case m: MethodSymbol if m.isCaseAccessor => m.name.toString
+    }
+    // It relies on the fact that members.sorted outputs fields in declaration order.
+    fieldNames.zipWithIndex.collect {
+      case (name, i) if this.productElement(i) != other.productElement(i) => name
+    }
+  }
+
+  /**
    * Column mapping mode for this table
    */
   @JsonIgnore

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -346,8 +346,7 @@ class RowTrackingConflictResolutionSuite extends QueryTest
     txn.commit(Nil, ManualUpdate, tags)
   }
 
-  test("RowTrackingEnablementOnly metadata update does not fail transactions "
-      + "that don't do metadata update") {
+  test("RowTrackingEnablementOnly metadata update does not fail txns that don't update metadata") {
     withTestTable {
       val txn = deltaLog.startTransaction()
       activateRowTracking()
@@ -358,7 +357,7 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       }
 
       assert(!rowTrackingPreserved, "Commits conflicting with a metadata update " +
-          "that enables row tracking only should have row tracking marked as not preserved.")
+        "that enables row tracking only should have row tracking marked as not preserved.")
 
       assertRowIdsAreValid(deltaLog)
       assert(RowTracking.isEnabled(latestSnapshot.protocol, latestSnapshot.metadata))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR sets the foundation for conflict free feature enablement. Today, enabling a feature causes all concurrent txns to fail with METADATA_CHANGED_EXCEPTION. This is unnecessarily restrictive.

This PR introduces an allowlist that allows to white list valid metadata changes and suppress the error. This is aided by a mechanism that allows to compare current and winning metadata and produce diffs.

The allow list should be populated by carefully considering feature by feature the correctness of such an operation. This approach might not be suitable for enabling conflict-free every feature. For example, features that require data rewrite at conflict are ill-fitted. We could use alternative approaches for such cases.

As a starting point, we white listed Row Tracking Enablement since this is already supported today. For now we kept the semantics the same. In the future we can easily allow also disabling Row Tracking.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing suites.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.