### PR TITLE
[Kernel] [UC] Allow for better extensbility of the UC CatalogManaged Client and Committer

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CatalogCommitterUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CatalogCommitterUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.commit;
+
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
+
+public class CatalogCommitterUtils {
+
+  private CatalogCommitterUtils() {}
+
+  /**
+   * Table property key to enable the catalogManaged table feature. This is a signal to Kernel to
+   * add this table feature to Kernel's protocol. This property won't be written to the delta
+   * metadata.
+   */
+  public static final String CATALOG_MANAGED_ENABLEMENT_KEY =
+      TableFeatures.SET_TABLE_FEATURE_SUPPORTED_PREFIX
+          + TableFeatures.CATALOG_MANAGED_R_W_FEATURE_PREVIEW.featureName();
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5242/files) to review incremental changes.
- [**stack/uc_client_and_committer_extensibility**](https://github.com/delta-io/delta/pull/5242) [[Files changed](https://github.com/delta-io/delta/pull/5242/files)]

---------

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Make the UC CatalogManaged client and committer more extensible for custom dependency injection.

e.g. you can inject your own custom UC committer.

## How was this patch tested?

Trivial. Existing UTs and CI.

## Does this PR introduce _any_ user-facing changes?

No.
