### PR TITLE
Fix the overflow error in delta.commit.stats

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2374,7 +2374,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     commitStatsComputer.addToCommitStats(actions.toIterator).foreach(_ => ())
     partitionsAddedToOpt = Some(commitStatsComputer.getPartitionsAddedByTransaction)
     collectAutoOptimizeStatsAndFinalize(actions, deltaLog.tableId)
-    val commitSizeBytes = jsonActions.map(_.length).sum
+    val commitSizeBytes: Long = jsonActions.map(_.length.toLong).sum
     commitStatsComputer.finalizeAndEmitCommitStats(
       spark,
       attemptVersion,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix the overflow error in delta.commit.stats.

## How was this patch tested?

Manual. Intentionally not adding a unit test because to simulate the overflow, the test would need to generate a large number of (~25K) Delta logs with each action of size (~100KB). The manual test took over a minute.

## Does this PR introduce _any_ user-facing changes?

No