### PR TITLE
[Spark] Make sure we never get NPE from CDC read

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -128,6 +128,8 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
     testNullRangeBoundary(start, EndingVersion("null"))
   }
 
+  testNullRangeBoundary(StartingVersion("CAST(null AS INT)"), Unbounded)
+
   test("select individual column should push down filters") {
     val tblName = "tbl"
     withTable(tblName) {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The previous fix for `NullPointerException` in #4489 wasn't enough to catch all cases: `table_changes('tableName', CAST(null AS INT))` would still result in NPE. This PR fixes it by wrapping the code in try-catch, and rethrowing correct error on NPE.

## How was this patch tested?

New unit test with casted null.

## Does this PR introduce _any_ user-facing changes?

No