### PR TITLE
[Spark] split auto-compact suite into config/exec suites

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
@@ -56,14 +56,19 @@ trait AutoCompactTestUtils {
  * This class extends the [[CompactionSuiteBase]] and runs all the [[CompactionSuiteBase]] tests
  * with AutoCompaction.
  *
- * It also tests any AutoCompaction specific behavior.
+ * It also tests AutoCompaction specific behavior around configuration settings.
  */
-class AutoCompactSuite extends
+class AutoCompactConfigurationSuite extends
     CompactionTestHelperForAutoCompaction
   with DeltaSQLCommandTest
   with SharedSparkSession
   with AutoCompactTestUtils
   with DeltaExcludedBySparkVersionTestMixinShims {
+
+  private def setTableProperty(log: DeltaLog, key: String, value: String): Unit = {
+    spark.sql(s"ALTER TABLE delta.`${log.dataPath}` SET TBLPROPERTIES " +
+      s"($key = $value)")
+  }
 
   test("auto-compact-type: test table properties") {
     withTempDir { tempDir =>
@@ -107,6 +112,20 @@ class AutoCompactSuite extends
     }
   }
 
+}
+
+/**
+ * This class extends the [[CompactionSuiteBase]] and runs all the [[CompactionSuiteBase]] tests
+ * with AutoCompaction.
+ *
+ * It also tests AutoCompaction specific behavior around compaction execution.
+ */
+class AutoCompactExecutionSuite extends
+    CompactionTestHelperForAutoCompaction
+  with DeltaSQLCommandTest
+  with SharedSparkSession
+  with AutoCompactTestUtils
+  with DeltaExcludedBySparkVersionTestMixinShims {
   private def testBothModesViaProperty(testName: String)(f: String => Unit): Unit = {
     def runTest(autoCompactConfValue: String): Unit = {
       withTempDir { dir =>
@@ -351,12 +370,22 @@ class AutoCompactSuite extends
   }
 }
 
-class AutoCompactIdColumnMappingSuite extends AutoCompactSuite
+class AutoCompactConfigurationIdColumnMappingSuite extends AutoCompactConfigurationSuite
   with DeltaColumnMappingEnableIdMode {
   override def runAllTests: Boolean = true
 }
 
-class AutoCompactNameColumnMappingSuite extends AutoCompactSuite
+class AutoCompactExecutionIdColumnMappingSuite extends AutoCompactExecutionSuite
+  with DeltaColumnMappingEnableIdMode {
+  override def runAllTests: Boolean = true
+}
+
+class AutoCompactConfigurationNameColumnMappingSuite extends AutoCompactConfigurationSuite
+  with DeltaColumnMappingEnableNameMode {
+  override def runAllTests: Boolean = true
+}
+
+class AutoCompactExecutionNameColumnMappingSuite extends AutoCompactExecutionSuite
   with DeltaColumnMappingEnableNameMode {
   override def runAllTests: Boolean = true
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This test-only change splits the relatively large AutoCompactSuite into AutoCompactConfigurationSuite and AutoCompactExecutionSuites.

## How was this patch tested?

Test-only

## Does this PR introduce _any_ user-facing changes?

No
