### PR TITLE
[Kernel] Fix shaded JsonProcessingException handling in LoggingMetricsReporter and kernel-defaults dependency on shaded kernel-api JAR

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/LoggingMetricsReporter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/LoggingMetricsReporter.java
@@ -15,9 +15,9 @@
  */
 package io.delta.kernel.defaults.engine;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.delta.kernel.engine.MetricsReporter;
 import io.delta.kernel.metrics.MetricsReport;
+import io.delta.kernel.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,9 @@ public class LoggingMetricsReporter implements MetricsReporter {
     try {
       logger.info("{} = {}", report.getClass().getSimpleName(), report.toJson());
     } catch (JsonProcessingException e) {
-      logger.info("Encountered exception while serializing report {}: {}", report, e);
+      logger.warn("Serialization issue while logging metrics report {}: {}", report, e.toString());
+    } catch (Exception e) {
+      logger.warn("Unexpected error while logging metrics report {}:", report, e);
     }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -37,6 +37,7 @@ import io.delta.kernel.internal.checkpoints.CheckpointerSuite.selectSingleElemen
 import io.delta.kernel.internal.table.SnapshotBuilderImpl
 import io.delta.kernel.internal.util.{Clock, JsonUtils}
 import io.delta.kernel.internal.util.SchemaUtils.casePreservingPartitionColNames
+import io.delta.kernel.shaded.com.fasterxml.jackson.databind.node.ObjectNode
 import io.delta.kernel.transaction.DataLayoutSpec
 import io.delta.kernel.types._
 import io.delta.kernel.types.ByteType.BYTE
@@ -1143,7 +1144,7 @@ abstract class AbstractDeltaTableWritesSuite extends AnyFunSuite with AbstractWr
       // we need to compare stats after removing the tightBounds field from Kernel stats
       val kernelStatsWithoutTightBounds = kernelStats.map { node =>
         val objectNode =
-          node.deepCopy().asInstanceOf[com.fasterxml.jackson.databind.node.ObjectNode]
+          node.deepCopy().asInstanceOf[ObjectNode]
         objectNode.remove("tightBounds")
         objectNode
       }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/LoggingMetricsReporterSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/LoggingMetricsReporterSuite.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.metrics
+
+import scala.collection.mutable.ArrayBuffer
+
+import io.delta.kernel.defaults.engine.LoggingMetricsReporter
+import io.delta.kernel.metrics.MetricsReport
+import io.delta.kernel.shaded.com.fasterxml.jackson.databind.exc.MismatchedInputException
+import io.delta.kernel.types.{FieldMetadata, StringType, StructType}
+
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.{LogEvent, Logger => Log4jLogger}
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.config.Property
+import org.scalatest.funsuite.AnyFunSuite
+
+class LoggingMetricsReporterSuite extends AnyFunSuite {
+
+  /** Captures logging events * */
+  private class BufferingAppender(name: String)
+      extends AbstractAppender(name, null, null, true, Property.EMPTY_ARRAY) {
+    val events: ArrayBuffer[LogEvent] = ArrayBuffer.empty[LogEvent]
+    override def append(event: LogEvent): Unit = events += event.toImmutable
+  }
+
+  private def withCapturedReporterLogger[T](f: BufferingAppender => T): T = {
+    val log = LogManager.getLogger("io.delta.kernel.defaults.engine.LoggingMetricsReporter")
+      .asInstanceOf[Log4jLogger]
+    val app = new BufferingAppender("test-appender")
+    app.start()
+    val oldLevel = log.getLevel
+    try {
+      log.addAppender(app)
+      log.setLevel(Level.ALL)
+      f(app)
+    } finally {
+      log.removeAppender(app)
+      log.setLevel(oldLevel)
+      app.stop()
+    }
+  }
+
+  test("LoggingMetricsReporter successfully logs a metrics report") {
+    val fmNull = FieldMetadata.builder().putString("kNull", null).build()
+    val fmArray =
+      FieldMetadata.builder().putStringArray("arr", Array[String]("x", null, "z")).build()
+    val schema = new StructType()
+      .add("c1", StringType.STRING, fmNull)
+      .add("c2", StringType.STRING, fmArray)
+    val schemaStr = schema.toString
+
+    val report = new MetricsReport {
+      override def toJson: String = {
+        val s = schemaStr.replace("\\", "\\\\").replace("\"", "\\\"")
+        s"""{"tableSchema":"$s"}"""
+      }
+    }
+
+    withCapturedReporterLogger { app =>
+      new LoggingMetricsReporter().report(report)
+      val msgs = app.events.map(e => (e.getLevel, e.getMessage.getFormattedMessage))
+      assert(
+        msgs.exists { case (lvl, msg) =>
+          lvl == Level.INFO && msg.contains("tableSchema")
+        },
+        s"Expected INFO log with 'tableSchema' but got: ${msgs.mkString("; ")}")
+      assert(
+        msgs.exists { case (lvl, msg) =>
+          lvl == Level.INFO && msg.contains("kNull=null") && msg.contains("arr=[x, null, z]")
+        },
+        s"Expected schema with null values and arrays to be serialized correctly")
+    }
+  }
+
+  test("LoggingMetricsReporter catches and logs kernel-api shaded JsonProcessingException") {
+    val shadedThrow = new MetricsReport {
+      override def toJson: String = {
+        val ex = MismatchedInputException.from(
+          null.asInstanceOf[io.delta.kernel.shaded.com.fasterxml.jackson.core.JsonParser],
+          classOf[Object],
+          "test exception")
+        throw ex
+      }
+    }
+
+    withCapturedReporterLogger { app =>
+      val reporter = new LoggingMetricsReporter()
+      reporter.report(shadedThrow)
+      val msgs = app.events.map(e => (e.getLevel, e.getMessage.getFormattedMessage))
+      assert(
+        msgs.exists { case (lvl, msg) =>
+          lvl == Level.WARN && msg.contains("Serialization issue")
+        },
+        s"Expected WARN with 'Serialization issue' but got: ${msgs.mkString("; ")}")
+    }
+  }
+
+  test("LoggingMetricsReporter logs generic Exception at WARN level") {
+    val genericThrow = new MetricsReport {
+      override def toJson: String = throw new RuntimeException("generic boom")
+    }
+
+    withCapturedReporterLogger { app =>
+      val reporter = new LoggingMetricsReporter()
+      reporter.report(genericThrow)
+      val msgs = app.events.map(e => (e.getLevel, e.getMessage.getFormattedMessage))
+      assert(
+        msgs.exists { case (lvl, msg) =>
+          lvl == Level.WARN && msg.contains("Unexpected error")
+        },
+        s"Expected WARN with 'Unexpected error' but got: ${msgs.mkString("; ")}")
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
**Issue**: `kernel-defaults` couldn't catch shaded `JsonProcessingException` from `kernel-api` because it depended on unshaded class directories instead of the assembled JAR. Because of this, JsonProcessingExceptions when logging serialized metrics was being re-thrown to consumers. 
 
**Changes**:
- Fixed `kernel-defaults` to depend on shaded `kernel-api` JAR instead of class directories
- Added exception handling in `LoggingMetricsReporter` to catch shaded `JsonProcessingException`
- Published `kernel-api` test JAR for test utility sharing

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No