### PR TITLE
[SPARK] Extract function from CDCReader into CDCReaderBase

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -605,37 +605,6 @@ trait CDCReaderImpl extends CDCReaderBase {
   }
 
   /**
-   * Builds a map from commit versions to associated commit timestamps where the timestamp
-   * is the modification time of the commit file. Note that this function will not return
-   * InCommitTimestamps, it is up to the consumer of this function to decide whether the
-   * file modification time is the correct commit timestamp or whether they need to read the ICT.
-   *
-   * @param start  start commit version
-   * @param end  end commit version (inclusive)
-   */
-  def getNonICTTimestampsByVersion(
-      deltaLog: DeltaLog,
-      start: Long,
-      end: Long): Map[Long, Timestamp] = {
-    // Correct timestamp values are only available through DeltaHistoryManager.getCommits(). Commit
-    // info timestamps are wrong, and file modification times are wrong because they need to be
-    // monotonized first. This just performs a list (we don't read the contents of the files in
-    // getCommits()) so the performance overhead is minimal.
-    val monotonizationStart =
-      math.max(start - DeltaHistoryManager.POTENTIALLY_UNMONOTONIZED_TIMESTAMPS, 0)
-    val commits = DeltaHistoryManager.getCommitsWithNonIctTimestamps(
-      deltaLog.store,
-      deltaLog.logPath,
-      monotonizationStart,
-      Some(end + 1),
-      deltaLog.newDeltaHadoopConf())
-
-    // Note that the timestamps come from filesystem modification timestamps, so they're
-    // milliseconds since epoch and we don't need to deal with timezones.
-    commits.map(f => (f.version -> new Timestamp(f.timestamp))).toMap
-  }
-
-  /**
    * Get the block of change data from start to end Delta log versions (both sides inclusive).
    * The returned DataFrame has isStreaming set to false.
    *

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReaderBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReaderBase.scala
@@ -462,6 +462,37 @@ trait CDCReaderBase extends DeltaLogging {
       endingVersion: Option[Long]): BaseRelation
 
   /**
+   * Builds a map from commit versions to associated commit timestamps where the timestamp
+   * is the modification time of the commit file. Note that this function will not return
+   * InCommitTimestamps, it is up to the consumer of this function to decide whether the
+   * file modification time is the correct commit timestamp or whether they need to read the ICT.
+   *
+   * @param start  start commit version
+   * @param end  end commit version (inclusive)
+   */
+  def getNonICTTimestampsByVersion(
+      deltaLog: DeltaLog,
+      start: Long,
+      end: Long): Map[Long, Timestamp] = {
+    // Correct timestamp values are only available through DeltaHistoryManager.getCommits(). Commit
+    // info timestamps are wrong, and file modification times are wrong because they need to be
+    // monotonized first. This just performs a list (we don't read the contents of the files in
+    // getCommits()) so the performance overhead is minimal.
+    val monotonizationStart =
+      math.max(start - DeltaHistoryManager.POTENTIALLY_UNMONOTONIZED_TIMESTAMPS, 0)
+    val commits = DeltaHistoryManager.getCommitsWithNonIctTimestamps(
+      deltaLog.store,
+      deltaLog.logPath,
+      monotonizationStart,
+      Some(end + 1),
+      deltaLog.newDeltaHadoopConf())
+
+    // Note that the timestamps come from filesystem modification timestamps, so they're
+    // milliseconds since epoch and we don't need to deal with timezones.
+    commits.map(f => (f.version -> new Timestamp(f.timestamp))).toMap
+  }
+
+  /**
    * Represents the changes between some start and end version of a Delta table
    * @param fileChangeDf contains all of the file changes (AddFile, RemoveFile, AddCDCFile)
    * @param numFiles the number of AddFile + RemoveFile + AddCDCFiles that are in the df


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Moving `getNonICTTimestampsByVersion` to the `CDCReaderBase.scala` since it's not specific to the `CDCReader` and could be reused by an implementing class.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing Unit tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
