### PR TITLE
[kernel-spark] Implement planInputPartitions and createReaderFactory for dsv2 streaming

### DIFF
--- a/kernel-spark/src/main/java/io/delta/kernel/spark/utils/PartitionUtils.java
+++ b/kernel-spark/src/main/java/io/delta/kernel/spark/utils/PartitionUtils.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.spark.utils;
+
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.spark.read.SparkReaderFactory;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.paths.SparkPath;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.execution.datasources.FileFormat$;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.execution.datasources.PartitioningUtils;
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat;
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import scala.Function1;
+import scala.Option;
+import scala.Tuple2;
+import scala.collection.Iterator;
+import scala.collection.JavaConverters;
+
+/** Utility class for partition-related operations shared across Delta Kernel Spark components. */
+public class PartitionUtils {
+
+  /**
+   * Calculate the maximum split bytes for file partitioning, considering total bytes and file
+   * count. This is used for optimal file splitting in both batch and streaming read.
+   */
+  public static long calculateMaxSplitBytes(
+      SparkSession sparkSession, long totalBytes, int fileCount, SQLConf sqlConf) {
+    long defaultMaxSplitBytes = sqlConf.filesMaxPartitionBytes();
+    long openCostInBytes = sqlConf.filesOpenCostInBytes();
+    Option<Object> minPartitionNumOption = sqlConf.filesMinPartitionNum();
+
+    int minPartitionNum =
+        minPartitionNumOption.isDefined()
+            ? ((Number) minPartitionNumOption.get()).intValue()
+            : sqlConf
+                .getConf(SQLConf.LEAF_NODE_DEFAULT_PARALLELISM())
+                .getOrElse(() -> sparkSession.sparkContext().defaultParallelism());
+    if (minPartitionNum <= 0) {
+      minPartitionNum = 1;
+    }
+
+    long calculatedTotalBytes = totalBytes + (long) fileCount * openCostInBytes;
+    long bytesPerCore = calculatedTotalBytes / minPartitionNum;
+
+    return Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore));
+  }
+
+  /**
+   * Build the partition {@link InternalRow} from kernel partition values by casting them to the
+   * desired Spark types using the session time zone for temporal types.
+   */
+  public static InternalRow getPartitionRow(
+      MapValue partitionValues, StructType partitionSchema, ZoneId zoneId) {
+    final int numPartCols = partitionSchema.fields().length;
+    assert partitionValues.getSize() == numPartCols
+        : String.format(
+            java.util.Locale.ROOT,
+            "Partition values size from add file %d != partition columns size %d",
+            partitionValues.getSize(),
+            numPartCols);
+
+    final Object[] values = new Object[numPartCols];
+
+    // Build field name -> index map once
+    final Map<String, Integer> fieldIndex = new HashMap<>(numPartCols);
+    for (int i = 0; i < numPartCols; i++) {
+      fieldIndex.put(partitionSchema.fields()[i].name(), i);
+      values[i] = null;
+    }
+
+    // Fill values in a single pass over partitionValues
+    for (int idx = 0; idx < partitionValues.getSize(); idx++) {
+      final String key = partitionValues.getKeys().getString(idx);
+      final String strVal = partitionValues.getValues().getString(idx);
+      final Integer pos = fieldIndex.get(key);
+      if (pos != null) {
+        final StructField field = partitionSchema.fields()[pos];
+        values[pos] =
+            (strVal == null)
+                ? null
+                : PartitioningUtils.castPartValueToDesiredType(field.dataType(), strVal, zoneId);
+      }
+    }
+    return InternalRow.fromSeq(
+        JavaConverters.asScalaIterator(Arrays.asList(values).iterator()).toSeq());
+  }
+
+  /**
+   * Build a PartitionedFile from an AddFile with the given partition schema and table path.
+   *
+   * @param addFile The AddFile to convert
+   * @param partitionSchema The partition schema for parsing partition values
+   * @param tablePath The table path (must end with '/')
+   * @param zoneId The timezone for temporal partition values
+   * @return A PartitionedFile ready for Spark execution
+   */
+  public static PartitionedFile buildPartitionedFile(
+      AddFile addFile, StructType partitionSchema, String tablePath, ZoneId zoneId) {
+    InternalRow partitionRow =
+        getPartitionRow(addFile.getPartitionValues(), partitionSchema, zoneId);
+
+    // Preferred node locations are not used.
+    String[] preferredLocations = new String[0];
+    // Constant metadata columns are not used.
+    scala.collection.immutable.Map<String, Object> otherConstantMetadataColumnValues =
+        scala.collection.immutable.Map$.MODULE$.empty();
+
+    return new PartitionedFile(
+        partitionRow,
+        SparkPath.fromUrlString(tablePath + addFile.getPath()),
+        /* start= */ 0L,
+        /* length= */ addFile.getSize(),
+        preferredLocations,
+        addFile.getModificationTime(),
+        /* fileSize= */ addFile.getSize(),
+        otherConstantMetadataColumnValues);
+  }
+
+  /** Create a PartitionReaderFactory for reading Parquet files with partition support. */
+  public static PartitionReaderFactory createParquetReaderFactory(
+      StructType dataSchema,
+      StructType partitionSchema,
+      StructType readDataSchema,
+      Filter[] dataFilters,
+      scala.collection.immutable.Map<String, String> scalaOptions,
+      Configuration hadoopConf,
+      SQLConf sqlConf) {
+    boolean enableVectorizedReader =
+        ParquetUtils.isBatchReadSupportedForSchema(sqlConf, readDataSchema);
+    scala.collection.immutable.Map<String, String> optionsWithVectorizedReading =
+        scalaOptions.$plus(
+            new Tuple2<>(
+                FileFormat$.MODULE$
+                    .OPTION_RETURNING_BATCH(), // Option name for enabling vectorized reading
+                String.valueOf(enableVectorizedReader)));
+    // TODO(#5318): deletion vector support.
+    Function1<PartitionedFile, Iterator<InternalRow>> readFunc =
+        new ParquetFileFormat()
+            .buildReaderWithPartitionValues(
+                SparkSession.active(),
+                dataSchema,
+                partitionSchema,
+                readDataSchema,
+                JavaConverters.asScalaBuffer(Arrays.asList(dataFilters)).toSeq(),
+                optionsWithVectorizedReading,
+                hadoopConf);
+
+    return new SparkReaderFactory(readFunc, enableVectorizedReader);
+  }
+}

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkMicroBatchStreamGetStartingVersionTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkMicroBatchStreamGetStartingVersionTest.java
@@ -90,7 +90,7 @@ public class SparkMicroBatchStreamGetStartingVersionTest extends SparkDsv2TestBa
 
     // dsv1
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
-    DeltaOptions emptyOptions = new DeltaOptions(Map$.MODULE$.empty(), spark.sessionState().conf());
+    DeltaOptions emptyOptions = emptyDeltaOptions();
     DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath, emptyOptions);
     scala.Option<Object> dsv1Result = deltaSource.getStartingVersion();
 
