### PR TITLE
[Kernel] Implement SnapshotBuilder::atTimestamp (doesn't support ratified commits)

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/SnapshotBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/SnapshotBuilder.java
@@ -42,7 +42,7 @@ public interface SnapshotBuilder {
   /**
    * Configures the builder to resolve the table at a specific version.
    *
-   * <p>This method is mutually exclusive with {@link #atTimestamp(Snapshot, long)}. If both are
+   * <p>This method is mutually exclusive with {@link #atTimestamp(long, Snapshot)}. If both are
    * called, an {@link IllegalArgumentException} will be thrown.
    *
    * @param version the version number to resolve to
@@ -74,7 +74,7 @@ public interface SnapshotBuilder {
    *     epoch
    * @return a new builder instance configured for the specified timestamp
    */
-  SnapshotBuilder atTimestamp(Snapshot latestSnapshot, long millisSinceEpochUTC);
+  SnapshotBuilder atTimestamp(long millisSinceEpochUTC, Snapshot latestSnapshot);
 
   /**
    * Provides a custom committer to use at transaction commit time.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/SnapshotBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/SnapshotBuilder.java
@@ -42,12 +42,39 @@ public interface SnapshotBuilder {
   /**
    * Configures the builder to resolve the table at a specific version.
    *
+   * <p>This method is mutually exclusive with {@link #atTimestamp(Snapshot, long)}. If both are
+   * called, an {@link IllegalArgumentException} will be thrown.
+   *
    * @param version the version number to resolve to
    * @return a new builder instance configured for the specified version
    */
   SnapshotBuilder atVersion(long version);
 
-  // TODO: atTimestamp
+  /**
+   * Configures the builder to resolve the table at a specific timestamp.
+   *
+   * <p>This returns a Snapshot for the latest version of the table that was committed before or at
+   * the given timestamp. Specifically:
+   *
+   * <ul>
+   *   <li>If a commit version exactly matches the provided timestamp, the snapshot at that version
+   *       is resolved.
+   *   <li>Otherwise, the latest commit version with a timestamp less than the provided one is
+   *       resolved.
+   *   <li>If the provided timestamp is less than the timestamp of any committed version, snapshot
+   *       resolution will fail.
+   *   <li>If the provided timestamp is after (strictly greater than) the timestamp of the latest
+   *       version of the table, snapshot resolution will fail.
+   * </ul>
+   *
+   * <p>This method is mutually exclusive with {@link #atVersion(long)}. If both are called, an
+   * {@link IllegalArgumentException} will be thrown.
+   *
+   * @param millisSinceEpochUTC timestamp to resolve the snapshot for in milliseconds since the unix
+   *     epoch
+   * @return a new builder instance configured for the specified timestamp
+   */
+  SnapshotBuilder atTimestamp(Snapshot latestSnapshot, long millisSinceEpochUTC);
 
   /**
    * Provides a custom committer to use at transaction commit time.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotQueryContext.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotQueryContext.java
@@ -91,7 +91,7 @@ public class SnapshotQueryContext {
     return tablePath;
   }
 
-  public Optional<Long> getVersion() {
+  public Optional<Long> getResolvedVersion() {
     return resolvedVersion;
   }
 
@@ -121,13 +121,15 @@ public class SnapshotQueryContext {
   }
 
   /**
-   * Updates the {@code version} stored in this snapshot context. This version should be updated
-   * upon version resolution for non time-travel-by-version queries. For latest snapshot queries
-   * this is after log segment construction. For time-travel by timestamp queries this is after
-   * timestamp to version resolution.
+   * Set the resolved version that was actually loaded for this snapshot query.
+   *
+   * <p>For AS OF TIMESTAMP queries, this should be set upon timestamp-to-version resolution.
+   *
+   * <p>For AS OF LATEST queries, this should be set after log segment construction, when we learn
+   * what the latest version of the table really is.
    */
-  public void setVersion(long updatedVersion) {
-    resolvedVersion = Optional.of(updatedVersion);
+  public void setResolvedVersion(long resolvedVersion) {
+    this.resolvedVersion = Optional.of(resolvedVersion);
   }
 
   /** Updates the {@code checkpointVersion} stored in this snapshot context. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotReportImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/SnapshotReportImpl.java
@@ -34,7 +34,7 @@ public class SnapshotReportImpl extends DeltaOperationReportImpl implements Snap
     return new SnapshotReportImpl(
         snapshotContext.getTablePath(),
         snapshotContext.getSnapshotMetrics(),
-        snapshotContext.getVersion(),
+        snapshotContext.getResolvedVersion(),
         snapshotContext.getCheckpointVersion(),
         snapshotContext.getProvidedTimestamp(),
         Optional.of(e));
@@ -49,7 +49,7 @@ public class SnapshotReportImpl extends DeltaOperationReportImpl implements Snap
     return new SnapshotReportImpl(
         snapshotContext.getTablePath(),
         snapshotContext.getSnapshotMetrics(),
-        snapshotContext.getVersion(),
+        snapshotContext.getResolvedVersion(),
         snapshotContext.getCheckpointVersion(),
         snapshotContext.getProvidedTimestamp(),
         Optional.empty() /* exception */);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -86,7 +86,7 @@ public class SnapshotManager {
             .getSnapshotMetrics()
             .loadLogSegmentTotalDurationTimer
             .time(() -> getLogSegmentForVersion(engine, Optional.empty() /* versionToLoad */));
-    snapshotContext.setVersion(logSegment.getVersion());
+    snapshotContext.setResolvedVersion(logSegment.getVersion());
     snapshotContext.setCheckpointVersion(logSegment.getCheckpointVersionOpt());
 
     return createSnapshot(logSegment, engine, snapshotContext);
@@ -112,7 +112,7 @@ public class SnapshotManager {
                 () -> getLogSegmentForVersion(engine, Optional.of(version) /* versionToLoadOpt */));
 
     snapshotContext.setCheckpointVersion(logSegment.getCheckpointVersionOpt());
-    snapshotContext.setVersion(logSegment.getVersion());
+    snapshotContext.setResolvedVersion(logSegment.getVersion());
 
     return createSnapshot(logSegment, engine, snapshotContext);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
@@ -118,6 +118,7 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
     validateVersionNonNegative();
     validateTimestampNonNegative();
     validateTimestampNotGreaterThanLatestSnapshot(engine);
+    validateLogDatasEmptyIfTimeTravelByTimestamp();
     validateVersionAndTimestampMutuallyExclusive();
     validateProtocolAndMetadataOnlyIfVersionProvided();
     validateProtocolRead();
@@ -152,6 +153,13 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
                 latestSnapshotVersion);
           }
         });
