### PR TITLE
[Kernel] Deprecate CommitRange::getActions in favor of CommitRange::getCommitActions

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.delta.kernel;
 
 import io.delta.kernel.annotation.Evolving;
@@ -92,6 +91,7 @@ public interface CommitRange {
    *
    * <p>The iterator must be closed after use to release any underlying resources.
    *
+   * @deprecated Use {@link #getCommitActions(Engine, Snapshot, Set)} instead
    * @param engine the {@link Engine} to use for reading the Delta log files
    * @param startSnapshot the snapshot for startVersion, required to ensure the table is readable by
    *     Kernel at startVersion
@@ -103,6 +103,7 @@ public interface CommitRange {
    * @throws KernelException if the version range contains a version with reader protocol that is
    *     unsupported by Kernel
    */
+  @Deprecated
   CloseableIterator<ColumnarBatch> getActions(
       Engine engine, Snapshot startSnapshot, Set<DeltaLogActionUtils.DeltaAction> actionSet);
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
