### PR TITLE
[Spark] Plumb catalog tables to `DeltaLog` API call sites in `changesToDF`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -126,6 +126,7 @@ object CDCReader extends CDCReaderImpl
           deltaLog.update(catalogTableOpt = catalogTableOpt).version
         },
         sqlContext.sparkSession,
+        catalogTableOpt,
         readSchemaSnapshot = Some(snapshotForBatchSchema))
       constructRDD(df, requiredColumns, filters)
     }
@@ -216,6 +217,7 @@ trait CDCReaderImpl extends CDCReaderBase {
    *                Note that for log files where InCommitTimestamps are enabled, the iterator
    *                must also contain the [[CommitInfo]] action.
    * @param spark - SparkSession
+   * @param catalogTableOpt - The catalog table for the Delta table
    * @param isStreaming - indicates whether the DataFrame returned is a streaming DataFrame
    * @param useCoarseGrainedCDC - ignores checks related to CDC being disabled in any of the
    *         versions and computes CDC entirely from AddFiles/RemoveFiles (ignoring
@@ -224,15 +226,18 @@ trait CDCReaderImpl extends CDCReaderBase {
    * @return CDCInfo which contains the DataFrame of the changes as well as the statistics
    *         related to the changes
    */
+  // scalastyle:off argcount
   def changesToDF(
       readSchemaSnapshot: SnapshotDescriptor,
       start: Long,
       end: Long,
       changes: Iterator[(Long, Seq[Action])],
       spark: SparkSession,
+      catalogTableOpt: Option[CatalogTable],
       isStreaming: Boolean = false,
       useCoarseGrainedCDC: Boolean = false,
       startVersionSnapshot: Option[SnapshotDescriptor] = None): CDCVersionDiffInfo = {
+  // scalastyle:on argcount
     val deltaLog = readSchemaSnapshot.deltaLog
 
     if (end < start) {
@@ -250,7 +255,7 @@ trait CDCReaderImpl extends CDCReaderBase {
     val removeFiles = ListBuffer[CDCDataSpec[RemoveFile]]()
 
     val startVersionMetadata = startVersionSnapshot.map(_.metadata).getOrElse {
-      deltaLog.getSnapshotAt(start).metadata
+      deltaLog.getSnapshotAt(start, catalogTableOpt = catalogTableOpt).metadata
     }
     if (!useCoarseGrainedCDC && !isCDCEnabledOnTable(startVersionMetadata, spark)) {
       throw DeltaErrors.changeDataNotRecordedException(start, start, end)
@@ -647,18 +652,20 @@ trait CDCReaderImpl extends CDCReaderBase {
       start: Long,
       end: Long,
       spark: SparkSession,
+      catalogTableOpt: Option[CatalogTable] = None,
       readSchemaSnapshot: Option[Snapshot] = None,
       useCoarseGrainedCDC: Boolean = false,
       startVersionSnapshot: Option[SnapshotDescriptor] = None): DataFrame = {
 
     val changesWithinRange = deltaLog.getChanges(
-      start, end, catalogTableOpt = None, failOnDataLoss = false)
+      start, end, catalogTableOpt, failOnDataLoss = false)
     changesToDF(
       readSchemaSnapshot.getOrElse(deltaLog.unsafeVolatileSnapshot),
       start,
       end,
       changesWithinRange,
       spark,
+      catalogTableOpt,
       isStreaming = false,
       useCoarseGrainedCDC = useCoarseGrainedCDC,
       startVersionSnapshot = startVersionSnapshot)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
@@ -213,6 +213,7 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
           endOffset.reservoirVersion,
           groupedFileAndCommitInfoActions,
           spark,
+          catalogTableOpt,
           isStreaming = true)
         .fileChangeDf
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.commands.DeltaReorgTableCommand
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.Path
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.delta.commands.cdc.CDCReader._
 import org.apache.spark.sql.delta.files.DelayedCommitProtocol
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
@@ -423,20 +424,23 @@ class CDCReaderSuite
         // commit 0: 2 inserts
         spark.range(start = 0, end = 2, step = 1, numPartitions = 1)
           .write.format("delta").save(dir.getAbsolutePath)
-        var df = CDCReader.changesToBatchDF(log, 0, 1, spark, useCoarseGrainedCDC = true)
+        var df = CDCReader.changesToBatchDF(
+          log, 0, 1, spark, catalogTableOpt = None, useCoarseGrainedCDC = true)
         checkAnswer(df.drop(CDC_COMMIT_TIMESTAMP),
           createCDFDF(start = 0, end = 2, commitVersion = 0, changeType = "insert"))
 
         // commit 1: 2 inserts
         spark.range(start = 2, end = 4)
           .write.mode("append").format("delta").save(dir.getAbsolutePath)
-        df = CDCReader.changesToBatchDF(log, 1, 2, spark, useCoarseGrainedCDC = true)
+        df = CDCReader.changesToBatchDF(
+          log, 1, 2, spark, catalogTableOpt = None, useCoarseGrainedCDC = true)
         checkAnswer(df.drop(CDC_COMMIT_TIMESTAMP),
           createCDFDF(start = 2, end = 4, commitVersion = 1, changeType = "insert"))
 
         // commit 2
         sql(s"DELETE FROM delta.`$dir` WHERE id = 0")
-        df = CDCReader.changesToBatchDF(log, 2, 3, spark, useCoarseGrainedCDC = true)
+        df = CDCReader.changesToBatchDF(
+          log, 2, 3, spark, catalogTableOpt = None, useCoarseGrainedCDC = true)
           .drop(CDC_COMMIT_TIMESTAMP)
 
         // Using only Add and RemoveFiles should generate 2 deletes and 1 insert. Even when CDF

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -21,8 +21,10 @@ import java.sql.Timestamp
 
 import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaHistoryManager, DeltaLog, OptimisticTransaction, Snapshot}
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Operation, Write}
+import org.apache.spark.sql.delta.SnapshotDescriptor
 import org.apache.spark.sql.delta.actions.{Action, AddFile, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
 import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
@@ -256,6 +258,33 @@ object DeltaTestImplicits {
       fileFilter: AddFile => Boolean = af => true): Unit = {
       StatisticsCollection.recompute(
         spark, deltaLog, catalogTable = None, predicates, fileFilter)
+    }
+  }
+
+  implicit class CDCReaderObjectTestHelper(cdcReader: CDCReader.type) {
+
+    /**
+     * Test helper method for changesToBatchDF that provides catalogTableOpt = None
+     * for backward compatibility with existing unit tests.
+     */
+    def changesToBatchDF(
+        deltaLog: DeltaLog,
+        start: Long,
+        end: Long,
+        spark: SparkSession,
+        readSchemaSnapshot: Option[Snapshot] = None,
+        useCoarseGrainedCDC: Boolean = false,
+        startVersionSnapshot: Option[SnapshotDescriptor] = None
+    ): org.apache.spark.sql.DataFrame = {
+      cdcReader.changesToBatchDF(
+        deltaLog,
+        start,
+        end,
+        spark,
+        catalogTableOpt = None,
+        readSchemaSnapshot,
+        useCoarseGrainedCDC,
+        startVersionSnapshot)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.typewidening
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.functions.col
@@ -85,6 +86,7 @@ trait TypeWideningCompatibilityTests {
           start,
           end,
           spark,
+          catalogTableOpt = None,
           readSchemaSnapshot = Some(readSchemaSnapshot)
         )
         .drop(CDCReader.CDC_COMMIT_TIMESTAMP)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is to plumb catalog tables to `CDCReader` API `changesToDF` call sites.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
