### PR TITLE
[Kernel][CCV2] Support time-travel-by-timestamp with CCV2 commits in SnapshotBuilder

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -137,7 +137,11 @@ public class SnapshotManager {
       throws TableNotFoundException {
     final long versionToLoad =
         SnapshotFactory.resolveTimestampToSnapshotVersion(
-            engine, snapshotContext, latestSnapshot, millisSinceEpochUTC);
+            engine,
+            snapshotContext,
+            latestSnapshot,
+            millisSinceEpochUTC,
+            Collections.emptyList() /* logDatas */);
 
     return getSnapshotAt(engine, versionToLoad, snapshotContext);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
@@ -118,7 +118,6 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
     validateVersionNonNegative();
     validateTimestampNonNegative();
     validateTimestampNotGreaterThanLatestSnapshot(engine);
-    validateLogDatasEmptyIfTimeTravelByTimestamp();
     validateVersionAndTimestampMutuallyExclusive();
     validateProtocolAndMetadataOnlyIfVersionProvided();
     validateProtocolRead();
@@ -153,13 +152,6 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
                 latestSnapshotVersion);
           }
         });
-  }
-
-  private void validateLogDatasEmptyIfTimeTravelByTimestamp() {
-    if (ctx.timestampQueryContextOpt.isPresent() && !ctx.logDatas.isEmpty()) {
-      throw new UnsupportedOperationException(
-          "Time travel by timestamp with logDatas is not yet implemented");
-    }
   }
 
   private void validateVersionAndTimestampMutuallyExclusive() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -25,14 +25,17 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.commit.DefaultFileSystemManagedTableOnlyCommitter;
+import io.delta.kernel.internal.files.ParsedDeltaData;
+import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.Lazy;
 import io.delta.kernel.internal.metrics.SnapshotQueryContext;
 import io.delta.kernel.internal.replay.LogReplay;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.snapshot.SnapshotManager;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,14 +63,23 @@ public class SnapshotFactory {
       Engine engine,
       SnapshotQueryContext snapshotQueryCtx,
       SnapshotImpl latestSnapshot,
-      long millisSinceEpochUTC) {
+      long millisSinceEpochUTC,
+      List<ParsedLogData> logDatas) {
+
+    // Filter out only the ratified staged commits as that is all that DeltaHistoryManager supports
+    List<ParsedDeltaData> parsedDeltaDatas =
+        logDatas.stream()
+            .filter(logData -> logData instanceof ParsedDeltaData)
+            .map(logData -> (ParsedDeltaData) logData)
+            .filter(deltaData -> deltaData.isFile() && deltaData.isRatifiedCommit())
+            .collect(Collectors.toList());
+
     final long resolvedVersionToLoad =
         snapshotQueryCtx
             .getSnapshotMetrics()
             .computeTimestampToVersionTotalDurationTimer
             .time(
                 () ->
-                    // TODO provide catalogCommits to support ccv2 time-travel
                     DeltaHistoryManager.getActiveCommitAtTimestamp(
                             engine,
                             latestSnapshot,
@@ -76,7 +88,7 @@ public class SnapshotFactory {
                             true /* mustBeRecreatable */,
                             false /* canReturnLastCommit */,
                             false /* canReturnEarliestCommit */,
-                            Collections.emptyList() /* parsedDeltaDatas */)
+                            parsedDeltaDatas)
                         .getVersion());
 
     snapshotQueryCtx.setResolvedVersion(resolvedVersionToLoad);
@@ -186,7 +198,8 @@ public class SnapshotFactory {
               engine,
               snapshotCtx,
               ctx.timestampQueryContextOpt.get()._1,
-              ctx.timestampQueryContextOpt.get()._2));
+              ctx.timestampQueryContextOpt.get()._2,
+              ctx.logDatas));
     } else if (ctx.versionOpt.isPresent()) {
       return ctx.versionOpt;
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -76,13 +76,13 @@ public class SnapshotFactory {
                   checkState(
                       logData instanceof ParsedDeltaData,
                       String.format(
-                          "SnapshotBuilderImpl only supported ParsedDeltaData but found something else: %s",
+                          "SnapshotBuilderImpl only supports ParsedDeltaData but found: %s",
                           logData));
                   ParsedDeltaData deltaData = (ParsedDeltaData) logData;
                   checkState(
                       deltaData.isFile() && deltaData.isRatifiedCommit(),
                       String.format(
-                          "SnapshotBuilderImpl only supports ratified staged commits but found something else: %s",
+                          "SnapshotBuilderImpl only supports ratified staged commits but found: %s",
                           deltaData));
                   return deltaData;
                 })

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
@@ -124,18 +124,6 @@ class SnapshotBuilderSuite extends AnyFunSuite
     assert(exMsg === "protocol and metadata can only be provided if a version is provided")
   }
 
