### PR TITLE
[Feature] Adding table_id prefix for VACUUM logging for observability

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -166,6 +166,8 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
 
       val snapshot = table.update()
       deltaLog.protocolWrite(snapshot.protocol)
+      val tableId = snapshot.metadata.id
+      val truncatedTableId = tableId.split("-").head
 
       if (snapshot.isCatalogOwned) {
         table.catalogTable.foreach { catalogTable =>
@@ -182,6 +184,10 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
       val isLiteVacuumEnabled = spark.sessionState.conf.getConf(DeltaSQLConf.LITE_VACUUM_ENABLED)
       val defaultType = if (isLiteVacuumEnabled) VacuumType.LITE else VacuumType.FULL
       val vacuumType = vacuumTypeOpt.map(VacuumType.withName).getOrElse(defaultType)
+      val vacuumTypeTag = vacuumType match {
+        case VacuumType.FULL => log"[VACUUM_FULL] "
+        case VacuumType.LITE => log"[VACUUM_LITE] "
+      }
 
       val snapshotTombstoneRetentionMillis = DeltaLog.tombstoneRetentionMillis(snapshot.metadata)
       val retentionMillis = retentionHours.flatMap { h =>
@@ -202,11 +208,14 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
         case Some(millis) => clock.getTimeMillis() - millis
         case _ => snapshot.minFileRetentionTimestamp
       }
-      logInfo(log"Starting garbage collection (dryRun = " +
-        log"${MDC(DeltaLogKeys.IS_DRY_RUN, dryRun)}) of untracked " +
-        log"files older than ${MDC(DeltaLogKeys.DATE,
-          new Date(deleteBeforeTimestamp).toGMTString)} in " +
-        log"${MDC(DeltaLogKeys.PATH, path)}")
+      logInfo(
+        log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] " +
+          vacuumTypeTag +
+          log"Starting garbage collection (dryRun = " +
+          log"${MDC(DeltaLogKeys.IS_DRY_RUN, dryRun)}) of untracked " +
+          log"files older than ${MDC(DeltaLogKeys.DATE,
+            new Date(deleteBeforeTimestamp).toGMTString)} in " +
+          log"${MDC(DeltaLogKeys.PATH, path)}")
       val hadoopConf = spark.sparkContext.broadcast(
         new SerializableConfiguration(deltaHadoopConf))
       val basePath = fs.makeQualified(path).toString
@@ -353,10 +362,14 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
             )
 
             recordDeltaEvent(deltaLog, "delta.gc.stats", data = stats)
-            logInfo(log"Found ${MDC(DeltaLogKeys.NUM_FILES, numFiles.toLong)} files " +
-              log"(${MDC(DeltaLogKeys.NUM_BYTES, sizeOfDataToDelete)} bytes) and directories in " +
-              log"a total of ${MDC(DeltaLogKeys.NUM_DIRS, dirCounts)} directories " +
-              log"that are safe to delete. Vacuum stats: ${MDC(DeltaLogKeys.VACUUM_STATS, stats)}")
+            logInfo(
+              log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] " +
+                vacuumTypeTag +
+                log"Found ${MDC(DeltaLogKeys.NUM_FILES, numFiles.toLong)} files " +
+                log"(${MDC(DeltaLogKeys.NUM_BYTES, sizeOfDataToDelete)} bytes) and " +
+                log"directories in a total of " +
+                log"${MDC(DeltaLogKeys.NUM_DIRS, dirCounts)} directories that are safe " +
+                log"to delete. Vacuum stats: ${MDC(DeltaLogKeys.VACUUM_STATS, stats)}")
 
             return diffFiles.map(f => urlEncodedStringToPath(f).toString).toDF("path")
           }
@@ -366,7 +379,9 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
             diffFiles,
             sizeOfDataToDelete,
             retentionMillis,
-            snapshotTombstoneRetentionMillis)
+            snapshotTombstoneRetentionMillis,
+            truncatedTableId,
+            vacuumTypeTag)
 
           val deleteStartTime = System.currentTimeMillis()
           val filesDeleted = try {
@@ -407,10 +422,13 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
           LastVacuumInfo.persistLastVacuumInfo(
             LastVacuumInfo(latestCommitVersionOutsideOfRetentionWindowOpt), deltaLog)
 
-          logInfo(log"Deleted ${MDC(DeltaLogKeys.NUM_FILES, filesDeleted)} files " +
-            log"(${MDC(DeltaLogKeys.NUM_BYTES, sizeOfDataToDelete)} bytes) and directories in " +
-            log"a total of ${MDC(DeltaLogKeys.NUM_DIRS, dirCounts)} directories. " +
-            log"Vacuum stats: ${MDC(DeltaLogKeys.VACUUM_STATS, stats)}")
+          logInfo(
+            log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] " +
+              vacuumTypeTag +
+              log"Deleted ${MDC(DeltaLogKeys.NUM_FILES, filesDeleted)} files " +
+              log"(${MDC(DeltaLogKeys.NUM_BYTES, sizeOfDataToDelete)} bytes) and directories in " +
+              log"a total of ${MDC(DeltaLogKeys.NUM_DIRS, dirCounts)} directories. " +
+              log"Vacuum stats: ${MDC(DeltaLogKeys.VACUUM_STATS, stats)}")
 
 
           spark.createDataset(Seq(basePath)).toDF("path")
