### PR TITLE
[Protocol] Clarify enablement/support of materializePartitionColumns

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1964,8 +1964,7 @@ When this feature is enabled, partition columns are physically written to Parque
  - The table must be on Writer Version 7, and a feature name `materializePartitionColumns` must exist in the table `protocol`'s `writerFeatures`.
 
 When supported:
- - The table respects metadata property `delta.enableMaterializePartitionColumnsFeature` for enablement of this feature. The writer feature `materializePartitionColumns` is auto-enabled when this property is set to `true`.
- - When the writer feature `materializePartitionColumns` is set in the protocol, writers must materialize partition columns into any newly created data file, placing them after the data columns in the parquet
+ - When the writer feature `materializePartitionColumns` is supported in the protocol, writers must materialize partition columns into any newly created data file, placing them after the data columns in the parquet
   schema. This mimics the same partition column materialization requirement from [IcebergCompatV1](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#iceberg-compatibility-v1)
 and
 [IcebergCompatV2](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#iceberg-compatibility-v2). As such, the `materializePartitionColumns` feature can be seen as a subset of the requirements imposed by those features, providing the partition column materialization guarantee independently without requiring full


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (protocol)

## Description

Some writer features are enabled everywhere where they're supported (ie. present in table protocol), while others are enabled only if a table property is also set alongside the feature being supported. The wording on materializePartitionColumns is mostly in line with enablement being the same as support, except for one line which makes it confusing. This change removes that line and clarifies that all writers must materialize partition columns _if_ the writer feature exists in table protocol.

## How was this patch tested?

N/a

## Does this PR introduce _any_ user-facing changes?

No
