### PR TITLE
[UC] Rename uc table id property to `io.unitycatalog.tableId`

### DIFF
--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
@@ -58,8 +58,10 @@ import org.slf4j.LoggerFactory;
 public class UCCatalogManagedClient {
   private static final Logger logger = LoggerFactory.getLogger(UCCatalogManagedClient.class);
 
+  public static final String UC_PROPERTY_NAMESPACE_PREFIX = "io.unitycatalog.";
+
   /** Key for identifying Unity Catalog table ID. */
-  public static final String UC_TABLE_ID_KEY = "catalogManaged.unityCatalog.tableId";
+  public static final String UC_TABLE_ID_KEY = UC_PROPERTY_NAMESPACE_PREFIX + "tableId";
 
   protected final UCClient ucClient;
 

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedClientSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedClientSuite.scala
@@ -284,7 +284,7 @@ class UCCatalogManagedClientSuite extends AnyFunSuite with UCCatalogManagedTestU
     // ===== THEN =====
     val builderTableProperties = createTableTxnBuilder.getTablePropertiesOpt.get()
     assert(builderTableProperties.get("delta.feature.catalogManaged") == "supported")
-    assert(builderTableProperties.get("catalogManaged.unityCatalog.tableId") == testUcTableId)
+    assert(builderTableProperties.get("io.unitycatalog.tableId") == testUcTableId)
     assert(builderTableProperties.get("foo") == "bar")
 
     val committerOpt = createTableTxnBuilder.getCommitterOpt


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5577/files) to review incremental changes.
- [**stack/kernel_uc_rename_io_unitycatalog_prop**](https://github.com/delta-io/delta/pull/5577) [[Files changed](https://github.com/delta-io/delta/pull/5577/files)]

---------

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Rename uc table id property to `io.unitycatalog.tableId`

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No
