### PR TITLE
[Spark] Plumb catalog tables to `DeltaLog` API call sites in `getChangeLogFiles` & `getChanges`

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -259,7 +259,8 @@ class HudiConverter(spark: SparkSession)
           spark = spark,
           deltaLog = log,
           startVersion = prevSnapshot.version + 1,
-          endVersion = snapshotToConvert.version)
+          endVersion = snapshotToConvert.version,
+          catalogTableOpt = catalogTable)
 
         recordDeltaEvent(
           snapshotToConvert.deltaLog,

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -353,7 +353,8 @@ class IcebergConverter(spark: SparkSession)
           spark = spark,
           deltaLog = log,
           startVersion = prevSnapshot.version + 1,
-          endVersion = snapshotToConvert.version)
+          endVersion = snapshotToConvert.version,
+          catalogTableOpt = Some(catalogTable))
 
         recordDeltaEvent(
           snapshotToConvert.deltaLog,

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -101,10 +101,13 @@ case class DeltaFormatSharingSource(
       deltaSharingTableMetadata,
       customTablePathWithUUIDSuffix
     )
+    // Delta sharing delta log doesn't have catalog table and `localDeltaLog` is not binded to
+    // catalog table.
     val schemaTrackingLogOpt =
       DeltaDataSource.getMetadataTrackingLogForDeltaSource(
         spark,
         snapshotDescriptor,
+        catalogTableOpt = None,
         parameters,
         // Pass in the metadata path opt so we can use it for validation
         sourceMetadataPathOpt = Some(metadataPath)

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -139,10 +139,12 @@ private[sharing] class DeltaSharingDataSource
         // streaming dataframe. We only need to merge consecutive schema changes here because the
         // process would create a new entry in the schema log such that when the schema log is
         // looked up again in the execution phase, we would use the correct schema.
+        // Delta sharing delta log doesn't have a catalog table, so we pass None here.
         DeltaDataSource
           .getMetadataTrackingLogForDeltaSource(
             sqlContext.sparkSession,
             snapshotDescriptor,
+            catalogTableOpt = None,
             parameters,
             mergeConsecutiveSchemaChanges = shouldMergeConsecutiveSchemas
           )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.JsonToStructs
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
@@ -58,12 +59,13 @@ object DeltaFileProviderUtils extends DeltaLogging {
       spark: SparkSession,
       deltaLog: DeltaLog,
       startVersion: Long,
-      endVersion: Long): Seq[FileStatus] = {
+      endVersion: Long,
+      catalogTableOpt: Option[CatalogTable]): Seq[FileStatus] = {
     // Pass `failOnDataLoss = false` as we are doing an explicit validation on the result ourselves
     // to identify that there are no gaps.
     val result =
       deltaLog
-        .getChangeLogFiles(startVersion, endVersion, failOnDataLoss = false)
+        .getChangeLogFiles(startVersion, endVersion, catalogTableOpt, failOnDataLoss = false)
         .map(_._2)
         .collect { case DeltaFile(fs, v) => (fs, v) }
         .toSeq

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -300,8 +300,10 @@ class DeltaLog private(
    */
   def getChanges(
       startVersion: Long,
+      catalogTableOpt: Option[CatalogTable] = None,
       failOnDataLoss: Boolean = false): Iterator[(Long, Seq[Action])] = {
-    getChangeLogFiles(startVersion, failOnDataLoss).map { case (version, status) =>
+    getChangeLogFiles(
+        startVersion, catalogTableOpt, failOnDataLoss).map { case (version, status) =>
       (version, store.read(status, newDeltaHadoopConf()).map(Action.fromJson(_)))
     }
   }
@@ -309,8 +311,13 @@ class DeltaLog private(
   private[sql] def getChanges(
       startVersion: Long,
       endVersion: Long,
+      catalogTableOpt: Option[CatalogTable],
       failOnDataLoss: Boolean): Iterator[(Long, Seq[Action])] = {
-    getChangeLogFiles(startVersion, endVersion, failOnDataLoss).map { case (version, status) =>
+    getChangeLogFiles(
+        startVersion,
+        endVersion,
+        catalogTableOpt,
+        failOnDataLoss).map { case (version, status) =>
       (version, store.read(status, newDeltaHadoopConf()).map(Action.fromJson(_)))
     }
   }
@@ -318,6 +325,7 @@ class DeltaLog private(
   private[sql] def getChangeLogFiles(
       startVersion: Long,
       endVersion: Long,
+      catalogTableOpt: Option[CatalogTable],
       failOnDataLoss: Boolean): Iterator[(Long, FileStatus)] = {
     implicit class IteratorWithStopAtHelper[T](underlying: Iterator[T]) {
       // This method is used to stop the iterator when the condition is met.
@@ -334,7 +342,7 @@ class DeltaLog private(
       }
     }
 
-    getChangeLogFiles(startVersion, failOnDataLoss)
+    getChangeLogFiles(startVersion, catalogTableOpt, failOnDataLoss)
       // takeWhile always looks at one extra item, which can trigger unnecessary work. Instead, we
       // stop if we've seen the item we believe should be the last interesting item, without
       // examining the one that follows.
@@ -351,8 +359,8 @@ class DeltaLog private(
    */
   def getChangeLogFiles(
       startVersion: Long,
-      failOnDataLoss: Boolean = false,
-      catalogTableOpt: Option[CatalogTable] = None): Iterator[(Long, FileStatus)] = {
+      catalogTableOpt: Option[CatalogTable] = None,
+      failOnDataLoss: Boolean = false): Iterator[(Long, FileStatus)] = {
     val deltasWithVersion = CoordinatedCommitsUtils.commitFilesIterator(
       this, catalogTableOpt, startVersion)
     // Subtract 1 to ensure that we have the same check for the inclusive startVersion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -667,7 +667,7 @@ case class CheckpointProtectionPreDowngradeCommand(table: DeltaTableV2)
   override def removeFeatureTracesIfNeeded(spark: SparkSession): PreDowngradeStatus = {
     val snapshot = table.initialSnapshot
 
-    if (!historyPriorToCheckpointProtectionVersionIsTruncated(snapshot)) {
+    if (!historyPriorToCheckpointProtectionVersionIsTruncated(snapshot, table.catalogTable)) {
       // Add a checkpoint here to make sure we can cleanup up everything before this commit.
       // This is because metadata cleanup operations, can only clean up to the latest checkpoint.
       createEmptyCommitAndCheckpoint(table, table.deltaLog.clock.nanoTime())
@@ -678,7 +678,7 @@ case class CheckpointProtectionPreDowngradeCommand(table: DeltaTableV2)
         deltaRetentionMillisOpt = Some(truncateHistoryLogRetentionMillis(snapshot.metadata)),
         cutoffTruncationGranularity = TruncationGranularity.MINUTE)
 
-      if (!historyPriorToCheckpointProtectionVersionIsTruncated(snapshot)) {
+      if (!historyPriorToCheckpointProtectionVersionIsTruncated(snapshot, table.catalogTable)) {
         throw DeltaErrors.dropCheckpointProtectionWaitForRetentionPeriod(
           table.initialSnapshot.metadata)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -651,7 +651,8 @@ trait CDCReaderImpl extends CDCReaderBase {
       useCoarseGrainedCDC: Boolean = false,
       startVersionSnapshot: Option[SnapshotDescriptor] = None): DataFrame = {
 
-    val changesWithinRange = deltaLog.getChanges(start, end, failOnDataLoss = false)
+    val changesWithinRange = deltaLog.getChanges(
+      start, end, catalogTableOpt = None, failOnDataLoss = false)
     changesToDF(
       readSchemaSnapshot.getOrElse(deltaLog.unsafeVolatileSnapshot),
       start,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -137,7 +137,7 @@ class DeltaDataSource
       // process would create a new entry in the schema log such that when the schema log is
       // looked up again in the execution phase, we would use the correct schema.
       DeltaDataSource.getMetadataTrackingLogForDeltaSource(
-          sqlContext.sparkSession, snapshot, parameters,
+          sqlContext.sparkSession, snapshot, catalogTableOpt, parameters,
           mergeConsecutiveSchemaChanges = shouldMergeConsecutiveSchemas)
         .flatMap(_.getCurrentTrackedMetadata.map(_.dataSchema))
         .getOrElse(snapshot.schema)
@@ -180,7 +180,7 @@ class DeltaDataSource
       getSnapshotFromTableOrPath(sqlContext.sparkSession, new Path(path))
     val schemaTrackingLogOpt =
       DeltaDataSource.getMetadataTrackingLogForDeltaSource(
-        sqlContext.sparkSession, snapshot, parameters,
+        sqlContext.sparkSession, snapshot, catalogTableOpt, parameters,
         // Pass in the metadata path opt so we can use it for validation
         sourceMetadataPathOpt = Some(metadataPath))
 
@@ -485,6 +485,7 @@ object DeltaDataSource extends DatabricksLogging {
   def getMetadataTrackingLogForDeltaSource(
       spark: SparkSession,
       sourceSnapshot: SnapshotDescriptor,
+      catalogTableOpt: Option[CatalogTable],
       parameters: Map[String, String],
       sourceMetadataPathOpt: Option[String] = None,
       mergeConsecutiveSchemaChanges: Boolean = false): Option[DeltaSourceMetadataTrackingLog] = {
@@ -498,7 +499,10 @@ object DeltaDataSource extends DatabricksLogging {
         }
 
         DeltaSourceMetadataTrackingLog.create(
-          spark, schemaTrackingLocation, sourceSnapshot,
+          spark,
+          schemaTrackingLocation,
+          sourceSnapshot,
+          catalogTableOpt,
           parameters,
           sourceMetadataPathOpt,
           mergeConsecutiveSchemaChanges

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -818,7 +818,7 @@ case class DeltaSource(
       require(options.failOnDataLoss || !trackingMetadataChange,
         "Using schema from schema tracking log cannot tolerate missing commit files.")
       deltaLog.getChangeLogFiles(
-        startVersion, options.failOnDataLoss, catalogTableOpt).flatMapWithClose {
+        startVersion, catalogTableOpt, options.failOnDataLoss).flatMapWithClose {
         case (version, filestatus) =>
           // First pass reads the whole commit and closes the iterator.
           val iter = DeltaSource.createRewindableActionIterator(spark, deltaLog, filestatus)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
@@ -250,7 +250,8 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
       //    in that case, we need to recompute the start snapshot and evolve the schema if needed
       require(options.failOnDataLoss || !trackingMetadataChange,
         "Using schema from schema tracking log cannot tolerate missing commit files.")
-      deltaLog.getChanges(startVersion, options.failOnDataLoss).map { case (version, actions) =>
+      deltaLog.getChanges(
+          startVersion, catalogTableOpt, options.failOnDataLoss).map { case (version, actions) =>
         // skipIndexedFile must be applied after creating IndexedFile so that
         // IndexedFile.index is consistent across all versions.
         val (fileActions, skipIndexedFile, metadataOpt, protocolOpt, commitInfoOpt) =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -188,7 +188,7 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
       startVersion: Long,
       endVersion: Long
   ): ClosableIterator[(Long, Action)] = {
-    deltaLog.getChangeLogFiles(startVersion, options.failOnDataLoss, catalogTableOpt).takeWhile {
+    deltaLog.getChangeLogFiles(startVersion, catalogTableOpt, options.failOnDataLoss).takeWhile {
       case (version, _) => version <= endVersion
     }.flatMapWithClose { case (version, fileStatus) =>
       DeltaSource.createRewindableActionIterator(spark, deltaLog, fileStatus)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBi
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.PathWithFileSystem
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -779,7 +779,7 @@ class DeltaLogSuite extends QueryTest
       spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
       val log = DeltaLog.forTable(spark, new Path(path))
       val result = DeltaFileProviderUtils.getDeltaFilesInVersionRange(
-        spark, log, startVersion = 1, endVersion = 3)
+        spark, log, startVersion = 1, endVersion = 3, catalogTableOpt = None)
       assert(result.map(FileNames.getFileVersion) === Seq(1, 2, 3))
       val filesAreUnbackfilledArray = result.map(FileNames.isUnbackfilledDeltaFile)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaMetricsUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaMetricsUtils.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, CommitInfo, RemoveFile}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.scalatest.Assertions._
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
 import org.apache.spark.sql.delta.sources.{DeltaSink, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.commons.io.FileUtils
 import org.scalatest.time.SpanSugar._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -223,6 +223,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
   )(implicit log: DeltaLog): DeltaSourceMetadataTrackingLog =
     DeltaSourceMetadataTrackingLog.create(
       spark, getDefaultSchemaLocation.toString, log.update(),
+      catalogTableOpt = None,
       parameters = sourceTrackingId.map(DeltaOptions.STREAMING_SOURCE_TRACKING_ID -> _).toMap,
       initMetadataLogEagerly = initializeEagerly)
 
@@ -536,9 +537,9 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       val schemaLocation = getDefaultSchemaLocation.toString
       val snapshot = log.update()
       val schemaLog1 = DeltaSourceMetadataTrackingLog.create(
-        spark, schemaLocation, snapshot, parameters = Map.empty)
+        spark, schemaLocation, snapshot, catalogTableOpt = None, parameters = Map.empty)
       val schemaLog2 = DeltaSourceMetadataTrackingLog.create(
-        spark, schemaLocation, snapshot, Map.empty)
+        spark, schemaLocation, snapshot, catalogTableOpt = None, Map.empty)
       val newSchema =
         PersistedMetadata("1", 1,
           makeMetadata(new StructType(), partitionSchema = new StructType()),
@@ -1610,9 +1611,9 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
 
     // Both schema log initialized
     def schemaLog1: DeltaSourceMetadataTrackingLog = DeltaSourceMetadataTrackingLog.create(
-      spark, schemaLog1Location, log.update(), parameters = Map.empty)
+      spark, schemaLog1Location, log.update(), catalogTableOpt = None, parameters = Map.empty)
     def schemaLog2: DeltaSourceMetadataTrackingLog = DeltaSourceMetadataTrackingLog.create(
-      spark, schemaLog2Location, log.update(), parameters = Map.empty)
+      spark, schemaLog2Location, log.update(), catalogTableOpt = None, parameters = Map.empty)
 
     // The schema log initializes @ v5 with schema <a, b>
     testStream(df)(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuite.scala
@@ -24,6 +24,7 @@ import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.hooks.UpdateCatalog
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaHiveTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import com.fasterxml.jackson.core.JsonParseException
 
 import org.apache.spark.{SparkConf, SparkContext}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -371,7 +371,8 @@ trait DeltaVacuumSuiteBase extends QueryTest
    * Helper method to get all of the [[AddCDCFile]]s that exist in the delta table
    */
   protected def getCDCFiles(deltaLog: DeltaLog): Seq[AddCDCFile] = {
-    val changes = deltaLog.getChanges(startVersion = 0, failOnDataLoss = true)
+    val changes = deltaLog.getChanges(
+      startVersion = 0, catalogTableOpt = None, failOnDataLoss = true)
     changes.flatMap(_._2).collect { case a: AddCDCFile => a }.toList
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnAdmissionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnAdmissionSuite.scala
@@ -21,6 +21,7 @@ import java.io.{File, FileNotFoundException, PrintWriter}
 import org.apache.spark.sql.delta.GeneratedAsIdentityType.GeneratedAlways
 import org.apache.spark.sql.delta.actions.RemoveFile
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkException}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 import org.apache.spark.sql.delta.actions.SetTransaction
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.plans.Inner

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.Utils.try_element_at
 
 import org.apache.spark.sql.{DataFrameWriter, QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.errors.QueryExecutionErrors.toSQLType

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1497,7 +1497,8 @@ abstract class CommitCoordinatorSuiteBase
     val usageRecords = Log4jUsageLogger.track {
       val iter = endVersionOpt match {
         case Some(endVersion) =>
-          deltaLog.getChangeLogFiles(startVersion, endVersion, failOnDataLoss = false)
+          deltaLog.getChangeLogFiles(
+            startVersion, endVersion, catalogTableOpt = None, failOnDataLoss = false)
         case None =>
           deltaLog.getChangeLogFiles(startVersion)
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -187,7 +187,8 @@ trait OptimizeCompactionSuiteBase extends QueryTest
         spark.range(start = 1, end = 2, step = 1, numPartitions = 1)
             .toDF("id").withColumn(colName = "extra", lit(""))
           .write.format("delta").mode("append").save(path) // v4
-        val smallFiles = addedFiles(deltaLog.getChanges(startVersion = 4).next()._2)
+        val smallFiles = addedFiles(
+          deltaLog.getChanges(startVersion = 4, catalogTableOpt = None).next()._2)
         assert(smallFiles.size == 1)
 
         // Save the data before optimize for comparing it later with optimize
@@ -199,7 +200,7 @@ trait OptimizeCompactionSuiteBase extends QueryTest
         withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE.key -> targetSmallSize.toString) {
           executeOptimizePath(path) // v5
         }
-        val changes = deltaLog.getChanges(startVersion = 5).next()._2
+        val changes = deltaLog.getChanges(startVersion = 5, catalogTableOpt = None).next()._2
 
         // We expect the two files containing more than the threshold rows to be compacted.
         var expectedRemoveFiles = Set(file0.path, file1.path)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.commands.backfill.{BackfillBatchStats, Backfil
 import org.apache.spark.sql.delta.rowtracking.RowTrackingTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.metadata.BlockMetaData

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/DefaultRowCommitVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/DefaultRowCommitVersionSuite.scala
@@ -39,7 +39,8 @@ class DefaultRowCommitVersionSuite extends QueryTest
 
   def expectedCommitVersionsForAllFiles(deltaLog: DeltaLog): Map[String, Long] = {
     val commitVersionForFiles = mutable.Map.empty[String, Long]
-    deltaLog.getChanges(startVersion = 0).foreach { case (commitVersion, actions) =>
+    deltaLog.getChanges(
+        startVersion = 0, catalogTableOpt = None).foreach { case (commitVersion, actions) =>
       actions.foreach {
         case a: AddFile if !commitVersionForFiles.contains(a.path) =>
           commitVersionForFiles += a.path -> commitVersion

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
@@ -39,7 +39,8 @@ class DeletionVectorFileSizeSuite extends QueryTest
       commitVersion: Long): (Seq[AddFile], Seq[RemoveFile]) = {
     require(commitVersion <= deltaLog.update().version,
       "Commit version should be less than or equal to the current version")
-    val changes = deltaLog.getChanges(commitVersion, commitVersion, failOnDataLoss = true)
+    val changes = deltaLog.getChanges(
+      commitVersion, commitVersion, catalogTableOpt = None, failOnDataLoss = true)
     val (changesItrForAddFiles, changesItrForRemoveFiles) = changes.duplicate
     val addFiles: Seq[AddFile] =
        changesItrForAddFiles.flatMap(_._2.collect { case a: AddFile => a }).toSeq

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.hooks.AutoCompact
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import io.delta.storage.commit.{CommitResponse, GetCommitsResponse, UpdatedActions}
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -184,6 +184,24 @@ object DeltaTestImplicits {
 
     def upgradeProtocol(snapshot: Snapshot, newVersion: Protocol): Unit = {
       deltaLog.upgradeProtocol(None, snapshot, newVersion)
+    }
+
+    /**
+     * Test helper method for getChangeLogFiles that provides catalogTableOpt = None
+     * for backward compatibility with existing unit tests.
+     */
+    def getChangeLogFiles(startVersion: Long): Iterator[(Long, FileStatus)] = {
+      deltaLog.getChangeLogFiles(startVersion, catalogTableOpt = None)
+    }
+
+    /**
+     * Test helper method for getChanges that provides catalogTableOpt = None for backward
+     * compatibility with existing unit tests.
+     */
+    def getChanges(
+        startVersion: Long,
+        failOnDataLoss: Boolean = false): Iterator[(Long, Seq[Action])] = {
+      deltaLog.getChanges(startVersion, catalogTableOpt = None, failOnDataLoss)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is to pass catalog tables to `DeltaLog` API `getChangeLogFiles` & `getChanges` call sites.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
