### PR TITLE
[kernel] Add support for the materializePartitionColumns writer feature

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -209,7 +209,7 @@ public class TransactionImpl implements Transaction {
 
   @Override
   public Row getTransactionState(Engine engine) {
-    return TransactionStateRow.of(metadata, dataPath.toString(), maxRetries);
+    return TransactionStateRow.of(metadata, protocol, dataPath.toString(), maxRetries);
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -507,6 +507,15 @@ public class TableFeatures {
     }
   }
 
+  public static final TableFeature MATERIALIZE_PARTITION_COLUMNS_W_FEATURE =
+      new MaterializePartitionColumnsFeature();
+
+  private static class MaterializePartitionColumnsFeature extends TableFeature.WriterFeature {
+    MaterializePartitionColumnsFeature() {
+      super("materializePartitionColumns", /* minWriterVersion = */ 7);
+    }
+  }
+
   /////////////////////////////////////////////////////////////////////////////////
   /// END: Define the {@link TableFeature}s                                     ///
   /////////////////////////////////////////////////////////////////////////////////
@@ -540,6 +549,7 @@ public class TableFeatures {
               IDENTITY_COLUMNS_W_FEATURE,
               IN_COMMIT_TIMESTAMP_W_FEATURE,
               INVARIANTS_W_FEATURE,
+              MATERIALIZE_PARTITION_COLUMNS_W_FEATURE,
               ROW_TRACKING_W_FEATURE,
               TIMESTAMP_NTZ_RW_FEATURE,
               TYPE_WIDENING_RW_PREVIEW_FEATURE,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/GenerateIcebergCompatActionUtilsSuite.scala
@@ -50,9 +50,16 @@ class GenerateIcebergCompatActionUtilsSuite extends AnyFunSuite {
       VectorUtils.buildArrayValue(partitionColumns.asJava, StringType.STRING),
       Optional.empty(), /* createdTime */
       VectorUtils.stringStringMapValue(tblProperties.asJava))
+    val protocol = new Protocol(
+      3, // minReaderVersion
+      7, // minWriterVersion to support table features
+      java.util.Collections.emptySet[String](), // readerFeatures
+      java.util.Collections.emptySet[String]() // writerFeatures
+    )
 
     TransactionStateRow.of(
       ColumnMapping.updateColumnMappingMetadataIfNeeded(metadata, true).orElse(metadata),
+      protocol,
       testTablePath,
       maxRetries)
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -68,7 +68,8 @@ class TableFeaturesSuite extends AnyFunSuite {
     "inCommitTimestamp",
     "icebergWriterCompatV1",
     "icebergWriterCompatV3",
-    "clustering")
+    "clustering",
+    "materializePartitionColumns")
 
   val legacyFeatures = Seq(
     "appendOnly",
@@ -286,7 +287,8 @@ class TableFeaturesSuite extends AnyFunSuite {
       "clustering",
       "variantType-preview",
       "variantType",
-      "variantShredding-preview")
+      "variantShredding-preview",
+      "materializePartitionColumns")
 
     assert(results.map(_.featureName()).toSet == expected.toSet)
   }
@@ -643,6 +645,11 @@ class TableFeaturesSuite extends AnyFunSuite {
   checkWriteSupported(
     "validateKernelCanWriteToTable: protocol 7 with clustering",
     new Protocol(3, 7, emptySet(), singleton("clustering")),
+    testMetadata())
+
+  checkWriteSupported(
+    "validateKernelCanWriteToTable: protocol 7 with materializePartitionColumns",
+    new Protocol(3, 7, emptySet(), singleton("materializePartitionColumns")),
     testMetadata())
 
   checkWriteSupported(


### PR DESCRIPTION
Java kernel equivalent of https://github.com/delta-io/delta-kernel-rs/pull/1476
Relevant protocol change: https://github.com/delta-io/delta/pull/5494

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This change adds support for the writer feature
materializePartitionColumns that requires all writers to include partition columns in parquet file schema.

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

No - squared away behind a writer feature.
