### PR TITLE
[Feature Request][Spark] Fix VACUUM FULL to unblock subsequent VACUUM LITE (fixes issue #4162)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.commands
 
 // scalastyle:off import.ordering.noEmptyLine
-import java.io.File
 import java.io.FileNotFoundException
 import java.net.URI
 import java.sql.Timestamp
@@ -165,7 +164,23 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
       import org.apache.spark.sql.delta.implicits._
 
       val snapshot = table.update()
+      // Fail fast for non-Delta paths (no valid snapshot), preserving the historical
+      // IllegalArgumentException contract when VACUUM is run on a non-reservoir path.
+      require(snapshot.version >= 0, "No state defined for this table. Is this really " +
+        "a Delta table? Refusing to garbage collect.")
+
       deltaLog.protocolWrite(snapshot.protocol)
+
+      // Determine whether VACUUM LITE is currently blocked because the log has been pruned
+      // and no usable last-vacuum info exists. We only want VACUUM FULL to "repair" the table
+      // in this case so that subsequent VACUUM LITE can succeed.
+      val earliestCommitVersion = DeltaHistoryManager.getEarliestDeltaFile(deltaLog)
+      val lastVacuumVersionOpt =
+        LastVacuumInfo.getLastVacuumInfo(deltaLog)
+          .flatMap(_.latestCommitVersionOutsideOfRetentionWindow)
+      val needsRepairForLite =
+        earliestCommitVersion != 0 &&
+          lastVacuumVersionOpt.forall(_ < earliestCommitVersion)
 
       // VACUUM can break clones by removing files that clones still references for managed tables.
       // Eventually the catalog should track this dependency to avoid breaking clones,
@@ -239,15 +254,22 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
       val partitionColumns = snapshot.metadata.partitionSchema.fieldNames
       val parallelism = spark.sessionState.conf.parallelPartitionDiscoveryParallelism
       val shouldIcebergMetadataDirBeHidden = UniversalFormat.icebergEnabled(snapshot.metadata)
+
+      // For VACUUM LITE we always need this. For VACUUM FULL we only compute it if the table is
+      // in a state where VACUUM LITE would be blocked (log pruned and no usable last-vacuum info).
       val latestCommitVersionOutsideOfRetentionWindowOpt: Option[Long] =
-        if (vacuumType == VacuumType.LITE) {
+        if (vacuumType == VacuumType.LITE ||
+            (vacuumType == VacuumType.FULL && needsRepairForLite)) {
           try {
             val timestamp = new Timestamp(deleteBeforeTimestamp)
             val commit = new DeltaHistoryManager(deltaLog).getActiveCommitAtTime(
-              timestamp, table.catalogTable, canReturnLastCommit = true, mustBeRecreatable = false)
+              timestamp,
+              table.catalogTable,
+              canReturnLastCommit = true,
+              mustBeRecreatable = false)
             Some(commit.version)
           } catch {
-            case ex: DeltaErrors.TimestampEarlierThanCommitRetentionException => None
+            case _: DeltaErrors.TimestampEarlierThanCommitRetentionException => None
           }
         } else {
           None
@@ -278,6 +300,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
           )
           (files, None, None)
           }
+
       val allFilesAndDirs = allFilesAndDirsWithDuplicates.groupByKey(_.path)
         .mapGroups { (k, v) =>
           val duplicates = v.toSeq
@@ -404,8 +427,16 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
             Some(filesDeleted),
             Some(dirCounts))
 
