### PR TITLE
 [Spark] Enable DROP/RENAME columns when dataSkippingStatsColumns is enabled 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -545,7 +545,9 @@ object StatisticsCollection extends DeltaCommand {
             commonPrefix == droppedColumnParts.size
           }.nonEmpty
         }
-        .map(columnParts => UnresolvedAttribute(columnParts).name)
+        // Preserve special characters via backticks when needed, while keeping the original
+        // unescaped format for normal identifiers (e.g. `a.b` stays `a.b`).
+        .map(columnParts => columnParts.map(quoteIfNeeded).mkString("."))
         .mkString(",")
       Map(DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.key -> deltaStatsColumnStr)
     }.getOrElse(Map.empty[String, String])

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -789,6 +789,39 @@ class StatsCollectionSuite
     }
   }
 
+  test("drop/rename columns with special characters updates dataSkippingStatsColumns") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (`c#c` INT, `c-1` INT, c3 INT)
+          |USING delta
+          |TBLPROPERTIES(
+          |  'delta.columnMapping.mode' = 'name',
+          |  'delta.minReaderVersion' = '2',
+          |  'delta.minWriterVersion' = '5',
+          |  'delta.dataSkippingStatsColumns' = '`c#c`,`c-1`'
+          |)
+          |""".stripMargin)
+
+      sql("ALTER TABLE delta_table DROP COLUMN `c#c`")
+
+      val statsAfterDrop = sql("SHOW TBLPROPERTIES delta_table")
+        .collect()
+        .map(r => r.getString(0) -> r.getString(1))
+        .toMap
+        .getOrElse("delta.dataSkippingStatsColumns", "")
+      assert(statsAfterDrop == "`c-1`")
+
+      sql("ALTER TABLE delta_table RENAME COLUMN `c-1` TO `c-2`")
+      val statsAfterRename = sql("SHOW TBLPROPERTIES delta_table")
+        .collect()
+        .map(r => r.getString(0) -> r.getString(1))
+        .toMap
+        .getOrElse("delta.dataSkippingStatsColumns", "")
+      assert(statsAfterRename == "`c-2`")
+    }
+  }
+
   test("Duplicated delta statistic columns: create") {
     Seq(
       ("'c0,c0'", "c0"),


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When `dataSkippingStatsColumns` is enabled and if column names containing special characters (e.g., -, !, @, etc.) are included in its configuration using escaped identifiers (e.g., backticks), those columns may become inaccessible — preventing operations like renaming or dropping them and throws the below exception:

**ERROR**:
```
org.apache.spark.sql.delta.DeltaAnalysisException: [DELTA_COLUMN_NOT_FOUND_IN_SCHEMA] Couldn't find column c in:
root
 |-- c-1: integer (nullable = true)
 |-- c3: integer (nullable = true)

	at org.apache.spark.sql.delta.DeltaErrorsBase.nonExistentColumnInSchema(DeltaErrors.scala:1583)
	at org.apache.spark.sql.delta.DeltaErrorsBase.nonExistentColumnInSchema$(DeltaErrors.scala:1582)
	at org.apache.spark.sql.delta.DeltaErrors$.nonExistentColumnInSchema(DeltaErrors.scala:3759)
	at org.apache.spark.sql.delta.DeltaErrorsBase.columnNotInSchemaException(DeltaErrors.scala:1783)
	at org.apache.spark.sql.delta.DeltaErrorsBase.columnNotInSchemaException$(DeltaErrors.scala:1782)
	at org.apache.spark.sql.delta.DeltaErrors$.columnNotInSchemaException(DeltaErrors.scala:3759)
	at org.apache.spark.sql.delta.schema.SchemaUtils$.findRecursively$2(SchemaUtils.scala:778)
	at org.apache.spark.sql.delta.schema.SchemaUtils$.findColumnPosition(SchemaUtils.scala:824)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.$anonfun$validateDeltaStatsColumns$4(StatisticsCollection.scala:523)
	at scala.collection.immutable.List.foreach(List.scala:334)
	at 
```



#### Repro steps with error message

The repro was done using:
- **Delta version 4.0.0**
- **Spark version 4.0.0**

##### Code

```
val db = "default"
val tbl = s"$db.t_4389_${System.currentTimeMillis()}"

// 1) Create a Delta table with special chars in column names
//    and set delta.dataSkippingStatsColumns using backticked names.
spark.sql(
  s"""
     |CREATE TABLE $tbl (`c#c` INT, `c-1` INT, c3 INT)
     |USING delta
     |TBLPROPERTIES (
     |  'delta.columnMapping.mode' = 'name',
     |  'delta.dataSkippingStatsColumns' = '`c#c`,`c-1`'
     |)
     |""".stripMargin
)

spark.sql(s"DESCRIBE TABLE $tbl").show(false)

// 2) Attempt to drop the special column that is listed in dataSkippingStatsColumns
//    This is expected to FAIL as  per the issue.
try {
  spark.sql(s"ALTER TABLE $tbl DROP COLUMN `c-1`")
  println("DROP COLUMN succeeded (unexpected for this repro).")
} catch {
  case e: Throwable =>
    println("DROP COLUMN failed as expected:")
    println(e.getMessage)
    e.printStackTrace()
}

```


### Fix

The root cause of this issue is that dropping/renaming triggers a rewrite of the `dataSkippingStatsColumns` property; the rewrite removes quoting; and then while reading it, delta parses it as arithmetic and searches for  **C** instead of  column **C-1**


- Updated` StatisticsCollection.dropDeltaStatsColumns ` to serialize the remaining stats columns using `.sql` instead of `.name`
- This ensures that after dropping a column, the updated delta.dataSkippingStatsColumns value remains valid and parsable for columns containing special characters.

**Example:**
Before: `c#c`,`c-1` + drop `c#c` → c-1 (unescaped; later parsed as c - 1)
After: `c#c`,`c-1` + drop `c#c` → `c-1` (escaped; parsed as identifier)

- Updated `SchemaUtils.renameColumnForConfig` so that for delta.dataSkippingStatsColumns we always serialize with .sql, regardless of **DELTA_RENAME_COLUMN_ESCAPE_NAME**.
- Addresses https://github.com/delta-io/delta/issues/4389

## How was this patch tested?

1. Added a TestSuite  class to test the DROP/RENAME containing special-character column names to prevent regressions.
2. Tested the fix on a cluster like setup by building an assembly jar .

## Does this PR introduce _any_ user-facing changes?

Yes

#### Before the fix when we run the above code 

If a table sets `delta.dataSkippingStatsColumns` to include column names that require escaping (e.g. `c-1`, `c#c`), then schema evolution commands like ALTER TABLE ... DROP COLUMN / RENAME COLUMN can fail during metadata validation with:

`[DELTA_COLUMN_NOT_FOUND_IN_SCHEMA] Couldn't find column c `


```
[root@hadoop /]# spark-shell --master spark://hadoop.spark:7077 --conf spark.cores.max=1 --conf spark.executor.cores=1 --conf spark.executor.instances=1 --packages io.delta:delta-spark_2.13:4.0.0 --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog
WARNING: Using incubator modules: jdk.incubator.vector
:: loading settings :: url = jar:file:/usr/bin/spark-4.0.0-bin-without-hadoop/jars/ivy-2.5.3.jar!/org/apache/ivy/core/settings/ivysettings.xml
Ivy Default Cache set to: /root/.ivy2.5.2/cache
The jars for the packages stored in: /root/.ivy2.5.2/jars
io.delta#delta-spark_2.13 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-3e77d57f-d354-4024-9a5c-c6305f0e110a;1.0
	confs: [default]
	found io.delta#delta-spark_2.13;4.0.0 in central
	found io.delta#delta-storage;4.0.0 in central
	found org.antlr#antlr4-runtime;4.13.1 in central
:: resolution report :: resolve 72ms :: artifacts dl 2ms
	:: modules in use:
	io.delta#delta-spark_2.13;4.0.0 from central in [default]
	io.delta#delta-storage;4.0.0 from central in [default]
	org.antlr#antlr4-runtime;4.13.1 from central in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   3   |   0   |   0   |   0   ||   3   |   0   |
	---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-3e77d57f-d354-4024-9a5c-c6305f0e110a
	confs: [default]
	0 artifacts copied, 3 already retrieved (0kB/2ms)
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.0.0
      /_/
         
Using Scala version 2.13.16 (OpenJDK 64-Bit Server VM, Java 17.0.9)
Type in expressions to have them evaluated.
Type :help for more information.
Spark context Web UI available at http://hadoop.spark:4040
Spark context available as 'sc' (master = spark://hadoop.spark:7077, app id = app-20251227114601-0016).
Spark session available as 'spark'.


scala> val db = "default"
     | val tbl = s"$db.t_4389_${System.currentTimeMillis()}"
     | 
     | // 1) Create a Delta table with special chars in column names
     | //    and set delta.dataSkippingStatsColumns using backticked names.
     | spark.sql(
     |   s"""
     |      |CREATE TABLE $tbl (`c#c` INT, `c-1` INT, c3 INT)
     |      |USING delta
     |      |TBLPROPERTIES (
     |      |  'delta.columnMapping.mode' = 'name',
     |      |  'delta.dataSkippingStatsColumns' = '`c#c`,`c-1`'
     |      |)
     |      |""".stripMargin
     | )
     | 
     | 
     | spark.sql(s"DESCRIBE TABLE $tbl").show(false)
     | 
     | // 2) Attempt to drop the special column that is listed in dataSkippingStatsColumns
     | try {
     |   spark.sql(s"ALTER TABLE $tbl DROP COLUMN `c#c`")
     |   println("DROP COLUMN succeeded (unexpected for this repro).")
     | } catch {
     |   case e: Throwable =>
     |     println("DROP COLUMN failed as expected:")
     |     println(e.getMessage)
     |     e.printStackTrace()
     | }
     | 
+--------+---------+-------+
|col_name|data_type|comment|
+--------+---------+-------+
|c#c     |int      |NULL   |
|c-1     |int      |NULL   |
|c3      |int      |NULL   |
+--------+---------+-------+

DROP COLUMN failed as expected:                                                 
[DELTA_COLUMN_NOT_FOUND_IN_SCHEMA] Couldn't find column c in:
root
 |-- c-1: integer (nullable = true)
 |-- c3: integer (nullable = true)

org.apache.spark.sql.delta.DeltaAnalysisException: [DELTA_COLUMN_NOT_FOUND_IN_SCHEMA] Couldn't find column c in:
root
 |-- c-1: integer (nullable = true)
 |-- c3: integer (nullable = true)

	at org.apache.spark.sql.delta.DeltaErrorsBase.nonExistentColumnInSchema(DeltaErrors.scala:1583)
	at org.apache.spark.sql.delta.DeltaErrorsBase.nonExistentColumnInSchema$(DeltaErrors.scala:1582)
	at org.apache.spark.sql.delta.DeltaErrors$.nonExistentColumnInSchema(DeltaErrors.scala:3759)
	at org.apache.spark.sql.delta.DeltaErrorsBase.columnNotInSchemaException(DeltaErrors.scala:1783)
	at org.apache.spark.sql.delta.DeltaErrorsBase.columnNotInSchemaException$(DeltaErrors.scala:1782)
	at org.apache.spark.sql.delta.DeltaErrors$.columnNotInSchemaException(DeltaErrors.scala:3759)
	at org.apache.spark.sql.delta.schema.SchemaUtils$.findRecursively$2(SchemaUtils.scala:778)
	at org.apache.spark.sql.delta.schema.SchemaUtils$.findColumnPosition(SchemaUtils.scala:824)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.$anonfun$validateDeltaStatsColumns$4(StatisticsCollection.scala:523)
	at scala.collection.immutable.List.foreach(List.scala:334)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.$anonfun$validateDeltaStatsColumns$3(StatisticsCollection.scala:514)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.$anonfun$validateDeltaStatsColumns$3$adapted(StatisticsCollection.scala:513)
	at scala.Option.foreach(Option.scala:437)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.validateDeltaStatsColumns(StatisticsCollection.scala:513)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.$anonfun$validateDeltaStatsColumns$1(StatisticsCollection.scala:454)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.$anonfun$validateDeltaStatsColumns$1$adapted(StatisticsCollection.scala:452)
	at scala.Option.foreach(Option.scala:437)
	at org.apache.spark.sql.delta.stats.StatisticsCollection$.validateDeltaStatsColumns(StatisticsCollection.scala:452)
	at org.apache.spark.sql.delta.OptimisticTransactionImpl.updateMetadataInternal(OptimisticTransaction.scala:556)
	at org.apache.spark.sql.delta.OptimisticTransactionImpl.updateMetadataInternal$(OptimisticTransaction.scala:551)
	at org.apache.spark.sql.delta.OptimisticTransaction.updateMetadataInternal(OptimisticTransaction.scala:169)
	at org.apache.spark.sql.delta.OptimisticTransactionImpl.updateMetadata(OptimisticTransaction.scala:527)
	at org.apache.spark.sql.delta.OptimisticTransactionImpl.updateMetadata$(OptimisticTransaction.scala:520)
	at org.apache.spark.sql.delta.OptimisticTransaction.updateMetadata(OptimisticTransaction.scala:169)
	at org.apache.spark.sql.delta.commands.AlterTableDropColumnsDeltaCommand.$anonfun$run$15(alterDeltaTableCommands.scala:730)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile(DeltaLogging.scala:171)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile$(DeltaLogging.scala:169)
	at org.apache.spark.sql.delta.commands.AlterTableDropColumnsDeltaCommand.recordFrameProfile(alterDeltaTableCommands.scala:682)
	at org.apache.spark.sql.delta.metering.DeltaLogging.$anonfun$recordDeltaOperationInternal$1(DeltaLogging.scala:139)
	at com.databricks.spark.util.DatabricksLogging.recordOperation(DatabricksLogging.scala:128)
	at com.databricks.spark.util.DatabricksLogging.recordOperation$(DatabricksLogging.scala:117)
	at org.apache.spark.sql.delta.commands.AlterTableDropColumnsDeltaCommand.recordOperation(alterDeltaTableCommands.scala:682)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperationInternal(DeltaLogging.scala:138)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation(DeltaLogging.scala:128)
	at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation$(DeltaLogging.scala:118)
	at org.apache.spark.sql.delta.commands.AlterTableDropColumnsDeltaCommand.recordDeltaOperation(alterDeltaTableCommands.scala:682)
```


#### After the fix using an assembly jar

```
[root@hadoop delta]# spark-shell --master spark://hadoop.spark:7077 --conf spark.cores.max=1 --conf spark.executor.cores=1 --conf spark.executor.instances=1 --jars /opt/delta/delta-spark-assembly-4.1.0-SNAPSHOT.jar --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog
WARNING: Using incubator modules: jdk.incubator.vector
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.0.0
      /_/
         
Using Scala version 2.13.16 (OpenJDK 64-Bit Server VM, Java 17.0.9)
Type in expressions to have them evaluated.
Type :help for more information.
Spark context Web UI available at http://hadoop.spark:4040
Spark context available as 'sc' (master = spark://hadoop.spark:7077, app id = app-20260102033039-0019).
Spark session available as 'spark'.

scala> val db = "default"
     | val tbl = s"$db.t_4389_${System.currentTimeMillis()}"
     | 
     | // 1) Create a Delta table with special chars in column names
     | //    and set delta.dataSkippingStatsColumns using backticked names.
     | spark.sql(
     |   s"""
     |      |CREATE TABLE $tbl (`c#c` INT, `c-1` INT, c3 INT)
     |      |USING delta
     |      |TBLPROPERTIES (
     |      |  'delta.columnMapping.mode' = 'name',
     |      |  'delta.dataSkippingStatsColumns' = '`c#c`,`c-1`'
     |      |)
     |      |""".stripMargin
     | )
     | 
     | spark.sql(s"DESCRIBE TABLE $tbl").show(false)
     | 
     | // 3) Attempt to drop the special column that is listed in dataSkippingStatsColumns
     | try {
     |   spark.sql(s"ALTER TABLE $tbl DROP COLUMN `c-1`")
     |   println("DROP COLUMN succeeded")
     | } catch {
     |   case e: Throwable =>
     |     println("DROP COLUMN failed as expected:")
     |     println(e.getMessage)
     |     e.printStackTrace()
     | }
     | 
+--------+---------+-------+
|col_name|data_type|comment|
+--------+---------+-------+
|c#c     |int      |NULL   |
|c-1     |int      |NULL   |
|c3      |int      |NULL   |
+--------+---------+-------+

DROP COLUMN succeeded                            
val db: String = default
val tbl: String = default.t_4389_1767324680132

```

