### PR TITLE
[kernel-spark] [DO-NOT-MERGE] Refactor hasNoColumnMappingSchemaChanges to support schema evolution in dsv2 streaming

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -283,8 +283,12 @@ case class IcebergCompatVersionBase(knownVersions: Set[IcebergCompatBase]) {
   /**
    * @return true if a CompatVx greater or eq to the required version is enabled
    */
+  def isGeqEnabled(conf: Map[String, String], requiredVersion: Int): Boolean =
+    anyEnabled(conf).exists(_.version >= requiredVersion)
+
   def isGeqEnabled(metadata: Metadata, requiredVersion: Int): Boolean =
     anyEnabled(metadata).exists(_.version >= requiredVersion)
+
   /**
    * @return true if any version of IcebergCompat is enabled, and is incompatible
    *         with the given table feature

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -629,7 +629,11 @@ trait DeltaSourceBase extends Source
       } else {
         // Column mapping schema changes
         assert(!trackingMetadataChange, "should not check schema change while tracking it")
-        !DeltaColumnMapping.hasNoColumnMappingSchemaChanges(newMetadata, oldMetadata,
+        !DeltaColumnMapping.hasNoColumnMappingSchemaChangesBySchema(
+          newMetadata.schema, oldMetadata.schema,
+          newMetadata.partitionColumns, oldMetadata.partitionColumns,
+          oldMetadata.configuration,
+          newMetadata.columnMappingMode, oldMetadata.columnMappingMode,
           allowUnsafeStreamingReadOnPartitionColumnChanges)
       }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is part of a series to support `checkReadIncompatible` in DSv2.

In v1, `checkReadIncompatible` is mostly static and we want to reuse it in v2. However, we can't convert Delta Kernel's `metadataAction` to Spark's `metadataAction` within the kernel. To work around this, we're refactoring the call chain to extract static logic and pass individual metadata fields (`schema`, `configuration`, `partitionColumns`, `columnMappingMode`) as parameters instead of the `metadataAction` object directly.

This PR refactors `hasNoColumnMappingSchemaChanges`, the deepest function in the `checkReadIncompatible` call chain that needs this change. By accepting metadata fields as separate parameters, it can now be reused in DSv2 without requiring `metadataAction` conversion.

The original API that takes `metadataAction` is preserved to avoid breaking changes—it now delegates to the new static function that accepts individual fields.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
No new tests added. This is a pure refactoring that extracts static logic without changing behavior—the original API delegates to the new implementation. Existing tests should provide adequate coverage.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
