### PR TITLE
[Kernel] Make workload benchmarks print in intermediate iterations

### DIFF
--- a/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmark.java
+++ b/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmark.java
@@ -98,6 +98,7 @@ public class WorkloadBenchmark<T> {
     Options opt =
         new OptionsBuilder()
             .include(WorkloadBenchmark.class.getSimpleName())
+            .shouldFailOnError(true)
             .param("workloadSpecJson", workloadSpecsArray)
             // TODO: In the future, this can be extended to support multiple engines.
             .param("engineName", "default")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
* This change makes the workload benchmarks emit logging for iterations. This way, a user can see the benchmarks that are being executed and their status.
* Additionally, this sets a flag in JMH to fail on any errors that occur during the benchmark. This way, a developer can find out and address any errors that occur. Previously, failures would go unnoticed.
* Finally, this fixes the aggregation of metrics in the output format. Previously, only one run result was being collected. Now, we aggregate data across all runs for given benchmark.

## How was this patch tested?
Tested manually. An example of the output is provided:
```
 Parameters: (engineName = default, workloadSpecJson = {
[info]   "type" : "read",
[info]   "table_info" : {
[info]     "name" : "basic_append",
[info]     "description" : "A basic table with two append writes.",
[info]     "engine_info" : "Apache-Spark/3.5.1 Delta-Lake/3.1.0",
[info]     "table_info_path" : "/Users/oussama.saoudi/projects/code/delta/kernel/kernel-benchmarks/src/test/resources/workload_specs/basic_append"
[info]   },
[info]   "case_name" : "read_v0",
[info]   "version" : 0,
[info]   "operation_type" : "read_metadata",
[info]   "full_name" : "basic_append/read_v0/read/read_metadata"
[info] })
[info] # Run progress: 0.00% complete, ETA 00:01:20
[info] # Warmup Fork: 1 of 1
[info] # Warmup Iteration   1: 0.425 ±(99.9%) 0.072 ms/op
[info] # Warmup Iteration   2: 0.536 ±(99.9%) 0.068 ms/op
[info] # Warmup Iteration   3: 0.344 ±(99.9%) 0.053 ms/op
[info] Iteration   1: 0.224 ±(99.9%) 0.021 ms/op
[info]                  p0.00:                                                    0.136 ms/op
[info]                  p0.50:                                                    0.198 ms/op
[info]                  p0.90:                                                    0.268 ms/op
[info]                  p0.95:                                                    0.307 ms/op
[info]                  p0.99:                                                    0.814 ms/op
[info]                  p0.999:                                                   4.583 ms/op
[info]                  p0.9999:                                                  4.653 ms/op
[info]                  p1.00:                                                    4.653 ms/op
[info]                  scan.scan_metrics.num_active_add_files:                   1.000 ±(99.9%) 0.001 count
[info]                  scan.scan_metrics.num_add_files_seen:                     1.000 ±(99.9%) 0.001 count
[info]                  scan.scan_metrics.num_add_files_seen_from_delta_files:    1.000 ±(99.9%) 0.001 count
[info]                  scan.scan_metrics.num_duplicate_add_files:                ≈ 0 count
[info]                  scan.scan_metrics.num_remove_files_seen_from_delta_files: ≈ 0 count
[info]                  scan.scan_metrics.total_planning_duration_ns:             220948.848 ±(99.9%) 20525.112 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p0.00:       134400.000 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p0.50:       195200.000 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p0.90:       263475.200 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p0.95:       300851.200 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p0.99:       804280.320 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p0.999:      4574822.400 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p0.9999:     4644864.000 ns/op
[info]                  scan.scan_metrics.total_planning_duration_ns:p1.00:       4644864.000 ns/op

```

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
