### PR TITLE
Fix the integration test failure in unity-catalog-commit-coordinator-integration-tests

### DIFF
--- a/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
+++ b/python/delta/integration_tests/unity-catalog-commit-coordinator-integration-tests.py
@@ -480,7 +480,8 @@ class UnityCatalogManagedTableUtilitySuite(UnityCatalogManagedTableTestBase):
         try:
             current_version = self.current_version(MANAGED_CATALOG_OWNED_TABLE_FULL_NAME)
             # Restore is currently unsupported on catalog owned tables.
-            spark.sql(f"RESTORE TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} TO VERSION AS OF {current_version-1}")
+            spark.sql(f"RESTORE TABLE {MANAGED_CATALOG_OWNED_TABLE_FULL_NAME} TO "
+                      f"VERSION AS OF {current_version-1}")
         except py4j.protocol.Py4JJavaError as error:
             assert("UPDATE_DELTA_METADATA" in str(error))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix the broken integration tests in `unity-catalog-commit-coordinator-integration-tests.py`,  there is an opened issue for it: https://github.com/delta-io/delta/issues/5440

## How was this patch tested?

Please see: https://github.com/delta-io/delta/issues/5440
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
