### PR TITLE
[Spark] Plumb catalog tables to to multiple DeltaLog API call sites

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -247,7 +247,7 @@ sealed trait RemovableFeature { self: TableFeature =>
 
     // Use the snapshot at earliestCheckpointVersion to validate the checkpoint identified by
     // findEarliestReliableCheckpoint.
-    val earliestSnapshot = deltaLog.getSnapshotAt(earliestCheckpointVersion)
+    val earliestSnapshot = table.getSnapshotAt(earliestCheckpointVersion)
 
     // Tombstones may contain traces of the removed feature. The earliest snapshot will include
     // all tombstones within the tombstoneRetentionPeriod. This may disallow protocol downgrade

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -550,7 +550,7 @@ object DropTableFeatureUtils extends DeltaLogging {
       table: DeltaTableV2,
       snapshotRefreshStartTimeTs: Long): Boolean = {
     val log = table.deltaLog
-    val snapshot = log.update(checkIfUpdatedSinceTs = Some(snapshotRefreshStartTimeTs))
+    val snapshot = table.update(checkIfUpdatedSinceTs = Some(snapshotRefreshStartTimeTs))
 
     def checkpointAndVerify(snapshot: Snapshot): Boolean = {
       try {
@@ -578,7 +578,7 @@ object DropTableFeatureUtils extends DeltaLogging {
       snapshotRefreshStartTs: Long,
       retryOnFailure: Boolean = false): Boolean = {
     val log = table.deltaLog
-    val snapshot = log.update(checkIfUpdatedSinceTs = Some(snapshotRefreshStartTs))
+    val snapshot = table.update(checkIfUpdatedSinceTs = Some(snapshotRefreshStartTs))
     val emptyCommitTS = table.deltaLog.clock.nanoTime()
     log.startTransaction(table.catalogTable, Some(snapshot))
       .commit(Nil, DeltaOperations.EmptyCommit)
@@ -588,7 +588,7 @@ object DropTableFeatureUtils extends DeltaLogging {
     if (retryOnFailure) {
       createCheckpointWithRetries(table, emptyCommitTS)
     } else {
-      log.checkpoint(log.update(checkIfUpdatedSinceTs = Some(emptyCommitTS)))
+      log.checkpoint(table.update(checkIfUpdatedSinceTs = Some(emptyCommitTS)))
       true
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -136,6 +136,15 @@ class DeltaTableV2 private[delta](
    */
   def update(): Snapshot = deltaLog.update(catalogTableOpt = catalogTable)
 
+  def update(checkIfUpdatedSinceTs: Option[Long]): Snapshot =
+    deltaLog.update(checkIfUpdatedSinceTs = checkIfUpdatedSinceTs, catalogTableOpt = catalogTable)
+
+  /**
+   * Gets the snapshot at the given version of this table
+   */
+  def getSnapshotAt(version: Long): Snapshot =
+    deltaLog.getSnapshotAt(version, catalogTableOpt = catalogTable)
+
   def getTableIdentifierIfExists: Option[TableIdentifier] = tableIdentifier.map { tableName =>
     spark.sessionState.sqlParser.parseMultipartIdentifier(tableName).asTableIdentifier
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
@@ -186,7 +186,7 @@ trait ReorgTableForUpgradeUniformHelper extends DeltaLogging {
     } else {
       (None, false)
     }
-    val updatedSnapshot = target.deltaLog.update()
+    val updatedSnapshot = target.update()
     val (numOfAddFiles, numOfAddFilesWithIcebergCompatTag) = getNumOfAddFiles(
       targetIcebergCompatVersion, target, updatedSnapshot)
     if (mayNeedRewrite && numOfAddFilesWithIcebergCompatTag != numOfAddFiles) {
@@ -219,7 +219,7 @@ trait ReorgTableForUpgradeUniformHelper extends DeltaLogging {
       "numOfAddFilesWithIcebergCompatTagBefore" -> numOfAddFilesWithTagBefore.toString,
       "numOfAddFilesAfter" -> numOfAddFiles.toString,
       "numOfAddFilesWithIcebergCompatTagAfter" -> numOfAddFilesWithIcebergCompatTag.toString,
-      "universalFormatIcebergEnabled" -> icebergEnabled(target.deltaLog.update().metadata).toString
+      "universalFormatIcebergEnabled" -> icebergEnabled(target.update().metadata).toString
     ))
     metricsOpt.getOrElse(Seq.empty[Row])
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -420,7 +420,7 @@ case class AlterTableDropFeatureDeltaCommand(
         }
       }
 
-      val startSnapshotOpt = status.lastCommitVersionOpt.map(deltaLog.getSnapshotAt(_))
+      val startSnapshotOpt = status.lastCommitVersionOpt.map(table.getSnapshotAt(_))
       val txn = table.startTransaction(snapshotOpt = startSnapshotOpt)
       val snapshot = txn.snapshot
 
@@ -534,7 +534,7 @@ case class AlterTableDropFeatureDeltaCommand(
         }
       }
 
-      val startSnapshotOpt = status.lastCommitVersionOpt.map(deltaLog.getSnapshotAt(_))
+      val startSnapshotOpt = status.lastCommitVersionOpt.map(table.getSnapshotAt(_))
       val txn = table.startTransaction(snapshotOpt = startSnapshotOpt)
       val snapshot = txn.snapshot
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -222,16 +222,18 @@ abstract class TahoeFileIndexWithSnapshotDescriptor(
  *
  * @param snapshot the [[Snapshot]] this pointer points to
  */
-class ShallowSnapshotDescriptor(snapshot: Snapshot) extends SnapshotDescriptor {
+class ShallowSnapshotDescriptor(
+    snapshot: Snapshot,
+    catalogTableOpt: Option[CatalogTable]) extends SnapshotDescriptor {
   override val deltaLog: DeltaLog = snapshot.deltaLog
   override val version: Long = snapshot.version
   override val metadata: Metadata = snapshot.metadata
   override val protocol: Protocol = snapshot.protocol
   // Avoid eager state reconstruction
   override protected[delta] def numOfFilesIfKnown: Option[Long] =
-    deltaLog.getSnapshotAt(version).numOfFilesIfKnown
+    deltaLog.getSnapshotAt(version, catalogTableOpt = catalogTableOpt).numOfFilesIfKnown
   override protected[delta] def sizeInBytesIfKnown: Option[Long] =
-    deltaLog.getSnapshotAt(version).sizeInBytesIfKnown
+    deltaLog.getSnapshotAt(version, catalogTableOpt = catalogTableOpt).sizeInBytesIfKnown
 }
 
 /**
@@ -263,7 +265,7 @@ case class TahoeLogFileIndex(
     deltaLog,
     path,
     if (isTimeTravelQuery) snapshotAtAnalysis
-    else new ShallowSnapshotDescriptor(snapshotAtAnalysis),
+    else new ShallowSnapshotDescriptor(snapshotAtAnalysis, catalogTableOpt),
     catalogTableOpt,
     partitionFilters,
     isTimeTravelQuery)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IcebergCompatUtilsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IcebergCompatUtilsBase.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql.delta
 
 import java.util.UUID
 
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
 import org.apache.spark.sql.{DataFrame, QueryTest, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 
@@ -62,13 +65,15 @@ trait IcebergCompatUtilsBase extends QueryTest {
   protected def executeSql(sqlStr: String): DataFrame
 
   protected def getProperties(tableId: String): Map[String, String] = {
-    DeltaLog.forTable(spark, TableIdentifier(tableId)).update().getProperties.toMap
+    val table = DeltaTableV2(spark, TableIdentifier(tableId))
+    table.update.getProperties.toMap
   }
 
   protected def assertIcebergCompatProtocolAndProperties(
       tableId: String,
       compatObj: IcebergCompatBase = compatObject): Unit = {
-    val snapshot = DeltaLog.forTable(spark, TableIdentifier(tableId)).update()
+    val table = DeltaTableV2(spark, TableIdentifier(tableId))
+    val snapshot = table.update
     val protocol = snapshot.protocol
     val tblProperties = snapshot.getProperties
     val tableFeature = compatObj.tableFeature


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Plumb catalog tables to multiple `DeltaLog` API call sites.

`DeltaLog` API call includes:
1. `DeltaLog.forTable`
2. `deltaLog.getSnapshotAt`
3. `deltaLog.update`

This PR include all call sites that can be easily fixed.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
