### PR TITLE
[Backport 4.0][Spark] Always send table properties to server when creating managed tables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -573,6 +573,7 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
     ),
 
     libraryDependencies ++= Seq(
+      "org.assertj" % "assertj-core" % "3.26.3" % "test",
       // JUnit 5 test dependencies
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test",
       "org.junit.jupiter" % "junit-jupiter-engine" % "5.8.2" % "test",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -210,7 +210,7 @@ class DeltaCatalog extends DelegatingCatalogExtension
       writer,
       operation,
       tableByPath = isByPath,
-      allowCatalogOwned = isUnityCatalog && tableType == CatalogTableType.MANAGED,
+      allowCatalogManaged = isUnityCatalog && tableType == CatalogTableType.MANAGED,
       // We should invoke the Spark catalog plugin API to create the table, to
       // respect third party catalogs. Note: only handle CREATE TABLE for now, we
       // should support CTAS later.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -62,6 +62,7 @@ import org.apache.spark.util.Utils
  * @param tableByPath Whether the table is identified by path
  * @param output SQL output of the command
  * @param protocol This is used to create a table with specific protocol version
+ * @param allowCatalogManaged This is used to create UC managed table with catalogManaged feature
  * @param createTableFunc If specified, call this function to create the table, instead of
  *                        Spark `SessionCatalog#createTable` which is backed by Hive Metastore.
  */
@@ -74,7 +75,7 @@ case class CreateDeltaTableCommand(
     override val tableByPath: Boolean = false,
     override val output: Seq[Attribute] = Nil,
     protocol: Option[Protocol] = None,
-    allowCatalogOwned: Boolean = false,
+    override val allowCatalogManaged: Boolean = false,
     createTableFunc: Option[CatalogTable => Unit] = None)
   extends LeafRunnableCommand
   with DeltaCommand
@@ -119,7 +120,7 @@ case class CreateDeltaTableCommand(
     // It gets bypassed in UTs to allow tests that use InMemoryCommitCoordinator to create tables
     val tableFeatures = TableFeatureProtocolUtils.
       getSupportedFeaturesFromTableConfigs(table.properties)
-    if (!Utils.isTesting && !allowCatalogOwned &&
+    if (!Utils.isTesting && !allowCatalogManaged &&
       (tableFeatures.contains(CatalogOwnedTableFeature) ||
       CatalogOwnedTableUtils.defaultCatalogOwnedEnabled(spark = sparkSession))) {
       throw DeltaErrors.deltaCannotCreateCatalogOwnedTable()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
@@ -49,6 +49,9 @@ trait CreateDeltaTableLike extends SQLConfHelper {
   // TABLE IF NOT EXISTS`.
   val mode: SaveMode
 
+  // Whether the table is UC managed table with catalogManaged feature.
+  val allowCatalogManaged: Boolean
+
   /**
    * Generates a `CatalogTable` with its `locationUri` set appropriately, depending on whether the
    * table already exists or is newly created.
@@ -150,9 +153,12 @@ trait CreateDeltaTableLike extends SQLConfHelper {
         storage = storageProps,
         tracksPartitionsInCatalog = true)
     } else {
+      // Setting table properties is required for creating catalogManaged tables.
+      val properties: Map[String, String] =
+        if (allowCatalogManaged) UpdateCatalog.updatedProperties(snapshot) else Map.empty
       table.copy(
         schema = new StructType(),
-        properties = Map.empty,
+        properties = properties,
         partitionColumnNames = Nil,
         // Remove write specific options when updating the catalog
         storage = storageProps,

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCManagedTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCManagedTableCreationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.TableInfo;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Test suite for creating UC Managed Delta Tables. */
+public class UCManagedTableCreationTest extends UCDeltaTableIntegrationBaseTest {
+
+  @Test
+  public void testCreateManagedTable() throws Exception {
+    // TODO: make this a thorough test of managed table creation with different parameters.
+    String tableName = "test_managed_table";
+    String fullTableName = getCatalogName() + ".default." + tableName;
+    String tableSchema = "id INT, active BOOLEAN";
+    try {
+      sql(
+          "CREATE TABLE %s (%s) USING DELTA "
+              + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported', 'Foo'='Bar')",
+          fullTableName, tableSchema);
+
+      // Verify that properties are set on server. This can not be done by DESC EXTENDED.
+      TablesApi tablesApi = new TablesApi(createClient());
+      TableInfo tableInfo = tablesApi.getTable(fullTableName, false, false);
+      List<ColumnInfo> columns = tableInfo.getColumns();
+      Map<String, String> properties = tableInfo.getProperties();
+
+      assertThat(columns).isNotNull();
+      // At this point table schema can not be sent to server yet because it won't be updated
+      // later and that would cause problem.
+      assertThat(columns).isEmpty();
+
+      final String SUPPORTED = "supported";
+      HashMap<String, String> expectedProperties = new HashMap<>();
+      expectedProperties.put("delta.enableInCommitTimestamps", "true");
+      expectedProperties.put("delta.feature.appendOnly", SUPPORTED);
+      expectedProperties.put("delta.feature.catalogManaged", SUPPORTED);
+      expectedProperties.put("delta.feature.inCommitTimestamp", SUPPORTED);
+      expectedProperties.put("delta.feature.invariants", SUPPORTED);
+      expectedProperties.put("delta.feature.vacuumProtocolCheck", SUPPORTED);
+      expectedProperties.put("delta.lastUpdateVersion", "0");
+      expectedProperties.put("delta.minReaderVersion", "3");
+      expectedProperties.put("delta.minWriterVersion", "7");
+      expectedProperties.put("io.unitycatalog.tableId", tableInfo.getTableId());
+      // User specified custom table property is also sent.
+      expectedProperties.put("Foo", "Bar");
+      // Verify that all entries are present
+      expectedProperties.forEach((key, value) -> assertThat(properties).containsEntry(key, value));
+      // Lastly the timestamp value is always changing so skip checking its value
+      assertThat(properties).containsKey("delta.lastCommitTimestamp");
+    } finally {
+      sql("DROP TABLE IF EXISTS %s", fullTableName);
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Original PR
#5730

## Description
Always send table properties to server when creating managed tables. Tables with catalogManaged feature should have the UC server as source of truth of table properties.

## How was this patch tested?
A new integration test case was created to verify that proper table properties are sent to server.

## Does this PR introduce _any_ user-facing changes?
No.
