### PR TITLE
[Feature Request][Spark] Add validateWhere write option to provide atomic validate and commit with append mode similar to replaceWhere

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3194,6 +3194,12 @@
     ],
     "sqlState" : "22003"
   },
+  "DELTA_VALIDATE_WHERE_WITH_OVERWRITE" : {
+    "message" : [
+      "Option '<validateWhere>' <message>"
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_VERSIONS_NOT_CONTIGUOUS" : {
     "message" : [
       "Versions (<versionList>) are not contiguous. ",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1081,6 +1081,13 @@ trait DeltaErrorsBase
         s"Invalid data would be written to partitions $badPartitions."))
   }
 
+  def validateWhereException(validateWhere: String, message: String): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_VALIDATE_WHERE_WITH_OVERWRITE",
+      messageParameters = Array(validateWhere, message)
+    )
+  }
+
   def illegalFilesFound(file: String): Throwable = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_ILLEGAL_FILE_FOUND",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -50,6 +50,7 @@ trait DeltaWriteOptions
   import DeltaOptions._
 
   val replaceWhere: Option[String] = options.get(REPLACE_WHERE_OPTION)
+  val validateWhere: Option[String] = options.get(VALIDATE_WHERE_OPTION)
   val userMetadata: Option[String] = options.get(USER_METADATA_OPTION)
 
   /**
@@ -239,6 +240,12 @@ object DeltaOptions extends DeltaLogging {
 
   /** An option to overwrite only the data that matches predicates over partition columns. */
   val REPLACE_WHERE_OPTION = "replaceWhere"
+  /**
+   * An option to validate that all rows being written match the given predicate, without changing
+   * the write mode semantics (e.g. append remains append). Intended to provide atomic "validate and
+   * commit" behavior for any write mode.
+   */
+  val VALIDATE_WHERE_OPTION = "validateWhere"
   /** An option to allow automatic schema merging during a write operation. */
   val MERGE_SCHEMA_OPTION = "mergeSchema"
   /** An option to allow overwriting schema and partitioning during an overwrite write operation. */
