### PR TITLE
[Spark] Plumb catalog tables to `DeltaLog` API call sites in `DeltaSInk`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{ImplicitMetadataOperation, SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.AllowAutomaticWideningMode
+import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.hadoop.fs.Path
 
 // scalastyle:off import.ordering.noEmptyLine
@@ -58,7 +59,8 @@ case class DeltaSink(
     with UpdateExpressionsSupport
     with DeltaLogging {
 
-  private val deltaLog = DeltaLog.forTable(sqlContext.sparkSession, path)
+  private lazy val deltaLog = DeltaUtils.getDeltaLogFromTableOrPath(
+    sqlContext.sparkSession, catalogTable, path)
 
   private val sqlConf = sqlContext.sparkSession.sessionState.conf
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
@@ -18,10 +18,14 @@ package org.apache.spark.sql.delta.util
 
 import scala.util.Random
 
-import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.delta.actions.Metadata
 
+import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.{functions, Column, Dataset}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.ElementAt
 
 /**
@@ -49,6 +53,22 @@ object Utils {
   /** Generates a string created of `randomPrefixLength` alphanumeric characters. */
   def getRandomPrefix(numChars: Int): String = {
     Random.alphanumeric.take(numChars).mkString
+  }
+
+  /**
+   * Construct a delta log from either the catalog table or a path.
+   *
+   * If catalogTableOpt is defined, use it to construct the delta log; otherwise, fall back to use
+   * path-based delta log construction.
+   */
+  def getDeltaLogFromTableOrPath(
+      sparkSession: SparkSession,
+      catalogTableOpt: Option[CatalogTable],
+      path: Path,
+      options: Map[String, String] = Map.empty): DeltaLog = {
+    catalogTableOpt
+      .map(catalogTable => DeltaLog.forTable(sparkSession, catalogTable, options))
+      .getOrElse(DeltaLog.forTable(sparkSession, path, options))
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -24,11 +24,13 @@ import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
 import org.apache.spark.sql.delta.sources.{DeltaSink, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
+import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.commons.io.FileUtils
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.DataSourceScanExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.streaming.{MemoryStream, MicroBatchExecution, StreamingQueryWrapper}
@@ -73,7 +75,8 @@ abstract class DeltaSinkTest
 class DeltaSinkSuite
   extends DeltaSinkTest
   with DeltaColumnMappingTestUtils
-  with CoordinatedCommitsBaseSuite  {
+  with CoordinatedCommitsBaseSuite
+  with DeltaSQLTestUtils {
 
   import testImplicits._
 
@@ -617,6 +620,40 @@ class DeltaSinkSuite
     }
   }
 
+  test(
+    "DeltaSink.deltaLog is not initialized in DeltaSink constructor"
+  ) {
+    withTempTable(createTable = true) { tableName =>
+      val outputDir = DeltaLog.forTable(spark, TableIdentifier(tableName)).dataPath
+
+      // Create a DeltaSink instance directly
+      val deltaSink = new DeltaSink(
+        spark.sqlContext,
+        outputDir,
+        partitionColumns = Seq.empty[String],
+        outputMode = OutputMode.Append,
+        options = new DeltaOptions(Map(
+          "checkpointlocation" -> outputDir.toString,
+          "path" -> outputDir.toString
+        ), spark.sessionState.conf)
+      )
+
+      // Helper function to check if deltaLog is initialized using reflection
+      def isDeltaLogInitialized(sink: DeltaSink): Boolean = {
+        val fieldOpt = classOf[DeltaSink].getDeclaredFields.find(
+          f => f.getName.contains("deltaLog") && f.getType == classOf[DeltaLog])
+        assert(fieldOpt.isDefined, "deltaLog field not found")
+        fieldOpt.exists { field =>
+          field.setAccessible(true)
+          field.get(sink) != null
+        }
+      }
+
+      // Test that deltaLog is NOT initialized after constructor
+      assert(!isDeltaLogInitialized(deltaSink),
+        "deltaLog should not be initialized after constructor")
+    }
+  }
 }
 
 class DeltaSinkWithCoordinatedCommitsBatch1Suite extends DeltaSinkSuite {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Plumb catalog tables to `DeltaLog` API call sites in class `DeltaSink`.

`DeltaLog` API call includes:
1. `DeltaLog.forTable`
2. `deltaLog.getSnapshotAt`
3. `deltaLog.update`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
