### PR TITLE
[Spark] Add sqlState for VersionNotFoundException

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3124,6 +3124,12 @@
     ],
     "sqlState" : "42815"
   },
+  "DELTA_VERSION_NOT_FOUND" : {
+    "message" : [
+      "Cannot time travel Delta table to version <userVersion>. Available versions: [<earliest>, <latest>]."
+    ],
+    "sqlState" : "22003"
+  },
   "DELTA_VIOLATE_CONSTRAINT_WITH_VALUES" : {
     "message" : [
       "CHECK constraint <constraintName> <expression> violated by row with values:",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3861,10 +3861,10 @@ class ConcurrentWriteException(message: String)
 case class VersionNotFoundException(
     userVersion: Long,
     earliest: Long,
-    latest: Long) extends AnalysisException(
-      s"Cannot time travel Delta table to version $userVersion. " +
-      s"Available versions: [$earliest, $latest]."
-    )
+    latest: Long) extends DeltaAnalysisException(
+  errorClass = "DELTA_VERSION_NOT_FOUND",
+  messageParameters = Array(userVersion.toString, earliest.toString, latest.toString)
+)
 
 /**
  * This class is kept for backward compatibility.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1547,6 +1547,18 @@ trait DeltaErrorsSuiteBase
       checkError(e, "DELTA_VERSION_INVALID", "42815", Map("version" -> version))
     }
     {
+      val version = 2
+      val earliest = 0
+      val latest = 1
+      val e = intercept[DeltaAnalysisException] {
+        throw VersionNotFoundException(version, earliest, latest)
+      }
+      checkError(e, "DELTA_VERSION_NOT_FOUND", "22003", Map(
+        "userVersion" -> version.toString,
+        "earliest" -> earliest.toString,
+        "latest" -> latest.toString))
+    }
+    {
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.notADeltaSourceException("sample")
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -629,9 +629,14 @@ class DeltaRetentionSuite extends QueryTest
               val ex = intercept[org.apache.spark.sql.delta.VersionNotFoundException] {
                 spark.sql(sqlCommand).collect()
               }
-              assert(ex.userVersion === version)
-              assert(ex.earliest === earliestExpectedChkVersion)
-              assert(ex.latest === 25)
+              checkError(
+                ex,
+                "DELTA_VERSION_NOT_FOUND",
+                sqlState = "22003",
+                parameters = Map(
+                  "userVersion" -> version.toString,
+                  "earliest" -> earliestExpectedChkVersion.toString,
+                  "latest" -> "25"))
             } else {
               spark.sql(sqlCommand).collect()
             }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -827,8 +827,11 @@ class DeltaTimeTravelSuite extends QueryTest
         val ex = intercept[VersionNotFoundException] {
           spark.sql(s"SELECT * from $tableName FOR VERSION AS OF 2")
         }
-        assert(ex.getMessage contains
-          "Cannot time travel Delta table to version 2. Available versions: [0, 1]")
+        checkError(
+          ex,
+          "DELTA_VERSION_NOT_FOUND",
+          sqlState = "22003",
+          parameters = Map("userVersion" -> "2", "earliest" -> "0", "latest" -> "1"))
 
         val timeAtVersion0 = new Timestamp(start).toString
         val timeAtVersion1 = new Timestamp(start + 20.minutes).toString


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Add sqlState and error class for `VersionNotFoundException`.

## How was this patch tested?
Existing UT.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
User-facing error w/ sqlState.
