### PR TITLE
[Spark] Simplify exception catching in ConflictResolutionTestUtils

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictResolutionTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictResolutionTestUtils.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.delta.fuzzer.{PhaseLockingTransactionExecutionObserv
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import io.delta.tables.{DeltaTable => IODeltaTable}
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
@@ -120,14 +119,7 @@ trait ConflictResolutionTestUtils
         ctx.trackTransaction(this) {
           unblockCommit(observer.get)
           waitForCommit(observer.get)
-          try {
-            ThreadUtils.awaitResult(future.get, Duration.Inf)
-          } catch {
-            case e: SparkException if e.getCause.isInstanceOf[ExecutionException] =>
-              throw e.getCause
-            case e: SparkException =>
-              throw e
-          }
+          ThreadUtils.awaitResult(future.get, Duration.Inf)
         }
       }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Remove try catch clause in `ConflictResolutionTestUtils` to not make assumption about the type of the exception

## How was this patch tested?
Existing UTs

## Does this PR introduce _any_ user-facing changes?

No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