@@ -98,8 +98,7 @@ public class SparkMicroBatchStreamGetStartingVersionTest extends SparkDsv2TestBa
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
     SparkMicroBatchStream dsv2Stream =
-        new SparkMicroBatchStream(
-            snapshotManager, snapshotManager.loadLatestSnapshot(), new Configuration());
+        createTestStreamWithDefaults(snapshotManager, new Configuration(), emptyDeltaOptions());
     Optional<Long> dsv2Result = dsv2Stream.getStartingVersion();
 
     compareStartingVersionResults(dsv1Result, dsv2Result, Optional.empty(), "No options provided");
@@ -220,12 +219,8 @@ public class SparkMicroBatchStreamGetStartingVersionTest extends SparkDsv2TestBa
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
     SparkMicroBatchStream dsv2Stream =
-        new SparkMicroBatchStream(
-            snapshotManager,
-            snapshotManager.loadLatestSnapshot(),
-            new Configuration(),
-            spark,
-            createDeltaOptions(startingVersion));
+        createTestStreamWithDefaults(
+            snapshotManager, new Configuration(), createDeltaOptions(startingVersion));
     Optional<Long> dsv2Result = dsv2Stream.getStartingVersion();
 
     compareStartingVersionResults(
@@ -238,6 +233,23 @@ public class SparkMicroBatchStreamGetStartingVersionTest extends SparkDsv2TestBa
   // ================================================================================================
   // Helper methods
   // ================================================================================================
+
+  /** Helper method to create a SparkMicroBatchStream with default empty values for testing. */
+  private SparkMicroBatchStream createTestStreamWithDefaults(
+      PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
+    return new SparkMicroBatchStream(
+        snapshotManager,
+        snapshotManager.loadLatestSnapshot(),
+        hadoopConf,
+        spark,
+        options,
+        /* tablePath= */ "",
+        /* dataSchema= */ new org.apache.spark.sql.types.StructType(),
+        /* partitionSchema= */ new org.apache.spark.sql.types.StructType(),
+        /* readDataSchema= */ new org.apache.spark.sql.types.StructType(),
+        /* dataFilters= */ new org.apache.spark.sql.sources.Filter[0],
+        /* scalaOptions= */ scala.collection.immutable.Map$.MODULE$.empty());
+  }
 
   /** Helper method to create multiple versions by inserting rows. */
   private void createVersions(String testTableName, int numVersions) {
@@ -263,12 +275,8 @@ public class SparkMicroBatchStreamGetStartingVersionTest extends SparkDsv2TestBa
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
     SparkMicroBatchStream dsv2Stream =
-        new SparkMicroBatchStream(
-            snapshotManager,
-            snapshotManager.loadLatestSnapshot(),
-            new Configuration(),
-            spark,
-            createDeltaOptions(startingVersion));
+        createTestStreamWithDefaults(
+            snapshotManager, new Configuration(), createDeltaOptions(startingVersion));
     Optional<Long> dsv2Result = dsv2Stream.getStartingVersion();
 
     compareStartingVersionResults(dsv1Result, dsv2Result, expectedVersion, testDescription);
@@ -297,11 +305,15 @@ public class SparkMicroBatchStreamGetStartingVersionTest extends SparkDsv2TestBa
         /* filters= */ emptySeq);
   }
 