+  }
+
+  private void validateLogDatasEmptyIfTimeTravelByTimestamp() {
+    if (ctx.timestampQueryContextOpt.isPresent() && !ctx.logDatas.isEmpty()) {
+      throw new UnsupportedOperationException(
+          "Time travel by timestamp with logDatas is not yet implemented");
+    }
   }
 
   private void validateVersionAndTimestampMutuallyExclusive() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
@@ -74,7 +74,7 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
   }
 
   @Override
-  public SnapshotBuilderImpl atTimestamp(Snapshot latestSnapshot, long millisSinceEpochUTC) {
+  public SnapshotBuilderImpl atTimestamp(long millisSinceEpochUTC, Snapshot latestSnapshot) {
     requireNonNull(latestSnapshot, "latestSnapshot is null");
     checkArgument(latestSnapshot instanceof SnapshotImpl, "latestSnapshot must be a SnapshotImpl");
     ctx.timestampQueryContextOpt =

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
@@ -75,13 +75,13 @@ class SnapshotBuilderSuite extends AnyFunSuite
 
   test("atTimestamp: null latestSnapshot throws NullPointerException") {
     assertThrows[NullPointerException] {
-      TableManager.loadSnapshot(dataPath.toString).atTimestamp(null, 1000L)
+      TableManager.loadSnapshot(dataPath.toString).atTimestamp(1000L, null)
     }
   }
 
   test("atTimestamp: negative timestamp throws IllegalArgumentException") {
     val builder =
-      TableManager.loadSnapshot(dataPath.toString).atTimestamp(mockSnapshotAtTimestamp0, -1L)
+      TableManager.loadSnapshot(dataPath.toString).atTimestamp(-1L, mockSnapshotAtTimestamp0)
 
     val exMsg = intercept[IllegalArgumentException] {
       builder.build(emptyMockEngine)
@@ -92,7 +92,7 @@ class SnapshotBuilderSuite extends AnyFunSuite
 
   test("atTimestamp: timestamp greater than latest snapshot throws IllegalArgumentException") {
     val builder =
-      TableManager.loadSnapshot(dataPath.toString).atTimestamp(mockSnapshotAtTimestamp0, 99)
+      TableManager.loadSnapshot(dataPath.toString).atTimestamp(99, mockSnapshotAtTimestamp0)
 
     val exMsg = intercept[KernelException] {
       builder.build(emptyMockEngine)
@@ -105,7 +105,7 @@ class SnapshotBuilderSuite extends AnyFunSuite
   test("atTimestamp: timestamp and version both provided throws IllegalArgumentException") {
     val builder = TableManager.loadSnapshot(dataPath.toString)
       .atVersion(1)
-      .atTimestamp(mockSnapshotAtTimestamp0, 0L)
+      .atTimestamp(0L, mockSnapshotAtTimestamp0)
 
     val exMsg = intercept[IllegalArgumentException] {
       builder.build(emptyMockEngine)
@@ -116,7 +116,7 @@ class SnapshotBuilderSuite extends AnyFunSuite
 
   test("atTimestamp: protocol and metadata with timestamp throws IllegalArgumentException") {
     val builder = TableManager.loadSnapshot(dataPath.toString)
-      .atTimestamp(mockSnapshotAtTimestamp0, 0L)
+      .atTimestamp(0L, mockSnapshotAtTimestamp0)
       .withProtocolAndMetadata(protocol, metadata)
 
     val exMsg = intercept[IllegalArgumentException] {
@@ -128,7 +128,7 @@ class SnapshotBuilderSuite extends AnyFunSuite
 
   test("atTimestamp: time travel by timestamp with logDatas throws UnsupportedOperationException") {
     val builder = TableManager.loadSnapshot(dataPath.toString)
-      .atTimestamp(mockSnapshotAtTimestamp0, 0L)
+      .atTimestamp(0L, mockSnapshotAtTimestamp0)
       .withLogData(parsedRatifiedStagedCommits(Seq(0)).toList.asJava)
 
     val exMsg = intercept[UnsupportedOperationException] {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
@@ -126,6 +126,18 @@ class SnapshotBuilderSuite extends AnyFunSuite
     assert(exMsg === "protocol and metadata can only be provided if a version is provided")
   }
 
+  test("atTimestamp: time travel by timestamp with logDatas throws UnsupportedOperationException") {
+    val builder = TableManager.loadSnapshot(dataPath.toString)
+      .atTimestamp(mockSnapshotAtTimestamp0, 0L)
+      .withLogData(parsedRatifiedStagedCommits(Seq(0)).toList.asJava)
+
+    val exMsg = intercept[UnsupportedOperationException] {
+      builder.build(emptyMockEngine)
+    }.getMessage
+
+    assert(exMsg === "Time travel by timestamp with logDatas is not yet implemented")
+  }
+
   // ===== Committer Tests ===== //
 
   test("withCommitter: null committer throws NullPointerException") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
@@ -94,11 +94,12 @@ class SnapshotBuilderSuite extends AnyFunSuite
     val builder =
       TableManager.loadSnapshot(dataPath.toString).atTimestamp(mockSnapshotAtTimestamp0, 99)
 
-    val exMsg = intercept[IllegalArgumentException] {
+    val exMsg = intercept[KernelException] {
       builder.build(emptyMockEngine)
     }.getMessage
 
-    assert(exMsg === "Requested load timestamp 99 is greater than the latest snapshot timestamp 0")
+    assert(exMsg.contains("The provided timestamp 99 ms"))
+    assert(exMsg.contains("is after the latest available version"))
   }
 
   test("atTimestamp: timestamp and version both provided throws IllegalArgumentException") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
@@ -25,12 +25,13 @@ import io.delta.kernel.commit.{CommitMetadata, CommitResponse, Committer}
 import io.delta.kernel.data.Row
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.internal.SnapshotImpl
 import io.delta.kernel.internal.actions.Protocol
 import io.delta.kernel.internal.commit.DefaultFileSystemManagedTableOnlyCommitter
 import io.delta.kernel.internal.files.ParsedLogData
 import io.delta.kernel.internal.files.ParsedLogData.ParsedLogType
 import io.delta.kernel.internal.table.SnapshotBuilderImpl
-import io.delta.kernel.test.{ActionUtils, MockFileSystemClientUtils, VectorTestUtils}
+import io.delta.kernel.test.{ActionUtils, MockFileSystemClientUtils, MockSnapshotUtils, VectorTestUtils}
 import io.delta.kernel.types.{IntegerType, StructType}
 import io.delta.kernel.utils.CloseableIterator
 
@@ -39,11 +40,14 @@ import org.scalatest.funsuite.AnyFunSuite
 class SnapshotBuilderSuite extends AnyFunSuite
     with MockFileSystemClientUtils
     with ActionUtils
-    with VectorTestUtils {
+    with VectorTestUtils
+    with MockSnapshotUtils {
 
   private val emptyMockEngine = createMockFSListFromEngine(Nil)
   private val protocol = new Protocol(1, 2)
   private val metadata = testMetadata(new StructType().add("c1", IntegerType.INTEGER))
+  private val mockSnapshotAtTimestamp0 =
+    getMockSnapshot(dataPath, latestVersion = 0L, timestamp = 0L)
 
   ///////////////////////////////////////
   // Builder Validation Tests -- START //
@@ -65,6 +69,60 @@ class SnapshotBuilderSuite extends AnyFunSuite
     }.getMessage
 
     assert(exMsg === "version must be >= 0")
+  }
+
+  // ===== Timestamp Tests ===== //
+
+  test("atTimestamp: null latestSnapshot throws NullPointerException") {
+    assertThrows[NullPointerException] {
+      TableManager.loadSnapshot(dataPath.toString).atTimestamp(null, 1000L)
+    }
+  }
+
+  test("atTimestamp: negative timestamp throws IllegalArgumentException") {
+    val builder =
+      TableManager.loadSnapshot(dataPath.toString).atTimestamp(mockSnapshotAtTimestamp0, -1L)
+
+    val exMsg = intercept[IllegalArgumentException] {
+      builder.build(emptyMockEngine)
+    }.getMessage
+
+    assert(exMsg === "timestamp must be >= 0")
+  }
+
+  test("atTimestamp: timestamp greater than latest snapshot throws IllegalArgumentException") {
+    val builder =
+      TableManager.loadSnapshot(dataPath.toString).atTimestamp(mockSnapshotAtTimestamp0, 99)
+
+    val exMsg = intercept[IllegalArgumentException] {
+      builder.build(emptyMockEngine)
+    }.getMessage
+
+    assert(exMsg === "Requested load timestamp 99 is greater than the latest snapshot timestamp 0")
+  }
+
+  test("atTimestamp: timestamp and version both provided throws IllegalArgumentException") {
+    val builder = TableManager.loadSnapshot(dataPath.toString)
+      .atVersion(1)
+      .atTimestamp(mockSnapshotAtTimestamp0, 0L)
+
+    val exMsg = intercept[IllegalArgumentException] {
+      builder.build(emptyMockEngine)
+    }.getMessage
+
+    assert(exMsg === "timestamp and version cannot be provided together")
+  }
+
+  test("atTimestamp: protocol and metadata with timestamp throws IllegalArgumentException") {
+    val builder = TableManager.loadSnapshot(dataPath.toString)
+      .atTimestamp(mockSnapshotAtTimestamp0, 0L)
+      .withProtocolAndMetadata(protocol, metadata)
+
+    val exMsg = intercept[IllegalArgumentException] {
+      builder.build(emptyMockEngine)
+    }.getMessage
+
+    assert(exMsg === "protocol and metadata can only be provided if a version is provided")
   }
 
   // ===== Committer Tests ===== //

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -79,7 +79,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
     snapshotContext1.getSnapshotMetrics.loadProtocolMetadataTotalDurationTimer.record(1000)
     snapshotContext1.getSnapshotMetrics.loadLogSegmentTotalDurationTimer.record(500)
     snapshotContext1.getSnapshotMetrics.loadCrcTotalDurationTimer.record(250)
-    snapshotContext1.setVersion(25)
+    snapshotContext1.setResolvedVersion(25)
     snapshotContext1.setCheckpointVersion(Optional.of(20))
     val exception = new RuntimeException("something something failed")
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockSnapshotUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockSnapshotUtils.scala
@@ -31,7 +31,9 @@ import io.delta.kernel.internal.util.VectorUtils.{buildArrayValue, stringStringM
 import io.delta.kernel.types.StringType
 import io.delta.kernel.utils.FileStatus
 
-object MockSnapshotUtils {
+object MockSnapshotUtils extends MockSnapshotUtils
+
+trait MockSnapshotUtils {
 
   /**
    * Creates a mock snapshot with valid metadata at the given version.
@@ -40,7 +42,8 @@ object MockSnapshotUtils {
   def getMockSnapshot(
       dataPath: Path,
       latestVersion: Long,
-      ictEnablementInfoOpt: Option[(Long, Long)] = None): SnapshotImpl = {
+      ictEnablementInfoOpt: Option[(Long, Long)] = None,
+      timestamp: Long = 0L): SnapshotImpl = {
     val configuration = ictEnablementInfoOpt match {
       case Some((version, _)) if version == 0L =>
         Map(TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true")
@@ -75,7 +78,7 @@ object MockSnapshotUtils {
       Seq.empty.asJava, /* compactions */
       Seq.empty.asJava, /* checkpoints */
       Optional.empty(), /* lastSeenChecksum */
-      0L /* lastCommitTimestamp */
+      timestamp /* lastCommitTimestamp */
     )
     val snapshotQueryContext = SnapshotQueryContext.forLatestSnapshot(dataPath.toString)
     new SnapshotImpl(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -270,11 +270,8 @@ trait AbstractDeltaTableReadsSuite extends AnyFunSuite { self: AbstractTestUtils
     expectTableNotFoundException { () =>
       tableManager.getSnapshotAtVersion(defaultEngine, invalidPath, 1)
     }
-
-    if (tableManager.supportsTimestampResolution) {
-      expectTableNotFoundException { () =>
-        tableManager.getSnapshotAtTimestamp(defaultEngine, invalidPath, 1)
-      }
+    expectTableNotFoundException { () =>
+      tableManager.getSnapshotAtTimestamp(defaultEngine, invalidPath, 1)
     }
   }
 
@@ -999,8 +996,6 @@ trait AbstractDeltaTableReadsSuite extends AnyFunSuite { self: AbstractTestUtils
   }
 
   test("getSnapshotAtTimestamp: basic end-to-end read") {
-    assume(getTableManagerAdapter.supportsTimestampResolution, "Timestamp queries not supported")
-
     withTempDir { tempDir =>
       val start = 1540415658000L
       val minuteInMilliseconds = 60000L
@@ -1057,8 +1052,6 @@ trait AbstractDeltaTableReadsSuite extends AnyFunSuite { self: AbstractTestUtils
   }
 
   test("getSnapshotAtTimestamp: empty _delta_log folder") {
-    assume(getTableManagerAdapter.supportsTimestampResolution, "Timestamp queries not supported")
-
     withTempDir { dir =>
       new File(dir, "_delta_log").mkdirs()
       intercept[TableNotFoundException] {
@@ -1069,8 +1062,6 @@ trait AbstractDeltaTableReadsSuite extends AnyFunSuite { self: AbstractTestUtils
   }
 
   test("getSnapshotAtTimestamp: empty folder no _delta_log dir") {
-    assume(getTableManagerAdapter.supportsTimestampResolution, "Timestamp queries not supported")
-
     withTempDir { dir =>
       intercept[TableNotFoundException] {
         getTableManagerAdapter
@@ -1080,8 +1071,6 @@ trait AbstractDeltaTableReadsSuite extends AnyFunSuite { self: AbstractTestUtils
   }
 
   test("getSnapshotAtTimestamp: non-empty folder not a delta table") {
-    assume(getTableManagerAdapter.supportsTimestampResolution, "Timestamp queries not supported")
-
     withTempDir { dir =>
       spark.range(20).write.format("parquet").mode("overwrite").save(dir.getCanonicalPath)
       intercept[TableNotFoundException] {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/MetricsReportTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/MetricsReportTestUtils.scala
@@ -25,6 +25,7 @@ import io.delta.kernel.engine._
 import io.delta.kernel.metrics.MetricsReport
 
 import org.apache.hadoop.conf.Configuration
+import org.slf4j.LoggerFactory
 
 /**
  * Test utilities for testing the Kernel-API created [[MetricsReports]]s.
@@ -33,6 +34,8 @@ import org.apache.hadoop.conf.Configuration
  * to mock both file listings AND file contents.
  */
 trait MetricsReportTestUtils extends TestUtils {
+
+  private val logger = LoggerFactory.getLogger(classOf[MetricsReportTestUtils])
 
   override lazy val defaultEngine = DefaultEngine.create(new Configuration() {
     {
@@ -54,8 +57,10 @@ trait MetricsReportTestUtils extends TestUtils {
     // Initialize a buffer for any metric reports and wrap the engine so that they are recorded
     val reports = ArrayBuffer.empty[MetricsReport]
     if (expectException) {
-      val e = intercept[Exception](
-        f(new EngineWithInMemoryMetricsReporter(reports, defaultEngine)))
+      val e = intercept[Exception] {
+        f(new EngineWithInMemoryMetricsReporter(reports, defaultEngine))
+      }
+      logger.warn("Caught exception:", e)
       (reports, Some(e))
     } else {
       f(new EngineWithInMemoryMetricsReporter(reports, defaultEngine))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/test/AbstractTableManagerAdapter.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/test/AbstractTableManagerAdapter.scala
@@ -107,7 +107,7 @@ class TableManagerAdapter extends AbstractTableManagerAdapter {
     TableManager
       .loadSnapshot(path)
       .asInstanceOf[SnapshotBuilderImpl]
-      .atTimestamp(getSnapshotAtLatest(engine, path), timestamp)
+      .atTimestamp(timestamp, getSnapshotAtLatest(engine, path))
       .build(engine)
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/test/AbstractTableManagerAdapter.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/test/AbstractTableManagerAdapter.scala
@@ -36,7 +36,14 @@ import io.delta.kernel.internal.table.SnapshotBuilderImpl
  */
 trait AbstractTableManagerAdapter {
 
-  /** Does this adapter support resolving a timestamp to a version? */
+  /**
+   * Does this adapter support resolving a timestamp to a version?
+   *
+   * e.g. getVersionBeforeOrAtTimestamp and getVersionAtOrAfterTimestamp
+   *
+   * This is different from loading a snapshot at a specific timestamp, which is supported by all
+   * adapter implementations.
+   */
   def supportsTimestampResolution: Boolean
 
   def getSnapshotAtLatest(engine: Engine, path: String): SnapshotImpl
@@ -97,6 +104,10 @@ class TableManagerAdapter extends AbstractTableManagerAdapter {
       engine: Engine,
       path: String,
       timestamp: Long): SnapshotImpl = {
-    throw new UnsupportedOperationException("not implemented")
+    TableManager
+      .loadSnapshot(path)
+      .asInstanceOf[SnapshotBuilderImpl]
+      .atTimestamp(getSnapshotAtLatest(engine, path), timestamp)
+      .build(engine)
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5145/files) to review incremental changes.
- [**stack/kernel_snapshot_builder_at_timestamp**](https://github.com/delta-io/delta/pull/5145) [[Files changed](https://github.com/delta-io/delta/pull/5145/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Implement `SnapshotBuilder::atTimestamp` API for the new SnapshotBuilder Kernel interface.

For now, this only supports tables where you are NOT passing in any ratifiedCommits (we need to still build the timestamp->version parsing logic to handle ratified commits)

## How was this patch tested?

New UTs for the builder.

Un-ignore other test cases so now we e2e test time-travel-by-timestamp with the new SnapshotBuilder API too 👍 

## Does this PR introduce _any_ user-facing changes?

New SnapshotBuilder::atTimestamp API