-  test("atTimestamp: time travel by timestamp with logDatas throws UnsupportedOperationException") {
-    val builder = TableManager.loadSnapshot(dataPath.toString)
-      .atTimestamp(0L, mockSnapshotAtTimestamp0)
-      .withLogData(parsedRatifiedStagedCommits(Seq(0)).toList.asJava)
-
-    val exMsg = intercept[UnsupportedOperationException] {
-      builder.build(emptyMockEngine)
-    }.getMessage
-
-    assert(exMsg === "Time travel by timestamp with logDatas is not yet implemented")
-  }
-
   // ===== Committer Tests ===== //
 
   test("withCommitter: null committer throws NullPointerException") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
@@ -166,4 +166,46 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite with TestUtilsWithTableMana
 
     }
   }
+
+  test("time-travel by ts read of catalogOwned-preview table with staged ratified commits") {
+    withCatalogOwnedPreviewTestTable { (tablePath, parsedLogData) =>
+      val v0Ts = 1749830855993L // published commit
+      val v1Ts = 1749830871085L // staged commit
+      val v2Ts = 1749830881799L // staged commit
+
+      val latestSnapshot = TableManager
+        .loadSnapshot(tablePath)
+        .asInstanceOf[SnapshotBuilderImpl]
+        .withLogData(parsedLogData.asJava)
+        .build(defaultEngine)
+
+      def checkTimeTravelByTimestamp(
+          timestamp: Long,
+          expectedVersion: Long,
+          expectedSnapshotTimestamp: Long): Unit = {
+        val snapshot = TableManager
+          .loadSnapshot(tablePath)
+          .atTimestamp(timestamp, latestSnapshot)
+          .withLogData(parsedLogData.asJava)
+          .build(defaultEngine)
+        assert(snapshot.getVersion == expectedVersion)
+        assert(snapshot.getTimestamp(defaultEngine) == expectedSnapshotTimestamp)
+      }
+
+      // Between v0 and v1 should return v0 (between published & staged)
+      checkTimeTravelByTimestamp(v0Ts + 1, 0, v0Ts)
+
+      // Exactly v1 should return v1
+      checkTimeTravelByTimestamp(v1Ts, 1, v1Ts)
+
+      // Between v1 and v2 should return v1 (between 2 staged commits)
+      checkTimeTravelByTimestamp(v1Ts + 1, 1, v1Ts)
+
+      // After v2 should fail
+      val e = intercept[KernelException] {
+        checkTimeTravelByTimestamp(v2Ts + 1, 2, v2Ts)
+      }
+      assert(e.getMessage.contains("is after the latest available version"))
+    }
+  }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
@@ -167,11 +167,11 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite with TestUtilsWithTableMana
     }
   }
 
-  test("time-travel by ts read of catalogOwned-preview table with staged ratified commits") {
+  test("time-travel by ts read of catalogOwned-preview table with ratified commits") {
     withCatalogOwnedPreviewTestTable { (tablePath, parsedLogData) =>
       val v0Ts = 1749830855993L // published commit
-      val v1Ts = 1749830871085L // staged commit
-      val v2Ts = 1749830881799L // staged commit
+      val v1Ts = 1749830871085L // ratified staged commit
+      val v2Ts = 1749830881799L // ratified staged commit
 
       val latestSnapshot = TableManager
         .loadSnapshot(tablePath)
@@ -192,14 +192,17 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite with TestUtilsWithTableMana
         assert(snapshot.getTimestamp(defaultEngine) == expectedSnapshotTimestamp)
       }
 
-      // Between v0 and v1 should return v0 (between published & staged)
+      // Between v0 and v1 should return v0 (between published & ratified)
       checkTimeTravelByTimestamp(v0Ts + 1, 0, v0Ts)
 
       // Exactly v1 should return v1
       checkTimeTravelByTimestamp(v1Ts, 1, v1Ts)
 
-      // Between v1 and v2 should return v1 (between 2 staged commits)
+      // Between v1 and v2 should return v1 (between 2 ratified commits)
       checkTimeTravelByTimestamp(v1Ts + 1, 1, v1Ts)
+
+      // Exactly v2 should return v2
+      checkTimeTravelByTimestamp(v2Ts, 2, v2Ts)
 
       // After v2 should fail
       val e = intercept[KernelException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Support time-travel-by-timestamp using the new SnapshotBuilder APIs with parsedLogData.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Adds an E2E test. The actual underlying timestamp-to-version resolution used for time-travel is already thoroughly unit tested in https://github.com/delta-io/delta/pull/5235.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

SnapshotBuilder.atTimestamp will work with parsedLogData.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
