### PR TITLE
[DO NOT MERGE][Asking for feedback][Spark]Generize Deltasource.checkReadIncompatibleSchemaChanges to make it avoid depending on Spark's V1 metadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -17,13 +17,14 @@
 package org.apache.spark.sql.delta.sources
 
 // scalastyle:off import.ordering.noEmptyLine
-import java.io.FileNotFoundException
-import java.sql.Timestamp
+import io.delta.storage.commit.actions.AbstractMetadata
 
+import java.io.FileNotFoundException
+import scala.collection.JavaConverters._
+import java.sql.Timestamp
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
-
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -33,10 +34,9 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.storage.{ClosableIterator, SupportsRewinding}
 import org.apache.spark.sql.delta.storage.ClosableIterator._
-import org.apache.spark.sql.delta.util.{DateTimeUtils, TimestampFormatter}
+import org.apache.spark.sql.delta.util.{AbstractMetadataUtils, DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.FileStatus
-
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -582,6 +582,31 @@ trait DeltaSourceBase extends Source
     hasCheckedReadIncompatibleSchemaChangesOnStreamStart = true
   }
 
+  protected def checkReadIncompatibleSchemaChanges(
+      metadata: Metadata,
+      version: Long,
+      batchStartVersion: Long,
+      batchEndVersionOpt: Option[Long] = None,
+      validatedDuringStreamStart: Boolean = false): Unit = {
+    checkReadIncompatibleSchemaChanges(
+      metadata,
+      version,
+      batchStartVersion,
+      batchEndVersionOpt,
+      validatedDuringStreamStart,
+      (oldMeta, targetMode) => {
+        val old = oldMeta.asInstanceOf[Metadata]
+        val upgraded = DeltaColumnMapping.assignColumnIdAndPhysicalName(
+          old, old, isChangingModeOnExistingTable = true, isOverwritingSchema = false
+        )
+        upgraded.copy(
+          configuration = upgraded.configuration ++
+            Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> targetMode.name)
+        )
+      }
+    )
+  }
+
   /**
    * Narrow waist to verify a metadata action for read-incompatible schema changes, specifically:
    * 1. Any column mapping related schema changes (rename / drop) columns
@@ -594,14 +619,23 @@ trait DeltaSourceBase extends Source
    * metadata tracking log upon any non-additive schema change failures.
    * @param metadata Metadata that contains a potential schema change
    * @param version Version for the metadata action
+   * @param batchStartVersion Start version of the batch
+   * @param batchEndVersionOpt Optional end version of the batch
    * @param validatedDuringStreamStart Whether this check is being done during stream start.
+   * @param assignColumnIdAndPhysicalNameFunc Callback function to assign column IDs and physical
+   *        names when upgrading metadata from no column mapping to column mapping mode.
+   *        Takes (oldMetadata, targetColumnMappingMode) and returns upgraded AbstractMetadata.
    */
   protected def checkReadIncompatibleSchemaChanges(
-      metadata: Metadata,
+      metadata: AbstractMetadata,
       version: Long,
       batchStartVersion: Long,
-      batchEndVersionOpt: Option[Long] = None,
-      validatedDuringStreamStart: Boolean = false): Unit = {
+      batchEndVersionOpt: Option[Long],
+      validatedDuringStreamStart: Boolean,
+      assignColumnIdAndPhysicalNameFunc: (AbstractMetadata, DeltaColumnMappingMode) =>
+        AbstractMetadata): Unit = {
+    import AbstractMetadataUtils._
+
     log.info(s"checking read incompatibility with schema at version $version, " +
       s"inside batch[$batchStartVersion, ${batchEndVersionOpt.getOrElse("latest")}]")
 
@@ -630,7 +664,7 @@ trait DeltaSourceBase extends Source
         // Column mapping schema changes
         assert(!trackingMetadataChange, "should not check schema change while tracking it")
         !DeltaColumnMapping.hasNoColumnMappingSchemaChanges(newMetadata, oldMetadata,
-          allowUnsafeStreamingReadOnPartitionColumnChanges)
+          allowUnsafeStreamingReadOnPartitionColumnChanges, assignColumnIdAndPhysicalNameFunc)
       }
 
     if (shouldTrackSchema) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/AbstractMetadataUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/AbstractMetadataUtils.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.actions.AbstractMetadata
+import org.apache.spark.sql.delta.{DeltaColumnMappingMode, DeltaConfigs}
+
+import org.apache.spark.sql.types.{DataType, StructType}
+
+/**
+ * Implicit class to provide convenience methods for AbstractMetadata,
+ * similar to those available in the Metadata class.
+ */
+object AbstractMetadataUtils {
+  implicit class RichAbstractMetadata(val metadata: AbstractMetadata) extends AnyVal {
+    /** Returns the table id */
+    def id: String = metadata.getId
+
+    /** Returns the schema as a [[StructType]] */
+    def schema: StructType = Option(metadata.getSchemaString)
+      .map(DataType.fromJson(_).asInstanceOf[StructType])
+      .getOrElse(StructType.apply(Nil))
+
+    /** Returns partition columns as Scala Seq */
+    def partitionColumns: Seq[String] = metadata.getPartitionColumns.asScala.toSeq
+
+    /** Returns the partitionSchema as a [[StructType]] */
+    def partitionSchema: StructType =
+      new StructType(partitionColumns.map(c => schema(c)).toArray)
+
+    /** Returns configuration as Scala Map */
+    def configuration: Map[String, String] = metadata.getConfiguration.asScala.toMap
+
+    /** Returns the column mapping mode for this table */
+    def columnMappingMode: DeltaColumnMappingMode =
+      DeltaConfigs.COLUMN_MAPPING_MODE.fromMap(configuration)
+  }
+}
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Next, we could implement

  protected def checkReadIncompatibleSchemaChanges(
      metadata: MetadataV2, //Using Kernel
      version: Long,
      batchStartVersion: Long,
      batchEndVersionOpt: Option[Long],
      validatedDuringStreamStart: Boolean,
      assignColumnIdAndPhysicalNameFunc: (MetadataV2, DeltaColumnMappingMode) =>
        MetadataV2):
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
