### PR TITLE
[Spark] Enable Support for Non-Nested Subqueries in UPDATE and DELETE Commands

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableDelete.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableDelete.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.catalyst.expressions.{Exists, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.delta.util.Utils.isAllowedSubqueryPattern
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -33,16 +34,8 @@ case class PreprocessTableDelete(sqlConf: SQLConf) extends Rule[LogicalPlan] {
     plan.resolveOperators {
       case d: DeltaDelete if d.resolved =>
         d.condition.foreach { cond =>
-          if (SubqueryExpression.hasSubquery(cond)) {
-            val hasExistsSubquery = cond.exists {
-              case _: Exists => false
-              case _: SubqueryExpression => true
-              case _ => false
-            }
-            if (!sqlConf.getConf(DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE) ||
-                hasExistsSubquery) {
-              throw DeltaErrors.subqueryNotSupportedException("DELETE", cond)
-            }
+          if (SubqueryExpression.hasSubquery(cond) && !isAllowedSubqueryPattern(cond)) {
+            throw DeltaErrors.subqueryNotSupportedException("DELETE", cond)
           }
         }
         DeleteCommand(d)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.delta.util.Utils.isAllowedSubqueryPattern
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -40,7 +41,7 @@ case class PreprocessTableUpdate(sqlConf: SQLConf)
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
     case u: DeltaUpdateTable if u.resolved =>
       u.condition.foreach { cond =>
-        if (SubqueryExpression.hasSubquery(cond)) {
+        if (SubqueryExpression.hasSubquery(cond) && !isAllowedSubqueryPattern(cond)) {
           throw DeltaErrors.subqueryNotSupportedException("UPDATE", cond)
         }
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SubqueryTransformerHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SubqueryTransformerHelper.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Subquery, SupportsSubquery}
+import org.apache.spark.sql.delta.commands.{DeleteCommand, UpdateCommand}
 
 /**
  * Trait to allow processing a special transformation of [[SubqueryExpression]]
@@ -45,7 +46,9 @@ trait SubqueryTransformerHelper {
 
   /** Is the give plan a subquery root. */
   def isSubqueryRoot(plan: LogicalPlan): Boolean = {
-    plan.isInstanceOf[Subquery] || plan.isInstanceOf[SupportsSubquery]
+    plan.isInstanceOf[Subquery] ||
+      (plan.isInstanceOf[SupportsSubquery] && !plan.isInstanceOf[UpdateCommand]
+        && !plan.isInstanceOf[DeleteCommand])
   }
 
   private def transformSubqueries(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, Not}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan, SupportsSubquery}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.catalyst.plans.logical.SupportsSubquery
 import org.apache.spark.sql.execution.command.LeafRunnableCommand

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, If, Literal}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SupportsSubquery}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -62,7 +62,7 @@ case class UpdateCommand(
     target: LogicalPlan,
     updateExpressions: Seq[Expression],
     condition: Option[Expression])
-  extends LeafRunnableCommand with DeltaCommand {
+  extends LeafRunnableCommand with DeltaCommand with SupportsSubquery {
 
   override val output: Seq[Attribute] = {
     Seq(AttributeReference("num_affected_rows", LongType)())

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, If, Literal}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SupportsSubquery}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -62,7 +62,7 @@ case class UpdateCommand(
     target: LogicalPlan,
     updateExpressions: Seq[Expression],
     condition: Option[Expression])
-  extends LeafRunnableCommand with DeltaCommand {
+  extends LeafRunnableCommand with DeltaCommand with SupportsSubquery {
 
   override val output: Seq[Attribute] = {
     Seq(AttributeReference("num_affected_rows", LongType, nullable = false)())

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
@@ -27,6 +27,9 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.ElementAt
 
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
 /**
  * Various utility methods used by Delta.
  */
@@ -83,5 +86,44 @@ object Utils {
    */
   def try_element_at(mapColumn: Column, key: Any): Column = {
     functions.try_element_at(mapColumn, functions.lit(key))
+  }
+
+  /**
+   * Check for the allowed subquery pattern for UPDATE and DELETE commands
+   */
+  def isAllowedSubqueryPattern(expr: Expression): Boolean = expr match {
+    case exists: Exists =>
+      !hasNestedSubquery(exists.plan)
+
+    case scalar: ScalarSubquery =>
+      !hasNestedSubquery(scalar.plan)
+
+    case InSubquery(_, ListQuery(plan, _, _, _, _, _)) =>
+      !hasNestedSubquery(plan)
+
+    case binary: BinaryExpression =>
+      isAllowedSubqueryPattern(binary.left) ||
+        isAllowedSubqueryPattern(binary.right)
+
+    case Not(InSubquery(_, ListQuery(plan, _, _, _, _, _))) =>
+      !hasNestedSubquery(plan)
+
+    case _ => false
+  }
+
+
+  /**
+   * Checks whether a query has nested subqueries
+   */
+  def hasNestedSubquery(plan: LogicalPlan): Boolean = {
+    // Check if any plan node contains an expression that itself contains a SubqueryExpression
+    plan.exists { planNode =>
+      planNode.expressions.exists { expr =>
+        expr.exists {
+          case _: SubqueryExpression => true
+          case _ => false
+        }
+      }
+    }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaExcludedTestMixin, DeltaSQLCommandTest}
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{AnalysisException, Row}
 
 trait DeleteSQLMixin extends DeleteBaseMixin
   with DeltaDMLTestUtils
@@ -84,6 +84,130 @@ trait DeleteSQLTests extends DeleteSQLMixin {
         sql("SELECT id, _change_type FROM tab").collect().foreach { row =>
           val _change_type = row.getString(1)
           assert(_change_type === "foo", s"Invalid _change_type for id=${row.get(0)}")
+        }
+      }
+    }
+  }
+
+  test("simple correlated IN subquery allowed via temp view") {
+    withTable("target") {
+      withTable("sourceTable") {
+        withTempView("t") {
+          Seq((1, "a"), (2, "b"), (3, "c")).toDF("key", "val")
+            .write.format("delta").saveAsTable("target")
+          Seq(2, 3).toDF("key").write.format("delta").saveAsTable("sourceTable")
+          sql("CREATE TEMP VIEW t AS SELECT * FROM target")
+
+          sql("""
+          DELETE FROM t
+          WHERE key IN (SELECT key FROM sourceTable WHERE sourceTable.key = t.key)
+          """)
+
+          checkAnswer(
+            sql("SELECT * FROM target ORDER BY key"),
+            Seq(Row(1, "a"))
+          )
+        }
+      }
+    }
+  }
+
+  test("exists subquery with correlation allowed via temp view") {
+    withTable("target") {
+      withTable("sourceTable") {
+        withTempView("t") {
+          Seq((1, 10), (2, 20), (3, 30)).toDF("key", "val")
+            .write.format("delta").saveAsTable("target")
+          Seq(1, 3).toDF("key").write.format("delta").saveAsTable("sourceTable")
+          sql("CREATE TEMP VIEW t AS SELECT * FROM target")
+
+          sql("""
+          DELETE FROM t WHERE EXISTS (
+            SELECT 1 FROM sourceTable WHERE t.key = sourceTable.key
+          )
+          """)
+
+          checkAnswer(
+            sql("SELECT * FROM target ORDER BY key"),
+            Seq(Row(2, 20))
+          )
+        }
+      }
+    }
+  }
+
+  test("scalar subquery in condition allowed via temp view") {
+    withTable("target") {
+      withTable("source") {
+        withTempView("t") {
+          Seq((1, "a"), (2, "b"))
+            .toDF("key", "val")
+            .write.format("delta")
+            .saveAsTable("target")
+          Seq(2, 3)
+            .toDF("key")
+            .write.format("delta")
+            .saveAsTable("source")
+
+          sql("CREATE TEMP VIEW t AS SELECT * FROM target")
+          sql("DELETE FROM t WHERE key < (SELECT min(key) FROM source)")
+
+          checkAnswer(
+            sql("SELECT * FROM target ORDER BY key"),
+            Seq(Row(2, "b"))
+          )
+        }
+      }
+    }
+  }
+
+  test("simple NOT IN subquery allowed via temp view") {
+    withTable("target") {
+      withTable("source") {
+        withTempView("t") {
+          Seq("X", "Y", "Z")
+            .toDF("category")
+            .write.format("delta")
+            .saveAsTable("target")
+          Seq("Y")
+            .toDF("category")
+            .write.format("delta")
+            .saveAsTable("source")
+
+          sql("CREATE TEMP VIEW t AS SELECT * FROM target")
+          sql("DELETE FROM t WHERE category NOT IN (SELECT category FROM source)")
+
+          checkAnswer(
+            sql("SELECT * FROM target ORDER BY category"),
+            Seq(Row("Y"))
+          )
+        }
+      }
+    }
+  }
+
+  test("nested subquery should fail via temp view") {
+    withTable("target") {
+      withTable("source1") {
+        withTable("source2") {
+          withTempView("t") {
+            Seq((1, "a"), (2, "b")).toDF("key", "col")
+              .write.format("delta").saveAsTable("target")
+
+            Seq(2).toDF("key").write.format("delta").saveAsTable("source1")
+            Seq(3).toDF("id").write.format("delta").saveAsTable("source2")
+
+            sql("CREATE TEMP VIEW t AS SELECT * FROM target")
+
+            val e = intercept[AnalysisException] {
+              sql(
+                "DELETE FROM t WHERE key IN (" +
+                  "SELECT key FROM source1 WHERE key IN (SELECT id FROM source2))"
+              )
+            }
+
+            assert(e.getMessage.contains("Subqueries are not supported in the DELETE"))
+          }
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -406,92 +406,6 @@ trait DeleteBaseTests extends DeleteBaseMixin {
       Row("c", "v") :: Row("d", "vv") :: Nil)
   }
 
-  test("do not support non-EXISTS subquery test",
-      DSv2Incompatible("asserts classic Delta DELETE subquery policy")) {
-    append(Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value"))
-    Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("c", "d").createOrReplaceTempView("source")
-
-    // basic subquery
-    val e0 = intercept[AnalysisException] {
-      executeDelete(target = tableSQLIdentifier, "key < (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e0.contains("Subqueries are not supported"))
-
-    // subquery with IN
-    val e3 = intercept[AnalysisException] {
-      executeDelete(target = tableSQLIdentifier, "key IN (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e3.contains("Subqueries are not supported"))
-
-    // subquery with NOT IN
-    val e4 = intercept[AnalysisException] {
-      executeDelete(target = tableSQLIdentifier, "key NOT IN (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e4.contains("Subqueries are not supported"))
-
-    // EXISTS mixed with IN: the IN subquery should still be blocked
-    withSQLConf(DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key -> "true") {
-      checkError(
-        intercept[DeltaAnalysisException] {
-          executeDelete(
-            target = tableSQLIdentifier,
-            where = "EXISTS (SELECT 1 FROM source WHERE key = c) AND key IN (SELECT c FROM source)")
-        },
-        condition = "DELTA_UNSUPPORTED_SUBQUERY",
-        sqlState = Some("0AKDC"),
-        parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
-        matchPVals = true)
-    }
-  }
-
-  test("delete with correlated EXISTS subquery") {
-    append(Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value"))
-    Seq((2, 2), (1, 4)).toDF("c", "d").createOrReplaceTempView("source")
-
-    withSQLConf(DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key -> "true") {
-      executeDelete(
-        target = tableSQLIdentifier,
-        where = "EXISTS (SELECT 1 FROM source WHERE key = c)")
-    }
-    checkAnswer(
-      readDeltaTableByIdentifier(tableSQLIdentifier),
-      Row(0, 3) :: Nil)
-  }
-
-  test("delete with correlated NOT EXISTS subquery") {
-    append(Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value"))
-    Seq((2, 2), (1, 4)).toDF("c", "d").createOrReplaceTempView("source")
-
-    withSQLConf(DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key -> "true") {
-      executeDelete(
-        target = tableSQLIdentifier,
-        where = "NOT EXISTS (SELECT 1 FROM source WHERE key = c)")
-    }
-    checkAnswer(
-      readDeltaTableByIdentifier(tableSQLIdentifier),
-      Row(2, 2) :: Row(1, 4) :: Row(1, 1) :: Nil)
-  }
-
-  test("EXISTS subquery kill switch",
-      DSv2Incompatible("asserts classic Delta DELETE subquery policy")) {
-    append(Seq((2, 2), (1, 4)).toDF("key", "value"))
-    Seq((2, 2)).toDF("c", "d").createOrReplaceTempView("source")
-
-    withSQLConf(
-        DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key -> "false") {
-      checkError(
-        intercept[DeltaAnalysisException] {
-          executeDelete(
-            target = tableSQLIdentifier,
-            where = "EXISTS (SELECT 1 FROM source WHERE key = c)")
-        },
-        condition = "DELTA_UNSUPPORTED_SUBQUERY",
-        sqlState = Some("0AKDC"),
-        parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
-        matchPVals = true)
-    }
-  }
-
   test("schema pruning on data condition",
       ChecksPhysicalDeltaPlan("checks Delta file-scan schema pruning")) {
     val input = Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value")
@@ -600,34 +514,6 @@ trait DeleteBaseTests extends DeleteBaseMixin {
     expectException = true
   )
 
-  testUnsupportedExpression(
-    function = "max",
-    functionType = "Aggregate",
-    data = Seq((2, 2), (1, 4)).toDF("key", "value"),
-    where = "key > max(value)",
-    expectException = true
-  )
-
-  // Explode functions are supported in where if only one row generated.
-  testUnsupportedExpression(
-    function = "explode",
-    functionType = "Generate",
-    data = Seq((2, List(2))).toDF("key", "value"),
-    where = "key = (select explode(value) from deltaTable)",
-    expectException = false // generate only one row, no exception.
-  )
-
-  // Explode functions are supported in where but if there's more than one row generated,
-  // it will throw an exception.
-  testUnsupportedExpression(
-    function = "explode",
-    functionType = "Generate",
-    data = Seq((2, List(2)), (1, List(4, 5))).toDF("key", "value"),
-    where = "key = (select explode(value) from deltaTable)",
-    expectException = true, // generate more than one row. Exception expected.
-    customErrorRegex =
-      Some(".*More than one row returned by a subquery used as an expression(?s).*")
-  )
 
   test("Variant type") {
     val dstDf = sql(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -163,6 +163,106 @@ trait UpdateSQLTests extends UpdateSQLMixin {
           "object")))
     }
   }
+
+  test("simple IN subquery allowed via temp view") {
+    withTable("target") {
+      withTable("source") {
+          Seq((1, "a"), (2, "b")).toDF("key", "val")
+            .write.format("delta").saveAsTable("target")
+          Seq((2)).toDF("key").write.format("delta").saveAsTable("source")
+          sql("UPDATE target SET val = 'update' WHERE key IN (SELECT key FROM source)")
+          checkAnswer(sql("SELECT * FROM target ORDER BY key"),
+            Seq(Row(1, "a"), Row(2, "update")))
+      }
+    }
+  }
+
+  test("simple IN correlated subquery allowed via temp view") {
+    withTable("target") {
+      withTable("source") {
+          Seq((1, "a"), (2, "b"), (3, "c")).toDF("key", "val")
+            .write.format("delta").saveAsTable("target")
+          Seq(2, 3).toDF("key").write.format("delta").saveAsTable("source")
+          sql("UPDATE target SET val = 'update' WHERE key IN" +
+            " (SELECT key FROM source where target.key = source.key)")
+          checkAnswer(sql("SELECT * FROM target ORDER BY key"),
+            Seq(Row(1, "a"), Row(2, "update"), Row(3, "update")))
+      }
+    }
+  }
+
+  test("exists subquery with correlated allowed via temp view") {
+    withTable("target") {
+      withTable("source") {
+          Seq((1, 10, "a"), (2, 20, "b"), (3, 30, "c")).toDF("key", "val_i", "val")
+            .write.format("delta").saveAsTable("target")
+          Seq(2, 1).toDF("key").write.format("delta").saveAsTable("source")
+          sql("UPDATE target SET val = 'update' WHERE EXISTS (" +
+            "SELECT 1 FROM source WHERE target.key = source.key)")
+          checkAnswer(sql("SELECT * FROM target ORDER BY key"),
+            Seq(Row(1, 10, "update"), Row(2, 20, "update"), Row(3, 30, "c")))
+      }
+    }
+  }
+
+  test("scalar subquery in condition allowed via temp view") {
+    withTable("target") {
+      withTable("source") {
+          Seq((1, "a"), (2, "b")).toDF("key", "val").write.format("delta").saveAsTable("target")
+          Seq(2, 3).toDF("key").write.format("delta").saveAsTable("source")
+          sql("UPDATE target SET val = 'update' WHERE key < (SELECT min(key) FROM source)")
+          checkAnswer(sql("SELECT * FROM target ORDER BY key"),
+            Seq(Row(1, "update"), Row(2, "b")))
+      }
+    }
+  }
+
+  test("simple NOT IN subquery allowed via temp view") {
+    withTable("target") {
+      withTable("source") {
+          Seq(("X"), ("Y"), ("Z")).toDF("category").write.format("delta").saveAsTable("target")
+          Seq(("Y")).toDF("category").write.format("delta").saveAsTable("source")
+          sql("UPDATE target SET category = 'unset'" +
+            " WHERE category NOT IN (SELECT category FROM source)")
+          checkAnswer(sql("SELECT * FROM target ORDER BY category"),
+            Seq(Row("Y"), Row("unset"), Row("unset")))
+      }
+    }
+  }
+
+  test("nested subquery should fail via temp view") {
+    withTable("target") {
+      withTable("source") {
+        withTable("source2") {
+            Seq((1, "a"), (2, "b")).toDF("key", "col").write.format("delta").saveAsTable("target")
+            Seq((2)).toDF("key").write.format("delta").saveAsTable("source")
+            Seq((3)).toDF("id").write.format("delta").saveAsTable("source2")
+            val e = intercept[AnalysisException] {
+              sql("UPDATE target SET col = 'C' WHERE key" +
+                " IN (SELECT key FROM source WHERE key IN (SELECT id FROM source2))")
+            }
+            assert(e.getMessage.contains("Subqueries are not supported in the UPDATE"))
+        }
+      }
+    }
+  }
+
+  test("nested subquery should fail via temp view") {
+    withTable("target") {
+      withTable("source") {
+        withTable("source2") {
+            Seq((1, "a"), (2, "b")).toDF("key", "col").write.format("delta").saveAsTable("target")
+            Seq((2)).toDF("key").write.format("delta").saveAsTable("source")
+            Seq((3)).toDF("id").write.format("delta").saveAsTable("source2")
+            val e = intercept[AnalysisException] {
+              sql("UPDATE target SET col = 'C' WHERE key" +
+                " IN (SELECT key FROM source WHERE key IN (SELECT id FROM source2))")
+            }
+            assert(e.getMessage.contains("Subqueries are not supported in the UPDATE"))
+        }
+      }
+    }
+  }
 }
 
 trait UpdateSQLWithDeletionVectorsMixin extends UpdateSQLMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -615,51 +615,6 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
     }
   }
 
-  test("Negative case - do not support subquery test") {
-    append(Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value"))
-    Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("c", "d").createOrReplaceTempView("source")
-
-    // basic subquery
-    val e0 = intercept[AnalysisException] {
-      executeUpdate(target = tableSQLIdentifier,
-        set = "key = 1",
-        where = "key < (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e0.contains("Subqueries are not supported"))
-
-    // subquery with EXISTS
-    val e1 = intercept[AnalysisException] {
-      executeUpdate(target = tableSQLIdentifier,
-        set = "key = 1",
-        where = "EXISTS (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e1.contains("Subqueries are not supported"))
-
-    // subquery with NOT EXISTS
-    val e2 = intercept[AnalysisException] {
-      executeUpdate(target = tableSQLIdentifier,
-        set = "key = 1",
-        where = "NOT EXISTS (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e2.contains("Subqueries are not supported"))
-
-    // subquery with IN
-    val e3 = intercept[AnalysisException] {
-      executeUpdate(target = tableSQLIdentifier,
-        set = "key = 1",
-        where = "key IN (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e3.contains("Subqueries are not supported"))
-
-    // subquery with NOT IN
-    val e4 = intercept[AnalysisException] {
-      executeUpdate(target = tableSQLIdentifier,
-        set = "key = 1",
-        where = "key NOT IN (SELECT max(c) FROM source)")
-    }.getMessage
-    assert(e4.contains("Subqueries are not supported"))
-  }
-
   test("nested data support") {
     // set a nested field
     checkUpdateJson(target = """
@@ -987,29 +942,6 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
     set = "b = max(c)",
     where = "b > max(c)",
     expectException = true
-  )
-
-  // Explode functions are supported in set and where if there's only one row generated.
-  testUnsupportedExpression(
-    function = "explode",
-    functionType = "Generate",
-    data = Seq((1, 2, List(3))).toDF("a", "b", "c"),
-    set = "b = (select explode(c) from deltaTable)",
-    where = "b = (select explode(c) from deltaTable)",
-    expectException = false // only one row generated, no exception.
-  )
-
-  // Explode functions are supported in set and where but if there's more than one row generated,
-  // it will throw an exception.
-  testUnsupportedExpression(
-    function = "explode",
-    functionType = "Generate",
-    data = Seq((1, 2, List(3, 4))).toDF("a", "b", "c"),
-    set = "b = (select explode(c) from deltaTable)",
-    where = "b = (select explode(c) from deltaTable)",
-    expectException = true, // more than one generated, expect exception.
-    customErrorRegex =
-      Some(".*ore than one row returned by a subquery used as an expression(?s).*")
   )
 
   test("Variant type") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingDeleteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingDeleteSuite.scala
@@ -136,22 +136,6 @@ trait RowTrackingDeleteSuiteBase extends RowTrackingDeleteTestDimension {
     }
   }
 
-  test("Preserving Row Tracking - DELETE with EXISTS subquery") {
-    withSQLConf(DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key -> "true") {
-      withRowIdTestTable(isPartitioned = false) {
-        // Use a different column name to avoid ambiguous resolution inside EXISTS.
-        sql(
-          s"CREATE TABLE $subqueryTableName USING delta " +
-            s"AS SELECT id AS src_id FROM $testTableName")
-        withTable(subqueryTableName) {
-          deleteAndValidateStableRowId(Some(
-            s"EXISTS (SELECT 1 FROM $subqueryTableName s " +
-              s"WHERE s.src_id = id AND (s.src_id = 7 OR s.src_id = 11))"))
-        }
-      }
-    }
-  }
-
   for (isPartitioned <- BOOLEAN_DOMAIN)  {
     test(s"Multiple DELETEs preserve Row IDs, isPartitioned=$isPartitioned") {
       withRowIdTestTable(isPartitioned) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingUpdateSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingUpdateSuite.scala
@@ -167,20 +167,6 @@ trait RowTrackingUpdateCommonTests extends RowTrackingUpdateSuiteBase {
     }
   }
 
-  test("Preserving Row Tracking - Subqueries are not supported in UPDATE") {
-    withRowTrackingEnabled(enabled = true) {
-      withRowIdTestTable(isPartitioned = false) {
-        val ex = intercept[AnalysisException] {
-          checkAndExecuteUpdate(
-            tableName = targetTableName,
-            condition = Some(
-              s"""id in (SELECT id FROM $targetTableName s
-              WHERE s.id = 0 OR s.id = $numRowsPerFile)"""))
-        }.getMessage
-        assert(ex.contains("Subqueries are not supported in the UPDATE"))
-      }
-    }
-  }
 
   for {
     isPartitioned <- BOOLEAN_DOMAIN


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR adds support for non-nested subqueries in the WHERE clause of UPDATE and DELETE commands on Delta tables. Previously, Delta rejected all subqueries in mutation commands with DELTA_UNSUPPORTED_SUBQUERY, even when the subquery could be safely analyzed and executed by Spark.
With this change, Delta enables a restricted set of subquery patterns that are already supported by Spark’s analyzer and optimizer.

Since Spark already rewrites supported subqueries into efficient physical plans (for example, using `BroadcastHashJoin` where applicable), it is not clear to me, why these patterns were previously not allowed in Delta. It would be helpful to understand whether the original restriction was driven by performance considerations, correctness concerns, or other design constraints specific to Delta’s execution model.

For the initial implementation, support is intentionally limited to a small set of basic subquery patterns that satisfy current requirements. This scoped approach simplifies validation and testing, while providing a foundation that can be incrementally extended to support additional subquery forms in future iterations. 

This PR enables the following subquery patterns in UPDATE and DELETE conditions

- Scalar subqueries

```
UPDATE t SET col = 'x'
WHERE id < (SELECT max(id) FROM s)

```

- IN / NOT IN subqueries

```
DELETE FROM t
WHERE id IN (SELECT id FROM s)

```

- EXISTS / NOT EXISTS subqueries

```
DELETE FROM t
WHERE EXISTS (SELECT 1 FROM s WHERE s.id = t.id)

```

**Restrictions**
- Nested subqueries are still not supported


## How was this patch tested?

Added new unit tests covering:

- UPDATE with scalar subquery
- DELETE with IN / NOT IN subqueries
- EXISTS / NOT EXISTS subqueries
- Negative cases for nested subqueries

## Does this PR introduce _any_ user-facing changes?
Yes

Git issue - https://github.com/delta-io/delta/issues/5760
