### PR TITLE
[UniForm] Add catalogTable to the IcebergCompat validation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.types._
 
 /**
@@ -124,6 +125,7 @@ case class IcebergCompatBase(
    */
   def enforceInvariantsAndDependencies(
       spark: SparkSession,
+      catalogTable: Option[CatalogTable],
       prevSnapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
@@ -204,6 +206,7 @@ case class IcebergCompatBase(
         // Apply additional checks
         val context = IcebergCompatContext(
           spark,
+          catalogTable,
           prevSnapshot,
           protocolResult.getOrElse(newestProtocol),
           metadataResult.getOrElse(newestMetadata),
@@ -355,6 +358,7 @@ object RequireColumnMapping extends RequireColumnMapping(Seq(NameMapping, IdMapp
 
 case class IcebergCompatContext(
     spark: SparkSession,
+    catalogTable: Option[CatalogTable],
     prevSnapshot: Snapshot,
     newestProtocol: Protocol,
     newestMetadata: Metadata,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2029,6 +2029,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val (protocolUpdate1, metadataUpdate1) =
       UniversalFormat.enforceInvariantsAndDependencies(
         spark,
+        catalogTable,
         // Note: if this txn has no protocol or metadata updates, then `prev` will equal `newest`.
         snapshot,
         newestProtocol = protocol, // Note: this will try to use `newProtocol`

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -109,6 +109,7 @@ object UniversalFormat extends DeltaLogging {
    */
   def enforceInvariantsAndDependencies(
       spark: SparkSession,
+      catalogTable: Option[CatalogTable],
       snapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
@@ -116,7 +117,9 @@ object UniversalFormat extends DeltaLogging {
       actions: Seq[Action]): (Option[Protocol], Option[Metadata]) = {
     enforceHudiDependencies(newestMetadata, snapshot)
     enforceIcebergInvariantsAndDependencies(
-      spark, snapshot, newestProtocol, newestMetadata, operation, actions)
+      spark, catalogTable,
+      snapshot,
+      newestProtocol, newestMetadata, operation, actions)
   }
 
   /**
@@ -152,6 +155,7 @@ object UniversalFormat extends DeltaLogging {
    */
   def enforceIcebergInvariantsAndDependencies(
       spark: SparkSession,
+      catalogTable: Option[CatalogTable],
       snapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
@@ -203,14 +207,15 @@ object UniversalFormat extends DeltaLogging {
     var metadataUpdate: Option[Metadata] = None
 
     val compatChecks: Seq[
-      (SparkSession, Snapshot, Protocol, Metadata, Option[DeltaOperations.Operation],
+      (SparkSession, Option[CatalogTable], Snapshot, Protocol, Metadata,
+        Option[DeltaOperations.Operation],
         Seq[Action]) => (Option[Protocol], Option[Metadata])] = Seq(
       IcebergCompatV1.enforceInvariantsAndDependencies,
       IcebergCompatV2.enforceInvariantsAndDependencies
     )
     compatChecks.foreach { compatCheck =>
       val updates = compatCheck(
-        spark, snapshot, protocolToCheck, metadataToCheck, operation, actions
+        spark, catalogTable, snapshot, protocolToCheck, metadataToCheck, operation, actions
       )
       protocolUpdate = updates._1
       metadataUpdate = updates._2
@@ -239,6 +244,7 @@ object UniversalFormat extends DeltaLogging {
    */
   def enforceDependenciesInConfiguration(
       spark: SparkSession,
+      catalogTable: CatalogTable,
       configuration: Map[String, String],
       snapshot: Snapshot): Map[String, String] = {
     var metadata = snapshot.metadata.copy(configuration = configuration)
@@ -246,6 +252,7 @@ object UniversalFormat extends DeltaLogging {
     // Check UniversalFormat related property dependencies
     val (_, universalMetadata) = UniversalFormat.enforceInvariantsAndDependencies(
       spark,
+      catalogTable = Some(catalogTable),
       snapshot,
       newestProtocol = snapshot.protocol,
       newestMetadata = metadata,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -331,6 +331,7 @@ case class CreateDeltaTableCommand(
     }
     val updatedConfiguration = UniversalFormat.enforceDependenciesInConfiguration(
       sparkSession,
+      tableWithLocation,
       deltaWriter.configuration,
       txn.snapshot
     )
@@ -398,6 +399,7 @@ case class CreateDeltaTableCommand(
         newMetadata = newMetadata.copy(configuration =
           UniversalFormat.enforceDependenciesInConfiguration(
             sparkSession,
+            tableWithLocation,
             newMetadata.configuration,
             txn.snapshot
           ))
@@ -727,6 +729,7 @@ case class CreateDeltaTableCommand(
       var newMetadata = getProvidedMetadata(table, schema.json)
       val updatedConfig = UniversalFormat.enforceDependenciesInConfiguration(
         sparkSession,
+        tableDesc,
         newMetadata.configuration,
         txn.snapshot)
       newMetadata = newMetadata.copy(configuration = updatedConfig)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -111,9 +111,9 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
 
   test("create new UniForm table while manually enabling IcebergCompat") {
     allReaderWriterVersions.foreach { case (r, w) =>
-      withTempTableAndDir { case (id, loc) =>
+      withTempTableAndDir { case (id, _) =>
         executeSql(s"""
-               |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+               |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
                |  'delta.universalFormat.enabledFormats' = 'iceberg',
                |  'delta.enableIcebergCompatV$compatVersion' = 'true',
                |  'delta.minReaderVersion' = $r,
@@ -126,9 +126,9 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
   }
 
   test("create new UniForm table while manually enabling IcebergCompat with no rw version") {
-    withTempTableAndDir { case (id, loc) =>
+    withTempTableAndDir { case (id, _) =>
       executeSql(s"""
-             |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+             |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
              |  'delta.universalFormat.enabledFormats' = 'iceberg',
              |  'delta.enableIcebergCompatV$compatVersion' = 'true'
              |)""".stripMargin)
@@ -139,18 +139,18 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
   test("create new UniForm table via clone") {
     withTempTableAndDir { case (id, loc) =>
       executeSql(s"""
-              |CREATE TABLE $id (ID INT) USING DELTA  TBLPROPERTIES (
+              |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
               | 'delta.columnMapping.mode' = 'name')
-              | LOCATION $loc """.stripMargin)
+              | """.stripMargin)
       executeSql(s"""
               |INSERT INTO $id values (1) """.stripMargin)
-      withTempTableAndDir { case (cloneId, loc1) =>
+      withTempTableAndDir { case (cloneId, _) =>
         executeSql(s"""
               |CREATE TABLE $cloneId SHALLOW CLONE $id TBLPROPERTIES (
               |  'delta.universalFormat.enabledFormats' = 'iceberg',
               |  'delta.enableIcebergCompatV$compatVersion' = 'true',
               |  'delta.columnMapping.mode' = 'name'
-              |) LOCATION $loc1 """.stripMargin)
+              |) """.stripMargin)
         assertUniFormIcebergProtocolAndProperties(cloneId)
       }
     }
@@ -158,9 +158,9 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
 
   test("enable UniForm on existing table with IcebergCompat enabled") {
     allReaderWriterVersions.foreach { case (r, w) =>
-      withTempTableAndDir { case (id, loc) =>
+      withTempTableAndDir { case (id, _) =>
         executeSql(s"""
-               |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+               |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
                |  'delta.minReaderVersion' = $r,
                |  'delta.minWriterVersion' = $w,
                |  'delta.enableIcebergCompatV$compatVersion' = true
@@ -176,9 +176,9 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
 
   test("enable UniForm on existing table without IcebergCompat") {
     allReaderWriterVersions.foreach { case (r, w) =>
-      withTempTableAndDir { case (id, loc) =>
+      withTempTableAndDir { case (id, _) =>
         executeSql(s"""
-          |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+          |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
           |  'delta.minReaderVersion' = $r,
           |  'delta.minWriterVersion' = $w
           |)""".stripMargin)
@@ -195,9 +195,9 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
 
   test("enable UniForm on existing table with ColumnMapping") {
     allReaderWriterVersions.foreach { case (r, w) =>
-      withTempTableAndDir { case (id, loc) =>
+      withTempTableAndDir { case (id, _) =>
         executeSql(s"""
-          |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+          |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
           |  'delta.minReaderVersion' = $r,
           |  'delta.minWriterVersion' = $w,
           |  'delta.columnMapping.mode' = 'name'
@@ -213,9 +213,9 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
 
   test("enable UniForm on existing table but IcebergCompat isn't enabled - fail") {
     allReaderWriterVersions.foreach { case (r, w) =>
-      withTempTableAndDir { case (id, loc) =>
+      withTempTableAndDir { case (id, _) =>
         executeSql(s"""
-               |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+               |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
                |  'delta.minReaderVersion' = $r,
                |  'delta.minWriterVersion' = $w,
                |  'delta.enableIcebergCompatV$compatVersion' = false,
@@ -232,10 +232,10 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
   }
 
   test("disabling UniForm will not disable IcebergCompat") {
-    withTempTableAndDir { case (id, loc) =>
+    withTempTableAndDir { case (id, _) =>
       executeSql(
         s"""
-           |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+           |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
            |  'delta.universalFormat.enabledFormats' = 'iceberg',
            |  'delta.enableIcebergCompatV$compatVersion' = 'true'
            |)""".stripMargin)
@@ -250,9 +250,9 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
 
   test("disabling IcebergCompat will disable UniForm if enabled") {
     allReaderWriterVersions.foreach { case (r, w) =>
-      withTempTableAndDir { case (id, loc) =>
+      withTempTableAndDir { case (id, _) =>
         executeSql(s"""
-               |CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+               |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
                |  'delta.minReaderVersion' = $r,
                |  'delta.minWriterVersion' = $w,
                |  'delta.universalFormat.enabledFormats' = 'iceberg',
@@ -297,9 +297,9 @@ trait UniFormWithIcebergCompatV1SuiteBase extends UniversalFormatSuiteBase {
 
   test("REORG TABLE for table from icebergCompatVx to icebergCompatV1, should skip rewrite") {
     getCompatVersionsOtherThan(1).foreach(originalVersion => {
-      withTempTableAndDir { case (id, loc) =>
+      withTempTableAndDir { case (id, _) =>
         executeSql(s"""
-               | CREATE TABLE $id (ID INT) USING DELTA LOCATION $loc TBLPROPERTIES (
+               | CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
                |  'delta.universalFormat.enabledFormats' = 'iceberg',
                |  'delta.enableIcebergCompatV$originalVersion' = 'true'
                |)
@@ -414,14 +414,16 @@ trait UniFormWithIcebergCompatV2SuiteBase extends UniversalFormatSuiteBase {
 
 trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with UniversalFormatTestHelper {
   test("enforceInvariantsAndDependenciesForCTAS") {
-    withTempTableAndDir { case (id, loc) =>
-      executeSql(s"CREATE TABLE $id (id INT) USING DELTA LOCATION $loc")
-      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, loc)
+    withTempTableAndDir { case (id, _) =>
+      executeSql(s"CREATE TABLE $id (id INT) USING DELTA")
+      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(id))
+      val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(id))
       var configurationUnderTest = Map("dummykey1" -> "dummyval1", "dummykey2" -> "dummyval2")
       // The enforce is not lossy. It will do nothing if there is no Universal related key.
 
       def getUpdatedConfiguration(conf: Map[String, String]): Map[String, String] =
-        UniversalFormat.enforceDependenciesInConfiguration(spark, conf, snapshot)
+        UniversalFormat.enforceDependenciesInConfiguration(spark,
+            catalogTable = catalogTable, conf, snapshot)
 
       var updatedConfiguration = getUpdatedConfiguration(configurationUnderTest)
       assert(configurationUnderTest == configurationUnderTest)
@@ -448,7 +450,7 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
         assert(updatedConfiguration("delta.universalFormat.enabledFormats") == "iceberg")
         assert(updatedConfiguration("delta.columnMapping.mode") == "name")
         assert(updatedConfiguration(s"delta.enableIcebergCompatV$icv") == "true")
-        assert(updatedConfiguration("delta.columnMapping.maxColumnId") == "0")
+        assert(updatedConfiguration("delta.columnMapping.maxColumnId") == "1")
 
         configurationUnderTest = Map(
           s"delta.enableIcebergCompatV$icv" -> "true",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR allows IcebergCompat checkers to use CatalogTable for validation
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UT
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
