### PR TITLE
[Kernel] Fix NPE in FieldMetadata with null values

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
@@ -119,12 +119,17 @@ public final class FieldMetadata {
   public String toString() {
     return metadata.entrySet().stream()
         .map(
-            entry ->
-                entry.getKey()
-                    + "="
-                    + (entry.getValue().getClass().isArray()
-                        ? Arrays.toString((Object[]) entry.getValue())
-                        : entry.getValue().toString()))
+            entry -> {
+              String key = entry.getKey();
+              Object value = entry.getValue();
+              if (value == null) {
+                return key + "=null";
+              }
+              String valueStr =
+                  value.getClass().isArray() ? Arrays.toString((Object[]) value) : value.toString();
+
+              return key + "=" + valueStr;
+            })
         .collect(Collectors.joining(", ", "{", "}"));
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 
 import io.delta.kernel.expressions.{Column, Literal, Predicate}
 import io.delta.kernel.metrics.{ScanReport, SnapshotReport, TransactionReport}
-import io.delta.kernel.types.{IntegerType, StructType}
+import io.delta.kernel.types.{FieldMetadata, IntegerType, StringType, StructType}
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -261,10 +261,18 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
   }
 
   test("ScanReport serializer") {
-    val snapshotReportUUID = UUID.randomUUID()
+    val snapshotReportUUID = java.util.UUID.randomUUID()
+
+    // tableSchema now includes FieldMetadata with a null value.
+    val fmNull = FieldMetadata.builder().putString("kNull", null).build()
+    val fmArray =
+      FieldMetadata.builder()
+        .putStringArray("arr", Array[String]("x", null, "z"))
+        .build()
     val tableSchema = new StructType()
-      .add("part", IntegerType.INTEGER)
-      .add("id", IntegerType.INTEGER)
+      .add("part", IntegerType.INTEGER, fmNull)
+      .add("id", IntegerType.INTEGER, fmArray)
+
     val partitionPredicate = new Predicate(">", new Column("part"), Literal.ofInt(1))
     val exception = new RuntimeException("something something failed")
 
@@ -289,11 +297,14 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       scanMetrics,
       Optional.of(exception))
 
-    // Manually check expected JSON
-    val tableSchemaStr = "struct(StructField(name=part,type=integer,nullable=true,metadata={}," +
-      "typeChanges=[]), StructField(name=id,type=integer,nullable=true,metadata={},typeChanges=[]))"
-    val readSchemaStr = "struct(StructField(name=id,type=integer,nullable=true,metadata={}," +
-      "typeChanges=[]))"
+    // Manually check expected JSON including field metadata
+    val tableSchemaStr =
+      "struct(StructField(name=part,type=integer,nullable=true,metadata={kNull=null}," +
+        "typeChanges=[]), " +
+        "StructField(name=id,type=integer,nullable=true,metadata={arr=[x, null, z]}," +
+        "typeChanges=[]))"
+    val readSchemaStr =
+      "struct(StructField(name=id,type=integer,nullable=true,metadata={},typeChanges=[]))"
 
     val expectedJson =
       s"""

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
@@ -139,4 +139,27 @@ class FieldMetadataSuite extends AnyFunSuite {
 
     assertThat(builder.getMetadata("fieldMetadataKey")).isEqualTo(innerMeta)
   }
+
+  test("toString handles empty metadata") {
+    val fieldMetadata = FieldMetadata.builder().build()
+    val result = fieldMetadata.toString
+
+    assertThat(result).isEqualTo("{}")
+  }
+
+  test("toString handles null values and arrays with null elements") {
+    val fieldMetadata = FieldMetadata.builder()
+      .putString("nullValueKey", null)
+      .putStringArray("arrayWithNulls", Array("a", null, "b"))
+      .putString("validValue", "test")
+      .putStringArray("validArray", Array("x", "y", "z"))
+      .build()
+
+    val result = fieldMetadata.toString
+
+    assertThat(result).contains("nullValueKey=null")
+    assertThat(result).contains("[a, null, b]")
+    assertThat(result).contains("validValue=test")
+    assertThat(result).contains("[x, y, z]")
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Fix an issue where `FieldMetadata.toString()` throws a `NullPointerException` when metadata contains null values. 


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added unit and integration tests
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No