### PR TITLE
[Kernel] Support reading/writing variant stats in JSON

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/JsonUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/JsonUtils.java
@@ -254,6 +254,13 @@ public class JsonUtils {
         long epochMicros = ChronoUnit.MICROS.between(EPOCH.toLocalDateTime(), localDateTime);
         return Literal.ofTimestampNtz(epochMicros);
 
+      } else if (dataType instanceof VariantType) {
+        if (!valueNode.isTextual()) {
+          throw new KernelException(
+              String.format("Expected variant as string value but got: %s", valueNode));
+        }
+        String textValue = valueNode.asText();
+        return Literal.ofString(textValue);
       } else {
         throw unsupportedStatsDataType(dataType);
       }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/DataFileStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/DataFileStatistics.java
@@ -382,7 +382,7 @@ public class DataFileStatistics {
         field.getDataType() instanceof VariantType ? StringType.STRING : field.getDataType();
     if (literal.getDataType() == null || !literal.getDataType().equals(expectedLiteralType)) {
       throw DeltaErrors.statsTypeMismatch(
-          field.getName(), field.getDataType(), literal.getDataType());
+          field.getName(), expectedLiteralType, literal.getDataType());
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/DataFileStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/DataFileStatistics.java
@@ -377,7 +377,10 @@ public class DataFileStatistics {
    * @throws KernelException if the data types don't match
    */
   private void validateLiteralType(StructField field, Literal literal) {
-    if (literal.getDataType() == null || !literal.getDataType().equals(field.getDataType())) {
+    // Variant stats in JSON are Z85 encoded strings, all other stats should match the field type
+    DataType expectedLiteralType =
+        field.getDataType() instanceof VariantType ? StringType.STRING : field.getDataType();
+    if (literal.getDataType() == null || !literal.getDataType().equals(expectedLiteralType)) {
       throw DeltaErrors.statsTypeMismatch(
           field.getName(), field.getDataType(), literal.getDataType());
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataFileStatisticsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataFileStatisticsSuite.scala
@@ -61,6 +61,7 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
       .add("TimestampNTZType", TimestampNTZType.TIMESTAMP_NTZ)
       .add("BinaryType", BinaryType.BINARY)
       .add("NestedStruct", nestedStructType)
+      .add("VariantType", VariantType.VARIANT)
 
     val minValues = Map(
       new Column("ByteType") -> Literal.ofByte(1.toByte),
@@ -76,7 +77,9 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
       new Column("TimestampNTZType") -> Literal.ofTimestampNtz(1L),
       new Column("BinaryType") -> Literal.ofBinary("a".getBytes),
       new Column(Array("NestedStruct", "aa")) -> Literal.ofString("a"),
-      new Column(Array("NestedStruct", "ac", "aca")) -> Literal.ofInt(1)).asJava
+      new Column(Array("NestedStruct", "ac", "aca")) -> Literal.ofInt(1),
+      new Column("VariantType") -> Literal.ofString(
+        "0S&u501fk+ze0(tB98CpzF6vU0rJl95HpNdvjbtatpi(cu0wW^cTu")).asJava
 
     val maxValues = Map(
       new Column("ByteType") -> Literal.ofByte(10.toByte),
@@ -92,7 +95,9 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
       new Column("TimestampNTZType") -> Literal.ofTimestampNtz(10L),
       new Column("BinaryType") -> Literal.ofBinary("z".getBytes),
       new Column(Array("NestedStruct", "aa")) -> Literal.ofString("z"),
-      new Column(Array("NestedStruct", "ac", "aca")) -> Literal.ofInt(10)).asJava
+      new Column(Array("NestedStruct", "ac", "aca")) -> Literal.ofInt(10),
+      new Column("VariantType") -> Literal.ofString(
+        "0S&u500&]LC42A9vqZe}wb#-i1}-a+cT!xdbWhT9cTx}7v<+K")).asJava
 
     val nullCount = Map(
       new Column("ByteType") -> 1L,
@@ -108,7 +113,8 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
       new Column("TimestampNTZType") -> 1L,
       new Column("BinaryType") -> 1L,
       new Column(Array("NestedStruct", "aa")) -> 1L,
-      new Column(Array("NestedStruct", "ac", "aca")) -> 1L)
+      new Column(Array("NestedStruct", "ac", "aca")) -> 1L,
+      new Column("VariantType") -> 1L)
 
     val tightBounds = false
 
@@ -140,7 +146,8 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
         |      "ac": {
         |        "aca": 1
         |      }
-        |    }
+        |    },
+        |    "VariantType": "0S&u501fk+ze0(tB98CpzF6vU0rJl95HpNdvjbtatpi(cu0wW^cTu"
         |  },
         |  "maxValues": {
         |    "ByteType": 10,
@@ -160,7 +167,8 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
         |      "ac": {
         |        "aca": 10
         |      }
-        |    }
+        |    },
+        |    "VariantType": "0S&u500&]LC42A9vqZe}wb#-i1}-a+cT!xdbWhT9cTx}7v<+K"
         |  },
         |  "nullCount": {
         |    "ByteType": 1,
@@ -180,7 +188,8 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
         |      "ac": {
         |        "aca": 1
         |      }
-        |    }
+        |    },
+        |    "VariantType": 1
         |},
         |"tightBounds": false
         |}""".stripMargin
@@ -489,6 +498,7 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
       .add("TimestampNTZType", TimestampNTZType.TIMESTAMP_NTZ)
       .add("BinaryType", BinaryType.BINARY)
       .add("BooleanType", BooleanType.BOOLEAN)
+      .add("VariantType", VariantType.VARIANT)
 
     val json =
       """{
@@ -506,7 +516,8 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
         |    "TimestampType": "1970-01-01T00:00:00.001Z",
         |    "TimestampNTZType": "1970-01-01T00:00:00.001",
         |    "BinaryType": "a",
-        |    "BooleanType": true
+        |    "BooleanType": true,
+        |    "VariantType": "0S&u501fk+ze0(tB98CpzF6vU0rJl95HpNdvjbtatpi(cu0wW^cTu"
         |  },
         |  "maxValues": {
         |    "ByteType": 10,
@@ -521,7 +532,8 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
         |    "TimestampType": "1970-01-01T00:00:00.010Z",
         |    "TimestampNTZType": "1970-01-01T00:00:00.010",
         |    "BinaryType": "z",
-        |    "BooleanType": false
+        |    "BooleanType": false,
+        |    "VariantType": "0S&u500&]LC42A9vqZe}wb#-i1}-a+cT!xdbWhT9cTx}7v<+K"
         |  },
         |  "nullCount": {
         |    "ByteType": 1,
@@ -544,11 +556,15 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
     assert(minValues.get(new Column("FloatType")).getValue == 0.1f)
     assert(minValues.get(new Column("StringType")).getValue == "a")
     assert(minValues.get(new Column("BooleanType")).getValue == true)
+    assert(minValues.get(new Column("VariantType")).getValue ==
+      "0S&u501fk+ze0(tB98CpzF6vU0rJl95HpNdvjbtatpi(cu0wW^cTu")
 
     val maxValues = stats.getMaxValues
     assert(maxValues.get(new Column("LongType")).getValue == 10L)
     assert(maxValues.get(new Column("DoubleType")).getValue == 10.1)
     assert(maxValues.get(new Column("BooleanType")).getValue == false)
+    assert(maxValues.get(new Column("VariantType")).getValue ==
+      "0S&u500&]LC42A9vqZe}wb#-i1}-a+cT!xdbWhT9cTx}7v<+K")
 
     val nullCount = stats.getNullCount
     assert(nullCount.get(new Column("ByteType")) == 1L)
@@ -957,5 +973,25 @@ class DataFileStatisticsSuite extends AnyFunSuite with Matchers {
     val resultFromEmpty = emptyTightBoundsStats.withoutTightBounds()
     assert(resultFromEmpty.getTightBounds.isPresent &&
       !resultFromEmpty.getTightBounds.get)
+  }
+
+  test("deserializing invalid variant stats throws KernelException") {
+    val schema = new StructType().add("VariantType", VariantType.VARIANT);
+    val invalidVariantStats =
+      """|{
+         |  "numRecords": 100,
+         |  "minValues": {
+         |    "VariantType": 1234
+         |  },
+         |  "maxValues": {
+         |    "VariantType": 5678
+         |  }
+         |}""".stripMargin
+
+    val exception = intercept[KernelException] {
+      DataFileStatistics.deserializeFromJson(invalidVariantStats, schema)
+    }
+
+    assert(exception.getMessage.contains("Expected variant as string value"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This change adds support for reading and writing variant stats in the Delta Log JSON.  
Details for the structure are in this protocol RFC: https://github.com/delta-io/delta/blob/master/protocol_rfcs/variant-shredding.md#statistics-for-variant-columns

These stats are themselves variants (metadata + values concatenated) and then z85 encoded into a String. 

-->

## How was this patch tested?
Added unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No because the ability to even create tables with variant is not supported yet, these are the underlying primitives....
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
