### PR TITLE
[kernel-spark] Enable a few E2E dsv2 streaming tests and fix offset management edge cases 

### DIFF
--- a/kernel-spark/src/test/java/io/delta/kernel/spark/Dsv2BasicTest.java
+++ b/kernel-spark/src/test/java/io/delta/kernel/spark/Dsv2BasicTest.java
@@ -24,8 +24,8 @@ import java.util.UUID;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.*;
 import org.apache.spark.sql.streaming.StreamingQuery;
-import org.apache.spark.sql.streaming.StreamingQueryException;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -34,6 +34,13 @@ public class Dsv2BasicTest {
 
   private SparkSession spark;
   private String nameSpace;
+
+  private static final StructType TEST_SCHEMA =
+      DataTypes.createStructType(
+          Arrays.asList(
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("name", DataTypes.StringType, false),
+              DataTypes.createStructField("value", DataTypes.DoubleType, false)));
 
   @BeforeAll
   public void setUp(@TempDir File tempDir) {
@@ -164,46 +171,89 @@ public class Dsv2BasicTest {
   }
 
   @Test
-  public void testStreamingRead(@TempDir File deltaTablePath) {
+  public void testStreamingReadMultipleVersions(@TempDir File deltaTablePath) throws Exception {
     String tablePath = deltaTablePath.getAbsolutePath();
-    // Create test data using standard Delta Lake
-    Dataset<Row> testData =
-        spark.createDataFrame(
-            Arrays.asList(RowFactory.create(1, "Alice", 100.0), RowFactory.create(2, "Bob", 200.0)),
-            DataTypes.createStructType(
-                Arrays.asList(
-                    DataTypes.createStructField("id", DataTypes.IntegerType, false),
-                    DataTypes.createStructField("name", DataTypes.StringType, false),
-                    DataTypes.createStructField("value", DataTypes.DoubleType, false))));
-    testData.write().format("delta").save(tablePath);
 
-    // Test streaming read using path-based table
+    // Write version 0
+    spark
+        .createDataFrame(Arrays.asList(RowFactory.create(1, "Alice", 100.0)), TEST_SCHEMA)
+        .write()
+        .format("delta")
+        .save(tablePath);
+
+    // Write version 1
+    spark
+        .createDataFrame(Arrays.asList(RowFactory.create(2, "Bob", 200.0)), TEST_SCHEMA)
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+
+    // Write version 2
+    spark
+        .createDataFrame(Arrays.asList(RowFactory.create(3, "Charlie", 300.0)), TEST_SCHEMA)
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+
+    // Start streaming from version 0 - should read all three versions
+    String dsv2TableRef = String.format("dsv2.delta.`%s`", tablePath);
     Dataset<Row> streamingDF =
-        spark.readStream().table(String.format("dsv2.delta.`%s`", tablePath));
-
+        spark.readStream().option("startingVersion", "0").table(dsv2TableRef);
     assertTrue(streamingDF.isStreaming(), "Dataset should be streaming");
-    StreamingQueryException exception =
+
+    // Process all batches - should have all data from versions 0, 1, and 2
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_multiple_versions");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1, "Alice", 100.0),
+            RowFactory.create(2, "Bob", 200.0),
+            RowFactory.create(3, "Charlie", 300.0));
+
+    assertStreamingDataEquals(actualRows, expectedRows);
+  }
+
+  @Test
+  public void testStreamingReadWithoutStartingVersionThrowsException(@TempDir File deltaTablePath) {
+    String tablePath = deltaTablePath.getAbsolutePath();
+
+    // Write initial data
+    List<Row> initialRows =
+        Arrays.asList(RowFactory.create(1, "Alice", 100.0), RowFactory.create(2, "Bob", 200.0));
+    spark.createDataFrame(initialRows, TEST_SCHEMA).write().format("delta").save(tablePath);
+
+    // Try to create streaming DataFrame without startingVersion using DSv2 path
+    // Using dsv2.delta.`path` syntax to force DSv2 (SparkMicroBatchStream) instead of DSv1
+    String dsv2TableRef = String.format("dsv2.delta.`%s`", tablePath);
+
+    // Should throw UnsupportedOperationException when trying to process
+    org.apache.spark.sql.streaming.StreamingQueryException exception =
         assertThrows(
-            StreamingQueryException.class,
+            org.apache.spark.sql.streaming.StreamingQueryException.class,
             () -> {
               StreamingQuery query =
-                  streamingDF
+                  spark
+                      .readStream()
+                      .table(dsv2TableRef)
                       .writeStream()
                       .format("memory")
-                      .queryName("test_streaming_query")
+                      .queryName("test_no_starting_version")
                       .outputMode("append")
                       .start();
               query.processAllAvailable();
               query.stop();
             });
+
+    // Verify the root cause is UnsupportedOperationException
     Throwable rootCause = exception.getCause();
     assertTrue(
         rootCause instanceof UnsupportedOperationException,
-        "Root cause should be UnsupportedOperationException");
+        "Root cause should be UnsupportedOperationException, but was: "
+            + (rootCause != null ? rootCause.getClass().getName() : "null"));
     assertTrue(
         rootCause.getMessage().contains("is not supported"),
-        "Root cause message should indicate that streaming operation is not supported: "
-            + rootCause.getMessage());
+        "Exception message should indicate operation is not supported: " + rootCause.getMessage());
   }
 
   //////////////////////
