### PR TITLE
[Kernel][CCv2] Support CCV2 catalog commits in the CommitRange API

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -68,7 +68,11 @@ public final class DeltaHistoryManager {
    * @throws KernelException if the timestamp is more than the timestamp of any committed version
    */
   public static long getVersionAtOrAfterTimestamp(
-      Engine engine, Path logPath, long millisSinceEpochUTC, SnapshotImpl latestSnapshot) {
+      Engine engine,
+      Path logPath,
+      long millisSinceEpochUTC,
+      SnapshotImpl latestSnapshot,
+      List<ParsedCatalogCommitData> parsedCatalogCommits) {
     DeltaHistoryManager.Commit commit =
         DeltaHistoryManager.getActiveCommitAtTimestamp(
             engine,
@@ -82,8 +86,7 @@ public final class DeltaHistoryManager {
             // e.g. we give time T-1 and first commit has time T, then we DO want that earliest
             // commit
             true /* canReturnEarliestCommit */,
-            // TODO: pass through parsedDeltaData for ccv2
-            Collections.emptyList() /* parsedDeltaDatas */);
+            parsedCatalogCommits);
 
     if (commit.getTimestamp() >= millisSinceEpochUTC) {
       return commit.getVersion();
@@ -114,7 +117,11 @@ public final class DeltaHistoryManager {
    * @throws KernelException if the timestamp is less than the timestamp of any committed version
    */
   public static long getVersionBeforeOrAtTimestamp(
-      Engine engine, Path logPath, long millisSinceEpochUTC, SnapshotImpl latestSnapshot) {
+      Engine engine,
+      Path logPath,
+      long millisSinceEpochUTC,
+      SnapshotImpl latestSnapshot,
+      List<ParsedCatalogCommitData> parsedCatalogCommits) {
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
             engine,
             latestSnapshot,
@@ -126,8 +133,7 @@ public final class DeltaHistoryManager {
             // e.g. we give time T-1 and first commit has time T, then do NOT want that earliest
             // commit
             false /* canReturnEarliestCommit */,
-            // TODO: pass through parsedDeltaData for ccv2
-            Collections.emptyList() /* parsedDeltaDatas */)
+            parsedCatalogCommits)
         .getVersion();
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -17,6 +17,7 @@ package io.delta.kernel.internal;
 
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineExceptionThrowsIO;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static java.util.Collections.emptyList;
 
 import io.delta.kernel.*;
 import io.delta.kernel.data.ColumnarBatch;
@@ -227,7 +228,11 @@ public class TableImpl implements Table {
   public long getVersionBeforeOrAtTimestamp(Engine engine, long millisSinceEpochUTC) {
     SnapshotImpl latestSnapshot = (SnapshotImpl) getLatestSnapshot(engine);
     return DeltaHistoryManager.getVersionBeforeOrAtTimestamp(
-        engine, getLogPath(), millisSinceEpochUTC, latestSnapshot);
+        engine,
+        getLogPath(),
+        millisSinceEpochUTC,
+        latestSnapshot,
+        emptyList() /* parsedDeltaDatas */);
   }
 
   /**
@@ -254,7 +259,11 @@ public class TableImpl implements Table {
   public long getVersionAtOrAfterTimestamp(Engine engine, long millisSinceEpochUTC) {
     SnapshotImpl latestSnapshot = (SnapshotImpl) getLatestSnapshot(engine);
     return DeltaHistoryManager.getVersionAtOrAfterTimestamp(
-        engine, getLogPath(), millisSinceEpochUTC, latestSnapshot);
+        engine,
+        getLogPath(),
+        millisSinceEpochUTC,
+        latestSnapshot,
+        emptyList() /* parsedDeltaDatas */);
   }
 
   /** Helper method that loads a snapshot with proper metrics recording, logging, and reporting. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeBuilderImpl.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.CommitRangeBuilder;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.files.LogDataUtils;
 import io.delta.kernel.internal.files.ParsedLogData;
 import java.util.Collections;
 import java.util.List;
@@ -76,9 +77,6 @@ public class CommitRangeBuilderImpl implements CommitRangeBuilder {
 
   @Override
   public CommitRange build(Engine engine) {
-    if (!ctx.logDatas.isEmpty()) {
-      throw new UnsupportedOperationException("CommitRange does not support providing logData yet");
-    }
     validateInputOnBuild();
     return new CommitRangeFactory(engine, ctx).create(engine);
   }
@@ -108,6 +106,8 @@ public class CommitRangeBuilderImpl implements CommitRangeBuilder {
       // Mixed types are allowed but will need runtime resolution
     }
 
-    // TODO: validate parsedLogData input
+    // Validate logData input
+    LogDataUtils.validateLogDataContainsOnlyRatifiedStagedCommits(ctx.logDatas);
+    LogDataUtils.validateLogDataIsSortedContiguous(ctx.logDatas);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeFactory.java
@@ -15,20 +15,28 @@
  */
 package io.delta.kernel.internal.commitrange;
 
+import static io.delta.kernel.internal.DeltaErrors.*;
+import static io.delta.kernel.internal.DeltaLogActionUtils.listDeltaLogFilesAsIter;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.Utils.resolvePath;
 
 import io.delta.kernel.CommitRangeBuilder;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.InvalidTableException;
 import io.delta.kernel.internal.DeltaHistoryManager;
-import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.files.LogDataUtils;
+import io.delta.kernel.internal.files.ParsedCatalogCommitData;
+import io.delta.kernel.internal.files.ParsedDeltaData;
+import io.delta.kernel.internal.files.ParsedLogData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.ListUtils;
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.utils.FileStatus;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,25 +55,24 @@ class CommitRangeFactory {
   }
 
   CommitRangeImpl create(Engine engine) {
-    long startVersion = resolveStartVersion(engine);
-    Optional<Long> endVersionOpt = resolveEndVersionIfSpecified(engine);
+    List<ParsedCatalogCommitData> ratifiedCommits = getFileBasedRatifiedCommits();
+    long startVersion = resolveStartVersion(engine, ratifiedCommits);
+    Optional<Long> endVersionOpt = resolveEndVersionIfSpecified(engine, ratifiedCommits);
     validateVersionRange(startVersion, endVersionOpt);
     logResolvedVersions(startVersion, endVersionOpt);
-    // TODO: for now we just store a list of commit files, this will be updated when we add support
-    //  for ccv2
-    List<FileStatus> deltaFiles =
-        DeltaLogActionUtils.getCommitFilesForVersionRange(
-            engine, tablePath, startVersion, endVersionOpt);
-    // Once we have listed files, we can resolve endVersion=latestVersion for the default case
-    long endVersion = endVersionOpt.orElseGet(() -> extractLatestVersion(deltaFiles));
+    List<ParsedDeltaData> deltas =
+        getDeltasForVersionRangeWithCatalogPriority(
+            engine, startVersion, endVersionOpt, ratifiedCommits);
+    // Once we have a list of deltas, we can resolve endVersion=latestVersion for the default case
+    long endVersion = endVersionOpt.orElseGet(() -> extractLatestVersion(deltas));
     if (!endVersionOpt.isPresent()) {
       logger.info("{}: Resolved end-boundary to the latest version {}", tablePath, endVersion);
     }
     return new CommitRangeImpl(
-        tablePath, ctx.startBoundaryOpt, ctx.endBoundaryOpt, startVersion, endVersion, deltaFiles);
+        tablePath, ctx.startBoundaryOpt, ctx.endBoundaryOpt, startVersion, endVersion, deltas);
   }
 
-  private long resolveStartVersion(Engine engine) {
+  private long resolveStartVersion(Engine engine, List<ParsedCatalogCommitData> parsedDeltas) {
     if (!ctx.startBoundaryOpt.isPresent()) {
       // Default to version 0 if no start boundary is provided
       return 0L;
@@ -79,12 +86,12 @@ class CommitRangeFactory {
           "{}: Trying to resolve start-boundary timestamp {} to version",
           tablePath,
           startBoundary.getTimestamp());
-      // TODO: support ccv2 tables
       return DeltaHistoryManager.getVersionAtOrAfterTimestamp(
           engine,
           logPath,
           startBoundary.getTimestamp(),
-          (SnapshotImpl) startBoundary.getLatestSnapshot());
+          (SnapshotImpl) startBoundary.getLatestSnapshot(),
+          parsedDeltas);
     }
   }
 
@@ -94,7 +101,8 @@ class CommitRangeFactory {
    * timestamp to version. When the boundary is not specified, this returns empty, as the version
    * cannot be resolved until later after we have performed any listing.
    */
-  private Optional<Long> resolveEndVersionIfSpecified(Engine engine) {
+  private Optional<Long> resolveEndVersionIfSpecified(
+      Engine engine, List<ParsedCatalogCommitData> parsedDeltas) {
     if (!ctx.endBoundaryOpt.isPresent()) {
       // When endBoundary is not provided, we default to the latest version. We cannot resolve the
       // latest version until later after we have performed any listing.
@@ -109,13 +117,13 @@ class CommitRangeFactory {
           "{}: Trying to resolve end-boundary timestamp {} to version",
           tablePath,
           endBoundary.getTimestamp());
-      // TODO: support ccv2 tables
       long resolvedVersion =
           DeltaHistoryManager.getVersionBeforeOrAtTimestamp(
               engine,
               logPath,
               endBoundary.getTimestamp(),
-              (SnapshotImpl) endBoundary.getLatestSnapshot());
+              (SnapshotImpl) endBoundary.getLatestSnapshot(),
+              parsedDeltas);
       return Optional.of(resolvedVersion);
     }
   }
@@ -139,7 +147,151 @@ class CommitRangeFactory {
         ctx.endBoundaryOpt);
   }
 
-  private long extractLatestVersion(List<FileStatus> deltaFiles) {
-    return FileNames.deltaVersion(ListUtils.getLast(deltaFiles).getPath());
+  private long extractLatestVersion(List<ParsedDeltaData> deltaDatas) {
+    return ListUtils.getLast(deltaDatas).getVersion();
+  }
+
+  private List<ParsedCatalogCommitData> getFileBasedRatifiedCommits() {
+    // Note: currently this is all we allow in CommitRangeBuilder anyway, but in the future that
+    // could change
+    return ctx.logDatas.stream()
+        .filter(logData -> logData instanceof ParsedCatalogCommitData)
+        .map(logData -> (ParsedCatalogCommitData) logData)
+        .filter(deltaData -> deltaData.isFile())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Lists the _delta_log and combines the found published deltas with the catalog ratified deltas
+   * to compile a single contiguous list of deltas. Catalog commits take priority over published
+   * deltas when both are present for the same commit version. Returned deltas are guaranteed to
+   * start with startVersion, end with endVersion if endVersionOpt is non-empty, and are contiguous.
+   * Throws an exception if no deltas are found in the version range, or if startVersion or
+   * endVersion cannot be found.
+   */
+  private List<ParsedDeltaData> getDeltasForVersionRangeWithCatalogPriority(
+      Engine engine,
+      long startVersion,
+      Optional<Long> endVersionOpt,
+      List<ParsedCatalogCommitData> ratifiedCommits) {
+    // Get published deltas between startVersion and endVersionOpt
+    List<ParsedDeltaData> publishedDeltas =
+        getPublishedDeltasInVersionRange(engine, startVersion, endVersionOpt);
+
+    // Get ratified deltas between startVersion and endVersionOpt
+    List<ParsedDeltaData> ratifiedDeltas =
+        ratifiedCommits.stream()
+            .filter(
+                x ->
+                    x.getVersion() >= startVersion
+                        && x.getVersion() <= endVersionOpt.orElse(Long.MAX_VALUE))
+            .collect(Collectors.toList());
+
+    // Validate they are contiguous and valid (i.e. backfill is ordered)
+    validatePublishedPlusRatifiedDeltas(publishedDeltas, ratifiedDeltas);
+    List<ParsedDeltaData> combinedDeltas =
+        LogDataUtils.combinePublishedAndRatifiedDeltasWithCatalogPriority(
+            publishedDeltas, ratifiedDeltas);
+    validateVersionRange(combinedDeltas, startVersion, endVersionOpt);
+    return combinedDeltas;
+  }
+
+  /**
+   * Returns any published deltas found on the file-system within the version range provided and
+   * validates that they are contiguous. Returns a sorted and contiguous list of deltas for the
+   * version range, but does no validation that the list fills the range.
+   */
+  private List<ParsedDeltaData> getPublishedDeltasInVersionRange(
+      Engine engine, long startVersion, Optional<Long> endVersionOpt) {
+    final List<FileStatus> commitFiles =
+        listDeltaLogFilesAsIter(
+                engine,
+                Collections.singleton(FileNames.DeltaLogFileType.COMMIT),
+                tablePath,
+                startVersion,
+                endVersionOpt,
+                false /* mustBeRecreatable */)
+            .toInMemoryList();
+    List<ParsedDeltaData> publishedDeltas =
+        commitFiles.stream().map(ParsedDeltaData::forFileStatus).collect(Collectors.toList());
+
+    // Validate listed delta files are contiguous
+    if (publishedDeltas.size() > 1) {
+      for (int i = 1; i < publishedDeltas.size(); i++) {
+        final ParsedLogData prev = publishedDeltas.get(i - 1);
+        final ParsedLogData curr = publishedDeltas.get(i);
+        if (prev.getVersion() + 1 != curr.getVersion()) {
+          throw new InvalidTableException(
+              tablePath.toString(),
+              String.format(
+                  "Missing delta files: versions are not contiguous: (%s)",
+                  publishedDeltas.stream()
+                      .map(ParsedDeltaData::getVersion)
+                      .collect(Collectors.toList())));
+        }
+      }
+    }
+    return publishedDeltas;
+  }
+
+  private void validatePublishedPlusRatifiedDeltas(
+      List<ParsedDeltaData> publishedDeltas, List<ParsedDeltaData> ratifiedDeltas) {
+    // Valid example: P0, P1, P2 + R1 (ratified within published)
+    // Valid example: P0, P1 + R2, R3 (no overlap)
+    // Valid example: P0, P1 + R1, R2 (overlap)
+    if (!publishedDeltas.isEmpty() && !ratifiedDeltas.isEmpty()) {
+      long earliestPublishedVersion = publishedDeltas.get(0).getVersion();
+      long earliestRatifiedVersion = ratifiedDeltas.get(0).getVersion();
+      // We cannot have ratifiedDeltas.head.version < publishedDeltas.head.version
+      // Example: P2, P3 + R1, R2, R3 is invalid
+      if (earliestRatifiedVersion < earliestPublishedVersion) {
+        throw new InvalidTableException(
+            tablePath.toString(),
+            String.format(
+                "Missing delta file: found staged ratified commit for version %s but no published "
+                    + "delta file. Found published deltas for versions: %s",
+                earliestRatifiedVersion,
+                publishedDeltas.stream()
+                    .map(ParsedDeltaData::getVersion)
+                    .collect(Collectors.toList())));
+      }
+      long lastPublishedVersion = ListUtils.getLast(publishedDeltas).getVersion();
+      // We must have publishedDeltas + ratifiedDeltas be contiguous
+      // Example: P0, P1 + R3, R4 is invalid
+      if (lastPublishedVersion + 1 < earliestRatifiedVersion) {
+        throw new InvalidTableException(
+            tablePath.toString(),
+            String.format(
+                "Missing delta files: found published delta files for versions %s and staged "
+                    + "ratified commits for versions %s",
+                publishedDeltas.stream()
+                    .map(ParsedDeltaData::getVersion)
+                    .collect(Collectors.toList()),
+                ratifiedDeltas.stream()
+                    .map(ParsedDeltaData::getVersion)
+                    .collect(Collectors.toList())));
+      }
+    }
+  }
+
+  private void validateVersionRange(
+      List<ParsedDeltaData> deltas, long startVersion, Optional<Long> endVersionOpt) {
+    // This can only happen if publishedDeltas.isEmpty && ratifiedDeltas.isEmpty
+    if (deltas.isEmpty()) {
+      throw noCommitFilesFoundForVersionRange(tablePath.toString(), startVersion, endVersionOpt);
+    }
+
+    long earliestVersion = ListUtils.getFirst(deltas).getVersion();
+    long latestVersion = ListUtils.getLast(deltas).getVersion();
+
+    if (earliestVersion != startVersion) {
+      throw startVersionNotFound(tablePath.toString(), startVersion, Optional.of(earliestVersion));
+    }
+    endVersionOpt.ifPresent(
+        endVersion -> {
+          if (latestVersion != endVersion) {
+            throw endVersionNotFound(tablePath.toString(), endVersion, latestVersion);
+          }
+        });
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
@@ -26,12 +26,14 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.annotation.VisibleForTesting;
+import io.delta.kernel.internal.files.ParsedDeltaData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Implementation of {@link CommitRange}. */
 public class CommitRangeImpl implements CommitRange {
@@ -42,9 +44,7 @@ public class CommitRangeImpl implements CommitRange {
 
   private final long startVersion;
   private final long endVersion;
-  // TODO: update contents of this class for CCV2 tables
-  //  (include ratified commits? store a LogSegment?)
-  private final List<FileStatus> deltaFiles;
+  private final List<ParsedDeltaData> deltas;
 
   public CommitRangeImpl(
       Path dataPath,
@@ -52,17 +52,16 @@ public class CommitRangeImpl implements CommitRange {
       Optional<CommitRangeBuilder.CommitBoundary> endBoundaryOpt,
       long startVersion,
       long endVersion,
-      List<FileStatus> deltaFiles) {
+      List<ParsedDeltaData> deltas) {
     checkArgument(startVersion <= endVersion, "must have startVersion <= endVersion");
     checkArgument(
-        deltaFiles.size() == endVersion - startVersion + 1,
-        "deltaFiles size must match size of range");
+        deltas.size() == endVersion - startVersion + 1, "deltaFiles size must match size of range");
     this.dataPath = requireNonNull(dataPath, "dataPath cannot be null");
     this.startBoundaryOpt = requireNonNull(startBoundaryOpt, "startSpecOpt cannot be null");
     this.endBoundaryOpt = requireNonNull(endBoundaryOpt, "endSpecOpt cannot be null");
     this.startVersion = startVersion;
     this.endVersion = endVersion;
-    this.deltaFiles = requireNonNull(deltaFiles, "deltaFiles cannot be null");
+    this.deltas = requireNonNull(deltas, "deltas cannot be null");
   }
 
   ////////////////////////////////////////
@@ -91,7 +90,7 @@ public class CommitRangeImpl implements CommitRange {
 
   @VisibleForTesting
   public List<FileStatus> getDeltaFiles() {
-    return deltaFiles;
+    return deltas.stream().map(ParsedDeltaData::getFileStatus).collect(Collectors.toList());
   }
 
   @Override
@@ -104,6 +103,6 @@ public class CommitRangeImpl implements CommitRange {
         startSnapshot.getVersion() == startVersion,
         "startSnapshot must have version = startVersion");
     return DeltaLogActionUtils.getActionsFromCommitFilesWithProtocolValidation(
-        engine, dataPath.toString(), deltaFiles, actionSet);
+        engine, dataPath.toString(), getDeltaFiles(), actionSet);
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -150,7 +150,11 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
    * file statuses.
    */
   def listFromProvider(files: Seq[FileStatus])(filePath: String): Seq[FileStatus] = {
-    files.filter(_.getPath.compareTo(filePath) >= 0).sortBy(_.getPath)
+    val parentPath = new Path(filePath).getParent
+    files
+      .filter(fs => new Path(fs.getPath).getParent == parentPath)
+      .filter(_.getPath.compareTo(filePath) >= 0)
+      .sortBy(_.getPath)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Support providing catalog commits when building a CommitRange, and use them when resolving start/end boundaries and building the file list.

## How was this patch tested?

Adds unit and E2E test.

## Does this PR introduce _any_ user-facing changes?

Yes, now when you provide parsedLogData to CommitRangeBuilder it will work.