### PR TITLE
[Spark] Move CDCVersionDiffInfo case class to CDCReaderBase

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -839,14 +839,6 @@ trait CDCReaderImpl extends CDCReaderBase {
     new CDCDataSpec(fileVersion, addFiles.toSeq, commitInfo)
   }.toSeq
 
-  /**
-   * Represents the changes between some start and end version of a Delta table
-   * @param fileChangeDf contains all of the file changes (AddFile, RemoveFile, AddCDCFile)
-   * @param numFiles the number of AddFile + RemoveFile + AddCDCFiles that are in the df
-   * @param numBytes the total size of the AddFile + RemoveFile + AddCDCFiles that are in the df
-   */
-  case class CDCVersionDiffInfo(fileChangeDf: DataFrame, numFiles: Long, numBytes: Long)
-
   override def getConstructedCDCRelation(
     snapshotWithSchema: SnapshotWithSchemaMode,
     sqlContext: SQLContext,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReaderBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReaderBase.scala
@@ -460,4 +460,12 @@ trait CDCReaderBase extends DeltaLogging {
       catalogTableOpt: Option[CatalogTable],
       startingVersion: Option[Long],
       endingVersion: Option[Long]): BaseRelation
+
+  /**
+   * Represents the changes between some start and end version of a Delta table
+   * @param fileChangeDf contains all of the file changes (AddFile, RemoveFile, AddCDCFile)
+   * @param numFiles the number of AddFile + RemoveFile + AddCDCFiles that are in the df
+   * @param numBytes the total size of the AddFile + RemoveFile + AddCDCFiles that are in the df
+   */
+  case class CDCVersionDiffInfo(fileChangeDf: DataFrame, numFiles: Long, numBytes: Long)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Refactor the CDCVersionDiffInfo case class from CDCReaderImpl trait to CDCReaderBase trait to improve code organization and make it accessible for future CDC reader implementations.


<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Refactor only, all tests should behave the same.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
