### PR TITLE
[Kernel-Spark] Refactor DeltaParquetFileFormatBase to support explicit useMetadataRowIndex control

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaParquetFileFormatV2.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaParquetFileFormatV2.java
@@ -42,6 +42,7 @@ public class DeltaParquetFileFormatV2 extends DeltaParquetFileFormatBase {
    * @param optimizationsEnabled whether to enable optimizations (splits, predicate pushdown)
    * @param tablePath table path for deletion vector support
    * @param isCDCRead whether this is a CDC read
+   * @param useMetadataRowIndex V2: explicit control over _metadata.row_index usage for DV filtering
    */
   public DeltaParquetFileFormatV2(
       Protocol protocol,
@@ -50,14 +51,19 @@ public class DeltaParquetFileFormatV2 extends DeltaParquetFileFormatBase {
       boolean nullableRowTrackingGeneratedFields,
       boolean optimizationsEnabled,
       Option<String> tablePath,
-      boolean isCDCRead) {
+      boolean isCDCRead,
+      Option<Boolean> useMetadataRowIndex) {
     super(
         new ProtocolMetadataAdapterV2(protocol, metadata),
         nullableRowTrackingConstantFields,
         nullableRowTrackingGeneratedFields,
         optimizationsEnabled,
         tablePath,
-        isCDCRead);
+        isCDCRead,
+        // Java's Option<Boolean> can't directly pass to Scala's Option[Boolean] parameter,
+        // because Scala compiles Option[Boolean] to Option<Object> in bytecode for primitive
+        // handling.
+        useMetadataRowIndex.map(x -> x));
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -194,7 +194,8 @@ public class PartitionUtils {
             /* nullableRowTrackingGeneratedFields */ false,
             /* optimizationsEnabled */ true,
             Option.apply(tablePath),
-            /* isCDCRead */ false);
+            /* isCDCRead */ false,
+            /* useMetadataRowIndexOpt */ Option.empty());
 
     Function1<PartitionedFile, Iterator<InternalRow>> readFunc =
         deltaFormat.buildReaderWithPartitionValues(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5773/files) to review incremental changes.
- [**stack/dv_pr1_refactor_parquet_format**](https://github.com/delta-io/delta/pull/5773) [[Files changed](https://github.com/delta-io/delta/pull/5773/files)]
  - [stack/dv_pr2_phase1_basic_read](https://github.com/delta-io/delta/pull/5774) [[Files changed](https://github.com/delta-io/delta/pull/5774/files/8f9bb845ea21215f9b79e3af0ab8bcb356ea2c7e..5b68dfa3775a7ebf926094801217df39d5730671)]
    - [stack/dv_pr3_phase2_vectorized](https://github.com/delta-io/delta/pull/5775) [[Files changed](https://github.com/delta-io/delta/pull/5775/files/4d5d453b538fff34d78df5cd2365d6bd26eaee4c..b120f75d3b02f1163a7fd4168b7d2a93a7a61c21)]
      - [stack/dv_pr4_phase3_file_splitting](https://github.com/delta-io/delta/pull/5776) [[Files changed](https://github.com/delta-io/delta/pull/5776/files/b120f75d3b02f1163a7fd4168b7d2a93a7a61c21..04064f296d184192998b31ed4aa8e0fefe9d73db)]
        - [stack/dv_pr5_streaming_support](https://github.com/delta-io/delta/pull/5877) [[Files changed](https://github.com/delta-io/delta/pull/5877/files/04064f296d184192998b31ed4aa8e0fefe9d73db..23f5b201df02e83dccaf8be40d409e68717e092f)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Refactor `DeltaParquetFileFormat` to support explicit control of `useMetadataRowIndex` for the V2 connector.

### Changes:
- Add `useMetadataRowIndexOpt: Option[Boolean]` parameter to `DeltaParquetFileFormatBase`
- V1 connector: Captures config value at construction time
- V2 connector: Explicitly passes the value per-scan via `DeltaParquetFileFormatV2`

This is a pure refactor with no behavioral changes for V1. It enables the V2 connector to control `_metadata.row_index` usage independently.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing V1 tests pass (no behavior change)
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No