### PR TITLE
[SPARK] Validate CHECK constraint user expressions

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -53,6 +53,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "DELTA_AGGREGATE_IN_CHECK_CONSTRAINT" : {
+    "message" : [
+      "Found <sqlExpr> in a CHECK constraint. Aggregate expressions are not allowed in CHECK constraints."
+    ],
+    "sqlState" : "42621"
+  },
   "DELTA_AGGREGATE_IN_GENERATED_COLUMN" : {
     "message" : [
       "Found <sqlExpr>. A generated column cannot use an aggregate expression"
@@ -1469,6 +1475,12 @@
     ],
     "sqlState" : "42K05"
   },
+  "DELTA_INVALID_CHECK_CONSTRAINT_REFERENCES" : {
+    "message" : [
+      "Found <colName> in CHECK constraint. A check constraint cannot use a non-existent column."
+    ],
+    "sqlState" : "42621"
+  },
   "DELTA_INVALID_CLONE_PATH" : {
     "message" : [
       "The target location for CLONE needs to be an absolute path or table name. Use an",
@@ -1891,6 +1903,12 @@
   "DELTA_NON_BOOLEAN_CHECK_CONSTRAINT" : {
     "message" : [
       "CHECK constraint '<name>' (<expr>) should be a boolean expression."
+    ],
+    "sqlState" : "42621"
+  },
+  "DELTA_NON_DETERMINISTIC_EXPRESSION_IN_CHECK_CONSTRAINT" : {
+    "message" : [
+      "Found <expr> in a CHECK constraint. A CHECK constraint cannot use a nondeterministic expression."
     ],
     "sqlState" : "42621"
   },
@@ -2650,6 +2668,12 @@
     ],
     "sqlState" : "XXKDS"
   },
