### PR TITLE
[Spark][Infra] Change delta spark default logging level from info -> warn

### DIFF
--- a/spark/src/test/resources/log4j2.properties
+++ b/spark/src/test/resources/log4j2.properties
@@ -28,7 +28,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
 
 appender.file.type = File

--- a/spark/src/test/resources/log4j2_spark_master.properties
+++ b/spark/src/test/resources/log4j2_spark_master.properties
@@ -28,7 +28,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
 
 appender.file.type = File


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Info logs are overloading the github actions CI for delta spark jobs. Note this also changes the default local level but this can be configured as needed.

## How was this patch tested?

See CI.

## Does this PR introduce _any_ user-facing changes?

No.