### PR TITLE
Handle checkpoint inputs lacking version-prefixed filenames

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -298,15 +298,13 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
    * than once).
    */
   private CloseableIterator<ColumnarBatch> getActionsIterFromSinglePartOrV2Checkpoint(
-      FileStatus file, String fileName) throws IOException {
+      FileStatus file, String fileName, long checkpointVersion) throws IOException {
     // If the sidecars may contain the current action, read sidecars from the top-level v2
     // checkpoint file(to be read later).
     StructType modifiedReadSchema = checkpointReadSchema;
     if (schemaContainsAddOrRemoveFiles) {
       modifiedReadSchema = LogReplay.withSidecarFileSchema(checkpointReadSchema);
     }
-
-    long checkpointVersion = checkpointVersion(file.getPath());
 
     // If the read schema contains Add/Remove files, we should always read the sidecar file
     // actions from the checkpoint manifest regardless of the checkpoint predicate.
@@ -442,18 +440,17 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
     final FileStatus nextFile = nextLogFile.getFile();
     final Path nextFilePath = new Path(nextFile.getPath());
     final String fileName = nextFilePath.getName();
+    final long logFileVersion = nextLogFile.getVersion();
     try {
       switch (nextLogFile.getLogType()) {
         case COMMIT:
           {
-            final long fileVersion = FileNames.deltaVersion(nextFilePath);
-            return readCommitOrCompactionFile(fileVersion, nextFile);
+            return readCommitOrCompactionFile(logFileVersion, nextFile);
           }
         case LOG_COMPACTION:
           {
             // use end version as this is like a mini checkpoint, and that's what checkpoints do
-            final long fileVersion = FileNames.logCompactionVersions(nextFilePath)._2;
-            return readCommitOrCompactionFile(fileVersion, nextFile);
+            return readCommitOrCompactionFile(logFileVersion, nextFile);
           }
         case CHECKPOINT_CLASSIC:
         case V2_CHECKPOINT_MANIFEST:
@@ -462,10 +459,9 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
             // checkpoint file and any potential sidecars. Otherwise, look for any other
             // parts of the current multipart checkpoint.
             CloseableIterator<FileReadResult> dataIter =
-                getActionsIterFromSinglePartOrV2Checkpoint(nextFile, fileName)
+                getActionsIterFromSinglePartOrV2Checkpoint(nextFile, fileName, logFileVersion)
                     .map(batch -> new FileReadResult(batch, nextFile.getPath()));
-            long version = checkpointVersion(nextFilePath);
-            return combine(dataIter, true /* isFromCheckpoint */, version, Optional.empty());
+            return combine(dataIter, true /* isFromCheckpoint */, logFileVersion, Optional.empty());
           }
         case MULTIPART_CHECKPOINT:
         case SIDECAR:
@@ -487,8 +483,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
                     deltaReadSchema,
                     checkpointPredicate);
 
-            long version = nextLogFile.getVersion();
-            return combine(dataIter, true /* isFromCheckpoint */, version, Optional.empty());
+            return combine(dataIter, true /* isFromCheckpoint */, logFileVersion, Optional.empty());
           }
         default:
           throw new IOException("Unrecognized log type: " + nextLogFile.getLogType());

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/ActionsIteratorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/ActionsIteratorSuite.scala
@@ -13,24 +13,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.delta.kernel.internal.replay
 
 import java.io.{InterruptedIOException, UncheckedIOException}
 import java.util.{Collections, Optional}
+import java.util.NoSuchElementException
 
-import scala.collection.JavaConverters._
-
-import io.delta.kernel.data.{ColumnarBatch, ColumnVector, Row}
+import io.delta.kernel.data.ColumnarBatch
 import io.delta.kernel.engine._
 import io.delta.kernel.expressions.Predicate
