### PR TITLE
[Spark] not using field id when read row tracking columns

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
@@ -36,10 +36,12 @@ object RowCommitVersion {
   def createMetadataStructField(
       protocol: Protocol,
       metadata: Metadata,
-      nullable: Boolean = false,
-      shouldSetIcebergReservedFieldId: Boolean): Option[StructField] =
+      nullable: Boolean = false): Option[StructField] =
     MaterializedRowCommitVersion.getMaterializedColumnName(protocol, metadata)
-      .map(MetadataStructField(_, nullable, shouldSetIcebergReservedFieldId))
+      // Use column name instead of field ID when accessing the materialized row commit version
+      // column. This handles cases where field IDs are not available in the Parquet file,
+      // such as with legacy materialized columns created before column mapping enabled.
+      .map(MetadataStructField(_, nullable, shouldSetIcebergReservedFieldId = false))
 
   /**
    * Add a new column to `dataFrame` that has the name of the materialized Row Commit Version column

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -209,10 +209,12 @@ object RowId {
   def createRowIdField(
     protocol: Protocol,
     metadata: Metadata,
-    nullable: Boolean,
-    shouldSetIcebergReservedFieldId: Boolean): Option[StructField] =
+    nullable: Boolean): Option[StructField] =
     MaterializedRowId.getMaterializedColumnName(protocol, metadata)
-      .map(RowIdMetadataStructField(_, nullable, shouldSetIcebergReservedFieldId))
+      // Use column name instead of field ID when accessing the materialized row id
+      // column. This handles cases where field IDs are not available in the Parquet file,
+      // such as with legacy materialized columns created before column mapping enabled.
+      .map(RowIdMetadataStructField(_, nullable, shouldSetIcebergReservedFieldId = false))
 
   /*
    * A specialization of [[FileSourceGeneratedMetadataStructField]] used to represent RowId columns.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
@@ -90,16 +90,13 @@ object RowTracking {
       metadata: Metadata,
       nullableConstantFields: Boolean,
       nullableGeneratedFields: Boolean): Iterable[StructField] = {
-    val needSetRowTrackingFieldIdForUniform =
-      IcebergCompat.isGeqEnabled(metadata, requiredVersion = 3)
-
     RowId.createRowIdField(
-      protocol, metadata, nullableGeneratedFields, needSetRowTrackingFieldIdForUniform) ++
+      protocol, metadata, nullableGeneratedFields) ++
       RowId.createBaseRowIdField(protocol, metadata, nullableConstantFields) ++
       DefaultRowCommitVersion.createDefaultRowCommitVersionField(
         protocol, metadata, nullableConstantFields) ++
       RowCommitVersion.createMetadataStructField(
-        protocol, metadata, nullableGeneratedFields, needSetRowTrackingFieldIdForUniform)
+        protocol, metadata, nullableGeneratedFields)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Not use field id when trying to access the two row tracking materialized columns

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No