### PR TITLE
[Delta Spark] always check iceberg MOR during clone

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
@@ -100,13 +100,6 @@ class IcebergFileManifest(
       return spark.emptyDataset[ConvertTargetFile]
     }
 
-    val hasMergeOnReadDeletionFiles = table.currentSnapshot().deleteManifests(table.io()).size() > 0
-    if (hasMergeOnReadDeletionFiles) {
-      throw new UnsupportedOperationException(
-        s"Cannot support convert Iceberg table with row-level deletes." +
-          s"Please trigger an Iceberg compaction and retry the command.")
-    }
-
     // Localize variables so we don't need to serialize the File Manifest class
     // Some contexts: Spark needs all variables in closure to be serializable
     // while class members carry the entire class, so they require serialization of the class


### PR DESCRIPTION
always check iceberg MOR during clone; The existing impl had day 0 problem that it miss to check iceberg MOR during incremental conversion, and thus its possible that the table has MOR with format-version 2. If the check is missed, the converted table state will be wrong and result in data corruption. This bug is not reported by customer and is found during internal code review.

Note we explicitly document we do not support iceberg format-version2 MOR; This fix hardens the detection.

This change also fixes an issue where it checks deleteManifests, which could contain removed DeleteFiles after the table is compacted. Using total-delete-files in summary is the right detection for if delete files are present.
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
