### PR TITLE
[Spark][CherryPick][3.3] Support RANDOMIZE_FILE_PREFIXES 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -69,8 +69,20 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
       Some("data")
     } else None
 
-  protected def getCommitter(outputPath: Path): DelayedCommitProtocol =
-    new DelayedCommitProtocol("delta", outputPath.toString, None, deltaDataSubdir)
+  // It's okay to make this a lazy val. Once this is read, the metadata will be marked as read
+  // and can't be changed again within the transaction, otherwise it will throw an exception.
+  private lazy val randomizeFilePrefixes =
+    DeltaConfigs.RANDOMIZE_FILE_PREFIXES.fromMetaData(metadata)
+  private lazy val randomPrefixLength = DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(metadata)
+
+  protected def getCommitter(outputPath: Path): DelayedCommitProtocol = {
+    // We force the use of random prefixes in column mapping modes.
+    // Note that here we need to use the txn metadata instead of the snapshot's metadata
+    val prefixLengthOpt = if (randomizeFilePrefixes || metadata.columnMappingMode != NoMapping) {
+      Some(randomPrefixLength)
+    } else None
+    new DelayedCommitProtocol("delta", outputPath.toString, prefixLengthOpt, deltaDataSubdir)
+  }
 
   /** Makes the output attributes nullable, so that we don't write unreadable parquet files. */
   protected def makeOutputNullable(output: Seq[Attribute]): Seq[Attribute] = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -222,6 +222,205 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
     }
   }
 
