### PR TITLE
[kernel-spark] Fix table schema column order; add golden table comparison test

### DIFF
--- a/connectors/golden-tables/src/main/scala/io/delta/golden/GoldenTableUtils.scala
+++ b/connectors/golden-tables/src/main/scala/io/delta/golden/GoldenTableUtils.scala
@@ -42,6 +42,8 @@ object GoldenTableUtils {
     }
 
     val rootPath = root.toPath
+    // Find all directories containing `_delta_log` under the `golden` resource and return their
+    // relative paths (to the golden root), sorted.
     loop(root).map(f => rootPath.relativize(f.toPath).toString).sorted
   }
 }

--- a/connectors/golden-tables/src/main/scala/io/delta/golden/GoldenTableUtils.scala
+++ b/connectors/golden-tables/src/main/scala/io/delta/golden/GoldenTableUtils.scala
@@ -30,4 +30,18 @@ object GoldenTableUtils {
   def goldenTableFile(name: String): File = {
     new File(classLoader.getResource(s"golden/$name").getFile)
   }
+
+  def allTableNames(): Seq[String] = {
+    val root = new File(goldenResourceURL.getFile)
+
+    def loop(dir: File): Seq[File] = {
+      val children = Option(dir.listFiles()).getOrElse(Array.empty[File])
+      val subdirs = children.filter(_.isDirectory)
+      val here = if (new File(dir, "_delta_log").isDirectory) Seq(dir) else Seq.empty[File]
+      here ++ subdirs.flatMap(loop)
+    }
+
+    val rootPath = root.toPath
+    loop(root).map(f => rootPath.relativize(f.toPath).toString).sorted
+  }
 }

