### PR TITLE
[Kernel-Spark] Fix SparkTable package name to match directory structure

### DIFF
--- a/kernel-spark/src/main/java/io/delta/kernel/spark/catalog/SparkTable.java
+++ b/kernel-spark/src/main/java/io/delta/kernel/spark/catalog/SparkTable.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.spark.table;
+package io.delta.kernel.spark.catalog;
 
 import static io.delta.kernel.spark.utils.ScalaUtils.toScalaMap;
 import static java.util.Objects.requireNonNull;

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/catalog/SparkTableTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/catalog/SparkTableTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.spark.table;
+package io.delta.kernel.spark.catalog;
 
 import static org.apache.spark.sql.connector.catalog.TableCapability.BATCH_READ;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/catalog/TestCatalog.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/catalog/TestCatalog.java
@@ -18,7 +18,6 @@ package io.delta.kernel.spark.catalog;
 import io.delta.kernel.Operation;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.spark.table.SparkTable;
 import io.delta.kernel.spark.utils.SchemaUtils;
 import io.delta.kernel.utils.CloseableIterable;
 import java.util.ArrayList;

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkGoldenTableTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkGoldenTableTest.java
@@ -22,7 +22,7 @@ import io.delta.golden.GoldenTableUtils$;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.expressions.Predicate;
-import io.delta.kernel.spark.table.SparkTable;
+import io.delta.kernel.spark.catalog.SparkTable;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkScanTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/read/SparkScanTest.java
@@ -3,7 +3,7 @@ package io.delta.kernel.spark.read;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.delta.kernel.spark.SparkDsv2TestBase;
-import io.delta.kernel.spark.table.SparkTable;
+import io.delta.kernel.spark.catalog.SparkTable;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;

--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.catalog;
 
-import io.delta.kernel.spark.table.SparkTable;
+import io.delta.kernel.spark.catalog.SparkTable;
 import org.apache.spark.sql.delta.sources.DeltaSQLConfV2;
 import java.util.HashMap;
 import java.util.function.Supplier;

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/catalog/DeltaCatalogSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/catalog/DeltaCatalogSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.catalog
 
-import io.delta.kernel.spark.table.SparkTable
+import io.delta.kernel.spark.catalog.SparkTable
 import org.apache.spark.sql.delta.sources.DeltaSQLConfV2
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the package name for `SparkTable.java` from `io.delta.kernel.spark.table` to `io.delta.kernel.spark.catalog` to match its directory location.

## How was this patch tested?

Existing tests.