### PR TITLE
[KERNEL] Partition pruning with collations

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ExpressionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ExpressionUtils.java
@@ -19,7 +19,10 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.types.CollationIdentifier;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class ExpressionUtils {
   /** Return an expression cast as a predicate, throw an error if it is not a predicate */
@@ -50,5 +53,24 @@ public class ExpressionUtils {
     checkArgument(
         children.size() == 1, "%s: expected one inputs, but got %s", expression, children.size());
     return children.get(0);
+  }
+
+  /** Utility method to create a predicate with an optional collation identifier */
+  public static Predicate createPredicate(
+      String name, List<Expression> children, Optional<CollationIdentifier> collationIdentifier) {
+    if (collationIdentifier.isPresent()) {
+      return new Predicate(name, children, collationIdentifier.get());
+    } else {
+      return new Predicate(name, children);
+    }
+  }
+
+  /** Utility method to create a binary predicate with an optional collation identifier */
+  public static Predicate createPredicate(
+      String name,
+      Expression left,
+      Expression right,
+      Optional<CollationIdentifier> collationIdentifier) {
+    return createPredicate(name, Arrays.asList(left, right), collationIdentifier);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -18,6 +18,7 @@ package io.delta.kernel.internal.util;
 import static io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE;
 import static io.delta.kernel.expressions.AlwaysTrue.ALWAYS_TRUE;
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineException;
+import static io.delta.kernel.internal.util.ExpressionUtils.createPredicate;
 import static io.delta.kernel.internal.util.InternalUtils.toLowerCaseSet;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.SchemaUtils.casePreservingPartitionColNames;
@@ -270,11 +271,12 @@ public class PartitionUtils {
    */
   public static Predicate rewritePartitionPredicateOnCheckpointFileSchema(
       Predicate predicate, Map<String, StructField> partitionColNameToField) {
-    return new Predicate(
+    return createPredicate(
         predicate.getName(),
         predicate.getChildren().stream()
             .map(child -> rewriteColRefOnPartitionValuesParsed(child, partitionColNameToField))
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        predicate.getCollationIdentifier());
   }
 
   private static Expression rewriteColRefOnPartitionValuesParsed(
@@ -319,11 +321,12 @@ public class PartitionUtils {
    */
   public static Predicate rewritePartitionPredicateOnScanFileSchema(
       Predicate predicate, Map<String, StructField> partitionColMetadata) {
-    return new Predicate(
+    return createPredicate(
         predicate.getName(),
         predicate.getChildren().stream()
             .map(child -> rewritePartitionColumnRef(child, partitionColMetadata))
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        predicate.getCollationIdentifier());
   }
 
   private static Expression rewritePartitionColumnRef(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -31,7 +31,6 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
@@ -512,16 +511,6 @@ class DefaultExpressionUtils {
   static void checkIsLiteral(Expression expr, Expression parentExpr, String errorMessage) {
     if (!(expr instanceof Literal)) {
       throw unsupportedExpressionException(parentExpr, errorMessage);
-    }
-  }
-
-  /** Creates a {@link Predicate} with name, children and optional collation. */
-  static Predicate createPredicate(
-      String name, List<Expression> children, Optional<CollationIdentifier> collationIdentifier) {
-    if (collationIdentifier.isPresent()) {
-      return new Predicate(name, children, collationIdentifier.get());
-    } else {
-      return new Predicate(name, children);
     }
   }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -15,9 +15,9 @@
  */
 package io.delta.kernel.defaults.internal.expressions;
 
-import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.createPredicate;
 import static io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE;
 import static io.delta.kernel.expressions.AlwaysTrue.ALWAYS_TRUE;
+import static io.delta.kernel.internal.util.ExpressionUtils.createPredicate;
 import static java.util.stream.Collectors.joining;
 
 import io.delta.kernel.expressions.*;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/StartsWithExpressionEvaluator.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.defaults.internal.expressions;
 
 import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.*;
+import static io.delta.kernel.internal.util.ExpressionUtils.createPredicate;
 
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.expressions.Expression;

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -19,10 +19,10 @@ import scala.collection.JavaConverters._
 
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
-import io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.createPredicate
 import io.delta.kernel.defaults.utils.{DefaultVectorTestUtils, TestUtils}
 import io.delta.kernel.defaults.utils.DefaultKernelTestUtils.getValueAsObject
 import io.delta.kernel.expressions._
+import io.delta.kernel.internal.util.ExpressionUtils.createPredicate
 import io.delta.kernel.types._
 
 trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description
This PR extends the Delta Kernel API to support creating collated predicates for partition pruning when the provided predicate includes a collated component. In https://github.com/delta-io/delta/pull/4250, we already merged the logic so that the default engine fails when trying to evaluate a non-default collated predicate. Therefore, the remaining work for partitions is only on the API side.

## How was this patch tested?
New tests.

## Does this PR introduce _any_ user-facing changes?
No.
