### PR TITLE
Add appropriate access denied error message

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1655,6 +1655,12 @@
     ],
     "sqlState" : "42K03"
   },
+  "DELTA_LOG_JSON_FILE_ACCESS_DENIED" : {
+    "message" : [
+      "Access denied when reading Delta log JSON file: <filePath>. Check that you have read permissions for the Delta table location."
+    ],
+    "sqlState" : "58000"
+  },
   "DELTA_MATERIALIZED_ROW_TRACKING_COLUMN_NAME_MISSING" : {
     "message" : [
       "Materialized <rowTrackingColumn> column name missing for <tableName>."

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1533,6 +1533,16 @@ trait DeltaErrorsSuiteBase
         "timestampString" -> "2022-02-28 11:00:00"))
     }
     {
+      val filePath = "s3a://bucket/table/_delta_log/00000000000000000476.json"
+      val cause = new java.nio.file.AccessDeniedException(filePath)
+      val e = intercept[DeltaIOException] {
+        throw DeltaErrors.deltaLogJsonFileAccessDenied(filePath, cause)
+      }
+      checkError(e, "DELTA_LOG_JSON_FILE_ACCESS_DENIED", "58000", Map("filePath" -> filePath))
+      // Verify the cause is still attached for debugging
+      assert(e.getCause == cause)
+    }
+    {
       val expr = "1".expr
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.timestampInvalid(expr)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Adds error class for access denied when reading Delta log JSON files.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added unit test

## Does this PR introduce _any_ user-facing changes?
No

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