@@ -215,5 +265,49 @@ public class Dsv2BasicTest {
         expectedRows,
         actualRows,
         () -> "Datasets differ: expected=" + expectedRows + "\nactual=" + actualRows);
+  }
+
+  private List<Row> processStreamingQuery(Dataset<Row> streamingDF, String queryName)
+      throws Exception {
+    StreamingQuery query = null;
+    try {
+      query =
+          streamingDF
+              .writeStream()
+              .format("memory")
+              .queryName(queryName)
+              .outputMode("append")
+              .start();
+
+      query.processAllAvailable();
+
+      // Query the memory sink to get results
+      Dataset<Row> results = spark.sql("SELECT * FROM " + queryName);
+      return results.collectAsList();
+    } finally {
+      if (query != null) {
+        query.stop();
+      }
+    }
+  }
+
+  private void assertStreamingDataEquals(List<Row> actualRows, List<Row> expectedRows) {
+    assertEquals(
+        expectedRows.size(),
+        actualRows.size(),
+        () ->
+            "Row count differs: expected="
+                + expectedRows.size()
+                + " actual="
+                + actualRows.size()
+                + "\nExpected rows: "
+                + expectedRows
+                + "\nActual rows: "
+                + actualRows);
+
+    // Compare rows (order-independent for robustness)
+    assertTrue(
+        actualRows.containsAll(expectedRows) && expectedRows.containsAll(actualRows),
+        () -> "Streaming data differs:\nExpected: " + expectedRows + "\nActual: " + actualRows);
   }
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/DataFrameWriterV2WithV2ConnectorSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/DataFrameWriterV2WithV2ConnectorSuite.scala
@@ -27,13 +27,14 @@ class DataFrameWriterV2WithV2ConnectorSuite
   with V2ForceTest {
 
   /**
-   * Skip tests that require write operations after initial table creation.
+   * Tests that we expect to fail because they require write operations after initial
+   * table creation.
    *
    * Kernel's SparkTable (V2 connector) only implements SupportsRead, not SupportsWrite.
-   * Tests that perform append/replace operations after table creation are skipped.
+   * Tests that perform append/replace operations after table creation are expected to fail.
    */
-  override protected def shouldSkipTest(testName: String): Boolean = {
-    val skippedTests = Set(
+  override protected def shouldFail(testName: String): Boolean = {
+    val shouldFailTests = Set(
       // Append operations - require SupportsWrite
       "Append: basic append",
       "Append: by name not position",
@@ -65,6 +66,6 @@ class DataFrameWriterV2WithV2ConnectorSuite
       "CreateOrReplace: table exists"
     )
 
-    skippedTests.contains(testName)
+    shouldFailTests.contains(testName)
   }
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaSourceDSv2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaSourceDSv2Suite.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.DeltaOperations
+import org.apache.spark.sql.delta.DeltaSourceSuite
+
+/**
+ * Test suite that runs DeltaSourceSuite using the V2 connector (V2_ENABLE_MODE=STRICT).
+ */
+class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
+
+  override protected def useDsv2: Boolean = true
+
+  /**
+   * Override disableLogCleanup to use DeltaLog API instead of SQL ALTER TABLE.
+   * Path-based ALTER TABLE doesn't work properly with V2_ENABLE_MODE=STRICT.
+   * TODO(#5731): pending kernel v2 connector support.
+   */
+  override protected def disableLogCleanup(tablePath: String): Unit = {
+    val deltaLog = DeltaLog.forTable(spark, tablePath)
+    val metadata = deltaLog.snapshot.metadata
+    val newConfiguration = metadata.configuration ++ Map(
+      DeltaConfigs.ENABLE_EXPIRED_LOG_CLEANUP.key -> "false"
+    )
+    deltaLog.startTransaction().commit(
+      metadata.copy(configuration = newConfiguration) :: Nil,
+      DeltaOperations.SetTableProperties(
+        Map(DeltaConfigs.ENABLE_EXPIRED_LOG_CLEANUP.key -> "false"))
+    )
+  }
+
+  private lazy val shouldPassTests = Set(
+    "startingVersion",
+    "startingVersion latest",
+    "startingVersion latest defined before started",
+    "startingVersion latest works on defined but empty table",
+    "startingVersion specific version: new commits arrive after stream initialization"
+  )
+
+  private lazy val shouldFailTests = Set(
+    // === Schema Evolution ===
+    "allow to change schema before starting a streaming query",
+    "restarting a query should pick up latest table schema and recover",
+    "handling nullability schema changes",
+    "allow user specified schema if consistent: v1 source",
+    "disallow user specified schema",
+    "createSource should create source with empty or matching table schema provided",
+
+    // === Null Type Column Handling ===
+    "streaming delta source should not drop null columns",
+    "streaming delta source should drop null columns without feature flag",
+    "DeltaLog.createDataFrame should drop null columns with feature flag",
+    "DeltaLog.createDataFrame should not drop null columns without feature flag",
+
+    // === read options ===
+    "skip change commits",
+    "excludeRegex works and doesn't mess up offsets across restarts - parquet version",
+    "startingVersion: user defined start works with mergeSchema",
+    "startingVersion latest calls update when starting",
+    "startingVersion should be ignored when restarting from a checkpoint, withRowTracking = true",
+    "startingVersion should be ignored when restarting from a checkpoint, withRowTracking = false",
+    "startingTimestamp",
+    "startingVersion and startingTimestamp are both set",
+
+    // === Other tests that bypass V2 by not using loadStreamWithOptions ===
+    "disallow to change schema after starting a streaming query",
+    "maxFilesPerTrigger: invalid parameter",
+    "maxBytesPerTrigger: invalid parameter",
+    "recreate the reservoir should fail the query",
+    "excludeRegex throws good error on bad regex pattern",
+    "SC-46515: deltaSourceIgnoreChangesError contains removeFile, version, tablePath",
+    "SC-46515: deltaSourceIgnoreDeleteError contains removeFile, version, tablePath",
+    "Delta sources should verify the protocol reader version",
+    "can delete old files of a snapshot without update",
+    "Delta source advances with non-data inserts and generates empty dataframe for " +
+      "non-data operations",
+
+    // === Data Loss Detection ===
+    "fail on data loss - starting from missing files",
+    "fail on data loss - gaps of files",
+    "fail on data loss - starting from missing files with option off",
+    "fail on data loss - gaps of files with option off",
+
+    // === Rate Limiting / Trigger Options ===
+    "maxFilesPerTrigger",
+    "maxFilesPerTrigger: metadata checkpoint",
+    "maxFilesPerTrigger: change and restart",
+    "maxFilesPerTrigger: ignored when using Trigger.Once",
+    "maxFilesPerTrigger: Trigger.AvailableNow respects read limits",
+    "maxBytesPerTrigger: process at least one file",
+    "maxBytesPerTrigger: metadata checkpoint",
+    "maxBytesPerTrigger: change and restart",
+    "maxBytesPerTrigger: Trigger.AvailableNow respects read limits",
+    "maxBytesPerTrigger: max bytes and max files together",
+    "Trigger.AvailableNow with an empty table",
+    "startingVersion should work with rate time",
+    "Rate limited Delta source advances with non-data inserts",
+    "ES-445863: delta source should not hang or reprocess data when using AvailableNow",
+
+    // === Source Offset / Version Handling ===
+    "unknown sourceVersion value",
+    "invalid sourceVersion value",
+    "missing sourceVersion",
+    "unmatched reservoir id",
+    "isInitialSnapshot serializes as isStartingVersion",
+    "DeltaSourceOffset deserialization",
+    "DeltaSourceOffset deserialization error",
+    "DeltaSourceOffset serialization",
+    "DeltaSourceOffset.validateOffsets",
+
+    // === Misc ===
+    "no schema should throw an exception",
+    "basic",
+    "initial snapshot ends at base index of next version",
+    "Delta sources don't write offsets with null json",
+    "Delta source advances with non-data inserts and generates empty dataframe for addl files",
+    "a fast writer should not starve a Delta source",
+    "start from corrupt checkpoint",
+    "SC-11561: can consume new data without update",
+    "make sure that the delta sources works fine",
+    "should not attempt to read a non exist version",
+    "self union a Delta table should pass the catalog table assert"
+  )
+
+  override protected def shouldFail(testName: String): Boolean = {
+    val inPassList = shouldPassTests.contains(testName)
+    val inFailList = shouldFailTests.contains(testName)
+
+    assert(inPassList || inFailList, s"Test '$testName' not in shouldPassTests or shouldFailTests")
+    assert(!(inPassList && inFailList),
+      s"Test '$testName' in both shouldPassTests and shouldFailTests")
+
+    inFailList
+  }
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
@@ -44,15 +44,16 @@ trait V2ForceTest extends DeltaSQLCommandTest {
   private val testsRun: mutable.Set[String] = mutable.Set.empty
 
   /**
-   * Override `test` to apply the `shouldSkipTest` logic.
-   * Tests that should be skipped are converted to ignored tests.
+   * Override `test` to apply the `shouldFail` logic.
+   * Tests that are expected to fail are converted to ignored tests.
    */
   abstract override protected def test(
       testName: String,
       testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
-    if (shouldSkipTest(testName)) {
+    if (shouldFail(testName)) {
+      // TODO(#5754): Assert on test failure instead of ignoring
       super.ignore(
-        s"$testName - skipped for Kernel-based V2 connector (not yet supported)")(testFun)
+        s"$testName - expected to fail with Kernel-based V2 connector (not yet supported)")(testFun)
     } else {
       super.test(testName, testTags: _*) {
         testsRun.add(testName)
@@ -62,14 +63,14 @@ trait V2ForceTest extends DeltaSQLCommandTest {
   }
 
   /**
-   * Determine if a test should be skipped based on the test name.
-   * Subclasses should override this method to define their skip logic.
-   * By default, no tests are skipped.
+   * Determine if a test is expected to fail based on the test name.
+   * Subclasses should override this method to define which tests are expected to fail.
+   * By default, no tests are expected to fail.
    *
    * @param testName The name of the test
-   * @return true if the test should be skipped, false otherwise
+   * @return true if the test is expected to fail, false otherwise
    */
-  protected def shouldSkipTest(testName: String): Boolean = false
+  protected def shouldFail(testName: String): Boolean = false
 
   /**
    * Override `sparkConf` to set V2_ENABLE_MODE to "STRICT".

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -255,9 +255,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
       withMetadata(deltaLog, StructType.fromDDL("value STRING"))
 
-      val df = spark.readStream
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map.empty)
         .filter($"value" contains "keep")
 
       testStream(df)(
@@ -1317,6 +1315,50 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
+  test("startingVersion specific version: new commits arrive after stream initialization") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      // Add version 0 and version 1
+      Seq(1, 2, 3).toDF("value").write.format("delta").save(inputDir.getCanonicalPath)
+      Seq(4, 5, 6).toDF("value").write
+        .format("delta").mode("append").save(inputDir.getCanonicalPath)
+
+      // Start streaming from version 1
+      val df = loadStreamWithOptions(
+        inputDir.getCanonicalPath,
+        Map(
+          "startingVersion" -> "1",
+          DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1"
+        )
+      )
+
+      val q = df.writeStream
+        .format("delta")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start(outputDir.getCanonicalPath)
+
+      try {
+        // Process version 1 only
+        q.processAllAvailable()
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq(4, 5, 6).toDF("value"))
+
+        // Add version 2 and version 3 (after snapshotAtSourceInit was captured)
+        Seq(7, 8, 9).toDF("value").write
+          .format("delta").mode("append").save(inputDir.getCanonicalPath)
+        Seq(10, 11, 12).toDF("value").write
+          .format("delta").mode("append").save(inputDir.getCanonicalPath)
+
+        q.processAllAvailable()
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          (4 to 12).toDF("value"))
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
   test(
       "can delete old files of a snapshot without update"
   ) {
@@ -1578,7 +1620,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
   }
 
   /** Disable log cleanup to avoid deleting logs we are testing. */
-  private def disableLogCleanup(tablePath: String): Unit = {
+  protected def disableLogCleanup(tablePath: String): Unit = {
     sql(s"alter table delta.`$tablePath` " +
       s"set tblproperties (${DeltaConfigs.ENABLE_EXPIRED_LOG_CLEANUP.key} = false)")
   }
@@ -1590,11 +1632,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       generateCommits(tablePath, start, start + 20.minutes)
 
       def testStartingVersion(startingVersion: Long): Unit = {
-        val q = spark.readStream
-          .format("delta")
-          .option("startingVersion", startingVersion)
-          .load(tablePath)
-          .writeStream
+        val df = loadStreamWithOptions(
+          tablePath, Map("startingVersion" -> startingVersion.toString))
+        val q = df.writeStream
           .format("memory")
           .queryName("startingVersion_test")
           .start()
@@ -1867,11 +1907,10 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           .save(inputDir.getCanonicalPath)
 
         // check answer from version 1
-        val q = spark.readStream
-          .format("delta")
-          .option("startingVersion", "1")
-          .load(inputDir.getCanonicalPath)
-          .writeStream
+        val q = loadStreamWithOptions(
+          inputDir.getCanonicalPath,
+          Map("startingVersion" -> "1")
+        ).writeStream
           .format("memory")
           .queryName("startingVersionTest")
           .start()
@@ -1899,10 +1938,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       withTempView("startingVersionTest") {
         val path = dir.getAbsolutePath
         spark.range(0, 10).write.format("delta").save(path)
-        val q = spark.readStream
-          .format("delta")
-          .option("startingVersion", "latest")
-          .load(path)
+        val q = loadStreamWithOptions(path, Map("startingVersion" -> "latest"))
           .writeStream
           .format("memory")
           .queryName("startingVersionLatest")
@@ -1935,10 +1971,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         // Define the stream, but don't start it, before a second write. The startingVersion
         // latest should be resolved when the query *starts*, so there'll be no data even though
         // some was added after the stream was defined.
-        val streamDef = spark.readStream
-          .format("delta")
-          .option("startingVersion", "latest")
-          .load(path)
+        val streamDef = loadStreamWithOptions(path, Map("startingVersion" -> "latest"))
           .writeStream
           .format("memory")
           .queryName("startingVersionLatest")
@@ -1963,10 +1996,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       withTempView("startingVersionTest") {
         val path = dir.getAbsolutePath
         spark.range(0).write.format("delta").save(path)
-        val streamDef = spark.readStream
-          .format("delta")
-          .option("startingVersion", "latest")
-          .load(path)
+        val streamDef = loadStreamWithOptions(path, Map("startingVersion" -> "latest"))
           .writeStream
           .format("memory")
           .queryName("startingVersionLatest")
@@ -1991,11 +2021,10 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         val path = dir.getAbsolutePath
         spark.range(0).write.format("delta").save(path)
 
-        val streamDef = spark.readStream
-          .format("delta")
-          .option("startingVersion", "latest")
-          .load(path)
-          .writeStream
+        val streamDef = loadStreamWithOptions(
+          path,
+          Map("startingVersion" -> "latest")
+        ).writeStream
           .format("memory")
           .queryName("startingVersionLatest")
         val log = DeltaLog.forTable(spark, path)
@@ -2031,12 +2060,13 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         spark.range(0, 5).repartition(2).write.mode("append").format("delta").save(path)
         spark.range(5, 10).repartition(2).write.mode("append").format("delta").save(path)
 
-        val q = spark.readStream
-          .format("delta")
-          .option("startingVersion", 1)
-          .option("maxFilesPerTrigger", 1)
-          .load(path)
-          .writeStream
+        val q = loadStreamWithOptions(
+          path,
+          Map(
+            "startingVersion" -> "1",
+            "maxFilesPerTrigger" -> "1"
+          )
+        ).writeStream
           .format("memory")
           .queryName("startingVersionWithRateLimit")
           .start()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5652/files) to review incremental changes.
- [**stack/integration2**](https://github.com/delta-io/delta/pull/5652) [[Files changed](https://github.com/delta-io/delta/pull/5652/files)]
  - [stack/reader](https://github.com/delta-io/delta/pull/5638) [[Files changed](https://github.com/delta-io/delta/pull/5638/files/52a3c8381bce050a392701b2a85b6a149b7ca9d3..5c9af512429c6f83c55538cff64c4c75502e1c12)]
    - [stack/lazy](https://github.com/delta-io/delta/pull/5650) [[Files changed](https://github.com/delta-io/delta/pull/5650/files/5c9af512429c6f83c55538cff64c4c75502e1c12..cce1148828608ac023bb94d5a5b0f5c43fe4cc25)]
      - [stack/lazy2](https://github.com/delta-io/delta/pull/5686) [[Files changed](https://github.com/delta-io/delta/pull/5686/files/cce1148828608ac023bb94d5a5b0f5c43fe4cc25..c4059b4696f87ed38fcfc43ef19ba65ae090f517)]
        - [stack/snapshot](https://github.com/delta-io/delta/pull/5651) [[Files changed](https://github.com/delta-io/delta/pull/5651/files/c4059b4696f87ed38fcfc43ef19ba65ae090f517..4d3946935a87170d58a2b219431ed536c979cce5)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

  Add integration tests for kernel-spark DSv2 streaming and fix edge cases in offset handling.

  **Changes:**

  1. **Fixed offset capping in `getBatch()`**: Cap `endVersion` to the latest available snapshot version to handle offsets pointing to non-existent future versions (which can occur when
  `buildOffsetFromIndexedFile` advances to the next version).

  2. **Fixed starting version caching**: Made `getStartingVersion()` synchronized and added caching to ensure idempotent behavior - `startingVersion: "latest"` must resolve to the same version across
  multiple calls.

  4. **Created `DeltaSourceDSv2Suite`**: Runs a subset of existing DSv1 streaming tests using DSv2 to verify API compatibility for `startingVersion` options.

## How was this patch tested?

End-to-end streaming tests. 

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
