### PR TITLE
[Feature] Vacuum progress logging for Observaility. Fixes #5611

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -596,6 +596,25 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+
+  val DELTA_VACUUM_PROGRESS_LOGGING_ENABLED =
+    buildConf("vacuum.progressLogging.enabled")
+      .internal()
+      .doc("When true, VACUUM periodically logs progress about file and directory listing " +
+        "approximately every 5 minutes while scanning the table for untracked files.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val DELTA_VACUUM_PROGRESS_LOGGING_INTERVAL_MS =
+    buildConf("vacuum.progressLogging.intervalMillis")
+      .internal()
+      .doc("Controls how often VACUUM logs file and directory listing progress when " +
+        s"'${DELTA_VACUUM_PROGRESS_LOGGING_ENABLED.key}' is enabled. " +
+        "Intended for testing; production should rely on the default ~10 minute interval.")
+      .longConf
+      .checkValue(_ > 0, "vacuum.progressLogging.intervalMillis must be positive")
+      .createWithDefault(java.util.concurrent.TimeUnit.MINUTES.toMillis(10))
+
   val DELTA_VACUUM_RETENTION_CHECK_ENABLED =
     buildConf("retentionDurationCheck.enabled")
       .doc("Adds a check preventing users from running vacuum with a very short retention " +


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Today when user runs a VACUUM command, we only get the below logs:

```
25/12/02 04:51:29 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 2 Dec 2025 04:51:29 GMT in hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress
25/12/02 04:51:41 INFO VacuumCommand: Deleting untracked files and empty directories in hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress. The amount of data to be deleted is 447370000324 (in bytes)

-- After ~1 hr 30 minutes ----

25/12/02 06:21:45 INFO VacuumCommand: Deleted 250000 files (44737324 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,Some(0),604800000,1764651089738,1,2500,2500,44737324,10938,1886,1764651089735,1764651105425,0,50,Some(0),Some(50),LITE)
```

From the above log the VACUUM completed successfully after 90 min , but throughout the command run time there is no log which tells us what is happening or how may files have been listed so far which makes it difficult to understand about the progress of the VACUUM command .

With this change we would have logs which will tell us how many files have been listed ,which would help us know the progress of the run along with helping us asses the time it would take for the VACUUM command to complete  resulting in better observability. Fixes #5611 

### Implementation details:

The progress logging can be enabled by setting the below config `vacuum.progressLogging.enabled`.The default value is **true**, meaning it is always enabled by default.

`spark.conf.set(“vacuum.progressLogging.enabled", "true")`

and the frequency of progress logs getting printed in the logs can be set using the config `vacuum.progressLogging.intervalMillis` .  The default value is 10 minutes .
So if you don't specify anything by default you see VACUUM progress logs getting printed in the logs for every **10 minutes** 

`spark.conf.set(“vacuum.progressLogging.intervalMillis", "2000")`

## How was this patch tested?

- Created a UT and ran the test which passed
- Regression testing by compiling an assembly jar and running it on spark-3.5.2, delta-3.4.0 using the below command

```
 spark-shell \
  --jars /opt/delta/delta-spark-assembly-3.4.0-SNAPSHOT.jar \
  --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
  --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog 
```

### Code used for Testing:

```
import org.apache.log4j.{Level, Logger}
import scala.util.Try
import scala.sys.process._

import org.apache.spark.sql.delta.sources.DeltaSQLConf

sc.setLogLevel("INFO")

// 2) Enable VACUUM progress logging and log frequently
spark.conf.set(“vacuum.progressLogging.enabled", "true")
spark.conf.set(“vacuum.progressLogging.intervalMillis", "2000")
spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
spark.conf.set("spark.databricks.delta.vacuum.parallelDelete.enabled", "false")

// Paths for two separate tables
val fullPath = "/tmp/delta_vacuum_full_progress"
val litePath = "/tmp/delta_vacuum_lite_progress"

// Helper to create a “large-ish” Delta table at a given path
def writeTestTable(path: String): Unit = {
  // Clean up from previous runs for that specific path (HDFS)
  Try {
    s"hdfs dfs -rm -r -f $path".!
  }

  println(s"Writing a large Delta table at $path to exercise VACUUM progress logging...")

  val numBatches    = 50
  val rowsPerBatch  = 200000L
  val filesPerBatch = 50

  (0 until numBatches).foreach { i =>
    val start = i * rowsPerBatch
    val end   = (i + 1) * rowsPerBatch

    spark.range(start, end)
      .repartition(filesPerBatch)
      .write
      .format("delta")
      .mode(if (i == 0) "overwrite" else "append")
      .save(path)

    if (i % 10 == 0) {
      println(s"  -> Finished batch $i / $numBatches for $path")
    }
  }

  println(s"Finished writing test data at $path")
}

// 3) Build both tables
writeTestTable(fullPath)
writeTestTable(litePath)

// 4) Run VACUUM FULL and VACUUM LITE in parallel on two different tables
val fullVacuumThread = new Thread(new Runnable {
  override def run(): Unit = {
    println(s"Starting FULL VACUUM on $fullPath")
    spark.sql(s"OPTIMIZE delta.`$fullPath`")
    spark.sql(s"VACUUM delta.`$fullPath` RETAIN 0 HOURS")
    println(s"Completed FULL VACUUM on $fullPath")
  }
})

val liteVacuumThread = new Thread(new Runnable {
  override def run(): Unit = {
    println(s"Starting LITE VACUUM on $litePath")
    spark.sql(s"OPTIMIZE delta.`$litePath`")
    spark.sql(s"VACUUM delta.`$litePath` LITE RETAIN 0 HOURS")
    println(s"Completed LITE VACUUM on $litePath")
  }
})

// Start both VACUUMs concurrently
fullVacuumThread.start()
liteVacuumThread.start()

// Wait for both to finish
fullVacuumThread.join()
liteVacuumThread.join()

println("Both VACUUM operations completed.")
```

### Output logs:

```
[root@hadoop /]# tail -f /opt/delta/vacuum_progress_regression_dirs_root_final_new.log | grep "VacuumCommand"

25/12/02 13:41:12 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 2 Dec 2025 13:41:12 GMT in hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final
25/12/02 13:41:13 INFO VacuumCommand: Starting garbage collection (dryRun = false) of untracked files older than 2 Dec 2025 13:41:13 GMT in hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_lite_final
25/12/02 13:41:14 INFO VacuumCommand: [tableId=15bd83cd] [VACUUM_FULL] Directory listing in progress for path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final: Listed 200 files in 1 directories scanned so far
25/12/02 13:41:16 INFO VacuumCommand: [tableId=15bd83cd] [VACUUM_FULL] Directory listing in progress for path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final: Listed 530 files in 1 directories scanned so far
25/12/02 13:41:20 INFO VacuumCommand: [tableId=15bd83cd] [VACUUM_FULL] Directory listing in progress for path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final: Listed 530 files in 1 directories scanned so far
25/12/02 13:41:22 INFO VacuumCommand: [tableId=15bd83cd] [VACUUM_FULL] Directory listing in progress for path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final: Listed 1973 files in 1 directories scanned so far

25/12/02 13:41:23 INFO VacuumCommand: [tableId=3bdcf34c] [VACUUM_LITE] Scanning Transaction log for files with delete/cdc action in path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_lite_final is in progress 
25/12/02 13:41:25 INFO VacuumCommand: [tableId=3bdcf34c] [VACUUM_LITE] Scanning Transaction log for files with delete/cdc action for path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_lite_final is in progress 

25/12/02 13:41:26 INFO VacuumCommand: [tableId=15bd83cd] [VACUUM_FULL] Directory listing in progress for path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final: Listed 2501 files in 1 directories scanned so far

25/12/02 13:41:27 INFO VacuumCommand: Deleting untracked files and empty directories in hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_lite_final. The amount of data to be deleted is 44737324 (in bytes)
25/12/02 13:41:27 INFO VacuumCommand: Deleting untracked files and empty directories in hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final. The amount of data to be deleted is 44737324 (in bytes)

25/12/02 13:41:27 INFO VacuumCommand: [tableId=3bdcf34c] [VACUUM_LITE] Scanning Transaction log for files with delete/cdc action in path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_lite_final is in progress 
25/12/02 13:41:29 INFO VacuumCommand: [tableId=3bdcf34c] [VACUUM_LITE] Scanning Transaction log for files with delete/cdc action in path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_lite_final is in progress 
25/12/02 13:41:30 INFO VacuumCommand: [tableId=15bd83cd] [VACUUM_FULL] Directory listing in progress for path hdfs://hadoop.spark:9000/tmp/delta_vacuum_progress_full_final: Listed 2501 files in 1 directories scanned so far

25/12/02 13:41:32 INFO VacuumCommand: Deleted 2500 files (44737324 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,Some(0),604800000,1764682873906,1,2500,2500,44737324,12298,1974,1764682873897,1764682891179,0,50,Some(0),Some(50),LITE)
25/12/02 13:41:32 INFO VacuumCommand: Deleted 2500 files (44737324 bytes) and directories in a total of 1 directories. Vacuum stats: DeltaVacuumStats(false,Some(0),604800000,1764682872341,1,2501,2500,44737324,13889,1576,1764682872337,1764682891180,0,50,None,None,FULL)

```



## Does this PR introduce _any_ user-facing changes?

Yes.
With this change VACUUM now emits periodic INFO logs on the listing progress . Default behavior is that you see the logs for every 10 minutes which is completely configurable as described above.

