### PR TITLE
[Feature Request] [SPARK] Add explicit VACUUM type to Delta log for observability 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -906,12 +906,15 @@ object DeltaOperations {
    * @param retentionCheckEnabled - whether retention check was enabled for this run of vacuum.
    * @param specifiedRetentionMillis - specified retention interval
    * @param defaultRetentionMillis - default retention period for the table
+   * @param vacuumType - the type of vacuum that was run; for example, "FULL" or "LITE"
    */
   case class VacuumStart(
       retentionCheckEnabled: Boolean,
       specifiedRetentionMillis: Option[Long],
-      defaultRetentionMillis: Long) extends Operation(VacuumStart.OPERATION_NAME) {
+      defaultRetentionMillis: Long,
+      vacuumType: String) extends Operation(VacuumStart.OPERATION_NAME) {
     override val parameters: Map[String, Any] = Map(
+      "typeOfVacuum" -> vacuumType,
       "retentionCheckEnabled" -> retentionCheckEnabled,
       "defaultRetentionMillis" -> defaultRetentionMillis
     ) ++ specifiedRetentionMillis.map("specifiedRetentionMillis" -> _)
@@ -932,9 +935,13 @@ object DeltaOperations {
 
   /**
    * @param status - whether the vacuum operation was successful; either "COMPLETED" or "FAILED"
+   * @param vacuumType - the type of vacuum that was run; for example, "FULL" or "LITE"
    */
-  case class VacuumEnd(status: String) extends Operation(VacuumEnd.OPERATION_NAME) {
+  case class VacuumEnd(
+      status: String,
+      vacuumType: String) extends Operation(VacuumEnd.OPERATION_NAME) {
     override val parameters: Map[String, Any] = Map(
+      "typeOfVacuum" -> vacuumType,
       "status" -> status
     )
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -366,7 +366,8 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
             diffFiles,
             sizeOfDataToDelete,
             retentionMillis,
-            snapshotTombstoneRetentionMillis)
+            snapshotTombstoneRetentionMillis,
+            vacuumType.toString)
 
           val deleteStartTime = System.currentTimeMillis()
           val filesDeleted = try {
@@ -374,7 +375,8 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
               hadoopConf, parallelDeleteEnabled, parallelDeletePartitions)
           } catch {
             case t: Throwable =>
-              logVacuumEnd(spark, table, commandMetrics = commandMetrics)
+              logVacuumEnd(spark, table,
+                commandMetrics = commandMetrics, vacuumType = vacuumType.toString)
               throw t
           }
           val timeTakenForDelete = System.currentTimeMillis() - deleteStartTime
@@ -402,7 +404,8 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
             table,
             commandMetrics = commandMetrics,
             Some(filesDeleted),
-            Some(dirCounts))
+            Some(dirCounts),
+            vacuumType.toString)
 
           LastVacuumInfo.persistLastVacuumInfo(
             LastVacuumInfo(latestCommitVersionOutsideOfRetentionWindowOpt), deltaLog)
