### PR TITLE
[Feature Request][Spark] Add configurable logging of deleted file paths during VACUUM

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -590,6 +590,15 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createOptional
 
+  val DELTA_VACUUM_MAX_FILES_TO_LOG =
+    buildConf("vacuum.maxFilesToLog")
+      .doc("The maximum number of files to log during vacuum operations. " +
+      "When set to 0, no file paths will be logged. When set to a positive value, " +
+      "VACUUM will log up to this number of file paths that have been deleted.")
+      .intConf
+      .checkValue(_ >= 0, "maxFilesToLog must be non-negative")
+      .createWithDefault(100)
+
   val LITE_VACUUM_ENABLED =
     buildConf("vacuum.lite.enabled")
       .doc("Allows Vacuum to be run in Lite mode")
@@ -2420,6 +2429,8 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .checkValue(_ >= 0, "maxDeletedRowsRatio must be in range [0.0, 1.0]")
       .checkValue(_ <= 1, "maxDeletedRowsRatio must be in range [0.0, 1.0]")
       .createWithDefault(0.05d)
+
+
 
   val DELTA_TABLE_PROPERTY_CONSTRAINTS_CHECK_ENABLED =
     buildConf("tablePropertyConstraintsCheck.enabled")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

#### What changes were proposed in this pull request?
This PR adds a new configuration `spark.databricks.delta.vacuum.maxFilesToLog` that controls logging of deleted file paths during VACUUM operations.

#### Changes:

1. New configuration (`DeltaSQLConf.scala`):
    - Added DELTA_VACUUM_MAX_FILES_TO_LOG config with key vacuum.maxFilesToLog
    - Default value: 100
    - When set to 0: No file paths are logged
    - When set to a positive value: Logs up to that many deleted file paths

2. Modified delete operation (`VacuumCommand.scala`):
    - Added DeleteResult case class to return both the count and list of deleted files
    - Modified delete() method to track successfully deleted file paths
    - Added logging after deletion that outputs file paths in a readable format (10 paths per line)

#### Why are the changes needed?
Currently, VACUUM only logs the count of deleted files but not which files were deleted. This makes debugging and auditing difficult. Users have no visibility into what was actually removed during a vacuum operation. 
This feature provides:

- Debugging capability: See exactly which files were removed
- Audit trail: Log output can be captured for compliance/auditing
- Configurable: Users can control verbosity or disable entirely

## How was this patch tested?

- Manual testing with spark-shell
- Verified logging output with various config values (0, 10, 100)
- Verified both parallel and sequential deletion paths

#### Example Usage
```
# Disable file path logging
spark-shell --conf spark.databricks.delta.vacuum.maxFilesToLog=0
# Log up to 50 deleted file paths
spark-shell --conf spark.databricks.delta.vacuum.maxFilesToLog=50
````
Or at runtime:
```
spark.conf.set("spark.databricks.delta.vacuum.maxFilesToLog", 20)
spark.sql("VACUUM my_table RETAIN 0 HOURS")
```

Example log output when spark.databricks.delta.vacuum.maxFilesToLog=15:
```
25/12/09 19:14:17 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 9 Dec 2025 19:14:17 GMT in hdfs://hadoop.spark:9000/tmp/delta_vacuum
25/12/09 19:14:25 INFO VacuumCommand: Deleting untracked files and empty directories in hdfs://hadoop.spark:9000/tmp/delta_vacuum. The amount of data to be deleted is 3015 (in bytes)
25/12/09 19:14:29 INFO VacuumCommand: Deleted 6 files (3015 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,Some(0),604800000,1765307657609,1,6,6,3015,5982,1638,1765307657604,1765307668991,0,7,Some(3),Some(7),LITE)
25/12/09 19:14:29 INFO VacuumCommand: [tableId=b4b17c00] Deleted file paths (showing 6 of 6): 
  hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00001-b1c7f485-dad2-4002-a01c-5d268982b903-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00000-91b56701-b16d-4c3d-93d3-0b12807408bf-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00000-e55e43eb-c791-42b8-8213-5460ecfec945-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00001-6332dfe7-bde2-42c5-a2cb-fd9732fb46b5-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00001-04c22450-78fb-4483-88d4-f40318f0036b-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00000-c24d2e76-b87a-49fb-aacd-fcc0daf9f091-c000.snappy.parquet
```
## Does this PR introduce _any_ user-facing changes?
Yes - This PR changes the format of INFO-level log messages during Delta Lake cleanup operations.
#### Previous Behavoiur:
```
25/12/09 19:14:17 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 9 Dec 2025 19:14:17 GMT in hdfs://hadoop.spark:9000/tmp/delta_vacuum
25/12/09 19:14:25 INFO VacuumCommand: Deleting untracked files and empty directories in hdfs://hadoop.spark:9000/tmp/delta_vacuum. The amount of data to be deleted is 3015 (in bytes)
25/12/09 19:14:29 INFO VacuumCommand: Deleted 6 files (3015 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,Some(0),604800000,1765307657609,1,6,6,3015,5982,1638,1765307657604,1765307668991,0,7,Some(3),Some(7),LITE)
```
#### New Behaviour:
```
25/12/09 19:14:17 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 9 Dec 2025 19:14:17 GMT in hdfs://hadoop.spark:9000/tmp/delta_vacuum
25/12/09 19:14:25 INFO VacuumCommand: Deleting untracked files and empty directories in hdfs://hadoop.spark:9000/tmp/delta_vacuum. The amount of data to be deleted is 3015 (in bytes)
25/12/09 19:14:29 INFO VacuumCommand: Deleted 6 files (3015 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,Some(0),604800000,1765307657609,1,6,6,3015,5982,1638,1765307657604,1765307668991,0,7,Some(3),Some(7),LITE)
25/12/09 19:14:29 INFO VacuumCommand: [tableId=b4b17c00] Deleted file paths (showing 6 of 6): 
  hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00001-b1c7f485-dad2-4002-a01c-5d268982b903-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00000-91b56701-b16d-4c3d-93d3-0b12807408bf-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00000-e55e43eb-c791-42b8-8213-5460ecfec945-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00001-6332dfe7-bde2-42c5-a2cb-fd9732fb46b5-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00001-04c22450-78fb-4483-88d4-f40318f0036b-c000.snappy.parquet, hdfs://hadoop.spark:9000/tmp/delta_vacuum/part-00000-c24d2e76-b87a-49fb-aacd-fcc0daf9f091-c000.snappy.parquet
```
#### Impact:
- Purely additive - adds [tableId=xxx] prefix to existing log messages and logs the deleted files (based on the maxFilesToLog config - default is 100, if set to 0 then no files are logged)
- No API changes or behavioral changes to Delta operations
- Benefits users monitoring multiple Delta tables in production environments(especially with delta metadata cleanup) and helps them identify the files that are deleted as part of the VACUUM command.
- The table ID format matches existing Delta logging conventions used elsewhere in the codebase