### PR TITLE
[Server-Side Planning] Add metadata abstraction and factory pattern

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.serverSidePlanning
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+
+/**
+ * Metadata required for creating a server-side planning client.
+ *
+ * This interface captures all information from the catalog's loadTable response
+ * that is needed to create and configure a ServerSidePlanningClient.
+ */
+private[serverSidePlanning] trait ServerSidePlanningMetadata {
+  /**
+   * The base URI for the planning endpoint.
+   */
+  def planningEndpointUri: String
+
+  /**
+   * Authentication token for the planning endpoint.
+   */
+  def authToken: Option[String]
+
+  /**
+   * Catalog name for configuration lookups.
+   */
+  def catalogName: String
+
+  /**
+   * Additional table properties that may be needed.
+   * For example, table UUID, credential hints, etc.
+   */
+  def tableProperties: Map[String, String]
+}
+
+/**
+ * Default metadata for non-UC catalogs.
+ * Used when server-side planning is force-enabled for testing/development.
+ */
+private[serverSidePlanning] case class DefaultMetadata(
+    catalogName: String,
+    tableProps: Map[String, String] = Map.empty) extends ServerSidePlanningMetadata {
+  override def planningEndpointUri: String = ""
+  override def authToken: Option[String] = None
+  override def tableProperties: Map[String, String] = tableProps
+}
+
+object ServerSidePlanningMetadata {
+  /**
+   * Create metadata from a loaded table.
+   *
+   * Currently returns DefaultMetadata for all catalogs.
+   * Unity Catalog-specific implementation will be added in a later PR.
+   */
+  def fromTable(
+      table: Table,
+      spark: SparkSession,
+      ident: Identifier,
+      isUnityCatalog: Boolean): ServerSidePlanningMetadata = {
+
+    val catalogName = extractCatalogName(ident)
+    DefaultMetadata(catalogName, Map.empty)
+  }
+
+  private def extractCatalogName(ident: Identifier): String = {
+    if (ident.namespace().length > 1) {
+      ident.namespace().head
+    } else {
+      "spark_catalog"
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -176,4 +176,25 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
       )
     }
   }
+
+  test("fromTable returns metadata with empty defaults for non-UC catalogs") {
+    import org.apache.spark.sql.connector.catalog.Identifier
+
+    // Create a simple identifier for testing
+    val ident = Identifier.of(Array("my_catalog", "my_schema"), "my_table")
+
+    // Call fromTable with a null table (we only use the identifier for catalog name extraction)
+    val metadata = ServerSidePlanningMetadata.fromTable(
+      table = null,
+      spark = spark,
+      ident = ident,
+      isUnityCatalog = false
+    )
+
+    // Verify the metadata has expected defaults
+    assert(metadata.catalogName == "my_catalog")
+    assert(metadata.planningEndpointUri == "")
+    assert(metadata.authToken.isEmpty)
+    assert(metadata.tableProperties.isEmpty)
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/TestServerSidePlanningClient.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/TestServerSidePlanningClient.scala
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.delta.serverSidePlanning
 
-import java.util.Locale
-
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -85,9 +83,9 @@ class TestServerSidePlanningClient(spark: SparkSession) extends ServerSidePlanni
  * Factory for creating TestServerSidePlanningClient instances.
  */
 class TestServerSidePlanningClientFactory extends ServerSidePlanningClientFactory {
-  override def buildForCatalog(
+  override def buildClient(
       spark: SparkSession,
-      catalogName: String): ServerSidePlanningClient = {
+      metadata: ServerSidePlanningMetadata): ServerSidePlanningClient = {
     new TestServerSidePlanningClient(spark)
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5671/files) to review all changes.

**Stack:**
- [Integrate DeltaCatalog with ServerSidePlannedTable and add tests](https://github.com/delta-io/delta/pull/5622) [[Files changed](https://github.com/delta-io/delta/pull/5622/files)] ✅ Merged
  - **[Add metadata abstraction and factory pattern](https://github.com/delta-io/delta/pull/5671)** [[Files changed](https://github.com/delta-io/delta/pull/5671/files)] ⬅️ _This PR_
    - [Add filter pushdown infrastructure](https://github.com/delta-io/delta/pull/5672) [[Files changed](https://github.com/delta-io/delta/pull/5672/files/6d76fced25e7e69053d96c5101f511184e1d0d49..fb69ce1801da7aee5b633ad9103d528ee14bac1e)]

---

## Summary

Introduces metadata abstraction pattern for ServerSidePlannedTable:
- `ServerSidePlanningMetadata` trait for catalog-specific configuration
- Factory pattern changed from `buildForCatalog()` to `buildClient(metadata)`
- Default implementation for non-UC catalogs

## Key Changes

**New file:**
- `ServerSidePlanningMetadata.scala` - Trait + DefaultMetadata + factory method

**Modified files:**
- `ServerSidePlanningClient.scala` - Update factory interface to accept metadata
- `ServerSidePlannedTable.scala` - Use metadata factory, pass metadata to client builder
- `ServerSidePlannedTableSuite.scala` - Test fromTable() method

## Architecture

```
Table Properties (from loadTable)
        ↓
ServerSidePlanningMetadata.fromTable()
        ↓
   DefaultMetadata (for now)
   [Future: catalog-specific implementations]
        ↓
ServerSidePlanningClientFactory.buildClient(metadata)
        ↓
ServerSidePlanningClient implementation
```

## Design Principles

### 1. Metadata as Interface

`ServerSidePlanningMetadata` trait captures what's needed to create a planning client:
- `planningEndpointUri` - REST endpoint (empty for default)
- `authToken` - Authentication token (None for default)
- `catalogName` - For configuration lookups
- `tableProperties` - Additional table properties

### 2. Factory Method for Metadata

`ServerSidePlanningMetadata.fromTable()` extracts metadata from loaded table:
- Currently returns DefaultMetadata for all catalogs
- Future PRs will add catalog-specific implementations

### 3. Package-Private Implementation

Trait and classes are `private[serverSidePlanning]` - implementation details hidden from outside.

## Testing

6 tests covering:
- Full query execution through DeltaCatalog
- Decision logic for server-side planning
- **fromTable() returns metadata with defaults** (updated)
- ServerSidePlannedTable is read-only
- Normal path unchanged when feature disabled

## Behavior

**No functional changes:**
- Same tables use server-side planning
- Same query execution flow
- Zero impact on existing Delta behavior

---

**Commit:** 6d76fced25e7e69053d96c5101f511184e1d0d49