### PR TITLE
Skip `_metadata` struct fields on data skipping

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -1316,8 +1316,12 @@ trait DataSkippingReaderBase
     // For data skipping, avoid using the filters that either:
     // 1. involve subqueries.
     // 2. are non-deterministic.
+    // 3. involve file metadata struct fields
     var (ineligibleFilters, eligibleFilters) = filters.partition {
-      case f => containsSubquery(f) || !f.deterministic
+      case f => containsSubquery(f) || !f.deterministic || f.exists {
+        case MetadataAttribute(_) => true
+        case _ => false
+      }
     }
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
If we have a table with an integer column `file_name` and run a query like:
```sql
select *
from file_metadata_test
where _metadata.file_name = 'part-00000-fab85aae-5302-49c9-8e4d-747da36e5ae9.c000.zstd.parquet'
```
we get an error:
```
[[CAST_INVALID_INPUT](https://docs.databricks.com/error-messages/error-classes.html#cast_invalid_input)] The value 'part-00000-fab85aae-5302-49c9-8e4d-747da36e5ae9.c000.zstd.parquet' of the type "STRING" cannot be cast to "BIGINT" because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. SQLSTATE: 22018
```
This happens because `FileSourceStrategy#rebindFileSourceMetadataAttributesInFilters` flattens `_metadata` struct, leaving just `file_name`, and then `DataSkippingReader` tries to use min-max stats of the actual `file_name` column to prune files and fails when it tries to cast the right-hand side of the equality predicate.

## What changes were proposed in this pull request?
Fix the bug by not using `dataFilters` involving `_metadata` fields for data skipping.

## How was this patch tested?
I added a new test case to `DataSkippingDeltaTests.scala`.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
