### PR TITLE
[Kernel][CCV2] Support DeltaHistoryManager. getActiveCommitAtTimestamp with catalog commits

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -144,46 +144,6 @@ public final class DeltaHistoryManager {
    *     provided timestamp is after the latest commit
    * @param canReturnEarliestCommit whether we can return the earliest version of the table if the
    *     provided timestamp is before the earliest commit
-   * @throws KernelException if the provided timestamp is before the earliest commit and
-   *     canReturnEarliestCommit is false
-   * @throws KernelException if the provided timestamp is after the latest commit and
-   *     canReturnLastCommit is false
-   * @throws TableNotFoundException when there is no Delta table at the given path
-   */
-  public static Commit getActiveCommitAtTimestamp(
-      Engine engine,
-      SnapshotImpl latestSnapshot,
-      Path logPath,
-      long timestamp,
-      boolean mustBeRecreatable,
-      boolean canReturnLastCommit,
-      boolean canReturnEarliestCommit) {
-    return getActiveCommitAtTimestamp(
-        engine,
-        latestSnapshot,
-        logPath,
-        timestamp,
-        mustBeRecreatable,
-        canReturnLastCommit,
-        canReturnEarliestCommit,
-        Optional.empty());
-  }
-
-  /**
-   * Returns the latest commit that happened at or before {@code timestamp}.
-   *
-   * <p>If the timestamp is outside the range of [earliestCommit, latestCommit] then use parameters
-   * {@code canReturnLastCommit} and {@code canReturnEarliestCommit} to control whether an exception
-   * is thrown or the corresponding earliest/latest commit is returned.
-   *
-   * @param engine instance of {@link Engine} to use
-   * @param logPath the _delta_log path of the table
-   * @param timestamp the timestamp find the version for in milliseconds since the unix epoch
-   * @param mustBeRecreatable whether the state at the returned commit should be recreatable
-   * @param canReturnLastCommit whether we can return the latest version of the table if the
-   *     provided timestamp is after the latest commit
-   * @param canReturnEarliestCommit whether we can return the earliest version of the table if the
-   *     provided timestamp is before the earliest commit
    * @param parsedLogDatas parsed log Deltas to use
    * @throws KernelException if the provided timestamp is before the earliest commit and
    *     canReturnEarliestCommit is false

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -293,7 +293,8 @@ public class DeltaLogActionUtils {
                 if (fileVersion > endVersion) {
                   if (mustBeRecreatable && !hasReturnedCommitOrCheckpoint.get()) {
                     final long earliestVersion =
-                        DeltaHistoryManager.getEarliestRecreatableCommit(engine, logPath);
+                        DeltaHistoryManager.getEarliestRecreatableCommit(
+                            engine, logPath, Optional.empty());
                     throw DeltaErrors.versionBeforeFirstAvailableCommit(
                         tablePath.toString(), endVersion, earliestVersion);
                   } else {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.internal.actions;
 
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineExceptionThrowsIO;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 import static io.delta.kernel.internal.util.VectorUtils.stringStringMapValue;
 import static java.util.Objects.requireNonNull;
@@ -127,6 +128,19 @@ public class CommitInfo {
       Engine engine, Path logPath, long version) {
     return extractRequiredIctFromCommitInfoOpt(
         unsafeTryReadCommitInfoFromPublishedDeltaFile(engine, logPath, version), version, logPath);
+  }
+
+  /**
+   * Returns the `inCommitTimestamp` of the provided delta file. Throws an exception if the delta
+   * file does not exist or does not have a commitInfo action or if the commitInfo action contains
+   * an empty `inCommitTimestamp`. The delta file can be either a published or staged commit file.
+   */
+  public static long getRequiredIctFromDeltaFile(
+      Engine engine, Path tablePath, FileStatus deltaFileStatus, long version) {
+    checkArgument(
+        FileNames.isCommitFile(deltaFileStatus.getPath()), "Must provide a valid commit file");
+    return extractRequiredIctFromCommitInfoOpt(
+        tryReadCommitInfoFromDeltaFile(engine, deltaFileStatus), version, tablePath);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -129,6 +129,10 @@ public class ParsedLogData {
     this.inlineDataOpt = inlineDataOpt;
   }
 
+  public long getVersion() {
+    return version;
+  }
+
   public boolean isMaterialized() {
     return fileStatusOpt.isPresent();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -66,6 +66,7 @@ public class SnapshotFactory {
             .computeTimestampToVersionTotalDurationTimer
             .time(
                 () ->
+                    // TODO provide catalogCommits to support ccv2 time-travel
                     DeltaHistoryManager.getActiveCommitAtTimestamp(
                             engine,
                             latestSnapshot,
@@ -73,7 +74,8 @@ public class SnapshotFactory {
                             millisSinceEpochUTC,
                             true /* mustBeRecreatable */,
                             false /* canReturnLastCommit */,
-                            false /* canReturnEarliestCommit */)
+                            false /* canReturnEarliestCommit */,
+                            Optional.empty())
                         .getVersion());
 
     snapshotQueryCtx.setResolvedVersion(resolvedVersionToLoad);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
@@ -23,9 +23,12 @@ import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 import io.delta.kernel.TransactionSuite.testSchema
+import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
+import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.exceptions.TableNotFoundException
 import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
 import io.delta.kernel.internal.commit.DefaultFileSystemManagedTableOnlyCommitter
+import io.delta.kernel.internal.files.ParsedLogData
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.lang.Lazy
 import io.delta.kernel.internal.metrics.SnapshotQueryContext
@@ -33,9 +36,10 @@ import io.delta.kernel.internal.snapshot.LogSegment
 import io.delta.kernel.internal.util.{FileNames, VectorUtils}
 import io.delta.kernel.internal.util.InCommitTimestampUtils
 import io.delta.kernel.internal.util.VectorUtils.{buildArrayValue, stringStringMapValue}
-import io.delta.kernel.test.MockFileSystemClientUtils
+import io.delta.kernel.test.{MockFileSystemClientUtils, MockListFromFileSystemClient, MockReadICTFileJsonHandler}
 import io.delta.kernel.test.MockSnapshotUtils.getMockSnapshot
 import io.delta.kernel.types.StringType
+import io.delta.kernel.types.StructType
 import io.delta.kernel.utils.FileStatus
 
 import org.scalatest.funsuite.AnyFunSuite
@@ -1144,5 +1148,501 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     assert(resultHigh.isPresent)
     assert(resultHigh.get._1 == 49L)
     assert(resultHigh.get._2 == 98L)
+  }
+
+  // ============== Tests for Staged Commits Support ===============
+
+  private def checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList: Seq[FileStatus],
+      stagedCommits: Seq[ParsedLogData],
+      versionToICT: Map[Long, Long],
+      timestampToQuery: Long,
+      expectedVersion: Long,
+      canReturnLastCommit: Boolean = false,
+      canReturnEarliestCommit: Boolean = false,
+      add10ToICTForStagedFiles: Boolean = false,
+      ictEnablementInfo: (Long, Long) = (0, 0)): Unit = {
+    // Create mock engine with ICT reading support
+    val mockJsonHandler = new MockReadICTFileJsonHandler(versionToICT, add10ToICTForStagedFiles)
+    val mockedEngine = mockEngine(
+      fileSystemClient = new MockListFromFileSystemClient(listFromProvider(fileList)),
+      jsonHandler = mockJsonHandler)
+
+    def getVersionFromFS(fs: FileStatus): Long = FileNames.getFileVersion(new Path(fs.getPath))
+    val latestVersion = fileList.map(getVersionFromFS(_)).max
+    // If we have a staged commit file at the end version, we want to use this in the log segment
+    // for our mockLatestSnapshot, so we get the ICT from that file
+    val deltaFileAtEndVersion = fileList
+      .filter(fs => FileNames.isStagedDeltaFile(fs.getPath))
+      .find(getVersionFromFS(_) == latestVersion)
+
+    val mockLatestSnapshot =
+      getMockSnapshot(
+        dataPath,
+        latestVersion = latestVersion,
+        ictEnablementInfoOpt = Some(ictEnablementInfo),
+        deltaFileAtEndVersion = deltaFileAtEndVersion)
+
+    val activeCommit = DeltaHistoryManager.getActiveCommitAtTimestamp(
+      mockedEngine,
+      mockLatestSnapshot,
+      logPath,
+      timestampToQuery,
+      false,
+      canReturnLastCommit,
+      canReturnEarliestCommit,
+      Optional.of(stagedCommits.asJava))
+    assert(
+      activeCommit.getVersion == expectedVersion,
+      s"Expected version $expectedVersion but got ${activeCommit.getVersion} for timestamp=$timestampToQuery")
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: empty log, 1 staged commit") {
+    // Published commits: _
+    // Ratified commits: V0
+    val stagedCommitFiles = Seq(stagedCommitFile(0L))
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+    val versionToICT = Map(0L -> 180L)
+
+    // Query the exact timestamp
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      stagedCommitFiles,
+      parsedLogData,
+      versionToICT,
+      180L,
+      0)
+
+    // Querying before without canReturnEarliestCommit results in error
+    intercept[KernelException] {
+      checkGetActiveCommitAtTimestampWithParsedLogData(
+        stagedCommitFiles,
+        parsedLogData,
+        versionToICT,
+        170L,
+        0)
+    }
+
+    // With canReturnEarliestCommit passes
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      stagedCommitFiles,
+      parsedLogData,
+      versionToICT,
+      170L,
+      0,
+      canReturnEarliestCommit = true)
+
+    // Querying after without canReturnLatestCommit results in error
+    intercept[KernelException] {
+      checkGetActiveCommitAtTimestampWithParsedLogData(
+        stagedCommitFiles,
+        parsedLogData,
+        versionToICT,
+        190L,
+        0)
+    }
+
+    // With canReturnEarliestCommit passes
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      stagedCommitFiles,
+      parsedLogData,
+      versionToICT,
+      190L,
+      0,
+      canReturnLastCommit = true)
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: empty log, 2 staged commit") {
+    // Published commits: _
+    // Ratified commits: V0, V1
+    val stagedCommitFiles = Seq(stagedCommitFile(0L), stagedCommitFile(1L))
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+    val versionToICT = Map(0L -> 180L, 1L -> 280L)
+
+    // Query the exact timestamp of V0
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      stagedCommitFiles,
+      parsedLogData,
+      versionToICT,
+      180L,
+      0)
+
+    // Query in between V0 and V1
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      stagedCommitFiles,
+      parsedLogData,
+      versionToICT,
+      200L,
+      0)
+
+    // Query the exact timestamp of V1
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      stagedCommitFiles,
+      parsedLogData,
+      versionToICT,
+      280L,
+      1)
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: no overlap") {
+    // Published commits: V0, V1
+    // Ratified commits: V2, V3
+    val stagedCommitFiles = Seq(stagedCommitFile(2L), stagedCommitFile(3L))
+    val fileList = Seq(
+      deltaFileStatus(0),
+      deltaFileStatus(1)) ++ stagedCommitFiles
+    val versionToICT = Map(0L -> 180L, 1L -> 280L, 2L -> 380L, 3L -> 480L)
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+
+    // Query the exact timestamp of V1
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      280L,
+      1)
+
+    // Query in between V1 and V2
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      300L,
+      1)
+
+    // Query the exact timestamp of V2
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      380L,
+      2)
+
+    // Query in between V2 and V3
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      400L,
+      2)
+
+    // Query the exact timestamp of V3
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      480L,
+      3)
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: v0 published and staged") {
+    // Published commits: V0
+    // Ratified commits: V0
+    val stagedCommitFiles = Seq(stagedCommitFile(0L))
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+    val fileList = Seq(deltaFileStatus(0)) ++ stagedCommitFiles
+    val versionToICT = Map(0L -> 200L)
+    // If we read from the published file, we should get ICT=200
+    // If we read from the staged file, we should get ICT=210 (correct behavior!)
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      210L,
+      0,
+      add10ToICTForStagedFiles = true)
+
+    intercept[KernelException] {
+      checkGetActiveCommitAtTimestampWithParsedLogData(
+        fileList,
+        parsedLogData,
+        versionToICT,
+        200L,
+        0,
+        add10ToICTForStagedFiles = true)
+    }
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: overlap") {
+    // Published commits: V10, V11
+    // Ratified commits: V11, V12
+    val stagedCommitFiles = Seq(stagedCommitFile(11), stagedCommitFile(12))
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+    val fileList = Seq(
+      classicCheckpointFileStatus(10),
+      deltaFileStatus(10),
+      deltaFileStatus(11)) ++ stagedCommitFiles
+    val versionToICT = Map(10L -> 1000L, 11L -> 1100L, 12L -> 1200L)
+    // We have v10=1000, v11=1110 (if we use the correct file), v12=1210
+
+    // Read at v10
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      1000L,
+      10,
+      add10ToICTForStagedFiles = true)
+
+    // Read between v10 and v11 (if we incorrectly use the published file this will fail!)
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      1101L,
+      10,
+      add10ToICTForStagedFiles = true)
+
+    // Read at v11
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      1110L,
+      11,
+      add10ToICTForStagedFiles = true)
+
+    // Read between v11 and v12
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      1150,
+      11,
+      add10ToICTForStagedFiles = true)
+
+    // Read at v12
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      1210,
+      12,
+      add10ToICTForStagedFiles = true)
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: discontinuous catalog commits") {
+    // Published commits: V0, V1, V2
+    // Ratified commits: V0, V2
+    val stagedCommitFiles = Seq(stagedCommitFile(0), stagedCommitFile(2))
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+    val fileList = Seq(
+      deltaFileStatus(0),
+      deltaFileStatus(1),
+      deltaFileStatus(2)) ++ stagedCommitFiles
+    val versionToICT = Map(0L -> 1000L, 1L -> 2000L, 2L -> 3000L)
+    // We have v0=1010, v1=2000, v2=3010 assuming we use the staged commits > published commits
+
+    // Read at published file ICT for v0 should fail
+    intercept[KernelException] {
+      checkGetActiveCommitAtTimestampWithParsedLogData(
+        stagedCommitFiles,
+        parsedLogData,
+        versionToICT,
+        1000L,
+        0,
+        add10ToICTForStagedFiles = true)
+    }
+
+    // Read at correct version for v0 if using staged commit
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      1010L,
+      0L,
+      add10ToICTForStagedFiles = true)
+
+    // Read between v0 and v1
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      1500L,
+      0,
+      add10ToICTForStagedFiles = true)
+
+    // Read at v1
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      2000L,
+      1,
+      add10ToICTForStagedFiles = true)
+
+    // Read between v1 and v2 (this will fail if we don't use the staged commit)
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      3000L,
+      1,
+      add10ToICTForStagedFiles = true)
+
+    // Read at v2
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      3010L,
+      2,
+      add10ToICTForStagedFiles = true)
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: ICT enabled after v0") {
+    // Published commits: V0 (non-ICT), V1 (enables ICT)
+    // Ratified commits: V2
+    val stagedCommitFiles = Seq(stagedCommitFile(2))
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+    val fileList = Seq(
+      deltaFileStatus(0),
+      deltaFileStatus(1)) ++ stagedCommitFiles
+    val versionToICT = Map(1L -> 2000L, 2L -> 3000L)
+    val ictEnablementInfo = (1L, 2000L) // (version, timestamp)
+
+    // Query exact timestamp of v0 (no ICT)
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      0L,
+      0,
+      ictEnablementInfo = ictEnablementInfo)
+
+    // Query between v0 and v1
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      8L,
+      0,
+      ictEnablementInfo = ictEnablementInfo)
+
+    // TODO: this fails due to an existing bug when querying a timestamp between
+    //  (ictEnablementVersionFsTs, ictEnablementTs) -- re-enable this once it's fixed
+    // Query between v0 and v1 - ICT based
+    /*
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      500L,
+      0,
+      ictEnablementInfo = ictEnablementInfo)
+     */
+
+    // Query exact timestamp of v1 (ICT)
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      2000L,
+      1,
+      ictEnablementInfo = ictEnablementInfo)
+
+    // Query between v1 and v2
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      2500L,
+      1,
+      ictEnablementInfo = ictEnablementInfo)
+
+    // Query exact v2
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      3000L,
+      2,
+      ictEnablementInfo = ictEnablementInfo)
+  }
+
+  test("getActiveCommitAtTimestamp with staged commits: ICT enabled after v0 and " +
+    "only ICT commits available") {
+    // This tests the scenario where we are searching for a pre-ICT time but all the non-ICT commits
+    // are missing. This throws an error based on `canReturnEarliestCommit`.
+    // Published commits: v10
+    // Ratified commits: V11
+    val stagedCommitFiles = Seq(stagedCommitFile(11))
+    val parsedLogData = stagedCommitFiles.map(ParsedLogData.forFileStatus(_))
+    val fileList = Seq(
+      classicCheckpointFileStatus(10),
+      deltaFileStatus(10)) ++ stagedCommitFiles
+    val versionToICT = Map(10L -> 1000L, 11L -> 1100L)
+    val ictEnablementInfo = (5L, 500L) // (version, timestamp)
+
+    // If we have canReturnEarliestCommit=false should fail
+    // Querying after without canReturnLatestCommit results in error
+    val e = intercept[KernelException] {
+      checkGetActiveCommitAtTimestampWithParsedLogData(
+        fileList,
+        parsedLogData,
+        versionToICT,
+        400,
+        0,
+        ictEnablementInfo = ictEnablementInfo)
+    }
+    assert(e.getMessage.contains("is before the earliest available version 10. Please use a " +
+      "timestamp greater than or equal to 1000 ms"))
+
+    // Query with canReturnEarliestCommit=true should pass
+    checkGetActiveCommitAtTimestampWithParsedLogData(
+      fileList,
+      parsedLogData,
+      versionToICT,
+      400,
+      10,
+      canReturnEarliestCommit = true,
+      ictEnablementInfo = ictEnablementInfo)
+  }
+
+  test("getActiveCommitAtTimestamp rejects non-ratified staged commits") {
+    val fileList = Seq(
+      classicCheckpointFileStatus(0),
+      deltaFileStatus(0))
+
+    // Test 1: Inline commits (non-materialized) should be rejected
+    val mockColumnarBatch = new ColumnarBatch {
+      override def getSchema: StructType = null
+      override def getColumnVector(ordinal: Int): ColumnVector = null
+      override def getSize: Int = 1
+    }
+    val inlineCommit = ParsedLogData.forInlineData(
+      1L,
+      ParsedLogData.ParsedLogType.RATIFIED_INLINE_COMMIT,
+      mockColumnarBatch)
+    val inlineData = Seq(inlineCommit).asJava
+
+    assertThrows[IllegalArgumentException] {
+      // Args don't matter as validation should fail immediately
+      DeltaHistoryManager.getActiveCommitAtTimestamp(
+        createMockFSListFromEngine(fileList),
+        getMockSnapshot(dataPath, latestVersion = 0),
+        logPath,
+        10,
+        false,
+        false,
+        false,
+        Optional.of(inlineData))
+    }
+
+    // Test 2: Published deltas in ParsedLogData should be rejected (only staged commits allowed)
+    val publishedDelta = ParsedLogData.forFileStatus(deltaFileStatus(1))
+    val publishedData = Seq(publishedDelta).asJava
+
+    assertThrows[IllegalArgumentException] {
+      // Args don't matter as validation should fail immediately
+      DeltaHistoryManager.getActiveCommitAtTimestamp(
+        createMockFSListFromEngine(fileList),
+        getMockSnapshot(dataPath, latestVersion = 0),
+        logPath,
+        10,
+        false,
+        false,
+        false,
+        Optional.of(publishedData))
+    }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockSnapshotUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockSnapshotUtils.scala
@@ -43,7 +43,8 @@ trait MockSnapshotUtils {
       dataPath: Path,
       latestVersion: Long,
       ictEnablementInfoOpt: Option[(Long, Long)] = None,
-      timestamp: Long = 0L): SnapshotImpl = {
+      timestamp: Long = 0L,
+      deltaFileAtEndVersion: Option[FileStatus] = None): SnapshotImpl = {
     val configuration = ictEnablementInfoOpt match {
       case Some((version, _)) if version == 0L =>
         Map(TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true")
@@ -67,10 +68,10 @@ trait MockSnapshotUtils {
       stringStringMapValue(configuration.asJava));
     val logPath = new Path(dataPath, "_delta_log")
 
-    val fs = FileStatus.of(
+    val fs = deltaFileAtEndVersion.getOrElse(FileStatus.of(
       FileNames.deltaFile(logPath, latestVersion),
       1, /* size */
-      1 /* modificationTime */ )
+      1 /* modificationTime */ ))
     val logSegment = new LogSegment(
       logPath, /* logPath */
       latestVersion,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Updates getActiveCommitAtTimestamp to accept an optional list of parsedLogDelta. For now, these can only be ratified staged commits. When provided, these are used instead of published commits, for reading ICT timestamps and resolving timestamp to version.

## How was this patch tested?

Adds unit tests.

TODO: add E2E tests

## Does this PR introduce _any_ user-facing changes?

No.
