### PR TITLE
[Spark] Remove the check of spark.testing when creating a managed table on UC.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -218,6 +218,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       writer,
       operation,
       tableByPath = isByPath,
+      allowCatalogOwned = isUnityCatalog && tableType == CatalogTableType.MANAGED,
       // We should invoke the Spark catalog plugin API to create the table, to
       // respect third party catalogs. Note: only handle CREATE TABLE for now, we
       // should support CTAS later.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -75,6 +75,7 @@ case class CreateDeltaTableCommand(
     override val tableByPath: Boolean = false,
     override val output: Seq[Attribute] = Nil,
     protocol: Option[Protocol] = None,
+    allowCatalogOwned: Boolean = false,
     createTableFunc: Option[CatalogTable => Unit] = None)
   extends LeafRunnableCommand
   with DeltaCommand
@@ -119,7 +120,8 @@ case class CreateDeltaTableCommand(
     // It gets bypassed in UTs to allow tests that use InMemoryCommitCoordinator to create tables
     val tableFeatures = TableFeatureProtocolUtils.
       getSupportedFeaturesFromTableConfigs(table.properties)
-    if (!Utils.isTesting && (tableFeatures.contains(CatalogOwnedTableFeature) ||
+    if (!Utils.isTesting && !allowCatalogOwned &&
+      (tableFeatures.contains(CatalogOwnedTableFeature) ||
       CatalogOwnedTableUtils.defaultCatalogOwnedEnabled(spark = sparkSession))) {
       throw DeltaErrors.deltaCannotCreateCatalogManagedTable()
     }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -71,11 +71,6 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     conf = configureSparkWithUnityCatalog(conf);
     
     sparkSession = SparkSession.builder().config(conf).getOrCreate();
-
-    // Enable testing so that catalogManaged UC tables can be created.
-    // This is checked by CreateDeltaTableCommand which calls org.apache.spark.util.Utils.isTesting.
-    // TODO: clean up once it's not required.
-    System.setProperty("spark.testing", "true");
   }
 
   /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Remove the check of spark.testing when creating a managed table on UC.
Previously this functionality was not ready so a spark.testing system property or SPARK_TESTING env has to be set in order to enable it.
Now we have the functionality working so this PR removes that check.

## How was this patch tested?
The UC integration tests needed the spark.testing system property in order to create managed tables. This PR removes that and the tests should still pass.

## Does this PR introduce _any_ user-facing changes?
Creation of managed table no longer requires setting spark.testing system property or SPARK_TESTING env.