### PR TITLE
[Kernel][CommitRange] Throw a more appropriate error when the *resolved* start and end version are not compatible

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -142,6 +142,17 @@ public final class DeltaErrors {
     return new KernelException(message);
   }
 
+  public static KernelException invalidResolvedVersionRange(
+      String tablePath, long startVersion, long endVersion) {
+    String message =
+        String.format(
+            "%s: Invalid resolved version range: after timestamp resolution, "
+                + "startVersion=%d > endVersion=%d. "
+                + "Please adjust the provided timestamp boundaries.",
+            tablePath, startVersion, endVersion);
+    return new KernelException(message);
+  }
+
   /* ------------------------ PROTOCOL EXCEPTIONS ----------------------------- */
   public static UnsupportedProtocolVersionException unsupportedReaderProtocol(
       String tablePath, int tableReaderVersion) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeFactory.java
@@ -18,7 +18,6 @@ package io.delta.kernel.internal.commitrange;
 import static io.delta.kernel.internal.DeltaErrors.*;
 import static io.delta.kernel.internal.DeltaErrorsInternal.*;
 import static io.delta.kernel.internal.DeltaLogActionUtils.listDeltaLogFilesAsIter;
-import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.Utils.resolvePath;
 
 import io.delta.kernel.CommitRangeBuilder;
@@ -124,11 +123,11 @@ class CommitRangeFactory {
 
   private void validateVersionRange(long startVersion, Optional<Long> endVersionOpt) {
     endVersionOpt.ifPresent(
-        endVersion ->
-            checkArgument(
-                startVersion <= endVersion,
-                String.format(
-                    "Resolved startVersion=%d > endVersion=%d", startVersion, endVersion)));
+        endVersion -> {
+          if (startVersion > endVersion) {
+            throw invalidResolvedVersionRange(tablePath.toString(), startVersion, endVersion);
+          }
+        });
   }
 
   private void logResolvedVersions(long startVersion, Optional<Long> endVersionOpt) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/CommitRangeBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/CommitRangeBuilderSuite.scala
@@ -219,8 +219,8 @@ class CommitRangeBuilderSuite extends AnyFunSuite with MockFileSystemClientUtils
       (endBoundary.timestamp.isDefined || endBoundary.version.isDefined)
     ) {
       return Some(
-        classOf[IllegalArgumentException],
-        s"Resolved startVersion=${startBoundary.expectedVersion} > " +
+        classOf[KernelException],
+        s"startVersion=${startBoundary.expectedVersion} > " +
           s"endVersion=${endBoundary.expectedVersion}")
     }
     // Now we query the file list, this is where we fail if the provided versions do not exist


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Currently we throw IllegalArgumentException when the start version is > end version in CommitRangeFactory. Given this error is hit _after_ timestamp resolution, we should throw a user-facing KernelException instead (other *statically* invalid inputs are caught earlier in CommitRangeBuilderImpl).

## How was this patch tested?

Updates tests.

## Does this PR introduce _any_ user-facing changes?

No.
