### PR TITLE
[Kernel]Introduce flatmap utility method for Closable Iterator

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Utils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Utils.java
@@ -181,11 +181,15 @@ public class Utils {
    * takes an iterator of iterators (nested structure) and flattens it into a single iterator that
    * yields all elements from all inner iterators in sequence.
    *
+   * <p><b>Important:</b> Callers must call {@link CloseableIterator#close()} on the returned
+   * iterator even if it is not fully consumed, to ensure all inner iterators are properly closed
+   * and resources are released.
+   *
    * @param nestedIterator An iterator of iterators to flatten
    * @param <T> The type of elements in the inner iterators
    * @return A new {@link CloseableIterator} that flattens all nested iterators
    */
-  public static <T> CloseableIterator<T> flatMap(
+  public static <T> CloseableIterator<T> flatten(
       CloseableIterator<CloseableIterator<T>> nestedIterator) {
     return new CloseableIterator<>() {
       private CloseableIterator<T> currentInnerIterator = null;
@@ -225,7 +229,7 @@ public class Utils {
       }
 
       @Override
-      public void close() throws IOException {
+      public void close() {
         // Close both the current inner iterator and the outer iterator
         // closeCloseables works with null closeable.
         closeCloseables(currentInnerIterator, nestedIterator);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/CloseableIteratorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/CloseableIteratorSuite.scala
@@ -99,7 +99,7 @@ class CloseableIteratorSuite extends AnyFunSuite {
     assert(toList(result) === List(1, 3))
   }
 
-  test("flatMap -- flattens nested iterators") {
+  test("flatten -- flattens nested iterators") {
     // Create an iterator of iterators
     val nestedIter = toCloseableIter(
       Seq(
@@ -107,11 +107,11 @@ class CloseableIteratorSuite extends AnyFunSuite {
         toCloseableIter(Seq(3, 4, 5)),
         toCloseableIter(Seq(6))))
 
-    val result = Utils.flatMap(nestedIter)
+    val result = Utils.flatten(nestedIter)
     assert(toList(result) === List(1, 2, 3, 4, 5, 6))
   }
 
-  test("flatMap -- handles empty inner iterators") {
+  test("flatten -- handles empty inner iterators") {
     val nestedIter = toCloseableIter(
       Seq(
         toCloseableIter(Seq(1, 2)),
@@ -120,20 +120,20 @@ class CloseableIteratorSuite extends AnyFunSuite {
         toCloseableIter(Seq[Int]()),
         toCloseableIter(Seq(5))))
 
-    val result = Utils.flatMap(nestedIter)
+    val result = Utils.flatten(nestedIter)
 
     assert(toList(result) === List(1, 2, 3, 4, 5))
   }
 
-  test("flatMap -- handles empty outer iterator") {
+  test("flatten -- handles empty outer iterator") {
     val nestedIter = toCloseableIter(Seq[CloseableIterator[Int]]())
 
-    val result = Utils.flatMap(nestedIter)
+    val result = Utils.flatten(nestedIter)
 
     assert(toList(result) === List())
   }
 
-  test("flatMap -- properly closes inner iterators") {
+  test("flatten -- properly closes inner iterators") {
     var innerClosedCount = 0
     var outerClosed = false
     val nestedIter = new CloseableIterator[CloseableIterator[Int]] {
@@ -148,7 +148,7 @@ class CloseableIteratorSuite extends AnyFunSuite {
       }
     }
 
-    val result = Utils.flatMap(nestedIter)
+    val result = Utils.flatten(nestedIter)
 
     // Consume the iterator fully
     toList(result)
@@ -159,7 +159,7 @@ class CloseableIteratorSuite extends AnyFunSuite {
     assert(outerClosed === true)
   }
 
-  test("flatMap -- closes iterators even when not fully consumed") {
+  test("flatten -- closes iterators even when not fully consumed") {
     var innerClosedCount = 0
     var outerClosed = false
 
@@ -175,7 +175,7 @@ class CloseableIteratorSuite extends AnyFunSuite {
       }
     }
 
-    val result = Utils.flatMap(nestedIter)
+    val result = Utils.flatten(nestedIter)
 
     // Only consume first 3 elements (from first 2 inner iterators)
     assert(result.hasNext === true)
@@ -190,7 +190,7 @@ class CloseableIteratorSuite extends AnyFunSuite {
     assert(outerClosed === true)
   }
 
-  test("flatMap -- handles exception during iteration and cleans up") {
+  test("flatten -- handles exception during iteration and cleans up") {
     var innerClosedCount = 0
     var outerClosed = false
 
@@ -209,7 +209,7 @@ class CloseableIteratorSuite extends AnyFunSuite {
       }
     }
 
-    val result = Utils.flatMap(nestedIter)
+    val result = Utils.flatten(nestedIter)
 
     // Consume first inner iterator completely
     assert(result.hasNext === true)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Adds a `Utils.flatMap` utility method for flattening nested `CloseableIterator<CloseableIterator<T>>` structures into `CloseableIterator<T>`.

It will be helpful for use case like https://github.com/delta-io/delta/pull/5290

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No