### PR TITLE
[SPARK][TEST-ONLY] Modularize CDC tests

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -136,6 +136,7 @@ object SuiteGeneratorConfig {
     val PERSISTENT_DV_OFF = PERSISTENT_DV.withValueAsDimension(_.head)
     val PERSISTENT_DV_ON = PERSISTENT_DV.withValueAsDimension(_.last)
     val ROW_TRACKING = DimensionWithMultipleValues("RowTracking", List("Disabled", "Enabled"))
+    val ROW_TRACKING_ON = ROW_TRACKING.withValueAsDimension(_.last)
     val MERGE_PERSISTENT_DV_OFF = DimensionMixin("MergePersistentDV", suffix = "Disabled")
     val MERGE_ROW_TRACKING_DV = DimensionMixin("RowTrackingMergeDV")
     val COLUMN_MAPPING = DimensionWithMultipleValues(
@@ -323,6 +324,7 @@ object SuiteGeneratorConfig {
           )
         )
       )
+    ),
     )
     // scalastyle:on line.size.limit
   )

--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -324,7 +324,6 @@ object SuiteGeneratorConfig {
           )
         )
       )
-    ),
     )
     // scalastyle:on line.size.limit
   )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -60,8 +60,7 @@ object DeltaTestUtilsBase {
 }
 
 trait CDCTestMixin extends SharedSparkSession {
-  override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
+  // Setting the spark Conf is left to the test implementation.
 
   def computeCDC(
       spark: SparkSession,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -41,7 +41,7 @@ import org.apache.hadoop.fs.Path
 import org.scalactic.source.Position
 import org.scalatest.{BeforeAndAfterEach, Tag}
 
-import org.apache.spark.{SparkContext, SparkFunSuite, SparkThrowable}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkThrowable}
 import org.apache.spark.scheduler.{JobFailed, SparkListener, SparkListenerJobEnd, SparkListenerJobStart}
 import org.apache.spark.sql.{AnalysisException, DataFrame, DataFrameWriter, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -56,6 +56,20 @@ import org.apache.spark.util.{ManualClock, SystemClock, Utils}
 
 object DeltaTestUtilsBase {
   final val BOOLEAN_DOMAIN: Seq[Boolean] = Seq(true, false)
+}
+
+trait CDCTestMixin extends SharedSparkSession {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
+
+  def computeCDC(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      startVersion: Long,
+      endVersion: Long,
+      predicates: Seq[Expression] = Seq.empty): DataFrame = {
+    CDCReader.changesToBatchDF(deltaLog, startVersion, endVersion, spark)
+  }
 }
 
 trait DeltaTestUtilsBase {
@@ -569,7 +583,8 @@ trait DeltaTestUtilsForTempViews
 trait DeltaDMLTestUtils
   extends DeltaSQLTestUtils
   with DeltaTestUtilsBase
-  with BeforeAndAfterEach {
+  with BeforeAndAfterEach
+  with CDCTestMixin {
   self: SharedSparkSession =>
 
   import testImplicits._
@@ -700,12 +715,12 @@ trait DeltaDMLTestUtils
     assert(latestOperationVersion.nonEmpty,
       s"Latest ${operation} operation doesn't have a version associated with it")
 
-    CDCReader
-      .changesToBatchDF(
+    computeCDC(
+        spark,
         deltaLog,
         latestOperationVersion.get,
-        latestOperationVersion.get,
-        spark)
+        latestOperationVersion.get
+    )
       .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
       .drop(CDCReader.CDC_COMMIT_VERSION)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -45,6 +45,7 @@ import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkThrowable}
 import org.apache.spark.scheduler.{JobFailed, SparkListener, SparkListenerJobEnd, SparkListenerJobStart}
 import org.apache.spark.sql.{AnalysisException, DataFrame, DataFrameWriter, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.{quietly, FailFastMode}
 import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution, RDDScanExec, SparkPlan, WholeStageCodegenExec}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
@@ -57,7 +57,8 @@ trait DeleteCDCMixin extends DeleteSQLMixin with CDCEnabled {
 
 }
 
-trait DeleteCDCTests extends DeleteCDCMixin {
+trait DeleteCDCTests extends DeleteCDCMixin
+  with CDCTestMixin {
   import testImplicits._
 
   testCDCDelete("unconditional")(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
@@ -49,7 +49,8 @@ trait MergeCDCMixin extends SharedSparkSession
  */
 trait MergeCDCTests extends QueryTest
   with CDCEnabled
-  with MergeCDCMixin {
+  with MergeCDCMixin
+  with CDCTestMixin {
 
   import testImplicits._
 
@@ -124,8 +125,7 @@ trait MergeCDCTests extends QueryTest
 
             // The timestamp is nondeterministic so we drop it when comparing results.
             checkAnswer(
-              CDCReader.changesToBatchDF(
-                deltaLog, latestVersion, latestVersion, spark)
+              computeCDC(spark, deltaLog, latestVersion, latestVersion)
                 .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
               expectedCdcData)
           }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
@@ -199,5 +199,6 @@ trait UpdateCDCWithDeletionVectorsTests extends UpdateSQLWithDeletionVectorsMixi
 
     assert(addActions.count(_.deletionVector != null) === 2)
     assert(removeActions.size === 2)
+    assert(cdcActions.nonEmpty)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 
 trait UpdateCDCTests  extends UpdateSQLMixin
   with DeltaColumnMappingTestUtils
-  with DeltaDMLTestUtilsPathBased {
+  with DeltaDMLTestUtilsPathBased
+  with CDCTestMixin {
   import testImplicits._
 
   test("CDC for unconditional update") {
@@ -41,8 +42,7 @@ trait UpdateCDCTests  extends UpdateSQLMixin
 
     val latestVersion = deltaLog.update().version
     checkAnswer(
-      CDCReader
-        .changesToBatchDF(deltaLog, latestVersion, latestVersion, spark)
+      computeCDC(spark, deltaLog, latestVersion, latestVersion)
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
       Row(1, 1, "update_preimage", latestVersion) ::
         Row(1, -1, "update_postimage", latestVersion) ::
@@ -65,8 +65,7 @@ trait UpdateCDCTests  extends UpdateSQLMixin
 
     val latestVersion = deltaLog.update().version
     checkAnswer(
-      CDCReader
-        .changesToBatchDF(deltaLog, latestVersion, latestVersion, spark)
+      computeCDC(spark, deltaLog, latestVersion, latestVersion)
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
       Row(1, 1, "update_preimage", latestVersion) ::
         Row(1, -1, "update_postimage", latestVersion) ::
@@ -89,8 +88,7 @@ trait UpdateCDCTests  extends UpdateSQLMixin
 
     val latestVersion = deltaLog.update().version
     checkAnswer(
-      CDCReader
-        .changesToBatchDF(deltaLog, latestVersion, latestVersion, spark)
+      computeCDC(spark, deltaLog, latestVersion, latestVersion)
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
       Row(1, 1, "update_preimage", latestVersion) ::
         Row(1, -1, "update_postimage", latestVersion) ::
@@ -107,8 +105,7 @@ trait UpdateCDCTests  extends UpdateSQLMixin
 
     val latestVersion1 = deltaLog.update().version
     checkAnswer(
-      CDCReader
-        .changesToBatchDF(deltaLog, latestVersion1, latestVersion1, spark)
+      computeCDC(spark, deltaLog, latestVersion1, latestVersion1)
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
       Row(1, 1, "update_preimage", latestVersion1) ::
         Row(1, -1, "update_postimage", latestVersion1) ::
@@ -121,8 +118,7 @@ trait UpdateCDCTests  extends UpdateSQLMixin
 
     val latestVersion2 = deltaLog.update().version
     checkAnswer(
-      CDCReader
-        .changesToBatchDF(deltaLog, latestVersion1, latestVersion2, spark)
+      computeCDC(spark, deltaLog, latestVersion1, latestVersion2)
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
       Row(1, 1, "update_preimage", latestVersion1) ::
         Row(1, -1, "update_postimage", latestVersion1) ::
@@ -143,8 +139,7 @@ trait UpdateCDCTests  extends UpdateSQLMixin
 
     val latestVersion = deltaLog.update().version
     checkAnswer(
-      CDCReader
-        .changesToBatchDF(deltaLog, latestVersion, latestVersion, spark)
+      computeCDC(spark, deltaLog, latestVersion, latestVersion)
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
       Row(1, 1, 1, "update_preimage", latestVersion) ::
         Row(1, -1, 1, "update_postimage", latestVersion) ::
@@ -166,11 +161,11 @@ trait UpdateCDCTests  extends UpdateSQLMixin
       sql(s"INSERT INTO $tableName VALUES (4, 4, 4)")
       sql(s"UPDATE $tableName SET partition_column = null WHERE partition_column = 4")
       checkAnswer(
-        CDCReader.changesToBatchDF(
+        computeCDC(spark,
           DeltaLog.forTable(
             spark,
             spark.sessionState.sqlParser.parseTableIdentifier(tableName)
-          ), 1, 3, spark)
+          ), 1, 2)
           .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
         Row(4, 4, 4, "insert", 1) ::
           Row(4, 4, 4, "update_preimage", 2) ::
@@ -179,15 +174,15 @@ trait UpdateCDCTests  extends UpdateSQLMixin
   }
 }
 
-trait UpdateCDCWithDeletionVectorsTests extends UpdateSQLWithDeletionVectorsMixin {
+trait UpdateCDCWithDeletionVectorsTests extends UpdateSQLWithDeletionVectorsMixin
+  with CDCTestMixin {
   test("UPDATE with DV write CDC files explicitly") {
     append(spark.range(0, 10, 1, numPartitions = 2).toDF())
     executeUpdate(tableSQLIdentifier, "id = -1", "id % 4 = 0")
 
     val latestVersion = deltaLog.update().version
     checkAnswer(
-      CDCReader
-        .changesToBatchDF(deltaLog, latestVersion, latestVersion, spark)
+      computeCDC(spark, deltaLog, latestVersion, latestVersion)
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP),
       Row(0, "update_preimage", latestVersion) ::
         Row(-1, "update_postimage", latestVersion) ::
@@ -204,6 +199,5 @@ trait UpdateCDCWithDeletionVectorsTests extends UpdateSQLWithDeletionVectorsMixi
 
     assert(addActions.count(_.deletionVector != null) === 2)
     assert(removeActions.size === 2)
-    assert(cdcActions.nonEmpty)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR modularizes how CDC tests are run by introducing a Mixin to run `CDCReader.changesToBatchDF` to be compatible with the new suite generator framework.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
This PR doesn't change any functionality and only refactors tests.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
