### PR TITLE
[kernel-spark] Basic initial snapshot support for dsv2 streaming

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaSourceDSv2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaSourceDSv2Suite.scala
@@ -47,11 +47,30 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
   }
 
   private lazy val shouldPassTests = Set(
+    // ========== Core streaming tests ==========
+    "basic",
+    "initial snapshot ends at base index of next version",
+    "new commits arrive after stream initialization - with explicit startingVersion",
+    "SC-11561: can consume new data without update",
+    "Delta sources don't write offsets with null json",
+
+    // ========== startingVersion option tests ==========
     "startingVersion",
     "startingVersion latest",
     "startingVersion latest defined before started",
     "startingVersion latest works on defined but empty table",
-    "startingVersion specific version: new commits arrive after stream initialization"
+    "startingVersion specific version: new commits arrive after stream initialization",
+
+    // ========== Rate limiting tests ==========
+    "maxFilesPerTrigger",
+    "maxBytesPerTrigger: process at least one file",
+    "maxFilesPerTrigger: change and restart",
+    "maxFilesPerTrigger: invalid parameter",
+    "maxFilesPerTrigger: ignored when using Trigger.Once",
+    "maxBytesPerTrigger: change and restart",
+    "maxBytesPerTrigger: invalid parameter",
+    "maxBytesPerTrigger: max bytes and max files together",
+    "startingVersion should work with rate time"
   )
 
   private lazy val shouldFailTests = Set(
@@ -81,8 +100,6 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
 
     // === Other tests that bypass V2 by not using loadStreamWithOptions ===
     "disallow to change schema after starting a streaming query",
-    "maxFilesPerTrigger: invalid parameter",
-    "maxBytesPerTrigger: invalid parameter",
     "recreate the reservoir should fail the query",
     "excludeRegex throws good error on bad regex pattern",
     "SC-46515: deltaSourceIgnoreChangesError contains removeFile, version, tablePath",
@@ -99,18 +116,11 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
     "fail on data loss - gaps of files with option off",
 
     // === Rate Limiting / Trigger Options ===
-    "maxFilesPerTrigger",
     "maxFilesPerTrigger: metadata checkpoint",
-    "maxFilesPerTrigger: change and restart",
-    "maxFilesPerTrigger: ignored when using Trigger.Once",
     "maxFilesPerTrigger: Trigger.AvailableNow respects read limits",
-    "maxBytesPerTrigger: process at least one file",
     "maxBytesPerTrigger: metadata checkpoint",
-    "maxBytesPerTrigger: change and restart",
     "maxBytesPerTrigger: Trigger.AvailableNow respects read limits",
-    "maxBytesPerTrigger: max bytes and max files together",
     "Trigger.AvailableNow with an empty table",
-    "startingVersion should work with rate time",
     "Rate limited Delta source advances with non-data inserts",
     "ES-445863: delta source should not hang or reprocess data when using AvailableNow",
 
@@ -127,13 +137,9 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
 
     // === Misc ===
     "no schema should throw an exception",
-    "basic",
-    "initial snapshot ends at base index of next version",
-    "Delta sources don't write offsets with null json",
     "Delta source advances with non-data inserts and generates empty dataframe for addl files",
     "a fast writer should not starve a Delta source",
     "start from corrupt checkpoint",
-    "SC-11561: can consume new data without update",
     "make sure that the delta sources works fine",
     "should not attempt to read a non exist version",
     "self union a Delta table should pass the catalog table assert"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -282,9 +282,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       Seq("keep1", "keep2", "drop3").toDF.write
         .format("delta").mode("append").save(inputDir.getAbsolutePath)
 
-      val df = spark.readStream
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map.empty)
         .filter($"value" contains "keep")
 
       testStream(df)(
@@ -316,9 +314,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val df = spark.readStream
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map.empty)
 
       val expected = (
           (0 until 5).map(_.toString -> null) ++ (5 until 10).map(_.toString).map(x => x -> x)
@@ -363,10 +359,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
-        .load(inputDir.getCanonicalPath)
+      val q = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1"))
         .writeStream
         .format("memory")
         .queryName("maxFilesPerTriggerTest")
@@ -393,10 +388,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
-        .load(inputDir.getCanonicalPath)
+      val q = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1"))
         .writeStream
         .format("memory")
         .queryName("maxFilesPerTriggerTest")
@@ -423,10 +417,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
-        .load(inputDir.getCanonicalPath)
+      val q = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1"))
         .writeStream
         .format("delta")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -450,10 +443,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q2 = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "2")
