### PR TITLE
[Kernel] Minor improvement to Kernel SnapshotManager LogSegment loading logging and observability

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -222,9 +222,9 @@ public class DeltaLogActionUtils {
     final Path logPath = new Path(tablePath, "_delta_log");
 
     logger.info(
-        "Listing log files types={} in path={} starting from {} and ending with {}",
-        fileTypes,
+        "[{}] Listing log files types={} starting from {} and ending with {}",
         logPath,
+        fileTypes,
         startVersion,
         endVersionOpt);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
@@ -315,15 +315,18 @@ public class LogSegment {
           long checksumVersion = FileNames.checksumVersion(new Path(checksumFile.getPath()));
           checkArgument(
               checksumVersion <= version,
-              "checksum file's version should be less than or equal to logSegment's version");
+              String.format(
+                  "Checksum file's version should be less than or equal to logSegment's version. "
+                      + "Expected: <= %d, Actual: %d",
+                  version, checksumVersion));
           checkpointVersionOpt.ifPresent(
               checkpointVersion ->
                   checkArgument(
                       checksumVersion >= checkpointVersion,
-                      "checksum file's version %s should be greater than or equal to "
-                          + "checkpoint version %s",
-                      checksumVersion,
-                      checkpointVersion));
+                      String.format(
+                          "Checksum file's version should be greater than or equal to "
+                              + "checkpoint version. Expected: >= %d, Actual: %d",
+                          checkpointVersion, checksumVersion)));
         });
   }
 
@@ -331,16 +334,25 @@ public class LogSegment {
       List<Long> deltaVersions, Optional<Long> checkpointVersionOpt) {
     checkpointVersionOpt.ifPresent(
         checkpointVersion -> {
+          final long expectedVersion = checkpointVersion + 1;
+          final long actualFirstDeltaVersion = deltaVersions.get(0);
           checkArgument(
-              deltaVersions.get(0) == checkpointVersion + 1,
-              "First delta file version must equal checkpointVersion + 1");
+              actualFirstDeltaVersion == expectedVersion,
+              String.format(
+                  "First delta file version must equal checkpointVersion + 1. "
+                      + "Expected: %d, Actual: %d",
+                  expectedVersion, actualFirstDeltaVersion));
         });
   }
 
   private void validateLastDeltaVersionIsLogSegmentVersion(List<Long> deltaVersions, long version) {
+    final long actualLastDeltaVersion = ListUtils.getLast(deltaVersions);
     checkArgument(
-        ListUtils.getLast(deltaVersions) == version,
-        "Last delta file version must equal the version of this LogSegment");
+        actualLastDeltaVersion == version,
+        String.format(
+            "Last delta file version must equal the version of this LogSegment. "
+                + "Expected: %d, Actual: %d",
+            version, actualLastDeltaVersion));
   }
 
   private void validateDeltaVersionsAreContiguous(List<Long> deltaVersions) {
@@ -374,8 +386,10 @@ public class LogSegment {
         checkpointVersion -> {
           checkArgument(
               checkpointVersion == version,
-              "If there are no deltas, then checkpointVersion must equal the version "
-                  + "of this LogSegment");
+              String.format(
+                  "If there are no deltas, then checkpointVersion must equal the version "
+                      + "of this LogSegment. Expected: %d, Actual: %d",
+                  version, checkpointVersion));
         });
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5158/files) to review incremental changes.
- [**stack/kernel_snapshot_log_segment_improved_observability**](https://github.com/delta-io/delta/pull/5158) [[Files changed](https://github.com/delta-io/delta/pull/5158/files)]

---------

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

We add more `logger.info` calls to SnapshotManager to give us a better sense of the files we are listing, filtering, etc.

Also add more info to our `checkArgument` statements in our `LogSegment` input validation.

## How was this patch tested?

Logging only. Existing CI and UTs.

## Does this PR introduce _any_ user-facing changes?

No.