@@ -536,13 +554,17 @@ trait VacuumCommandImpl extends DeltaCommand {
       diff: Dataset[String],
       sizeOfDataToDelete: Long,
       specifiedRetentionMillis: Option[Long],
-      defaultRetentionMillis: Long): Unit = {
+      defaultRetentionMillis: Long,
+      truncatedTableId: String,
+      vacuumTypeLogPrefix: org.apache.spark.internal.MessageWithContext): Unit = {
     val deltaLog = table.deltaLog
     logInfo(
-      log"Deleting untracked files and empty directories in " +
-      log"${MDC(DeltaLogKeys.PATH, deltaLog.dataPath)}. The amount " +
-      log"of data to be deleted is ${MDC(DeltaLogKeys.NUM_BYTES, sizeOfDataToDelete)} (in bytes)"
-      )
+      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] " +
+        vacuumTypeLogPrefix +
+        log"Deleting untracked files and empty directories in " +
+        log"${MDC(DeltaLogKeys.PATH, deltaLog.dataPath)}. The amount " +
+        log"of data to be deleted is " +
+        log"${MDC(DeltaLogKeys.NUM_BYTES, sizeOfDataToDelete)} (in bytes)")
 
     // We perform an empty commit in order to record information about the Vacuum
     if (shouldLogVacuum(spark, table, deltaLog.newDeltaHadoopConf(), deltaLog.dataPath)) {
@@ -929,7 +951,6 @@ trait VacuumCommandImpl extends DeltaCommand {
 
     files
   }
-
 
   /**
    * Helper to compute all valid files based on basePath and Snapshot provided.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Improve observability of Delta Lake VACUUM operations by including the table identifier (table ID / table path) in all VACUUM‑related log messages. This helps users understand exactly which table is being vacuumed when multiple Delta tables are processed within the same job. Though we have the table path in the logswhen the VACUUM job starts , it is not very debug friendly and searchable as the paths are very long. This fixes #5594  

Currently, when user runs VACUUM on Multiple tables , the log messages do not include any table identifier. When multiple tables are processed in a single job, users cannot determine which table is being cleaned up from the logs alone:

**Current logs:**
```
25/11/27 05:05:14 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 20 Nov 2025 05:05:14 GMT in /tmp/delta/vacuum
25/11/27 05:05:38 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 20 Nov 2025 05:05:38 GMT in  /tmp/delta/orders
25/11/27 05:05:44 INFO VacuumCommand: Deleting untracked files and empty directories in  /tmp/delta/orders The amount of data to be deleted is 0 (in bytes)
25/11/27 05:05:26 INFO VacuumCommand: Deleting untracked files and empty directories in  /tmp/delta/vacuum. The amount of data to be deleted is 0 (in bytes)
25/11/27 05:05:29 INFO VacuumCommand: Deleted 0 files (0 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,None,604800000,1763615114082,1,4,0,0,10038,1158,1764219914030,1764219929008,8,8,8,false,0,0,7,None,None,FULL)

25/11/27 05:05:45 INFO VacuumCommand: Deleted 0 files (0 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,None,604800000,1763615138428,1,4,0,0,4887,938,1764219938390,1764219945316,8,8,8,false,0,0,5,None,None,LITE)
```

## How was this patch tested?

Ran the below code , on delta-3.3.0 before the change and then ran the same code by building an assembly jar after the fix and below is the difference in the logs

**Code:**

```
import org.apache.spark.sql.functions._
import java.nio.file.{Files, Paths}
import scala.util.Try

val path = "/tmp/delta_vacuum"

// Clean up from previous runs
Try {
  import sys.process._
  s"rm -rf $path".!
}

// Write a simple Delta table
spark.range(10).write.format("delta").mode("overwrite").save(path)

// Make a few commits so VACUUM has something to work with
spark.range(10, 20).write.format("delta").mode("append").save(path)
spark.range(20, 30).write.format("delta").mode("append").save(path)

// Disable retention check for testing
spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")

// Run VACUUM
spark.sql(s"VACUUM delta.`$path` RETAIN 0 HOURS")
```

**Logs before the fix:**

```
25/11/27 05:05:38 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 20 Nov 2025 05:05:38 GMT in  /tmp/delta/orders
25/11/27 05:05:44 INFO VacuumCommand: Deleting untracked files and empty directories in  /tmp/delta/orders The amount of data to be deleted is 0 (in bytes)
25/11/27 05:05:45 INFO VacuumCommand: Deleted 0 files (0 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,None,604800000,1763615138428,1,4,0,0,4887,938,1764219938390,1764219945316,8,8,8,false,0,0,5,None,None,FULL)
```

**Logs with this fix:**

```
25/11/27 14:36:18 INFO VacuumCommand: [tableId=e63846fa] [VACUUM_FULL] Starting garbage collection (dryRun = false) of untracked files older than 20 Nov 2025 05:05:38 GMT in  /tmp/delta/orders
25/11/27 14:36:30 INFO VacuumCommand: [tableId=e63846fa] [VACUUM_FULL] Deleting untracked files and empty directories in  /tmp/delta/orders The amount of data to be deleted is 0 (in bytes)
25/11/27 14:36:40 INFO VacuumCommand: [tableId=e63846fa] [VACUUM_FULL] Deleted 13 files (6473 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,Some(0),604800000,1764254189829,1,25,13,6473,7982,581,1764254189825,1764254199336,0,13,None,None,FULL)
```


## Does this PR introduce _any_ user-facing changes?

Yes, it improves observability and debugging capability . To get all the vacuum logs for a specific table , user can now search with the string `"VacuumCommand: [tableId=<table_id>]"` to get all the required logs
