### PR TITLE
[Kernel][Test-only] Run DomainMetadataSuite with the new and legacy APIs for both read/write loads

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
@@ -91,17 +91,14 @@ trait AbstractDomainMetadataSuite extends AnyFunSuite with AbstractWriteUtils
       tablePath: String,
       domainMetadatas: Seq[DomainMetadata],
       expectedValue: Map[String, DomainMetadata],
-      useInternalApi: Boolean = false,
-      enableDomainMetadata: Boolean = false): Unit = {
+      useInternalApi: Boolean = false): Unit = {
     // Create the transaction with domain metadata and commit
 
-    // I think this can actually just not override enableDomainMetadata & remove the arg?...
     val txn = createTxnWithDomainMetadatas(
       engine,
       tablePath,
       domainMetadatas,
-      useInternalApi,
-      enableDomainMetadata = enableDomainMetadata)
+      useInternalApi)
     commitTransaction(txn, engine, emptyIterable())
 
     // Verify the final state includes the expected domain metadata
@@ -235,8 +232,7 @@ trait AbstractDomainMetadataSuite extends AnyFunSuite with AbstractWriteUtils
         engine,
         tablePath,
         domainMetadatas = Seq(dm1),
-        expectedValue = Map("domain1" -> dm1),
-        enableDomainMetadata = true)
+        expectedValue = Map("domain1" -> dm1))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
@@ -141,6 +141,9 @@ trait AbstractDomainMetadataSuite extends AnyFunSuite with AbstractWriteUtils
      * t5 ------- Txn3 commits.
      * t6 ------------------------ Txn1 commits (SUCCESS or FAIL).
      */
+    // For these txns, set enableDomainMetadata = false since it's already been enabled in the
+    // initial table, and for V2 builders, re-enabling it will commit a new Metadata change (which
+    // will always trigger a conflict!)
     val txn1 = createTxnWithDomainMetadatas(
       engine,
       tablePath,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.Seq
 import io.delta.kernel._
 import io.delta.kernel.data.Row
 import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
-import io.delta.kernel.defaults.utils.WriteUtils
+import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV1Builders, WriteUtilsWithV2Builders}
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions._
 import io.delta.kernel.expressions.Literal
@@ -40,7 +40,14 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits.OptimisticTxnTestHelpe
 import org.apache.hadoop.fs.Path
 import org.scalatest.funsuite.AnyFunSuite
 
