### PR TITLE
[Kernel] Refactor P&M replay to static utility

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -63,6 +63,7 @@ public class SnapshotImpl implements Snapshot {
   private Lazy<SnapshotReport> lazySnapshotReport;
   private Lazy<Optional<List<Column>>> lazyClusteringColumns;
 
+  // TODO: Do not take in LogReplay as a constructor argument.
   public SnapshotImpl(
       Path dataPath,
       long version,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumReader.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumReader.java
@@ -15,7 +15,6 @@
  */
 package io.delta.kernel.internal.checksum;
 
-import static io.delta.kernel.internal.util.FileNames.*;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 
 import io.delta.kernel.data.ColumnarBatch;
@@ -40,7 +39,7 @@ public class ChecksumReader {
    * @return Optional {@link CRCInfo} containing the information included in the checksum file, such
    *     as protocol, metadata.
    */
-  public static Optional<CRCInfo> getCRCInfo(Engine engine, FileStatus checkSumFile) {
+  public static Optional<CRCInfo> tryReadChecksumFile(Engine engine, FileStatus checkSumFile) {
     try (CloseableIterator<ColumnarBatch> iter =
         engine
             .getJsonHandler()

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -126,7 +126,7 @@ public class ChecksumUtils {
     Optional<CRCInfo> lastSeenCrcInfo =
         logSegmentAtVersion
             .getLastSeenChecksum()
-            .flatMap(file -> ChecksumReader.getCRCInfo(engine, file));
+            .flatMap(file -> ChecksumReader.tryReadChecksumFile(engine, file));
     // Try to build CRC incrementally if possible
     Optional<CRCInfo> incrementallyBuiltCrc =
         lastSeenCrcInfo.isPresent()

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -176,7 +176,7 @@ public class ConflictChecker {
     }
 
     Optional<CRCInfo> updatedCrcInfo =
-        ChecksumReader.getCRCInfo(
+        ChecksumReader.tryReadChecksumFile(
             engine,
             FileStatus.of(checksumFile(transaction.getLogPath(), lastWinningVersion).toString()));
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -24,15 +24,11 @@ import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.checkpoints.SidecarFile;
 import io.delta.kernel.internal.checksum.CRCInfo;
-import io.delta.kernel.internal.checksum.ChecksumReader;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.Lazy;
 import io.delta.kernel.internal.metrics.ScanMetrics;
-import io.delta.kernel.internal.metrics.SnapshotMetrics;
 import io.delta.kernel.internal.snapshot.LogSegment;
-import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.DomainMetadataUtils;
-import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
@@ -67,11 +63,7 @@ public class LogReplay {
 
   //////////////////////////
   // Static Schema Fields //
-  //////////////////////////
-
-  /** Read schema when searching for the latest Protocol and Metadata. */
-  public static final StructType PROTOCOL_METADATA_READ_SCHEMA =
-      new StructType().add("protocol", Protocol.FULL_SCHEMA).add("metaData", Metadata.FULL_SCHEMA);
+  /////////////////////////
 
   /** We don't need to read the entire RemoveFile, only the path and dv info */
   private static StructType REMOVE_FILE_SCHEMA =
@@ -131,32 +123,26 @@ public class LogReplay {
   private final Path dataPath;
   private final Lazy<LogSegment> lazyLogSegment;
   private final Lazy<Optional<CRCInfo>> lazyLatestCrcInfo;
-  private final Lazy<Tuple2<Protocol, Metadata>> lazyProtocolAndMetadata;
   private final Lazy<Map<String, DomainMetadata>> lazyActiveDomainMetadataMap;
 
+  /**
+   * Creates a new LogReplay instance.
+   *
+   * @param dataPath the path to the Delta table
+   * @param engine the engine to use for reading log files
+   * @param lazyLogSegment lazy loader for the log segment
+   * @param lazyCrcInfo lazy loader for the CRC file (shared with ProtocolMetadataLogReplay)
+   */
   public LogReplay(
-      Path dataPath,
       Engine engine,
+      Path dataPath,
       Lazy<LogSegment> lazyLogSegment,
-      SnapshotMetrics snapshotMetrics) {
+      Lazy<Optional<CRCInfo>> lazyCrcInfo) {
     this.dataPath = dataPath;
-
     this.lazyLogSegment = lazyLogSegment;
+    this.lazyLatestCrcInfo = lazyCrcInfo;
 
-    // Lazy loading of CRC info only when needed
-    this.lazyLatestCrcInfo =
-        new Lazy<>(
-            () ->
-                getLogSegment()
-                    .getLastSeenChecksum()
-                    .flatMap(
-                        crcFile ->
-                            snapshotMetrics.loadCrcTotalDurationTimer.time(
-                                () -> ChecksumReader.getCRCInfo(engine, crcFile))));
-
-    // Lazy loading of protocol and metadata only when needed
-    this.lazyProtocolAndMetadata = createLazyProtocolAndMetadata(engine, snapshotMetrics);
-
+    // TODO: Refactor DomainMetadata loading to static utility, just like P & M loading
     // Lazy loading of domain metadata only when needed
     this.lazyActiveDomainMetadataMap =
         new Lazy<>(
@@ -170,12 +156,8 @@ public class LogReplay {
   // Public APIs //
   /////////////////
 
-  public Protocol getProtocol() {
-    return lazyProtocolAndMetadata.get()._1;
-  }
-
-  public Metadata getMetadata() {
-    return lazyProtocolAndMetadata.get()._2;
+  public long getVersion() {
+    return getLogSegment().getVersion();
   }
 
   public Optional<Long> getLatestTransactionIdentifier(Engine engine, String applicationId) {
@@ -185,10 +167,6 @@ public class LogReplay {
   /** Returns map for all active domain metadata. */
   public Map<String, DomainMetadata> getActiveDomainMetadataMap() {
     return lazyActiveDomainMetadataMap.get();
-  }
-
-  public long getVersion() {
-    return getLogSegment().getVersion();
   }
 
   /**
@@ -254,143 +232,6 @@ public class LogReplay {
     } else {
       return logSegment.allLogFilesReversed();
     }
-  }
-
-  private Lazy<Tuple2<Protocol, Metadata>> createLazyProtocolAndMetadata(
-      Engine engine, SnapshotMetrics snapshotMetrics) {
-    return new Lazy<>(
-        () -> {
-          // Ensure log segment is loaded and valid before starting any protocol/metadata loading
-          // timers. This ensures that failures during log segment construction (e.g., invalid
-          // version, missing table) occur before protocol/metadata loading metrics are recorded.
-          final LogSegment logSegment = getLogSegment();
-          final long targetVersion = logSegment.getVersion();
-
-          final Tuple2<Protocol, Metadata> result =
-              snapshotMetrics.loadProtocolMetadataTotalDurationTimer.time(
-                  () -> {
-                    Tuple2<Protocol, Metadata> protocolAndMetadata =
-                        loadTableProtocolAndMetadata(
-                            engine, logSegment, lazyLatestCrcInfo.get(), targetVersion);
-
-                    TableFeatures.validateKernelCanReadTheTable(
-                        protocolAndMetadata._1, dataPath.toString());
-
-                    return protocolAndMetadata;
-                  });
-
-          logger.info(
-              "[{}] Took {}ms to load Protocol and Metadata at version {}",
-              dataPath.toString(),
-              snapshotMetrics.loadProtocolMetadataTotalDurationTimer.totalDurationMs(),
-              targetVersion);
-
-          return result;
-        });
-  }
-
-  /**
-   * Returns the latest Protocol and Metadata from the delta files in the `logSegment`. Does *not*
-   * validate that this delta-kernel connector understands the table at that protocol.
-   *
-   * <p>Uses the `latestCrcInfo` to bound how many delta files it reads. i.e. we only need to read
-   * delta files newer than the latestCrcInfo to search for any new P & M. If we don't find them, we
-   * can just use the P and/or M from the latestCrcInfo.
-   */
-  protected Tuple2<Protocol, Metadata> loadTableProtocolAndMetadata(
-      Engine engine, LogSegment logSegment, Optional<CRCInfo> latestCrcInfo, long snapshotVersion) {
-    long logReadCount = 0;
-    // Exit early if the CRC already has the info we need.
-    if (latestCrcInfo.isPresent() && latestCrcInfo.get().getVersion() == snapshotVersion) {
-      return new Tuple2<>(latestCrcInfo.get().getProtocol(), latestCrcInfo.get().getMetadata());
-    }
-
-    Protocol protocol = null;
-    Metadata metadata = null;
-
-    try (CloseableIterator<ActionWrapper> reverseIter =
-        new ActionsIterator(
-            engine,
-            getLogReplayFiles(logSegment),
-            PROTOCOL_METADATA_READ_SCHEMA,
-            Optional.empty())) {
-      while (reverseIter.hasNext()) {
-        final ActionWrapper nextElem = reverseIter.next();
-        final long version = nextElem.getVersion();
-        logReadCount++;
-        // Load this lazily (as needed). We may be able to just use the CRC.
-        ColumnarBatch columnarBatch = null;
-
-        if (protocol == null) {
-          columnarBatch = nextElem.getColumnarBatch();
-          assert (columnarBatch.getSchema().equals(PROTOCOL_METADATA_READ_SCHEMA));
-
-          final ColumnVector protocolVector = columnarBatch.getColumnVector(0);
-
-          for (int i = 0; i < protocolVector.getSize(); i++) {
-            if (!protocolVector.isNullAt(i)) {
-              protocol = Protocol.fromColumnVector(protocolVector, i);
-
-              if (metadata != null) {
-                // Stop since we have found the latest Protocol and Metadata.
-                return new Tuple2<>(protocol, metadata);
-              }
-
-              break; // We just found the protocol, exit this for-loop
-            }
-          }
-        }
-
-        if (metadata == null) {
-          if (columnarBatch == null) {
-            columnarBatch = nextElem.getColumnarBatch();
-            assert (columnarBatch.getSchema().equals(PROTOCOL_METADATA_READ_SCHEMA));
-          }
-          final ColumnVector metadataVector = columnarBatch.getColumnVector(1);
-
-          for (int i = 0; i < metadataVector.getSize(); i++) {
-            if (!metadataVector.isNullAt(i)) {
-              metadata = Metadata.fromColumnVector(metadataVector, i);
-
-              if (protocol != null) {
-                // Stop since we have found the latest Protocol and Metadata.
-                return new Tuple2<>(protocol, metadata);
-              }
-
-              break; // We just found the metadata, exit this for-loop
-            }
-          }
-        }
-
-        // Since we haven't returned, at least one of P or M is null.
-        // Note: Suppose the CRC is at version N. We check the CRC eagerly at N + 1 so
-        // that we don't read or open any files at version N.
-        if (latestCrcInfo.isPresent() && version == latestCrcInfo.get().getVersion() + 1) {
-          if (protocol == null) {
-            protocol = latestCrcInfo.get().getProtocol();
-          }
-          if (metadata == null) {
-            metadata = latestCrcInfo.get().getMetadata();
-          }
-          logger.info(
-              "{}: Loading Protocol and Metadata read {} logs with CRC at version {}",
-              dataPath.toString(),
-              logReadCount,
-              latestCrcInfo.map(crcInfo -> String.valueOf(crcInfo.getVersion())).orElse("N/A"));
-          return new Tuple2<>(protocol, metadata);
-        }
-      }
-    } catch (IOException ex) {
-      throw new RuntimeException("Could not close iterator", ex);
-    }
-
-    if (protocol == null) {
-      throw new IllegalStateException(
-          String.format("No protocol found at version %s", logSegment.getVersion()));
-    }
-
-    throw new IllegalStateException(
-        String.format("No metadata found at version %s", logSegment.getVersion()));
   }
 
   private Optional<Long> loadLatestTransactionVersion(Engine engine, String applicationId) {
@@ -488,8 +329,7 @@ public class LogReplay {
    * Retrieves a map of domainName to {@link DomainMetadata} from the log files.
    *
    * <p>Loading domain metadata requires an additional round of log replay so this is done lazily
-   * only when domain metadata is requested. We might want to merge this into {@link
-   * #loadTableProtocolAndMetadata}.
+   * and only when domain metadata is requested.
    *
    * @param engine The engine used to process the log files.
    * @param minLogVersion The minimum log version to read (inclusive). When provided, only reads log

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
@@ -56,10 +56,6 @@ public class ProtocolMetadataLogReplay {
       this.metadata = metadata;
       this.logFilesRead = logFilesRead;
     }
-
-    public long getLogFilesRead() {
-      return logFilesRead;
-    }
   }
 
   /**
@@ -92,7 +88,7 @@ public class ProtocolMetadataLogReplay {
         dataPath,
         snapshotMetrics.loadProtocolMetadataTotalDurationTimer.totalDurationMs(),
         logSegment.getVersion(),
-        result.getLogFilesRead());
+        result.logFilesRead);
 
     return result;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.replay;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.checksum.CRCInfo;
+import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.lang.Lazy;
+import io.delta.kernel.internal.metrics.SnapshotMetrics;
+import io.delta.kernel.internal.snapshot.LogSegment;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.io.IOException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Static utility class for loading Protocol and Metadata from Delta log files. */
+public class ProtocolMetadataLogReplay {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProtocolMetadataLogReplay.class);
+
+  /** Read schema when searching for the latest Protocol and Metadata. */
+  public static final StructType PROTOCOL_METADATA_READ_SCHEMA =
+      new StructType().add("protocol", Protocol.FULL_SCHEMA).add("metaData", Metadata.FULL_SCHEMA);
+
+  /** Result of loading Protocol and Metadata from a LogSegment. */
+  public static class Result {
+    public final Protocol protocol;
+    public final Metadata metadata;
+    private final long logFilesRead;
+
+    public Result(Protocol protocol, Metadata metadata, long logFilesRead) {
+      this.protocol = protocol;
+      this.metadata = metadata;
+      this.logFilesRead = logFilesRead;
+    }
+
+    public long getLogFilesRead() {
+      return logFilesRead;
+    }
+  }
+
+  /**
+   * Loads the latest Protocol and Metadata from the log files in the given LogSegment.
+   *
+   * <p>Uses the provided lazy CRC loader to bound how many delta files it reads, and to ensure we
+   * only read the CRC file if needed.
+   *
+   * <p>We read delta files in reverse order (newest first) searching for the latest Protocol and
+   * Metadata. When we reach the version just before (greater than) the CRC file version (if
+   * present), we lazily load the CRC file to fill in any missing Protocol or Metadata, avoiding
+   * reading older delta files.
+   *
+   * <p>Also validates that the Kernel can read the table at the loaded protocol version.
+   */
+  public static Result loadProtocolAndMetadata(
+      Engine engine,
+      Path dataPath,
+      LogSegment logSegment,
+      Lazy<Optional<CRCInfo>> lazyCrcInfo,
+      SnapshotMetrics snapshotMetrics) {
+    final Result result =
+        snapshotMetrics.loadProtocolMetadataTotalDurationTimer.time(
+            () -> loadProtocolAndMetadataInternal(engine, logSegment, lazyCrcInfo));
+
+    TableFeatures.validateKernelCanReadTheTable(result.protocol, dataPath.toString());
+
+    logger.info(
+        "[{}] Took {}ms to load Protocol and Metadata at version {}, read {} log files",
+        dataPath,
+        snapshotMetrics.loadProtocolMetadataTotalDurationTimer.totalDurationMs(),
+        logSegment.getVersion(),
+        result.getLogFilesRead());
+
+    return result;
+  }
+
+  private static Result loadProtocolAndMetadataInternal(
+      Engine engine, LogSegment logSegment, Lazy<Optional<CRCInfo>> lazyCrcInfo) {
+    final long snapshotVersion = logSegment.getVersion();
+    final Optional<FileStatus> crcFileOpt = logSegment.getLastSeenChecksum();
+    final Optional<Long> crcVersionOpt =
+        crcFileOpt.map(f -> FileNames.checksumVersion(f.getPath()));
+
+    // If CRC is at this exact snapshot version, use it directly
+    if (crcVersionOpt.isPresent() && crcVersionOpt.get() == snapshotVersion) {
+      final Optional<CRCInfo> crcInfo = lazyCrcInfo.get();
+      if (crcInfo.isPresent()) {
+        final Protocol protocol = crcInfo.get().getProtocol();
+        final Metadata metadata = crcInfo.get().getMetadata();
+        return new Result(protocol, metadata, 0 /* logFilesRead */);
+      }
+    }
+
+    // Otherwise, we need to read log files. The CRC (if present) might still be useful to avoid
+    // reading older files.
+
+    long logReadCount = 0;
+    Protocol protocol = null;
+    Metadata metadata = null;
+
+    try (CloseableIterator<ActionWrapper> reverseIter =
+        new ActionsIterator(
+            engine,
+            logSegment.allFilesWithCompactionsReversed(),
+            PROTOCOL_METADATA_READ_SCHEMA,
+            Optional.empty())) {
+      while (reverseIter.hasNext()) {
+        final ActionWrapper nextElem = reverseIter.next();
+        final long version = nextElem.getVersion();
+        logReadCount++;
+        // Load this lazily (as needed). We may be able to just use the CRC.
+        ColumnarBatch columnarBatch = null;
+
+        if (protocol == null) {
+          columnarBatch = nextElem.getColumnarBatch();
+          assert (columnarBatch.getSchema().equals(PROTOCOL_METADATA_READ_SCHEMA));
+
+          final ColumnVector protocolVector = columnarBatch.getColumnVector(0);
+
+          for (int i = 0; i < protocolVector.getSize(); i++) {
+            if (!protocolVector.isNullAt(i)) {
+              protocol = Protocol.fromColumnVector(protocolVector, i);
+
+              if (metadata != null) {
+                // Stop since we have found the latest Protocol and Metadata.
+                return new Result(protocol, metadata, logReadCount);
+              }
+
+              break; // We just found the protocol, exit this for-loop
+            }
+          }
+        }
+
+        if (metadata == null) {
+          if (columnarBatch == null) {
+            columnarBatch = nextElem.getColumnarBatch();
+            assert (columnarBatch.getSchema().equals(PROTOCOL_METADATA_READ_SCHEMA));
+          }
+          final ColumnVector metadataVector = columnarBatch.getColumnVector(1);
+
+          for (int i = 0; i < metadataVector.getSize(); i++) {
+            if (!metadataVector.isNullAt(i)) {
+              metadata = Metadata.fromColumnVector(metadataVector, i);
+
+              if (protocol != null) {
+                // Stop since we have found the latest Protocol and Metadata.
+                return new Result(protocol, metadata, logReadCount);
+              }
+
+              break; // We just found the metadata, exit this for-loop
+            }
+          }
+        }
+
+        // Since we haven't returned, then at least one of P or M is null.
+        // Note: Suppose the CRC is at version N. We check the CRC eagerly at N + 1 so
+        //       that we don't read or open any files at version N.
+        if (crcVersionOpt.isPresent() && version == crcVersionOpt.get() + 1) {
+          final Optional<CRCInfo> crcInfo = lazyCrcInfo.get();
+          if (crcInfo.isPresent()) {
+            if (protocol == null) {
+              protocol = crcInfo.get().getProtocol();
+            }
+            if (metadata == null) {
+              metadata = crcInfo.get().getMetadata();
+            }
+
+            return new Result(protocol, metadata, logReadCount);
+          }
+        }
+      }
+    } catch (IOException ex) {
+      throw new RuntimeException("Could not close iterator", ex);
+    }
+
+    if (protocol == null) {
+      throw new IllegalStateException(
+          String.format("No protocol found at version %s", logSegment.getVersion()));
+    }
+
+    if (metadata == null) {
+      throw new IllegalStateException(
+          String.format("No metadata found at version %s", logSegment.getVersion()));
+    }
+
+    return new Result(protocol, metadata, logReadCount);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -126,10 +126,10 @@ public class SnapshotFactory {
    * </ul>
    */
   public static Lazy<Optional<CRCInfo>> createLazyChecksumFileLoaderWithMetrics(
-      Engine engine, LogSegment logSegment, SnapshotMetrics snapshotMetrics) {
+      Engine engine, Lazy<LogSegment> lazyLogSegment, SnapshotMetrics snapshotMetrics) {
     return new Lazy<>(
         () -> {
-          final Optional<FileStatus> crcFileOpt = logSegment.getLastSeenChecksum();
+          final Optional<FileStatus> crcFileOpt = lazyLogSegment.get().getLastSeenChecksum();
           if (!crcFileOpt.isPresent()) {
             return Optional.empty();
           }
@@ -185,7 +185,7 @@ public class SnapshotFactory {
     final Lazy<LogSegment> lazyLogSegment = getLazyLogSegment(engine, snapshotCtx, versionToLoad);
     final Lazy<Optional<CRCInfo>> lazyCrcInfo =
         createLazyChecksumFileLoaderWithMetrics(
-            engine, lazyLogSegment.get(), snapshotCtx.getSnapshotMetrics());
+            engine, lazyLogSegment, snapshotCtx.getSnapshotMetrics());
 
     Protocol protocol;
     Metadata metadata;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -24,15 +24,20 @@ import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.checksum.CRCInfo;
+import io.delta.kernel.internal.checksum.ChecksumReader;
 import io.delta.kernel.internal.commit.DefaultFileSystemManagedTableOnlyCommitter;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.Lazy;
+import io.delta.kernel.internal.metrics.SnapshotMetrics;
 import io.delta.kernel.internal.metrics.SnapshotQueryContext;
 import io.delta.kernel.internal.replay.LogReplay;
+import io.delta.kernel.internal.replay.ProtocolMetadataLogReplay;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.snapshot.SnapshotManager;
+import io.delta.kernel.utils.FileStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -51,6 +56,10 @@ import org.slf4j.LoggerFactory;
  * Snapshot}.
  */
 public class SnapshotFactory {
+
+  //////////////////////////////////////////
+  // Static utility methods and variables //
+  //////////////////////////////////////////
 
   /**
    * Resolves the latest table version that exists at or before the given {@code
@@ -103,7 +112,37 @@ public class SnapshotFactory {
     return resolvedVersionToLoad;
   }
 
+  /**
+   * Creates a lazy loader for CRC file information. The CRC file is loaded only once when needed.
+   *
+   * <p>If {@link Lazy#isPresent()} is false, then the CRC file was never attempted to be loaded.
+   *
+   * <p>If {@link Lazy#isPresent()} is true, then the result is:
+   *
+   * <ul>
+   *   <li>{@code Optional.empty()} if there is no CRC file in this LogSegment, we failed to read
+   *       it, or we failed to parse it (e.g. missing required fields)
+   *   <li>{@code Optional.of(crcInfo)} if the file exists and was successfully read and parsed
+   * </ul>
+   */
+  public static Lazy<Optional<CRCInfo>> createLazyChecksumFileLoaderWithMetrics(
+      Engine engine, LogSegment logSegment, SnapshotMetrics snapshotMetrics) {
+    return new Lazy<>(
+        () -> {
+          final Optional<FileStatus> crcFileOpt = logSegment.getLastSeenChecksum();
+          if (!crcFileOpt.isPresent()) {
+            return Optional.empty();
+          }
+          return snapshotMetrics.loadCrcTotalDurationTimer.time(
+              () -> ChecksumReader.tryReadChecksumFile(engine, crcFileOpt.get()));
+        });
+  }
+
   private static final Logger logger = LoggerFactory.getLogger(SnapshotFactory.class);
+
+  //////////////////////////////////
+  // Member methods and variables //
+  //////////////////////////////////
 
   private final SnapshotBuilderImpl.Context ctx;
   private final Path tablePath;
@@ -144,15 +183,38 @@ public class SnapshotFactory {
   private SnapshotImpl createSnapshot(Engine engine, SnapshotQueryContext snapshotCtx) {
     final Optional<Long> versionToLoad = getTargetVersionToLoad(engine, snapshotCtx);
     final Lazy<LogSegment> lazyLogSegment = getLazyLogSegment(engine, snapshotCtx, versionToLoad);
-    final LogReplay logReplay = getLogReplay(engine, lazyLogSegment, snapshotCtx);
+    final Lazy<Optional<CRCInfo>> lazyCrcInfo =
+        createLazyChecksumFileLoaderWithMetrics(
+            engine, lazyLogSegment.get(), snapshotCtx.getSnapshotMetrics());
+
+    Protocol protocol;
+    Metadata metadata;
+
+    if (ctx.protocolAndMetadataOpt.isPresent()) {
+      protocol = ctx.protocolAndMetadataOpt.get()._1;
+      metadata = ctx.protocolAndMetadataOpt.get()._2;
+    } else {
+      ProtocolMetadataLogReplay.Result result =
+          ProtocolMetadataLogReplay.loadProtocolAndMetadata(
+              engine,
+              tablePath,
+              lazyLogSegment.get(),
+              lazyCrcInfo,
+              snapshotCtx.getSnapshotMetrics());
+      protocol = result.protocol;
+      metadata = result.metadata;
+    }
+
+    // TODO: When LogReplay becomes static utilities, we can create it inside of SnapshotImpl
+    final LogReplay logReplay = new LogReplay(engine, tablePath, lazyLogSegment, lazyCrcInfo);
 
     return new SnapshotImpl(
         tablePath,
         versionToLoad.orElseGet(() -> lazyLogSegment.get().getVersion()),
         lazyLogSegment,
         logReplay,
-        getProtocol(logReplay),
-        getMetadata(logReplay),
+        protocol,
+        metadata,
         ctx.committerOpt.orElse(DefaultFileSystemManagedTableOnlyCommitter.INSTANCE),
         snapshotCtx);
   }
@@ -201,18 +263,5 @@ public class SnapshotFactory {
       return ctx.versionOpt;
     }
     return Optional.empty();
-  }
-
-  private LogReplay getLogReplay(
-      Engine engine, Lazy<LogSegment> lazyLogSegment, SnapshotQueryContext snapshotCtx) {
-    return new LogReplay(tablePath, engine, lazyLogSegment, snapshotCtx.getSnapshotMetrics());
-  }
-
-  private Protocol getProtocol(LogReplay logReplay) {
-    return ctx.protocolAndMetadataOpt.map(x -> x._1).orElseGet(logReplay::getProtocol);
-  }
-
-  private Metadata getMetadata(LogReplay logReplay) {
-    return ctx.protocolAndMetadataOpt.map(x -> x._2).orElseGet(logReplay::getMetadata);
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumSimpleComparisonSuite.scala
@@ -155,7 +155,7 @@ trait ChecksumComparisonSuiteBase extends AnyFunSuite with WriteUtils with TestU
 
   private def readCrcInfo(engine: Engine, path: String, version: Long): CRCInfo = {
     ChecksumReader
-      .getCRCInfo(
+      .tryReadChecksumFile(
         engine,
         FileStatus.of(checksumFile(new Path(f"$path/_delta_log/"), version).toString))
       .orElseThrow(() => new IllegalStateException(s"CRC info not found for version $version"))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumStatsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumStatsSuite.scala
@@ -94,7 +94,7 @@ trait ChecksumStatsSuiteBase extends AnyFunSuite with WriteUtils {
       expectedTableSize: Long,
       expectedFileSizeHistogram: FileSizeHistogram): Unit = {
     def verifyCrcExistsAndCorrect(): Unit = {
-      val crcInfo = ChecksumReader.getCRCInfo(
+      val crcInfo = ChecksumReader.tryReadChecksumFile(
         engine,
         FileStatus.of(checksumFile(
           new Path(tablePath + "/_delta_log"),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -810,7 +810,7 @@ trait AbstractTestUtils
       tablePath: String,
       version: Long): Unit = {
     val logPath = new KernelPath(s"$tablePath/_delta_log");
-    val crcInfo = ChecksumReader.getCRCInfo(
+    val crcInfo = ChecksumReader.tryReadChecksumFile(
       engine,
       FileStatus.of(checksumFile(
         logPath,
@@ -856,7 +856,7 @@ trait AbstractTestUtils
       snapshot: Snapshot,
       expectEmptyTable: Boolean = false): Unit = {
     val logPath = snapshot.asInstanceOf[SnapshotImpl].getLogPath
-    val crcInfoOpt = ChecksumReader.getCRCInfo(
+    val crcInfoOpt = ChecksumReader.tryReadChecksumFile(
       defaultEngine,
       FileStatus.of(checksumFile(
         logPath,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5292/files) to review incremental changes.
- [**stack/kernel_protocol_metadata_log_replay_refactor_b**](https://github.com/delta-io/delta/pull/5292) [[Files changed](https://github.com/delta-io/delta/pull/5292/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Today, LogReplay <> P&M is a bit odd. LogReplay can load the P & M for you (def getProtocol, def getMetadata), but then when we create a snapshot we are injecting (a) the LogReplay object, but (b) the pre-loaded P & M, too.

This PR splits up that functionality. There is now an individual ProtocolMetadataLogReplay static loader that loads the P & M and returns any CRC file that was read along the way.

## How was this patch tested?

Just a refactor. Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.
