### PR TITLE
[Kernel] Make kernel benchmark configurable using command line arguments

### DIFF
--- a/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmark.java
+++ b/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmark.java
@@ -76,6 +76,9 @@ public class WorkloadBenchmark<T> {
    * can be easily constructed.
    */
   public static void main(String[] args) throws RunnerException, IOException {
+    // Parse command line arguments
+    CommandLineArgs cliArgs = CommandLineArgs.parse(args);
+
     // Get workload specs from the workloads directory
     List<WorkloadSpec> workloadSpecs = BenchmarkUtils.loadAllWorkloads(WORKLOAD_SPECS_DIR);
     if (workloadSpecs.isEmpty()) {
@@ -83,11 +86,18 @@ public class WorkloadBenchmark<T> {
           "No workloads found. Please add workload specs to the workloads directory.");
     }
 
-    // Parse the Json specs from the json paths
+    // Parse the Json specs from the json paths and apply optional filtering.
     List<WorkloadSpec> filteredSpecs = new ArrayList<>();
     for (WorkloadSpec spec : workloadSpecs) {
-      // TODO(#5420): In the future, we can filter specific workloads using command line args here.
-      filteredSpecs.addAll(spec.getWorkloadVariants());
+      for (WorkloadSpec variant : spec.getWorkloadVariants()) {
+        if (cliArgs.shouldInclude(variant.getFullName())) {
+          filteredSpecs.add(variant);
+        }
+      }
+    }
+    if (filteredSpecs.isEmpty()) {
+      throw new RunnerException(
+          "No workloads matched filters. Try removing --include-test or using a broader substring.");
     }
 
     // Convert paths into a String array for JMH. JMH requires that parameters be of type String[].
@@ -102,15 +112,163 @@ public class WorkloadBenchmark<T> {
             .param("workloadSpecJson", workloadSpecsArray)
             // TODO: In the future, this can be extended to support multiple engines.
             .param("engineName", "default")
-            // TODO(#5420): Allow configuring forks, warmup, and measurement via command line args.
-            .forks(1)
-            .warmupIterations(3) // Proper warmup for production benchmarks
-            .measurementIterations(5) // Proper measurement iterations for production benchmarks
-            .warmupTime(TimeValue.seconds(1))
-            .measurementTime(TimeValue.seconds(1))
+            .forks(cliArgs.forks)
+            .warmupIterations(cliArgs.warmupIterations)
+            .measurementIterations(cliArgs.measurementIterations)
+            .warmupTime(TimeValue.seconds(cliArgs.warmupTimeSeconds))
+            .measurementTime(TimeValue.seconds(cliArgs.measurementTimeSeconds))
             .addProfiler(KernelMetricsProfiler.class)
             .build();
 
     new Runner(opt, new WorkloadOutputFormat()).run();
+  }
+
+  /**
+   * Minimal command-line parser for configuring benchmark runs.
+   *
+   * <p>See delta-io/delta#5420: https://github.com/delta-io/delta/issues/5420
+   *
+   * <p>Supported options:
+   *
+   * <ul>
+   *   <li>{@code --include-test SUBSTRING} (repeatable): include only workload variants whose
+   *       {@code full_name} contains {@code SUBSTRING}.
+   *   <li>{@code --forks <int>}: number of forks (default: 1)
+   *   <li>{@code --warmup-iterations <int>} (alias: {@code --warum-iterations}): warmup iterations
+   *       (default: 3)
+   *   <li>{@code --measurement-iterations <int>}: measurement iterations (default: 5)
+   *   <li>{@code --warmup-time-seconds <int>}: warmup time per iteration, seconds (default: 1)
+   *   <li>{@code --measurement-time-seconds <int>}: measurement time per iteration, seconds
+   *       (default: 1)
+   * </ul>
+   */
+  static class CommandLineArgs {
+    final List<String> includeTestSubstrings;
+    final int forks;
+    final int warmupIterations;
+    final int measurementIterations;
+    final int warmupTimeSeconds;
+    final int measurementTimeSeconds;
+
+    private CommandLineArgs(
+        List<String> includeTestSubstrings,
+        int forks,
+        int warmupIterations,
+        int measurementIterations,
+        int warmupTimeSeconds,
+        int measurementTimeSeconds) {
+      this.includeTestSubstrings = includeTestSubstrings;
+      this.forks = forks;
+      this.warmupIterations = warmupIterations;
+      this.measurementIterations = measurementIterations;
+      this.warmupTimeSeconds = warmupTimeSeconds;
+      this.measurementTimeSeconds = measurementTimeSeconds;
+    }
+
+    static CommandLineArgs parse(String[] args) {
+      List<String> include = new ArrayList<>();
+
+      // Defaults match existing hard-coded values.
+      int forks = 1;
+      int warmupIterations = 3;
+      int measurementIterations = 5;
+      int warmupTimeSeconds = 1;
+      int measurementTimeSeconds = 1;
+
+      for (int i = 0; i < args.length; i++) {
+        String arg = args[i];
+
+        if ("--help".equals(arg) || "-h".equals(arg)) {
+          throw new IllegalArgumentException(usage());
+        }
+
+        switch (arg) {
+          case "--include-test":
+            include.add(requireValue(args, ++i, arg));
+            break;
+          case "--forks":
+            forks = parsePositiveInt(requireValue(args, ++i, arg), arg);
+            break;
+          case "--warmup-iterations":
+          case "--warum-iterations": // tolerate typo from issue description
+            warmupIterations = parseNonNegativeInt(requireValue(args, ++i, arg), arg);
+            break;
+          case "--measurement-iterations":
+            measurementIterations = parseNonNegativeInt(requireValue(args, ++i, arg), arg);
+            break;
+          case "--warmup-time-seconds":
+            warmupTimeSeconds = parsePositiveInt(requireValue(args, ++i, arg), arg);
+            break;
+          case "--measurement-time-seconds":
+            measurementTimeSeconds = parsePositiveInt(requireValue(args, ++i, arg), arg);
+            break;
+          default:
+            throw new IllegalArgumentException("Unknown argument: " + arg + "\n\n" + usage());
+        }
+      }
+
+      return new CommandLineArgs(
+          include,
+          forks,
+          warmupIterations,
+          measurementIterations,
+          warmupTimeSeconds,
+          measurementTimeSeconds);
+    }
+
+    boolean shouldInclude(String fullName) {
+      if (includeTestSubstrings.isEmpty()) {
+        return true;
+      }
+      for (String s : includeTestSubstrings) {
+        if (fullName.contains(s)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private static String requireValue(String[] args, int idx, String flag) {
+      if (idx >= args.length) {
+        throw new IllegalArgumentException("Missing value for " + flag + "\n\n" + usage());
+      }
+      return args[idx];
+    }
+
+    private static int parsePositiveInt(String raw, String flag) {
+      int v = parseInt(raw, flag);
+      if (v <= 0) {
+        throw new IllegalArgumentException(flag + " must be > 0, got: " + raw + "\n\n" + usage());
+      }
+      return v;
+    }
+
+    private static int parseNonNegativeInt(String raw, String flag) {
+      int v = parseInt(raw, flag);
+      if (v < 0) {
+        throw new IllegalArgumentException(flag + " must be >= 0, got: " + raw + "\n\n" + usage());
+      }
+      return v;
+    }
+
+    private static int parseInt(String raw, String flag) {
+      try {
+        return Integer.parseInt(raw);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Invalid integer for " + flag + ": " + raw + "\n\n" + usage(), e);
+      }
+    }
+
+    private static String usage() {
+      return "WorkloadBenchmark options:\n"
+          + "  --include-test SUBSTRING               (repeatable) filter workload variants by full name\n"
+          + "  --forks <int>                          default: 1\n"
+          + "  --warmup-iterations <int>              default: 3\n"
+          + "  --measurement-iterations <int>         default: 5\n"
+          + "  --warmup-time-seconds <int>            default: 1\n"
+          + "  --measurement-time-seconds <int>       default: 1\n"
+          + "  --help | -h\n";
+    }
   }
 }

--- a/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmarkCliArgsTests.java
+++ b/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmarkCliArgsTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Anudeep Konaboina <krantianudeep@gmail.com>
+ */
+
+package io.delta.kernel.benchmarks;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class WorkloadBenchmarkCliArgsTests {
+
+  @Test
+  public void defaultsMatchCurrentHardcodedValues() {
+    WorkloadBenchmark.CommandLineArgs args =
+        WorkloadBenchmark.CommandLineArgs.parse(new String[] {});
+    assertEquals(1, args.forks);
+    assertEquals(3, args.warmupIterations);
+    assertEquals(5, args.measurementIterations);
+    assertEquals(1, args.warmupTimeSeconds);
+    assertEquals(1, args.measurementTimeSeconds);
+    assertTrue(args.includeTestSubstrings.isEmpty());
+  }
+
+  @Test
+  public void includeTestUsesSubstringMatchAndIsRepeatable() {
+    WorkloadBenchmark.CommandLineArgs args =
+        WorkloadBenchmark.CommandLineArgs.parse(
+            new String[] {"--include-test", "read_metadata", "--include-test", "snapshot"});
+
+    assertTrue(args.shouldInclude("basic_append/read_metadata/read"));
+    assertTrue(args.shouldInclude("basic_append/snapshot_latest/snapshot_construction"));
+    assertFalse(args.shouldInclude("basic_append/write_appends/write"));
+  }
+
+  @Test
+  public void parsesNumericOverrides() {
+    WorkloadBenchmark.CommandLineArgs args =
+        WorkloadBenchmark.CommandLineArgs.parse(
+            new String[] {
+              "--forks",
+              "2",
+              "--warmup-iterations",
+              "7",
+              "--measurement-iterations",
+              "9",
+              "--warmup-time-seconds",
+              "3",
+              "--measurement-time-seconds",
+              "4"
+            });
+
+    assertEquals(2, args.forks);
+    assertEquals(7, args.warmupIterations);
+    assertEquals(9, args.measurementIterations);
+    assertEquals(3, args.warmupTimeSeconds);
+    assertEquals(4, args.measurementTimeSeconds);
+  }
+
+  @Test
+  public void supportsWarmupIterationsTypoAlias() {
+    WorkloadBenchmark.CommandLineArgs args =
+        WorkloadBenchmark.CommandLineArgs.parse(new String[] {"--warum-iterations", "10"});
+    assertEquals(10, args.warmupIterations);
+  }
+
+  @Test
+  public void invalidArgsThrowHelpfulError() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WorkloadBenchmark.CommandLineArgs.parse(new String[] {"--forks", "0"}));
+    assertTrue(e.getMessage().contains("--forks"));
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Changes included:
- Added a class called `CommandLineArgs` to parse benchmark runner flags.
- Support filtering benchmarks via `--include-test <substring>` (repeatable) to run only a subset
  of workloads/spec variants.
- Support overriding JMH knobs from the command line:
  - `--warmup-iterations <int>` (also accepts alias `--warum-iterations` for compatibility with the issue text)
  - `--measurement-iterations <int>`
  - `--warmup-time-seconds <int>` (and `--warmup-time <int>` alias)
- Preserve defaults when flags are not provided (all overrides are optional / nullable).
- Added `--help/-h` usage output.

This improves developer productivity (fast local runs), makes perf testing more repeatable, and
enables CI/automation to run consistent benchmark configurations.

Resolves #5420

## How was this patch tested?

- Verified benchmark filtering works by running with `--include-test <substring>` and confirming
  only matching benchmarks execute.
- Verified JMH option overrides are applied by running with:
  - `--warmup-iterations 2`
  - `--measurement-iterations 3`
  - `--warmup-time-seconds 5`
  and confirming the run configuration matches expected warmup/measurement settings (via JMH output).
- Verified invalid inputs fail fast:
  - unknown flags throw `IllegalArgumentException`
  - missing values for flags throw `IllegalArgumentException`
  - non-integer values for numeric flags throw `NumberFormatException`

Example commands:
```bash
# Quick dev run on a subset
./build/sbt "kernel/benchmarks:testOnly *WorkloadBenchmark -- \
  --include-test read_metadata \
  --warmup-iterations 2 \
  --measurement-iterations 3 \
  --warmup-time-seconds 5"
```


## Does this PR introduce _any_ user-facing changes?

Yes — but limited to benchmark tooling only
