### PR TITLE
[Kernel] Allow IcebergWriterCompatV1 to coexist with inactive RowTracking Feature 

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatMetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatMetadataValidatorAndUpdater.java
@@ -83,6 +83,7 @@ abstract class IcebergWriterCompatMetadataValidatorAndUpdater
               // Incompatible, but not active, legacy table features
               INVARIANTS_W_FEATURE,
               CHANGE_DATA_FEED_W_FEATURE,
+              ROW_TRACKING_W_FEATURE,
               CONSTRAINTS_W_FEATURE,
               IDENTITY_COLUMNS_W_FEATURE,
               GENERATED_COLUMNS_W_FEATURE,
@@ -199,6 +200,18 @@ abstract class IcebergWriterCompatMetadataValidatorAndUpdater
         if (TableConfig.CHANGE_DATA_FEED_ENABLED.fromMetadata(inputContext.newMetadata)) {
           throw DeltaErrors.icebergCompatIncompatibleTableFeatures(
               inputContext.compatFeatureName, Collections.singleton(CHANGE_DATA_FEED_W_FEATURE));
+        }
+      };
+
+  /**
+   * Checks that the table feature `rowTracking` is not active in the table, meaning the table
+   * property `delta.enableRowTracking` is not enabled.
+   */
+  protected static final IcebergCompatCheck ROW_TRACKING_INACTIVE_CHECK =
+      (inputContext) -> {
+        if (TableConfig.ROW_TRACKING_ENABLED.fromMetadata(inputContext.newMetadata)) {
+          throw DeltaErrors.icebergCompatIncompatibleTableFeatures(
+              inputContext.compatFeatureName, Collections.singleton(ROW_TRACKING_W_FEATURE));
         }
       };
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdater.java
@@ -160,7 +160,9 @@ public class IcebergWriterCompatV1MetadataValidatorAndUpdater
 
   @Override
   List<IcebergCompatCheck> icebergCompatChecks() {
-    return Stream.concat(Stream.of(createUnsupportedFeaturesCheck(this)), COMMON_CHECKS.stream())
+    return Stream.concat(
+            Stream.of(createUnsupportedFeaturesCheck(this), ROW_TRACKING_INACTIVE_CHECK),
+            COMMON_CHECKS.stream())
         .collect(toList());
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV3MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV3MetadataValidatorAndUpdater.java
@@ -107,7 +107,6 @@ public class IcebergWriterCompatV3MetadataValidatorAndUpdater
                   VARIANT_RW_FEATURE,
                   VARIANT_SHREDDING_PREVIEW_RW_FEATURE,
                   VARIANT_RW_PREVIEW_FEATURE,
-                  ROW_TRACKING_W_FEATURE,
                   // Also allow writerV1 features for backward compatibility.
                   //
                   // Note: We already enforce that these features cannot be enabled

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite.scala
@@ -346,7 +346,6 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
 
   Seq(
     // "defaultColumns", add this to this test once we support defaultColumns
-    "rowTracking",
     // "collations", add this to this test once we support collations
     "variantType").foreach { incompatibleFeature =>
     test(s"cannot enable with incompatible feature $incompatibleFeature") {
@@ -409,6 +408,12 @@ class IcebergWriterCompatV1MetadataValidatorAndUpdaterSuite
     getCompatEnabledMetadata(cmTestSchema())
       .withMergedConfiguration(Map("delta.constraints.a" -> "a = b").asJava),
     "checkConstraints")
+
+  /* --- ROW_TRACKING_INACTIVE_CHECK tests --- */
+  testIncompatibleActiveLegacyFeature(
+    getCompatEnabledMetadata(cmTestSchema())
+      .withMergedConfiguration(Map(TableConfig.ROW_TRACKING_ENABLED.getKey -> "true").asJava),
+    "rowTracking")
 
   /* --- IDENTITY_COLUMNS_INACTIVE_CHECK tests --- */
   testIncompatibleActiveLegacyFeature(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -504,12 +504,6 @@ class IcebergWriterCompatV1Suite extends AnyFunSuite with WriteUtils
     expectedErrorMessage =
       "Table features [deletionVectors] are incompatible with icebergCompatV2")
 
-  testIncompatibleTableFeature(
-    "rowTracking inactive",
-    tablePropertiesToEnable = Map("delta.feature.rowTracking" -> "supported"),
-    expectedErrorMessage =
-      "Table features [rowTracking] are incompatible with icebergWriterCompatV1")
-
   // defaultColumns is not added to Kernel yet --> throws an error on feature lookup
   testIncompatibleUnsupportedTableFeature(
     "defaultColumns inactive",
@@ -533,7 +527,8 @@ class IcebergWriterCompatV1Suite extends AnyFunSuite with WriteUtils
         "identityColumns",
         "generatedColumns",
         "typeWidening",
-        "typeWidening-preview")
+        "typeWidening-preview",
+        "rowTracking")
         .map(tableFeature => s"delta.feature.$tableFeature" -> "supported")
         .toMap
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
RFC for the change:
 https://github.com/delta-io/delta/pull/5166
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UT
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No