### PR TITLE
[Kernel] Create ParsedCatalogCommitData class

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitResponse.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitResponse.java
@@ -17,16 +17,16 @@
 package io.delta.kernel.commit;
 
 import io.delta.kernel.annotation.Experimental;
-import io.delta.kernel.internal.files.ParsedLogData;
+import io.delta.kernel.internal.files.ParsedDeltaData;
 
 /** Response container for the result of a commit operation. */
 @Experimental
 public class CommitResponse {
 
   // TODO: Create a DeltaLogData extends ParsedLogData that includes commit timestamp information.
-  private final ParsedLogData commitLogData;
+  private final ParsedDeltaData commitLogData;
 
-  public CommitResponse(ParsedLogData commitLogData) {
+  public CommitResponse(ParsedDeltaData commitLogData) {
     this.commitLogData = commitLogData;
   }
 
@@ -36,7 +36,7 @@ public class CommitResponse {
    * file that the {@link Committer} implementation decided to publish after committing to the
    * managing catalog.
    */
-  public ParsedLogData getCommitLogData() {
+  public ParsedDeltaData getCommitLogData() {
     return commitLogData;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -26,7 +26,7 @@ import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.checkpoints.CheckpointInstance;
-import io.delta.kernel.internal.files.ParsedDeltaData;
+import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.util.FileNames;
@@ -145,7 +145,7 @@ public final class DeltaHistoryManager {
    *     provided timestamp is after the latest commit
    * @param canReturnEarliestCommit whether we can return the earliest version of the table if the
    *     provided timestamp is before the earliest commit
-   * @param parsedDeltaDatas parsed log Deltas to use
+   * @param parsedCatalogCommits parsed log Deltas to use
    * @throws KernelException if the provided timestamp is before the earliest commit and
    *     canReturnEarliestCommit is false
    * @throws KernelException if the provided timestamp is after the latest commit and
@@ -160,20 +160,19 @@ public final class DeltaHistoryManager {
       boolean mustBeRecreatable,
       boolean canReturnLastCommit,
       boolean canReturnEarliestCommit,
-      List<ParsedDeltaData> parsedDeltaDatas)
+      List<ParsedCatalogCommitData> parsedCatalogCommits)
       throws TableNotFoundException {
 
-    // For now, we only accept ratified staged commits
+    // For now, we only accept ratified *staged* commits (not inline)
     checkArgument(
-        parsedDeltaDatas.stream()
-            .allMatch(deltaData -> deltaData.isFile() && deltaData.isRatifiedCommit()),
+        parsedCatalogCommits.stream().allMatch(ParsedCatalogCommitData::isFile),
         "Currently getActiveCommitAtTimestamp only accepts ratified staged file commits");
 
     // Create a mapper for delta version -> file status that takes into account ratified commits
     Function<Long, FileStatus> versionToFileStatusFunction =
-        getVersionToFileStatusFunction(parsedDeltaDatas, logPath);
+        getVersionToFileStatusFunction(parsedCatalogCommits, logPath);
     Optional<Long> earliestRatifiedCommitVersion =
-        parsedDeltaDatas.stream().map(ParsedLogData::getVersion).min(Long::compare);
+        parsedCatalogCommits.stream().map(ParsedLogData::getVersion).min(Long::compare);
 
     long earliestVersion =
         (mustBeRecreatable)
@@ -609,10 +608,10 @@ public final class DeltaHistoryManager {
    * exist either in the list of ratified commits provided by the catalog or on the file-system.
    */
   private static Function<Long, FileStatus> getVersionToFileStatusFunction(
-      List<ParsedDeltaData> parsedDeltaDatas, Path logPath) {
+      List<ParsedCatalogCommitData> parsedCatalogCommits, Path logPath) {
     Map<Long, FileStatus> versionToFileStatusMap = new HashMap<>();
-    for (ParsedDeltaData parsedDeltaData : parsedDeltaDatas) {
-      versionToFileStatusMap.put(parsedDeltaData.getVersion(), parsedDeltaData.getFileStatus());
+    for (ParsedCatalogCommitData catalogCommit : parsedCatalogCommits) {
+      versionToFileStatusMap.put(catalogCommit.getVersion(), catalogCommit.getFileStatus());
     }
     return version -> {
       if (versionToFileStatusMap.containsKey(version)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -162,8 +162,7 @@ public final class DeltaHistoryManager {
       boolean canReturnEarliestCommit,
       List<ParsedCatalogCommitData> parsedCatalogCommits)
       throws TableNotFoundException {
-
-    // For now, we only accept ratified *staged* commits (not inline)
+    // For now, we only accept *staged* ratified  commits (not inline)
     checkArgument(
         parsedCatalogCommits.stream().allMatch(ParsedCatalogCommitData::isFile),
         "Currently getActiveCommitAtTimestamp only accepts ratified staged file commits");

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commit/DefaultFileSystemManagedTableOnlyCommitter.java
@@ -26,7 +26,7 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaErrorsInternal;
 import io.delta.kernel.internal.actions.Protocol;
-import io.delta.kernel.internal.files.ParsedLogData;
+import io.delta.kernel.internal.files.ParsedPublishedDeltaData;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.CloseableIterator;
@@ -82,7 +82,8 @@ public class DefaultFileSystemManagedTableOnlyCommitter implements Committer {
     }
 
     // TODO: [delta-io/delta#5021] Use FileSystemClient::getFileStatus API instead
-    return new CommitResponse(ParsedLogData.forFileStatus(FileStatus.of(jsonCommitFile)));
+    return new CommitResponse(
+        ParsedPublishedDeltaData.forFileStatus(FileStatus.of(jsonCommitFile)));
   }
 
   private void validateProtocol(Protocol protocol) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCatalogCommitData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCatalogCommitData.java
@@ -24,36 +24,34 @@ import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
 /**
- * Version checksum file containing table state information for integrity validation.
+ * A catalog commit Delta file represent an atomic change to a table.
  *
- * <p>These auxiliary files contain important metadata about the table state at a specific version
- * to enable detection of non-compliant modifications to Delta files. Contains information like
- * table size, file counts, and metadata. Example: {@code 00000000000000000001.crc}
+ * <p>Example: {@code _delta_log/_staged_commits/00000000000000000001.uuid-1234.json}
  */
-public final class ParsedChecksumData extends ParsedLogData {
+public final class ParsedCatalogCommitData extends ParsedDeltaData {
 
-  public static ParsedChecksumData forFileStatus(FileStatus fileStatus) {
+  public static ParsedCatalogCommitData forFileStatus(FileStatus fileStatus) {
     checkArgument(
-        FileNames.isChecksumFile(fileStatus.getPath()),
-        "Expected a checksum file but got %s",
+        FileNames.isStagedDeltaFile(fileStatus.getPath()),
+        "Expected a staged commit file but got %s",
         fileStatus.getPath());
 
     final String path = fileStatus.getPath();
-    final long version = FileNames.checksumVersion(path);
-    return new ParsedChecksumData(version, Optional.of(fileStatus), Optional.empty());
+    final long version = FileNames.deltaVersion(path);
+    return new ParsedCatalogCommitData(version, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedChecksumData forInlineData(long version, ColumnarBatch inlineData) {
-    return new ParsedChecksumData(version, Optional.empty(), Optional.of(inlineData));
+  public static ParsedCatalogCommitData forInlineData(long version, ColumnarBatch inlineData) {
+    return new ParsedCatalogCommitData(version, Optional.empty(), Optional.of(inlineData));
   }
 
-  private ParsedChecksumData(
+  private ParsedCatalogCommitData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {
     super(version, fileStatusOpt, inlineDataOpt);
   }
 
   @Override
   public Class<? extends ParsedLogData> getGroupByCategoryClass() {
-    return ParsedChecksumData.class;
+    return ParsedCatalogCommitData.class;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCatalogCommitData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCatalogCommitData.java
@@ -24,7 +24,7 @@ import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
 /**
- * A catalog commit Delta file represents an atomic change to a table.
+ * A catalog commit represents an atomic change to a table.
  *
  * <p>Can be staged and written to a staged commit file, like so: {@code
  * _delta_log/_staged_commits/00000000000000000001.uuid-1234.json}.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCatalogCommitData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCatalogCommitData.java
@@ -24,9 +24,12 @@ import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
 /**
- * A catalog commit Delta file represent an atomic change to a table.
+ * A catalog commit Delta file represents an atomic change to a table.
  *
- * <p>Example: {@code _delta_log/_staged_commits/00000000000000000001.uuid-1234.json}
+ * <p>Can be staged and written to a staged commit file, like so: {@code
+ * _delta_log/_staged_commits/00000000000000000001.uuid-1234.json}.
+ *
+ * <p>Can also be inline.
  */
 public final class ParsedCatalogCommitData extends ParsedDeltaData {
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -17,6 +17,7 @@
 package io.delta.kernel.internal.files;
 
 import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
@@ -25,6 +26,20 @@ import java.util.Optional;
  */
 public abstract class ParsedCheckpointData extends ParsedLogData
     implements Comparable<ParsedCheckpointData> {
+
+  public static ParsedCheckpointData forFileStatus(FileStatus fileStatus) {
+    final String path = fileStatus.getPath();
+
+    if (FileNames.isClassicCheckpointFile(path)) {
+      return ParsedClassicCheckpointData.forFileStatus(fileStatus);
+    } else if (FileNames.isV2CheckpointFile(path)) {
+      return ParsedV2CheckpointData.forFileStatus(fileStatus);
+    } else if (FileNames.isMultiPartCheckpointFile(path)) {
+      return ParsedMultiPartCheckpointData.forFileStatus(fileStatus);
+    } else {
+      throw new IllegalArgumentException("Unknown checkpoint file type: " + path);
+    }
+  }
 
   /**
    * Enum representing checkpoint type priorities for comparison when multiple checkpoint types

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedCheckpointData.java
@@ -54,7 +54,7 @@ public abstract class ParsedCheckpointData extends ParsedLogData
   protected abstract int compareToSameType(ParsedCheckpointData that);
 
   @Override
-  public Class<? extends ParsedLogData> getParentCategoryClass() {
+  public Class<? extends ParsedLogData> getGroupByCategoryClass() {
     return ParsedCheckpointData.class;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedChecksumData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedChecksumData.java
@@ -43,10 +43,6 @@ public final class ParsedChecksumData extends ParsedLogData {
     return new ParsedChecksumData(version, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedChecksumData forInlineData(long version, ColumnarBatch inlineData) {
-    return new ParsedChecksumData(version, Optional.empty(), Optional.of(inlineData));
-  }
-
   private ParsedChecksumData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {
     super(version, fileStatusOpt, inlineDataOpt);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedClassicCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedClassicCheckpointData.java
@@ -41,10 +41,6 @@ public final class ParsedClassicCheckpointData extends ParsedCheckpointData {
     return new ParsedClassicCheckpointData(version, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedClassicCheckpointData forInlineData(long version, ColumnarBatch inlineData) {
-    return new ParsedClassicCheckpointData(version, Optional.empty(), Optional.of(inlineData));
-  }
-
   private ParsedClassicCheckpointData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {
     super(version, fileStatusOpt, inlineDataOpt);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedDeltaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedDeltaData.java
@@ -16,70 +16,15 @@
 
 package io.delta.kernel.internal.files;
 
-import static io.delta.kernel.internal.util.Preconditions.checkArgument;
-
 import io.delta.kernel.data.ColumnarBatch;
-import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
-/**
- * Delta commit file represent atomic changes to a table.
- *
- * <p>There are different types of Delta files:
- *
- * <ul>
- *   <li><b>Published commits</b>: Normal delta files in {@code _delta_log/} directory like {@code
- *       00000000000000000001.json}
- *   <li><b>Staged commits</b>: Files in {@code _delta_log/_staged_commits/} with UUID naming like
- *       {@code 00000000000000000001.uuid-1234.json}
- *   <li><b>Inline commits</b>: Content stored directly by the catalog, not as files
- * </ul>
- */
-public final class ParsedDeltaData extends ParsedLogData {
+/** Base class for Delta commit files that represent atomic changes to a table. */
+public abstract class ParsedDeltaData extends ParsedLogData {
 
-  public static ParsedDeltaData forFileStatus(FileStatus fileStatus) {
-    checkArgument(
-        FileNames.isCommitFile(fileStatus.getPath()),
-        "Expected a Delta file but got %s",
-        fileStatus.getPath());
-
-    final String path = fileStatus.getPath();
-    final long version = FileNames.deltaVersion(path);
-    return new ParsedDeltaData(version, Optional.of(fileStatus), Optional.empty());
-  }
-
-  public static ParsedDeltaData forInlineData(long version, ColumnarBatch inlineData) {
-    return new ParsedDeltaData(version, Optional.empty(), Optional.of(inlineData));
-  }
-
-  /* Stores whether this delta is a ratified commit. Stored to avoid repeated Path parsing */
-  private final boolean isRatifiedCommit;
-
-  private ParsedDeltaData(
+  protected ParsedDeltaData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {
     super(version, fileStatusOpt, inlineDataOpt);
-    // Compute and store whether this is a ratified commit
-    if (isFile()) {
-      isRatifiedCommit = FileNames.isStagedDeltaFile(getFileStatus().getPath());
-    } else { // isInline
-      // TODO: revisit whether we can have inline data of a published delta file
-      isRatifiedCommit = true;
-    }
-  }
-
-  /** Whether this ParsedDeltaData is a ratified commit. False if it's published. */
-  public boolean isRatifiedCommit() {
-    return isRatifiedCommit;
-  }
-
-  @Override
-  public String getParentCategoryName() {
-    return "Delta";
-  }
-
-  @Override
-  public Class<? extends ParsedLogData> getParentCategoryClass() {
-    return ParsedDeltaData.class;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedDeltaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedDeltaData.java
@@ -20,7 +20,7 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
-/** Base class for Delta commit files that represent atomic changes to a table. */
+/** Base class for Delta types that represent atomic changes to a table. */
 public abstract class ParsedDeltaData extends ParsedLogData {
 
   protected ParsedDeltaData(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedDeltaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedDeltaData.java
@@ -17,11 +17,24 @@
 package io.delta.kernel.internal.files;
 
 import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
 /** Base class for Delta types that represent atomic changes to a table. */
 public abstract class ParsedDeltaData extends ParsedLogData {
+
+  public static ParsedDeltaData forFileStatus(FileStatus fileStatus) {
+    final String path = fileStatus.getPath();
+
+    if (FileNames.isPublishedDeltaFile(path)) {
+      return ParsedPublishedDeltaData.forFileStatus(fileStatus);
+    } else if (FileNames.isStagedDeltaFile(path)) {
+      return ParsedCatalogCommitData.forFileStatus(fileStatus);
+    } else {
+      throw new IllegalArgumentException("Unknown delta file type: " + path);
+    }
+  }
 
   protected ParsedDeltaData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogCompactionData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogCompactionData.java
@@ -46,11 +46,6 @@ public final class ParsedLogCompactionData extends ParsedLogData {
         startEnd._1, startEnd._2, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedLogCompactionData forInlineData(
-      int start, int end, ColumnarBatch inlineData) {
-    return new ParsedLogCompactionData(start, end, Optional.empty(), Optional.of(inlineData));
-  }
-
   public final long startVersion;
   public final long endVersion;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogCompactionData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogCompactionData.java
@@ -68,12 +68,7 @@ public final class ParsedLogCompactionData extends ParsedLogData {
   }
 
   @Override
-  public String getParentCategoryName() {
-    return "LogCompaction";
-  }
-
-  @Override
-  public Class<? extends ParsedLogData> getParentCategoryClass() {
+  public Class<? extends ParsedLogData> getGroupByCategoryClass() {
     return ParsedLogCompactionData.class;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -30,14 +30,20 @@ import java.util.Optional;
  *
  * <p>Different child classes are used to represent the different log types.
  *
- * <p>Any given type can be written as a file or represented inline as a {@link ColumnarBatch}.
+ * <p>Any given log type can be written as a file or represented inline and given to Kernel as a
+ * {@link ColumnarBatch}. That is: Kernel just needs to know how to parse and interpret a given log
+ * type (Kernel will of course treat Deltas differently than Checksums) as well as how to get that
+ * log type's bytes. This is why a given log type can be represented as either a file or inline.
+ *
+ * <p>For now, our APIs only allow creating {@link ParsedCatalogCommitData} inline, but we may
+ * change and expand this capability in the future.
  *
  * <p>The supported log types are:
  *
  * <ul>
- *   <li>Published Delta files: {@code 00000000000000000001.json}
- *   <li>Catalog Commit files: {@code _staged_commits/00000000000000000001.uuid-1234.json} *
- *   <li>Log compaction files: {@code 00000000000000000001.00000000000000000009.compacted.json} *
+ *   <li>Published Deltas: {@code 00000000000000000001.json}
+ *   <li>Catalog Commits: {@code _staged_commits/00000000000000000001.uuid-1234.json}
+ *   <li>Log compaction files: {@code 00000000000000000001.00000000000000000009.compacted.json}
  *   <li>Checksum files: {@code 00000000000000000001.crc}
  *   <li>Classic Checkpoint files: {@code 00000000000000000001.checkpoint.parquet}
  *   <li>V2 checkpoint files: {@code 00000000000000000001.checkpoint.uuid-1234.json}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -32,7 +32,8 @@ import java.util.Optional;
  * file types include:
  *
  * <ul>
- *   <li>Delta commit files: {@code 00000000000000000001.json}
+ *   <li>Published Delta files: {@code 00000000000000000001.json}
+ *   <li>Catalog Commit files: {@code _staged_commits/00000000000000000001.uuid-1234.json}
  *   <li>Checkpoint files: {@code 00000000000000000001.checkpoint.parquet}
  *   <li>V2 checkpoint files: {@code 00000000000000000001.checkpoint.uuid-1234.json}
  *   <li>Multi-part checkpoint files: {@code
@@ -47,8 +48,10 @@ public abstract class ParsedLogData {
   public static ParsedLogData forFileStatus(FileStatus fileStatus) {
     final String path = fileStatus.getPath();
 
-    if (FileNames.isCommitFile(path)) {
-      return ParsedDeltaData.forFileStatus(fileStatus);
+    if (FileNames.isPublishedDeltaFile(path)) {
+      return ParsedPublishedDeltaData.forFileStatus(fileStatus);
+    } else if (FileNames.isStagedDeltaFile(path)) {
+      return ParsedCatalogCommitData.forFileStatus(fileStatus);
     } else if (FileNames.isLogCompactionFile(path)) {
       return ParsedLogCompactionData.forFileStatus(fileStatus);
     } else if (FileNames.isChecksumFile(path)) {
@@ -122,16 +125,8 @@ public abstract class ParsedLogData {
     return inlineDataOpt.get();
   }
 
-  /**
-   * Returns a human-readable name for the parent category class. Used as a helper utility for
-   * debugging and print statements.
-   */
-  public String getParentCategoryName() {
-    return getParentCategoryClass().getSimpleName();
-  }
-
-  /** Returns the parent category class used for grouping collections of ParsedLogData instances. */
-  public abstract Class<? extends ParsedLogData> getParentCategoryClass();
+  /** Returns the category class used for grouping collections of LISTed ParsedLogData instances. */
+  public abstract Class<? extends ParsedLogData> getGroupByCategoryClass();
 
   /** Protected method for subclasses to override to add output to {@link #toString}. */
   protected void appendAdditionalToStringFields(StringBuilder sb) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -26,20 +26,23 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Abstract representation of any valid file type in a Delta log.
+ * Abstract representation of any valid log type in the Delta log.
  *
- * <p>Content may be stored as a file on disk or inline as a columnar batch in memory. Supported log
- * file types include:
+ * <p>Different child classes are used to represent the different log types.
+ *
+ * <p>Any given type can be written as a file or represented inline as a {@link ColumnarBatch}.
+ *
+ * <p>The supported log types are:
  *
  * <ul>
  *   <li>Published Delta files: {@code 00000000000000000001.json}
- *   <li>Catalog Commit files: {@code _staged_commits/00000000000000000001.uuid-1234.json}
- *   <li>Checkpoint files: {@code 00000000000000000001.checkpoint.parquet}
+ *   <li>Catalog Commit files: {@code _staged_commits/00000000000000000001.uuid-1234.json} *
+ *   <li>Log compaction files: {@code 00000000000000000001.00000000000000000009.compacted.json} *
+ *   <li>Checksum files: {@code 00000000000000000001.crc}
+ *   <li>Classic Checkpoint files: {@code 00000000000000000001.checkpoint.parquet}
  *   <li>V2 checkpoint files: {@code 00000000000000000001.checkpoint.uuid-1234.json}
  *   <li>Multi-part checkpoint files: {@code
  *       00000000000000000001.checkpoint.0000000001.0000000010.parquet}
- *   <li>Log compaction files: {@code 00000000000000000001.00000000000000000009.compacted.json}
- *   <li>Checksum files: {@code 00000000000000000001.crc}
  * </ul>
  */
 // TODO: Move this to be a public API

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedLogData.java
@@ -57,20 +57,14 @@ public abstract class ParsedLogData {
   public static ParsedLogData forFileStatus(FileStatus fileStatus) {
     final String path = fileStatus.getPath();
 
-    if (FileNames.isPublishedDeltaFile(path)) {
-      return ParsedPublishedDeltaData.forFileStatus(fileStatus);
-    } else if (FileNames.isStagedDeltaFile(path)) {
-      return ParsedCatalogCommitData.forFileStatus(fileStatus);
+    if (FileNames.isCommitFile(path)) {
+      return ParsedDeltaData.forFileStatus(fileStatus);
+    } else if (FileNames.isCheckpointFile(path)) {
+      return ParsedCheckpointData.forFileStatus(fileStatus);
     } else if (FileNames.isLogCompactionFile(path)) {
       return ParsedLogCompactionData.forFileStatus(fileStatus);
     } else if (FileNames.isChecksumFile(path)) {
       return ParsedChecksumData.forFileStatus(fileStatus);
-    } else if (FileNames.isClassicCheckpointFile(path)) {
-      return ParsedClassicCheckpointData.forFileStatus(fileStatus);
-    } else if (FileNames.isV2CheckpointFile(path)) {
-      return ParsedV2CheckpointData.forFileStatus(fileStatus);
-    } else if (FileNames.isMultiPartCheckpointFile(path)) {
-      return ParsedMultiPartCheckpointData.forFileStatus(fileStatus);
     } else {
       throw new IllegalArgumentException("Unknown log file type: " + path);
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedMultiPartCheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedMultiPartCheckpointData.java
@@ -44,12 +44,6 @@ public final class ParsedMultiPartCheckpointData extends ParsedCheckpointData {
         version, partInfo._1, partInfo._2, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedMultiPartCheckpointData forInlineData(
-      long version, int part, int numParts, ColumnarBatch inlineData) {
-    return new ParsedMultiPartCheckpointData(
-        version, part, numParts, Optional.empty(), Optional.of(inlineData));
-  }
-
   public final int part;
   public final int numParts;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedPublishedDeltaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedPublishedDeltaData.java
@@ -24,36 +24,34 @@ import io.delta.kernel.utils.FileStatus;
 import java.util.Optional;
 
 /**
- * Version checksum file containing table state information for integrity validation.
+ * A published Delta commit file represent an atomic change to a table.
  *
- * <p>These auxiliary files contain important metadata about the table state at a specific version
- * to enable detection of non-compliant modifications to Delta files. Contains information like
- * table size, file counts, and metadata. Example: {@code 00000000000000000001.crc}
+ * <p>Example: {@code _delta_log/00000000000000000001.json}
  */
-public final class ParsedChecksumData extends ParsedLogData {
+public final class ParsedPublishedDeltaData extends ParsedDeltaData {
 
-  public static ParsedChecksumData forFileStatus(FileStatus fileStatus) {
+  public static ParsedPublishedDeltaData forFileStatus(FileStatus fileStatus) {
     checkArgument(
-        FileNames.isChecksumFile(fileStatus.getPath()),
-        "Expected a checksum file but got %s",
+        FileNames.isPublishedDeltaFile(fileStatus.getPath()),
+        "Expected a published Delta file but got %s",
         fileStatus.getPath());
 
     final String path = fileStatus.getPath();
-    final long version = FileNames.checksumVersion(path);
-    return new ParsedChecksumData(version, Optional.of(fileStatus), Optional.empty());
+    final long version = FileNames.deltaVersion(path);
+    return new ParsedPublishedDeltaData(version, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedChecksumData forInlineData(long version, ColumnarBatch inlineData) {
-    return new ParsedChecksumData(version, Optional.empty(), Optional.of(inlineData));
+  public static ParsedPublishedDeltaData forInlineData(long version, ColumnarBatch inlineData) {
+    return new ParsedPublishedDeltaData(version, Optional.empty(), Optional.of(inlineData));
   }
 
-  private ParsedChecksumData(
+  private ParsedPublishedDeltaData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {
     super(version, fileStatusOpt, inlineDataOpt);
   }
 
   @Override
   public Class<? extends ParsedLogData> getGroupByCategoryClass() {
-    return ParsedChecksumData.class;
+    return ParsedPublishedDeltaData.class;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedPublishedDeltaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedPublishedDeltaData.java
@@ -41,10 +41,6 @@ public final class ParsedPublishedDeltaData extends ParsedDeltaData {
     return new ParsedPublishedDeltaData(version, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedPublishedDeltaData forInlineData(long version, ColumnarBatch inlineData) {
-    return new ParsedPublishedDeltaData(version, Optional.empty(), Optional.of(inlineData));
-  }
-
   private ParsedPublishedDeltaData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {
     super(version, fileStatusOpt, inlineDataOpt);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedV2CheckpointData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/files/ParsedV2CheckpointData.java
@@ -41,10 +41,6 @@ public final class ParsedV2CheckpointData extends ParsedCheckpointData {
     return new ParsedV2CheckpointData(version, Optional.of(fileStatus), Optional.empty());
   }
 
-  public static ParsedV2CheckpointData forInlineData(long version, ColumnarBatch inlineData) {
-    return new ParsedV2CheckpointData(version, Optional.empty(), Optional.of(inlineData));
-  }
-
   private ParsedV2CheckpointData(
       long version, Optional<FileStatus> fileStatusOpt, Optional<ColumnarBatch> inlineDataOpt) {
     super(version, fileStatusOpt, inlineDataOpt);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
@@ -27,7 +27,7 @@ import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
-import io.delta.kernel.internal.files.ParsedDeltaData;
+import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.Tuple2;
@@ -174,7 +174,7 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
   private void validateLogDataContainsOnlyRatifiedCommits() {
     for (ParsedLogData logData : ctx.logDatas) {
       checkArgument(
-          logData instanceof ParsedDeltaData && logData.isFile(),
+          logData instanceof ParsedCatalogCommitData && logData.isFile(),
           "Only staged ratified commits are supported, but found: " + logData);
     }
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
@@ -121,7 +121,8 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
     validateVersionAndTimestampMutuallyExclusive();
     validateProtocolAndMetadataOnlyIfVersionProvided();
     validateProtocolRead();
-    validateLogDataContainsOnlyRatifiedCommits(); // TODO: delta-io/delta#4765 support other types
+    // TODO: delta-io/delta#4765 support other types
+    validateLogDataContainsOnlyStagedRatifiedCommits();
     validateLogDataIsSortedContiguous();
   }
 
@@ -171,7 +172,7 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
         x -> TableFeatures.validateKernelCanReadTheTable(x._1, ctx.unresolvedPath));
   }
 
-  private void validateLogDataContainsOnlyRatifiedCommits() {
+  private void validateLogDataContainsOnlyStagedRatifiedCommits() {
     for (ParsedLogData logData : ctx.logDatas) {
       checkArgument(
           logData instanceof ParsedCatalogCommitData && logData.isFile(),

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
@@ -27,7 +27,7 @@ import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.actions.Protocol
 import io.delta.kernel.internal.commit.DefaultFileSystemManagedTableOnlyCommitter
-import io.delta.kernel.internal.files.{ParsedDeltaData, ParsedLogData}
+import io.delta.kernel.internal.files.{ParsedCatalogCommitData, ParsedLogData, ParsedPublishedDeltaData}
 import io.delta.kernel.internal.table.SnapshotBuilderImpl
 import io.delta.kernel.test.{ActionUtils, MockFileSystemClientUtils, MockSnapshotUtils, VectorTestUtils}
 import io.delta.kernel.types.{IntegerType, StructType}
@@ -221,9 +221,10 @@ class SnapshotBuilderSuite extends AnyFunSuite
   }
 
   Seq(
-    ParsedDeltaData.forInlineData(1, emptyColumnarBatch),
+    ParsedCatalogCommitData.forInlineData(1, emptyColumnarBatch),
+    ParsedPublishedDeltaData.forFileStatus(deltaFileStatus(1, logPath)),
     ParsedLogData.forFileStatus(logCompactionStatus(0, 1))).foreach { parsedLogData =>
-    val suffix = s"- type=${parsedLogData.getParentCategoryName}"
+    val suffix = s"- type=${parsedLogData.getClass.getSimpleName}"
     test(s"withLogData: non-staged-ratified-commit throws IllegalArgumentException $suffix") {
       val builder = TableManager
         .loadSnapshot(dataPath.toString)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
@@ -16,15 +16,13 @@
 
 package io.delta.kernel.defaults.catalogManaged
 
-import java.util.Optional
-
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.{SnapshotBuilder, TableManager}
 import io.delta.kernel.defaults.utils.{TestRow, TestUtilsWithTableManagerAPIs}
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.DeltaHistoryManager
-import io.delta.kernel.internal.files.{ParsedDeltaData, ParsedLogData}
+import io.delta.kernel.internal.files.{ParsedCatalogCommitData, ParsedLogData}
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.table.SnapshotBuilderImpl
 import io.delta.kernel.internal.tablefeatures.TableFeatures.{CATALOG_MANAGED_R_W_FEATURE_PREVIEW, IN_COMMIT_TIMESTAMP_W_FEATURE, TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
@@ -100,9 +98,9 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite with TestUtilsWithTableMana
     withCatalogOwnedPreviewTestTable { (tablePath, parsedLogData) =>
       val logPath = new Path(tablePath, "_delta_log")
 
-      val parsedDeltaData = parsedLogData
-        .filter(_.isInstanceOf[ParsedDeltaData])
-        .map(_.asInstanceOf[ParsedDeltaData])
+      val parsedRatifiedCatalogCommits = parsedLogData
+        .filter(_.isInstanceOf[ParsedCatalogCommitData])
+        .map(_.asInstanceOf[ParsedCatalogCommitData])
 
       val latestSnapshot = TableManager
         .loadSnapshot(tablePath)
@@ -123,7 +121,7 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite with TestUtilsWithTableMana
           true, /* mustBeRecreatable */
           canReturnLastCommit,
           canReturnEarliestCommit,
-          parsedDeltaData.asJava)
+          parsedRatifiedCatalogCommits.asJava)
         assert(activeCommit.getVersion == expectedVersion)
       }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestCommitterUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestCommitterUtils.scala
@@ -19,7 +19,7 @@ package io.delta.kernel.defaults.utils
 import io.delta.kernel.commit.{CommitMetadata, CommitResponse, Committer}
 import io.delta.kernel.data.Row
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.internal.files.ParsedLogData
+import io.delta.kernel.internal.files.ParsedPublishedDeltaData
 import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.utils.{CloseableIterator, FileStatus}
 
@@ -34,7 +34,7 @@ trait TestCommitterUtils {
       engine
         .getJsonHandler
         .writeJsonFileAtomically(filePath, finalizedActions, false)
-      new CommitResponse(ParsedLogData.forFileStatus(FileStatus.of(filePath)))
+      new CommitResponse(ParsedPublishedDeltaData.forFileStatus(FileStatus.of(filePath)))
     }
   }
 }

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
@@ -27,7 +27,7 @@ import io.delta.kernel.annotation.Experimental;
 import io.delta.kernel.commit.Committer;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.annotation.VisibleForTesting;
-import io.delta.kernel.internal.files.ParsedDeltaData;
+import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.transaction.CreateTableTransactionBuilder;
@@ -286,7 +286,7 @@ public class UCCatalogManagedClient {
                     .sorted(Comparator.comparingLong(Commit::getVersion))
                     .map(
                         commit ->
-                            ParsedDeltaData.forFileStatus(
+                            ParsedCatalogCommitData.forFileStatus(
                                 hadoopFileStatusToKernelFileStatus(commit.getFileStatus())))
                     .collect(Collectors.toList()));
 

--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedCommitter.java
@@ -29,7 +29,8 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.annotation.VisibleForTesting;
-import io.delta.kernel.internal.files.ParsedLogData;
+import io.delta.kernel.internal.files.ParsedCatalogCommitData;
+import io.delta.kernel.internal.files.ParsedPublishedDeltaData;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.commit.Commit;
@@ -106,7 +107,8 @@ public class UCCatalogManagedCommitter implements Committer {
     final FileStatus kernelPublishedDeltaFileStatus =
         writeDeltaFile(engine, finalizedActions, commitMetadata.getPublishedDeltaFilePath());
 
-    return new CommitResponse(ParsedLogData.forFileStatus(kernelPublishedDeltaFileStatus));
+    return new CommitResponse(
+        ParsedPublishedDeltaData.forFileStatus(kernelPublishedDeltaFileStatus));
   }
 
   /**
@@ -124,7 +126,7 @@ public class UCCatalogManagedCommitter implements Committer {
 
     commitToUC(commitMetadata, kernelStagedCommitFileStatus);
 
-    return new CommitResponse(ParsedLogData.forFileStatus(kernelStagedCommitFileStatus));
+    return new CommitResponse(ParsedCatalogCommitData.forFileStatus(kernelStagedCommitFileStatus));
   }
 
   /////////////////////////////////////////


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5279/files) to review incremental changes.
- [**stack/kernel_parsed_delta_data_refactor**](https://github.com/delta-io/delta/pull/5279) [[Files changed](https://github.com/delta-io/delta/pull/5279/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Create ParsedCatalogCommitData -- an explicit type of the now-abstarct-parent-class ParsedLogData.

The reason for this change is:
- catalog commits are different file types than published deltas. they have a different name (when as a file) and take priority over published deltas
- Note then that there is the type (catalog commit, published delta, crc, checkpoint, etc.) and then there is "where are the bytes?" --> which is either in a file or inline.

Refactor existing codes.

## How was this patch tested?

Mainly just a refactor. Updated a few tests. Added some new UTs.

## Does this PR introduce _any_ user-facing changes?

No.