-class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteBase {
+/** Runs domain metadata tests using the TableManager snapshot APIs and V2 transaction builders */
+class DomainMetadataSuite extends AbstractDomainMetadataSuite with WriteUtilsWithV2Builders
+
+/** Runs domain metadata tests using the legacy Table snapshot APIs and V1 transaction builders */
+class LegacyDomainMetadataSuite extends AbstractDomainMetadataSuite with WriteUtilsWithV1Builders
+
+trait AbstractDomainMetadataSuite extends AnyFunSuite with AbstractWriteUtils
+    with ParquetSuiteBase {
 
   private def assertDomainMetadata(
       snapshot: SnapshotImpl,
@@ -59,14 +66,13 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
   }
 
   private def assertDomainMetadata(
-      table: Table,
+      tablePath: String,
       engine: Engine,
       expectedValue: Map[String, DomainMetadata]): Unit = {
-    // Get the latest snapshot of the table
-    val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+    // Get the table and latest snapshot
+    val snapshot = getTableManagerAdapter.getSnapshotAtLatest(engine, tablePath)
     assertDomainMetadata(snapshot, expectedValue)
     // verifyChecksum will check the domain metadata in CRC against the lastest snapshot.
-    val tablePath = table.getPath(engine)
     verifyChecksum(tablePath)
     // Delete CRC and reload snapshot from log.
     deleteChecksumFileForTable(
@@ -74,10 +80,10 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
       versions = Seq(snapshot.getVersion.toInt))
     // Rebuild table to avoid loading domain metadata from cached crc info.
     assertDomainMetadata(
-      Table.forPath(engine, tablePath).getLatestSnapshot(engine).asInstanceOf[SnapshotImpl],
+      getTableManagerAdapter.getSnapshotAtLatest(engine, tablePath),
       expectedValue)
     // Write CRC back so that subsequence operation could generate CRC incrementally.
-    table.checksum(engine, snapshot.getVersion)
+    Table.forPath(engine, tablePath).checksum(engine, snapshot.getVersion)
   }
 
   private def commitDomainMetadataAndVerify(
@@ -85,14 +91,21 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
       tablePath: String,
       domainMetadatas: Seq[DomainMetadata],
       expectedValue: Map[String, DomainMetadata],
-      useInternalApi: Boolean = false): Unit = {
+      useInternalApi: Boolean = false,
+      enableDomainMetadata: Boolean = false): Unit = {
     // Create the transaction with domain metadata and commit
-    val txn = createTxnWithDomainMetadatas(engine, tablePath, domainMetadatas, useInternalApi)
+
+    // I think this can actually just not override enableDomainMetadata & remove the arg?...
+    val txn = createTxnWithDomainMetadatas(
+      engine,
+      tablePath,
+      domainMetadatas,
+      useInternalApi,
+      enableDomainMetadata = enableDomainMetadata)
     commitTransaction(txn, engine, emptyIterable())
 
     // Verify the final state includes the expected domain metadata
-    val table = Table.forPath(engine, tablePath)
-    assertDomainMetadata(table, engine, expectedValue)
+    assertDomainMetadata(tablePath, engine, expectedValue)
   }
 
   private def createTableWithDomainMetadataSupported(engine: Engine, tablePath: String): Unit = {
@@ -102,7 +115,6 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
         engine,
         tablePath,
         testSchema,
-        Seq.empty,
         withDomainMetadataSupported = true),
       engine,
       emptyIterable())
@@ -117,7 +129,6 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
       expectedConflict: Boolean): Unit = {
     // Create table with domain metadata support
     createTableWithDomainMetadataSupported(engine, tablePath)
-    val table = Table.forPath(engine, tablePath)
 
     /**
      * Txn1: i.e. the current transaction that comes later than winning transactions.
@@ -133,12 +144,24 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
      * t5 ------- Txn3 commits.
      * t6 ------------------------ Txn1 commits (SUCCESS or FAIL).
      */
-    val txn1 = createTxnWithDomainMetadatas(engine, tablePath, currentTxn1DomainMetadatas)
+    val txn1 = createTxnWithDomainMetadatas(
+      engine,
+      tablePath,
+      currentTxn1DomainMetadatas,
+      enableDomainMetadata = false)
 
-    val txn2 = createTxnWithDomainMetadatas(engine, tablePath, winningTxn2DomainMetadatas)
+    val txn2 = createTxnWithDomainMetadatas(
+      engine,
+      tablePath,
+      winningTxn2DomainMetadatas,
+      enableDomainMetadata = false)
     commitTransaction(txn2, engine, emptyIterable())
 
-    val txn3 = createTxnWithDomainMetadatas(engine, tablePath, winningTxn3DomainMetadatas)
+    val txn3 = createTxnWithDomainMetadatas(
+      engine,
+      tablePath,
+      winningTxn3DomainMetadatas,
+      enableDomainMetadata = false)
     commitTransaction(txn3, engine, emptyIterable())
 
     if (expectedConflict) {
@@ -157,7 +180,7 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
         (winningTxn2DomainMetadatas ++ winningTxn3DomainMetadatas ++ currentTxn1DomainMetadatas)
           .groupBy(_.getDomain)
           .mapValues(_.last)
-      assertDomainMetadata(table, engine, expectedMetadata)
+      assertDomainMetadata(tablePath, engine, expectedMetadata)
     }
   }
 
@@ -170,16 +193,14 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
 
   test("create table w/o domain metadata") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = Table.forPath(engine, tablePath)
-
       // Create an empty table
       commitTransaction(
-        getCreateTxn(engine, tablePath, testSchema, Seq.empty),
+        getCreateTxn(engine, tablePath, testSchema),
         engine,
         emptyIterable())
 
       // Verify that the table doesn't have any domain metadata
-      assertDomainMetadata(table, engine, Map.empty)
+      assertDomainMetadata(tablePath, engine, Map.empty)
     }
   }
 
@@ -214,7 +235,8 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
         engine,
         tablePath,
         domainMetadatas = Seq(dm1),
-        expectedValue = Map("domain1" -> dm1))
+        expectedValue = Map("domain1" -> dm1),
+        enableDomainMetadata = true)
     }
   }
 
@@ -253,14 +275,12 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
         expectedValue = Map("domain1" -> dm1, "domain2" -> dm2))
 
       // Restart the table and verify the domain metadata
-      val table2 = Table.forPath(engine, tablePath)
-      assertDomainMetadata(table2, engine, Map("domain1" -> dm1, "domain2" -> dm2))
+      assertDomainMetadata(tablePath, engine, Map("domain1" -> dm1, "domain2" -> dm2))
     }
   }
 
   test("only the latest domain metadata per domain is stored in checkpoints") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = Table.forPath(engine, tablePath)
       createTableWithDomainMetadataSupported(engine, tablePath)
 
       val dm1 = new DomainMetadata("domain1", """{"key1":"1"}, {"key2":"2"}""", false)