-          LastVacuumInfo.persistLastVacuumInfo(
-            LastVacuumInfo(latestCommitVersionOutsideOfRetentionWindowOpt), deltaLog)
+          // Persist last-vacuum info for:
+          //  - VACUUM LITE (existing behavior), or
+          //  - VACUUM FULL when it is repairing a table whose log has been pruned such that
+          //    VACUUM LITE would otherwise be blocked.
+          if (latestCommitVersionOutsideOfRetentionWindowOpt.nonEmpty &&
+              (vacuumType == VacuumType.LITE ||
+                (vacuumType == VacuumType.FULL && needsRepairForLite))) {
+            LastVacuumInfo.persistLastVacuumInfo(
+              LastVacuumInfo(latestCommitVersionOutsideOfRetentionWindowOpt), deltaLog)
+          }
 
           logInfo(log"Deleted ${MDC(DeltaLogKeys.NUM_FILES, filesDeleted)} files " +
             log"(${MDC(DeltaLogKeys.NUM_BYTES, sizeOfDataToDelete)} bytes) and directories in " +
@@ -948,8 +979,9 @@ trait VacuumCommandImpl extends DeltaCommand {
       clock: Clock,
       config: ValidFilesConfig): DataFrame = {
     import org.apache.spark.sql.delta.implicits._
-    require(snapshot.version >= 0, "No state defined for this table. Is this really " +
-      "a Delta table? Refusing to garbage collect.")
+    require(
+      snapshot.version >= 0,
+      "No state defined for this table. Is this really a Delta table? Refusing to garbage collect.")
 
     val snapshotTombstoneRetentionMillis = DeltaLog.tombstoneRetentionMillis(snapshot.metadata)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -1613,6 +1613,68 @@ class DeltaLiteVacuumSuite
     }
   }
 
