### PR TITLE
[Spark] Fix bug when renamimg column metadata with special chars

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -1687,7 +1687,13 @@ def normalizeColumnNamesInDataType(
             attributeNameParts
           }
         }
-        .map(columnParts => UnresolvedAttribute(columnParts).name)
+        .map(columnParts =>
+          if (SparkSession.active.conf.get(DeltaSQLConf.DELTA_RENAME_COLUMN_ESCAPE_NAME)) {
+            UnresolvedAttribute(columnParts).sql
+          } else {
+            UnresolvedAttribute(columnParts).name
+          }
+        )
       Map(deltaConfig -> deltaColumnsPath.mkString(","))
     }.getOrElse(Map.empty[String, String])
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1936,6 +1936,19 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_RENAME_COLUMN_ESCAPE_NAME =
+    buildConf("changeColumn.renameColumnEscapeName")
+      .internal()
+      .doc(
+        """
+          |Properly escape column names when renaming a column in the metadata.
+          |
+          |This is a safety switch - we should only set this to false if the fix introduces some
+          |regression.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED =
     buildConf("alterTable.dropColumn.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -567,4 +567,71 @@ class DeltaColumnRenameSuite extends QueryTest
       checkAnswer(spark.table("t1"), expDf3)
     }
   }
+
+  testColumnMapping("rename column with special characters and data skipping stats") { mode =>
+    withTable("t1") {
+      spark.sql(
+        s"""
+           |CREATE TABLE t1 (c int, d string)
+           |USING DELTA
+           |TBLPROPERTIES (
+           |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = '$mode',
+           |  '${DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.key}' = 'c,d'
+           |)
+           |""".stripMargin)
+      spark.sql("INSERT INTO t1 VALUES (1, 'value1'), (2, 'value2'), (3, 'value3')")
+
+      // Verify stats are collected before rename
+      val deltaLog = DeltaLog.forTable(spark, spark.sessionState.catalog.getTableMetadata(
+        spark.sessionState.sqlParser.parseTableIdentifier("t1")))
+      val statsBefore = deltaLog.update().allFiles.collect().head.stats
+      assert(statsBefore != null && statsBefore.contains("numRecords"))
+
+      // Rename column c to a name with special characters
+      spark.sql("ALTER TABLE t1 RENAME COLUMN c TO `c#2`")
+
+      // Verify the rename worked
+      checkAnswer(
+        spark.table("t1"),
+        Seq(Row(1, "value1"), Row(2, "value2"), Row(3, "value3")))
+
+      // Verify we can query using the new column name
+      checkAnswer(
+        spark.sql("SELECT `c#2` FROM t1 WHERE `c#2` > 1"),
+        Seq(Row(2), Row(3)))
+
+      // Insert data after rename to ensure stats collection still works
+      spark.sql("INSERT INTO t1 VALUES (4, 'value4'), (5, 'value5')")
+
+      checkAnswer(
+        spark.table("t1"),
+        Seq(
+          Row(1, "value1"),
+          Row(2, "value2"),
+          Row(3, "value3"),
+          Row(4, "value4"),
+          Row(5, "value5")))
+
+      // Verify stats are still being collected after rename
+      val statsAfter = deltaLog.update().allFiles.collect().last.stats
+      assert(statsAfter != null && statsAfter.contains("numRecords"))
+
+      // Verify the rename history includes the escaped column name
+      val renameHistoryDf = sql("DESCRIBE HISTORY t1")
+        .where("operation = 'RENAME COLUMN'")
+        .select("operationParameters")
+
+      val operationParams = renameHistoryDf.head().getMap[String, String](0)
+      assert(operationParams("oldColumnPath") == "c")
+      assert(operationParams("newColumnPath").contains("c#2"))
+
+      // Rename c#2 back to c before renaming column d
+      spark.sql("ALTER TABLE t1 RENAME COLUMN `c#2` TO c")
+
+      // Verify rename back worked
+      checkAnswer(
+        spark.sql("SELECT c FROM t1 WHERE c = 3"),
+        Seq(Row(3)))
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
It fixes a problem with renaming columns with `dataSkipping` enabled. 

Currently the following column rename will fail
```sql
create or replace table main.default.delta_rename_test (c int) tblproperties ("delta.columnMapping.mode" = "name", "delta.dataSkippingStatsColumns" = "c");
alter table main.default.delta_rename_test rename column c to `c#2`;
```
This PR addresses the issue.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Tests were added to [DeltaColumnRenameSuite.scala](spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala)

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


<!--
Please read [go/dbr-dev-guides](https://go/dbr-dev-guides/) before creating a pull request against files shared between Databricks Runtime and open-source Apache Spark.
For example, this includes files under the `org.apache.spark` package path.
If in doubt, please reach out to a member of the open-source team for help.
-->



