### PR TITLE
[KERNEL] Remove `isCollatedSkipping` param

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -265,7 +265,7 @@ public class DataSkippingUtils {
         if (left instanceof Column && right instanceof Literal) {
           Column leftCol = (Column) left;
           Literal rightLit = (Literal) right;
-          if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol, collationIdentifier.isPresent())
+          if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol)
               && schemaHelper.isSkippingEligibleLiteral(rightLit)) {
             return constructComparatorDataSkippingFilters(
                 dataFilters.getName(), leftCol, rightLit, collationIdentifier, schemaHelper);
@@ -604,7 +604,7 @@ public class DataSkippingUtils {
     if (leftChild instanceof Column && rightChild instanceof Literal) {
       Column leftCol = (Column) leftChild;
       Literal rightLit = (Literal) rightChild;
-      if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol, collationIdentifier.isPresent())
+      if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol)
           && schemaHelper.isSkippingEligibleLiteral(rightLit)) {
         return buildDataSkippingPredicateFunc.apply(leftCol, rightLit);
       }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -281,7 +281,7 @@ public class SchemaUtils {
 
     List<String> nonSkippingEligibleColumns =
         physicalColumnsWithTypes.stream()
-            .filter(tuple -> !StatsSchemaHelper.isSkippingEligibleDataType(tuple._2, false))
+            .filter(tuple -> !StatsSchemaHelper.isSkippingEligibleDataType(tuple._2))
             .map(tuple -> tuple._1.toString() + " : " + tuple._2)
             .collect(Collectors.toList());
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/DataSkippingUtilsSuite.scala
@@ -495,12 +495,17 @@ class DataSkippingUtilsSuite extends AnyFunSuite with TestUtils {
             dataSkippingPredicateWithCollation("<", Seq(minA, literal("m")), utf8Lcase, Set(minA)),
             dataSkippingPredicate("<", Seq(minB, literal(1)), Set(minB))))
         }),
-      // Ineligible: non-string column with collation
       (
         new StructType()
           .add("a", IntegerType.INTEGER),
-        createPredicate("<", col("a"), literal("m"), Optional.of(utf8Lcase)),
-        None))
+        createPredicate("<", col("a"), literal(1), Optional.of(utf8Lcase)), {
+          val minA = collatedStatsCol(utf8Lcase, MIN, "a")
+          Some(dataSkippingPredicateWithCollation(
+            "<",
+            Seq(minA, literal(1)),
+            utf8Lcase,
+            Set(minA)))
+        }))
 
     testCases.foreach { case (schema, predicate, expectedDataSkippingPredicateOpt) =>
       val dataSkippingPredicateOpt =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
In this PR, the `isCollatedSkipping` parameter is removed from methods like `isSkippingEligibleDataType`. The idea behind this change is that the parameter only adds noise, since collated skipping is just one specific case of skipping.

## How was this patch tested?
Existing tests.

## Does this PR introduce _any_ user-facing changes?
No.