@@ -281,13 +301,12 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
       }
 
       // Checkpoint the table
-      val latestVersion = table.getLatestSnapshot(engine).getVersion()
-      table.checkpoint(engine, latestVersion)
+      val latestVersion = getTableManagerAdapter.getSnapshotAtLatest(engine, tablePath).getVersion()
+      Table.forPath(engine, tablePath).checkpoint(engine, latestVersion)
 
       // Verify that only the latest domain metadata is persisted in the checkpoint
-      val table2 = Table.forPath(engine, tablePath)
       assertDomainMetadata(
-        table2,
+        tablePath,
         engine,
         Map("domain1" -> dm1_2, "domain2" -> dm2))
     }
@@ -449,7 +468,7 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
         val dm3 = new DomainMetadata("testDomain3", "", false)
 
         assertDomainMetadata(
-          Table.forPath(defaultEngine, tablePath),
+          tablePath,
           defaultEngine,
           Map("testDomain1" -> dm1, "testDomain3" -> dm3))
       }
@@ -478,9 +497,9 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
           data = Seq(Map.empty[String, Literal] -> dataBatches1))
 
         // Checkpoint the table so domain metadata is distributed to both checkpoint and log files
-        val table = Table.forPath(engine, tablePath)
-        val latestVersion = table.getLatestSnapshot(engine).getVersion()
-        table.checkpoint(engine, latestVersion)
+        val latestVersion =
+          getTableManagerAdapter.getSnapshotAtLatest(engine, tablePath).getVersion()
+        Table.forPath(engine, tablePath).checkpoint(engine, latestVersion)
 
         // Manually commit two domain metadata actions
         val dm1_2 = new DomainMetadata("testDomain1", """{"key1":"10"}""", false)
@@ -531,8 +550,7 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
       )
 
       // Read the RowTrackingMetadataDomain from the table and verify
-      val table = Table.forPath(engine, tablePath)
-      val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val snapshot = getTableManagerAdapter.getSnapshotAtLatest(engine, tablePath)
       val rowTrackingMetadataDomainFromSnapshot =
         RowTrackingMetadataDomain.fromSnapshot(snapshot)
 
@@ -557,8 +575,7 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
         spark.range(20, 100).write.format("delta").mode("append").save(tablePath)
 
         // Read the RowTrackingMetadataDomain from the table using Kernel
-        val table = Table.forPath(engine, tablePath)
-        val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+        val snapshot = getTableManagerAdapter.getSnapshotAtLatest(engine, tablePath)
         val rowTrackingMetadataDomainRead = RowTrackingMetadataDomain.fromSnapshot(snapshot)
 
         assert(rowTrackingMetadataDomainRead.isPresent)
@@ -621,7 +638,7 @@ class DomainMetadataSuite extends AnyFunSuite with WriteUtils with ParquetSuiteB
 
   test("updating domain metadata fails after transaction committed") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val txn = getCreateTxn(engine, tablePath, testSchema, Seq.empty)