+  "DELTA_UDF_IN_CHECK_CONSTRAINT" : {
+    "message" : [
+      "Found <expr> in a CHECK constraint. A CHECK constraint cannot use a user-defined function."
+    ],
+    "sqlState" : "42621"
+  },
   "DELTA_UDF_IN_GENERATED_COLUMN" : {
     "message" : [
       "Found <udfExpr>. A generated column cannot use a user-defined function"
@@ -2909,6 +2933,12 @@
       "Unsupported expression type(<expType>) for <causedBy>. The supported types are [<supportedTypes>]."
     ],
     "sqlState" : "0A000"
+  },
+  "DELTA_UNSUPPORTED_EXPRESSION_CHECK_CONSTRAINT" : {
+    "message" : [
+      "Found <expression> in a CHECK constraint. <expression> cannot be used in a CHECK constraint."
+    ],
+    "sqlState" : "42621"
   },
   "DELTA_UNSUPPORTED_EXPRESSION_GENERATED_COLUMN" : {
     "message" : [

--- a/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
@@ -21,8 +21,10 @@ import scala.reflect.ClassTag
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.xml._
 
-/** This class defines the list of expressions that can be used in a generated column. */
-object SupportedGenerationExpressions {
+/** This class defines the list of expressions that can be used when providing custom expressions.
+ * e.g. in a generated column or a check constraint.
+ * */
+object AllowedUserProvidedExpressions {
 
   /**
    * This method has the same signature as `FunctionRegistry.expression` so that we can define the
@@ -332,5 +334,12 @@ object SupportedGenerationExpressions {
     // Special expressions that are not built-in expressions.
     expression[AttributeReference]("col"),
     expression[Literal]("lit")
+  )
+
+  val checkConstraintExpressions: Set[Class[_]] = Set(
+    expression[Contains]("contains"),
+    expression[StartsWith]("startswith"),
+    expression[EndsWith]("endswith"),
+    expression[InSet]("inset")
   )
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -356,6 +356,39 @@ trait DeltaErrorsBase
     )
   }
 
+  def checkConstraintReferToWrongColumns(colName: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_INVALID_CHECK_CONSTRAINT_REFERENCES",
+      messageParameters = Array(colName)
+    )
+  }
+
+  def checkConstraintUDF(expr: Expression): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UDF_IN_CHECK_CONSTRAINT",
+      messageParameters = Array(expr.sql))
+  }
+
+  def checkConstraintNonDeterministicExpression(expr: Expression): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_NON_DETERMINISTIC_EXPRESSION_IN_CHECK_CONSTRAINT",
+      messageParameters = Array(expr.sql))
+  }
+
+  def checkConstraintAggregateExpression(expr: Expression): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_AGGREGATE_IN_CHECK_CONSTRAINT",
+      messageParameters = Array(expr.sql))
+  }
+
+  def checkConstraintUnsupportedExpression(expr: Expression): Throwable = {
+    val expressionSql = expr.sql
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_EXPRESSION_CHECK_CONSTRAINT",
+      messageParameters = Array(expressionSql, expressionSql)
+    )
+  }
+
   def deltaRelationPathMismatch(
       relationPath: Seq[String],
       targetType: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -250,6 +250,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
           throw e
         }
     }
+
     // Check whether the generation expressions are valid
     dfWithExprs.queryExecution.analyzed.transformAllExpressions {
       case expr: Alias =>
@@ -267,7 +268,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
         throw DeltaErrors.generatedColumnsNonDeterministicExpression(expr)
       case expr if expr.isInstanceOf[AggregateExpression] =>
         throw DeltaErrors.generatedColumnsAggregateExpression(expr)
-      case expr if !SupportedGenerationExpressions.expressions.contains(expr.getClass) =>
+      case expr if !AllowedUserProvidedExpressions.expressions.contains(expr.getClass) =>
         throw DeltaErrors.generatedColumnsUnsupportedExpression(expr)
     }
     // Compare the columns types defined in the schema and the expression types.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -1291,6 +1291,13 @@ case class AlterTableAddConstraintDeltaCommand(
           throw a.copy(context = Array.empty)
       }
 
+      Constraints.validateCheckConstraints(
+        sparkSession,
+        Seq(Constraints.Check(name, unresolvedExpr)),
+        deltaLog,
+        txn.metadata.schema
+      )
+
       logInfo(log"Checking that ${MDC(DeltaLogKeys.EXPR, exprText)} " +
         log"is satisfied for existing data. This will require a full table scan.")
       recordDeltaOperation(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -427,6 +427,7 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
 
     val constraints =
       Constraints.getAll(metadata, spark) ++ generatedColumnConstraints ++ additionalConstraints
+    Constraints.validateCheckConstraints(spark, constraints, deltaLog, metadata.schema)
 
     val identityTrackerOpt = IdentityColumn.createIdentityColumnStatsTracker(
       spark,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1802,6 +1802,26 @@ trait DeltaSQLConfBase {
       .checkValues(GeneratedColumnValidateOnWriteMode.values.map(_.toString))
       .createWithDefault(GeneratedColumnValidateOnWriteMode.LOG_ONLY.toString)
 
+  object ValidateCheckConstraintsMode extends Enumeration {
+    val OFF, LOG_ONLY, ASSERT = Value
+
+    def fromConf(conf: SQLConf): Value =
+      withName(conf.getConf(VALIDATE_CHECK_CONSTRAINTS))
+
+    def default: Value =
+      withName(VALIDATE_CHECK_CONSTRAINTS.defaultValueString)
+  }
+
+  val VALIDATE_CHECK_CONSTRAINTS =
+    buildConf("checkConstraints.validation.enabled")
+      .internal()
+      .doc("When enabled, validates check constraints expressions during both creation and write" +
+        " paths to protect against disallowed expressions.")
+      .stringConf
+      .transform(_.toUpperCase(Locale.ROOT))
+      .checkValues(ValidateCheckConstraintsMode.values.map(_.toString))
+      .createWithDefault(ValidateCheckConstraintsMode.LOG_ONLY.toString)
+
   val DELTA_CONVERT_ICEBERG_ENABLED =
     buildConf("convert.iceberg.enabled")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add validation to CHECK constraint user expression using the same validation as GeneratedColumns, however there are some differences that still need to be accounted for that add more flexibility particularly the following functions:
- Functions: contains, startsWith, endsWith and GetMapValue.

Validation on both CHECK creation and execution path.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
The PR adds validation to CHECK constraints expressions, the validation is currently not enabled by default. 
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
