### PR TITLE
[Spark] Revert "Make all MERGE APIs return a DataFrame instead of Unit" for Delta 3.x

### DIFF
--- a/project/SparkMimaExcludes.scala
+++ b/project/SparkMimaExcludes.scala
@@ -84,12 +84,7 @@ object SparkMimaExcludes {
 
       // Changes in 1.2.0
       ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.LogStore"),
-      ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.CloseableIterator"),
-
-      // Changes in 4.0.0
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaTable.improveUnsupportedOpError"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaMergeBuilder.improveUnsupportedOpError"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.tables.DeltaMergeBuilder.execute")
+      ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.CloseableIterator")
 
       // scalastyle:on line.size.limit
   )

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -1236,15 +1236,13 @@ class DeltaMergeBuilder(object):
         return DeltaMergeBuilder(self._spark, new_jbuilder)
 
     @since(0.4)  # type: ignore[arg-type]
-    def execute(self) -> DataFrame:
+    def execute(self) -> None:
         """
         Execute the merge operation based on the built matched and not matched actions.
 
         See :py:class:`~delta.tables.DeltaMergeBuilder` for complete usage details.
         """
-        return DataFrame(
-            self._jbuilder.execute(),
-            getattr(self._spark, "_wrapped", self._spark))  # type: ignore[attr-defined]
+        self._jbuilder.execute()
 
     def __getMatchedBuilder(
         self, condition: OptionalExpressionOrColumn = None

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -152,27 +152,17 @@ class DeltaTableTestsMixin:
 
         # String expressions in merge condition and dicts
         reset_table()
-        merge_output = dt.merge(source, "key = k") \
+        dt.merge(source, "key = k") \
             .whenMatchedUpdate(set={"value": "v + 0"}) \
             .whenNotMatchedInsert(values={"key": "k", "value": "v + 0"}) \
             .whenNotMatchedBySourceUpdate(set={"value": "value + 0"}) \
             .execute()
-        self.__checkAnswer(merge_output,
-                           ([Row(6,  # type: ignore[call-overload]
-                                 4,  # updated rows (a and b in WHEN MATCHED
-                                     # and c and d in WHEN NOT MATCHED BY SOURCE)
-                                 0,  # deleted rows
-                                 2)]),  # inserted rows (e and f)
-                           StructType([StructField('num_affected_rows', LongType(), False),
-                                        StructField('num_updated_rows', LongType(), False),
-                                        StructField('num_deleted_rows', LongType(), False),
-                                        StructField('num_inserted_rows', LongType(), False)]))
         self.__checkAnswer(dt.toDF(),
                            ([('a', -1), ('b', 0), ('c', 3), ('d', 4), ('e', -5), ('f', -6)]))
 
         # Column expressions in merge condition and dicts
         reset_table()
-        merge_output = dt.merge(source, expr("key = k")) \
+        dt.merge(source, expr("key = k")) \
             .whenMatchedUpdate(set={"value": col("v") + 0}) \
             .whenNotMatchedInsert(values={"key": "k", "value": col("v") + 0}) \
             .whenNotMatchedBySourceUpdate(set={"value": col("value") + 0}) \

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -291,7 +291,7 @@ class DeltaMergeBuilder private(
    *
    * @since 0.3.0
    */
-  def execute(): DataFrame = improveUnsupportedOpError {
+  def execute(): Unit = improveUnsupportedOpError {
     val sparkSession = targetTable.toDF.sparkSession
     withActiveSession(sparkSession) {
       // Note: We are explicitly resolving DeltaMergeInto plan rather than going to through the

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
@@ -92,7 +92,7 @@ trait AnalysisHelper {
     DataFrameUtils.ofRows(sparkSession, logicalPlan)
   }
 
-  protected def improveUnsupportedOpError[T](f: => T): T = {
+  protected def improveUnsupportedOpError(f: => Unit): Unit = {
     val possibleErrorMsgs = Seq(
       "is only supported with v2 table", // full error: DELETE is only supported with v2 tables
       "is not supported temporarily",    // full error: UPDATE TABLE is not supported temporarily


### PR DESCRIPTION
This reverts commit 4cf685bda9f57583159f6e18206bbaab7898ab4d.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Revert the breaking API changes from #4460 on this branch, since they aren't supposed to occur on pre-4.0 Delta version.

## How was this patch tested?

n/a

## Does this PR introduce _any_ user-facing changes?

No.
