### PR TITLE
[Kernel] Add support for setting `delta.dataSkippingStatsColumns`, though its behavior is unimplemented

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -19,8 +19,8 @@ import io.delta.kernel.exceptions.InvalidConfigurationValueException;
 import io.delta.kernel.exceptions.UnknownConfigurationException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
-import io.delta.kernel.internal.util.*;
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
+import io.delta.kernel.internal.util.IntervalParserUtils;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -278,6 +278,37 @@ public class TableConfig<T> {
           true);
 
   /**
+   * IMPORTANT: This table property is recognized but is not yet validated, enforced, or implemented
+   * by Kernel.
+   *
+   * <p>The names of specific columns to collect stats on for data skipping. If present, it takes
+   * precedence over {@link #DATA_SKIPPING_NUM_INDEXED_COLS}, and the system will only collect stats
+   * for columns that exactly match those specified. If a nested column is specified, the system
+   * will collect stats for all leaf fields of that column. If a non-existent column is specified,
+   * it will be ignored. Updating this config does not trigger stats re-collection, but redefines
+   * the stats schema of the table, i.e., it will change the behavior of future stats collection
+   * (e.g., in append and OPTIMIZE) as well as data skipping (e.g., the column stats not mentioned
+   * by this config will be ignored even if they exist).
+   *
+   * <p>The value is a comma-separated list of case-insensitive column identifiers. Each column
+   * identifier can consist of letters, digits, and underscores. If a column identifier includes
+   * special characters, the column name should be enclosed in backticks (`) to escape the special
+   * characters.
+   *
+   * <p>A column identifier can refer to one of the following: the name of a non-struct column, the
+   * leaf field's name of a struct column, or the name of a struct column. When a struct column's
+   * name is specified, statistics for all its leaf fields will be collected.
+   */
+  public static final TableConfig<Optional<String>> DATA_SKIPPING_STATS_COLUMNS =
+      new TableConfig<>(
+          "delta.dataSkippingStatsColumns",
+          null,
+          v -> Optional.ofNullable(v),
+          value -> true,
+          "needs to be a comma-separated list of column identifiers.",
+          true);
+
+  /**
    * Table property that enables modifying the table in accordance with the Delta-Iceberg Writer
    * Compatibility V1 ({@code icebergCompatWriterV1}) protocol.
    */
@@ -398,6 +429,9 @@ public class TableConfig<T> {
               addConfig(this, MATERIALIZED_ROW_ID_COLUMN_NAME);
               addConfig(this, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME);
               addConfig(this, VARIANT_SHREDDING_ENABLED);
+
+              // The below configs do not yet have their behavior correctly implemented in Kernel.
+              addConfig(this, DATA_SKIPPING_STATS_COLUMNS);
             }
           });
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TablePropertiesSuite.scala
@@ -333,4 +333,33 @@ trait TablePropertiesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
     val metadata = getMetadata(defaultEngine, tablePath)
     assert(keys.forall(!metadata.getConfiguration.containsKey(_)))
   }
+
+  val recognizedButUnimplementedProps = Seq(
+    ("delta.dataSkippingStatsColumns", "col1,col2,nested.field"))
+
+  recognizedButUnimplementedProps.foreach { case (propKey, value) =>
+    test(s"$propKey is allowed (but not implemented) - create table") {
+      withTempDir { tempFile =>
+        val tablePath = tempFile.getAbsolutePath
+        createUpdateTableWithProps(
+          tablePath,
+          createTable = true,
+          propsAdded = Map(propKey -> value))
+        assertHasProp(tablePath, Map(propKey -> value))
+      }
+    }
+
+    test(s"$propKey is allowed (but not implemented) - update table") {
+      withTempDir { tempFile =>
+        val tablePath = tempFile.getAbsolutePath
+        createUpdateTableWithProps(tablePath, createTable = true)
+
+        val updatedValue = s"${value}_updated"
+        createUpdateTableWithProps(
+          tablePath,
+          propsAdded = Map(propKey -> updatedValue))
+        assertHasProp(tablePath, Map(propKey -> updatedValue))
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5642/files) to review incremental changes.
- [**stack/kernel_data_skipping_stats_columns**](https://github.com/delta-io/delta/pull/5642) [[Files changed](https://github.com/delta-io/delta/pull/5642/files)]

---------

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR allows Kernel to set the `delta.dataSkippingStatsColumns` table property.

Note that (1) its value is not validated/checked, and (2) its desired behavior is not yet enforced.

## How was this patch tested?

Fairly trivial to add a new table property. Added a new UT nonetheless.

## Does this PR introduce _any_ user-facing changes?

No.
