### PR TITLE
[SPARK] Refactor `TableFeatureSupport.checkpointAndVerify`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -548,6 +548,13 @@ trait Checkpoints extends DeltaLogging {
     None
   }
 
+  /** Returns whether a checkpoint exists at `version`. */
+  def checkpointExistsAtVersion(version: Long): Boolean = {
+    val upperBoundVersion = Some(CheckpointInstance(version = version + 1))
+    val lastVerifiedCheckpoint = findLastCompleteCheckpointBefore(upperBoundVersion)
+    lastVerifiedCheckpoint.exists(_.version == version)
+  }
+
   /** Returns the last complete checkpoint in the delta log directory (if any) */
   private def findLastCompleteCheckpoint(): Option[CheckpointInstance] = {
     val hadoopConf = newDeltaHadoopConf()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -555,9 +555,7 @@ object DropTableFeatureUtils extends DeltaLogging {
     def checkpointAndVerify(snapshot: Snapshot): Boolean = {
       try {
         log.checkpoint(snapshot)
-        val upperBoundVersion = Some(CheckpointInstance(version = snapshot.version + 1))
-        val lastVerifiedCheckpoint = log.findLastCompleteCheckpointBefore(upperBoundVersion)
-        lastVerifiedCheckpoint.exists(_.version == snapshot.version)
+        log.checkpointExistsAtVersion(snapshot.version)
       } catch {
         case NonFatal(e) =>
           recordDeltaEvent(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
It extracts the logic to verify the existence of a checkpoint at certain version into a helper method in `DeltaLog`.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
