### PR TITLE
Update table feature to indicate writing variant is supported by kern…

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionMetadataFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionMetadataFactory.java
@@ -627,7 +627,9 @@ public class TransactionMetadataFactory {
                     oldMetadata,
                     getEffectiveMetadata(),
                     clusteringColumnPhysicalNames,
-                    false /* allowNewRequiredFields */);
+                    false /* allowNewRequiredFields */,
+                    getEffectiveProtocol()
+                        .getImplicitlyAndExplicitlySupportedReaderWriterFeatures());
 
             schemaWithTypeWidening.ifPresent(
                 structType ->
@@ -664,7 +666,8 @@ public class TransactionMetadataFactory {
                 emptySet() /* clusteringCols */,
                 // We allow new non-null fields in REPLACE since we know all existing data is
                 // removed
-                true /* allowNewRequiredFields */);
+                true /* allowNewRequiredFields */,
+                getEffectiveProtocol().getImplicitlyAndExplicitlySupportedReaderWriterFeatures());
         schemaWithTypeWidening.ifPresent(
             structType ->
                 newMetadata = Optional.of(getEffectiveMetadata().withNewSchema(structType)));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -220,7 +220,10 @@ public class TableFeatures {
 
     @Override
     public boolean hasKernelWriteSupport(Metadata metadata) {
-      return false; // TODO: yet to be implemented in Kernel
+      // Kernel supports writing Delta metadata with variant but not actual data yet.
+      // In case there's data attempting to be written when variant is in the schema, Kernel fails
+      // during logical data transformation in Transaction#transformLogicalData
+      return true;
     }
   }
 


### PR DESCRIPTION
…el, update SChemaUtils to consider table features and compare variant

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
