### PR TITLE
[kernel dsv2 streaming] Add logic that reads the delta commit log in preparation for streaming read (Part I)  

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -727,7 +727,7 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
 lazy val kernelSpark = (project in file("kernel-spark"))
   .dependsOn(kernelApi)
   .dependsOn(kernelDefaults)
-  .dependsOn(spark % "test->test")
+  .dependsOn(spark % "compile->compile;test->test")
   .dependsOn(goldenTables % "test")
   .settings(
     name := "kernel-spark",

--- a/kernel-spark/src/main/java/io/delta/kernel/spark/read/KernelIndexedFile.java
+++ b/kernel-spark/src/main/java/io/delta/kernel/spark/read/KernelIndexedFile.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.spark.read;
+
+import io.delta.kernel.internal.actions.AddFile;
+
+/**
+ * Java version of IndexedFile.scala that uses Kernel's action classes.
+ *
+ * <p> File: represents a data file in Delta. 
+ * <p> Indexed: refers to the index in DeltaSourceOffset, assigned by the streaming engine.
+ */
+public class KernelIndexedFile {
+  private final long version;
+  private final long index;
+  private final AddFile addFile;
+
+  public KernelIndexedFile(long version, long index, AddFile addFile) {
+    this.version = version;
+    this.index = index;
+    this.addFile = addFile;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public long getIndex() {
+    return index;
+  }
+
+  public AddFile getAddFile() {
+    return addFile;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("KernelIndexedFile{");
+    sb.append("version=").append(version);
+    sb.append(", index=").append(index);
+    sb.append(", addFile=").append(addFile);
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/kernel-spark/src/main/java/io/delta/kernel/spark/read/SparkMicroBatchStream.java
+++ b/kernel-spark/src/main/java/io/delta/kernel/spark/read/SparkMicroBatchStream.java
@@ -15,12 +15,36 @@
  */
 package io.delta.kernel.spark.read;
 
+import io.delta.kernel.*;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.RemoveFile;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.spark.utils.StreamingHelper;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.IOException;
+import java.util.*;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.delta.DeltaErrors;
+import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
+import scala.Option;
 
 public class SparkMicroBatchStream implements MicroBatchStream {
+
+  private final Engine engine;
+  private final String tablePath;
+
+  public SparkMicroBatchStream(String tablePath, Configuration hadoopConf) {
+    this.tablePath = tablePath;
+    this.engine = DefaultEngine.create(hadoopConf);
+  }
 
   ////////////
   // offset //
@@ -67,5 +91,201 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   @Override
   public void stop() {
     throw new UnsupportedOperationException("stop is not supported");
+  }
+
+  ////////////////////
+  // getFileChanges //
+  ////////////////////
+
+  /**
+   * Get file changes between fromVersion/fromIndex and endOffset. This is the Kernel-based
+   * implementation of DeltaSource.getFileChanges.
+   *
+   * <p>Package-private for testing.
+   */
+  CloseableIterator<KernelIndexedFile> getFileChanges(
+      long fromVersion,
+      long fromIndex,
+      boolean isInitialSnapshot,
+      Option<DeltaSourceOffset> endOffset) {
+
+    CloseableIterator<KernelIndexedFile> result;
+
+    if (isInitialSnapshot) {
+      // TODO(M1): Implement initial snapshot
+      throw new UnsupportedOperationException("initial snapshot is not supported yet");
+    } else {
+      result = filterDeltaLogs(fromVersion, endOffset);
+    }
+
+    // Check start boundary (exclusive)
+    result =
+        result.filter(
+            file ->
+                file.getVersion() > fromVersion
+                    || (file.getVersion() == fromVersion && file.getIndex() > fromIndex));
+
+    // Check end boundary (inclusive)
+    if (endOffset.isDefined()) {
+      DeltaSourceOffset bound = endOffset.get();
+      result =
+          result.takeWhile(
+              file ->
+                  file.getVersion() < bound.reservoirVersion()
+                      || (file.getVersion() == bound.reservoirVersion()
+                          && file.getIndex() <= bound.index()));
+    }
+
+    return result;
+  }
+
+  // TODO(M1): implement lazy loading (one batch at a time).
+  private CloseableIterator<KernelIndexedFile> filterDeltaLogs(
+      long startVersion, Option<DeltaSourceOffset> endOffset) {
+    List<KernelIndexedFile> allIndexedFiles = new ArrayList<>();
+    // StartBoundary (inclusive)
+    CommitRangeBuilder builder =
+        TableManager.loadCommitRange(tablePath)
+            .withStartBoundary(CommitRangeBuilder.CommitBoundary.atVersion(startVersion));
+    if (endOffset.isDefined()) {
+      // EndBoundary (inclusive)
+      builder =
+          builder.withEndBoundary(
+              CommitRangeBuilder.CommitBoundary.atVersion(endOffset.get().reservoirVersion()));
+    }
+    CommitRange commitRange = builder.build(engine);
+    // Required by kernel: perform protocol validation by creating a snapshot at startVersion.
+    Snapshot startSnapshot =
+        TableManager.loadSnapshot(tablePath).atVersion(startVersion).build(engine);
+    // TODO(M1): This is not working with ccv2 table
+    Set<DeltaAction> actionSet = new HashSet<>(Arrays.asList(DeltaAction.ADD, DeltaAction.REMOVE));
+    try (CloseableIterator<ColumnarBatch> actionsIter =
+        commitRange.getActions(engine, startSnapshot, actionSet)) {
+      // Each batch is guaranteed to have the same commit version.
+      // A version can be split across multiple batches.
+      long currentVersion = -1;
+      long currentIndex = 0;
+      List<KernelIndexedFile> currentVersionFiles = new ArrayList<>();
+
+      while (actionsIter.hasNext()) {
+        ColumnarBatch batch = actionsIter.next();
+        if (batch.getSize() == 0) {
+          continue;
+        }
+        long version = StreamingHelper.getVersion(batch);
+        validateCommit(batch, version, endOffset);
+        // TODO(M1): migrate to kernel's commit-level iterator (WIP).
+        // The current one-pass algorithm assumes REMOVE actions proceed ADD actions
+        // in a commit; we should implement a proper two-pass approach once kernel API is ready.
+
+        if (currentVersion != -1 && version != currentVersion) {
+          // Process the previous version's files
+          List<KernelIndexedFile> versionFilesWithSentinels =
+              addBeginAndEndIndexOffsetsForVersion(currentVersion, currentVersionFiles);
+          allIndexedFiles.addAll(versionFilesWithSentinels);
+
+          // Reset for the new version - we start collecting files for the new version,
+          // so we clear the list to accumulate files from the new version's batches
+          currentVersionFiles = new ArrayList<>();
+          currentIndex = 0;
+        }
+
+        // Update current version tracking
+        currentVersion = version;
+        List<KernelIndexedFile> batchFiles =
+            extractIndexedFilesFromBatch(batch, version, currentIndex);
+        currentIndex += batchFiles.size();
+        currentVersionFiles.addAll(batchFiles);
+      }
+
+      // Process the last version's files if any
+      if (currentVersion != -1) {
+        List<KernelIndexedFile> versionFilesWithSentinels =
+            addBeginAndEndIndexOffsetsForVersion(currentVersion, currentVersionFiles);
+        allIndexedFiles.addAll(versionFilesWithSentinels);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read commit range", e);
+    }
+    return Utils.toCloseableIterator(allIndexedFiles.iterator());
+  }
+
+  /**
+   * Validates a commit and fail the stream if it's invalid. Mimics
+   * DeltaSource.validateCommitAndDecideSkipping in Scala.
+   *
+   * @throws RuntimeException if the commit is invalid.
+   */
+  private void validateCommit(
+      ColumnarBatch batch, long version, Option<DeltaSourceOffset> endOffsetOpt) {
+    // If endOffset is at the beginning of this version, exit early.
+    if (endOffsetOpt.isDefined()) {
+      DeltaSourceOffset endOffset = endOffsetOpt.get();
+      if (endOffset.reservoirVersion() == version
+          && endOffset.index() == DeltaSourceOffset.BASE_INDEX()) {
+        return;
+      }
+    }
+
+    int numRows = batch.getSize();
+    // TODO(M2): Implement ignoreChanges & skipChangeCommits & ignoreDeletes (legacy)
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      // RULE 1: If commit has RemoveFile(dataChange=true), fail this stream.
+      Optional<RemoveFile> removeOpt = StreamingHelper.getDataChangeRemove(batch, rowId);
+      if (removeOpt.isPresent()) {
+        RemoveFile removeFile = removeOpt.get();
+        Throwable error =
+            DeltaErrors.deltaSourceIgnoreDeleteError(version, removeFile.getPath(), tablePath);
+        if (error instanceof RuntimeException) {
+          throw (RuntimeException) error;
+        } else {
+          throw new RuntimeException(error);
+        }
+      }
+    }
+  }
+
+  /**
+   * Extracts KernelIndexedFiles from a batch of actions for a given version. Assigns an index to
+   * each KernelIndexedFile.
+   */
+  private List<KernelIndexedFile> extractIndexedFilesFromBatch(
+      ColumnarBatch batch, long version, long startIndex) {
+    List<KernelIndexedFile> indexedFiles = new ArrayList<>();
+    long index = startIndex;
+    for (int rowId = 0; rowId < batch.getSize(); rowId++) {
+      Optional<AddFile> addOpt = StreamingHelper.getDataChangeAdd(batch, rowId);
+      if (addOpt.isPresent()) {
+        AddFile addFile = addOpt.get();
+        indexedFiles.add(new KernelIndexedFile(version, index++, addFile));
+      }
+    }
+
+    return indexedFiles;
+  }
+
+  /**
+   * Adds BEGIN and END sentinel KernelIndexedFiles for a version. Sentinels are used to mark the
+   * beginning and end of a version.
+   *
+   * <p>This mimics DeltaSource.addBeginAndEndIndexOffsetsForVersion and
+   * getMetadataOrProtocolChangeIndexedFileIterator.
+   */
+  private List<KernelIndexedFile> addBeginAndEndIndexOffsetsForVersion(
+      long version, List<KernelIndexedFile> dataFiles) {
+
+    List<KernelIndexedFile> result = new ArrayList<>();
+
+    // Add BEGIN sentinel
+    result.add(new KernelIndexedFile(version, DeltaSourceOffset.BASE_INDEX(), /* addFile= */ null));
+
+    // TODO(M2): check trackingMetadataChange flag and compare with stream metadata.
+
+    result.addAll(dataFiles);
+
+    // Add END sentinel
+    result.add(new KernelIndexedFile(version, DeltaSourceOffset.END_INDEX(), /* addFile= */ null));
+
+    return result;
   }
 }

--- a/kernel-spark/src/main/java/io/delta/kernel/spark/read/SparkScan.java
+++ b/kernel-spark/src/main/java/io/delta/kernel/spark/read/SparkScan.java
@@ -126,7 +126,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
-    return new SparkMicroBatchStream();
+    return new SparkMicroBatchStream(tablePath, hadoopConf);
   }
 
   @Override

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkMicroBatchStreamTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkMicroBatchStreamTest.java
@@ -18,17 +18,37 @@ package io.delta.kernel.spark.read;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.delta.kernel.spark.SparkDsv2TestBase;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.delta.DeltaLog;
+import org.apache.spark.sql.delta.DeltaOptions;
+import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
+import org.apache.spark.sql.delta.sources.IndexedFile;
+import org.apache.spark.sql.delta.storage.ClosableIterator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import scala.Option;
+import scala.collection.immutable.Map$;
 
-public class SparkMicroBatchStreamTest {
+public class SparkMicroBatchStreamTest extends SparkDsv2TestBase {
 
   private SparkMicroBatchStream microBatchStream;
 
   @BeforeEach
   void setUp() {
-    microBatchStream = new SparkMicroBatchStream();
+    microBatchStream = new SparkMicroBatchStream(null, new Configuration());
   }
 
   @Test
@@ -85,5 +105,249 @@ public class SparkMicroBatchStreamTest {
     UnsupportedOperationException exception =
         assertThrows(UnsupportedOperationException.class, () -> microBatchStream.stop());
     assertEquals("stop is not supported", exception.getMessage());
+  }
+
+  private String formatIndexedFile(IndexedFile file) {
+    return String.format(
+        "IndexedFile(version=%d, index=%d, hasAdd=%b)",
+        file.version(), file.index(), file.add() != null);
+  }
+
+  private String formatKernelIndexedFile(KernelIndexedFile file) {
+    return String.format(
+        "KernelIndexedFile(version=%d, index=%d, hasAdd=%b)",
+        file.getVersion(), file.getIndex(), file.getAddFile() != null);
+  }
+
+  private void compareFileChanges(
+      List<IndexedFile> deltaSourceFiles, List<KernelIndexedFile> kernelFiles) {
+    assertEquals(
+        deltaSourceFiles.size(),
+        kernelFiles.size(),
+        String.format(
+            "Number of file changes should match between dsv1 (%d) and dsv2 (%d)",
+            deltaSourceFiles.size(), kernelFiles.size()));
+
+    for (int i = 0; i < deltaSourceFiles.size(); i++) {
+      IndexedFile deltaFile = deltaSourceFiles.get(i);
+      KernelIndexedFile kernelFile = kernelFiles.get(i);
+
+      assertEquals(
+          deltaFile.version(),
+          kernelFile.getVersion(),
+          String.format(
+              "Version mismatch at index %d: dsv1=%d, dsv2=%d",
+              i, deltaFile.version(), kernelFile.getVersion()));
+
+      assertEquals(
+          deltaFile.index(),
+          kernelFile.getIndex(),
+          String.format(
+              "Index mismatch at index %d: dsv1=%d, dsv2=%d",
+              i, deltaFile.index(), kernelFile.getIndex()));
+
+      String deltaPath = deltaFile.add() != null ? deltaFile.add().path() : null;
+      String kernelPath =
+          kernelFile.getAddFile() != null ? kernelFile.getAddFile().getPath() : null;
+
+      if (deltaPath != null || kernelPath != null) {
+        assertEquals(
+            deltaPath,
+            kernelPath,
+            String.format(
+                "AddFile path mismatch at index %d: dsv1=%s, dsv2=%s", i, deltaPath, kernelPath));
+      }
+    }
+  }
+
+  /**
+   * Parameterized test that verifies parity between DSv1 DeltaSource.getFileChanges and DSv2
+   * SparkMicroBatchStream.getFileChanges using Delta Kernel APIs.
+   */
+  @ParameterizedTest
+  @MethodSource("getFileChangesParameters")
+  public void testGetFileChanges(
+      long fromVersion,
+      long fromIndex,
+      boolean isInitialSnapshot,
+      Optional<Long> endVersion,
+      Optional<Long> endIndex,
+      String testDescription,
+      @TempDir File tempDir)
+      throws Exception {
+    String testTablePath = tempDir.getAbsolutePath();
+    // Use unique table name per test instance to avoid conflicts
+    String testTableName =
+        "test_file_changes_" + Math.abs(testDescription.hashCode()) + "_" + System.nanoTime();
+    createEmptyTestTable(testTablePath, testTableName);
+
+    // Create 5 versions of data (versions 1-5, version 0 is the CREATE TABLE)
+    // Insert 100 rows per commit to potentially trigger multiple batches
+    for (int i = 0; i < 5; i++) {
+      StringBuilder insertValues = new StringBuilder();
+      for (int j = 0; j < 100; j++) {
+        if (j > 0) insertValues.append(", ");
+        int id = i * 100 + j;
+        insertValues.append(String.format("(%d, 'User%d')", id, id));
+      }
+      spark.sql(String.format("INSERT INTO %s VALUES %s", testTableName, insertValues.toString()));
+    }
+    SparkMicroBatchStream stream = new SparkMicroBatchStream(testTablePath, new Configuration());
+
+    // dsv1 DeltaSource
+    DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
+    org.apache.spark.sql.delta.sources.DeltaSource deltaSource =
+        createDeltaSource(deltaLog, testTablePath);
+
+    scala.Option<DeltaSourceOffset> scalaEndOffset = scala.Option.empty();
+    if (endVersion.isPresent()) {
+      long offsetIndex = endIndex.orElse(DeltaSourceOffset.END_INDEX());
+      scalaEndOffset =
+          scala.Option.apply(
+              new DeltaSourceOffset(
+                  deltaLog.tableId(), endVersion.get(), offsetIndex, isInitialSnapshot));
+    }
+    ClosableIterator<IndexedFile> deltaChanges =
+        deltaSource.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, scalaEndOffset, true);
+    List<IndexedFile> deltaFilesList = new ArrayList<>();
+    while (deltaChanges.hasNext()) {
+      deltaFilesList.add(deltaChanges.next());
+    }
+    deltaChanges.close();
+
+    // dsv2 SparkMicroBatchStream
+    Option<DeltaSourceOffset> endOffsetOption = scalaEndOffset;
+    try (CloseableIterator<KernelIndexedFile> kernelChanges =
+        stream.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, endOffsetOption)) {
+      List<KernelIndexedFile> kernelFilesList = new ArrayList<>();
+      while (kernelChanges.hasNext()) {
+        kernelFilesList.add(kernelChanges.next());
+      }
+      compareFileChanges(deltaFilesList, kernelFilesList);
+    }
+  }
+
+  /** Provides test parameters for the parameterized getFileChanges test. */
+  private static Stream<Arguments> getFileChangesParameters() {
+    boolean isInitialSnapshot = false;
+    long BASE_INDEX = DeltaSourceOffset.BASE_INDEX();
+    return Stream.of(
+        // Arguments: fromVersion, fromIndex, isInitialSnapshot, endVersion, endIndex,
+        // testDescription
+        // Basic cases: fromIndex = BASE_INDEX, no endVersion
+        Arguments.of(
+            0L,
+            BASE_INDEX,
+            isInitialSnapshot,
+            Optional.empty(),
+            Optional.empty(),
+            "Basic: from v0"),
+        Arguments.of(
+            3L,
+            BASE_INDEX,
+            isInitialSnapshot,
+            Optional.empty(),
+            Optional.empty(),
+            "Basic: from v3"),
+
+        // With fromIndex > BASE_INDEX
+        Arguments.of(
+            0L, 0L, isInitialSnapshot, Optional.empty(), Optional.empty(), "from: v0 id:0"),
+        Arguments.of(
+            1L, 5L, isInitialSnapshot, Optional.empty(), Optional.empty(), "from: v1 id:5"),
+
+        // With endVersion
+        Arguments.of(
+            1L, BASE_INDEX, isInitialSnapshot, Optional.of(3L), Optional.empty(), "v1 to v3"),
+        Arguments.of(
+            0L, BASE_INDEX, isInitialSnapshot, Optional.of(2L), Optional.of(5L), "v0 to v2 id:5"),
+        Arguments.of(
+            1L, 5L, isInitialSnapshot, Optional.of(3L), Optional.of(10L), "v1 id:5 to v3 id:10"),
+
+        // Same version start and end (narrow range within single version)
+        Arguments.of(2L, 50L, isInitialSnapshot, Optional.of(2L), Optional.of(40L), "empty range"));
+  }
+
+  private org.apache.spark.sql.delta.sources.DeltaSource createDeltaSource(
+      DeltaLog deltaLog, String tablePath) {
+    DeltaOptions options = new DeltaOptions(Map$.MODULE$.empty(), spark.sessionState().conf());
+    scala.collection.immutable.Seq<org.apache.spark.sql.catalyst.expressions.Expression> emptySeq =
+        scala.collection.JavaConverters.asScalaBuffer(
+                new java.util.ArrayList<org.apache.spark.sql.catalyst.expressions.Expression>())
+            .toList();
+    return new org.apache.spark.sql.delta.sources.DeltaSource(
+        spark,
+        deltaLog,
+        Option.empty(),
+        options,
+        deltaLog.update(false, Option.empty(), Option.empty()),
+        tablePath + "/_checkpoint",
+        Option.empty(),
+        emptySeq);
+  }
+
+  @Test
+  public void testErrorOnRemoveFileWithDataChange(@TempDir File tempDir) throws Exception {
+    String testTablePath = tempDir.getAbsolutePath();
+    String testTableName = "test_delete_error_" + System.nanoTime();
+    createEmptyTestTable(testTablePath, testTableName);
+
+    // Create initial data (version 1)
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", testTableName));
+
+    // Add more data (version 2)
+    spark.sql(String.format("INSERT INTO %s VALUES (3, 'User3'), (4, 'User4')", testTableName));
+
+    // Delete some data (version 3) - this creates RemoveFile actions with dataChange=true
+    spark.sql(String.format("DELETE FROM %s WHERE id = 1", testTableName));
+
+    // Try to read from version 0, which should include the REMOVE commit at version 3
+    long fromVersion = 0L;
+    long fromIndex = DeltaSourceOffset.BASE_INDEX();
+    boolean isInitialSnapshot = false;
+    scala.Option<DeltaSourceOffset> endOffset = scala.Option.empty();
+
+    // Test DSv1 DeltaSource - should throw exception when encountering REMOVE 
+    DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
+    org.apache.spark.sql.delta.sources.DeltaSource deltaSource =
+        createDeltaSource(deltaLog, testTablePath);
+
+    UnsupportedOperationException dsv1Exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+              ClosableIterator<IndexedFile> deltaChanges =
+                  deltaSource.getFileChanges(
+                      fromVersion, fromIndex, isInitialSnapshot, endOffset, true);
+              // Consume the iterator to trigger validation
+              while (deltaChanges.hasNext()) {
+                IndexedFile file = deltaChanges.next();
+                System.out.println(
+                    String.format(
+                        "  DSv1 Read: version=%d, index=%d, hasAdd=%b",
+                        file.version(), file.index(), file.add() != null));
+              }
+              deltaChanges.close();
+            });
+
+    // Test DSv2 SparkMicroBatchStream - should throw the same exception
+    SparkMicroBatchStream stream = new SparkMicroBatchStream(testTablePath, new Configuration());
+
+    UnsupportedOperationException dsv2Exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+              try (CloseableIterator<KernelIndexedFile> kernelChanges =
+                  stream.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, endOffset)) {
+                // Consume the iterator to trigger validation
+                while (kernelChanges.hasNext()) {
+                  KernelIndexedFile file = kernelChanges.next();
+                  System.out.println(
+                      String.format(
+                          "  DSv2 Read: version=%d, index=%d, hasAdd=%b",
+                          file.getVersion(), file.getIndex(), file.getAddFile() != null));
+                }
+              }
+            });
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Implement SparkMicroBatchStream.getFileChanges() to support Kernel-based dsv2 Delta streaming (M1 milestone).
- Reads Delta commit range and converts actions to KernelIndexedFile objects with proper indexing and sentinel values. 
- Basic 1-pass commit validation. 

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Parameterized tests verifying parity between DSv1 (DeltaSource) and DSv2 (SparkMicroBatchStream).

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

No

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
