### PR TITLE
[0.4][Spark] Support the spark-uc tests run on various env.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -600,6 +600,22 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
       "org.apache.spark" %% "spark-core" % sparkVersion.value % "test",
     ),
 
+    // Conditionally add hadoop-aws dependency only when UC_REMOTE=true
+    // Please see: https://github.com/delta-io/delta/issues/5624#issuecomment-3673383736
+    // Once we release the relocated unitycatalog-server, we can remove this.
+    libraryDependencies ++= {
+      if (sys.env.get("UC_REMOTE").contains("true")) {
+        Seq(
+          "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % "test",
+          "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test",
+          "org.apache.hadoop" % "hadoop-client-api" % hadoopVersion % "test",
+          "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion % "test"
+        )
+      } else {
+        Seq.empty
+      }
+    },
+
     Test / testOptions += Tests.Argument("-oDF"),
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
   )

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -16,12 +16,12 @@
 
 package io.sparkuctest;
 
-import java.io.File;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -76,6 +76,18 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     sparkSession = SparkSession.builder().config(conf).getOrCreate();
   }
 
+  private SparkConf configureSparkWithUnityCatalog(SparkConf conf) {
+    // Set the AWS S3 implementation for remote unity catalog server testing.
+    conf.set("spark.hadoop.fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+
+    // Set the catalog specific configs.
+    UnityCatalogInfo uc = unityCatalogInfo();
+    String catalogName = uc.catalogName();
+    return conf.set("spark.sql.catalog." + catalogName, "io.unitycatalog.spark.UCSingleCatalog")
+        .set("spark.sql.catalog." + catalogName + ".uri", uc.serverUri())
+        .set("spark.sql.catalog." + catalogName + ".token", uc.serverToken());
+  }
+
   /** Stop the SparkSession after all tests. */
   @AfterAll
   public void tearDownSpark() {
@@ -100,7 +112,7 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
    * sql("INSERT INTO %s VALUES (%d, '%s')", tableName, 1, "value")
    * </pre>
    *
-   * When called without arguments, executes the SQL as-is:
+   * <p>When called without arguments, executes the SQL as-is:
    *
    * <pre>
    * sql("CREATE TABLE test (id INT)")
@@ -128,25 +140,9 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
 
   /** Helper method to run code with a temporary directory that gets cleaned up. */
   protected void withTempDir(TempDirCode code) throws Exception {
-    File tempDir = Files.createTempDirectory("spark-test-").toFile();
-    try {
-      code.run(tempDir);
-    } finally {
-      deleteRecursively(tempDir);
-    }
-  }
-
-  /** Recursively delete a directory. */
-  private void deleteRecursively(File file) {
-    if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null) {
-        for (File child : files) {
-          deleteRecursively(child);
-        }
-      }
-    }
-    file.delete();
+    UnityCatalogInfo uc = unityCatalogInfo();
+    Path tempDir = new Path(uc.baseTableLocation(), "temp-" + UUID.randomUUID());
+    code.run(tempDir);
   }
 
   /** Table types for parameterized testing. */
