### PR TITLE
[kernel-spark] Refactor schema changes compatibility check in DeltaSource

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
@@ -108,27 +108,41 @@ object DeltaSourceUtils {
     case sources.AlwaysFalse() => expressions.Literal.FalseLiteral
   }.reduceOption(expressions.And).getOrElse(expressions.Literal.TrueLiteral)
 
+  /**
+   * Configuration options for schema compatibility validation during Delta streaming reads.
+   *
+   * This class encapsulates various flags and settings that control how Delta streaming handles
+   * schema changes and compatibility checks.
+   *
+   * @param allowUnsafeStreamingReadOnColumnMappingSchemaChanges
+   *        Flag that allows user to force enable unsafe streaming read on Delta table with
+   *        column mapping enabled AND drop/rename actions.
+   * @param allowUnsafeStreamingReadOnPartitionColumnChanges
+   *        Flag that allows user to force enable unsafe streaming read on Delta table with
+   *        column mapping enabled AND partition column changes.
+   * @param forceEnableStreamingReadOnReadIncompatibleSchemaChangesDuringStreamStart
+   *        Flag that allows user to disable the read-compatibility check during stream start which
+   *        protects against a corner case in which verifyStreamHygiene could not detect.
+   *        This is a bug fix but yet a potential behavior change, so we add a flag to fallback.
+   * @param forceEnableUnsafeReadOnNullabilityChange
+   *        Flag that allows user to fallback to the legacy behavior in which user can allow
+   *        nullable=false schema to read nullable=true data, which is incorrect but a behavior
+   *        change regardless.
+   * @param isStreamingFromColumnMappingTable
+   *        Whether we are streaming from a table with column mapping enabled.
+   * @param typeWideningEnabled
+   *        Whether we are streaming from a table that has the type widening table feature enabled.
+   * @param enableSchemaTrackingForTypeWidening
+   *        Whether we should track widening type changes to allow users to accept them and resume
+   *        stream processing.
+   */
   case class SchemaReadOptions(
-      // Flag that allows user to force enable unsafe streaming read on Delta table with
-      // column mapping enabled AND drop/rename actions.
       allowUnsafeStreamingReadOnColumnMappingSchemaChanges: Boolean,
-      // Flag that allows user to force enable unsafe streaming read on Delta table with
-      // column mapping enabled AND partition column changes.
       allowUnsafeStreamingReadOnPartitionColumnChanges: Boolean,
-      // Flag that allows user to disable the read-compatibility check during stream start which
-      // protects against an corner case in which verifyStreamHygiene could not detect.
-      // This is a bug fix but yet a potential behavior change, so we add a flag to fallback.
       forceEnableStreamingReadOnReadIncompatibleSchemaChangesDuringStreamStart: Boolean,
-      // Flag that allow user to fallback to the legacy behavior in which user can allow
-      // nullable=false schema to read nullable=true data, which is incorrect but a behavior
-      // change regardless.
       forceEnableUnsafeReadOnNullabilityChange: Boolean,
-      // Whether we are streaming from a table with column mapping enabled
       isStreamingFromColumnMappingTable: Boolean,
-      // Whether we are streaming from a table that has the type widening table feature enabled.
       typeWideningEnabled: Boolean,
-      // Whether we should track widening type changes to allow users to accept them and resume
-      // stream processing.
       enableSchemaTrackingForTypeWidening: Boolean
   )
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is part of a series to support `checkReadIncompatible` in DSv2.
We aim to reuse as much v1 code as possible to support `checkReadIncompatible` in v2. To enable this, we need to refactor the singleton v1 function by splitting it into two distinct checks:

- Column mapping-related non-additive schema changes check
- Basic schema changes check

This separation aligns with our v2 Schema Evolution milestones: M1 (basic) and M2 (non-additive).
We've converted the basic check into a static function so it can be reused in v2 code.

## How was this patch tested?
Only refactor the code but don't change the logic. Guarded by original unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