+  test("vacuum full repairs pruned log so subsequent lite vacuum can run (issue 4162)") {
+    withSQLConf(
+      DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false"
+    ) {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+
+        // Set up a table similar to "lite vacuum not possible - commit 0 is missing", where
+        // we have a checkpoint so that the table snapshot is still reconstructable even after
+        // the earliest commit file (version 0) has been deleted.
+        spark.range(10)
+          .write
+          .format("delta")
+          .save(path) // version 0
+        spark.range(10)
+          .write
+          .format("delta")
+          .mode("append")
+          .save(path) // version 1
+
+        val table = DeltaTableV2(spark, new Path(path))
+        // Checkpoint at the latest existing version (1) so the table can still be reconstructed
+        // after deleting v0.
+        table.deltaLog.createCheckpointAtVersion(1L)
+        // Simulate log pruning by deleting the first commit file.
+        deleteCommitFile(table, 0L)
+
+        // 1) VACUUM LITE should be blocked and throw DELTA_CANNOT_VACUUM_LITE.
+        val e1 = intercept[DeltaIllegalStateException] {
+          VacuumCommand.gc(
+            spark,
+            table,
+            dryRun = false,
+            retentionHours = Some(0),
+            inventory = None,
+            vacuumTypeOpt = Some("LITE"))
+        }
+        assert(e1.getMessage.contains(
+          "VACUUM LITE cannot delete all eligible files as some files" +
+            " are not referenced by the Delta log. Please run VACUUM FULL."))
+
+        // 2) VACUUM FULL should "repair" the log for LITE by persisting last vacuum info.
+        VacuumCommand.gc(
+          spark,
+          table,
+          dryRun = false,
+          retentionHours = Some(0),
+          inventory = None,
+          vacuumTypeOpt = Some("FULL"))
+
+        // 3) After the FULL repair, VACUUM LITE should now succeed without throwing.
+        VacuumCommand.gc(
+          spark,
+          table,
+          dryRun = false,
+          retentionHours = Some(0),
+          inventory = None,
+          vacuumTypeOpt = Some("LITE"))
+      }
+    }
+  }
+
   test("lite vacuum not possible - commits since last vacuum is missing") {
     withSQLConf(
       DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`VACUUM LITE` relies on `_last_vacuum_info` to know up to which commit version it is safe to reason about file references when deleting data files.

But for old tables where the Delta log has already been pruned:

* When user runs `VACUUM LITE`, it  fails with `DELTA_CANNOT_VACUUM_LITE` because some files are no longer referenced by the current log history, and the error message suggests to run a ` VACUUM FULL`.
* This happens  because the **_delta_log** dir does **not** have a usable `_last_vacuum_info`, so there is no way to "bootstrap" LITE.
* Now based on the suggestion  , when we run `VACUUM FULL` ,it deletes eligible files, but it does **not** compute or persist a `latestCommitVersionOutsideOfRetentionWindow`, so `_last_vacuum_info` still remains missing.

As a result, once the table’s tx. log has been pruned past the point where LITE can reason about all files, it is effectively impossible to ever run `VACUUM LITE` on that table.

This PR (fixes #4162 ) allows a one-time `VACUUM FULL` to repair that state and make `VACUUM LITE` usable again.

### **Implementation details (brief)**

* Compute a `needsRepairForLite` flag from `earliestDeltaFile` and existing `_last_vacuum_info`.
* When `needsRepairForLite` is true, `VACUUM FULL` also computes `latestCommitVersionOutsideOfRetentionWindow`
  using `DeltaHistoryManager.getActiveCommitAtTime`.
* Persist `_last_vacuum_info` only when we have a valid version and the run is either:
  * `VACUUM LITE` (existing behavior), or
  * `VACUUM FULL` with `needsRepairForLite = true` (repair case).



## How was this patch tested?

### Below code was run on spark3.5.2, delta-3.3.0 before and after the fix

**Code for reproducing the issue:**
```
import org.apache.spark.sql.functions._
import org.apache.hadoop.fs.{FileSystem, Path}

// ---------------------------------------------------------------------
// 0. Cleanup 
// ---------------------------------------------------------------------
val path = "/tmp/delta_4162_vacuum_lite_repro" 
val tablePath = s"delta.`$path`"

val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
fs.delete(new Path(path), true)

// ---------------------------------------------------------------------
// 1. Create a Delta table with some commits
// ---------------------------------------------------------------------
(0 to 10).foreach { b =>
  spark.range(b * 100, b * 100 + 100)
    .withColumn("batch", lit(b))
    .write
    .format("delta")
    .mode("overwrite")
    .option("overwriteSchema", "true")
    .save(path)
}

println("Row count = " + spark.read.format("delta").load(path).count())

// ---------------------------------------------------------------------
// 2. Artificially prune the Delta log using Hadoop FS
// ---------------------------------------------------------------------
val logPath = new Path(s"$path/_delta_log")

val jsonStatuses = fs
  .listStatus(logPath)
  .filter(st => st.getPath.getName.endsWith(".json"))
  .sortBy(_.getPath.getName)

require(jsonStatuses.nonEmpty, s"No JSON log files found under $logPath")

// Keep only the last 3 JSON logs, delete the rest
val toDelete = jsonStatuses.dropRight(3)
println(s"Deleting ${toDelete.length} JSON log files from $logPath to simulate pruning")

toDelete.foreach { st =>
  println(s"Deleting: ${st.getPath.getName}")
  fs.delete(st.getPath, /* recursive = */ false)
}

// ---------------------------------------------------------------------
// 3. Disable retention check (just for the repro)
// ---------------------------------------------------------------------
spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")

// ---------------------------------------------------------------------
// 4. VACUUM LITE → expected to fail with DELTA_CANNOT_VACUUM_LITE
// ---------------------------------------------------------------------
try {
  println("Running VACUUM LITE (fails with DELTA_CANNOT_VACUUM_LITE).")
  spark.sql(
    s"""
       |VACUUM $tablePath
       |LITE
       |RETAIN 0 HOURS
       |""".stripMargin
  ).show(false)
} catch {
  case e: Exception =>
    e.printStackTrace()
}

// ---------------------------------------------------------------------
// 5. VACUUM FULL to 'fix' the table based on the error message
// ---------------------------------------------------------------------
println("Running VACUUM FULL RETAIN 0 HOURS")
spark.sql(
  s"""
     |VACUUM $tablePath
     |FULL
     |RETAIN 0 HOURS
     |""".stripMargin
).show(false)

// ---------------------------------------------------------------------
// 6. Run VACUUM LITE again will still fail  (repro for #4162)
// ---------------------------------------------------------------------
try {
  println("Running VACUUM LITE again after FULL (should still fail)...")
  spark.sql(
    s"""
       |VACUUM $tablePath
       |LITE
       |RETAIN 0 HOURS
       |""".stripMargin
  ).show(false)
} catch {
  case e: Exception =>
    println("VACUUM LITE still cannot run after FULL → reproduces 4162 behavior:")
    e.printStackTrace()
}
```


#### **Logs before the fix:**

```
Row count = 100                                                                 
Deleting 8 JSON log files from /tmp/delta_4162_vacuum_lite_repro/_delta_log to simulate pruning
Deleting: 00000000000000000000.json
Deleting: 00000000000000000001.json
Deleting: 00000000000000000002.json
Deleting: 00000000000000000003.json
Deleting: 00000000000000000004.json
Deleting: 00000000000000000005.json
Deleting: 00000000000000000006.json
Deleting: 00000000000000000007.json
Running VACUUM LITE (should fail with DELTA_CANNOT_VACUUM_LITE)...
org.apache.spark.sql.delta.DeltaIllegalStateException: [DELTA_CANNOT_VACUUM_LITE] VACUUM LITE cannot delete all eligible files as some files are not referenced by the Delta log. Please run VACUUM FULL.
	at org.apache.spark.sql.delta.DeltaErrorsBase.deltaCannotVacuumLite(DeltaErrors.scala:1724)
	at org.apache.spark.sql.delta.DeltaErrorsBase.deltaCannotVacuumLite$(DeltaErrors.scala:1723)
	at org.apache.spark.sql.delta.DeltaErrors$.deltaCannotVacuumLite(DeltaErrors.scala:3598)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.getFilesFromDeltaLog(VacuumCommand.scala:530)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.$anonfun$gc$1(VacuumCommand.scala:306)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile(DeltaLogging.scala:171)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile$(DeltaLogging.scala:169)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordFrameProfile(VacuumCommand.scala:58)
	at org.apache.spark.sql.delta.metering.DeltaLogging.$anonfun$recordDeltaOperationInternal$1(DeltaLogging.scala:139)
	at com.databricks.spark.util.DatabricksLogging.recordOperation(DatabricksLogging.scala:128)
	at com.databricks.spark.util.DatabricksLogging.recordOperation$(DatabricksLogging.scala:117)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordOperation(VacuumCommand.scala:58)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperationInternal(DeltaLogging.scala:138)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation(DeltaLogging.scala:128)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation$(DeltaLogging.scala:118)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordDeltaOperation(VacuumCommand.scala:58)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.gc(VacuumCommand.scala:230)
	at io.delta.tables.execution.VacuumTableCommand.run(VacuumTableCommand.scala:67)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:75)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:73)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:84)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$1(QueryExecution.scala:107)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:125)
	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:201)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:108)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:66)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:107)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:98)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:461)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(origin.scala:76)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:461)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.org$apache$spark$sql$catalyst$plans$logical$AnalysisHelper$$super$transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning(AnalysisHelper.scala:267)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning$(AnalysisHelper.scala:263)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:437)
	at org.apache.spark.sql.execution.QueryExecution.eagerlyExecuteCommands(QueryExecution.scala:98)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted$lzycompute(QueryExecution.scala:85)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted(QueryExecution.scala:83)
	at org.apache.spark.sql.Dataset.<init>(Dataset.scala:220)
	at org.apache.spark.sql.Dataset$.$anonfun$ofRows$2(Dataset.scala:100)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:97)
	at org.apache.spark.sql.SparkSession.$anonfun$sql$4(SparkSession.scala:691)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:682)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:713)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:744)
	at $line14.$read$$iw.<init>(<pastie>:71)
	at $line14.$read.<init>(<pastie>:15)
	at $line14.$read$.<clinit>(<pastie>:1)
	at $line14.$eval$.$print$lzycompute(<synthetic>:6)
	at $line14.$eval$.$print(<synthetic>:5)
	at $line14.$eval.$print(<synthetic>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:670)
	at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:1020)
	at scala.tools.nsc.interpreter.IMain.$anonfun$doInterpret$1(IMain.scala:506)
	at scala.reflect.internal.util.ScalaClassLoader.asContext(ScalaClassLoader.scala:36)
	at scala.reflect.internal.util.ScalaClassLoader.asContext$(ScalaClassLoader.scala:116)
	at scala.reflect.internal.util.AbstractFileClassLoader.asContext(AbstractFileClassLoader.scala:43)
	at scala.tools.nsc.interpreter.IMain.loadAndRunReq$1(IMain.scala:505)
	at scala.tools.nsc.interpreter.IMain.$anonfun$doInterpret$3(IMain.scala:519)
	at scala.tools.nsc.interpreter.IMain.doInterpret(IMain.scala:519)
	at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:503)
	at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:501)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$pasteCommand$12(ILoop.scala:823)
	at scala.tools.nsc.interpreter.IMain.withLabel(IMain.scala:112)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$pasteCommand$13(ILoop.scala:823)
	at scala.tools.nsc.interpreter.shell.ReplReporterImpl.indenting(Reporter.scala:51)
	at scala.tools.nsc.interpreter.shell.ILoop.pasteCommand(ILoop.scala:830)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$standardCommands$8(ILoop.scala:201)
	at scala.tools.nsc.interpreter.shell.LoopCommands$LineCmd.apply(LoopCommands.scala:164)
	at scala.tools.nsc.interpreter.shell.LoopCommands.colonCommand(LoopCommands.scala:126)
	at scala.tools.nsc.interpreter.shell.LoopCommands.colonCommand$(LoopCommands.scala:124)
	at scala.tools.nsc.interpreter.shell.ILoop.colonCommand(ILoop.scala:45)
	at scala.tools.nsc.interpreter.shell.ILoop.command(ILoop.scala:431)
	at scala.tools.nsc.interpreter.shell.ILoop.processLine(ILoop.scala:440)
	at scala.tools.nsc.interpreter.shell.ILoop.loop(ILoop.scala:458)
	at scala.tools.nsc.interpreter.shell.ILoop.run(ILoop.scala:968)
	at org.apache.spark.repl.Main$.doMain(Main.scala:84)
	at org.apache.spark.repl.Main$.main(Main.scala:59)
	at org.apache.spark.repl.Main.main(Main.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Running VACUUM FULL RETAIN 0 HOURS...
Deleted 40 files and directories in a total of 1 directories.                   
+---------------------------------------------------------+
|path                                                     |
+---------------------------------------------------------+
|hdfs://hadoop.spark:9000/tmp/delta_4162_vacuum_lite_repro|
+---------------------------------------------------------+

Running VACUUM LITE again after FULL (should still fail)...
VACUUM LITE still cannot run after FULL ... reproduces 4162 behavior:
org.apache.spark.sql.delta.DeltaIllegalStateException: [DELTA_CANNOT_VACUUM_LITE] VACUUM LITE cannot delete all eligible files as some files are not referenced by the Delta log. Please run VACUUM FULL.
	at org.apache.spark.sql.delta.DeltaErrorsBase.deltaCannotVacuumLite(DeltaErrors.scala:1724)
	at org.apache.spark.sql.delta.DeltaErrorsBase.deltaCannotVacuumLite$(DeltaErrors.scala:1723)
	at org.apache.spark.sql.delta.DeltaErrors$.deltaCannotVacuumLite(DeltaErrors.scala:3598)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.getFilesFromDeltaLog(VacuumCommand.scala:530)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.$anonfun$gc$1(VacuumCommand.scala:306)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile(DeltaLogging.scala:171)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile$(DeltaLogging.scala:169)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordFrameProfile(VacuumCommand.scala:58)
	at org.apache.spark.sql.delta.metering.DeltaLogging.$anonfun$recordDeltaOperationInternal$1(DeltaLogging.scala:139)
	at com.databricks.spark.util.DatabricksLogging.recordOperation(DatabricksLogging.scala:128)
	at com.databricks.spark.util.DatabricksLogging.recordOperation$(DatabricksLogging.scala:117)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordOperation(VacuumCommand.scala:58)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperationInternal(DeltaLogging.scala:138)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation(DeltaLogging.scala:128)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation$(DeltaLogging.scala:118)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordDeltaOperation(VacuumCommand.scala:58)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.gc(VacuumCommand.scala:230)
	at io.delta.tables.execution.VacuumTableCommand.run(VacuumTableCommand.scala:67)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:75)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:73)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:84)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$1(QueryExecution.scala:107)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:125)
	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:201)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:108)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:66)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:107)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:98)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:461)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(origin.scala:76)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:461)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.org$apache$spark$sql$catalyst$plans$logical$AnalysisHelper$$super$transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning(AnalysisHelper.scala:267)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning$(AnalysisHelper.scala:263)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:437)
	at org.apache.spark.sql.execution.QueryExecution.eagerlyExecuteCommands(QueryExecution.scala:98)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted$lzycompute(QueryExecution.scala:85)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted(QueryExecution.scala:83)
	at org.apache.spark.sql.Dataset.<init>(Dataset.scala:220)
	at org.apache.spark.sql.Dataset$.$anonfun$ofRows$2(Dataset.scala:100)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:97)
	at org.apache.spark.sql.SparkSession.$anonfun$sql$4(SparkSession.scala:691)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:682)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:713)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:744)
	at $line14.$read$$iw.liftedTree1$1(<pastie>:101)
	at $line14.$read$$iw.<init>(<pastie>:97)
	at $line14.$read.<init>(<pastie>:15)
	at $line14.$read$.<clinit>(<pastie>:1)
	at $line14.$eval$.$print$lzycompute(<synthetic>:6)
	at $line14.$eval$.$print(<synthetic>:5)
	at $line14.$eval.$print(<synthetic>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:670)
	at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:1020)
	at scala.tools.nsc.interpreter.IMain.$anonfun$doInterpret$1(IMain.scala:506)
	at scala.reflect.internal.util.ScalaClassLoader.asContext(ScalaClassLoader.scala:36)
	at scala.reflect.internal.util.ScalaClassLoader.asContext$(ScalaClassLoader.scala:116)
	at scala.reflect.internal.util.AbstractFileClassLoader.asContext(AbstractFileClassLoader.scala:43)
	at scala.tools.nsc.interpreter.IMain.loadAndRunReq$1(IMain.scala:505)
	at scala.tools.nsc.interpreter.IMain.$anonfun$doInterpret$3(IMain.scala:519)
	at scala.tools.nsc.interpreter.IMain.doInterpret(IMain.scala:519)
	at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:503)
	at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:501)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$pasteCommand$12(ILoop.scala:823)
	at scala.tools.nsc.interpreter.IMain.withLabel(IMain.scala:112)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$pasteCommand$13(ILoop.scala:823)
	at scala.tools.nsc.interpreter.shell.ReplReporterImpl.indenting(Reporter.scala:51)
	at scala.tools.nsc.interpreter.shell.ILoop.pasteCommand(ILoop.scala:830)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$standardCommands$8(ILoop.scala:201)
	at scala.tools.nsc.interpreter.shell.LoopCommands$LineCmd.apply(LoopCommands.scala:164)
	at scala.tools.nsc.interpreter.shell.LoopCommands.colonCommand(LoopCommands.scala:126)
	at scala.tools.nsc.interpreter.shell.LoopCommands.colonCommand$(LoopCommands.scala:124)
	at scala.tools.nsc.interpreter.shell.ILoop.colonCommand(ILoop.scala:45)
	at scala.tools.nsc.interpreter.shell.ILoop.command(ILoop.scala:431)
	at scala.tools.nsc.interpreter.shell.ILoop.processLine(ILoop.scala:440)
	at scala.tools.nsc.interpreter.shell.ILoop.loop(ILoop.scala:458)
	at scala.tools.nsc.interpreter.shell.ILoop.run(ILoop.scala:968)
	at org.apache.spark.repl.Main$.doMain(Main.scala:84)
	at org.apache.spark.repl.Main$.main(Main.scala:59)
	at org.apache.spark.repl.Main.main(Main.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

### Made the fix built the assembly jar and re-tested with the same code:

**Logs: after the fix **

```
Row count = 100                                                                 
Deleting 8 JSON log files from /tmp/delta_4162_vacuum_lite_repro_2/_delta_log to simulate pruning
Deleting: 00000000000000000000.json
Deleting: 00000000000000000001.json
Deleting: 00000000000000000002.json
Deleting: 00000000000000000003.json
Deleting: 00000000000000000004.json
Deleting: 00000000000000000005.json
Deleting: 00000000000000000006.json
Deleting: 00000000000000000007.json
Running VACUUM LITE (should fail with DELTA_CANNOT_VACUUM_LITE)...
VACUUM LITE failed as expected:
org.apache.spark.sql.delta.DeltaIllegalStateException: [DELTA_CANNOT_VACUUM_LITE] VACUUM LITE cannot delete all eligible files as some files are not referenced by the Delta log. Please run VACUUM FULL.
	at org.apache.spark.sql.delta.DeltaErrorsBase.deltaCannotVacuumLite(DeltaErrors.scala:1867)
	at org.apache.spark.sql.delta.DeltaErrorsBase.deltaCannotVacuumLite$(DeltaErrors.scala:1866)
	at org.apache.spark.sql.delta.DeltaErrors$.deltaCannotVacuumLite(DeltaErrors.scala:3863)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.getFilesFromDeltaLog(VacuumCommand.scala:484)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.$anonfun$gc$1(VacuumCommand.scala:285)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile(DeltaLogging.scala:171)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile$(DeltaLogging.scala:169)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordFrameProfile(VacuumCommand.scala:59)
	at org.apache.spark.sql.delta.metering.DeltaLogging.$anonfun$recordDeltaOperationInternal$1(DeltaLogging.scala:139)
	at com.databricks.spark.util.DatabricksLogging.recordOperation(DatabricksLogging.scala:128)
	at com.databricks.spark.util.DatabricksLogging.recordOperation$(DatabricksLogging.scala:117)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordOperation(VacuumCommand.scala:59)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperationInternal(DeltaLogging.scala:138)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation(DeltaLogging.scala:128)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation$(DeltaLogging.scala:118)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.recordDeltaOperation(VacuumCommand.scala:59)
	at org.apache.spark.sql.delta.commands.VacuumCommand$.gc(VacuumCommand.scala:157)
	at io.delta.tables.execution.VacuumTableCommand.run(VacuumTableCommand.scala:67)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult$lzycompute(commands.scala:75)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.sideEffectResult(commands.scala:73)
	at org.apache.spark.sql.execution.command.ExecutedCommandExec.executeCollect(commands.scala:84)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$1(QueryExecution.scala:107)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:125)
	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:201)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:108)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:66)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:107)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:98)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:461)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(origin.scala:76)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:461)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.org$apache$spark$sql$catalyst$plans$logical$AnalysisHelper$$super$transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning(AnalysisHelper.scala:267)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning$(AnalysisHelper.scala:263)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:32)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:437)
	at org.apache.spark.sql.execution.QueryExecution.eagerlyExecuteCommands(QueryExecution.scala:98)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted$lzycompute(QueryExecution.scala:85)
	at org.apache.spark.sql.execution.QueryExecution.commandExecuted(QueryExecution.scala:83)
	at org.apache.spark.sql.Dataset.<init>(Dataset.scala:220)
	at org.apache.spark.sql.Dataset$.$anonfun$ofRows$2(Dataset.scala:100)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:97)
	at org.apache.spark.sql.SparkSession.$anonfun$sql$4(SparkSession.scala:691)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:900)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:682)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:713)
	at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:744)
	at $line14.$read$$iw.<init>(<pastie>:71)
	at $line14.$read.<init>(<pastie>:15)
	at $line14.$read$.<clinit>(<pastie>:1)
	at $line14.$eval$.$print$lzycompute(<synthetic>:6)
	at $line14.$eval$.$print(<synthetic>:5)
	at $line14.$eval.$print(<synthetic>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:670)
	at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:1020)
	at scala.tools.nsc.interpreter.IMain.$anonfun$doInterpret$1(IMain.scala:506)
	at scala.reflect.internal.util.ScalaClassLoader.asContext(ScalaClassLoader.scala:36)
	at scala.reflect.internal.util.ScalaClassLoader.asContext$(ScalaClassLoader.scala:116)
	at scala.reflect.internal.util.AbstractFileClassLoader.asContext(AbstractFileClassLoader.scala:43)
	at scala.tools.nsc.interpreter.IMain.loadAndRunReq$1(IMain.scala:505)
	at scala.tools.nsc.interpreter.IMain.$anonfun$doInterpret$3(IMain.scala:519)
	at scala.tools.nsc.interpreter.IMain.doInterpret(IMain.scala:519)
	at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:503)
	at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:501)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$pasteCommand$12(ILoop.scala:823)
	at scala.tools.nsc.interpreter.IMain.withLabel(IMain.scala:112)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$pasteCommand$13(ILoop.scala:823)
	at scala.tools.nsc.interpreter.shell.ReplReporterImpl.indenting(Reporter.scala:51)
	at scala.tools.nsc.interpreter.shell.ILoop.pasteCommand(ILoop.scala:830)
	at scala.tools.nsc.interpreter.shell.ILoop.$anonfun$standardCommands$8(ILoop.scala:201)
	at scala.tools.nsc.interpreter.shell.LoopCommands$LineCmd.apply(LoopCommands.scala:164)
	at scala.tools.nsc.interpreter.shell.LoopCommands.colonCommand(LoopCommands.scala:126)
	at scala.tools.nsc.interpreter.shell.LoopCommands.colonCommand$(LoopCommands.scala:124)
	at scala.tools.nsc.interpreter.shell.ILoop.colonCommand(ILoop.scala:45)
	at scala.tools.nsc.interpreter.shell.ILoop.command(ILoop.scala:431)
	at scala.tools.nsc.interpreter.shell.ILoop.processLine(ILoop.scala:440)
	at scala.tools.nsc.interpreter.shell.ILoop.loop(ILoop.scala:458)
	at scala.tools.nsc.interpreter.shell.ILoop.run(ILoop.scala:968)
	at org.apache.spark.repl.Main$.doMain(Main.scala:84)
	at org.apache.spark.repl.Main$.main(Main.scala:59)
	at org.apache.spark.repl.Main.main(Main.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Running VACUUM FULL RETAIN 0 HOURS...
Deleted 40 files and directories in a total of 1 directories.                   
+-----------------------------------------------------------+
|path                                                       |
+-----------------------------------------------------------+
|hdfs://hadoop.spark:9000/tmp/delta_4162_vacuum_lite_repro|
+-----------------------------------------------------------+

Running VACUUM LITE again after FULL (shouldnt error out )...
Deleted 0 files and directories in a total of 1 directories.
+-----------------------------------------------------------+
|path                                                       |
+-----------------------------------------------------------+
|hdfs://hadoop.spark:9000/tmp/delta_4162_vacuum_lite_repro|
+-----------------------------------------------------------+

```

## Does this PR introduce _any_ user-facing changes?

Yes.

On tables where the Delta log has been pruned and `VACUUM LITE` is currently blocked
(i.e. no usable `_last_vacuum_info` and `earliestDeltaFile` > 0), a successful
`VACUUM FULL` will now:

* Compute `latestCommitVersionOutsideOfRetentionWindow`, and
* Persist `_last_vacuum_info` with that version,

so that subsequent `VACUUM LITE` runs can succeed instead of continuing to fail with
`DELTA_CANNOT_VACUUM_LITE`.

Behavior of `VACUUM FULL` and `VACUUM LITE` on healthy tables is unchanged.
No new configuration flags, SQL syntax, or error messages are introduced.

