### PR TITLE
[Spark] Use PathWithFileSystem in DeltaLog API

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -39,8 +39,7 @@ import org.apache.spark.sql.delta.redirect.RedirectFeature
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources._
 import org.apache.spark.sql.delta.storage.LogStoreProvider
-import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
-import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.util.{FileNames, PathWithFileSystem, Utils => DeltaUtils}
 import com.google.common.cache.{Cache, CacheBuilder, RemovalNotification}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
@@ -510,7 +509,7 @@ class DeltaLog private(
 
   /** Creates the log directory and commit directory if it does not exist. */
   def createLogDirectoriesIfNotExists(): Unit = {
-    val fs = logPath.getFileSystem(newDeltaHadoopConf())
+    val fs = PathWithFileSystem.withConf(logPath, newDeltaHadoopConf()).fs
     def createDirIfNotExists(path: Path): Unit = {
       // Optimistically attempt to create the directory first without checking its existence.
       // This is efficient because we're assuming it's more likely that the directory doesn't
@@ -936,8 +935,10 @@ object DeltaLog extends DeltaLogging {
     // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConfWithOptions(fileSystemOptions)
     // scalastyle:on deltahadoopconfiguration
-    val fs = rootPath.getFileSystem(hadoopConf)
-    fs.makeQualified(rootPath)
+    PathWithFileSystem
+      .withConf(rootPath, hadoopConf)
+      .fs
+      .makeQualified(rootPath)
   }
 
   /**
@@ -976,8 +977,10 @@ object DeltaLog extends DeltaLogging {
     // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConfWithOptions(fileSystemOptions)
     // scalastyle:on deltahadoopconfiguration
-    val fs = rawPath.getFileSystem(hadoopConf)
-    val path = fs.makeQualified(rawPath)
+    val path = PathWithFileSystem
+      .withConf(rawPath, hadoopConf)
+      .fs
+      .makeQualified(rawPath)
     def createDeltaLog(tablePath: Path = path): DeltaLog = recordDeltaOperation(
       null,
       "delta.log.create",
@@ -1069,7 +1072,7 @@ object DeltaLog extends DeltaLogging {
       // scalastyle:off deltahadoopconfiguration
       // This method cannot be called from DataFrameReader/Writer so it's safe to assume the user
       // has set the correct file system configurations in the session configs.
-      val fs = rawPath.getFileSystem(spark.sessionState.newHadoopConf())
+      val fs = PathWithFileSystem.withConf(rawPath, spark.sessionState.newHadoopConf()).fs
       // scalastyle:on deltahadoopconfiguration
       val path = fs.makeQualified(rawPath)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PathWithFileSystem.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PathWithFileSystem.scala
@@ -34,7 +34,7 @@ case class PathWithFileSystem private (path: Path, fs: FileSystem) {
   def withSuffix(s: String): PathWithFileSystem = new PathWithFileSystem(new Path(path, s), fs)
 
   /**
-   * Qualify `path`` using `fs`
+   * Qualify `path` using `fs`
    */
   def makeQualified(): PathWithFileSystem = {
     val qualifiedPath = fs.makeQualified(path)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR refactors the `getFileSystem` call in `DeltaLog` to use `PathWithFileSystem` more consistently.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No