### PR TITLE
[Kernel-Spark] Add ProtocolMetadataAdapterV2 for DeltaParquetFileFormat reuse

### DIFF
--- a/kernel-spark/src/main/java/io/delta/kernel/spark/read/ProtocolMetadataAdapterV2.java
+++ b/kernel-spark/src/main/java/io/delta/kernel/spark/read/ProtocolMetadataAdapterV2.java
@@ -102,6 +102,9 @@ public class ProtocolMetadataAdapterV2 implements ProtocolMetadataAdapter, Seria
   public boolean isIcebergCompatGeqEnabled(int version) {
     boolean v2Enabled = TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(metadata);
     boolean v3Enabled = TableConfig.ICEBERG_COMPAT_V3_ENABLED.fromMetadata(metadata);
+    // IcebergCompatV1 is not supported in Kernel, so V2 is the minimum version for v2 connector
+    // until kernel supports IcebergCompatV1.
+    // For version 1 or 2, we return true if V2 or V3 is enabled.
     switch (version) {
       case 1:
       case 2:
@@ -115,7 +118,7 @@ public class ProtocolMetadataAdapterV2 implements ProtocolMetadataAdapter, Seria
 
   @Override
   public void assertTableReadable(SparkSession sparkSession) {
-    // TODO: Add type widening validation.
+    // TODO(delta-io/delta#5649): Add type widening validation.
   }
 
   @Override

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV2Suite.scala
@@ -26,7 +26,7 @@ import org.scalactic.source.Position
 import org.scalatest.Tag
 
 import java.util.Optional
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Unit tests for ProtocolMetadataAdapterV2.
@@ -41,7 +41,7 @@ class ProtocolMetadataAdapterV2Suite extends ProtocolMetadataAdapterSuiteBase {
    * These tests can be ignored because V2 has different behavior or limitations.
    */
   protected def ignoredTests: Set[String] = Set(
-    // TODO: add type widening validation
+    // TODO(delta-io/delta#5649): add type widening validation
     "assertTableReadable with table with unsupported type widening",
     // V1 IcebergCompat is not supported in Kernel (only V2/V3)
     "isIcebergCompatAnyEnabled when v1 enabled",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds `ProtocolMetadataAdapterV2` to enable kernel-spark to reuse delta-spark's `DeltaParquetFileFormat` without depending on delta-spark's Protocol and Metadata action classes.

**Changes:**

1. **ProtocolMetadataAdapterV2** (`kernel-spark/src/main/java/.../read/`)
   - Implements `ProtocolMetadataAdapter` interface using Kernel's Protocol and Metadata
   - Converts column mapping modes between Kernel enums and Scala case objects
   - Provides feature checks: deletion vectors, row tracking, Iceberg compatibility (V2/V3)
   - Uses `RowTrackingUtils.createMetadataStructFields` from #5483 for row tracking metadata

2. **ProtocolMetadataAdapterV2Suite** (`spark-unified/src/test/scala/` as the base test is visible only in spark-unified module)
   - Extends `ProtocolMetadataAdapterSuiteBase` with 19 tests
   - Selectively ignores V2-incompatible tests (IcebergCompatV1, type widening assertions)

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No