### PR TITLE
[Spark] Prevent FetchFailedException when enabling optimize write feature when running remote shuffle service (e.g. celeborn)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/DeltaOptimizedWriterExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/DeltaOptimizedWriterExec.scala
@@ -130,7 +130,7 @@ case class DeltaOptimizedWriterExec(
 
       // Large reducers: each gets its own bin (may exceed maxBinSize, but that's acceptable)
       val largeBins = largeReducers.map { case (_, blocks, _) =>
-        blocks.map(_._1).toSeq
+        blocks.map(_._1)
       }
 
       // Small reducers: bin-pack together, keeping each reducer's blocks atomic
@@ -155,7 +155,7 @@ case class DeltaOptimizedWriterExec(
       val duplicates = reducerToBinCount.filter(_._2 > 1)
       assert(duplicates.isEmpty,
         s"Reducer(s) split across multiple bins in remote shuffle mode, " +
-        s"which would cause data duplication: ${duplicates.keys.mkString(", ")}")
+          s"which would cause data duplication: ${duplicates.keys.mkString(", ")}")
 
       result
     } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/DeltaOptimizedWriterExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/DeltaOptimizedWriterExec.scala
@@ -32,8 +32,9 @@ import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.rdd.RDD
 import org.apache.spark.shuffle._
+import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal, MonotonicallyIncreasingID, Pmod}
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.execution.{ShuffledRowRDD, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -78,7 +79,13 @@ case class DeltaOptimizedWriterExec(
   }
 
   private lazy val useShuffleManager: Boolean =
-    getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_USE_SHUFFLE_MANAGER)
+    getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_USE_SHUFFLE_MANAGER).getOrElse {
+      // Auto-detect: a non-default ShuffleManager (e.g. a remote shuffle service like
+      // Celeborn or Uniffle) cannot serve direct block fetches through
+      // ShuffleBlockFetcherIterator. The check errs on the safe side: getReader() is always
+      // correct for any ShuffleManager, just less block-precise than the fetcher path.
+      !SparkEnv.get.shuffleManager.isInstanceOf[SortShuffleManager]
+    }
 
   @transient private var cachedShuffleRDD: ShuffledRowRDD = _
 