@@ -536,7 +539,8 @@ trait VacuumCommandImpl extends DeltaCommand {
       diff: Dataset[String],
       sizeOfDataToDelete: Long,
       specifiedRetentionMillis: Option[Long],
-      defaultRetentionMillis: Long): Unit = {
+      defaultRetentionMillis: Long,
+      vacuumType: String): Unit = {
     val deltaLog = table.deltaLog
     logInfo(
       log"Deleting untracked files and empty directories in " +
@@ -557,11 +561,13 @@ trait VacuumCommandImpl extends DeltaCommand {
       metrics("numFilesToDelete").set(diff.count())
       metrics("sizeOfDataToDelete").set(sizeOfDataToDelete)
       txn.registerSQLMetrics(spark, metrics)
-      val version = txn.commit(actions = Seq(), DeltaOperations.VacuumStart(
-        checkEnabled,
-        specifiedRetentionMillis,
-        defaultRetentionMillis
-      ))
+      val version = txn.commit(
+        actions = Seq(),
+        DeltaOperations.VacuumStart(
+          checkEnabled,
+          specifiedRetentionMillis,
+          defaultRetentionMillis,
+          vacuumType))
       setCommitClock(deltaLog, version)
     }
   }
@@ -581,7 +587,8 @@ trait VacuumCommandImpl extends DeltaCommand {
       table: DeltaTableV2,
       commandMetrics: Map[String, SQLMetric],
       filesDeleted: Option[Long] = None,
-      dirCounts: Option[Long] = None): Unit = {
+      dirCounts: Option[Long] = None,
+      vacuumType: String = "UNKNOWN"): Unit = {
     val deltaLog = table.deltaLog
     if (shouldLogVacuum(spark, table, deltaLog.newDeltaHadoopConf(), deltaLog.dataPath)) {
       val txn = table.startTransaction()
@@ -602,7 +609,8 @@ trait VacuumCommandImpl extends DeltaCommand {
         txn.registerSQLMetrics(spark, metrics)
       }
       val version = txn.commit(actions = Seq(), DeltaOperations.VacuumEnd(
-        status
+        status,
+        vacuumType
       ))
       setCommitClock(deltaLog, version)
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
@@ -176,10 +176,11 @@ class CommitInfoSerializerSuite extends QueryTest with SharedSparkSession {
       source = "s3://bucket/path/to/table",
       sourceVersion = 10L)),
     "VacuumStart" -> (() => DeltaOperations.VacuumStart(
-      retentionCheckEnabled = true,
-      specifiedRetentionMillis = Some(604800000L),
-      defaultRetentionMillis = 604800000L)),
-    "VacuumEnd" -> (() => DeltaOperations.VacuumEnd("COMPLETED")),
+      true,
+      Some(604800000L),
+      604800000L,
+      "FULL")),
+    "VacuumEnd" -> (() => DeltaOperations.VacuumEnd("COMPLETED", "FULL")),
     "Reorg" -> (() => DeltaOperations.Reorg(
       predicate = Seq(EqualTo(Literal("col1"), Literal("value1"))),
       applyPurge = true)),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -1411,6 +1411,8 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
             assert(operationParamsBegin("retentionCheckEnabled") === "false")
             assert(operationMetricsBegin("numFilesToDelete") === filesDeleted.toString)
             assert(operationMetricsBegin("sizeOfDataToDelete") === (filesDeleted * 9).toString)
+            assert(operationParamsBegin("typeOfVacuum") ===
+              (if (isLiteVacuum) "LITE" else "FULL"))
 
             if (retentionHours == 0) {
               assert(
@@ -1421,7 +1423,10 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
               operationParamsBegin("defaultRetentionMillis") ===
                 DeltaLog.tombstoneRetentionMillis(table.initialSnapshot.metadata).toString)
 
-            assert(operationParamsEnd === Map("status" -> "COMPLETED"))
+            val expectedVacuumType = if (isLiteVacuum) "LITE" else "FULL"
+            assert(operationParamsEnd === Map(
+              "typeOfVacuum" -> expectedVacuumType,
+              "status" -> "COMPLETED"))
             assert(operationMetricsEnd === Map("numDeletedFiles" -> filesDeleted.toString,
               "numVacuumedDirectories" -> "1"))
           }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

### Overview

Improve observability of Delta Lake maintenance operations by adding an explicit type  for VACUUM commands in the Delta transaction log to differentiate between VACUUM FULLL or VACUUM LITE when users check delta history.Fixes #5586 

This would allow users  that read the transaction log to distinguish VACUUM vs VACUUM LITE runs in a simple, structured way, without having to infer the type of vacuum deep diving into the logs.

### Motivation

Today, VACUUM operations are logged in the Delta transaction log via commitInfo entries such as:

- operation = "VACUUM START" / "VACUUM END"
- operationParameters containing retention and other runtime parameters

However, there is no explicit, stable field that indicates whether the command that produced those commits was:

```
VACUUM <table> RETAIN N HOURS (full vacuum)

( or )

VACUUM <table> LITE RETAIN N HOURS (lite vacuum).
```

#### Summary of Changes

##### **DeltaOperations.scala**

- Extended **DeltaOperations.VacuumStart** to take a new **opType** parameter.
- Updated **VacuumStart.parameters** to include "opType" -> opType as the first key in the map. Now the json would look something like 
`{"opType": "FULL" | "LITE", "retentionCheckEnabled": ..., "defaultRetentionMillis": ..., ...}`
- Left DeltaOperations.VacuumEnd unchanged .

##### **VacuumCommand***

- Updated logVacuumStart to accept an opType: String argument.
- When calling logVacuumStart, passed vacuumType.toString ("FULL" or "LITE") so that:
- VACUUM START entries in the log now record the type of vacuum run in **operationParameters.opType**.


## How was this patch tested?

- Ran the below code , on delta-3.3.0 before the change and then ran the same code by building an assembly jar after the fix and below is the difference

