### PR TITLE
[CatalogManaged] Rename catalog owned error codes and messages to catalog managed

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -213,9 +213,9 @@
     ],
     "sqlState" : "42809"
   },
-  "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES" : {
+  "DELTA_CANNOT_MODIFY_CATALOG_MANAGED_DEPENDENCIES" : {
     "message" : [
-      "Cannot override or unset in-commit timestamp table properties because this table is catalog-owned. Remove \"delta.enableInCommitTimestamps\", \"delta.inCommitTimestampEnablementVersion\", and \"delta.inCommitTimestampEnablementTimestamp\" from the TBLPROPERTIES clause and then retry the command."
+      "Cannot override or unset in-commit timestamp table properties because this table is catalog-managed. Remove \"delta.enableInCommitTimestamps\", \"delta.inCommitTimestampEnablementVersion\", and \"delta.inCommitTimestampEnablementTimestamp\" from the TBLPROPERTIES clause and then retry the command."
     ],
     "sqlState" : "42616"
   },
@@ -2824,9 +2824,9 @@
     ],
     "sqlState" : "0AKDC"
   },
-  "DELTA_UNSUPPORTED_CATALOG_OWNED_TABLE_CREATION" : {
+  "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_CREATION" : {
     "message" : [
-      "Creating a catalog owned table using delta is unsupported."
+      "Creating a catalog-managed table using delta is unsupported."
     ],
     "sqlState" : "0AKDC"
   },
@@ -3113,7 +3113,7 @@
   },
   "DELTA_UNSUPPORTED_VACUUM_ON_MANAGED_TABLE" : {
     "message" : [
-      "Running vacuum on catalog owned managed tables is currently not supported."
+      "Running vacuum on catalog-managed tables is currently not supported."
     ],
     "sqlState" : "0AKDC"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3827,9 +3827,9 @@ trait DeltaErrorsBase
       messageParameters = Array.empty)
   }
 
-  def deltaCannotCreateCatalogOwnedTable(): Throwable = {
+  def deltaCannotCreateCatalogManagedTable(): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_UNSUPPORTED_CATALOG_OWNED_TABLE_CREATION",
+      errorClass = "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_CREATION",
       messageParameters = Array.empty)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -121,7 +121,7 @@ case class CreateDeltaTableCommand(
       getSupportedFeaturesFromTableConfigs(table.properties)
     if (!Utils.isTesting && (tableFeatures.contains(CatalogOwnedTableFeature) ||
       CatalogOwnedTableUtils.defaultCatalogOwnedEnabled(spark = sparkSession))) {
-      throw DeltaErrors.deltaCannotCreateCatalogOwnedTable()
+      throw DeltaErrors.deltaCannotCreateCatalogManagedTable()
     }
 
     val tableWithLocation = getCatalogTableWithLocation(sparkSession)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -193,7 +193,7 @@ object CatalogOwnedTableUtils extends DeltaLogging {
     ICT_TABLE_PROPERTY_KEYS.foreach { key =>
       if (propKeys.contains(key)) {
         throw new DeltaIllegalArgumentException(
-          "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+          "DELTA_CANNOT_MODIFY_CATALOG_MANAGED_DEPENDENCIES",
           messageParameters = Array.empty)
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -263,7 +263,7 @@ class CatalogOwnedEnablementSuite
       }
       checkError(
         error,
-        "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+        "DELTA_CANNOT_MODIFY_CATALOG_MANAGED_DEPENDENCIES",
         sqlState = "42616",
         parameters = Map[String, String]())
     }
@@ -276,7 +276,7 @@ class CatalogOwnedEnablementSuite
       }
       checkError(
         error,
-        "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+        "DELTA_CANNOT_MODIFY_CATALOG_MANAGED_DEPENDENCIES",
         sqlState = "42616",
         parameters = Map[String, String]())
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1685,7 +1685,7 @@ abstract class CommitCoordinatorSuiteBase
       if (isCatalogOwnedTest) {
         checkError(
           e,
-          "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+          "DELTA_CANNOT_MODIFY_CATALOG_MANAGED_DEPENDENCIES",
           sqlState = "42616",
           parameters = Map[String, String]())
       } else {
@@ -1733,7 +1733,7 @@ abstract class CommitCoordinatorSuiteBase
       if (isCatalogOwnedTest) {
         checkError(
           e,
-          "DELTA_CANNOT_MODIFY_CATALOG_OWNED_DEPENDENCIES",
+          "DELTA_CANNOT_MODIFY_CATALOG_MANAGED_DEPENDENCIES",
           sqlState = "42616",
           parameters = Map[String, String]())
       } else {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
As titled.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes, changing the error messages/codes from `catalog owned` to `catalog managed`.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