-        .load(inputDir.getCanonicalPath)
+      val q2 = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "2"))
         .writeStream
         .format("delta")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -482,10 +474,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
       Seq(0, -1, "string").foreach { invalidMaxFilesPerTrigger =>
         val e = intercept[StreamingQueryException] {
-          spark.readStream
-            .format("delta")
-            .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, invalidMaxFilesPerTrigger.toString)
-            .load(inputDir.getCanonicalPath)
+          loadStreamWithOptions(
+            inputDir.getCanonicalPath,
+            Map(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> invalidMaxFilesPerTrigger.toString))
             .writeStream
             .format("console")
             .start()
@@ -508,10 +499,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       }
 
       def runTriggerOnceAndVerifyResult(expected: Seq[Int]): Unit = {
-        val q = spark.readStream
-          .format("delta")
-          .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
-          .load(inputDir.getCanonicalPath)
+        val q = loadStreamWithOptions(
+          inputDir.getCanonicalPath,
+          Map(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1"))
           .writeStream
           .format("memory")
           .trigger(Trigger.Once)
@@ -659,10 +649,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION, "1b")
-        .load(inputDir.getCanonicalPath)
+      val q = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION -> "1b"))
         .writeStream
         .format("memory")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -690,10 +679,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION, "1b")
-        .load(inputDir.getCanonicalPath)
+      val q = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION -> "1b"))
         .writeStream
         .format("memory")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -721,10 +709,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION, "1b")
-        .load(inputDir.getCanonicalPath)
+      val q = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION -> "1b"))
         .writeStream
         .format("delta")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -748,10 +735,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q2 = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION, "100g")
-        .load(inputDir.getCanonicalPath)
+      val q2 = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION -> "100g"))
         .writeStream
         .format("delta")
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -780,10 +766,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
       Seq(0, -1, "string").foreach { invalidMaxBytesPerTrigger =>
         val e = intercept[StreamingQueryException] {
-          spark.readStream
-            .format("delta")
-            .option(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION, invalidMaxBytesPerTrigger.toString)
-            .load(inputDir.getCanonicalPath)
+          loadStreamWithOptions(
+            inputDir.getCanonicalPath,
+            Map(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION -> invalidMaxBytesPerTrigger.toString))
             .writeStream
             .format("console")
             .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -848,11 +833,12 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1") // should process a file at a time
-        .option(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION, "100gb")
-        .load(inputDir.getCanonicalPath)
+      // should process a file at a time due to MAX_FILES_PER_TRIGGER_OPTION
+      val q = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(
+          DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1",
+          DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION -> "100gb"))
         .writeStream
         .format("memory")
         .queryName("maxBytesPerTriggerTest")
@@ -869,11 +855,11 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         q.stop()
       }
 
-      val q2 = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "2")
-        .option(DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION, "1b")
-        .load(inputDir.getCanonicalPath)
+      val q2 = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(
+          DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "2",
+          DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION -> "1b"))
         .writeStream
         .format("memory")
         .queryName("maxBytesPerTriggerTest")
@@ -1283,7 +1269,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
       withMetadata(deltaLog, StructType.fromDDL("value STRING"))
 
-      val df = spark.readStream.format("delta").load(inputDir.getCanonicalPath)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map.empty)
 
       // clear the cache so that the writer creates its own DeltaLog instead of reusing the reader's
       DeltaLog.clearCache()