@@ -88,29 +95,10 @@ case class DeltaOptimizedWriterExec(
   private def getShuffleRDD: ShuffledRowRDD = {
     if (cachedShuffleRDD == null) {
       val resolver = org.apache.spark.sql.catalyst.analysis.caseInsensitiveResolution
-      val partitionExprs = partitionColumns.map { p =>
-        output.find(o => resolver(p, o.name)).getOrElse(
-          throw DeltaErrors.failedFindPartitionColumnInOutputPlan(p))
-      }
-
-      val hashExprs = if (useShuffleManager) {
-        // ShuffleManager.getReader() path: reducers are read atomically and cannot be split
-        // across output bins. With low-cardinality partition columns (or unpartitioned tables),
-        // all rows hash to one or very few reducers, collapsing bin-packing into a single output
-        // bin regardless of data volume. This path is designed to be compatible with remote
-        // shuffle services (e.g. Celeborn, Uniffle) whose implementations live outside Delta.
-        //
-        // We append a salt (Pmod(MonotonicallyIncreasingID(), numPartitions)) so that rows
-        // sharing the same partition value are spread across multiple reducers. Each reducer
-        // still contains rows from predominantly one Delta partition value (cross-partition
-        // hash collisions are rare with 2000 slots). Multiple files per Delta partition are
-        // valid, so correctness is preserved.
-        partitionExprs :+ Pmod(MonotonicallyIncreasingID(), Literal(numPartitions.toLong))
-      } else {
-        partitionExprs
-      }
-
-      val saltedPartitioning = HashPartitioning(hashExprs, numPartitions)
+      val saltedPartitioning = HashPartitioning(
+        partitionColumns.map(p => output.find(o => resolver(p, o.name)).getOrElse(
+          throw DeltaErrors.failedFindPartitionColumnInOutputPlan(p))),
+        numPartitions)
 
       val shuffledRDD =
         ShuffleExchangeExec(saltedPartitioning, child).execute().asInstanceOf[ShuffledRowRDD]
@@ -142,14 +130,27 @@ case class DeltaOptimizedWriterExec(
       }.toSeq
 
     val bins = if (useShuffleManager) {
-      // ShuffleManager.getReader() path: never split reducers across bins to avoid duplicate
-      // reads. getReader() reads entire partitions; splitting a reducer across bins would cause
-      // each bin to read the full partition, producing data duplication.
+      // ShuffleManager.getReader() path: data can only be fetched at (reducer, contiguous
+      // map-index range) granularity, never as arbitrary block subsets. Map-range reads are
+      // the same API Spark AQE uses to split skewed partitions, so remote shuffle services
+      // that support AQE (e.g. Celeborn, Uniffle) support them too.
       val (largeReducers, smallReducers) = reducerGroups.partition(_._3 >= maxBinSize)
 
-      // Large reducers: each gets its own bin (may exceed maxBinSize, but that's acceptable)
-      val largeBins = largeReducers.map { case (_, blocks, _) =>
-        blocks.map(_._1)
+      // Large reducers: split into contiguous map-index chunks of up to maxBinSize each.
+      // This keeps output files near the target size and the write parallel even when all
+      // rows hash to one reducer (a single partition value, or an unpartitioned table).
+      val largeBins = largeReducers.flatMap { case (_, blocks, _) =>
+        val chunks = ArrayBuffer(ArrayBuffer[(BlockId, Long, Int)]())
+        var chunkSize = 0L
+        blocks.sortBy(_._3).foreach { block =>
+          if (chunks.last.nonEmpty && chunkSize + block._2 > maxBinSize) {
+            chunks += ArrayBuffer[(BlockId, Long, Int)]()
+            chunkSize = 0L
+          }
+          chunks.last += block
+          chunkSize += block._2
+        }
+        chunks.map(_.map(_._1).toSeq)
       }
 
       // Small reducers: bin-pack together, keeping each reducer's blocks atomic
@@ -166,15 +167,24 @@ case class DeltaOptimizedWriterExec(
 
       val result = largeBins ++ smallBins
 
-      // Verify no reducer is split across multiple bins (would cause duplicate data)
-      val reducerToBinCount = result.zipWithIndex.flatMap { case (bin, binIdx) =>
-        bin.map(_.asInstanceOf[ShuffleBlockId].reduceId).distinct.map(_ -> binIdx)
-      }.groupBy(_._1).mapValues(_.map(_._2).distinct.size)
-
-      val duplicates = reducerToBinCount.filter(_._2 > 1)
-      assert(duplicates.isEmpty,
-        s"Reducer(s) split across multiple bins in remote shuffle mode, " +
-          s"which would cause data duplication: ${duplicates.keys.mkString(", ")}")
+      // The reader fetches [minMapIndex, maxMapIndex + 1) per (bin, reducer), so a reducer's
+      // map-index ranges must not overlap across bins or rows would be read twice. The
+      // contiguous chunking above guarantees this; verify it.
+      val rangesPerReducer = result.zipWithIndex.flatMap { case (bin, binIdx) =>
+        bin.groupBy(_.asInstanceOf[ShuffleBlockId].reduceId).map { case (reducerId, ids) =>
+          val mapIndexes = ids.map(blockInfo(_)._3)
+          (reducerId, mapIndexes.min, mapIndexes.max, binIdx)
+        }
+      }
+      rangesPerReducer.groupBy(_._1).foreach { case (reducerId, ranges) =>
+        ranges.sortBy(_._2).sliding(2).foreach {
+          case Seq((_, _, prevMax, prevBin), (_, curMin, _, curBin)) =>
+            assert(prevMax < curMin,
+              s"Overlapping map-index ranges for reducer $reducerId between bins $prevBin " +
+                s"and $curBin would duplicate data in remote shuffle mode")
+          case _ => // reducer is covered by a single bin
+        }
+      }
 
       result
     } else {
@@ -243,6 +253,15 @@ case class DeltaOptimizedWriterExec(
 
     val partitions = computeBins()
 
+    val readPath = if (useShuffleManager) {
+      "ShuffleManager.getReader() (non-default shuffle manager)"
+    } else {
+      "ShuffleBlockFetcherIterator (local shuffle blocks)"
+    }
+    logInfo(s"Optimized write: reading shuffle data via $readPath, planned " +
+      s"${partitions.length} bins from $numPartitions shuffle partitions " +
+      s"(${childNumPartitions} input partitions)")
+
     recordDeltaEvent(deltaLog,
       "delta.optimizeWrite.planned",
       data = Map(
@@ -252,7 +271,8 @@ case class DeltaOptimizedWriterExec(
         "numShuffleBlocks" -> getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_BLOCKS),
         "binSize" -> getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_BIN_SIZE),
         "maxShufflePartitions" ->
-          getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_MAX_SHUFFLE_PARTITIONS)
+          getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_MAX_SHUFFLE_PARTITIONS),
+        "useShuffleManager" -> useShuffleManager
       )
     )
 
@@ -301,46 +321,32 @@ private class DeltaOptimizedWriterRDD(
     val tempMetrics = context.taskMetrics().createTempShuffleReadMetrics()
     val sqlMetricsReporter = new SQLShuffleReadMetricsReporter(tempMetrics, metrics)
 
-    val blocks = if (context.stageAttemptNumber() > 0) {
-      // We lost shuffle blocks, so we need to now get new manager addresses.
+    val blocks = if (useShuffleManager) {
+      // ShuffleManager.getReader() path: the reader consumes only (reduceId, mapIndex) from
+      // the bin spec -- both stable across stage attempts -- and getReader() resolves the
+      // current block locations through the MapOutputTracker at read time. Stale
+      // BlockManagerId addresses are never used, so no refresh is needed after shuffle
+      // block loss.
+      split.asInstanceOf[ShuffleBlockRDDPartition].blocks.iterator
+    } else if (context.stageAttemptNumber() > 0) {
+      // We lost shuffle blocks, so we need to now get new manager addresses
       val executorTracker = SparkEnv.get.mapOutputTracker
       val oldBlockLocations = split.asInstanceOf[ShuffleBlockRDDPartition].blocks
 
-      // Refresh block locations. Keyed by (mapIndex, reduceId) in both branches so the
-      // lookup site below is uniform; for the local branch every block in the bin shares
-      // the same reduceId, so the extra tuple dimension is a no-op there.
-      val newLocations: Map[(Int, Int), (BlockManagerId, (BlockId, Long, Int))] =
-        if (useShuffleManager) {
-          // useShuffleManager=true bins small reducers together (lines 156-165), so one bin
-          // can contain blocks from multiple reducers. We must refresh every reducer's
-          // locations; using only the first reduceId would leave the rest stale.
-          // Keying by (mapIndex, reduceId) avoids collisions: the same map task produces
-          // one block per reduce partition, so mapIndex alone is not unique across reducers.
-          val reducerIds = oldBlockLocations.flatMap { case (_, blockList) =>
-            blockList.map(_._1.asInstanceOf[ShuffleBlockId].reduceId)
-          }.toSet
-          reducerIds.flatMap { rid =>
-            executorTracker.getMapSizesByExecutorId(dep.shuffleId, rid)
-              .flatMap { case (bmId, newBlocks) =>
-                newBlocks.map { blockInfo => (blockInfo._3, rid) -> (bmId, blockInfo) }
-              }
-          }.toMap
-        } else {
-          // Local mode: reducerGroups.flatMap { binPackBySize } processes each reducer
-          // independently, so every bin belongs to exactly one reducer.
-          val reducerId =
-            oldBlockLocations.head._2.head._1.asInstanceOf[ShuffleBlockId].reduceId
-          executorTracker.getMapSizesByExecutorId(dep.shuffleId, reducerId)
-            .flatMap { case (bmId, newBlocks) =>
-              newBlocks.map { blockInfo => (blockInfo._3, reducerId) -> (bmId, blockInfo) }
-            }.toMap
-        }
+      // assumes we bin-pack by reducerId: in local mode every bin holds exactly one reducer
+      val reducerId = oldBlockLocations.head._2.head._1.asInstanceOf[ShuffleBlockId].reduceId
+      // Get block addresses
+      val newLocations = executorTracker.getMapSizesByExecutorId(dep.shuffleId, reducerId)
+        .flatMap { case (bmId, newBlocks) =>
+          newBlocks.map { blockInfo =>
+            (blockInfo._3, (bmId, blockInfo))
+          }
+        }.toMap
 
       val blockLocations = new mutable.HashMap[BlockManagerId, ArrayBuffer[(BlockId, Long, Int)]]()
       oldBlockLocations.foreach { case (_, oldBlocks) =>
         oldBlocks.foreach { oldBlock =>
-          val reduceId = oldBlock._1.asInstanceOf[ShuffleBlockId].reduceId
-          val (bmId, blockInfo) = newLocations((oldBlock._3, reduceId))
+          val (bmId, blockInfo) = newLocations(oldBlock._3)
           val blocksAtBM = blockLocations.getOrElseUpdate(bmId,
             new ArrayBuffer[(BlockId, Long, Int)]())
           blocksAtBM.append(blockInfo)
@@ -384,31 +390,34 @@ private class OptimizedWriterShuffleReader(
   override def read(): Iterator[Product2[Int, InternalRow]] = {
 
     if (useShuffleManager) {
-      // ShuffleManager.getReader() path: reads entire reducer partitions rather than
-      // individual blocks. This avoids assuming direct block access, making it compatible
-      // with remote shuffle services (e.g. Celeborn, Uniffle) that live outside this repo.
+      // ShuffleManager.getReader() path: fetch this bin's slice of each reducer as a
+      // contiguous [startMapIndex, endMapIndex) range -- the same map-range API Spark AQE
+      // uses for skew splitting, so it avoids assuming direct block access and stays
+      // compatible with remote shuffle services (e.g. Celeborn, Uniffle) that live outside
+      // this repo. computeBins() guarantees each (bin, reducer) pair covers a map-index
+      // range that no other bin overlaps. Map outputs absent from the range are empty for
+      // this reducer, so nothing is missed.
+      val rangesByReducer = blocks.flatMap { case (_, blockList) =>
+        blockList.map(b => (b._1.asInstanceOf[ShuffleBlockId].reduceId, b._3))
+      }.toSeq.groupBy(_._1).toSeq.sortBy(_._1).map { case (reducerId, pairs) =>
+        val mapIndexes = pairs.map(_._2)
+        (reducerId, mapIndexes.min, mapIndexes.max + 1)
+      }
 
-      // Collect all reducer IDs (partition IDs) from our blocks
-      val reducerIds = blocks.flatMap { case (_, blockList) =>
-        blockList.map(_._1.asInstanceOf[ShuffleBlockId].reduceId)
-      }.toSet
-
-      // Read from all the partitions we need using ShuffleManager API
-      val iterators = reducerIds.toSeq.sorted.map { reducerId =>
-        val reader = SparkEnv.get.shuffleManager.getReader(
+      // flatMap keeps this lazy: only one underlying reader is open at a time.
+      val recordIter = rangesByReducer.iterator.flatMap { case (reducerId, startMap, endMap) =>
+        SparkEnv.get.shuffleManager.getReader(
           dep.shuffleHandle,
+          startMap,
+          endMap,
           reducerId,
           reducerId + 1,
           context,
           readMetrics)
-        reader.read().asInstanceOf[Iterator[Product2[Int, InternalRow]]]
+          .read().asInstanceOf[Iterator[Product2[Int, InternalRow]]]
       }
 
-      // Combine all iterators into one
-      val combinedIterator = iterators.foldLeft(
-        Iterator.empty: Iterator[Product2[Int, InternalRow]])(_ ++ _)
-
-      new InterruptibleIterator[Product2[Int, InternalRow]](context, combinedIterator)
+      new InterruptibleIterator[Product2[Int, InternalRow]](context, recordIter)
     } else {
       // Default mode: Use ShuffleBlockFetcherIterator for optimal performance
       // This reads only the specific blocks assigned to this bin.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3208,9 +3208,11 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
     buildConf("optimizeWrite.useShuffleManager")
       .doc("When true, uses ShuffleManager.getReader() API for reading shuffle data, " +
         "which is compatible with remote shuffle services like Apache Celeborn and Uniffle. " +
+        "In this mode, shuffle partitions are never split across bins to avoid reading " +
+        "duplicate data - small partitions are bin-packed together, while large partitions " +
+        "(exceeding binSize) each get their own bin and may produce larger output files. " +
         "When false (default), uses ShuffleBlockFetcherIterator for optimal performance with " +
-        "local shuffle. Note: Setting this to true may read more data than necessary if " +
-        "bin-packing splits a shuffle partition across multiple output files.")
+        "local shuffle, allowing individual blocks to be bin-packed for precise file sizes.")
       .booleanConf
       .createWithDefault(false)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3204,6 +3204,16 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .bytesConf(ByteUnit.MiB)
       .createWithDefault(512)
 
+  val DELTA_OPTIMIZE_WRITE_USE_SHUFFLE_MANAGER =
+    buildConf("optimizeWrite.useShuffleManager")
+      .doc("When true, uses ShuffleManager.getReader() API for reading shuffle data, " +
+        "which is compatible with remote shuffle services like Apache Celeborn and Uniffle. " +
+        "When false (default), uses ShuffleBlockFetcherIterator for optimal performance with " +
+        "local shuffle. Note: Setting this to true may read more data than necessary if " +
+        "bin-packing splits a shuffle partition across multiple output files.")
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_OPTIMIZE_CLUSTERING_MIN_CUBE_SIZE =
   buildConf("optimize.clustering.mergeStrategy.minCubeSize.threshold")
     .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3206,15 +3206,18 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
 
   val DELTA_OPTIMIZE_WRITE_USE_SHUFFLE_MANAGER =
     buildConf("optimizeWrite.useShuffleManager")
-      .doc("When true, uses ShuffleManager.getReader() API for reading shuffle data, " +
+      .doc("When true, uses the ShuffleManager.getReader() API for reading shuffle data, " +
         "which is compatible with remote shuffle services like Apache Celeborn and Uniffle. " +
-        "In this mode, shuffle partitions are never split across bins to avoid reading " +
-        "duplicate data - small partitions are bin-packed together, while large partitions " +
-        "(exceeding binSize) each get their own bin and may produce larger output files. " +
-        "When false (default), uses ShuffleBlockFetcherIterator for optimal performance with " +
-        "local shuffle, allowing individual blocks to be bin-packed for precise file sizes.")
+        "In this mode data is read at (shuffle partition, map-index range) granularity, the " +
+        "same API Spark AQE uses for skew splitting: small shuffle partitions are bin-packed " +
+        "together, while large ones are split into contiguous map-index ranges of up to " +
+        "binSize, keeping writes parallel and output files near the target size. " +
+        "When false, uses ShuffleBlockFetcherIterator, which can bin-pack individual " +
+        "shuffle blocks for precise file sizes but only works with local shuffle. " +
+        "When unset (default), this is detected automatically: the getReader() path is used " +
+        "whenever a non-default shuffle manager is configured.")
       .booleanConf
-      .createWithDefault(false)
+      .createOptional
 
   val DELTA_OPTIMIZE_CLUSTERING_MIN_CUBE_SIZE =
   buildConf("optimize.clustering.mergeStrategy.minCubeSize.threshold")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizedWritesSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizedWritesSuite.scala
@@ -62,6 +62,12 @@ abstract class OptimizedWritesSuiteBase extends QueryTest
 
   protected implicit def fileToPathString(dir: File): String = dir.getCanonicalPath
 
+  // Expected "outputPartitions" (number of bins) logged for the write in
+  // "do not create tons of shuffle partitions during optimized writes": one bin per reducer
+  // in the block-fetcher path; suites running under a non-default shuffle manager pack the
+  // small reducers into a single bin and override this.
+  protected def expectedLoggedOutputPartitions: Int = 5
+
   writeTest("non-partitioned write - table config") { dir =>
     val df = spark.range(0, 100, 1, 4).toDF()
     df.write.format("delta").save(dir)
@@ -339,7 +345,7 @@ abstract class OptimizedWritesSuiteBase extends QueryTest
 
       assert(logs1.length === 1)
       val blob = JsonUtils.fromJson[Map[String, Any]](logs1.head.blob)
-      assert(blob("outputPartitions") === 5)
+      assert(blob("outputPartitions") === expectedLoggedOutputPartitions)
       assert(blob("originalPartitions") === 2)
       assert(blob("numShuffleBlocks") === 50000000)
       assert(blob("shufflePartitions") ===
@@ -359,30 +365,30 @@ abstract class OptimizedWritesSuiteBase extends QueryTest
   // designed to be compatible with remote shuffle services (e.g. Celeborn, Uniffle),
   // whose implementations live in separate repositories; no RSS is present here.
   //
-  // The bug: HashPartitioning(partitionColumns, N) sends all rows with the same Delta partition
-  // value to ONE reducer. ShuffleManager.getReader() reads reducers atomically, so
-  // 1 reducer = 1 bin = 1 file regardless of data volume.
-  //
-  // The fix: append Pmod(MonotonicallyIncreasingID(), N) as a salt so that same-partition rows
-  // are spread across multiple reducers = multiple bins = multiple, correctly-sized output files.
+  // Data is fetched at (reducer, contiguous map-index range) granularity -- the same API
+  // AQE uses to split skewed partitions. computeBins() packs small reducers together as
+  // atomic units and splits large reducers into map-index chunks of up to binSize, so the
+  // write stays parallel and files stay near the target size even when all rows hash to a
+  // single reducer (one partition value, or an unpartitioned table).
   //
   // Note on bin-size choice in these tests: "1b" is parsed by bytesConf(MiB) as 0 MiB (integer
-  // division 1 / 1048576 = 0). maxBinSize = 0 means every non-empty reducer is classified as
-  // "large" and gets its own bin, regardless of actual data volume. This lets us verify the
-  // salt distributes data across reducers without needing a multi-GB test dataset.
+  // division 1 / 1048576 = 0). maxBinSize = 0 classifies every non-empty reducer as "large"
+  // and makes every map block its own chunk, forcing the splitting machinery to engage
+  // without needing a multi-GB test dataset.
   // maxShufflePartitions is capped at 20 to keep bin/file counts manageable.
 
-  writeTest("useShuffleManager=true - salt distributes single-partition-value rows across bins") {
+  writeTest("useShuffleManager=true - oversized partition value is split across multiple files") {
     dir =>
-      // 4 input partitions, ALL rows share the same Delta partition value "x".
-      // Without salt: HashPartitioning(["x"], 20) -- all rows to 1 reducer -- 1 bin -- 1 file.
-      // With salt:    HashPartitioning(["x", salt], 20) -- rows spread to multiple reducers.
+      // 4 input partitions, ALL rows share the same Delta partition value "x", so every row
+      // hashes to ONE reducer. With bin size forced to 0 that reducer must be split into one
+      // map-range chunk per map block -- multiple bins -- multiple files -- instead of a
+      // single task writing one giant file. checkResult calls checkAnswer, so this also
+      // verifies the split does not duplicate or drop rows.
       val df = spark.range(0, 200, 1, 4).withColumn("part", lit("x"))
 
       withSQLConf(
         DeltaSQLConf.DELTA_OPTIMIZE_WRITE_USE_SHUFFLE_MANAGER.key -> "true",
         DeltaSQLConf.DELTA_OPTIMIZE_WRITE_MAX_SHUFFLE_PARTITIONS.key -> "20",
-        // 0-byte effective bin: each non-empty reducer gets its own bin (data-size independent)
         DeltaSQLConf.DELTA_OPTIMIZE_WRITE_BIN_SIZE.key -> "1b") {
 
         df.write.partitionBy("part").format("delta").save(dir)
@@ -391,11 +397,12 @@ abstract class OptimizedWritesSuiteBase extends QueryTest
       checkResult(df, numFileCheck = _ > 1, dir)
   }
 
-  writeTest("useShuffleManager=true - salt fixes single-bucket problem for unpartitioned tables") {
+  writeTest("useShuffleManager=true - unpartitioned write does not collapse into one file") {
     dir =>
-      // Unpartitioned: partitionColumns = Seq() -- HashPartitioning(Seq(), N) = constant hash
-      // -- all rows to reducer 0 -- 1 bin -- 1 file, regardless of data size.
-      // With salt: rows spread across reducers -- multiple bins -- multiple files.
+      // Unpartitioned: partitionColumns = Seq() -- HashPartitioning(Seq(), N) is a constant
+      // -- all rows land in one reducer regardless of data size. Map-range splitting breaks
+      // that reducer into multiple bins -- multiple files; checkAnswer verifies no row
+      // duplication or loss.
       val df = spark.range(0, 200, 1, 4).toDF()
 
       withSQLConf(
@@ -409,9 +416,10 @@ abstract class OptimizedWritesSuiteBase extends QueryTest
       checkResult(df, numFileCheck = _ > 1, dir)
   }
 
-  writeTest("useShuffleManager=true - salt does not cause data loss or duplication") { dir =>
-    // Primary correctness requirement: the salt must not add or drop any rows.
-    // Uses default bin size so this tests a realistic code path, not the "0-bin" edge case.
+  writeTest("useShuffleManager=true - no data loss or duplication at default bin size") { dir =>
+    // Primary correctness requirement: bin packing and map-range splitting must not add or
+    // drop rows. Uses default bin size so this tests a realistic code path, not the "0-bin"
+    // edge case (here the small per-value reducers get packed together into shared bins).
     val df = spark.range(0, 1000, 1, 8).withColumn("part", 'id % 3)
 
     withSQLConf(
@@ -426,7 +434,7 @@ abstract class OptimizedWritesSuiteBase extends QueryTest
 
   writeTest("useShuffleManager=false still coalesces unpartitioned write to one file") { dir =>
     // Local-shuffle path unchanged: ShuffleBlockFetcherIterator can split individual blocks
-    // across bins, so 4 input partitions coalesce into 1 output file. No salt in this path.
+    // across bins, so 4 input partitions coalesce into 1 output file.
     val df = spark.range(0, 100, 1, 4).toDF()
 
     withSQLConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizedWritesWithCustomShuffleManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizedWritesWithCustomShuffleManagerSuite.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.perf
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import scala.jdk.CollectionConverters._
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.shuffle._
+import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.sql.functions.lit
+
+/**
+ * A [[ShuffleManager]] that delegates everything to [[SortShuffleManager]] but records every
+ * getReader() call. Because it is not a SortShuffleManager, DeltaOptimizedWriterExec
+ * auto-detects it as a non-default shuffle manager and takes the ShuffleManager.getReader()
+ * read path -- the same code path a remote shuffle service (e.g. Celeborn, Uniffle) would
+ * take -- while data is still served from local shuffle files.
+ */
+class RecordingDelegatingShuffleManager(conf: SparkConf) extends ShuffleManager {
+  private val delegate = new SortShuffleManager(conf)
+
+  override def registerShuffle[K, V, C](
+      shuffleId: Int,
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle =
+    delegate.registerShuffle(shuffleId, dependency)
+
+  override def getWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] =
+    delegate.getWriter(handle, mapId, context, metrics)
+
+  override def getReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    RecordingDelegatingShuffleManager.recordedReads.add(
+      (startMapIndex, endMapIndex, startPartition, endPartition))
+    delegate.getReader(
+      handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics)
+  }
+
+  override def unregisterShuffle(shuffleId: Int): Boolean =
+    delegate.unregisterShuffle(shuffleId)
+
+  override def shuffleBlockResolver: ShuffleBlockResolver = delegate.shuffleBlockResolver
+
+  override def stop(): Unit = delegate.stop()
+}
+
+object RecordingDelegatingShuffleManager {
+  /**
+   * (startMapIndex, endMapIndex, startPartition, endPartition) of every getReader() call.
+   * Tests run in local mode, so executor-side calls land in this JVM.
+   */
+  val recordedReads = new ConcurrentLinkedQueue[(Int, Int, Int, Int)]()
+
+  /**
+   * Reads issued with a bounded map-index range: DeltaOptimizedWriterExec's reads. Generic
+   * ShuffledRowRDD reads (e.g. Delta state reconstruction) pass endMapIndex = Int.MaxValue.
+   */
+  def boundedReads: Seq[(Int, Int, Int, Int)] =
+    recordedReads.asScala.toSeq.filter(_._2 != Int.MaxValue).distinct
+
+  def reset(): Unit = recordedReads.clear()
+}
+
+/**
+ * Runs the full optimized-writes suite under a non-default ShuffleManager -- exercising the
+ * auto-detected ShuffleManager.getReader() path end to end -- plus targeted tests for the
+ * detection logic and the map-range read behavior.
+ */
+class OptimizedWritesWithCustomShuffleManagerSuite extends OptimizedWritesSuiteBase
+  with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(
+      "spark.shuffle.manager", classOf[RecordingDelegatingShuffleManager].getName)
+
+  // Under the getReader() path the 5 small per-partition-value reducers are bin-packed into
+  // a single bin, vs one bin per reducer in the block-fetcher path.
+  override protected def expectedLoggedOutputPartitions: Int = 1
+
+  writeTest("auto-detection - non-default shuffle manager uses getReader() without any conf") {
+    dir =>
+      RecordingDelegatingShuffleManager.reset()
+      val df = spark.range(0, 100, 1, 4).withColumn("part", 'id % 5)
+
+      // DELTA_OPTIMIZE_WRITE_USE_SHUFFLE_MANAGER is unset: detection alone must route the
+      // read through ShuffleManager.getReader().
+      val events = Log4jUsageLogger.track {
+        df.write.partitionBy("part").format("delta").save(dir)
+      }.filter(_.metric == "tahoeEvent")
+        .filter(_.tags.get("opType") === Some("delta.optimizeWrite.planned"))
+
+      assert(RecordingDelegatingShuffleManager.boundedReads.nonEmpty,
+        "expected the optimized write to read shuffle data through ShuffleManager.getReader()")
+
+      // The planned event must report the detected read path.
+      assert(events.length === 1)
+      val blob = JsonUtils.fromJson[Map[String, Any]](events.head.blob)
+      assert(blob("useShuffleManager") === true)
+
+      checkResult(df, numFileCheck = _ <= 5, dir)
+  }
+
+  writeTest("auto-detection - explicit useShuffleManager=false overrides detection") { dir =>
+    val df = spark.range(0, 100, 1, 4).withColumn("part", 'id % 5)
+
+    withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_USE_SHUFFLE_MANAGER.key -> "false") {
+      RecordingDelegatingShuffleManager.reset()
+      df.write.partitionBy("part").format("delta").save(dir)
+      assert(RecordingDelegatingShuffleManager.boundedReads.isEmpty,
+        "expected the block-fetcher path: no bounded-map-range getReader() calls")
+    }
+
+    checkResult(df, numFileCheck = _ <= 5, dir)
+  }
+
+  writeTest("map-range reads target single reducers with disjoint ranges") { dir =>
+    // All rows share one partition value -> one reducer. Bin size 0 forces one map-range
+    // chunk per map block, so the reducer must be read via several disjoint single-reducer
+    // ranges rather than one whole-partition read.
+    val df = spark.range(0, 200, 1, 4).withColumn("part", lit("x"))
+
+    withSQLConf(
+      DeltaSQLConf.DELTA_OPTIMIZE_WRITE_MAX_SHUFFLE_PARTITIONS.key -> "20",
+      DeltaSQLConf.DELTA_OPTIMIZE_WRITE_BIN_SIZE.key -> "1b") {
+      RecordingDelegatingShuffleManager.reset()
+      df.write.partitionBy("part").format("delta").save(dir)
+    }
+
+    val reads = RecordingDelegatingShuffleManager.boundedReads
+    assert(reads.nonEmpty, "expected map-range getReader() calls")
+    assert(reads.forall { case (_, _, startPartition, endPartition) =>
+      endPartition == startPartition + 1
+    }, s"every read should target exactly one reducer, got: $reads")
+
+    reads.groupBy(_._3).foreach { case (reducerId, readsForReducer) =>
+      val sorted = readsForReducer.sortBy(_._1)
+      sorted.sliding(2).foreach {
+        case Seq((_, prevEnd, _, _), (curStart, _, _, _)) =>
+          assert(prevEnd <= curStart, s"map ranges for reducer $reducerId overlap: $sorted")
+        case _ => // single range for this reducer
+      }
+    }
+
+    // The single oversized reducer must have been split into multiple map ranges.
+    assert(reads.map(_._3).distinct.size < reads.size,
+      s"expected at least one reducer to be split into multiple map ranges, got: $reads")
+
+    checkResult(df, numFileCheck = _ > 1, dir)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves #4343 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

This was tested with running apache spark + deltalake + celeborn with client mode. No row duplicates + no shuffle fetch failures happens

```
Test Environment

- Platform: Kind (Kubernetes in Docker) cluster
- Shuffle Service: Apache Celeborn 0.6.2
- Spark: 4.0.1 with Delta Lake 4.1.0-SNAPSHOT
- Configuration:
  - spark.databricks.delta.optimizeWrite.enabled=true
  - spark.databricks.delta.optimizeWrite.useShuffleManager=true
  - spark.databricks.delta.optimizeWrite.binSize=512
  - spark.databricks.delta.optimizeWrite.numShuffleBlocks=2000
  - spark.shuffle.manager=org.apache.spark.shuffle.celeborn.SparkShuffleManager

Test Results

Test 1 - Basic Write (600K records)
- No FetchFailedException
- No data duplication (600K total = 600K distinct)
- Files properly consolidated

Test 2 - Partitioned Write (1M records)
- Partitioned by date + region
- No duplicates across partitions
- All partition data intact

```

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, previous behavior is that when the optimizeWrite feature is enabled + when running in parallel remote shuffle service for spark, the `FetchFailedException` happens. After this PR, by specifying the flag `useShuffleManager` to be `true`,  the `FetchFailedException` is prevented even using remote shuffle service (e.g. apache celeborn)

