### PR TITLE
[kernel-spark] Enable integration test for availableNow trigger using dsv2

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaSourceDSv2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaSourceDSv2Suite.scala
@@ -51,7 +51,13 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
     "startingVersion latest",
     "startingVersion latest defined before started",
     "startingVersion latest works on defined but empty table",
-    "startingVersion specific version: new commits arrive after stream initialization"
+    "startingVersion specific version: new commits arrive after stream initialization",
+
+    // === Rate Limiting / Trigger Options ===
+    "maxFilesPerTrigger: Trigger.AvailableNow respects read limits",
+    "maxBytesPerTrigger: Trigger.AvailableNow respects read limits",
+    "Trigger.AvailableNow with an empty table",
+    "ES-445863: delta source should not hang or reprocess data when using AvailableNow"
   )
 
   private lazy val shouldFailTests = Set(
@@ -103,16 +109,12 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
     "maxFilesPerTrigger: metadata checkpoint",
     "maxFilesPerTrigger: change and restart",
     "maxFilesPerTrigger: ignored when using Trigger.Once",
-    "maxFilesPerTrigger: Trigger.AvailableNow respects read limits",
     "maxBytesPerTrigger: process at least one file",
     "maxBytesPerTrigger: metadata checkpoint",
     "maxBytesPerTrigger: change and restart",
-    "maxBytesPerTrigger: Trigger.AvailableNow respects read limits",
     "maxBytesPerTrigger: max bytes and max files together",
-    "Trigger.AvailableNow with an empty table",
     "startingVersion should work with rate time",
     "Rate limited Delta source advances with non-data inserts",
-    "ES-445863: delta source should not hang or reprocess data when using AvailableNow",
 
     // === Source Offset / Version Handling ===
     "unknown sourceVersion value",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Enable integration tests in DeltaSourceSuite for availableNow trigger for dsv2
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Integration test
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
