### PR TITLE
[Kernel] [Refactor] Create `TestFixtures` util trait and `createCommitMetadata` test helper method with default params

### DIFF
--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/TestFixtures.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/TestFixtures.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.test
+
+import java.util.Optional
+
+import io.delta.kernel.commit.CommitMetadata
+import io.delta.kernel.internal.actions.{CommitInfo, Metadata, Protocol}
+import io.delta.kernel.internal.util.Tuple2
+
+/**
+ * Test fixtures including factory methods and constants for creating test objects with sensible
+ * defaults.
+ */
+trait TestFixtures extends ActionUtils {
+  def createCommitMetadata(
+      version: Long,
+      logPath: String = "/fake/_delta_log",
+      commitInfo: CommitInfo = testCommitInfo(),
+      readPandMOpt: Optional[Tuple2[Protocol, Metadata]] = Optional.empty(),
+      newProtocolOpt: Optional[Protocol] = Optional.empty(),
+      newMetadataOpt: Optional[Metadata] = Optional.empty()): CommitMetadata = {
+    new CommitMetadata(
+      version,
+      logPath,
+      commitInfo,
+      readPandMOpt,
+      newProtocolOpt,
+      newMetadataOpt)
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5174/files) to review incremental changes.
- [**stack/kernel_refactor_commit_metadata_test_creation**](https://github.com/delta-io/delta/pull/5174) [[Files changed](https://github.com/delta-io/delta/pull/5174/files)]

---------

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Simple refactor. This PR creates a `TestFixtures` trait -- a generic utility we can use to have helper methods for creating objects. For now, it only contains `createCommitMetadata`. This method creates a CommitMetadata, and provides reasonable defaults (e.g. Optional.empty). This can make creating a CommitMetadata more succinct, and also allows us to add more params to CommitMetadata (e.g. domain metadatas) without having to refactor all the constructor instances!

## How was this patch tested?

Refactor. Existing UTs and CI.

## Does this PR introduce _any_ user-facing changes?

No.
