### PR TITLE
[Spark] Don't add implicit cast in streaming write for extra/missing/reordered fields

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2068,6 +2068,22 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_STREAMING_SINK_IMPLICIT_CAST_FOR_TYPE_MISMATCH_ONLY =
+    buildConf("streaming.sink.implicitCastForTypeMismatchOnly")
+      .internal()
+      .doc(
+        """Controls when an implicit cast is added when writing data to a Delta table using
+          |streaming.
+          |When true, a cast is added only when there is a type mismatch between a column or
+          |nested field in the data and table schema.
+          |When false, missing, extra or reordered columns or nested fields also trigger adding an
+          |implicit cast.
+          |Only takes effect when implicit casting is enabled in streaming writes to a Delta table
+          |via `spark.databricks.delta.streaming.sink.allowImplicitCasts`.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES =
     buildConf("changeDataFeed.unsafeBatchReadOnIncompatibleSchemaChanges.enabled")
       .doc(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
@@ -179,37 +179,29 @@ class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
     includeInserts = insertsWithoutImplicitCastSupport
   )
 
-   for { (inserts: Set[Insert], expectedAnswer) <- Seq(
-    insertsAppend - SQLInsertByName(SaveMode.Append) ->
+  for { (inserts: Set[Insert], expectedAnswer) <- Seq(
+    insertsAppend ->
       TestData("a int, s struct <x int, y: int>",
         Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": null }""")),
-    insertsOverwrite - SQLInsertByName(SaveMode.Overwrite) ->
-      TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": null }""")),
-    // In SQLInsertByName, the `null` struct gets incorrectly expanded to `struct<null, null>
-    Set(SQLInsertByName(SaveMode.Append)) ->
-      TestData("a int, s struct <x int, y: int>",
-        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""",
-        """{ "a": 1, "s": { "x": null, "y": null } }""")),
-    Set(SQLInsertByName(SaveMode.Overwrite)) ->
-      TestData("a int, s struct <x int, y: int>",
-        Seq("""{ "a": 1, "s": { "x": null, "y": null } }"""))
+    insertsOverwrite ->
+      TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": null }"""))
     )
   } {
-     testInserts(s"null struct with different field order")(
-       initialData = TestData(
-         "a int, s struct <x: int, y int>",
-         Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
-       partitionBy = Seq("a"),
-       overwriteWhere = "a" -> 1,
-       insertData = TestData("a int, s struct <y int, x: int>", Seq("""{ "a": 1, "s": null }""")),
-       expectedResult = ExpectedResult.Success(expectedAnswer),
-       includeInserts = inserts,
-       confs = Seq(
-         // Implicit casts in streaming writes would cause the `null` struct to be incorrectly
-         // expanded, same as SQLInsertByName. This conf allows skipping adding casts since there
-         // are no actual data type mismatch.
-         DeltaSQLConf.DELTA_STREAMING_SINK_IMPLICIT_CAST_FOR_TYPE_MISMATCH_ONLY.key -> "true"
-       )
-     )
-   }
+    testInserts(s"null struct with different field order")(
+      initialData = TestData(
+        "a int, s struct <x: int, y int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, s struct <y int, x: int>", Seq("""{ "a": 1, "s": null }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts,
+      confs = Seq(
+        // Implicit casts in streaming writes would cause the `null` struct to be incorrectly
+        // expanded. This conf allows skipping adding casts since there are no actual data type
+        // mismatch.
+        DeltaSQLConf.DELTA_STREAMING_SINK_IMPLICIT_CAST_FOR_TYPE_MISMATCH_ONLY.key -> "true"
+      )
+    )
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
@@ -178,4 +178,38 @@ class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
         ))}),
     includeInserts = insertsWithoutImplicitCastSupport
   )
+
+   for { (inserts: Set[Insert], expectedAnswer) <- Seq(
+    insertsAppend - SQLInsertByName(SaveMode.Append) ->
+      TestData("a int, s struct <x int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": null }""")),
+    insertsOverwrite - SQLInsertByName(SaveMode.Overwrite) ->
+      TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": null }""")),
+    // In SQLInsertByName, the `null` struct gets incorrectly expanded to `struct<null, null>
+    Set(SQLInsertByName(SaveMode.Append)) ->
+      TestData("a int, s struct <x int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""",
+        """{ "a": 1, "s": { "x": null, "y": null } }""")),
+    Set(SQLInsertByName(SaveMode.Overwrite)) ->
+      TestData("a int, s struct <x int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": null, "y": null } }"""))
+    )
+  } {
+     testInserts(s"null struct with different field order")(
+       initialData = TestData(
+         "a int, s struct <x: int, y int>",
+         Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+       partitionBy = Seq("a"),
+       overwriteWhere = "a" -> 1,
+       insertData = TestData("a int, s struct <y int, x: int>", Seq("""{ "a": 1, "s": null }""")),
+       expectedResult = ExpectedResult.Success(expectedAnswer),
+       includeInserts = inserts,
+       confs = Seq(
+         // Implicit casts in streaming writes would cause the `null` struct to be incorrectly
+         // expanded, same as SQLInsertByName. This conf allows skipping adding casts since there
+         // are no actual data type mismatch.
+         DeltaSQLConf.DELTA_STREAMING_SINK_IMPLICIT_CAST_FOR_TYPE_MISMATCH_ONLY.key -> "true"
+       )
+     )
+   }
 }


### PR DESCRIPTION
## Description
An implicit cast is currently added during streaming writes whenever there is any schema mismatch between the data and the table schema.

While this is generally ok, it is too broad as just having extra, missing or differently ordered fields in the data to write is acceptable: the data written to Parquet files can be read back correctly in these cases.

Casting suffers from a long-standing issue, where `null` structs get incorrectly expanded to struct of null fields. To reduce the impact of that issue, we limit the cases where we add an implicit cast to the strict minimum: when there's actually a type mismatch in the data.

## How was this patch tested?
Added test cases covering the null expansion issue with casting in stream and other insert types:

For differently ordered fields: streaming doesn't add a cast anymore and correctly keep the null struct. Note that INSERT by name still suffers from this issue as it does today.
For type mismatches: streaming adds a cast and still incorrectly expands null structs.

## Does this PR introduce _any_ user-facing changes?
No
