### PR TITLE
Rename table loading methods in DeltaCatalog for clarity

### DIFF
--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -65,7 +65,7 @@ import org.apache.spark.sql.connector.catalog.Table;
 public class DeltaCatalog extends AbstractDeltaCatalog {
 
   /**
-   * Loads a Delta table from a catalog.
+   * Loads a Delta table that is registered in the catalog.
    *
    * <p>Routing logic based on {@link DeltaSQLConfV2#V2_ENABLE_MODE}:
    * <ul>
@@ -73,9 +73,9 @@ public class DeltaCatalog extends AbstractDeltaCatalog {
    *   <li>NONE (default): Returns {@link DeltaTableV2} (V1 connector)</li>
    * </ul>
    *
-   * @param ident Table identifier
-   * @param catalogTable Catalog table metadata
-   * @return Table instance (SparkTable for V2, DeltaTableV2 for V1)
+   * @param ident The identifier of the table in the catalog.
+   * @param catalogTable The catalog table metadata containing table properties and location.
+   * @return Table instance (SparkTable for V2, DeltaTableV2 for V1).
    */
   @Override
   public Table loadCatalogTable(Identifier ident, CatalogTable catalogTable) {
@@ -85,7 +85,8 @@ public class DeltaCatalog extends AbstractDeltaCatalog {
   }
 
   /**
-   * Loads a path-based Delta table.
+   * Loads a Delta table directly from a path.
+   * This is used for path-based table access where the identifier name is the table path.
    *
    * <p>Routing logic based on {@link DeltaSQLConfV2#V2_ENABLE_MODE}:
    * <ul>
@@ -93,8 +94,8 @@ public class DeltaCatalog extends AbstractDeltaCatalog {
    *   <li>NONE (default): Returns {@link DeltaTableV2} (V1 connector)</li>
    * </ul>
    *
-   * @param ident Table identifier containing table path
-   * @return Table instance (SparkTable for V2, DeltaTableV2 for V1)
+   * @param ident The identifier whose name contains the path to the Delta table.
+   * @return Table instance (SparkTable for V2, DeltaTableV2 for V1).
    */
   @Override
   public Table loadPathTable(Identifier ident) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -316,6 +316,13 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   }
 
 
+  /**
+   * Loads a Delta table that is registered in the catalog.
+   *
+   * @param ident The identifier of the table in the catalog.
+   * @param catalogTable The catalog table metadata containing table properties and location.
+   * @return A DeltaTableV2 instance with catalog metadata attached.
+   */
   protected def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table = {
     DeltaTableV2(
       spark,
@@ -324,6 +331,13 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       tableIdentifier = Some(ident.toString))
   }
 
+  /**
+   * Loads a Delta table directly from a path.
+   * This is used for path-based table access where the identifier name is the table path.
+   *
+   * @param ident The identifier whose name contains the path to the Delta table.
+   * @return A DeltaTableV2 instance loaded from the specified path.
+   */
   protected def loadPathTable(ident: Identifier): Table = {
     DeltaTableV2(spark, new Path(ident.name()))
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Follow-up of https://github.com/delta-io/delta/pull/5501.
Rename table loading methods to better reflect their purpose:

- `newDeltaCatalogBasedTable` → `loadCatalogTable`
- `newDeltaPathTable` → `loadPathTable`
- `createBasedOnV2Mode` → `loadTableInternal`

Updated corresponding Javadoc comments from "Creates" to "Loads" to match the method semantics.

## How was this patch tested?
Existing tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No