### PR TITLE
[DO_NOT_MERGE]

### DIFF
--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         # Spark versions - must match CrossSparkVersions.ALL_SPECS in project/CrossSparkVersions.scala
         # Update this list when adding new Spark versions to CrossSparkVersions.scala
-        spark_version: ["4.0.1", "4.1.0-SNAPSHOT"]
+        spark_version: ["4.0.1", "4.1.1-SNAPSHOT"]
         # These Scala versions must match those in the build.sbt
         scala: [2.13.16]
         # Important: This list of shards must be [0..NUM_SHARDS - 1]

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -231,7 +231,7 @@ object SparkVersionSpec {
   )
 
   private val spark41Snapshot = SparkVersionSpec(
-    fullVersion = "4.1.0-SNAPSHOT",
+    fullVersion = "4.1.1-SNAPSHOT",
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.1"),
     antlr4Version = "4.13.1",

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -86,7 +86,7 @@ class SparkVersionSpec:
 # Spark versions to test (key = full version string, value = spec with suffix)
 SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
     "4.0.1": SparkVersionSpec(""),      # Default Spark version without suffix
-    "4.1.0-SNAPSHOT": SparkVersionSpec("_4.1")
+    "4.1.1-SNAPSHOT": SparkVersionSpec("_4.1")
 }
 
 # The default Spark version (no suffix in artifact names)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
