### PR TITLE
[Spark] Throw exception when validation fails in ALTER COLUMN AFTER

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2005,6 +2005,24 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_LIQUID_ALTER_COLUMN_AFTER_STATS_SCHEMA_CHECK =
+    buildConf("liquid.alterColumnAfter.statsSchemaCheck")
+      .internal()
+      .doc(
+         """
+           |When enabled, validates that clustering columns remain in the stats schema after
+           | a user executes `ALTER TABLE ALTER COLUMN col1 AFTER col2`. The validation checks
+           | that all clustering columns that were in the stats schema before the column reordering
+           | remain in the stats schema after the operation. This ensures that clustering columns
+           | continue to have statistics collected even if their position in the table schema
+           | changes. When disabled, no validation is performed and stats collection may follow
+           | position-based indexing rules (e.g., `dataSkippingNumIndexedCols`), potentially
+           | causing clustering columns to lose stats collection if they move outside the indexed
+           | range.
+        """.stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_CHANGE_COLUMN_CHECK_DEPENDENT_EXPRESSIONS_USE_V2 =
     buildConf("changeColumn.checkDependentExpressionsUseV2")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -825,6 +825,55 @@ trait ClusteredTableDDLSuiteBase
     }
   }
 
+  Seq("true", "false").foreach { checkEnabled =>
+    test(s"Alter column after statement with stats schema update - checkEnabled=$checkEnabled") {
+      withTable(testTable) {
+        withSQLConf(
+          DeltaSQLConf.DELTA_LIQUID_ALTER_COLUMN_AFTER_STATS_SCHEMA_CHECK.key -> checkEnabled) {
+          val tableSchema = "c1 int, c2 int, c3 int, c4 int"
+          val indexedColumns = 2
+
+          testStatsCollectionHelper(
+            tableSchema = tableSchema,
+            numberOfIndexedCols = indexedColumns) {
+
+            createTableWithStatsColumns(
+              "CREATE",
+              testTable,
+              Seq("c1", "c2"),
+              indexedColumns,
+              Some(tableSchema))
+
+            // Insert data to ensure stats are collected
+            sql(s"INSERT INTO $testTable VALUES(1, 2, 3, 4), (5, 6, 7, 8)")
+
+            // ALTER TABLE ALTER COLUMN should succeed when checkEnabled=false
+            sql(s"ALTER TABLE $testTable ALTER COLUMN c1 AFTER c3")
+
+            // Verify the column order changed
+            val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTable))
+            assert(snapshot.schema.fieldNames.toSeq === Seq("c2", "c3", "c1", "c4"))
+
+            // Try another ALTER - behavior depends on checkEnabled
+            if (checkEnabled == "true") {
+              // Should fail when validation is enabled
+              val e = intercept[DeltaAnalysisException] {
+                sql(s"ALTER TABLE $testTable ALTER COLUMN c2 AFTER c3")
+              }
+              assert(e.errorClass.contains("DELTA_CLUSTERING_COLUMN_MISSING_STATS"))
+            } else {
+              // Should succeed when validation is disabled
+              sql(s"ALTER TABLE $testTable ALTER COLUMN c2 AFTER c3")
+              val (_, snapshot2) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTable))
+              assert(snapshot2.schema.fieldNames.toSeq === Seq("c3", "c2", "c1", "c4"))
+            }
+          }
+        }
+      }
+    }
+  }
+
+
   test("validate CLONE on clustered table") {
     import testImplicits._
     val srcTable = "SrcTbl"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

 This change series adds validation to ensure clustering columns remain in the statistics schema when executing `ALTER TABLE ALTER COLUMN col AFTER position` commands on clustered Delta tables. Without proper stats schema handling, column reordering  can cause clustering columns to lose statistics collection due to position-based indexing rules, degrading query optimization performance.

## How was this patch tested?

The test suite verifies the following scenarios:                                                                                                                                                                                                           
 1. **checkEnabled=false (default)**:                                                                                                                                                                                                                       
    - First ALTER COLUMN AFTER succeeds (c1 moves after c3)                                                                                                                                                                                                 
    - Second ALTER COLUMN AFTER succeeds (c2 moves after c3)                                                                                                                                                                                                
    - No validation errors thrown                                                                                                                                                                                                                           
    - Column order changes as expected                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                            
 2. **checkEnabled=true**:                                                                                                                                                                                                                                  
    - First ALTER COLUMN AFTER succeeds (c1 moves after c3)                                                                                                                                                                                                 
    - Second ALTER COLUMN AFTER fails with `DELTA_CLUSTERING_COLUMN_MISSING_STATS` error                                                                                                                                                                    
    - Clustering column c2 would lose stats collection                                                                                                                                                                                                      
    - Original schema and stats remain unchanged
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
