### PR TITLE
[Kernel] Incremental LogSegment update APIs

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
@@ -40,28 +40,27 @@ public class LogSegment {
   //////////////////////////////////////////
 
   /**
-   * Creates a LogSegment from a single ParsedDeltaData. Used to construct a post-commit Snapshot
-   * after a CREATE transaction.
+   * Creates a LogSegment for a newly created table from a single {@link ParsedDeltaData}. Used to
+   * construct a post-commit Snapshot after a CREATE transaction.
    *
    * @param logPath The path to the _delta_log directory
-   * @param parsedDelta The ParsedDeltaData (e.g., version 0)
+   * @param parsedDeltaVersion0 The ParsedDeltaData that must be for version 0
    * @return A new LogSegment with just this delta
    * @throws IllegalArgumentException if the ParsedDeltaData is not file-based
    */
-  public static LogSegment createFromSingleDelta(Path logPath, ParsedDeltaData parsedDelta) {
-    checkArgument(parsedDelta.isFile(), "Currently, only file-based deltas are supported");
+  public static LogSegment createForNewTable(Path logPath, ParsedDeltaData parsedDeltaVersion0) {
+    checkArgument(parsedDeltaVersion0.isFile(), "Currently, only file-based deltas are supported");
     checkArgument(
-        parsedDelta.getVersion() == 0L,
+        parsedDeltaVersion0.getVersion() == 0L,
         "Version must be 0 for a LogSegment with only a single delta");
 
-    final FileStatus deltaFile = parsedDelta.getFileStatus();
-    final long version = parsedDelta.getVersion();
+    final FileStatus deltaFile = parsedDeltaVersion0.getFileStatus();
     final List<FileStatus> deltas = Collections.singletonList(deltaFile);
     final List<FileStatus> checkpoints = Collections.emptyList();
     final List<FileStatus> compactions = Collections.emptyList();
 
     return new LogSegment(
-        logPath, version, deltas, compactions, checkpoints, deltaFile, Optional.empty());
+        logPath, 0 /* version */, deltas, compactions, checkpoints, deltaFile, Optional.empty());
   }
 
   private static final Logger logger = LoggerFactory.getLogger(LogSegment.class);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
@@ -528,7 +528,7 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils with Ve
 
   test("fromSingleDelta -- creates valid LogSegment") {
     val deltaData = ParsedDeltaData.forFileStatus(deltaFileStatus(0))
-    val logSegment = LogSegment.createFromSingleDelta(logPath, deltaData)
+    val logSegment = LogSegment.createForNewTable(logPath, deltaData)
 
     assert(logSegment.getVersion === 0)
     assert(logSegment.getDeltas.size() === 1)
@@ -540,7 +540,7 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils with Ve
   test("fromSingleDelta -- non-zero version fails") {
     val deltaData = ParsedDeltaData.forFileStatus(deltaFileStatus(1))
     val exMsg = intercept[IllegalArgumentException] {
-      LogSegment.createFromSingleDelta(logPath, deltaData)
+      LogSegment.createForNewTable(logPath, deltaData)
     }.getMessage
     assert(exMsg.contains("Version must be 0 for a LogSegment with only a single delta"))
   }
@@ -548,7 +548,7 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils with Ve
   test("fromSingleDelta -- inline delta fails") {
     val inlineDelta = ParsedDeltaData.forInlineData(0, emptyColumnarBatch)
     val exMsg = intercept[IllegalArgumentException] {
-      LogSegment.createFromSingleDelta(logPath, inlineDelta)
+      LogSegment.createForNewTable(logPath, inlineDelta)
     }.getMessage
     assert(exMsg.contains("Currently, only file-based deltas are supported"))
   }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5262/files) to review incremental changes.
- [**stack/kernel_post_commit_snapshot_1_log_segment_extension**](https://github.com/delta-io/delta/pull/5262) [[Files changed](https://github.com/delta-io/delta/pull/5262/files)]
  - [stack/kernel_post_commit_snapshot_2_snapshot_extension](https://github.com/delta-io/delta/pull/5280) [[Files changed](https://github.com/delta-io/delta/pull/5280/files/94155a89873b25094372f2de53e3c9346e7e6296..4b5dd1cec83f66a4d7ae70461d9ad479b3263944)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR adds two new internal LogSegment APIs that will help us create updated LogSegments after a transaction.

This is PR 1 as part of the post-commit-snapshot effort.

For the e2e prototype that has already derisked all of this, please see https://github.com/delta-io/delta/pull/5213

## How was this patch tested?

New UTs.

## Does this PR introduce _any_ user-facing changes?

No.
