### PR TITLE
[Spark] Deflake tests relying on catalog update awaits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
@@ -272,8 +272,8 @@ case class UpdateCatalog(table: CatalogTable) extends UpdateCatalogBase {
       spark: SparkSession,
       snapshot: Snapshot): Unit = {
     if (!shouldRun(spark, snapshot)) return
+    UpdateCatalog.activeAsyncRequests.incrementAndGet()
     Future[Unit] {
-      UpdateCatalog.activeAsyncRequests.incrementAndGet()
       execute(spark, snapshot)
     }(UpdateCatalog.getOrCreateExecutionContext(spark.sessionState.conf)).onComplete { _ =>
       UpdateCatalog.activeAsyncRequests.decrementAndGet()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Spark's awaitCompletion method in UpdateCatalog does not take into account queued, but not yet in-flight catalog update requests and therefore may ignore these requests when they should otherwise be awaited. This may produce flaky tests. This PR fixes this issue by moving the tracking of these requests before the future is created (so this happens synchronously as part of the post-commit hook for each command).

## How was this patch tested?
N/A.