+      val txn = getCreateTxn(engine, tablePath, testSchema)
       commitTransaction(txn, engine, emptyIterable())
 
       intercept[IllegalStateException] {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
@@ -18,7 +18,7 @@ package io.delta.kernel.defaults
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.{Table, TableManager}
-import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
+import io.delta.kernel.defaults.utils.{AbstractTestUtils, AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.exceptions.{KernelException, UnknownConfigurationException}
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
 
@@ -77,7 +77,7 @@ class TablePropertiesTransactionBuilderV2Suite extends TablePropertiesSuiteBase
 /**
  * Suite to set or get table properties.
  */
-trait TablePropertiesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
+trait TablePropertiesSuiteBase extends AnyFunSuite with AbstractTestUtils with AbstractWriteUtils {
   test("create/update/replace table - allow arbitrary properties") {
     withTempDir { tempFile =>
       val tablePath = tempFile.getAbsolutePath

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
@@ -18,7 +18,7 @@ package io.delta.kernel.defaults
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.{Table, TableManager}
-import io.delta.kernel.defaults.utils.{AbstractTestUtils, AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
+import io.delta.kernel.defaults.utils.{AbstractWriteUtils, WriteUtils, WriteUtilsWithV2Builders}
 import io.delta.kernel.exceptions.{KernelException, UnknownConfigurationException}
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
 
@@ -77,7 +77,7 @@ class TablePropertiesTransactionBuilderV2Suite extends TablePropertiesSuiteBase
 /**
  * Suite to set or get table properties.
  */
-trait TablePropertiesSuiteBase extends AnyFunSuite with AbstractTestUtils with AbstractWriteUtils {
+trait TablePropertiesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
   test("create/update/replace table - allow arbitrary properties") {
     withTempDir { tempFile =>
       val tablePath = tempFile.getAbsolutePath

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
@@ -50,11 +50,17 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
-/** Default write utilities that use the V1 transaction builders. */
+/** Default write utilities that use the V1 transaction builders and legacy Table Snapshot APIs */
 trait WriteUtils extends AbstractWriteUtils with TransactionBuilderV1Support
     with TestUtilsWithLegacyKernelAPIs
 
-/** Write utilities that use the V2 transaction builders to create transactions */
+/**
+ * DO NOT MODIFY this trait -- this is just syntactic sugar to clearly indicate we are extending the
+ * "default" TestUtils which happens to use the legacy Kernel APIs
+ */
+trait WriteUtilsWithV1Builders extends WriteUtils
+
+/** Write utilities that use the V2 transaction builders to create transactions and TableManager snapshot APIs */
 trait WriteUtilsWithV2Builders extends AbstractWriteUtils with TransactionBuilderV2Support
     with TestUtilsWithTableManagerAPIs
 
@@ -66,7 +72,6 @@ trait WriteUtilsWithV2Builders extends AbstractWriteUtils with TransactionBuilde
  * overridden in child suites.
  */
 trait AbstractWriteUtils extends TestUtils with TransactionBuilderSupport {
-
   val OBJ_MAPPER = new ObjectMapper()
   val testEngineInfo = "test-engine"
 
@@ -319,10 +324,11 @@ trait AbstractWriteUtils extends TestUtils with TransactionBuilderSupport {
       engine: Engine,
       tablePath: String,
       domainMetadatas: Seq[DomainMetadata],
-      useInternalApi: Boolean = false): Transaction = {
+      useInternalApi: Boolean = false,
+      enableDomainMetadata: Boolean = true): Transaction = {
 
     val txn = if (domainMetadatas.nonEmpty && !useInternalApi) {
-      getUpdateTxn(engine, tablePath, withDomainMetadataSupported = true)
+      getUpdateTxn(engine, tablePath, withDomainMetadataSupported = enableDomainMetadata)
         .asInstanceOf[TransactionImpl]
     } else {
       getUpdateTxn(engine, tablePath).asInstanceOf[TransactionImpl]

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
@@ -65,7 +65,8 @@ trait WriteUtilsWithV2Builders extends AbstractWriteUtils with TransactionBuilde
  * example, `commitTransaction` could go into a [[TransactionCommitSupport]] trait since it is
  * overridden in child suites.
  */
-trait AbstractWriteUtils extends TransactionBuilderSupport { self: AbstractTestUtils =>
+trait AbstractWriteUtils extends TestUtils with TransactionBuilderSupport {
+
   val OBJ_MAPPER = new ObjectMapper()
   val testEngineInfo = "test-engine"
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
@@ -52,9 +52,11 @@ import org.apache.hadoop.fs.Path
 
 /** Default write utilities that use the V1 transaction builders. */
 trait WriteUtils extends AbstractWriteUtils with TransactionBuilderV1Support
+    with TestUtilsWithLegacyKernelAPIs
 
 /** Write utilities that use the V2 transaction builders to create transactions */
 trait WriteUtilsWithV2Builders extends AbstractWriteUtils with TransactionBuilderV2Support
+    with TestUtilsWithTableManagerAPIs
 
 /**
  * Common utility methods for write test suites. For now, this includes mostly concrete
@@ -63,7 +65,7 @@ trait WriteUtilsWithV2Builders extends AbstractWriteUtils with TransactionBuilde
  * example, `commitTransaction` could go into a [[TransactionCommitSupport]] trait since it is
  * overridden in child suites.
  */
-trait AbstractWriteUtils extends TestUtils with TransactionBuilderSupport {
+trait AbstractWriteUtils extends TransactionBuilderSupport { self: AbstractTestUtils =>
   val OBJ_MAPPER = new ObjectMapper()
   val testEngineInfo = "test-engine"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Refactors DomainMetadataSuite to run with both
- New APIs: load snapshots using TableManager and build transactions using V2 builders
- Legacy APIs: load snapshots using Table and build transactions with the V1 builder

This is done to increase test coverage.

## How was this patch tested?

Test change.

## Does this PR introduce _any_ user-facing changes?

No.