-import io.delta.kernel.test.BaseMockJsonHandler
-import io.delta.kernel.test.MockEngineUtils
+import io.delta.kernel.test.{BaseMockJsonHandler, BaseMockParquetHandler, MockEngineUtils}
 import io.delta.kernel.types.StructType
 import io.delta.kernel.utils.{CloseableIterator, FileStatus}
 
 import org.scalatest.funsuite.AnyFunSuite
 
 class ActionsIteratorSuite extends AnyFunSuite with MockEngineUtils {
+
+  private class EmptyParquetHandler extends BaseMockParquetHandler {
+    override def readParquetFiles(
+        fileIter: CloseableIterator[FileStatus],
+        physicalSchema: StructType,
+        predicate: Optional[Predicate]): CloseableIterator[FileReadResult] = {
+      new CloseableIterator[FileReadResult] {
+        override def close(): Unit = {}
+        override def hasNext: Boolean = false
+        override def next(): FileReadResult =
+          throw new NoSuchElementException("empty iterator")
+      }
+    }
+  }
+
+  test("sidecar files without version prefix do not throw") {
+    val engine = mockEngine(parquetHandler = new EmptyParquetHandler)
+    val iterator =
+      new ActionsIterator(engine, Collections.emptyList(), new StructType(), Optional.empty())
+
+    val filesListField = classOf[ActionsIterator].getDeclaredField("filesList")
+    filesListField.setAccessible(true)
+    val filesList =
+      filesListField.get(iterator).asInstanceOf[java.util.LinkedList[DeltaLogFile]]
+
+    val sidecarStatus =
+      FileStatus.of("/tmp/_delta_log/_sidecars/part-0000-random.c000.snappy.parquet", 0L, 0L)
+    filesList.addFirst(DeltaLogFile.ofSideCar(sidecarStatus, 5L))
+
+    assert(!iterator.hasNext())
+    iterator.close()
+  }
 
   /**
    * Test for ActionsIterator resource leak fix validation

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
@@ -16,24 +16,23 @@
 package io.delta.kernel.defaults
 
 import java.io.File
-import java.nio.file.Files
 import java.util.Optional
 
 import scala.collection.JavaConverters._
 
 import io.delta.golden.GoldenTableUtils.goldenTablePath
-import io.delta.kernel.Table
-import io.delta.kernel.defaults.engine.DefaultEngine
-import io.delta.kernel.defaults.utils.{AbstractTestUtils, TestRow, TestUtils, TestUtilsWithLegacyKernelAPIs, TestUtilsWithTableManagerAPIs}
+import io.delta.kernel.defaults.utils.{AbstractTestUtils, TestRow, TestUtilsWithLegacyKernelAPIs, TestUtilsWithTableManagerAPIs}
 import io.delta.kernel.internal.{InternalScanFileUtils, SnapshotImpl}
 import io.delta.kernel.internal.data.ScanStateRow
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.types.{LongType, StructType}
 
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.{DeltaLog, SerializableFileStatus}
+import org.apache.spark.sql.delta.actions.{AddFile, CheckpointMetadata, SidecarFile}
+import org.apache.spark.sql.delta.util.FileNames.newV2CheckpointJsonFile
 
-import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path => HadoopPath}
 import org.scalatest.funsuite.AnyFunSuite
 
 class LogReplaySuite extends AbstractLogReplaySuite with TestUtilsWithTableManagerAPIs {
@@ -336,6 +335,72 @@ trait AbstractLogReplaySuite extends AnyFunSuite {
       deleteChecksumFileForTable(tablePath, versions = Seq(0, 1))
       val snapshot = getTableManagerAdapter.getSnapshotAtLatest(defaultEngine, tablePath)
       assert(!snapshot.getCurrentCrcInfo.isPresent)
+    }
+  }
+
+  // Regression test for issue #4807
+  test("read v2 checkpoint with sidecars lacking version prefix") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+
+      spark.sql(
+        s"""CREATE TABLE delta.`$tablePath` (id INT) USING delta
+           |TBLPROPERTIES('delta.checkpointPolicy' = 'v2')
+           |""".stripMargin)
+      spark.sql(s"INSERT INTO delta.`$tablePath` VALUES (1), (2)")
+
+      val log = DeltaLog.forTable(spark, new HadoopPath(tablePath))
+      val hadoopConf = log.newDeltaHadoopConf()
+      val fs = log.logPath.getFileSystem(hadoopConf)
+
+      // Create sidecar file with Spark-style naming (no version prefix)
+      var sidecarFileName: String = ""
+      withTempDir { dir =>
+        // scalastyle:off sparkimplicits
+        import spark.implicits._
+        // scalastyle:on sparkimplicits
+        val addFile = AddFile(
+          path = "fake-data-file.parquet",
+          partitionValues = Map.empty,
+          size = 100L,
+          modificationTime = System.currentTimeMillis(),
+          dataChange = true)
+        Seq(addFile.wrap).toDF.repartition(1).write.mode("overwrite").parquet(dir.getAbsolutePath)
+        val srcPath = new HadoopPath(
+          dir.listFiles().filter(_.getName.endsWith("parquet")).head.getAbsolutePath)
+        val dstPath = new HadoopPath(log.sidecarDirPath, srcPath.getName)
+        fs.mkdirs(log.sidecarDirPath)
+        fs.rename(srcPath, dstPath)
+        sidecarFileName = fs.getFileStatus(dstPath).getPath.getName
+      }
+      assert(sidecarFileName.startsWith("part-"))
+
+      val version = log.update().version
+      val snapshot = log.getSnapshotAt(version)
+      val sidecarPath = new HadoopPath(log.sidecarDirPath.toString, sidecarFileName)
+      intercept[NumberFormatException] {
+        FileNames.checkpointVersion(new Path(sidecarPath.toString))
+      }
+      val sidecarFileStatus = SerializableFileStatus.fromStatus(fs.getFileStatus(sidecarPath))
+      val sidecarFile = SidecarFile(sidecarFileStatus)
+      val actionsForCheckpoint = Seq(
+        snapshot.protocol,
+        snapshot.metadata,
+        sidecarFile,
+        CheckpointMetadata(version))
+      log.store.write(
+        newV2CheckpointJsonFile(log.logPath, version),
+        actionsForCheckpoint.map(_.json).toIterator,
+        overwrite = true,
+        hadoopConf = hadoopConf)
+
+      val kernelSnapshot = latestSnapshot(tablePath)
+      val scan = kernelSnapshot.getScanBuilder().build()
+      val foundFiles = collectScanFileRows(scan)
+        .map(InternalScanFileUtils.getAddFileStatus)
+        .map(_.getPath.split('/').last)
+        .toSet
+      assert(foundFiles == Set("fake-data-file.parquet"))
     }
   }
 }


### PR DESCRIPTION
## Description
Resolves #4807.

- Reuse the log/checkpoint version already computed for each `DeltaLogFile` while replaying commits, compactions, checkpoint manifests, and sidecars, instead of reparsing versions from file names.
- Add kernel-api coverage for sidecar files whose names do not start with a checkpoint version.
- Add a Spark-backed `kernelDefaults` regression that writes a Spark-style sidecar file named `part-...parquet`, references it from a v2 checkpoint manifest, asserts that `FileNames.checkpointVersion` cannot parse that sidecar path, and verifies Kernel reads the `AddFile` from the sidecar.

## How was this patch tested?
- `build/sbt "kernelDefaults/testOnly io.delta.kernel.defaults.LogReplaySuite -- -z read v2 checkpoint with sidecars lacking version prefix"`
- Applied the same kernel-defaults test patch to `23e56555^`; it failed with `NumberFormatException` at `FileNames.checkpointVersion` from `ActionsIterator.getNextActionsIter`, matching #4807.
- Applied the same test-only patch to current master (`33112149d`); it passed because master already contains the sidecar replay part of the fix from #5860.

## Does this PR introduce any user-facing changes?
No.