### PR TITLE
[Spark] Translate old property ucTableId to io.unitycatalog.tableId when creating a new table.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -120,9 +120,6 @@ sealed abstract class TableFeature(
    * to be enabled if this table feature is enabled.
    */
   def requiredFeatures: Set[TableFeature] = Set.empty
-
-  /** The table property config key. */
-  val propertyKey: String = TableFeatureProtocolUtils.propertyKey(name)
 }
 
 /** A trait to indicate a feature applies to readers and writers. */
@@ -1127,12 +1124,6 @@ object CatalogOwnedTableFeature
 
   // Before downgrade, we require to backfill all unbackfilled commits, hence time-travel is safe.
   override def actionUsesFeature(action: Action): Boolean = false
-
-  // This table property was once renamed from an old name. In a transition period we need to
-  // support translation of the old name to the new name.
-  // TODO: clean up once callers are migrated.
-  private val oldFeatureName: String = "catalogOwned-preview"
-  val oldPropertyKey: String = TableFeatureProtocolUtils.propertyKey(oldFeatureName)
 }
 
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Translate old property ucTableId to io.unitycatalog.tableId when creating a new table.

This table property was renamed by https://github.com/delta-io/delta/pull/5534. However caller to AbstractDeltaCatalog.createTable (UCSingleCatalog from unitycatalog-spark) still sets the old property name and new property name in its current release. This change is needed until UCSingleCatalog moves away from the old table property name.

## How was this patch tested?
A test is added in DeltaDDLSuite to exercise the table creation with old property name.

## Does this PR introduce _any_ user-facing changes?
No.