#### Code used for testing:
```
import org.apache.spark.sql.functions._
import java.nio.file.{Files, Paths}
import scala.util.Try

val path = "/tmp/delta_vacuum"

// Clean up from previous runs
Try {
  import sys.process._
  s"rm -rf $path".!
}

// Write a simple Delta table
spark.range(10).write.format("delta").mode("overwrite").save(path)

// Make a few commits so VACUUM has something to work with
spark.range(10, 20).write.format("delta").mode("append").save(path)
spark.range(20, 30).write.format("delta").mode("append").save(path)

// Disable retention check for testing
spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")

// Run VACUUM LITE
spark.sql(s"VACUUM delta.`$path` LITE RETAIN 0 HOURS")

// Read the Delta log JSON files
val logDf = spark.read.json(s"$path/_delta_log/*.json")

logDf
  .select(
    "commitInfo.operation",
    "commitInfo.operationParameters",
    "commitInfo.operationMetrics"
  )
  .where("commitInfo.operation like 'VACUUM%'")

// Convert operationParameters / operationMetrics structs to JSON strings
val vacuumOps = logDf
  .select(
    col("commitInfo.operation").as("operation"),
    col("commitInfo.operationParameters").as("operationParameters"),
    col("commitInfo.operationMetrics").as("operationMetrics")
  )
  .where(col("operation").like("VACUUM%"))
  .withColumn("operationParameters", to_json(col("operationParameters")))
  .withColumn("operationMetrics", to_json(col("operationMetrics")))

vacuumOps
  .select("operation", "operationParameters", "operationMetrics")
  .show(truncate = false)
```

#### Logs using spark 3.5.2 ,delta 3.3.0

```
[root@hadoop /]# spark-shell   --packages io.delta:delta-spark_2.13:3.3.0   --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension   --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog
:: loading settings :: url = jar:file:/usr/bin/spark-3.5.2-bin-hadoop3/jars/ivy-2.5.1.jar!/org/apache/ivy/core/settings/ivysettings.xml
Ivy Default Cache set to: /root/.ivy2/cache
The jars for the packages stored in: /root/.ivy2/jars
io.delta#delta-spark_2.13 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-92e59b5b-1b44-4ed9-a102-7691081efd31;1.0
	confs: [default]
	found io.delta#delta-spark_2.13;3.3.0 in central
	found io.delta#delta-storage;3.3.0 in central
	found org.antlr#antlr4-runtime;4.9.3 in central
:: resolution report :: resolve 59ms :: artifacts dl 2ms
	:: modules in use:
	io.delta#delta-spark_2.13;3.3.0 from central in [default]
	io.delta#delta-storage;3.3.0 from central in [default]
	org.antlr#antlr4-runtime;4.9.3 from central in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   3   |   0   |   0   |   0   ||   3   |   0   |
	---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-92e59b5b-1b44-4ed9-a102-7691081efd31
	confs: [default]
	0 artifacts copied, 3 already retrieved (0kB/2ms)
25/11/25 15:18:41 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.5.2
      /_/
         
Using Scala version 2.13.8 (OpenJDK 64-Bit Server VM, Java 17.0.9)
Type in expressions to have them evaluated.
Type :help for more information.
Spark context Web UI available at http://hadoop.spark:4040
Spark context available as 'sc' (master = local[*], app id = local-1764083923757).
Spark session available as 'spark'.

scala> :paste
// Entering paste mode (ctrl-D to finish)

>....                                                                                                                                                                                           .mode("overwrite")
  .save(path)....
vacuumOps
  .select("operation", "operationParameters", "operationMetrics")
  .show(truncate = false)

// Exiting paste mode, now interpreting.

25/11/25 15:18:59 WARN SparkStringUtils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.
Deleted 0 files and directories in a total of 1 directories.                    


+------------+-----------------------------------------------------------------------------------------------+----------------------------------------------------+
|operation   |operationParameters                                                                            |operationMetrics                                    |
+------------+-----------------------------------------------------------------------------------------------+----------------------------------------------------+
|VACUUM START|{"defaultRetentionMillis":604800000,"retentionCheckEnabled":false,"specifiedRetentionMillis":0}|{"numFilesToDelete":"0","sizeOfDataToDelete":"0"}   |
|VACUUM END  |{"status":"COMPLETED"}                                                                         |{"numDeletedFiles":"0","numVacuumedDirectories":"1"}|
+------------+-----------------------------------------------------------------------------------------------+----------------------------------------------------+

import org.apache.spark.sql.functions._
import java.nio.file.{Files, Paths}
import scala.util.Try
val path: String = /tmp/delta_vacuum_lite
val logDf: org.apache.spark.sql.DataFrame = [add: struct<dataChange: boolean, modificationTime: bigint ... 3 more fields>, commitInfo: struct<engineInfo: string, isBlindAppend: boolean ... 7 more fields> ... 2 more fields]
val vacuumOps: org.apache.spark.sql.DataFrame = [operation: string, operationParameters: string ... 1 more field]
```