--- a/kernel-spark/src/main/java/io/delta/kernel/spark/catalog/SparkTable.java
+++ b/kernel-spark/src/main/java/io/delta/kernel/spark/catalog/SparkTable.java
@@ -80,7 +80,7 @@ public class SparkTable implements Table, SupportsRead {
             io.delta.kernel.TableManager.loadSnapshot(tablePath)
                 .build(io.delta.kernel.defaults.engine.DefaultEngine.create(hadoopConf));
 
-    StructType snapshotSchema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
+    this.schema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
     this.partColNames =
         Collections.unmodifiableList(new ArrayList<>(snapshot.getPartitionColumnNames()));
 
@@ -89,7 +89,7 @@ public class SparkTable implements Table, SupportsRead {
 
     // Build a map for O(1) field lookups to improve performance
     Map<String, StructField> fieldMap = new HashMap<>();
-    for (StructField field : snapshotSchema.fields()) {
+    for (StructField field : schema.fields()) {
       fieldMap.put(field.name(), field);
     }
 
@@ -106,17 +106,14 @@ public class SparkTable implements Table, SupportsRead {
 
     // Add remaining fields as data fields (non-partition columns)
     // These are fields that exist in the schema but are not partition columns
-    for (StructField field : snapshotSchema.fields()) {
+    for (StructField field : schema.fields()) {
       if (!partColNames.contains(field.name())) {
         dataFields.add(field);
       }
     }
     this.dataSchema = new StructType(dataFields.toArray(new StructField[0]));
     this.partitionSchema = new StructType(partitionFields.toArray(new StructField[0]));
-    // For Spark, the table schema is always data columns plus partition columns.
-    // This is different from the schema from snapshot which is partition columns plus data columns.
-    dataFields.addAll(partitionFields);
-    this.schema = new StructType(dataFields.toArray(new StructField[0]));
+
     this.columns = CatalogV2Util.structTypeToV2Columns(schema);
     this.partitionTransforms =
         partColNames.stream().map(Expressions::identity).toArray(Transform[]::new);

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/read/GoldTableTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/read/GoldTableTest.java
@@ -366,6 +366,18 @@ public class GoldTableTest extends QueryTest {
     checkAnswer(dfFunc, expectedSeq);
   }
 
+  @Test
+  public void testAllGoldenTables() {
+    List<String> tableNames = getAllGoldenTableNames();
+    for (String tableName : tableNames) {
+      // For simplicity, just check that we can read the table and it has at least one row
+      String tablePath = goldenTablePath(tableName);
+      Dataset<Row> df = spark.sql("SELECT * FROM `spark_catalog`.`delta`.`" + tablePath + "`");
+      Dataset<Row> df2 = spark.sql("SELECT * FROM `dsv2`.`delta`.`" + tablePath + "`");
+      checkAnswer(df.collect(), df2.collect());
+    }
+  }
+
   private void checkTable(String path, List<Row> expected) {
     String tablePath = goldenTablePath(path);
 
@@ -385,5 +397,9 @@ public class GoldTableTest extends QueryTest {
 
   private String goldenTablePath(String name) {
     return GoldenTableUtils$.MODULE$.goldenTablePath(name);
+  }
+
+  private List<String> getAllGoldenTableNames() {
+    return scala.collection.JavaConverters.seqAsJavaList(GoldenTableUtils$.MODULE$.allTableNames());
   }
 }

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/read/GoldTableTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/read/GoldTableTest.java
@@ -106,19 +106,19 @@ public class GoldTableTest extends QueryTest {
     StructType expectedSchema =
         DataTypes.createStructType(
             new StructField[] {
-              expectedDataSchema.fields()[0],
-              expectedDataSchema.fields()[1],
+              expectedPartitionSchema.fields()[1],
               expectedPartitionSchema.fields()[0],
-              expectedPartitionSchema.fields()[1]
+              expectedDataSchema.fields()[0],
+              expectedDataSchema.fields()[1]
             });
     assertEquals(expectedSchema, table.schema());
     assertEquals(tableName, table.name());
     // Check table columns
     assertEquals(4, table.columns().length);
-    assertEquals("name", table.columns()[0].name());
-    assertEquals("cnt", table.columns()[1].name());
-    assertEquals("date", table.columns()[2].name());
-    assertEquals("city", table.columns()[3].name());
+    assertEquals("city", table.columns()[0].name());
+    assertEquals("date", table.columns()[1].name());
+    assertEquals("name", table.columns()[2].name());
+    assertEquals("cnt", table.columns()[3].name());
 
     // Check table partitioning
     assertEquals(2, table.partitioning().length);
@@ -297,9 +297,6 @@ public class GoldTableTest extends QueryTest {
       expected.add(
           new GenericRow(
               new Object[] {
-                arrSeq, // array<struct>
-                middle, // nested struct
-                Integer.toString(i), // final string
                 i, // int
                 (long) i, // long
                 (byte) i, // byte
@@ -310,7 +307,10 @@ public class GoldTableTest extends QueryTest {
                 Integer.toString(i), // string
                 "null", // literal string
                 fixedDate, // date (was daysSinceEpoch int)
-                new BigDecimal(i) // decimal
+                new BigDecimal(i), // decimal
+                arrSeq, // array<struct>
+                middle, // nested struct
+                Integer.toString(i) // final string
               }));
     }
 
@@ -326,20 +326,20 @@ public class GoldTableTest extends QueryTest {
     expected.add(
         new GenericRow(
             new Object[] {
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
               nullArrSeq,
               nullMiddle,
-              "2",
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null
+              "2"
             }));
 
     // Read table, drop unsupported column `as_timestamp`
@@ -407,7 +407,7 @@ public class GoldTableTest extends QueryTest {
       // For simplicity, just check that we can read the table and it has at least one row
       String tablePath = goldenTablePath(tableName);
       // Many golden tables only have corrupted _delta_log subdir. The new kernel table reader will
-      // fail on those.
+      // fail on some of those.
       // TODO: fix the read result of those tables.
       if (hasOnlyDeltaLogSubdir(tablePath)) {
         continue;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Follow-up to https://github.com/delta-io/delta/pull/5201.  
Before that PR, the table schema column order was correct. After it, the schema aligned with Spark’s Parquet tables but diverged from Delta tables.  

This PR reverts the affected changes and adds tests to validate consistency between the delta-spark and kernel-spark connectors in both schema and table data.

## How was this patch tested?

Added new tests to compare schema and table data between delta-spark and kernel-spark connectors.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the kernel-spark connector is not released yet.