+  private DeltaOptions emptyDeltaOptions() {
+    return new DeltaOptions(Map$.MODULE$.empty(), spark.sessionState().conf());
+  }
+
   /** Helper method to create DeltaOptions with startingVersion for testing. */
   private DeltaOptions createDeltaOptions(String startingVersionValue) {
     if (startingVersionValue == null) {
       // Empty options
-      return new DeltaOptions(Map$.MODULE$.empty(), spark.sessionState().conf());
+      return emptyDeltaOptions();
     } else {
       // Create Scala Map with startingVersion
       scala.collection.immutable.Map<String, String> scalaMap =

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/utils/PartitionUtilsTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/utils/PartitionUtilsTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.spark.utils;
+
+import static io.delta.kernel.internal.util.VectorUtils.stringStringMapValue;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.Scan;
+import io.delta.kernel.Table;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.spark.SparkDsv2TestBase;
+import io.delta.kernel.utils.CloseableIterator;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import scala.collection.immutable.Map$;
+
+public class PartitionUtilsTest extends SparkDsv2TestBase {
+
+  private static final long MB = 1024 * 1024;
+
+  @Test
+  public void testGetPartitionRow_FieldOrdering() {
+    // Schema defines order: year, month, day
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("year", DataTypes.IntegerType, true),
+              DataTypes.createStructField("month", DataTypes.IntegerType, true),
+              DataTypes.createStructField("day", DataTypes.IntegerType, true)
+            });
+
+    // map value has different order: day, year, month
+    Map<String, String> partitionValues = new HashMap<>();
+    partitionValues.put("day", "25");
+    partitionValues.put("year", "2024");
+    partitionValues.put("month", "11");
+
+    MapValue mapValue = stringStringMapValue(partitionValues);
+    InternalRow row = PartitionUtils.getPartitionRow(mapValue, partitionSchema, ZoneId.of("UTC"));
+
+    // verify order is schema order: year, month, day
+    assertEquals(2024, row.getInt(0));
+    assertEquals(11, row.getInt(1));
+    assertEquals(25, row.getInt(2));
+  }
+
+  @Test
+  public void testGetPartitionRow_SizeMismatchExtraKeys() {
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("year", DataTypes.IntegerType, true),
+              DataTypes.createStructField("month", DataTypes.IntegerType, true)
+            });
+
+    Map<String, String> partitionValues = new HashMap<>();
+    partitionValues.put("year", "2024");
+    partitionValues.put("month", "11");
+    partitionValues.put("day", "25");
+    partitionValues.put("hour", "10");
+
+    MapValue mapValue = stringStringMapValue(partitionValues);
+
+    assertThrows(
+        AssertionError.class,
+        () -> PartitionUtils.getPartitionRow(mapValue, partitionSchema, ZoneId.of("UTC")));
+  }
+
+  @Test
+  public void testGetPartitionRow_SizeMismatchMissingKeys() {
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("year", DataTypes.IntegerType, true),
+              DataTypes.createStructField("month", DataTypes.IntegerType, true),
+              DataTypes.createStructField("day", DataTypes.IntegerType, true)
+            });
+
+    Map<String, String> partitionValues = new HashMap<>();
+    partitionValues.put("year", "2024");
+    partitionValues.put("month", "11");
+
+    MapValue mapValue = stringStringMapValue(partitionValues);
+
+    assertThrows(
+        AssertionError.class,
+        () -> PartitionUtils.getPartitionRow(mapValue, partitionSchema, ZoneId.of("UTC")));
+  }
+
+  @Test
+  public void testCreateParquetReaderFactory_Basic() {
+    StructType dataSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("name", DataTypes.StringType, true)
+            });
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("year", DataTypes.IntegerType, true)});
+    StructType readDataSchema = dataSchema;
+    Filter[] filters = new Filter[0];
+    scala.collection.immutable.Map<String, String> options = Map$.MODULE$.empty();
+    Configuration hadoopConf = new Configuration();
+    SQLConf sqlConf = SQLConf.get();
+
+    PartitionReaderFactory factory =
+        PartitionUtils.createParquetReaderFactory(
+            dataSchema, partitionSchema, readDataSchema, filters, options, hadoopConf, sqlConf);
+
+    assertNotNull(factory, "PartitionReaderFactory should not be null");
+  }
+
+  @Test
+  public void testCalculateMaxSplitBytes_Basic() {
+    SQLConf sqlConf = SQLConf.get();
+    long minPartitionNum = 4;
+    sqlConf.setConfString("spark.sql.files.minPartitionNum", String.valueOf(minPartitionNum));
+
+    long totalBytes = 100 * MB;
+    int fileCount = 10;
+
+    long result = PartitionUtils.calculateMaxSplitBytes(spark, totalBytes, fileCount, sqlConf);
+    long openCostInBytes = sqlConf.filesOpenCostInBytes();
+    long maxPartitionBytes = sqlConf.filesMaxPartitionBytes();
+
+    long calculatedTotalBytes = totalBytes + (long) fileCount * openCostInBytes;
+    assertEquals(calculatedTotalBytes / minPartitionNum, result);
+  }
+
+  @Test
+  public void testCalculateMaxSplitBytes_BoundaryConditions() {
+    SQLConf sqlConf = SQLConf.get();
+    // Set minPartitionNum=1 for predictable calculations
+    sqlConf.setConfString("spark.sql.files.minPartitionNum", "1");
+    long openCostInBytes = sqlConf.filesOpenCostInBytes();
+    long maxPartitionBytes = sqlConf.filesMaxPartitionBytes();
+
+    // Zero files and bytes
+    long result1 = PartitionUtils.calculateMaxSplitBytes(spark, 0L, 0, sqlConf);
+    assertEquals(openCostInBytes, result1);
+
+    // Single large file (exceeds maxPartitionBytes)
+    long result2 = PartitionUtils.calculateMaxSplitBytes(spark, 1000 * MB, 1, sqlConf);
+    assertEquals(maxPartitionBytes, result2);
+
+    // Very small totalBytes
+    long result3 = PartitionUtils.calculateMaxSplitBytes(spark, 1024L, 1, sqlConf);
+    long expected3 = 1024L + openCostInBytes;
+    assertEquals(expected3, result3);
+
+    // Many small files
+    long result4 = PartitionUtils.calculateMaxSplitBytes(spark, 1 * MB, 1000, sqlConf);
+    assertEquals(maxPartitionBytes, result4);
+  }
+
+  @Test
+  public void testCalculateMaxSplitBytes_UndefinedMinPartitionNum() {
+    SQLConf sqlConf = SQLConf.get();
+    // Ensure filesMinPartitionNum is undefined
+    if (sqlConf.filesMinPartitionNum().isDefined()) {
+      sqlConf.unsetConf("spark.sql.files.minPartitionNum");
+    }
+
+    long totalBytes = 200 * MB;
+    int fileCount = 10;
+
+    long result = PartitionUtils.calculateMaxSplitBytes(spark, totalBytes, fileCount, sqlConf);
+
+    // Verify the result is still valid
+    assertTrue(result > 0);
+    assertTrue(result >= sqlConf.filesOpenCostInBytes());
+    assertTrue(result <= sqlConf.filesMaxPartitionBytes());
+    long calculatedTotalBytes = totalBytes + (long) fileCount * sqlConf.filesOpenCostInBytes();
+    assertTrue(result <= calculatedTotalBytes);
+  }
+
+  @Test
+  public void testBuildPartitionedFile() throws Exception {
+    String tablePath = createTestTable("test_build_partitioned_file_" + System.nanoTime(), true);
+
+    // Get an AddFile from the table
+    Table table = Table.forPath(defaultEngine, tablePath);
+    Scan scan = table.getLatestSnapshot(defaultEngine).getScanBuilder().build();
+    FilteredColumnarBatch batch = scan.getScanFiles(defaultEngine).next();
+    CloseableIterator<Row> rows = batch.getRows();
+    AddFile addFile = new AddFile(rows.next().getStruct(0));
+    rows.close();
+
+    // Build PartitionedFile
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("part", DataTypes.StringType, true)});
+    String normalizedTablePath = tablePath.endsWith("/") ? tablePath : tablePath + "/";
+    PartitionedFile partitionedFile =
+        PartitionUtils.buildPartitionedFile(
+            addFile, partitionSchema, normalizedTablePath, ZoneId.of("UTC"));
+
+    assertNotNull(partitionedFile);
+    assertEquals(addFile.getSize(), partitionedFile.fileSize());
+    assertEquals(1, partitionedFile.partitionValues().numFields());
+  }
+
+  /** Helper to create a test Delta table. */
+  private String createTestTable(String tableName, boolean partitioned) {
+    String tablePath = getTempTablePath(tableName);
+    if (partitioned) {
+      spark
+          .range(10)
+          .selectExpr("id", "cast(id % 3 as string) as part")
+          .write()
+          .format("delta")
+          .partitionBy("part")
+          .save(tablePath);
+    } else {
+      spark.range(10).write().format("delta").save(tablePath);
+    }
+    return tablePath;
+  }
+
+  private String getTempTablePath(String tableName) {
+    return java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"), "delta-test-" + tableName)
+        .toString();
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5499/files) to review incremental changes.
- [**stack/plan1**](https://github.com/delta-io/delta/pull/5499) [[Files changed](https://github.com/delta-io/delta/pull/5499/files)]
  - [stack/integration](https://github.com/delta-io/delta/pull/5572) [[Files changed](https://github.com/delta-io/delta/pull/5572/files/a0512bb563ff00a31461c2a188e11d59f19146e1..321432605fc1efe3253b30116de2d389f6f66977)]
    - [stack/integration2](https://github.com/delta-io/delta/pull/5652) [[Files changed](https://github.com/delta-io/delta/pull/5652/files/321432605fc1efe3253b30116de2d389f6f66977..dee64c4ca3abbdd530c232e42325e702e9d61a0b)]
      - [stack/reader](https://github.com/delta-io/delta/pull/5638) [[Files changed](https://github.com/delta-io/delta/pull/5638/files/dee64c4ca3abbdd530c232e42325e702e9d61a0b..7703f4a8ddd89414002fab23cc694d5538eeb0e3)]
        - [stack/lazy](https://github.com/delta-io/delta/pull/5650) [[Files changed](https://github.com/delta-io/delta/pull/5650/files/7703f4a8ddd89414002fab23cc694d5538eeb0e3..44e60b5bf03641eaff1ca8bb6fec10927aa6d98e)]
          - [stack/snapshot](https://github.com/delta-io/delta/pull/5651) [[Files changed](https://github.com/delta-io/delta/pull/5651/files/44e60b5bf03641eaff1ca8bb6fec10927aa6d98e..26ab449443a7542c572808a934e43a5692605c46)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In this PR, we implement the DSv2 methods `planInputPartitions()` and `createReaderFactory()`. 
These are DSv2-only API that will replace DSv1's `getBatch()`

`planInputPartitions()`:   Returns physical partitions describing how to read the data; Called once per micro-batch during planning 
`createReaderFactory()`: Returns a factory that creates readers for the partitions; Each executor uses this factory to read its assigned partitions


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