#### Logs using spark 3.5.2 ,delta-3.4.0-SNAPSHOT.jar(built with the fix)

```
[root@hadoop /]# spark-shell \
>   --jars /tmp/delta-spark_2.13-3.4.0-SNAPSHOT.jar,/tmp/delta-storage-3.4.0-SNAPSHOT.jar \
>   --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
>   --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog
25/11/25 15:20:05 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.5.2
      /_/
         
Using Scala version 2.13.8 (OpenJDK 64-Bit Server VM, Java 17.0.9)
Type in expressions to have them evaluated.
Type :help for more information.
Spark context Web UI available at http://hadoop.spark:4040
Spark context available as 'sc' (master = local[*], app id = local-1764084006997).
Spark session available as 'spark'.

scala> :paste
// Entering paste mode (ctrl-D to finish)

>....                                                                                                                                                                                           .save(path)
// Exiting paste mode, now interpreting.

25/11/25 15:20:38 WARN SparkStringUtils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.
Deleted 0 files and directories in a total of 1 directories.                    

+------------+---------------------------------------------------------------------------------------------------------------+----------------------------------------------------+
|operation   |operationParameters                                                                                                  |operationMetrics                                    |
+------------+---------------------------------------------------------------------------------------------------------------+----------------------------------------------------+
|VACUUM START|{"defaultRetentionMillis":604800000,"retentionCheckEnabled":false,"specifiedRetentionMillis":0,"typeOfVacuum":"LITE"}|{"numFilesToDelete":"0","sizeOfDataToDelete":"0"}   |
|VACUUM END  |{"status":"COMPLETED"}                                                                                               |{"numDeletedFiles":"0","numVacuumedDirectories":"1"}|
+------------+---------------------------------------------------------------------------------------------------------------+----------------------------------------------------+
```

#### For normal VACUUM:

```
25/11/25 17:20:38 WARN SparkStringUtils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.
Deleted 0 files and directories in a total of 1 directories.                    

+------------+---------------------------------------------------------------------------------------------------------------+----------------------------------------------------+
|operation   |operationParameters                                                                                            |operationMetrics                                    |
+------------+---------------------------------------------------------------------------------------------------------------+----------------------------------------------------+
|VACUUM START|{"defaultRetentionMillis":604800000,"retentionCheckEnabled":false,"specifiedRetentionMillis":0,"typeOfVacuum":"LITE"}|{"numFilesToDelete":"0","sizeOfDataToDelete":"0"}   |
|VACUUM END  |{"status":"COMPLETED"}                                                                                         |{"numDeletedFiles":"0","numVacuumedDirectories":"1"}|
+------------+---------------------------------------------------------------------------------------------------------------+----------------------------------------------------+

```

### Output of DESCRIBE HISTORY

```
scala> spark.sql("describe history delta.`/tmp/delta_vacuum`").select("version","timestamp","operation","operationParameters").show(false)
+-------+-----------------------+------------+--------------------------------------------------------------------------------------------------------------------+
|version|timestamp              |operation   |operationParameters                                                                                                 |
+-------+-----------------------+------------+--------------------------------------------------------------------------------------------------------------------+
|4      |2025-11-26 09:48:04.901|VACUUM END  |{status -> COMPLETED}                                                                                               |
|3      |2025-11-26 09:48:03.838|VACUUM START|{"defaultRetentionMillis":604800000,"retentionCheckEnabled":false,"specifiedRetentionMillis":0,"typeOfVacuum":"LITE"}|
|2      |2025-11-26 09:47:58.205|WRITE       |{mode -> Append, partitionBy -> []}                                                                                 |
|1      |2025-11-26 09:47:57.238|WRITE       |{mode -> Append, partitionBy -> []}                                                                                 |
|0      |2025-11-26 09:47:56.021|WRITE       |{mode -> Overwrite, partitionBy -> []}                                                                              |
+-------+-----------------------+------------+--------------------------------------------------------------------------------------------------------------------+
```

## Does this PR introduce _any_ user-facing changes?

Yes, but only in metadata, not behavior.

It adds a new opType field to the operationParameters (e.g., "opType":"FULL" | "LITE") filed to the tx. log ,which is visible to users when they read Delta log using **DESCRIBE HISTORY**, but it does not change VACUUM semantics, SQL syntax, or query results