@@ -1422,7 +1408,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     withTempDirs { (inputDir, outputDir, checkpointDir) =>
       Seq(1, 2, 3).toDF("x").write.format("delta").save(inputDir.toString)
 
-      val df = spark.readStream.format("delta").load(inputDir.toString)
+      val df = loadStreamWithOptions(inputDir.toString, Map.empty)
       val stream = df.writeStream
         .format("delta")
         .option("checkpointLocation", checkpointDir.toString)

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.spark.sql.*;
-import org.apache.spark.sql.streaming.StreamingQuery;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -30,7 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class V2StreamingReadTest extends V2TestBase {
 
   @Test
-  public void testStreamingReadMultipleVersions(@TempDir File deltaTablePath) throws Exception {
+  public void testStreamingReadWithStartingVersion(@TempDir File deltaTablePath) throws Exception {
     String tablePath = deltaTablePath.getAbsolutePath();
 
     // Write version 0
@@ -59,59 +58,44 @@ public class V2StreamingReadTest extends V2TestBase {
     // Start streaming from version 0 - should read all three versions
     String dsv2TableRef = str("dsv2.delta.`%s`", tablePath);
     Dataset<Row> streamingDF =
-        spark.readStream().option("startingVersion", "0").table(dsv2TableRef);
+        spark.readStream().option("startingVersion", "1").table(dsv2TableRef);
     assertTrue(streamingDF.isStreaming(), "Dataset should be streaming");
 
     // Process all batches - should have all data from versions 0, 1, and 2
-    List<Row> actualRows = processStreamingQuery(streamingDF, "test_multiple_versions");
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_with_starting_version");
     List<Row> expectedRows =
-        Arrays.asList(
-            RowFactory.create(1, "Alice", 100.0),
-            RowFactory.create(2, "Bob", 200.0),
-            RowFactory.create(3, "Charlie", 300.0));
+        Arrays.asList(RowFactory.create(2, "Bob", 200.0), RowFactory.create(3, "Charlie", 300.0));
 
     assertDataEquals(actualRows, expectedRows);
   }
 
   @Test
-  public void testStreamingReadWithoutStartingVersionThrowsException(@TempDir File deltaTablePath) {
+  public void testStreamingRead(@TempDir File deltaTablePath) throws Exception {
     String tablePath = deltaTablePath.getAbsolutePath();
 
-    // Write initial data
-    List<Row> initialRows =
-        Arrays.asList(RowFactory.create(1, "Alice", 100.0), RowFactory.create(2, "Bob", 200.0));
-    spark.createDataFrame(initialRows, TEST_SCHEMA).write().format("delta").save(tablePath);
+    // Write version 0
+    spark
+        .createDataFrame(Arrays.asList(RowFactory.create(1, "Alice", 100.0)), TEST_SCHEMA)
+        .write()
+        .format("delta")
+        .save(tablePath);
 
-    // Try to create streaming DataFrame without startingVersion using V2 path
-    // Using dsv2.delta.`path` syntax to force V2 (SparkMicroBatchStream) instead of V1
+    // Write version 1
+    spark
+        .createDataFrame(Arrays.asList(RowFactory.create(2, "Bob", 200.0)), TEST_SCHEMA)
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+
     String dsv2TableRef = str("dsv2.delta.`%s`", tablePath);
+    Dataset<Row> streamingDF = spark.readStream().table(dsv2TableRef);
+    assertTrue(streamingDF.isStreaming(), "Dataset should be streaming");
 
-    // Should throw UnsupportedOperationException when trying to process
-    org.apache.spark.sql.streaming.StreamingQueryException exception =
-        assertThrows(
-            org.apache.spark.sql.streaming.StreamingQueryException.class,
-            () -> {
-              StreamingQuery query =
-                  spark
-                      .readStream()
-                      .table(dsv2TableRef)
-                      .writeStream()
-                      .format("memory")
-                      .queryName("test_no_starting_version")
-                      .outputMode("append")
-                      .start();
-              query.processAllAvailable();
-              query.stop();
-            });
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_streaming_read");
+    List<Row> expectedRows =
+        Arrays.asList(RowFactory.create(1, "Alice", 100.0), RowFactory.create(2, "Bob", 200.0));
 
-    // Verify the root cause is UnsupportedOperationException
-    Throwable rootCause = exception.getCause();
-    assertTrue(
-        rootCause instanceof UnsupportedOperationException,
-        "Root cause should be UnsupportedOperationException, but was: "
-            + (rootCause != null ? rootCause.getClass().getName() : "null"));
-    assertTrue(
-        rootCause.getMessage().contains("is not supported"),
-        "Exception message should indicate operation is not supported: " + rootCause.getMessage());
+    assertDataEquals(actualRows, expectedRows);
   }
 }

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/utils/CatalogTableTestUtils.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/utils/CatalogTableTestUtils.scala
@@ -81,4 +81,3 @@ object CatalogTableTestUtils {
       properties = scalaProps)
   }
 }
-


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

  Implements initial snapshot support for Delta streaming in Kernel-Spark (DSv2). Users can now start streaming queries without specifying a `startingVersion` option, and the stream will:
  1. Read all existing data from the current snapshot
  2. Continue processing new commits as they arrive

  This brings DSv2 closer to feature parity with DSv1 DeltaSource.

The focus of this PR is correctness; not performance or scalability. Key follow-up TODOs:
1. Memory Protection (TODO #5318) for tables with a large number of files. 
2. Caching (TODO #5318)

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests (`SparkMicroBatchStreamTest`) and E2E tests (`DeltaSourceDSv2Suite`). 

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
