### PR TITLE
[Spark] Plumbing the table feature properties to server when create a table.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -193,7 +193,7 @@ trait DeltaConfigsBase extends DeltaLogging {
           kv
         case lKey if lKey.startsWith(TableFeatureProtocolUtils.FEATURE_PROP_PREFIX) =>
           // This is a table feature, we should allow it.
-          lKey -> value
+          key -> value
         case lKey if lKey.startsWith("delta.") =>
           Option(entries.get(lKey.stripPrefix("delta."))) match {
             case Some(deltaConfig) if (

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -457,6 +457,9 @@ object TableFeatureProtocolUtils {
   /** Min reader version that supports writer features. */
   val TABLE_FEATURES_MIN_WRITER_VERSION = 7
 
+  /** The table ID property key needed by feature catalogManaged. */
+  val UC_TABLE_ID_KEY = "io.unitycatalog.tableId"
+
   /** Get the table property config key for the `feature`. */
   def propertyKey(feature: TableFeature): String = propertyKey(feature.name)
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Plumbing the table feature properties to server when create a table.
These table properties need to be set if Delta creates a managed table with catalogManaged feature on UC.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.