### PR TITLE
[Spark] Plumb catalog tables to `DeltaLog` API call sites in `DeltaSource` and `DeltaDataSource`

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -118,9 +118,12 @@ case class DeltaFormatSharingSource(
       throw DeltaErrors.schemaNotSetException
     }
 
+    // Catalog table represents the table's catalog metadata and it's managed by Unity Catalog.
+    // Delta sharing delta log doesn't have it and `localDeltaLog` is not bound to it.
     DeltaSource(
       spark = spark,
       deltaLog = localDeltaLog,
+      catalogTableOpt = None,
       options = new DeltaOptions(parameters, sqlConf),
       snapshotAtSourceInit = snapshotDescriptor,
       metadataPath = metadataPath,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -351,8 +351,10 @@ class DeltaLog private(
    */
   def getChangeLogFiles(
       startVersion: Long,
-      failOnDataLoss: Boolean = false): Iterator[(Long, FileStatus)] = {
-    val deltasWithVersion = CoordinatedCommitsUtils.commitFilesIterator(this, startVersion)
+      failOnDataLoss: Boolean = false,
+      catalogTableOpt: Option[CatalogTable] = None): Iterator[(Long, FileStatus)] = {
+    val deltasWithVersion = CoordinatedCommitsUtils.commitFilesIterator(
+      this, catalogTableOpt, startVersion)
     // Subtract 1 to ensure that we have the same check for the inclusive startVersion
     var lastSeenVersion = startVersion - 1
     deltasWithVersion.map { case (status, version) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -255,7 +255,8 @@ trait CDCReaderImpl extends DeltaLogging {
       val resolvedVersion = if (timestampKey == DeltaDataSource.CDC_START_TIMESTAMP_KEY) {
         // For the starting timestamp we need to find a version after the provided timestamp
         // we can use the same semantics as streaming.
-        DeltaSource.getStartingVersionFromTimestamp(spark, deltaLog, timestamp, allowOutOfRange)
+        DeltaSource.getStartingVersionFromTimestamp(
+          spark, deltaLog, catalogTableOpt, timestamp, allowOutOfRange)
       } else {
         // For ending timestamp the version should be before the provided timestamp.
         DeltaTableUtils.resolveTimeTravelVersion(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -410,6 +410,7 @@ object CoordinatedCommitsUtils extends DeltaLogging {
    */
   def commitFilesIterator(
       deltaLog: DeltaLog,
+      catalogTableOpt: Option[CatalogTable],
       startVersion: Long): Iterator[(FileStatus, Long)] = {
 
     def listDeltas(startVersion: Long, endVersion: Option[Long]): Iterator[(FileStatus, Long)] = {
@@ -438,7 +439,7 @@ object CoordinatedCommitsUtils extends DeltaLogging {
         return Iterator.empty
       }
 
-      val endSnapshot = deltaLog.update()
+      val endSnapshot = deltaLog.update(catalogTableOpt = catalogTableOpt)
       // No need to worry if we already reached the end
       if (maxVersionSeen >= endSnapshot.version) {
         return Iterator.empty

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -40,6 +40,7 @@ import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.connector.read.streaming
@@ -565,7 +566,7 @@ trait DeltaSourceBase extends Source
     if (hasCheckedReadIncompatibleSchemaChangesOnStreamStart) return
 
     lazy val (startVersionSnapshotOpt, errOpt) =
-      Try(deltaLog.getSnapshotAt(batchStartVersion)) match {
+      Try(deltaLog.getSnapshotAt(batchStartVersion, catalogTableOpt = catalogTableOpt)) match {
         case Success(snapshot) => (Some(snapshot), None)
         case Failure(exception) => (None, Some(exception))
       }
@@ -754,6 +755,7 @@ trait DeltaSourceBase extends Source
 case class DeltaSource(
     spark: SparkSession,
     deltaLog: DeltaLog,
+    catalogTableOpt: Option[CatalogTable],
     options: DeltaOptions,
     snapshotAtSourceInit: SnapshotDescriptor,
     metadataPath: String,
@@ -815,7 +817,8 @@ case class DeltaSource(
       //    in that case, we need to recompute the start snapshot and evolve the schema if needed
       require(options.failOnDataLoss || !trackingMetadataChange,
         "Using schema from schema tracking log cannot tolerate missing commit files.")
-      deltaLog.getChangeLogFiles(startVersion, options.failOnDataLoss).flatMapWithClose {
+      deltaLog.getChangeLogFiles(
+        startVersion, options.failOnDataLoss, catalogTableOpt).flatMapWithClose {
         case (version, filestatus) =>
           // First pass reads the whole commit and closes the iterator.
           val iter = DeltaSource.createRewindableActionIterator(spark, deltaLog, filestatus)
@@ -943,7 +946,7 @@ case class DeltaSource(
    */
   protected def getSnapshotFromDeltaLog(version: Long): Snapshot = {
     try {
-      deltaLog.getSnapshotAt(version)
+      deltaLog.getSnapshotAt(version, catalogTableOpt = catalogTableOpt)
     } catch {
       case e: FileNotFoundException =>
         throw DeltaErrors.logFileNotFoundExceptionForStreamingSource(e)
@@ -1391,9 +1394,9 @@ case class DeltaSource(
     if (options.startingVersion.isDefined) {
       val v = options.startingVersion.get match {
         case StartingVersionLatest =>
-          deltaLog.update().version + 1
+          deltaLog.update(catalogTableOpt = catalogTableOpt).version + 1
         case StartingVersion(version) =>
-          if (!DeltaSource.validateProtocolAt(spark, deltaLog, version)) {
+          if (!DeltaSource.validateProtocolAt(spark, deltaLog, catalogTableOpt, version)) {
             // When starting from a given version, we don't require that the snapshot of this
             // version can be reconstructed, even though the input table is technically in an
             // inconsistent state. If the snapshot cannot be reconstructed, then the protocol
@@ -1414,6 +1417,7 @@ case class DeltaSource(
         .getStartingVersionFromTimestamp(
           spark,
           deltaLog,
+          catalogTableOpt,
           tt.getTimestamp(spark.sessionState.conf),
           allowOutOfRange))
     } else {
@@ -1432,7 +1436,11 @@ object DeltaSource extends DeltaLogging {
    *
    * Returns true when the validation was performed and succeeded.
    */
-  def validateProtocolAt(spark: SparkSession, deltaLog: DeltaLog, version: Long): Boolean = {
+  def validateProtocolAt(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      catalogTableOpt: Option[CatalogTable],
+      version: Long): Boolean = {
     val alwaysValidateProtocol = spark.sessionState.conf.getConf(
       DeltaSQLConf.FAST_DROP_FEATURE_STREAMING_ALWAYS_VALIDATE_PROTOCOL)
     if (!alwaysValidateProtocol) return false
@@ -1441,7 +1449,7 @@ object DeltaSource extends DeltaLogging {
       // We attempt to construct a snapshot at the startingVersion in order to validate the
       // protocol. If snapshot reconstruction fails, fall back to the old behavior where the
       // only requirement was for the commit to exist.
-      deltaLog.getSnapshotAt(version)
+      deltaLog.getSnapshotAt(version, catalogTableOpt = catalogTableOpt)
       return true
     } catch {
       case e: DeltaUnsupportedTableFeatureException =>
@@ -1472,6 +1480,7 @@ object DeltaSource extends DeltaLogging {
    *
    * @param spark - current spark session
    * @param deltaLog - Delta log of the table for which we find the version.
+   * @param catalogTableOpt - The CatalogTable for the Delta table.
    * @param timestamp - user specified timestamp
    * @param canExceedLatest - if true, version can be greater than the latest snapshot commit
    * @return - corresponding version number for timestamp
@@ -1479,17 +1488,18 @@ object DeltaSource extends DeltaLogging {
   def getStartingVersionFromTimestamp(
       spark: SparkSession,
       deltaLog: DeltaLog,
+      catalogTableOpt: Option[CatalogTable],
       timestamp: Timestamp,
       canExceedLatest: Boolean = false): Long = {
     val tz = spark.sessionState.conf.sessionLocalTimeZone
     val commit = deltaLog.history.getActiveCommitAtTime(
       timestamp,
-      catalogTableOpt = None,
+      catalogTableOpt = catalogTableOpt,
       canReturnLastCommit = true,
       mustBeRecreatable = false,
       canReturnEarliestCommit = true)
     if (commit.timestamp >= timestamp.getTime) {
-      validateProtocolAt(spark, deltaLog, commit.version)
+      validateProtocolAt(spark, deltaLog, catalogTableOpt, commit.version)
       // Find the commit at the `timestamp` or the earliest commit
       commit.version
     } else {
@@ -1501,7 +1511,9 @@ object DeltaSource extends DeltaLogging {
       // timestamp, caller doesn't expect exception, and can handle the non-existent version.
       val latestNotExceeded = commit.version + 1 <= deltaLog.unsafeVolatileSnapshot.version
       if (latestNotExceeded || canExceedLatest) {
-        if (latestNotExceeded) validateProtocolAt(spark, deltaLog, commit.version + 1)
+        if (latestNotExceeded) {
+          validateProtocolAt(spark, deltaLog, catalogTableOpt, commit.version + 1)
+        }
         commit.version + 1
       } else {
         val commitTs = new Timestamp(commit.timestamp)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -188,7 +188,7 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
       startVersion: Long,
       endVersion: Long
   ): ClosableIterator[(Long, Action)] = {
-    deltaLog.getChangeLogFiles(startVersion, options.failOnDataLoss).takeWhile {
+    deltaLog.getChangeLogFiles(startVersion, options.failOnDataLoss, catalogTableOpt).takeWhile {
       case (version, _) => version <= endVersion
     }.flatMapWithClose { case (version, fileStatus) =>
       DeltaSource.createRewindableActionIterator(spark, deltaLog, fileStatus)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -1798,8 +1798,12 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
 
     // Manually construct a Delta source since it's hard to test multiple (2+) latestOffset() calls
     // with the current streaming engine without incurring the schema evolution failure.
+    // TODO(LC-9908): Plumb catalog table to DeltaSource. Deferring this and passing None for now,
+    //                as the change requires a large refactor.
     def getSource: DeltaSource = DeltaSource(
-      spark, log,
+      spark,
+      log,
+      catalogTableOpt = None,
       new DeltaOptions(Map("startingVersion" -> "0"), spark.sessionState.conf),
       log.update(),
       metadataPath = "",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Plumb catalog tables to `DeltaLog` API call sites in class `DeltaSource` and `DeltaDataSource`.

`DeltaLog` API call includes:
1. `DeltaLog.forTable`
2. `deltaLog.getSnapshotAt`
3. `deltaLog.update`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