@@ -307,6 +314,7 @@ object DeltaOptions extends DeltaLogging {
 
   val validOptionKeys : Set[String] = Set(
     REPLACE_WHERE_OPTION,
+    VALIDATE_WHERE_OPTION,
     MERGE_SCHEMA_OPTION,
     EXCLUDE_REGEX_OPTION,
     OVERWRITE_SCHEMA_OPTION,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -232,6 +232,25 @@ case class WriteIntoDelta(
       }
     }
 
+    if (mode == SaveMode.Overwrite && options.validateWhere.nonEmpty) {
+      throw DeltaErrors.validateWhereException(
+        DeltaOptions.VALIDATE_WHERE_OPTION,
+        s"cannot be used with `overwrite` mode. Use '${DeltaOptions.REPLACE_WHERE_OPTION}' instead"
+      )
+    }
+
+    // validateWhere is a validation-only predicate. If provided, we enforce it as a write-time
+    // invariant for any write mode (including append), so the write remains atomic
+    // (fail => no commit) and efficient (no second pass).
+    val validateConstraints = options.validateWhere.toSeq.flatMap { validate =>
+      val parsed = parsePredicates(sparkSession, validate)
+      // If validateWhere is set, enforce it via constraints during write.
+      parsed.map { e =>
+        val arbitraryExpression = ArbitraryExpression(e)
+        Check(arbitraryExpression.name, arbitraryExpression.expression)
+      }
+    }
+
     if (txn.readVersion < 0) {
       // Initialize the log path
       deltaLog.createLogDirectoriesIfNotExists()
@@ -240,7 +259,7 @@ case class WriteIntoDelta(
     val (newFiles, addFiles, deletedFiles) = (mode, replaceWhere) match {
       case (SaveMode.Overwrite, Some(predicates)) if !replaceWhereOnDataColsEnabled =>
         // fall back to match on partition cols only when replaceArbitrary is disabled.
-        val newFiles = txn.writeFiles(data, Some(options))
+        val newFiles = txn.writeFiles(data, Some(options), validateConstraints)
         val addFiles = newFiles.collect { case a: AddFile => a }
         // Check to make sure the files we wrote out were actually valid.
         val matchingFiles = DeltaLog.filterFileList(
@@ -256,7 +275,7 @@ case class WriteIntoDelta(
         }
         (newFiles, addFiles, txn.filterFiles(predicates).map(_.remove))
       case (SaveMode.Overwrite, Some(conditions)) if txn.snapshot.version >= 0 =>
-        val constraints = extractConstraints(sparkSession, conditions)
+        val constraints = extractConstraints(sparkSession, conditions) ++ validateConstraints
 
         val removedFileActions = removeFiles(sparkSession, txn, conditions)
         val cdcExistsInRemoveOp = removedFileActions.exists(_.isInstanceOf[AddCDCFile])
@@ -322,9 +341,7 @@ case class WriteIntoDelta(
           newFiles.collect { case a: AddFile => a },
           removedFileActions)
       case (SaveMode.Overwrite, None) =>
-        val newFiles = writeFiles(
-          txn, data, options
-        )
+        val newFiles = txn.writeFiles(data, Some(options), validateConstraints)
         val addFiles = newFiles.collect { case a: AddFile => a }
         val deletedFiles = if (useDynamicPartitionOverwriteMode) {
           // with dynamic partition overwrite for any partition that is being written to all
@@ -337,9 +354,7 @@ case class WriteIntoDelta(
         }
         (newFiles, addFiles, deletedFiles)
       case _ =>
-        val newFiles = writeFiles(
-          txn, data, options
-        )
+        val newFiles = txn.writeFiles(data, Some(options), validateConstraints)
         (newFiles, newFiles.collect { case a: AddFile => a }, Nil)
     }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR introduces a new write-time validation option validateWhere to provide atomic “validate and commit” semantics without changing the write mode behavior.
Today, replaceWhere provides validation semantics but is tied to mode("overwrite") and has overwrite-specific behavior (partition/data replacement). Users who want the same “only commit if data matches predicate” behavior for append (and other non-overwrite writes) have no dedicated option.

**Changes included:**
- Add a new DataFrameWriter option called **validateWhere**.
- When set, parse the predicate and enforce it as a write-time constraint and abort the write if any row violates it
- `validateWhere` fails with mode("overwrite") and the error message instructs users to use `replaceWhere` instead.
- Resolves delta-io/delta#5764

## How was this patch tested?

- Added the below UT's for testing the feature:
     - `append + validateWhere `succeeds when all rows match predicate
     - `append + validateWhere `fails atomically when any row violates predicate
     - `overwrite + validateWhere` is not allowed (use replaceWhere instead)

- Built the assembly jar with the fix and tested it on a cluster using the below code:

**code:**

```
import org.apache.spark.sql.functions._
val tbl = s"default.table_5764_${System.currentTimeMillis()}"

// Create a partitioned Delta table
spark.sql(s"DROP TABLE IF EXISTS $tbl")

spark.sql(
  s"""
     |CREATE TABLE $tbl (
     |  id INT,
     |  ds STRING
     |)
     |USING delta
     |PARTITIONED BY (ds)
     |""".stripMargin
)

// insert sample data
spark
  .range(0, 3)
  .select(
    col("id").cast("int"),
    lit("2026-01-01").as("ds")
  )
  .write
  .format("delta")
  .mode("append")
  .saveAsTable(tbl)

// Incoming data contains a bad row outside the predicate
val incoming = Seq(
  (10, "2026-01-01"),
  (11, "2099-01-01") // violates the replaceWhere predicate
).toDF("id", "ds")

// append + validateWhere should pass
try {
  incoming
    .write
    .format("delta")
    .mode(“append")
    .option("validateWhere", "ds = '2026-01-01'")
    .saveAsTable(tbl)
} catch {
  case e: Throwable =>
    println("Expected: overwrite+replaceWhere failed")
    println(e.getMessage)
}

```

## Does this PR introduce _any_ user-facing changes?

Yes.
**New option**: users can now set `option("validateWhere", "<predicate>") `with append mode on writes to enforce predicate compliance at write time with atomic failure.This way the current `replaceWhere` semantics is kept unchanged .
**Overwrite behavior:** validateWhere is not allowed with **mode("overwrite")** and users should use replaceWhere for overwrite semantics.
