### PR TITLE
[Spark] Remove partial rewrites of conjunctions for partition-like data skipping

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -732,8 +732,8 @@ trait DataSkippingReaderBase
      */
     private def shouldRewriteAsPartitionLike(expr: Expression): Boolean = expr match {
       // Expressions supported by traditional data skipping.
-      // Boolean operators. AND is explicitly handled by the caller.
-      case _: Not | _: Or => true
+      // Boolean operators.
+      case _: Not | _: Or | _: And => true
       // Comparison operators.
       case _: EqualNullSafe | _: EqualTo | _: GreaterThan | _: GreaterThanOrEqual | _: IsNull |
            _: IsNotNull | _: LessThan | _: LessThanOrEqual => true
@@ -871,20 +871,6 @@ trait DataSkippingReaderBase
             case (rewrittenChildren, referencedStats) =>
               Some(InSet(rewrittenChildren, possiblyNullValues.toSet), referencedStats)
           }
-        }
-      // Pushdown NOT through OR - we prefer AND to OR because AND can tolerate one branch not being
-      // rewriteable.
-      case Not(Or(e1, e2)) =>
-        rewriteDataFiltersAsPartitionLikeInternal(And(Not(e1), Not(e2)), clusteringColumnPaths)
-      // For AND expressions, we can tolerate one side not being eligible for partition-like
-      // data skipping - simply remove the ineligible side.
-      case And(left, right) =>
-        val leftResult = rewriteDataFiltersAsPartitionLikeInternal(left, clusteringColumnPaths)
-        val rightResult = rewriteDataFiltersAsPartitionLikeInternal(right, clusteringColumnPaths)
-        (leftResult, rightResult) match {
-          case (Some((newLeft, statsLeft)), Some((newRight, statsRight))) =>
-            Some((And(newLeft, newRight), statsLeft ++ statsRight))
-          case _ => leftResult.orElse(rightResult)
         }
       // For all other eligible expressions, recursively rewrite the children.
       case other if shouldRewriteAsPartitionLike(other) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/PartitionLikeDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/PartitionLikeDataSkippingSuite.scala
@@ -201,13 +201,20 @@ trait PartitionLikeDataSkippingSuiteBase
     (
       "AND (one valid)",
       "(ISEVEN(s.a) AND ENDSWITH(s.b, '7.007')) OR ENDSWITH(s.b, '008')",
-      2,
-      1,
-      true
+      11,
+      0,
+      false
     ),
     (
       "OR (one valid)",
       "DATE_FROM_UNIX_DATE(e) = '1977-01-05' OR ENDSWITH(s.b, '7.007')",
+      11,
+      0,
+      false
+    ),
+    (
+      "Inverted partially valid AND",
+      "STRING((ENDSWITH(s.b, '7.007') OR ENDSWITH(s.b, '001')) AND e > 5) = 'false'",
       11,
       0,
       false
@@ -253,12 +260,12 @@ trait PartitionLikeDataSkippingSuiteBase
     ("d < '1975-01-01' AND DATE(s.b) > '1974-01-01'", 1 + 5 + 1, 1, true),
     // Some partition-like filters are eligible.
     ("ISEVEN(s.a) AND ENDSWITH(s.b, '007') AND s.a < 5", 1 + 5 + 1, 1, false),
-    ("(ISEVEN(s.a) AND s.a > 5) OR ENDSWITH(s.b, '008')", 5 + 10 + 1, 1, true),
+    ("(ISEVEN(s.a) AND s.a > 5) OR ENDSWITH(s.b, '008')", 11 + 10 + 1, 0, false),
     (
       "((ISEVEN(s.a) AND ENDSWITH(s.b, '007')) OR ENDSWITH(s.b, '008')) AND s.a < 5",
-      2 + 5 + 1,
-      1,
-      true
+      5 + 5 + 1,
+      0,
+      false
     ),
     // No partition-like filters are eligible.
     ("ISEVEN(s.a) AND s.a < 5", 5 + 5 + 1, 0, false),


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Currently, partition-like data skipping supports partial rewrites of conjunctions when rewriting a data filter as a partition-like data skipping predicate. For example, we currently might rewrite: `(UPPER(str_clustering_col) = 'ABC' AND UPPER(non_clustering_col) = 'DEF') OR clustering_col > 5`  to `(UPPER(minValues.str_clustering_col) = 'ABC' OR minValues.clustering_col > 5) AND (... stats validation ...)`. 

The assumption that both sides of a conjunction may be safely rewritten held for traditional data skipping, where we explicitly handled recursion, ensuring that all of the expressions above the current filter are conjunctive (making it safe to return false positives, but not false negatives). However, this assumption no longer holds for partition-like skipping: the parent expressions of an AND expression might not necessarily be conjunctive, making false positives by partial rewrites no longer acceptable.

For example, consider: `NOT(UPPER(str_clustering_col) = 'ABC' AND UPPER(non_clulstering_col) = 'DEF'))`. This expression currently would be rewritten to `NOT(UPPER(minValues.str_clustering_col) = 'ABC')) AND (...stats validation...)`, which is invalid - because of the `NOT`, we can no longer tolerate false positives from the `AND` expression.

As a result, this PR removes:
1. The partition-like skipping logic allowing partial rewrites of each branch of an `AND` expression, as this logic is unsafe (as noted above).
2. The partition-like skipping logic that pushes down `NOT` through `OR` to get an `AND` expression: this logic is no longer needed (we don't actually have any preference for `AND` over `OR` anymore).

This change will reduce the coverage of partition-like data skipping, but must be made to ensure correctness. In theory, it's possible to increase partition-like coverage by tracking the parent expressions of the current expression during the partition-like rewrite, applying partial rewrites for `AND` expressions for a known-good set of parent expressions, but this would be a significant change that likely would not yield a significant increase in partition-like skipping coverage.

## How was this patch tested?
See test changes.

## Does this PR introduce _any_ user-facing changes?
No.