### PR TITLE
[Spark] Add the Table Creation Spark UC integration tests.

### DIFF
--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -379,8 +379,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
                 DELTA_CATALOG_MANAGED_KEY, SUPPORTED));
   }
 
-  @ParameterizedTest
-  @MethodSource("allTableTypes")
+  @TestAllTableTypes
   public void testCreateOrReplaceTable(TableType tableType) throws Exception {
     UnityCatalogInfo uc = unityCatalogInfo();
     String tableName = String.format("%s.%s.create_or_replace", uc.catalogName(), uc.schemaName());
@@ -410,8 +409,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         });
   }
 
-  @ParameterizedTest
-  @MethodSource("allTableTypes")
+  @TestAllTableTypes
   public void testTableWithSupportedDataTypes(TableType tableType) throws Exception {
     String schema =
         // Numeric types
@@ -493,8 +491,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         });
   }
 
-  @ParameterizedTest
-  @MethodSource("allTableTypes")
+  @TestAllTableTypes
   public void testTableWithComplexTypes(TableType tableType) throws Exception {
     String schema =
         "id INT, arr ARRAY<INT>, "
@@ -530,8 +527,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         });
   }
 
-  @ParameterizedTest
-  @MethodSource("allTableTypes")
+  @TestAllTableTypes
   public void testTableWithNotNullConstraints(TableType tableType) throws Exception {
     withNewTable(
         "not_null_table",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5752/files) to review incremental changes.
- [**stack/port-python-it-tests**](https://github.com/delta-io/delta/pull/5752) [[Files changed](https://github.com/delta-io/delta/pull/5752/files)]

---------
Signed-off-by: openinx <openinx@gmail.com>


#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR add the e2e test coverage for the table creation cases. 

## How was this patch tested?

I had two kinds of verification. 

* Locally verification. 

```bash
./build/sbt "sparkUnityCatalog/testOnly io.sparkuctest.UCManagedTableCreationTest"
```

* Run those tests remotely against the external remote UC server. 

```bash
export UC_REMOTE=true
export UC_URI=$UC_URI
export UC_TOKEN=$UC_TOKEN
export UC_CATALOG_NAME=main
export UC_SCHEMA_NAME=demo_zh
export UC_BASE_TABLE_LOCATION=$S3_BASE_LOCATION

./build/sbt "sparkUnityCatalog/testOnly io.sparkuctest.UCManagedTableCreationTest"
```


## Does this PR introduce _any_ user-facing changes?
No
