### PR TITLE
[Kernel][Test-only] Run more write test suites with both the V1 and V2 transaction builders

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
@@ -19,7 +19,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 
 import io.delta.kernel.Table
-import io.delta.kernel.defaults.utils.WriteUtils
+import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.exceptions.InvalidConfigurationValueException
 import io.delta.kernel.expressions.Literal
 import io.delta.kernel.internal.TableConfig
@@ -28,7 +28,13 @@ import io.delta.kernel.types.{FieldMetadata, IntegerType, StringType, StructFiel
 
 import org.scalatest.funsuite.AnyFunSuite
 
-class DeltaColumnMappingSuite extends AnyFunSuite with WriteUtils
+class DeltaColumnMappingTransactionBuilderV1Suite extends DeltaColumnMappingSuiteBase
+    with WriteUtils {}
+
+class DeltaColumnMappingTransactionBuilderV2Suite extends DeltaColumnMappingSuiteBase
+    with WriteUtilsWithV2Builders {}
+
+trait DeltaColumnMappingSuiteBase extends AnyFunSuite with AbstractWriteUtils
     with ColumnMappingSuiteBase {
 
   val simpleTestSchema = new StructType()

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatBaseSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatBaseSuite.scala
@@ -19,7 +19,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.reflect.ClassTag
 
-import io.delta.kernel.defaults.utils.WriteUtils
+import io.delta.kernel.defaults.utils.AbstractWriteUtils
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.tablefeatures.{TableFeature, TableFeatures}
@@ -32,7 +32,7 @@ import org.scalatest.funsuite.AnyFunSuite
  * Base suite containing common test cases for Delta Iceberg compatibility features.
  * This includes tests that apply to both V2 and V3 compatibility modes.
  */
-trait DeltaIcebergCompatBaseSuite extends AnyFunSuite with WriteUtils
+trait DeltaIcebergCompatBaseSuite extends AnyFunSuite with AbstractWriteUtils
     with ColumnMappingSuiteBase {
 
   /** The name of the iceberg compatibility version for display in test names */

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV2Suite.scala
@@ -21,14 +21,21 @@ import scala.reflect.ClassTag
 
 import io.delta.kernel.Table
 import io.delta.kernel.data.Row
+import io.delta.kernel.defaults.utils.{WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.tablefeatures.{TableFeature, TableFeatures}
 import io.delta.kernel.internal.util.{ColumnMapping, VectorUtils}
 import io.delta.kernel.types.{DataType, DateType, FieldMetadata, StructField, StructType, TimestampNTZType, TypeChange}
 
+class DeltaIcebergCompatV2TransactionBuilderV1Suite extends DeltaIcebergCompatV2SuiteBase
+    with WriteUtils {}
+
+class DeltaIcebergCompatV2TransactionBuilderV2Suite extends DeltaIcebergCompatV2SuiteBase
+    with WriteUtilsWithV2Builders {}
+
 /** This suite tests reading or writing into Delta table that have `icebergCompatV2` enabled. */
-class DeltaIcebergCompatV2Suite extends DeltaIcebergCompatBaseSuite {
+trait DeltaIcebergCompatV2SuiteBase extends DeltaIcebergCompatBaseSuite {
 
   import io.delta.kernel.internal.icebergcompat.IcebergCompatMetadataValidatorAndUpdaterSuiteBase._
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV3Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaIcebergCompatV3Suite.scala
@@ -20,14 +20,21 @@ import scala.collection.immutable.Seq
 
 import io.delta.kernel.Table
 import io.delta.kernel.data.Row
+import io.delta.kernel.defaults.utils.{WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableConfig
 import io.delta.kernel.internal.tablefeatures.{TableFeature, TableFeatures}
 import io.delta.kernel.internal.util.{ColumnMapping, VectorUtils}
 import io.delta.kernel.types.{DataType, DateType, FieldMetadata, IntegerType, LongType, StructField, StructType, TimestampNTZType, TypeChange, VariantType}
 
+class DeltaIcebergCompatV3TransactionBuilderV1Suite extends DeltaIcebergCompatV3SuiteBase
+    with WriteUtils {}
+
+class DeltaIcebergCompatV3TransactionBuilderV2Suite extends DeltaIcebergCompatV3SuiteBase
+    with WriteUtilsWithV2Builders {}
+
 /** This suite tests reading or writing into Delta table that have `icebergCompatV3` enabled. */
-class DeltaIcebergCompatV3Suite extends DeltaIcebergCompatBaseSuite {
+trait DeltaIcebergCompatV3SuiteBase extends DeltaIcebergCompatBaseSuite {
 
   import io.delta.kernel.internal.icebergcompat.IcebergCompatMetadataValidatorAndUpdaterSuiteBase._
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableClusteringSuite.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.Seq
 import io.delta.kernel.{Table, Transaction, TransactionCommitResult}
 import io.delta.kernel.Operation.{CREATE_TABLE, WRITE}
 import io.delta.kernel.data.Row
-import io.delta.kernel.defaults.utils.WriteUtils
+import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.{KernelException, TableAlreadyExistsException}
 import io.delta.kernel.expressions.{Column, Literal}
@@ -42,7 +42,32 @@ import org.apache.spark.sql.delta.clustering.{ClusteringMetadataDomain => SparkC
 import org.apache.hadoop.fs.Path
 import org.scalatest.funsuite.AnyFunSuite
 
-class DeltaTableClusteringSuite extends AnyFunSuite with WriteUtils {
+class DeltaTableClusteringTransactionBuilderV1Suite extends DeltaTableClusteringSuiteBase
+    with WriteUtils {
+
+  // It is not possible on an API level to set both clustering and partition columns in V2 builders
+  test("build table txn: " +
+    "clustering column and partition column cannot be set at same time") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val ex = intercept[IllegalArgumentException] {
+        getCreateTxn(
+          engine,
+          tablePath,
+          testPartitionSchema,
+          partCols = Seq("part1"),
+          clusteringColsOpt = Some(List(new Column("PART1"), new Column("part2"))))
+      }
+      assert(
+        ex.getMessage
+          .contains("Partition Columns and Clustering Columns cannot be set at the same time"))
+    }
+  }
+}
+
+class DeltaTableClusteringTransactionBuilderV2Suite extends DeltaTableClusteringSuiteBase
+    with WriteUtilsWithV2Builders {}
+
+trait DeltaTableClusteringSuiteBase extends AnyFunSuite with AbstractWriteUtils {
 
   private val testingDomainMetadata = new DomainMetadata(
     "delta.clustering",
@@ -74,23 +99,6 @@ class DeltaTableClusteringSuite extends AnyFunSuite with WriteUtils {
           clusteringColsOpt = Some(List(new Column("PART1"), new Column("part3"))))
       }
       assert(ex.getMessage.contains("Column 'column(`part3`)' was not found in the table schema"))
-    }
-  }
-
-  test("build table txn: " +
-    "clustering column and partition column cannot be set at same time") {
-    withTempDirAndEngine { (tablePath, engine) =>
-      val ex = intercept[IllegalArgumentException] {
-        getCreateTxn(
-          engine,
-          tablePath,
-          testPartitionSchema,
-          partCols = Seq("part1"),
-          clusteringColsOpt = Some(List(new Column("PART1"), new Column("part2"))))
-      }
-      assert(
-        ex.getMessage
-          .contains("Partition Columns and Clustering Columns cannot be set at the same time"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters._
 
 import io.delta.kernel.{Operation, Table}
 import io.delta.kernel.Operation.CREATE_TABLE
-import io.delta.kernel.defaults.utils.WriteUtils
+import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.{InvalidConfigurationValueException, KernelException}
 import io.delta.kernel.expressions.Literal
@@ -39,10 +39,16 @@ import org.apache.spark.sql.delta.actions.Protocol
 
 import org.scalatest.funsuite.AnyFunSuite
 
+class DeltaTableFeaturesTransactionBuilderV1Suite extends DeltaTableFeaturesSuiteBase
+    with WriteUtils {}
+
+class DeltaTableFeaturesTransactionBuilderV2Suite extends DeltaTableFeaturesSuiteBase
+    with WriteUtilsWithV2Builders {}
+
 /**
  * Integration test suite for Delta table features.
  */
-class DeltaTableFeaturesSuite extends AnyFunSuite with WriteUtils {
+trait DeltaTableFeaturesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
 
   ///////////////////////////////////////////////////////////////////////////
   // Tests for deletionVector, v2Checkpoint table features

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -22,7 +22,7 @@ import scala.collection.immutable.Seq
 
 import io.delta.kernel.{Operation, Table, Transaction, TransactionCommitResult}
 import io.delta.kernel.data.Row
-import io.delta.kernel.defaults.utils.WriteUtils
+import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.expressions.Column
@@ -38,11 +38,17 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables
 
+class DeltaTableSchemaEvolutionTransactionBuilderV1Suite extends DeltaTableSchemaEvolutionSuiteBase
+    with WriteUtils {}
+
+class DeltaTableSchemaEvolutionTransactionBuilderV2Suite extends DeltaTableSchemaEvolutionSuiteBase
+    with WriteUtilsWithV2Builders {}
+
 /**
  * ToDo: Clean this up by moving some common schemas to fixtures and abstracting
  * the setup/run schema evolution/assert loop
  */
-class DeltaTableSchemaEvolutionSuite extends AnyFunSuite with WriteUtils
+trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteUtils
     with ColumnMappingSuiteBase {
 
   test("Add nullable column succeeds and correctly updates maxFieldId") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/IcebergWriterCompatV1Suite.scala
@@ -20,7 +20,7 @@ import scala.collection.immutable.Seq
 
 import io.delta.kernel.{Operation, Table}
 import io.delta.kernel.data.Row
-import io.delta.kernel.defaults.utils.WriteUtils
+import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableConfig
@@ -34,7 +34,13 @@ import io.delta.kernel.utils.CloseableIterable.emptyIterable
 import org.assertj.core.api.Assertions.assertThat
 import org.scalatest.funsuite.AnyFunSuite
 
-class IcebergWriterCompatV1Suite extends AnyFunSuite with WriteUtils
+class IcebergWriterCompatV1TransactionBuilderV1Suite extends IcebergWriterCompatV1SuiteBase
+    with WriteUtils {}
+
+class IcebergWriterCompatV1TransactionBuilderV2Suite extends IcebergWriterCompatV1SuiteBase
+    with WriteUtilsWithV2Builders {}
+
+trait IcebergWriterCompatV1SuiteBase extends AnyFunSuite with AbstractWriteUtils
     with ColumnMappingSuiteBase {
 
   private val tblPropertiesIcebergWriterCompatV1Enabled = Map(
@@ -243,10 +249,12 @@ class IcebergWriterCompatV1Suite extends AnyFunSuite with WriteUtils
                 .build())
         }
         val e = intercept[KernelException] {
-          updateTableMetadata(
+          appendData(
             engine,
             tablePath,
+            isNewTable = isNewTable,
             schema = schemaToCommit,
+            data = Seq.empty,
             tableProperties = tblPropertiesIcebergWriterCompatV1Enabled)
         }
         val expectedInvalidColumnId = if (isNewTable) 1 else 2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Runs additional test suites with both the V1 and V2 transaction builders to increase test coverage. Previously these suites were run using only the V1 builders.

## How was this patch tested?

Test only change.

## Does this PR introduce _any_ user-facing changes?

No.