### PR TITLE
Add an streaming write tests in the unitycatalog-commit-coordinator-integration-test

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.4.0-SNAPSHOT"
+ThisBuild / version := "4.0.2-SNAPSHOT"


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Please refer to this issue: https://github.com/delta-io/delta/issues/5459

## How was this patch tested?

Use the following command to test:

```bash
export PATH=$HOME/soft/spark-4.0.2-SNAPSHOT-bin-test/bin:$PATH

export CATALOG_TOKEN=$UC_TOKEN
export CATALOG_URI=$UC_URI
export CATALOG_NAME=main
export SCHEMA=demo_zh
export MANAGED_CC_TABLE=managedCcTable
export MANAGED_NON_CC_TABLE=managedNonCcTable

python3 ./run-integration-tests.py \
    --unity-catalog-commit-coordinator-integration-tests \
    --packages \
    io.unitycatalog:unitycatalog-spark_2.13:0.3.0-SNAPSHOT,org.apache.spark:spark-hadoop-cloud_2.13:4.0.2-SNAPSHOT
```

## Does this PR introduce _any_ user-facing changes?

No