+  ddlTest("SET TBLPROPERTIES - delta.randomizeFilePrefixes") {
+    withDeltaTable("v1 int, v2 string") { tableName =>
+      // Initially, randomizeFilePrefixes should be false (default)
+      val (deltaLog, initialSnapshot) = getDeltaLogWithSnapshot(tableName)
+      assert(!DeltaConfigs.RANDOMIZE_FILE_PREFIXES.fromMetaData(initialSnapshot.metadata),
+        "randomizeFilePrefixes should be false by default")
+
+      // Set delta.randomizeFilePrefixes and delta.randomPrefixLength
+      sql(s"""
+         |ALTER TABLE $tableName
+         |SET TBLPROPERTIES (
+         |  'delta.randomizeFilePrefixes' = 'true',
+         |  'delta.randomPrefixLength' = '5'
+         |)""".stripMargin)
+
+      val snapshot1 = deltaLog.update()
+      assertEqual(snapshot1.metadata.configuration, Map(
+        "delta.randomizeFilePrefixes" -> "true",
+        "delta.randomPrefixLength" -> "5"
+      ))
+
+      // Verify the configuration is properly parsed
+      assert(DeltaConfigs.RANDOMIZE_FILE_PREFIXES.fromMetaData(snapshot1.metadata),
+        "randomizeFilePrefixes should be enabled")
+      assert(DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(snapshot1.metadata) == 5,
+        "randomPrefixLength should be 5")
+
+      // Insert data to create files with random prefixes
+      sql(s"INSERT INTO $tableName VALUES (1, 'test1'), (2, 'test2'), (3, 'test3')")
+
+      val snapshot2 = deltaLog.update()
+      val allFiles = snapshot2.allFiles.collect()
+
+      // Verify that files exist and have random prefixes
+      assert(allFiles.nonEmpty, "Table should have data files")
+
+      // Check that file paths contain 5-character random prefix pattern
+      val prefixLength = DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(snapshot2.metadata)
+      assert(prefixLength == 5, s"Expected prefix length of 5, but got $prefixLength")
+
+      val pattern = s"[A-Za-z0-9]{$prefixLength}/.*part-.*parquet"
+      allFiles.foreach { file =>
+        assert(file.path.matches(pattern),
+          s"File path '${file.path}' does not match expected random prefix pattern '$pattern'")
+      }
+    }
+  }
+
+  ddlTest("UNSET TBLPROPERTIES - delta.randomizeFilePrefixes") {
+    withDeltaTable("v1 int, v2 string") { tableName =>
+      // First, set the randomizeFilePrefixes properties
+      sql(s"""
+         |ALTER TABLE $tableName
+         |SET TBLPROPERTIES (
+         |  'delta.randomizeFilePrefixes' = 'true',
+         |  'delta.randomPrefixLength' = '8',
+         |  'key' = 'value'
+         |)""".stripMargin)
+
+      val (deltaLog, snapshot1) = getDeltaLogWithSnapshot(tableName)
+      assertEqual(snapshot1.metadata.configuration, Map(
+        "delta.randomizeFilePrefixes" -> "true",
+        "delta.randomPrefixLength" -> "8",
+        "key" -> "value"
+      ))
+
+      // Verify the configuration is properly set
+      assert(DeltaConfigs.RANDOMIZE_FILE_PREFIXES.fromMetaData(snapshot1.metadata),
+        "randomizeFilePrefixes should be enabled")
+      assert(DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(snapshot1.metadata) == 8,
+        "randomPrefixLength should be 8")
+
+      // Insert data to create files with random prefixes
+      sql(s"INSERT INTO $tableName VALUES (1, 'test1'), (2, 'test2')")
+
+      val snapshot1WithData = deltaLog.update()
+      val filesWithPrefixes = snapshot1WithData.allFiles.collect()
+
+      // Verify files have random prefixes
+      assert(filesWithPrefixes.nonEmpty, "Table should have data files")
+      val pattern8 = s"[A-Za-z0-9]{8}/.*part-.*parquet"
+      filesWithPrefixes.foreach { file =>
+        assert(file.path.matches(pattern8),
+          s"File path '${file.path}' should have 8-character random prefix")
+      }
+
+      // Now UNSET the randomizeFilePrefixes property
+      sql(s"ALTER TABLE $tableName UNSET TBLPROPERTIES ('delta.randomizeFilePrefixes', 'key')")
+
+      val snapshot2 = deltaLog.update()
+      assertEqual(snapshot2.metadata.configuration,
+        Map("delta.randomPrefixLength" -> "8"))
+
+      // Verify that randomizeFilePrefixes is now disabled (reverted to default)
+      assert(!DeltaConfigs.RANDOMIZE_FILE_PREFIXES.fromMetaData(snapshot2.metadata),
+        "randomizeFilePrefixes should be disabled after UNSET")
+      assert(DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(snapshot2.metadata) == 8,
+        "randomPrefixLength should still be 8 (not unset)")
+
+      // Insert more data to verify new files don't have random prefixes
+      sql(s"INSERT INTO $tableName VALUES (3, 'test3'), (4, 'test4')")
+
+      val snapshot3 = deltaLog.update()
+      val allFiles = snapshot3.allFiles.collect()
+      val newFiles = allFiles.filterNot(f => filesWithPrefixes.exists(_.path == f.path))
+
+      // Verify that new files don't have random prefixes (should be regular paths)
+      assert(newFiles.nonEmpty, "Should have new files after second insert")
+      newFiles.foreach { file =>
+        assert(!file.path.matches(pattern8),
+          s"New file path '${file.path}' should NOT have random prefix after UNSET")
+        // New files should have regular naming without random prefixes
+        assert(file.path.matches(".*part-.*parquet"),
+          s"New file path '${file.path}' should have regular parquet file naming")
+      }
+    }
+  }
+
+
+  ddlTest("SET/UNSET TBLPROPERTIES - delta.randomizeFilePrefixes - partitioned table") {
+    withDeltaTable(Seq((1, "x", 100), (2, "y", 200)).toDF("id", "part", "value"),
+                   Seq("part")) { tableName =>
+      // First, set the randomizeFilePrefixes properties
+      sql(s"""
+         |ALTER TABLE $tableName
+         |SET TBLPROPERTIES (
+         |  'delta.randomizeFilePrefixes' = 'true',
+         |  'delta.randomPrefixLength' = '7',
+         |  'key' = 'value'
+         |)""".stripMargin)
+
+      val (deltaLog, snapshot1) = getDeltaLogWithSnapshot(tableName)
+      assertEqual(snapshot1.metadata.configuration, Map(
+        "delta.randomizeFilePrefixes" -> "true",
+        "delta.randomPrefixLength" -> "7",
+        "key" -> "value"
+      ))
+
+      // Get initial files (created during table setup - should have partition structure)
+      val initialFiles = deltaLog.update().allFiles.collect()
+
+      // Insert data to create files with random prefixes
+      sql(s"INSERT INTO $tableName VALUES (3, 'x', 300), (4, 'z', 400)")
+
+      val snapshot1WithData = deltaLog.update()
+      val filesInSnapshot1 = snapshot1WithData.allFiles.collect()
+
+      // Separate initial files from new files with prefixes
+      val filesWithPrefixes = filesInSnapshot1.filterNot(f => initialFiles.exists(_.path == f.path))
+
+      // Verify INITIAL files have partition directory structure
+      // (created before random prefixes enabled)
+      val initialPartitionPattern = s"part=[xyz]/.*part-.*parquet"
+      initialFiles.foreach { file =>
+        assert(file.path.matches(initialPartitionPattern),
+          s"Initial file path '${file.path}' should have partition directory structure")
+      }
+
+      // Verify NEW files have random prefixes (created after random prefixes enabled)
+      assert(filesWithPrefixes.nonEmpty, "Should have new files with random prefixes")
+      val pattern7 = s"[A-Za-z0-9]{7}/.*part-.*parquet"
+      filesWithPrefixes.foreach { file =>
+        assert(file.path.matches(pattern7),
+          s"New file path '${file.path}' should have 7-character random prefix")
+      }
+
+      // Now UNSET the randomizeFilePrefixes property
+      sql(s"ALTER TABLE $tableName UNSET TBLPROPERTIES ('delta.randomizeFilePrefixes', 'key')")
+
+      val snapshot2 = deltaLog.update()
+      assertEqual(snapshot2.metadata.configuration,
+        Map("delta.randomPrefixLength" -> "7"))
+
+      // Verify that randomizeFilePrefixes is now disabled
+      assert(!DeltaConfigs.RANDOMIZE_FILE_PREFIXES.fromMetaData(snapshot2.metadata),
+        "randomizeFilePrefixes should be disabled after UNSET")
+      assert(DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(snapshot2.metadata) == 7,
+        "randomPrefixLength should still be 7 (not unset)")
+
+      // Insert more data to verify new files don't have random prefixes
+      sql(s"INSERT INTO $tableName VALUES (5, 'x', 500), (6, 'y', 600)")
+
+      val snapshot3 = deltaLog.update()
+      val allFinalFiles = snapshot3.allFiles.collect()
+      val filesAfterUnset = allFinalFiles.filterNot(f => filesInSnapshot1.exists(_.path == f.path))
+
+      // Verify that new files don't have random prefixes (should revert to partition structure)
+      assert(filesAfterUnset.nonEmpty, "Should have new files after UNSET and second insert")
+      val partitionPatternAfterUnset = s"part=[xy]/.*part-.*parquet"
+      filesAfterUnset.foreach { file =>
+        assert(!file.path.matches(pattern7),
+          s"File after UNSET '${file.path}' should NOT have random prefix")
+        // New files should revert to partition directory structure
+        assert(file.path.matches(partitionPatternAfterUnset),
+          s"File after UNSET '${file.path}' should have partition directory structure")
+      }
+    }
+  }
+
   test("SET/UNSET comment by TBLPROPERTIES") {
     withDeltaTable("v1 int, v2 string") { tableName =>
       def assertCommentEmpty(): Unit = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -1024,6 +1024,113 @@ trait DeltaTableCreationTests
     }
   }
 
