### PR TITLE
[Spark] reduce size of optimize in RowTrackingBackfillConflictsSuite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillConflictsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillConflictsSuite.scala
@@ -679,7 +679,7 @@ class RowTrackingBackfillConflictsSuite extends RowTrackingBackfillConflictsTest
   }
 
   testAllScenarios("OPTIMIZE") { () =>
-    sql(s"OPTIMIZE $testTableName WHERE $partitionColumnName < ($numFiles / 2)").collect()
+    sql(s"OPTIMIZE $testTableName WHERE $partitionColumnName < ($numFiles / 4)").collect()
   } { () =>
     tableCreationDF
   }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This reduces the size of data optimized in the Optimize call in RowTrackingBackfillConflictsSuite and should increase odds of success of this test.

## How was this patch tested?

Test-only change

## Does this PR introduce _any_ user-facing changes?

No
