### PR TITLE
[Kernel] [UC] Add metrics report for UC::loadSnapshot (e.g. getCommits RPC duration)

### DIFF
--- a/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
+++ b/unity/src/main/java/io/delta/unity/UCCatalogManagedClient.java
@@ -38,6 +38,7 @@ import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
+import io.delta.unity.metrics.UcLoadSnapshotTelemetry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.*;
@@ -106,37 +107,71 @@ public class UCCatalogManagedClient {
         "[{}] Loading Snapshot at {}",
         ucTableId,
         getVersionOrTimestampString(versionOpt, timestampOpt));
-    final GetCommitsResponse response = getRatifiedCommitsFromUC(ucTableId, tablePath, versionOpt);
-    final long ucTableVersion = getTrueUCTableVersion(ucTableId, response.getLatestTableVersion());
-    versionOpt.ifPresent(
-        version -> validateLoadTableVersionExists(ucTableId, version, ucTableVersion));
-    final List<ParsedLogData> logData =
-        getSortedKernelParsedDeltaDataFromRatifiedCommits(ucTableId, response.getCommits());
 
-    return timeUncheckedOperation(
-        logger,
-        "TableManager.loadSnapshot",
-        ucTableId,
-        () -> {
-          SnapshotBuilder snapshotBuilder = TableManager.loadSnapshot(tablePath);
+    final UcLoadSnapshotTelemetry telemetry =
+        new UcLoadSnapshotTelemetry(ucTableId, tablePath, versionOpt, timestampOpt);
 
-          if (versionOpt.isPresent()) {
-            snapshotBuilder = snapshotBuilder.atVersion(versionOpt.get());
-          }
+    final UcLoadSnapshotTelemetry.MetricsCollector metricsCollector =
+        telemetry.getMetricsCollector();
 
-          if (timestampOpt.isPresent()) {
-            // If timestampOpt is present, we know versionOpt is not ==> logData was not requested
-            // with an endVersion and thus can be re-used to load the latest snapshot
-            Snapshot latestSnapshot =
-                loadLatestSnapshotForTimestampResolution(engine, ucTableId, tablePath, logData);
-            snapshotBuilder = snapshotBuilder.atTimestamp(timestampOpt.get(), latestSnapshot);
-          }
+    try {
+      final Snapshot result =
+          metricsCollector.totalSnapshotLoadTimer.timeChecked(
+              () -> {
+                final GetCommitsResponse response =
+                    metricsCollector.getCommitsTimer.timeChecked(
+                        () -> getRatifiedCommitsFromUC(ucTableId, tablePath, versionOpt));
 
-          return snapshotBuilder
-              .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath))
-              .withLogData(logData)
-              .build(engine);
-        });
+                metricsCollector.setNumCatalogCommits(response.getCommits().size());
+
+                final long ucTableVersion =
+                    getTrueUCTableVersion(ucTableId, response.getLatestTableVersion());
+                versionOpt.ifPresent(
+                    version -> validateLoadTableVersionExists(ucTableId, version, ucTableVersion));
+                final List<ParsedLogData> logData =
+                    getSortedKernelParsedDeltaDataFromRatifiedCommits(
+                        ucTableId, response.getCommits());
+
+                return metricsCollector.kernelSnapshotBuildTimer.timeChecked(
+                    () -> {
+                      SnapshotBuilder snapshotBuilder = TableManager.loadSnapshot(tablePath);
+
+                      if (versionOpt.isPresent()) {
+                        snapshotBuilder = snapshotBuilder.atVersion(versionOpt.get());
+                      }
+
+                      if (timestampOpt.isPresent()) {
+                        // If timestampOpt is present, we know versionOpt is not present. This means
+                        // logData was not requested with an endVersion and thus it can be re-used
+                        // to load the latest snapshot
+                        Snapshot latestSnapshot =
+                            metricsCollector.loadLatestSnapshotForTimestampTimeTravelTimer
+                                .timeChecked(
+                                    () ->
+                                        loadLatestSnapshotForTimestampResolution(
+                                            engine, ucTableId, tablePath, logData));
+                        snapshotBuilder =
+                            snapshotBuilder.atTimestamp(timestampOpt.get(), latestSnapshot);
+                      }
+
+                      Snapshot snapshot =
+                          snapshotBuilder
+                              .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath))
+                              .withLogData(logData)
+                              .build(engine);
+                      metricsCollector.setResolvedSnapshotVersion(snapshot.getVersion());
+                      return snapshot;
+                    });
+              });
+
+      final UcLoadSnapshotTelemetry.Report successReport = telemetry.createSuccessReport();
+      engine.getMetricsReporters().forEach(r -> r.report(successReport));
+      return result;
+    } catch (Exception e) {
+      final UcLoadSnapshotTelemetry.Report failureReport = telemetry.createFailureReport(e);
+      engine.getMetricsReporters().forEach(r -> r.report(failureReport));
+      throw e;
+    }
   }
 
   /**
@@ -337,6 +372,7 @@ public class UCCatalogManagedClient {
         ucTableId,
         getVersionString(versionOpt));
 
+    // TODO: We can remove timeUncheckedOperation when the commitRange code integrates with metrics
     final GetCommitsResponse response =
         timeUncheckedOperation(
             logger,
@@ -460,6 +496,7 @@ public class UCCatalogManagedClient {
    */
   private Snapshot loadLatestSnapshotForTimestampResolution(
       Engine engine, String ucTableId, String tablePath, List<ParsedLogData> logData) {
+    // TODO: We can remove timeUncheckedOperation when the commitRange code integrates with metrics
     return timeUncheckedOperation(
         logger,
         "TableManager.loadSnapshot at latest for time-travel query",

--- a/unity/src/main/java/io/delta/unity/metrics/UcLoadSnapshotTelemetry.java
+++ b/unity/src/main/java/io/delta/unity/metrics/UcLoadSnapshotTelemetry.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.unity.metrics;
+
+import io.delta.kernel.internal.metrics.MetricsReportSerializer;
+import io.delta.kernel.internal.metrics.Timer;
+import io.delta.kernel.metrics.MetricsReport;
+import io.delta.kernel.shaded.com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.delta.kernel.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+
+/**
+ * Telemetry framework for Unity Catalog snapshot loading operations.
+ *
+ * <p>Collects timing metrics for snapshot loading and generates reports for successful and failed
+ * loads.
+ */
+public class UcLoadSnapshotTelemetry {
+
+  private final String ucTableId;
+  private final String ucTablePath;
+  private final Optional<Long> versionOpt;
+  private final Optional<Long> timestampOpt;
+  private final MetricsCollector metricsCollector;
+
+  public UcLoadSnapshotTelemetry(
+      String ucTableId,
+      String ucTablePath,
+      Optional<Long> versionOpt,
+      Optional<Long> timestampOpt) {
+    this.ucTableId = ucTableId;
+    this.ucTablePath = ucTablePath;
+    this.versionOpt = versionOpt;
+    this.timestampOpt = timestampOpt;
+    this.metricsCollector = new MetricsCollector();
+  }
+
+  public MetricsCollector getMetricsCollector() {
+    return metricsCollector;
+  }
+
+  public Report createSuccessReport() {
+    return new Report(metricsCollector.capture(), Optional.empty());
+  }
+
+  public Report createFailureReport(Exception error) {
+    return new Report(metricsCollector.capture(), Optional.of(error));
+  }
+
+  /** Mutable collector for gathering metrics during snapshot loading. */
+  public static class MetricsCollector {
+    public final Timer totalSnapshotLoadTimer = new Timer();
+    public final Timer getCommitsTimer = new Timer();
+    public final Timer kernelSnapshotBuildTimer = new Timer();
+    public final Timer loadLatestSnapshotForTimestampTimeTravelTimer = new Timer();
+    private int numCatalogCommits = -1;
+    private long resolvedSnapshotVersion = -1;
+
+    public void setNumCatalogCommits(int count) {
+      this.numCatalogCommits = count;
+    }
+
+    public void setResolvedSnapshotVersion(long version) {
+      this.resolvedSnapshotVersion = version;
+    }
+
+    public MetricsResult capture() {
+      return new MetricsResult(this);
+    }
+  }
+
+  /** Immutable snapshot of collected metric results. */
+  @JsonPropertyOrder({
+    "totalLoadSnapshotDurationNs",
+    "getCommitsDurationNs",
+    "numCatalogCommits",
+    "kernelSnapshotBuildDurationNs",
+    "loadLatestSnapshotForTimestampTimeTravelDurationNs",
+    "resolvedSnapshotVersion"
+  })
+  public static class MetricsResult {
+    public final long totalLoadSnapshotDurationNs;
+    public final long getCommitsDurationNs;
+    public final int numCatalogCommits;
+    public final long kernelSnapshotBuildDurationNs;
+    public final long loadLatestSnapshotForTimestampTimeTravelDurationNs;
+    public final long resolvedSnapshotVersion;
+
+    MetricsResult(MetricsCollector collector) {
+      this.totalLoadSnapshotDurationNs = collector.totalSnapshotLoadTimer.totalDurationNs();
+      this.getCommitsDurationNs = collector.getCommitsTimer.totalDurationNs();
+      this.numCatalogCommits = collector.numCatalogCommits;
+      this.kernelSnapshotBuildDurationNs = collector.kernelSnapshotBuildTimer.totalDurationNs();
+      this.loadLatestSnapshotForTimestampTimeTravelDurationNs =
+          collector.loadLatestSnapshotForTimestampTimeTravelTimer.totalDurationNs();
+      this.resolvedSnapshotVersion = collector.resolvedSnapshotVersion;
+    }
+  }
+
+  /** Complete UC snapshot loading report with metadata and metrics. */
+  @JsonPropertyOrder({
+    "operationType",
+    "reportUUID",
+    "ucTableId",
+    "ucTablePath",
+    "versionOpt",
+    "timestampOpt",
+    "metrics",
+    "exception"
+  })
+  public class Report implements MetricsReport {
+    public final String operationType = "UcLoadSnapshot";
+    public final String reportUUID = java.util.UUID.randomUUID().toString();
+    public final String ucTableId = UcLoadSnapshotTelemetry.this.ucTableId;
+    public final String ucTablePath = UcLoadSnapshotTelemetry.this.ucTablePath;
+    public final Optional<Long> versionOpt = UcLoadSnapshotTelemetry.this.versionOpt;
+    public final Optional<Long> timestampOpt = UcLoadSnapshotTelemetry.this.timestampOpt;
+    public final MetricsResult metrics;
+    public final Optional<Exception> exception;
+
+    public Report(MetricsResult metrics, Optional<Exception> exception) {
+      this.metrics = metrics;
+      this.exception = exception;
+    }
+
+    @Override
+    public String toJson() throws JsonProcessingException {
+      return MetricsReportSerializer.OBJECT_MAPPER.writeValueAsString(this);
+    }
+  }
+}

--- a/unity/src/test/scala/io/delta/unity/UcLoadSnapshotTelemetrySuite.scala
+++ b/unity/src/test/scala/io/delta/unity/UcLoadSnapshotTelemetrySuite.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.unity
+
+import java.util.Optional
+
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.test.MockFileSystemClientUtils
+import io.delta.kernel.utils.CloseableIterable
+import io.delta.unity.metrics.UcLoadSnapshotTelemetry
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class UcLoadSnapshotTelemetrySuite
+    extends AnyFunSuite
+    with UCCatalogManagedTestUtils
+    with MockFileSystemClientUtils {
+
+  /**
+   * Helper to set up a table with v0 published and v1, v2 as staged commits.
+   *
+   * @return timestamp between v1 and v2 creation
+   */
+  private def setupTableWithCommits(
+      engine: Engine,
+      tablePath: String,
+      ucClient: InMemoryUCClient,
+      ucCatalogManagedClient: UCCatalogManagedClient): Long = {
+    val result0 = ucCatalogManagedClient
+      .buildCreateTableTransaction("ucTableId", tablePath, testSchema, "test-engine")
+      .build(engine)
+      .commit(engine, CloseableIterable.emptyIterable())
+
+    val tableData = new InMemoryUCClient.TableData(-1, scala.collection.mutable.ArrayBuffer())
+    ucClient.createTableIfNotExistsOrThrow("ucTableId", tableData)
+
+    val result1 = result0.getPostCommitSnapshot.get()
+      .buildUpdateTableTransaction("engineInfo", io.delta.kernel.Operation.MANUAL_UPDATE)
+      .build(engine)
+      .commit(engine, CloseableIterable.emptyIterable())
+
+    val timestampBetweenV1AndV2 = System.currentTimeMillis()
+
+    Thread.sleep(100) // Ensure v2 timestamp is sufficiently after our captured timestamp
+
+    val result2 = result1.getPostCommitSnapshot.get()
+      .buildUpdateTableTransaction("engineInfo", io.delta.kernel.Operation.MANUAL_UPDATE)
+      .build(engine)
+      .commit(engine, CloseableIterable.emptyIterable())
+
+    timestampBetweenV1AndV2
+  }
+
+  test("snapshot loading metrics for latest version") {
+    withTempDirAndEngine { case (tablePathUnresolved, _) =>
+      // ===== GIVEN =====
+      val reporter = new CapturingMetricsReporter[UcLoadSnapshotTelemetry#Report]
+      val engine = createEngineWithMetricsCapture(reporter)
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val (ucClient, ucCatalogManagedClient) = createUCClientAndCatalogManagedClient()
+      setupTableWithCommits(engine, tablePath, ucClient, ucCatalogManagedClient)
+      reporter.reports.clear()
+
+      // ===== WHEN =====
+      ucCatalogManagedClient.loadSnapshot(
+        engine,
+        "ucTableId",
+        tablePath,
+        Optional.empty(),
+        Optional.empty())
+
+      // ===== THEN =====
+      assert(reporter.reports.size === 1)
+      val report = reporter.reports.head
+      assert(report.operationType === "UcLoadSnapshot")
+      assert(report.ucTableId === "ucTableId")
+      assert(report.ucTablePath === tablePath)
+      assert(report.versionOpt.isEmpty)
+      assert(report.timestampOpt.isEmpty)
+      assert(!report.exception.isPresent)
+
+      val metrics = report.metrics
+      assert(metrics.totalLoadSnapshotDurationNs > 0)
+      assert(metrics.getCommitsDurationNs > 0)
+      assert(metrics.numCatalogCommits === 2) // v1.uuid.json and v2.uuid.json
+      assert(metrics.kernelSnapshotBuildDurationNs > 0)
+      assert(metrics.loadLatestSnapshotForTimestampTimeTravelDurationNs === 0)
+      assert(metrics.resolvedSnapshotVersion === 2) // v2 is the latest
+      assert(
+        metrics.totalLoadSnapshotDurationNs >=
+          metrics.getCommitsDurationNs + metrics.kernelSnapshotBuildDurationNs)
+    }
+  }
+
+  test("snapshot loading metrics with timestamp") {
+    withTempDirAndEngine { case (tablePathUnresolved, _) =>
+      // ===== GIVEN =====
+      val reporter = new CapturingMetricsReporter[UcLoadSnapshotTelemetry#Report]
+      val engine = createEngineWithMetricsCapture(reporter)
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val (ucClient, ucCatalogManagedClient) = createUCClientAndCatalogManagedClient()
+
+      val timestampBetweenV1AndV2 =
+        setupTableWithCommits(engine, tablePath, ucClient, ucCatalogManagedClient)
+      reporter.reports.clear()
+
+      // Time travel to timestamp between v1 and v2 - should resolve to v1
+      ucCatalogManagedClient.loadSnapshot(
+        engine,
+        "ucTableId",
+        tablePath,
+        Optional.empty(),
+        Optional.of(timestampBetweenV1AndV2))
+
+      // Verify snapshot loading metrics
+      assert(reporter.reports.size === 1)
+      val report = reporter.reports.head
+      assert(report.operationType === "UcLoadSnapshot")
+      assert(report.ucTableId === "ucTableId")
+      assert(report.ucTablePath === tablePath)
+      assert(report.versionOpt.isEmpty)
+      assert(report.timestampOpt.isPresent)
+      assert(report.timestampOpt.get() === timestampBetweenV1AndV2)
+      assert(!report.exception.isPresent)
+
+      val metrics = report.metrics
+      assert(metrics.totalLoadSnapshotDurationNs > 0)
+      assert(metrics.getCommitsDurationNs > 0)
+      assert(metrics.numCatalogCommits === 2) // v1.uuid.json and v2.uuid.json from loading latest
+      assert(metrics.kernelSnapshotBuildDurationNs > 0)
+      assert(metrics.loadLatestSnapshotForTimestampTimeTravelDurationNs > 0)
+      assert(metrics.resolvedSnapshotVersion === 1) // v1, since timestamp is between v1 and v2
+    }
+  }
+
+  test("telemetry captures exceptions during snapshot loading") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      val reporter = new CapturingMetricsReporter[UcLoadSnapshotTelemetry#Report]
+      val engineWithReporter = new io.delta.kernel.defaults.engine.DefaultEngine(
+        new io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO(
+          new org.apache.hadoop.conf.Configuration())) {
+        override def getMetricsReporters = java.util.Arrays.asList(reporter)
+      }
+
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val (_, ucCatalogManagedClient) = createUCClientAndCatalogManagedClient()
+
+      intercept[RuntimeException] {
+        // Try to load snapshot from non-existent table
+        ucCatalogManagedClient.loadSnapshot(
+          engineWithReporter,
+          "nonExistentTableId",
+          tablePath,
+          Optional.empty(),
+          Optional.empty())
+      }
+
+      assert(reporter.reports.size === 1)
+      val report = reporter.reports.head
+      assert(report.operationType === "UcLoadSnapshot")
+      assert(report.ucTableId === "nonExistentTableId")
+      assert(report.exception.isPresent)
+      assert(report.metrics.numCatalogCommits === -1) // Not set due to failure
+      assert(report.metrics.resolvedSnapshotVersion === -1) // Not set due to failure
+    }
+  }
+
+  test("JSON serialization: success report for latest version") {
+    val telemetry = new UcLoadSnapshotTelemetry(
+      "ucTableId",
+      "ucTablePath",
+      Optional.empty(), // versionOpt
+      Optional.empty() // timestampOpt
+    )
+
+    telemetry.getMetricsCollector.totalSnapshotLoadTimer.record(500)
+    telemetry.getMetricsCollector.getCommitsTimer.record(200)
+    telemetry.getMetricsCollector.kernelSnapshotBuildTimer.record(250)
+    telemetry.getMetricsCollector.setNumCatalogCommits(5)
+    telemetry.getMetricsCollector.setResolvedSnapshotVersion(3)
+
+    val report = telemetry.createSuccessReport()
+
+    // scalastyle:off line.size.limit
+    val expectedJson =
+      s"""
+         |{"operationType":"UcLoadSnapshot",
+         |"reportUUID":"${report.reportUUID}",
+         |"ucTableId":"ucTableId",
+         |"ucTablePath":"ucTablePath",
+         |"versionOpt":null,
+         |"timestampOpt":null,
+         |"metrics":{"totalLoadSnapshotDurationNs":500,"getCommitsDurationNs":200,"numCatalogCommits":5,"kernelSnapshotBuildDurationNs":250,"loadLatestSnapshotForTimestampTimeTravelDurationNs":0,"resolvedSnapshotVersion":3},
+         |"exception":null}
+         |""".stripMargin.replaceAll("\n", "")
+    // scalastyle:on line.size.limit
+
+    assert(report.toJson() === expectedJson)
+  }
+
+  test("JSON serialization: failure report") {
+    val telemetry = new UcLoadSnapshotTelemetry(
+      "ucTableId",
+      "ucTablePath",
+      Optional.empty(), // versionOpt
+      Optional.of(123456789L) // timestampOpt
+    )
+
+    telemetry.getMetricsCollector.totalSnapshotLoadTimer.record(100)
+    telemetry.getMetricsCollector.getCommitsTimer.record(100)
+
+    val exception = new RuntimeException("Failed to load snapshot")
+    val report = telemetry.createFailureReport(exception)
+
+    // scalastyle:off line.size.limit
+    val expectedJson =
+      s"""
+         |{"operationType":"UcLoadSnapshot",
+         |"reportUUID":"${report.reportUUID}",
+         |"ucTableId":"ucTableId",
+         |"ucTablePath":"ucTablePath",
+         |"versionOpt":null,
+         |"timestampOpt":123456789,
+         |"metrics":{"totalLoadSnapshotDurationNs":100,"getCommitsDurationNs":100,"numCatalogCommits":-1,"kernelSnapshotBuildDurationNs":0,"loadLatestSnapshotForTimestampTimeTravelDurationNs":0,"resolvedSnapshotVersion":-1},
+         |"exception":"java.lang.RuntimeException: Failed to load snapshot"}
+         |""".stripMargin.replaceAll("\n", "")
+    // scalastyle:on line.size.limit
+
+    assert(report.toJson() === expectedJson)
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5493/files) to review incremental changes.
- [**stack/kernel_uc_load_snapshot_metrics**](https://github.com/delta-io/delta/pull/5493) [[Files changed](https://github.com/delta-io/delta/pull/5493/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR adds a new metrics report + unit tests for the UCCatalogManagedClient::loadSnapshot API.

For context, this integration is similar to the existing [commit](https://github.com/delta-io/delta/blob/master/unity/src/main/java/io/delta/unity/metrics/UcCommitTelemetry.java) and [publish](https://github.com/delta-io/delta/blob/master/unity/src/main/java/io/delta/unity/metrics/UcPublishTelemetry.java) metrics.

## How was this patch tested?

New UTs.

## Does this PR introduce _any_ user-facing changes?

No.