+ test("create table with table properties - delta.randomizeFilePrefixes") {
+    withTable("delta_test") {
+      sql(s"""
+             |CREATE TABLE delta_test(a LONG, b String)
+             |USING delta
+             |TBLPROPERTIES(
+             |  'delta.randomizeFilePrefixes' = 'true',
+             |  'delta.randomPrefixLength' = '5'
+             |)
+          """.stripMargin)
+
+      val deltaLog = getDeltaLog("delta_test")
+      val snapshot = deltaLog.update()
+
+      // Verify the properties are set correctly
+      assertEqual(snapshot.metadata.configuration, Map(
+        "delta.randomizeFilePrefixes" -> "true",
+        "delta.randomPrefixLength" -> "5"
+      ))
+
+      // Insert some data to create files
+      sql("INSERT INTO delta_test VALUES (1, 'test1'), (2, 'test2'), (3, 'test3')")
+
+      val updatedSnapshot = deltaLog.update()
+      val allFiles = updatedSnapshot.allFiles.collect()
+
+      // Verify that files exist and have random prefixes
+      assert(allFiles.nonEmpty, "Table should have data files")
+
+      // Check that file paths contain 5-character random prefix pattern
+      val prefixLength = DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(updatedSnapshot.metadata)
+      assert(prefixLength == 5, s"Expected prefix length of 5, but got $prefixLength")
+
+      val pattern = s"[A-Za-z0-9]{$prefixLength}/.*part-.*parquet"
+      allFiles.foreach { file =>
+        assert(file.path.matches(pattern),
+          s"File path '${file.path}' does not match expected random prefix pattern '$pattern'")
+      }
+    }
+  }
+
+  test("create partitioned table with table properties - delta.randomizeFilePrefixes") {
+    withTable("delta_test") {
+      sql(s"""
+             |CREATE TABLE delta_test(id LONG, part String, value INT)
+             |USING delta
+             |PARTITIONED BY (part)
+             |TBLPROPERTIES(
+             |  'delta.randomizeFilePrefixes' = 'true',
+             |  'delta.randomPrefixLength' = '4'
+             |)
+          """.stripMargin)
+
+      val deltaLog = getDeltaLog("delta_test")
+      val snapshot = deltaLog.update()
+
+      // Verify the properties are set correctly
+      assertEqual(snapshot.metadata.configuration, Map(
+        "delta.randomizeFilePrefixes" -> "true",
+        "delta.randomPrefixLength" -> "4"
+      ))
+
+      // Verify the configuration is properly parsed
+      assert(DeltaConfigs.RANDOMIZE_FILE_PREFIXES.fromMetaData(snapshot.metadata),
+        "randomizeFilePrefixes should be enabled")
+      assert(DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(snapshot.metadata) == 4,
+        "randomPrefixLength should be 4")
+
+      // Verify table is partitioned correctly
+      assert(snapshot.metadata.partitionColumns == Seq("part"),
+        "Table should be partitioned by 'part' column")
+
+      // Insert data to create files with random prefixes across multiple partitions
+      sql("""INSERT INTO delta_test VALUES
+            |(1, 'A', 100), (2, 'B', 200), (3, 'A', 300), (4, 'C', 400)""".stripMargin)
+
+      val updatedSnapshot = deltaLog.update()
+      val allFiles = updatedSnapshot.allFiles.collect()
+
+      // Verify that files exist and have random prefixes
+      assert(allFiles.nonEmpty, "Partitioned table should have data files")
+
+      // Check that file paths contain 4-character random prefix pattern
+      val prefixLength = DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(updatedSnapshot.metadata)
+      assert(prefixLength == 4, s"Expected prefix length of 4, but got $prefixLength")
+
+      // For partitioned tables, files still use random prefix pattern (same as non-partitioned)
+      // Partition information is stored separately in metadata
+      val pattern = s"[A-Za-z0-9]{$prefixLength}/.*part-.*parquet"
+      allFiles.foreach { file =>
+        assert(file.path.matches(pattern),
+          s"Partitioned file path '${file.path}' does not match expected random prefix pattern " +
+          s"'$pattern'")
+      }
+
+      // Verify we have files for multiple partitions (by checking partition values in metadata)
+      val partitionValues = allFiles.map(_.partitionValues("part")).distinct
+      assert(partitionValues.length >= 2,
+        s"Expected files in multiple partitions, but only found partitions: " +
+        s"${partitionValues.mkString(", ")}")
+
+      // Verify we have the expected partition values
+      val expectedPartitions = Set("A", "B", "C")
+      assert(partitionValues.toSet.subsetOf(expectedPartitions),
+        s"Found unexpected partition values: ${partitionValues.toSet}")
+    }
+  }
 
   test("schema mismatch between DDL and table location should throw an error") {
     withTempDir { tempDir =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add implementation for DeltaConfigs.RANDOM_PREFIX_LENGTH.

## How was this patch tested?

Added a unit test in DeltaTableCreationTest.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
