### PR TITLE
[Spark] Add tests for INSERT INTO BY NAME REPLACE WHERE

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -118,6 +118,17 @@ trait DeltaInsertIntoTest
           s"SELECT ${columns.mkString(", ")} FROM source")
   }
 
+  /** INSERT INTO BY NAME REPLACE WHERE */
+  object SQLInsertOverwriteByNameReplaceWhere extends Insert {
+    val name: String = s"INSERT INTO BY NAME REPLACE WHERE"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = true
+    val isSQL: Boolean = true
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
+      sql(s"INSERT INTO target BY NAME REPLACE WHERE $whereCol = $whereValue " +
+        s"SELECT ${columns.mkString(", ")} FROM source")
+  }
+
   /** INSERT OVERWRITE PARTITION (part = 1) */
   object SQLInsertOverwritePartitionByPosition extends Insert {
     val name: String = s"INSERT OVERWRITE PARTITION (partition)"
@@ -243,6 +254,7 @@ trait DeltaInsertIntoTest
   /** Collects all the types of insert previously defined. */
   protected lazy val allInsertTypes: Set[Insert] = Set(
         SQLInsertOverwriteReplaceWhere,
+        SQLInsertOverwriteByNameReplaceWhere,
         SQLInsertOverwritePartitionByPosition,
         SQLInsertOverwritePartitionColList,
         DFv1InsertIntoDynamicPartitionOverwrite,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark is adding support for BY NAME with INSERT INTO ... REPLACE WHERE: https://github.com/apache/spark/pull/53567/

This PR adds Delta tests to ensure that this works correctly with Delta.

## How was this patch tested?

It's just tests.

## Does this PR introduce _any_ user-facing changes?

No.