@@ -166,16 +162,17 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
   protected void withNewTable(
       String tableName, String tableSchema, TableType tableType, TestCode testCode)
       throws Exception {
-    String fullTableName = getCatalogName() + ".default." + tableName;
+    UnityCatalogInfo uc = unityCatalogInfo();
+    String fullTableName = uc.catalogName() + "." + uc.schemaName() + "." + tableName;
 
     if (tableType == TableType.EXTERNAL) {
       // External table requires a location
       withTempDir(
-          (File dir) -> {
-            File tablePath = new File(dir, tableName);
+          (Path dir) -> {
+            Path tablePath = new Path(dir, tableName);
             sql(
                 "CREATE TABLE %s (%s) USING DELTA LOCATION '%s'",
-                fullTableName, tableSchema, tablePath.getAbsolutePath());
+                fullTableName, tableSchema, tablePath.toString());
 
             try {
               testCode.run(fullTableName);
@@ -202,12 +199,14 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
   /** Functional interface for test code that takes a temporary directory. */
   @FunctionalInterface
   protected interface TempDirCode {
-    void run(File dir) throws Exception;
+
+    void run(Path dir) throws Exception;
   }
 
   /** Functional interface for test code that takes a table name parameter. */
   @FunctionalInterface
   protected interface TestCode {
+
     void run(String tableName) throws Exception;
   }
 
@@ -218,6 +217,7 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
    * test the same logic via different interfaces (Spark SQL, JDBC, etc.).
    */
   public interface SQLExecutor {
+
     /**
      * Execute a SQL statement and return the results.
      *
@@ -242,6 +242,7 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
    * for easy comparison.
    */
   public static class SparkSQLExecutor implements SQLExecutor {
+
     private final SparkSession spark;
 
     public SparkSQLExecutor(SparkSession spark) {
@@ -269,15 +270,9 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
       List<List<String>> actual = runSQL(sql);
       if (!actual.equals(expected)) {
         throw new AssertionError(
-            "Query results do not match.\n"
-                + "SQL: "
-                + sql
-                + "\n"
-                + "Expected: "
-                + expected
-                + "\n"
-                + "Actual: "
-                + actual);
+            String.format(
+                "Query results do not match.\nSQL: %s\n Expected: %s\nActual: %s",
+                sql, expected, actual));
       }
     }
   }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCManagedTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCManagedTableCreationTest.java
@@ -32,8 +32,9 @@ public class UCManagedTableCreationTest extends UCDeltaTableIntegrationBaseTest 
   @Test
   public void testCreateManagedTable() throws Exception {
     // TODO: make this a thorough test of managed table creation with different parameters.
+    UnityCatalogInfo uc = unityCatalogInfo();
     String tableName = "test_managed_table";
-    String fullTableName = getCatalogName() + ".default." + tableName;
+    String fullTableName = uc.catalogName() + ".default." + tableName;
     String tableSchema = "id INT, active BOOLEAN";
     try {
       sql(
@@ -42,7 +43,7 @@ public class UCManagedTableCreationTest extends UCDeltaTableIntegrationBaseTest 
           fullTableName, tableSchema);
 
       // Verify that properties are set on server. This can not be done by DESC EXTENDED.
-      TablesApi tablesApi = new TablesApi(createClient());
+      TablesApi tablesApi = new TablesApi(uc.createApiClient());
       TableInfo tableInfo = tablesApi.getTable(fullTableName, false, false);
       List<ColumnInfo> columns = tableInfo.getColumns();
       Map<String, String> properties = tableInfo.getProperties();

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
@@ -16,9 +16,13 @@
 
 package io.sparkuctest;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.api.CatalogsApi;
 import io.unitycatalog.client.api.SchemasApi;
+import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.model.CreateCatalog;
 import io.unitycatalog.client.model.CreateSchema;
 import io.unitycatalog.server.UnityCatalogServer;
@@ -28,8 +32,8 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.util.Properties;
+import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
-import org.apache.spark.SparkConf;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
@@ -37,28 +41,20 @@ import org.junit.jupiter.api.TestInstance;
 /**
  * Abstract base class that provides Unity Catalog server integration for Delta tests.
  *
- * <p>This class automatically: - Starts a local Unity Catalog server before all tests - Configures
- * Spark to connect to the UC server - Stops the server and cleans up after all tests
+ * <p>Automatically starts a local Unity Catalog server before tests and stops it after. To use a
+ * remote server instead, set {@code UC_REMOTE=true} and configure {@code UC_URI}, {@code UC_TOKEN},
+ * {@code UC_CATALOG_NAME}, {@code UC_SCHEMA_NAME}, and {@code UC_BASE_TABLE_LOCATION}.
  *
- * <p>The UC server runs with Unity Catalog dependencies to provide catalog functionality for
- * integration testing.
- *
- * <p>Usage:
+ * <p>{@code unityCatalogInfo()} is the only API for subclasses, All other methods are internal
+ * implementation details.
  *
  * <pre>
  * public class MyUCTest extends UnityCatalogSupport {
- *
- *   {@literal @}Override
- *   protected SparkConf getSparkConf() {
- *     SparkConf conf = new SparkConf();
- *     // ... configure spark ...
- *     return configureSparkWithUnityCatalog(conf);
- *   }
- *
  *   {@literal @}Test
  *   public void myTest() {
- *     // Use getCatalogName() to reference the catalog
- *     getSparkSession().sql("CREATE TABLE " + getCatalogName() + ".default.test_table ...");
+ *     UnityCatalogInfo ucInfo = unityCatalogInfo();
+ *     String tableName = ucInfo.catalogName() + "." + ucInfo.schemaName() + ".my_table";
+ *     spark.sql("CREATE TABLE " + tableName + " (id INT) USING DELTA");
  *   }
  * }
  * </pre>
@@ -66,45 +62,134 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class UnityCatalogSupport {
 
-  private static final Logger logger = Logger.getLogger(UnityCatalogSupport.class);
+  private static final Logger LOG = Logger.getLogger(UnityCatalogSupport.class);
+
+  protected static class UnityCatalogInfo {
+
+    private final String serverUri;
+    private final String catalogName;
+    private final String serverToken;
+    private final String schemaName;
+    private final String baseTableLocation;
+
+    public UnityCatalogInfo(
+        String serverUri,
+        String catalogName,
+        String serverToken,
+        String schemaName,
+        String baseTableLocation) {
+      this.serverUri = serverUri;
+      this.catalogName = catalogName;
+      this.serverToken = serverToken;
+      this.schemaName = schemaName;
+      this.baseTableLocation = baseTableLocation;
+    }
+
+    public String serverUri() {
+      return serverUri;
+    }
+
+    public String catalogName() {
+      return catalogName;
+    }
+
+    public String serverToken() {
+      return serverToken;
+    }
+
+    public String schemaName() {
+      return schemaName;
+    }
+
+    public String baseTableLocation() {
+      return baseTableLocation;
+    }
+
+    /** Creates a configured Unity Catalog API client. */
+    public ApiClient createApiClient() {
+      return ApiClientBuilder.create()
+          .uri(serverUri)
+          .tokenProvider(
+              TokenProvider.create(ImmutableMap.of("type", "static", "token", serverToken)))
+          .build();
+    }
+  }
+
+  public static final String UC_STATIC_TOKEN = "static-token";
+
+  // Environment variables for configuring access to remote unity catalog server.
+  public static final String UC_REMOTE = "UC_REMOTE";
+  public static final String UC_URI = "UC_URI";
+  public static final String UC_TOKEN = "UC_TOKEN";
+  public static final String UC_CATALOG_NAME = "UC_CATALOG_NAME";
+  public static final String UC_SCHEMA_NAME = "UC_SCHEMA_NAME";
+  public static final String UC_BASE_TABLE_LOCATION = "UC_BASE_TABLE_LOCATION";
+
+  private static boolean isUCRemoteConfigured() {
+    String ucRemote = System.getenv(UC_REMOTE);
+    return ucRemote != null && ucRemote.equalsIgnoreCase("true");
+  }
+
+  /** The Unity Catalog info instance for subclasses access */
+  private UnityCatalogInfo ucInfo = null;
 
   /** The Unity Catalog server instance. */
   private UnityCatalogServer ucServer;
 
   /** The port on which the UC server is running. */
-  private int ucPort;
+  private int ucServerPort;
 
   /** The temporary directory for UC server data. */
-  private File ucTempDir;
+  private File ucServerDir;
+
+  /** The temporary directory for external table location */
+  private File ucBaseTableLocation = null;
 
   /**
-   * The name of the Unity Catalog in Spark's catalog registry. Subclasses can override this if they
-   * need a different catalog name.
+   * Returns the Unity Catalog configuration for use in tests.
+   *
+   * <p>This is the primary method subclasses should use to access Unity Catalog connection details,
+   * authentication tokens, and storage locations.
+   *
+   * <p><strong>Note:</strong> This is the only public API intended for subclasses. All other
+   * methods are internal implementation details.
+   *
+   * @return the Unity Catalog configuration
+   * @see UnityCatalogInfo
    */
-  protected String getCatalogName() {
-    return "unity";
+  protected synchronized UnityCatalogInfo unityCatalogInfo() {
+    Preconditions.checkNotNull(
+        ucInfo,
+        "No UnityCatalogInfo available, please make sure the unity catalog server is available");
+    return ucInfo;
   }
 
-  /** The URI of the Unity Catalog server. Available after setupServer() is called. */
-  protected String getServerUri() {
-    return "http://localhost:" + ucPort;
+  private UnityCatalogInfo remoteUnityCatalogInfo() {
+    String serverUri = System.getenv(UC_URI);
+    String catalogName = System.getenv(UC_CATALOG_NAME);
+    String serverToken = System.getenv(UC_TOKEN);
+    String schemaName = System.getenv(UC_SCHEMA_NAME);
+    String baseTableLocation = System.getenv(UC_BASE_TABLE_LOCATION);
+    Preconditions.checkNotNull(serverUri, "%s must be set when UC_REMOTE=true", UC_URI);
+    Preconditions.checkNotNull(catalogName, "%s must be set when UC_REMOTE=true", UC_CATALOG_NAME);
+    Preconditions.checkNotNull(serverToken, "%s must be set when UC_REMOTE=true", UC_TOKEN);
+    Preconditions.checkNotNull(schemaName, "%s must be set when UC_REMOTE=true", UC_SCHEMA_NAME);
+    Preconditions.checkNotNull(
+        baseTableLocation, "%s must be set when UC_REMOTE=true", UC_BASE_TABLE_LOCATION);
+    return new UnityCatalogInfo(serverUri, catalogName, serverToken, schemaName, baseTableLocation);
   }
 
-  /**
-   * The authentication token for the Unity Catalog server. Currently using a test token; in
-   * production scenarios this would be more secure.
-   */
-  protected String getServerToken() {
-    return "not-a-token";
-  }
-
-  /** Creates a Unity Catalog API client configured for this server. */
-  protected ApiClient createClient() {
-    ApiClient client = new ApiClient();
-    client.setScheme("http");
-    client.setHost("localhost");
-    client.setPort(ucPort);
-    return client;
+  private UnityCatalogInfo localUnityCatalogInfo() {
+    Preconditions.checkNotNull(ucServer, "Local Unity Catalog Server is not configured");
+    Preconditions.checkNotNull(
+        ucBaseTableLocation, "Local Unity Catalog Temp Directory is not configured");
+    // For local UC, use default schema and temp directory
+    return new UnityCatalogInfo(
+        String.format("http://localhost:%s/", ucServerPort),
+        "unity",
+        UC_STATIC_TOKEN,
+        "default",
+        ucBaseTableLocation.getAbsolutePath());
   }
 
   /** Finds an available port for the UC server. */
@@ -120,25 +205,55 @@ public abstract class UnityCatalogSupport {
    */
   @BeforeAll
   public void setupServer() throws Exception {
+    if (isUCRemoteConfigured()) {
+      setUpRemoteServer();
+    } else {
+      setUpLocalServer();
+    }
+  }
+
+  private void setUpRemoteServer() {
+    // For remote UC, log the configuration
+    ucInfo = remoteUnityCatalogInfo();
+    LOG.info("Using remote Unity Catalog server at " + ucInfo.serverUri());
+    LOG.info("Catalog: " + ucInfo.catalogName() + ", Schema: " + ucInfo.schemaName());
+    LOG.info("Base location: " + ucInfo.baseTableLocation());
+    LOG.info(
+        "Note: Schema '"
+            + ucInfo.catalogName()
+            + "."
+            + ucInfo.schemaName()
+            + "' must already exist in the remote UC server");
+  }
+
+  private void setUpLocalServer() throws Exception {
     // Create temporary directory for UC server data
-    ucTempDir = Files.createTempDirectory("unity-catalog-test-").toFile();
-    ucTempDir.deleteOnExit();
+    ucServerDir = Files.createTempDirectory("unity-catalog-test-").toFile();
+    ucServerDir.deleteOnExit();
+
+    // Create temporary directory for external tables testing.
+    ucBaseTableLocation = Files.createTempDirectory("base-table-location-").toFile();
+    ucBaseTableLocation.deleteOnExit();
 
     // Find an available port
-    ucPort = findAvailablePort();
+    ucServerPort = findAvailablePort();
 
     // Set up server properties
     Properties serverProps = new Properties();
     serverProps.setProperty("server.env", "test");
     // Enable managed tables (experimental feature in Unity Catalog)
     serverProps.setProperty("server.managed-table.enabled", "true");
-    serverProps.setProperty("storage-root.tables", new File(ucTempDir, "ucroot").getAbsolutePath());
+    serverProps.setProperty(
+        "storage-root.tables", new File(ucServerDir, "ucroot").getAbsolutePath());
 
     // Start UC server with configuration
     ServerProperties initServerProperties = new ServerProperties(serverProps);
 
     UnityCatalogServer server =
-        UnityCatalogServer.builder().port(ucPort).serverProperties(initServerProperties).build();
+        UnityCatalogServer.builder()
+            .port(ucServerPort)
+            .serverProperties(initServerProperties)
+            .build();
 
     server.start();
     ucServer = server;
@@ -149,13 +264,10 @@ public abstract class UnityCatalogSupport {
     boolean serverReady = false;
     int retries = 0;
 
+    ucInfo = localUnityCatalogInfo();
     while (!serverReady && retries < maxRetries) {
       try {
-        ApiClient testClient = new ApiClient();
-        testClient.setScheme("http");
-        testClient.setHost("localhost");
-        testClient.setPort(ucPort);
-        CatalogsApi catalogsApi = new CatalogsApi(testClient);
+        CatalogsApi catalogsApi = new CatalogsApi(ucInfo.createApiClient());
         catalogsApi.listCatalogs(null, null); // This will throw if server is not ready
         serverReady = true;
       } catch (Exception e) {
@@ -170,7 +282,7 @@ public abstract class UnityCatalogSupport {
     }
 
     // Create the catalog and default schema in the UC server
-    ApiClient client = createClient();
+    ApiClient client = ucInfo.createApiClient();
 
     CatalogsApi catalogsApi = new CatalogsApi(client);
     SchemasApi schemasApi = new SchemasApi(client);
@@ -178,63 +290,42 @@ public abstract class UnityCatalogSupport {
     // Create catalog
     catalogsApi.createCatalog(
         new CreateCatalog()
-            .name(getCatalogName())
+            .name(ucInfo.catalogName())
             .comment("Test catalog for Delta Lake integration"));
 
     // Create default schema
-    schemasApi.createSchema(new CreateSchema().name("default").catalogName(getCatalogName()));
+    schemasApi.createSchema(new CreateSchema().name("default").catalogName(ucInfo.catalogName()));
 
-    logger.info("Unity Catalog server started and ready at " + getServerUri());
-    logger.info("Created catalog '" + getCatalogName() + "' with schema 'default'");
+    LOG.info("Unity Catalog server started and ready at " + ucInfo.serverUri());
+    LOG.info("Created catalog '" + ucInfo.catalogName() + "' with schema 'default'");
   }
 
   /** Stops the Unity Catalog server after all tests. */
   @AfterAll
-  public void tearDownServer() throws Exception {
+  public void tearDownServer() {
+    if (isUCRemoteConfigured()) {
+      return;
+    }
+
     if (ucServer != null) {
       ucServer.stop();
-      logger.info("Unity Catalog server stopped");
+      LOG.info("Unity Catalog server stopped");
       ucServer = null;
     }
 
-    // Clean up temporary directory
-    if (ucTempDir != null && ucTempDir.exists()) {
-      deleteRecursively(ucTempDir);
+    // Clean up uc server temporary directory
+    if (ucServerDir != null && ucServerDir.exists()) {
+      deleteRecursively(ucServerDir);
     }
-  }
 
-  /**
-   * Configures a SparkConf with Unity Catalog settings.
-   *
-   * <p>This method should be called in the test's sparkConf override:
-   *
-   * <pre>
-   * {@literal @}Override
-   * protected SparkConf sparkConf() {
-   *   return configureSparkWithUnityCatalog(super.sparkConf());
-   * }
-   * </pre>
-   *
-   * @param conf The base SparkConf to configure
-   * @return The configured SparkConf with Unity Catalog settings
-   */
-  protected SparkConf configureSparkWithUnityCatalog(SparkConf conf) {
-    String catalogName = getCatalogName();
-    return conf.set("spark.sql.catalog." + catalogName, "io.unitycatalog.spark.UCSingleCatalog")
-        .set("spark.sql.catalog." + catalogName + ".uri", getServerUri())
-        .set("spark.sql.catalog." + catalogName + ".token", getServerToken());
+    // Clear up base table locations.
+    if (ucBaseTableLocation != null && ucBaseTableLocation.exists()) {
+      deleteRecursively(ucBaseTableLocation);
+    }
   }
 
   /** Recursively deletes a directory and all its contents. */
   private void deleteRecursively(File file) {
-    if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null) {
-        for (File child : files) {
-          deleteRecursively(child);
-        }
-      }
-    }
-    file.delete();
+    FileUtils.deleteQuietly(file);
   }
 }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupportTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupportTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest;
+
+import static io.sparkuctest.UnityCatalogSupport.UC_BASE_TABLE_LOCATION;
+import static io.sparkuctest.UnityCatalogSupport.UC_CATALOG_NAME;
+import static io.sparkuctest.UnityCatalogSupport.UC_REMOTE;
+import static io.sparkuctest.UnityCatalogSupport.UC_SCHEMA_NAME;
+import static io.sparkuctest.UnityCatalogSupport.UC_TOKEN;
+import static io.sparkuctest.UnityCatalogSupport.UC_URI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.sparkuctest.UnityCatalogSupport.UnityCatalogInfo;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class UnityCatalogSupportTest {
+
+  private static final List<String> ALL_ENVS =
+      ImmutableList.of(
+          UC_REMOTE, UC_URI, UC_TOKEN, UC_CATALOG_NAME, UC_SCHEMA_NAME, UC_BASE_TABLE_LOCATION);
+
+  @Test
+  public void testUnityCatalogInfo() throws Exception {
+    withEnvTesting(
+        ImmutableMap.of(
+            UC_REMOTE,
+            "true",
+            UC_URI,
+            "http://localhost:8080",
+            UC_TOKEN,
+            "TestRemoteToken",
+            UC_CATALOG_NAME,
+            "TestRemoteCatalog",
+            UC_SCHEMA_NAME,
+            "TestRemoteSchema",
+            UC_BASE_TABLE_LOCATION,
+            "s3://test-bucket/key"),
+        () -> {
+          TestingUCSupport ucSupport = new TestingUCSupport();
+          UnityCatalogInfo uc = ucSupport.accessUnityCatalogInfo();
+          assertThat(uc.catalogName()).isEqualTo("TestRemoteCatalog");
+          assertThat(uc.serverUri()).isEqualTo("http://localhost:8080");
+          assertThat(uc.serverToken()).isEqualTo("TestRemoteToken");
+          assertThat(uc.schemaName()).isEqualTo("TestRemoteSchema");
+          assertThat(uc.baseTableLocation()).isEqualTo("s3://test-bucket/key");
+        });
+  }
+
+  @Test
+  public void testNoUri() throws Exception {
+    withEnvTesting(
+        ImmutableMap.of(
+            UC_REMOTE,
+            "true",
+            UC_TOKEN,
+            "TestRemoteToken",
+            UC_CATALOG_NAME,
+            "TestRemoteCatalog",
+            UC_SCHEMA_NAME,
+            "TestRemoteSchema",
+            UC_BASE_TABLE_LOCATION,
+            "s3://test-bucket/key"),
+        () -> {
+          TestingUCSupport uc = new TestingUCSupport();
+          assertThatThrownBy(uc::accessUnityCatalogInfo)
+              .isInstanceOf(NullPointerException.class)
+              .hasMessageContaining("UC_URI must be set when UC_REMOTE=true");
+        });
+  }
+
+  @Test
+  public void testNoCatalogName() throws Exception {
+    withEnvTesting(
+        ImmutableMap.of(
+            UC_REMOTE,
+            "true",
+            UC_URI,
+            "http://localhost:8080",
+            UC_TOKEN,
+            "TestRemoteToken",
+            UC_SCHEMA_NAME,
+            "TestRemoteSchema",
+            UC_BASE_TABLE_LOCATION,
+            "s3://test-bucket/key"),
+        () -> {
+          TestingUCSupport uc = new TestingUCSupport();
+          assertThatThrownBy(uc::accessUnityCatalogInfo)
+              .isInstanceOf(NullPointerException.class)
+              .hasMessageContaining("UC_CATALOG_NAME must be set when UC_REMOTE=true");
+        });
+  }
+
+  @Test
+  public void testNoToken() throws Exception {
+    withEnvTesting(
+        ImmutableMap.of(
+            UC_REMOTE,
+            "true",
+            UC_URI,
+            "http://localhost:8080",
+            UC_CATALOG_NAME,
+            "TestRemoteCatalog",
+            UC_SCHEMA_NAME,
+            "TestRemoteSchema",
+            UC_BASE_TABLE_LOCATION,
+            "s3://test-bucket/key"),
+        () -> {
+          TestingUCSupport uc = new TestingUCSupport();
+          assertThatThrownBy(uc::accessUnityCatalogInfo)
+              .isInstanceOf(NullPointerException.class)
+              .hasMessageContaining("UC_TOKEN must be set when UC_REMOTE=true");
+        });
+  }
+
+  @Test
+  public void testNoSchemaName() throws Exception {
+    withEnvTesting(
+        ImmutableMap.of(
+            UC_REMOTE,
+            "true",
+            UC_URI,
+            "http://localhost:8080",
+            UC_TOKEN,
+            "TestRemoteToken",
+            UC_CATALOG_NAME,
+            "TestRemoteCatalog",
+            UC_BASE_TABLE_LOCATION,
+            "s3://test-bucket/key"),
+        () -> {
+          TestingUCSupport uc = new TestingUCSupport();
+          assertThatThrownBy(uc::accessUnityCatalogInfo)
+              .isInstanceOf(NullPointerException.class)
+              .hasMessageContaining("UC_SCHEMA_NAME must be set when UC_REMOTE=true");
+        });
+  }
+
+  @Test
+  public void testNoBaseTableLocation() throws Exception {
+    withEnvTesting(
+        ImmutableMap.of(
+            UC_REMOTE,
+            "true",
+            UC_URI,
+            "http://localhost:8080",
+            UC_TOKEN,
+            "TestRemoteToken",
+            UC_CATALOG_NAME,
+            "TestRemoteCatalog",
+            UC_SCHEMA_NAME,
+            "TestRemoteSchema"),
+        () -> {
+          TestingUCSupport uc = new TestingUCSupport();
+          assertThatThrownBy(uc::accessUnityCatalogInfo)
+              .isInstanceOf(NullPointerException.class)
+              .hasMessageContaining("UC_BASE_TABLE_LOCATION must be set when UC_REMOTE=true");
+        });
+  }
+
+  public interface TestCall {
+
+    void call() throws Exception;
+  }
+
+  public void withEnvTesting(Map<String, String> envs, TestCall testCall) throws Exception {
+    // Clear all UC-related environment variables first to ensure clean state
+    ALL_ENVS.forEach(UnityCatalogSupportTest::removeEnv);
+    envs.forEach(UnityCatalogSupportTest::setEnv);
+    try {
+      testCall.call();
+    } finally {
+      // Clean up all UC-related environment variables after test
+      ALL_ENVS.forEach(UnityCatalogSupportTest::removeEnv);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void setEnv(String key, String value) {
+    try {
+      Map<String, String> env = System.getenv();
+      Field f = env.getClass().getDeclaredField("m");
+      f.setAccessible(true);
+      ((Map<String, String>) f.get(env)).put(key, value);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void removeEnv(String key) {
+    try {
+      Map<String, String> env = System.getenv();
+      Field field = env.getClass().getDeclaredField("m");
+      field.setAccessible(true);
+      ((Map<String, String>) field.get(env)).remove(key);
+    } catch (NoSuchFieldException e) {
+      // Ignore if field doesn't exist (different JVM implementation)
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static class TestingUCSupport extends UnityCatalogSupport {
+
+    public UnityCatalogInfo accessUnityCatalogInfo() throws Exception {
+      setupServer();
+      return unityCatalogInfo();
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Backport the [PR](https://github.com/delta-io/delta/pull/5721) from master branch to branch-4.0 branch, via the command

```bash
git cherry-pick 05bbd9a543c09ed44bfcdbd8424e8ec3a80b5dff
Auto-merging build.sbt
Auto-merging spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
[backport-5721 4e487095f] [Spark] Support the spark-uc tests run on various env. (#5721)
 Date: Mon Jan 5 16:36:08 2026 -0800
 5 files changed, 462 insertions(+), 130 deletions(-)
 create mode 100644 spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupportTest.java
```

There is no conflict when do the cherry-pick.


## How was this patch tested?

Let's see what the CI will say firstly, and then I will do the validation which run all the tests under the `sparkUnityCatalog` module against the remote UC server.

Updated: I used this command line to run all the tests against the remote UC server.

```bash
export UC_REMOTE=true
export UC_URI=$UC_URI
export UC_CATALOG_NAME=main
export UC_SCHEMA_NAME=demo_zh
export UC_BASE_TABLE_LOCATION=$S3_BASE_LOCATION

build/sbt "sparkUnityCatalog/testOnly io.sparkuctest.*"
```

And those test results are:

```
[info] Test run started (JUnit Jupiter)
[info] Test io.sparkuctest.UnityCatalogSupportTest#testNoUri() started
[info] Test io.sparkuctest.UnityCatalogSupportTest#testUnityCatalogInfo() started
[info] Test io.sparkuctest.UnityCatalogSupportTest#testNoBaseTableLocation() started
[info] Test io.sparkuctest.UnityCatalogSupportTest#testNoToken() started
[info] Test io.sparkuctest.UnityCatalogSupportTest#testNoCatalogName() started
[info] Test io.sparkuctest.UnityCatalogSupportTest#testNoSchemaName() started
[info] Test run finished: 0 failed, 0 ignored, 6 total, 0.195s
[info] Test run started (JUnit Jupiter)
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testBasicInsertOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testBasicInsertOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeWithDeleteAction(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeWithDeleteAction(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeUpdateOnly(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeUpdateOnly(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeInsertOnly(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeInsertOnly(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testAdvancedInsertOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testAdvancedInsertOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeCombinedInsertAndUpdate(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testMergeCombinedInsertAndUpdate(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testDeleteOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testDeleteOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testUpdateOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#1 started
[info] Test io.sparkuctest.UCDeltaTableDMLTest#testUpdateOperations(io.sparkuctest.UCDeltaTableIntegrationBaseTest$TableType):#2 started
[info] Test run finished: 0 failed, 0 ignored, 16 total, 46.08s
[info] Test run started (JUnit Jupiter)
[info] Test io.sparkuctest.UCManagedTableCreationTest#testCreateManagedTable() started
[info] Test run finished: 0 failed, 0 ignored, 1 total, 2.586s
[info] Passed: Total 23, Failed 0, Errors 0, Passed 23
[success] Total time: 54 s, completed Jan 6, 2026, 11:44:36 AM
```

## Does this PR introduce _any_ user-facing changes?

No
