### PR TITLE
Fix the CCv2 integration tests.

### DIFF
--- a/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
+++ b/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
@@ -221,9 +221,8 @@ class UnityCatalogManagedTableTestSuite(unittest.TestCase):
             f"DESCRIBE formatted {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME}").collect()[5].data_type
         try:
             single_col_df.write.format("delta").save(mode="append", path=tbl_path)
-        except Exception as error:
-            assert("Forbidden (Service: Amazon S3; Status Code: 403; "
-                   "Error Code: 403 Forbidden;" in str(error))
+        except py4j.protocol.Py4JJavaError as error:
+            assert("Unable to load credentials" in str(error))
         updated_tbl = self.read(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME).toDF("id")
         assertDataFrameEqual(updated_tbl, self.setup_df)
 

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -381,7 +381,7 @@ def run_unity_catalog_commit_coordinator_integration_tests(root_dir, version, te
 
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
-    packages = "io.delta:delta-%s_2.12:%s" % (get_artifact_name(version), version)
+    packages = "io.delta:delta-%s_2.13:%s" % (get_artifact_name(version), version)
     if extra_packages:
         packages += "," + extra_packages
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix this issue: https://github.com/delta-io/delta/issues/5384

## How was this patch tested?

Yes,  we use this command to successfully test:

```bash
export PATH=$HOME/soft/spark-4.0.1/spark-4.0.1-bin-hadoop3/bin:$PATH

export CATALOG_TOKEN=$UC_TOKEN
export CATALOG_URI=$UC_URI
export CATALOG_NAME=main
export SCHEMA=demo_zh
export MANAGED_CC_TABLE=managedCcTable
export MANAGED_NON_CC_TABLE=managedNonCcTable

python3 ./run-integration-tests.py \
    --unity-catalog-commit-coordinator-integration-tests \
    --packages \
    io.unitycatalog:unitycatalog-spark_2.13:0.3.0,org.apache.spark:spark-hadoop-cloud_2.13:4.0.1

```

## Does this PR introduce _any_ user-facing changes?

No
