### PR TITLE
[Spark] ConditionalIncrementMetric

### DIFF
--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -18,6 +18,7 @@ package io.delta.sql
 
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.delta.metric.OptimizeConditionalIncrementMetric
 import org.apache.spark.sql.delta.optimizer.RangePartitionIdRewrite
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -112,6 +113,9 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule { session =>
       new RangePartitionIdRewrite(session)
     }
+    // Optimize ConditionalIncrementMetric with constant condition.
+    extensions.injectOptimizerRule { _ => OptimizeConditionalIncrementMetric }
+
     extensions.injectPostHocResolutionRule { session =>
       PreprocessTableUpdate(session.sessionState.conf)
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/metric/IncrementMetric.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metric/IncrementMetric.scala
@@ -16,12 +16,19 @@
 
 package org.apache.spark.sql.delta.metric
 
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, Nondeterministic, UnaryExpression}
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, Literal, Nondeterministic, UnaryExpression}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BooleanType, DataType}
 
 /**
  * IncrementMetric is used to count the number of rows passing through it. It can be used to
@@ -74,4 +81,120 @@ case class IncrementMetric(child: Expression, metric: SQLMetric)
 
   override protected def withNewChildInternal(newChild: Expression): IncrementMetric =
     copy(child = newChild)
+}
+
+/**
+ * ConditionalIncrementMetric is used to count the number of rows passing through it based on
+ * a condition. It can be used to wrap a child expression to count the number of rows only when
+ * the condition is true. Its currently only accessible via the Scala DSL.
+ *
+ * For example, consider the following expression:
+ * ConditionalIncrementMetric(Literal("SomeValue"), GreaterThan(col("count"), Literal(10)),
+ *   countMetric)
+ *
+ * The SQLMetric `countMetric` would be incremented whenever the condition is true.
+ * Note: Be careful about nullability! The metric will not be incremented if the condition
+ *       evaluates to NULL.
+ *       When trying to invert a condition, use `condition = false` instead of `not condition`,
+ *       if the metrics is supposed to be incremented if condition was NULL.
+ *
+ * The Expression returns the value computed by the child expression.
+ *
+ * It is marked as non deterministic to ensure that it retains strong affinity with the `child`
+ * expression, and is not optimized out, so as to accurately update the `metric`.
+ *
+ * It takes the following parameters:
+ * @param child is the actual expression to call.
+ * @param condition is the Boolean expression that determines whether to increment the metric.
+ * @param metric is the SQLMetric to increment.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(expr, condition, metric) " +
+    "- Returns `expr` as is, while incrementing metric when condition is true.")
+case class ConditionalIncrementMetric(child: Expression, condition: Expression, metric: SQLMetric)
+  extends Expression with Nondeterministic {
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (condition.dataType != BooleanType) {
+      TypeCheckResult.DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_INPUT_TYPE",
+        messageParameters = Map(
+          "paramIndex" -> "second",
+          "requiredType" -> TypeUtils.toSQLType(BooleanType),
+          "inputSql" -> TypeUtils.toSQLExpr(condition),
+          "inputType" -> TypeUtils.toSQLType(condition.dataType)
+        )
+      )
+    } else {
+      TypeCheckResult.TypeCheckSuccess
+    }
+  }
+
+  override def nullable: Boolean = child.nullable
+
+  override def dataType: DataType = child.dataType
+
+  override protected def initializeInternal(partitionIndex: Int): Unit = {}
+
+  override def toString: String = s"conditional_increment_metric($child, $condition)"
+
+  override def prettyName: String = "conditional_increment_metric"
+
+  override def children: Seq[Expression] = Seq(child, condition)
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val childEval = child.genCode(ctx)
+    val conditionEval = condition.genCode(ctx)
+    val metricRef = ctx.addReferenceObj(metric.name.getOrElse("metric"), metric)
+
+    val incrementCode = code"""
+      |${conditionEval.code}
+      |if (!${conditionEval.isNull} && ${conditionEval.value}) {
+      |  $metricRef.add(1L);
+      |}
+      |""".stripMargin
+
+    childEval.copy(code = incrementCode + childEval.code)
+  }
+
+  override def evalInternal(input: InternalRow): Any = {
+    val conditionResult = condition.eval(input)
+    if (conditionResult != null && conditionResult.asInstanceOf[Boolean]) {
+      metric.add(1L)
+    }
+    child.eval(input)
+  }
+
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): ConditionalIncrementMetric = {
+    require(newChildren.length == 2, "ConditionalIncrementMetric requires exactly 2 children")
+    copy(child = newChildren(0), condition = newChildren(1))
+  }
+}
+
+/**
+ * Optimization rule that simplifies ConditionalIncrementMetric expressions with constant
+ * conditions.
+ */
+object OptimizeConditionalIncrementMetric extends Rule[LogicalPlan] {
+  private def isEnabled: Boolean =
+    SQLConf.get.getConf(DeltaSQLConf.DELTA_OPTIMIZE_CONDITIONAL_INCREMENT_METRIC_ENABLED)
+
+  override def apply(plan: LogicalPlan): LogicalPlan = if (isEnabled) {
+    plan.transformAllExpressionsWithSubqueries {
+      case ConditionalIncrementMetric(child, Literal(true, BooleanType), metric) =>
+        // Always true condition: convert to regular IncrementMetric
+        IncrementMetric(child, metric)
+
+      case ConditionalIncrementMetric(child, Literal(false, BooleanType), metric) =>
+        // Always false condition: remove metric logic, keep only child
+        child
+
+      case ConditionalIncrementMetric(child, Literal(null, BooleanType), metric) =>
+        // Null condition: remove metric logic, keep only child
+        child
+    }
+  } else {
+    plan
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1731,6 +1731,14 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_OPTIMIZE_CONDITIONAL_INCREMENT_METRIC_ENABLED =
+    buildConf("optimize.conditionalIncrementMetric.enabled")
+      .internal()
+      .doc("Whether to enable optimization of ConditionalIncrementMetric expressions with " +
+        "constant conditions.")
+      .booleanConf
+      .createWithDefault(true)
+
   val GENERATED_COLUMN_PARTITION_FILTER_OPTIMIZATION_ENABLED =
     buildConf("generatedColumn.partitionFilterOptimization.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/metric/IncrementMetricSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/metric/IncrementMetricSuite.scala
@@ -16,17 +16,22 @@
 
 package org.apache.spark.sql.delta.metric
 
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{Column, DataFrame, QueryTest}
+import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{Expression, GreaterThan, If, Literal}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.BooleanType
 
-abstract class IncrementMetricSuiteBase extends QueryTest with SharedSparkSession {
+abstract class IncrementMetricSuiteBase
+  extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
   import testImplicits._
   import SQLMetrics._
 
@@ -83,6 +88,270 @@ abstract class IncrementMetricSuiteBase extends QueryTest with SharedSparkSessio
     assert(incrementPreFilterMetric.value === ROWS_IN_DF)
     assert(trueBranchCount.value === numRows)
     assert(falseBranchCount.value + numRows === incrementMetric.value)
+  }
+
+  test("ConditionalIncrementMetric with mixed conditions in filters") {
+    val divisibleBy3Metric = createMetric(sparkContext, "divisibleBy3")
+    val oneMod7Metric = createMetric(sparkContext, "divisibleBy7")
+    val rangeMetric = createMetric(sparkContext, "inRange")
+    val largeEvenMetric = createMetric(sparkContext, "largeEven")
+
+    // Count rows divisible by 3 (metric condition) while filtering for divisible by 5
+    // (filter inside ConditionalIncrementMetric).
+    val divisibleBy5Filter =
+      ConditionalIncrementMetric(
+        EqualTo(Pmod(UnresolvedAttribute("a"), Literal(5)), Literal(0)),
+        EqualTo(Pmod(UnresolvedAttribute("a"), Literal(3)), Literal(0)),
+        divisibleBy3Metric)
+
+    // Count numbers where a % 7 == 1 while filtering for a > 10
+    // (filter outside ConditionalIncrementMetric).
+    val divisibleBy7Condition = EqualTo(Pmod(UnresolvedAttribute("a"), Literal(7)), Literal(1))
+    val divisibleBy7Increment =
+      ConditionalIncrementMetric(
+        UnresolvedAttribute("a"),
+        EqualTo(Pmod(UnresolvedAttribute("a"), Literal(7)), Literal(1)),
+        oneMod7Metric)
+    val greaterThan10Filter = GreaterThan(divisibleBy7Increment, Literal(10))
+
+    // Count rows in range 30-70 while filtering for < 50.
+    val rangeCondition = And(
+      GreaterThanOrEqual(UnresolvedAttribute("a"), Literal(30)),
+      LessThanOrEqual(UnresolvedAttribute("a"), Literal(70))
+    )
+    val rangeIncrement =
+      ConditionalIncrementMetric(
+        UnresolvedAttribute("a"),
+        rangeCondition,
+        rangeMetric)
+    val lessThan50Filter = LessThan(rangeIncrement, Literal(50))
+
+    // Count even numbers >= 20 while selecting column a.
+    val largeEvenCondition = And(
+      GreaterThanOrEqual(UnresolvedAttribute("a"), Literal(20)),
+      EqualTo(Pmod(UnresolvedAttribute("a"), Literal(2)), Literal(0))
+    )
+    val largeEvenIncrement =
+      ConditionalIncrementMetric(UnresolvedAttribute("a"), largeEvenCondition, largeEvenMetric)
+
+    val df = testDf
+      .filter(Column(divisibleBy5Filter))    // Filter: a % 5 == 0, Metric: counts a % 3 == 0
+      .filter(Column(greaterThan10Filter))   // Filter: a > 10, Metric: counts a % 7 == 1
+      .filter(Column(lessThan50Filter))      // Filter: a < 80, Metric: counts 30 <= a <= 70
+      .select(
+        Column(largeEvenIncrement).as("result"), // Metric inside Project: counts even a >= 20
+        col("a")
+      )
+      .filter(col("a") >= 30)  // Additional filter after select.
+    val results = df.collect()
+    val numRows = results.size
+    validatePlan(df.queryExecution.executedPlan)
+    // divisibleBy3Metric counts values divisible by 3 among ALL rows (0-999)
+    // The ConditionalIncrementMetric outputs (a % 5 == 0) as boolean for filtering,
+    // but internally counts when (a % 3 == 0).
+    // Divisible by 3: 0,3,6,9,12,15,...,999
+    // Count: 1000/3 = 333.33, so 334 values (includes 0)
+    assert(divisibleBy3Metric.value === 334)
+    // oneMod7Metric counts a % 7 == 1 among rows that pass divisible by 5 filter.
+    // Divisible by 5: 0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,...,995 (200 values)
+    // Among these, a % 7 == 1: 15,50,85,...,995
+    // Pattern: starts at 15, then every 35 (LCM of 5 and 7)
+    // Count: (995-15)/35 + 1 = 29 values
+    assert(oneMod7Metric.value === 29)
+
+    // After divisible by 5 and > 10 filters: 15,20,25,30,35,40,45,50,55,60,65,70,75,...
+    // Among these, in range [30,70]: 30,35,40,45,50,55,60,65,70 = 9 values
+    assert(rangeMetric.value === 9)
+
+    // After divisible by 5, > 10, < 50: 15,20,25,30,35,40,45
+    // Among these, even and >= 20: 20,30,40 = 3 values.
+    assert(largeEvenMetric.value === 3)
+
+    // Final result: divisible by 5, > 10, < 50, >= 30
+    // Values: 30,35,40,45 = 4 rows.
+    assert(numRows === 4)
+  }
+
+  test("ConditionalIncrementMetric with mixed conditions in projections") {
+    val trueMetric = createMetric(sparkContext, "conditionTrue")
+    val falseMetric = createMetric(sparkContext, "conditionFalse")
+    val equalMetric = createMetric(sparkContext, "conditionEqual")
+
+    val trueCondition = LessThan(UnresolvedAttribute("a"), Literal(500))
+    val falseCondition = GreaterThan(UnresolvedAttribute("a"), Literal(ROWS_IN_DF))
+    val equalCondition = EqualTo(UnresolvedAttribute("a"), Literal(42))
+
+    val trueIncrement = ConditionalIncrementMetric(UnresolvedAttribute("a"), trueCondition,
+      trueMetric)
+    val falseIncrement = ConditionalIncrementMetric(UnresolvedAttribute("a"), falseCondition,
+      falseMetric)
+    val equalIncrement = ConditionalIncrementMetric(UnresolvedAttribute("a"), equalCondition,
+      equalMetric)
+
+    val df = testDf
+      .select(
+        Column(trueIncrement).as("true_result"),
+        Column(falseIncrement).as("false_result"),
+        Column(equalIncrement).as("equal_result")
+      )
+    val numRows = df.collect().size
+    validatePlan(df.queryExecution.executedPlan)
+
+    assert(trueMetric.value === 500) // a < 500: rows 0-499
+    assert(falseMetric.value === 0)  // a > 1000: no rows
+    assert(equalMetric.value === 1)  // a == 42: exactly 1 row
+    assert(numRows === ROWS_IN_DF)
+  }
+
+  test("ConditionalIncrementMetric with nullable condition") {
+    val metric = createMetric(sparkContext, "nullable_condition")
+
+    // Create a DataFrame with nullable boolean values.
+    val df = spark.range(10).selectExpr(
+      "id",
+      "CASE WHEN id % 3 = 0 THEN null WHEN id % 3 = 1 THEN true ELSE false END AS nullable_bool"
+    )
+
+    // Create condition that can be null.
+    val conditionExpr = UnresolvedAttribute("nullable_bool")
+    val incrementExpr = ConditionalIncrementMetric(
+      UnresolvedAttribute("id"),
+      conditionExpr,
+      metric
+    )
+
+    val resultDf = df.select(Column(incrementExpr).as("result"))
+    val numRows = resultDf.collect().size
+    validatePlan(resultDf.queryExecution.executedPlan)
+
+    // The metric should only count rows where condition is true (not null and not false).
+    // id=1,4,7 have nullable_bool=true (3 rows)
+    // id=0,3,6,9 have nullable_bool=null (4 rows) - should NOT be counted
+    // id=2,5,8 have nullable_bool=false (3 rows) - should NOT be counted
+    assert(metric.value === 3)
+    assert(numRows === 10)
+  }
+
+  test("ConditionalIncrementMetric with invalid condition type") {
+    val metric = createMetric(sparkContext, "invalidType")
+    val nonBooleanCondition = UnresolvedAttribute("a")  // Integer type
+    val increment =
+      ConditionalIncrementMetric(UnresolvedAttribute("a"), nonBooleanCondition, metric)
+
+    // This should fail during analysis due to non-boolean condition type.
+    val exception = intercept[AnalysisException] {
+      val df = testDf.select(Column(increment).as("result"))
+      df.collect()
+    }
+    assert(exception.getErrorClass == "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE")
+  }
+
+  for (enabled <- BOOLEAN_DOMAIN) {
+    test(s"ConditionalIncrementMetric optimization - literal conditions - enabled=$enabled") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_OPTIMIZE_CONDITIONAL_INCREMENT_METRIC_ENABLED.key -> enabled.toString) {
+        val trueMetric = createMetric(sparkContext, s"literalTrue$enabled")
+        val falseMetric = createMetric(sparkContext, s"literalFalse$enabled")
+        val nullMetric = createMetric(sparkContext, s"literalNull$enabled")
+        val nonConstMetric = createMetric(sparkContext, s"nonConst$enabled")
+
+        val childExpr = UnresolvedAttribute("a")
+        val trueCondition = Literal(true, BooleanType)
+        val falseCondition = Literal(false, BooleanType)
+        val nullCondition = Literal(null, BooleanType)
+        val nonConstCondition = GreaterThan(UnresolvedAttribute("a"), Literal(100))
+
+        val trueExpr = ConditionalIncrementMetric(childExpr, trueCondition, trueMetric)
+        val falseExpr = ConditionalIncrementMetric(childExpr, falseCondition, falseMetric)
+        val nullExpr = ConditionalIncrementMetric(childExpr, nullCondition, nullMetric)
+        val nonConstExpr = ConditionalIncrementMetric(childExpr, nonConstCondition, nonConstMetric)
+
+        val df = testDf.select(
+          Column(trueExpr).as("true_result"),
+          Column(falseExpr).as("false_result"),
+          Column(nullExpr).as("null_result"),
+          Column(nonConstExpr).as("nonconst_result")
+        )
+
+        // Check optimized plan transformations.
+        val optimizedPlan = df.queryExecution.optimizedPlan
+        var conditionalCount = 0
+        var nonConditionalCount = 0
+        optimizedPlan.foreach {
+          _.transformExpressions {
+            case e: ConditionalIncrementMetric =>
+              conditionalCount += 1
+              e
+            case e: IncrementMetric =>
+              nonConditionalCount += 1
+              e
+          }
+        }
+
+        if (enabled) {
+          assert(conditionalCount === 1,
+            s"ConditionalIncrementMetric with non-const cond should remain unchanged." +
+              s"\n$optimizedPlan")
+          assert(nonConditionalCount === 1,
+            s"ConditionalIncrementMetric with cond true should become IncrementMetric" +
+              s"\n$optimizedPlan")
+          // ConditionalIncrementMetric with condition false or null have gotten removed.
+        } else {
+          assert(conditionalCount === 4,
+            s"All ConditionalIncrementMetric expressions should remain unchanged when " +
+              s"optimization is disabled.\n$optimizedPlan")
+          assert(nonConditionalCount === 0,
+            s"No ConditionalIncrementMetric should be converted to IncrementMetric when " +
+              s"optimization is disabled.\n$optimizedPlan")
+        }
+
+        // Verify metrics work correctly regardless of optimization state.
+        df.collect()
+
+        validatePlan(df.queryExecution.executedPlan)
+
+        assert(trueMetric.value === ROWS_IN_DF)  // All rows counted (true condition)
+        assert(falseMetric.value === 0)          // No rows counted (false condition)
+        assert(nullMetric.value === 0)           // No rows counted (null condition)
+        assert(nonConstMetric.value === 899)   // Rows where a > 100 (101-999)
+      }
+    }
+  }
+
+  test("ConditionalIncrementMetric with all-null condition column") {
+    val metric = createMetric(sparkContext, "allNullCondition")
+
+    // Create a DataFrame where the condition column is always null.
+    val df = spark.range(10).selectExpr("id", "try_divide(id, 0) < 0 as null_condition")
+
+    // Use the null condition column (not a literal, but all values are null).
+    val incrementExpr = ConditionalIncrementMetric(
+      UnresolvedAttribute("id"),
+      UnresolvedAttribute("null_condition"),
+      metric)
+
+    val resultDf = df.select(Column(incrementExpr).as("result"))
+
+    // This should NOT be optimized away since it's not a literal condition.
+    val optimizedPlan = resultDf.queryExecution.optimizedPlan
+    var conditionalCount = 0
+    optimizedPlan.foreach {
+      _.transformExpressions {
+        case e: ConditionalIncrementMetric =>
+          conditionalCount += 1
+          e
+      }
+    }
+
+    assert(conditionalCount === 1,
+      s"Non-literal all-null condition should preserve ConditionalIncrementMetric\n$optimizedPlan")
+
+    val numRows = resultDf.collect().size
+    validatePlan(resultDf.queryExecution.executedPlan)
+
+    // The metric should be 0 since all condition values are null.
+    assert(metric.value === 0, "All-null condition should count 0 rows")
+    assert(numRows === 10)
   }
 
   protected def validatePlan(plan: SparkPlan): Unit = {}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Resubmit https://github.com/delta-io/delta/pull/5172 which needed to be reverted because of failure.

Add `ConditionalIncrementMetric` expression that allows to increment a metric only if an additional conditions is passed.
In some cases, `IncrementMetric` is used inside a more complex expression, like `if (updated) IncrementMetric("numUpdatedRows", true) else IncrementMetric("numCopiedRows", false)`. But in some cases, Spark can optimize some of these out. `ConditionalIncrementMetric` will let us express this better.

## How was this patch tested?

Tests added.

## Does this PR introduce _any_ user-facing changes?

No