### PR TITLE
[All] Update com.fasterxml.jackson to version 2.20.1

### DIFF
--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -219,7 +219,8 @@ case class SparkVersionSpec(
   supportHudi: Boolean = true,
   antlr4Version: String,
   additionalJavaOptions: Seq[String] = Seq.empty,
-  jacksonVersion: String = "2.15.2",
+  jacksonVersion: String = "2.20.1",
+  jacksonAnnotationsVersion: String = "2.20",
   additionalResolvers: Seq[Resolver] = Seq.empty
 ) {
   /** Returns the Spark short version (e.g., "3.5", "4.0") */
@@ -269,7 +270,8 @@ object SparkVersionSpec {
     supportIceberg = true,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2"
+    jacksonVersion = "2.18.2",
+    jacksonAnnotationsVersion = "2.18.2"
   )
 
   private val spark41 = SparkVersionSpec(
@@ -280,7 +282,8 @@ object SparkVersionSpec {
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2"
+    jacksonVersion = "2.20.0",
+    jacksonAnnotationsVersion = "2.20"
   )
 
   private val spark42Snapshot = SparkVersionSpec(
@@ -291,7 +294,8 @@ object SparkVersionSpec {
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2",
+    jacksonVersion = "2.20.1",
+    jacksonAnnotationsVersion = "2.20",
     // Artifact updates in maven central for roaringbitmap stopped after 1.3.0.
     // Spark master uses 1.5.3. Relevant Spark PR here https://github.com/apache/spark/pull/52892
     additionalResolvers = Seq("jitpack" at "https://jitpack.io")
@@ -415,10 +419,13 @@ object CrossSparkVersions extends AutoPlugin {
         val jacksonVer = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
           .getOrElse(throw new IllegalArgumentException(s"Unknown Spark version: $sparkVer"))
           .jacksonVersion
+        val jacksonAnnotationsVer = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
+          .getOrElse(throw new IllegalArgumentException(s"Unknown Spark version: $sparkVer"))
+          .jacksonAnnotationsVersion
         Seq(
           "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVer,
           "com.fasterxml.jackson.core" % "jackson-core" % jacksonVer,
-          "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVer,
+          "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVer,
           "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVer,
           "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVer
         )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -778,10 +778,15 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
    */
   def validateFileListAgainstCRC(checksum: VersionChecksum, contextOpt: Option[String]): Boolean = {
     val fileSortKey = (f: AddFile) => (f.path, f.modificationTime, f.size)
-    val filesFromCrc = checksum.allFiles.map(_.sortBy(fileSortKey)).getOrElse { return true }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    // So we convert null tags to empty maps before comparison.
+    val filesFromCrc = checksum.allFiles
+      .map(_.sortBy(fileSortKey))
+      .getOrElse { return true }
+      .map(af => if (af.tags == null) af.copy(tags = Map.empty) else af)
     val filesFromStateReconstruction = recordFrameProfile("Delta", "snapshot.allFiles") {
       allFilesViaStateReconstruction.collect().toSeq.sortBy(fileSortKey)
-    }
+    }.map(af => if (af.tags == null) af.copy(tags = Map.empty) else af)
     if (filesFromCrc == filesFromStateReconstruction) return true
 
     val filesFromCrcWithoutStats = filesFromCrc.map(_.copy(stats = ""))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -773,7 +773,8 @@ case class AddFile(
     modificationTime: Long,
     override val dataChange: Boolean,
     override val stats: String = null,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -1054,10 +1055,12 @@ case class RemoveFile(
     deletionTimestamp: Option[Long],
     override val dataChange: Boolean = true,
     extendedFileMetadata: Option[Boolean] = None,
-    partitionValues: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    partitionValues: Map[String, String] = Map.empty,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     size: Option[Long] = None,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -1114,7 +1117,8 @@ case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val stats: String = null) extends FileAction with HasNumRecords {
   override val dataChange = false
   @JsonIgnore
@@ -1482,15 +1486,15 @@ sealed trait CheckpointOnlyAction extends Action
  * @param path - sidecar path relative to `_delta_log/_sidecar` directory
  * @param sizeInBytes - size in bytes for the sidecar file
  * @param modificationTime - modification time of the sidecar file
- * @param tags - attributes of the sidecar file, defaults to null (which is semantically same as an
- *               empty Map). This is kept null to ensure that the field is not present in the
- *               generated json.
+ * @param tags - attributes of the sidecar file, defaults to an empty map. Both
+ *               null and empty maps are not included in the generated json.
  */
 case class SidecarFile(
     path: String,
     sizeInBytes: Long,
     modificationTime: Long,
-    tags: Map[String, String] = null)
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty)
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(sidecar = this)
@@ -1515,13 +1519,13 @@ object SidecarFile {
  * Holds information about the Delta Checkpoint. This action will only be part of checkpoints.
  *
  * @param version version of the checkpoint
- * @param tags    attributes of the checkpoint, defaults to null (which is semantically same as an
- *                empty Map). This is kept null to ensure that the field is not present in the
- *                generated json.
+ * @param tags    attributes of the checkpoint, defaults to empty map. Both null and empty
+ *                maps are not included in the generated json.
  */
 case class CheckpointMetadata(
     version: Long,
-    tags: Map[String, String] = null)
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty)
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(checkpointMetadata = this)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -20,6 +20,8 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.NumRecordsStats
 import org.apache.spark.sql.util.ScalaExtensions._
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.commons.lang3.StringUtils
 
@@ -85,14 +87,19 @@ case class MergeStats(
 
     // Expressions used in old MERGE stats, now always Null
     updateConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     updateExprs: Seq[String],
     insertConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     insertExprs: Seq[String],
     deleteConditionExpr: String,
 
     // Newer expressions used in MERGE with any number of MATCHED/NOT MATCHED/NOT MATCHED BY SOURCE
+    @JsonInclude(Include.NON_EMPTY)
     matchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedBySourceStats: Seq[MergeClauseStats],
 
     // Timings

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -334,7 +334,7 @@ class DeltaLogSuite extends QueryTest
         createTestAddFile(encodedPath = "bar", modificationTime = System.currentTimeMillis())
       log.startTransaction().commit(otherAdd :: Nil, DeltaOperations.ManualUpdate)
 
-      assert(log.update().allFiles.collect().find(_.path == "foo")
+      assert(log.update().allFiles.collect().find(_.path == "foo").map(_.copy(tags = Map.empty))
         // `dataChange` is set to `false` after replaying logs.
         === Some(add2.copy(
           dataChange = false, baseRowId = Some(1), defaultRowCommitVersion = Some(2))))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1067,7 +1067,13 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata === newMetadata2)
         // State reconstruction should give correct results
         var expectedFileNames = Set("1", "2", "post-upgrade-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        // Jackson 2.19+ deserializes null collection values as empty collections.
+        // So we convert null tags to empty maps before comparison.
+        val unsafeVolatileSnapshotFiles = log.unsafeVolatileSnapshot.allFiles
+          .map(f => if (f.tags == null) f.copy(tags = Map.empty) else f)
+          .collect()
+          .toSet
+        assert(unsafeVolatileSnapshotFiles ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         // commit-coordinator should not be invoked for commit API.
         // Register table API should not be called until the end
@@ -1099,7 +1105,13 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsCoordinatorConf === Map.empty)
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsTableConf === Map.empty)
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        // Jackson 2.19+ deserializes null collection values as empty collections.
+        // So we convert null tags to empty maps before comparison.
+        val unsafeVolatileSnapshotFiles2 = log.unsafeVolatileSnapshot.allFiles
+          .map(f => if (f.tags == null) f.copy(tags = Map.empty) else f)
+          .collect()
+          .toSet
+        assert(unsafeVolatileSnapshotFiles2 ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 0))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))
@@ -1112,7 +1124,13 @@ abstract class CommitCoordinatorSuiteBase
         // Make 1 more commit, this should go to new owner
         log.startTransaction().commitManually(newMetadata3, createTestAddFile("4"))
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file", "4")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        // Jackson 2.19+ deserializes null collection values as empty collections.
+        // So we convert null tags to empty maps before comparison.
+        val unsafeVolatileSnapshotFiles3 = log.unsafeVolatileSnapshot.allFiles
+          .map(f => if (f.tags == null) f.copy(tags = Map.empty) else f)
+          .collect()
+          .toSet
+        assert(unsafeVolatileSnapshotFiles3 ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 1))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Update com.fasterxml.jackson to version 2.20.0 for spark 4.1 and to 2.20.1 for spark 4.2 to match the shipped 4.1 and the current version in 4.2 snapshots.

The only observable difference in this jackson update is that scala deserialization has changed to map non-existing/null values for collections to empty collections. That change is documented [here](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.19#scala).

A flag has been added to force the old behavior. However, that flag is global, so it seems like a bad idea to rely on it: https://github.com/FasterXML/jackson-module-scala/pull/745

To ensure that the json representation of various objects do not include empty collections when not necessary, we use the `JsonInclude(Include.NON_EMPTY)` annotation that does not put empty collections in the json representation.

Various tests need updating to deal with the fact that deserialized versions of objects now contain empty collections instead of null.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.