### PR TITLE
[SPARK] Add sql_state for Vacuum retention window errors

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3141,6 +3141,23 @@
     ],
     "sqlState" : "42846"
   },
+  "DELTA_VACUUM_RETENTION_PERIOD_NEGATIVE" : {
+    "message" : [
+      "Retention period for Vacuum can't be less than 0 hours."
+    ],
+    "sqlState" : "22003"
+  },
+  "DELTA_VACUUM_RETENTION_PERIOD_TOO_SHORT" : {
+    "message" : [
+      "The specified VACUUM retention period is too low and may corrupt this Delta table if any writes are in progress.",
+      "",
+      "If no operations (insert, upsert, delete, optimize) are running, you can disable this safety check by setting:",
+      "delta.retentionDurationCheck.enabled = false",
+      "",
+      "Otherwise, use a retention period of at least <configuredRetentionHours> hours."
+    ],
+    "sqlState" : "22003"
+  },
   "DELTA_VERSIONS_NOT_CONTIGUOUS" : {
     "message" : [
       "Versions (<versionList>) are not contiguous. ",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1868,6 +1868,17 @@ trait DeltaErrorsBase
       errorClass = "DELTA_CANNOT_VACUUM_LITE")
   }
 
+  def vacuumRetentionPeriodNegative(): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_VACUUM_RETENTION_PERIOD_NEGATIVE")
+  }
+
+  def vacuumRetentionPeriodTooShort(configuredRetentionHours: Long): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_VACUUM_RETENTION_PERIOD_TOO_SHORT",
+      messageParameters = Array(configuredRetentionHours.toString))
+  }
+
   def updateSchemaMismatchExpression(from: StructType, to: StructType): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -947,7 +947,7 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
           CheckFiles(Seq("file1.txt")),
           ExpectFailure(
             GC(false, Seq(tempDir), Some(-2)),
-            classOf[IllegalArgumentException],
+            classOf[DeltaIllegalArgumentException],
             Seq("Retention", "less than", "0"))
         )
         val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tempDir.getAbsolutePath)
@@ -956,7 +956,7 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
           CheckFiles(Seq("file2.txt")),
           ExpectFailure(
             ExecuteVacuumInScala(deltaTable, Seq(), Some(-2)),
-            classOf[IllegalArgumentException],
+            classOf[DeltaIllegalArgumentException],
             Seq("Retention", "less than", "0"))
         )
       }
@@ -1008,8 +1008,8 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
           CheckFiles(Seq("file1.txt")),
           ExpectFailure(
             GC(false, Nil, Some(0)),
-            classOf[IllegalArgumentException],
-            Seq("spark.databricks.delta.retentionDurationCheck.enabled = false", "168 hours"))
+            classOf[DeltaIllegalArgumentException],
+            Seq("delta.retentionDurationCheck.enabled = false", "168 hours"))
         )
       }
 
@@ -1047,11 +1047,11 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
       withTempDeltaTable(targetDF, enableDVs = true) { (targetTable, targetLog) =>
         // Add some DVs.
         targetTable().delete("id < 10")
-        val e = intercept[IllegalArgumentException] {
+        val e = intercept[DeltaIllegalArgumentException] {
           spark.sql(s"VACUUM delta.`${targetLog.dataPath}` RETAIN 0 HOURS")
         }
         assert(e.getMessage.contains(
-          "Are you sure you would like to vacuum files with such a low retention period?"))
+          "The specified VACUUM retention period is too low"))
       }
   }
 


### PR DESCRIPTION
<!--


#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Replaced the following checks in VacuumCommand.scala to invoke these errors, specifically:

require(retentionMs.forall(_ >= 0), ...) with DELTA_VACUUM_RETENTION_PERIOD_NEGATIVE
require(!checkEnabled || retentionSafe, ...) with DELTA_VACUUM_RETENTION_PERIOD_TOO_SHORT


## How was this patch tested?

Added new tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
