### PR TITLE
[Delta-Unity] Make Delta-Unity depend on assembled version of KernelAPI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -963,7 +963,6 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
 
 lazy val unity = (project in file("unity"))
   .enablePlugins(ScalafmtPlugin)
-  .dependsOn(kernelApi % "compile->compile;test->test")
   .dependsOn(kernelDefaults % "test->test")
   .dependsOn(storage)
   .settings (
@@ -974,6 +973,16 @@ lazy val unity = (project in file("unity"))
     javaCheckstyleSettings("dev/kernel-checkstyle.xml"),
     scalaStyleSettings,
     scalafmtCheckSettings,
+
+    // Put the shaded kernel-api JAR on the classpath (compile & test)
+    Compile / unmanagedJars += (kernelApi / Compile / packageBin).value,
+    Test / unmanagedJars += (kernelApi / Compile / packageBin).value,
+
+    // Make sure the shaded JAR is produced before we compile/run tests
+    Compile / compile := (Compile / compile).dependsOn(kernelApi / Compile / packageBin).value,
+    Test / test       := (Test    / test).dependsOn(kernelApi / Compile / packageBin).value,
+    Test / unmanagedJars += (kernelApi / Test / packageBin).value,
+
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "provided",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",

--- a/unity/src/main/java/io/delta/unity/metrics/UcCommitTelemetry.java
+++ b/unity/src/main/java/io/delta/unity/metrics/UcCommitTelemetry.java
@@ -16,12 +16,12 @@
 
 package io.delta.unity.metrics;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.delta.kernel.commit.CommitMetadata;
 import io.delta.kernel.internal.metrics.MetricsReportSerializer;
 import io.delta.kernel.internal.metrics.Timer;
 import io.delta.kernel.metrics.MetricsReport;
+import io.delta.kernel.shaded.com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.delta.kernel.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Optional;
 
 /**

--- a/unity/src/main/java/io/delta/unity/metrics/UcPublishTelemetry.java
+++ b/unity/src/main/java/io/delta/unity/metrics/UcPublishTelemetry.java
@@ -16,11 +16,11 @@
 
 package io.delta.unity.metrics;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.delta.kernel.internal.metrics.MetricsReportSerializer;
 import io.delta.kernel.internal.metrics.Timer;
 import io.delta.kernel.metrics.MetricsReport;
+import io.delta.kernel.shaded.com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.delta.kernel.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Optional;
 
 /**


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5491/files) to review incremental changes.
- [**stack/kernel_unity_fix_dependency**](https://github.com/delta-io/delta/pull/5491) [[Files changed](https://github.com/delta-io/delta/pull/5491/files)]

---------

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR updates the `delta-unity` sbt project to depend on the assembled version of the KernelAPI project.

This will fix a user-reported error of `delta-unity` using the wrong jackson dependency (unshaded).

## How was this patch tested?

Infra change. Existing CI.

## Does this PR introduce _any_ user-facing changes?

No.