### PR TITLE
add-table-property-for-skipping-prefix-string-length

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -670,6 +670,18 @@ trait DeltaConfigsBase extends DeltaLogging {
       |collected.
       |""".stripMargin)
 
+  /**
+   * For string columns, how long prefix to store in the data skipping index.
+   * Note that the behavior from table property overrides the config:
+   * [[DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH]]
+   */
+  val DATA_SKIPPING_STRING_PREFIX_LENGTH = buildConfig[Option[Int]](
+    "dataSkippingStringPrefixLength",
+    null,
+    v => Option(v).map(_.toInt),
+    v => v.forall(_ >= 0),
+    "needs to be greater or equal to zero.")
+
   val SYMLINK_FORMAT_MANIFEST_ENABLED = buildConfig[Boolean](
     s"${hooks.GenerateSymlinkManifest.CONFIG_NAME_ROOT}.enabled",
     "false",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.commands.{DeletionVectorBitmapGenerator, DMLWi
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_TYPE_COLUMN_NAME, CDC_TYPE_NOT_CDC}
 import org.apache.spark.sql.delta.commands.merge.MergeOutputGeneration.{SOURCE_ROW_INDEX_COL, TARGET_ROW_INDEX_COL}
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
+import org.apache.spark.sql.delta.stats.StatsCollectionUtils
 import org.apache.spark.sql.delta.util.SetAccumulator
 
 import org.apache.spark.sql.{Column, Dataset, SparkSession}
@@ -552,7 +553,8 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
     val (dvActions, metricsMap) = DMLWithDeletionVectorsHelper.processUnmodifiedData(
       spark,
       touchedFilesWithDVs,
-      deltaTxn.snapshot)
+      deltaTxn.snapshot,
+      StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, deltaTxn.metadata))
 
     metrics("numTargetDeletionVectorsAdded")
       .set(metricsMap.getOrElse("numDeletionVectorsAdded", 0L))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.DELTA_COLLECT_STATS_USING_TABLE_SCHEMA
 import org.apache.spark.sql.delta.stats.{
   DeltaJobStatisticsTracker,
-  StatisticsCollection
+  StatisticsCollection,
+  StatsCollectionUtils
 }
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.Path
@@ -370,6 +371,8 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
         override val spark: SparkSession = data.sparkSession
         override val statsColumnSpec = StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
         override val protocol: Protocol = newProtocol.getOrElse(snapshot.protocol)
+        override def getDataSkippingStringPrefixLength: Int =
+          StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, metadata)
       }
       val (statsColExpr, newOutputStatsCollectionSchema) =
         getStatsColExpr(outputStatsCollectionSchema, statsCollection)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.stats.{DeltaStatistics, SkippingEligibleDataType, StatisticsCollection}
+import org.apache.spark.sql.delta.stats.{DeltaStatistics, SkippingEligibleDataType, StatisticsCollection, StatsCollectionUtils}
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
 import org.apache.spark.sql.{AnalysisException, SparkSession}
@@ -336,6 +336,8 @@ trait ClusteredTableUtilsBase extends DeltaLogging {
       override val statsColumnSpec = StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
       override val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
       override val protocol: Protocol = p
+      override def getDataSkippingStringPrefixLength: Int =
+        StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, metadata)
 
       override def spark: SparkSession = {
         throw new Exception("Method not used in statisticsCollectionFromMetadata")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -1114,6 +1114,10 @@ trait DataSkippingReaderBase
   final protected[delta] def getStatsColumnOrNullLiteral(stat: StatsColumn): Column =
     getStatsColumnOpt(stat.pathToStatType, stat.pathToColumn).getOrElse(lit(null))
 
+  /** Overload for delta table property override */
+  override protected def getDataSkippingStringPrefixLength: Int =
+    StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, metadata)
+
   /**
    * Returns an expression that can be used to check that the required statistics are present for a
    * given file. If any required statistics are missing we must include the corresponding file.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -238,6 +238,13 @@ trait StatisticsCollection extends DeltaLogging {
   }
 
   /**
+   * Returns the prefix length of strings that should be used for data skipping.
+   * Intentionally left abstract to let implementation decide whether table property overrides
+   * need to be included.
+   */
+  protected def getDataSkippingStringPrefixLength: Int
+
+  /**
    * Returns a struct column that can be used to collect statistics for the current
    * schema of the table.
    * The types we keep stats on must be consistent with DataSkippingReader.SkippingEligibleLiteral.
@@ -245,8 +252,7 @@ trait StatisticsCollection extends DeltaLogging {
    * collect the NULL_COUNT stats for it as the number of rows.
    */
   lazy val statsCollector: Column = {
-    val stringPrefix =
-      spark.sessionState.conf.getConf(DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH)
+    val stringPrefix = getDataSkippingStringPrefixLength
 
     // On file initialization/stat recomputation TIGHT_BOUNDS is always set to true
     val tightBoundsColOpt =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -24,11 +24,12 @@ import java.time.LocalDateTime
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.StatisticsCollection.{ASCII_MAX_CHARACTER, UTF8_MAX_CHARACTER}
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils, TestsStatistics}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 import org.scalatest.exceptions.TestFailedException
 
@@ -81,6 +82,8 @@ class StatsCollectionSuite
         )
         override def columnMappingMode: DeltaColumnMappingMode = deltaLog.snapshot.columnMappingMode
         override val protocol: Protocol = snapshot.protocol
+        override def getDataSkippingStringPrefixLength: Int =
+          StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, snapshot.metadata)
       }
 
       val correctAnswer = dataRenamed
@@ -923,6 +926,231 @@ class StatsCollectionSuite
     val df = getStatsDf(deltaLog, Seq($"numRecords", minValues, maxValues))
     val numRecordsCol = df.schema.head.name
     df.withColumnRenamed(numRecordsCol, "numRecords")
+  }
+
+  /**
+   * Checks if the min/max values in the collected stats for the given string column are truncated
+   * to the expected length.
+   */
+  private def checkDataSkippingStringPrefixLength(
+      tableName: String,
+      columnName: String,
+      expectedLength: Int,
+      minValueRowContent: String,
+      maxValueRowContent: String): Unit = {
+    val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))
+    val physicalColumnName = DeltaColumnMapping.getPhysicalName(
+      SchemaUtils.findNestedFieldIgnoreCase(snapshot.schema, Seq(columnName)).get)
+
+    val statsDf = statsDF(deltaLog)
+    val minValue = statsDf
+      .select(s"`struct(minValues.$physicalColumnName)`")
+      .collect().last
+      .getStruct(0).getString(0)
+    val maxValue = statsDf
+      .select(s"`struct(maxValues.$physicalColumnName)`")
+      .collect().last
+      .getStruct(0).getString(0)
+
+    assert(minValue == minValueRowContent.take(expectedLength))
+    assert(maxValue == maxValueRowContent.take(expectedLength) + ASCII_MAX_CHARACTER)
+  }
+
+  statsTest("Data-skipping-string-prefix-length delta table property override: basic") {
+    val tableName = "delta_table"
+    val strCol = "strCol"
+    withTable(tableName) {
+      val (a1000, b1000, c1000) = ("a" * 1000, "b" * 1000, "c" * 1000)
+
+      // Create a table with table property override.
+      sql(
+        s"""
+           | create table $tableName ($strCol string) using delta tblproperties
+           | ('${DeltaConfigs.DATA_SKIPPING_STRING_PREFIX_LENGTH.key}' = '64')
+           |""".stripMargin)
+      sql(s"insert into $tableName values ('$a1000'), ('$b1000'), ('$c1000')")
+      checkDataSkippingStringPrefixLength(
+        tableName,
+        columnName = strCol,
+        expectedLength = 64,
+        minValueRowContent = a1000,
+        maxValueRowContent = c1000
+      )
+    }
+  }
+
+  statsTest("Data-skipping-string-prefix-length delta table property override: recompute stats") {
+    val tableName = "delta_table"
+    val strCol = "strCol"
+    withTable(tableName) {
+      val (a1000, b1000, c1000) = ("a" * 1000, "b" * 1000, "c" * 1000)
+
+      // Create a table without table property override.
+      sql(s"create table $tableName ($strCol string) using delta")
+      sql(s"insert into $tableName values ('$a1000'), ('$b1000'), ('$c1000')")
+      checkDataSkippingStringPrefixLength(
+        tableName,
+        columnName = strCol,
+        expectedLength = DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH.defaultValue.get,
+        minValueRowContent = a1000,
+        maxValueRowContent = c1000
+      )
+
+      // Set the table property override and recompute stats.
+      sql(
+        s"""
+           | alter table $tableName set tblproperties
+           | ('${DeltaConfigs.DATA_SKIPPING_STRING_PREFIX_LENGTH.key}' = '64')
+           | """.stripMargin)
+      sql(s"analyze table $tableName compute delta statistics")
+      checkDataSkippingStringPrefixLength(
+        tableName,
+        columnName = strCol,
+        expectedLength = 64,
+        minValueRowContent = a1000,
+        maxValueRowContent = c1000
+      )
+    }
+  }
+
+  statsTest("Data-skipping-string-prefix-length delta table property override: RTAS") {
+    val tableName = "delta_table"
+    val sourceTableName = "source_table"
+    val strCol = "strCol"
+    withTable(tableName, sourceTableName) {
+      val (a1000, b1000, c1000) = ("a" * 1000, "b" * 1000, "c" * 1000)
+      val (x1000, y1000, z1000) = ("x" * 1000, "y" * 1000, "z" * 1000)
+
+      // Create a source table.
+      sql(s"create table $sourceTableName ($strCol string) using delta")
+      sql(s"insert into $sourceTableName values ('$a1000'), ('$b1000'), ('$c1000')")
+
+      // Create a table without table property override.
+      sql(s"create table $tableName (strCol string) using delta")
+      sql(s"insert into $tableName values ('$x1000'), ('$y1000'), ('$z1000')")
+      checkDataSkippingStringPrefixLength(
+        tableName,
+        columnName = strCol,
+        expectedLength = DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH.defaultValue.get,
+        minValueRowContent = x1000,
+        maxValueRowContent = z1000
+      )
+
+      // Replace the table with table property override by selecting from the source table.
+      sql(
+        s"""
+           | replace table $tableName using delta tblproperties
+           | ('${DeltaConfigs.DATA_SKIPPING_STRING_PREFIX_LENGTH.key}' = '64')
+           | as (select * from $sourceTableName)
+           | """.stripMargin)
+      checkDataSkippingStringPrefixLength(
+        tableName,
+        columnName = strCol,
+        expectedLength = 64,
+        minValueRowContent = a1000,
+        maxValueRowContent = c1000
+      )
+    }
+  }
+
+  statsTest("Data-skipping-string-prefix-length delta table property override: Add/Remove Files") {
+    /**
+     * In the commit JSON file at the given version, checks if the min/max values for the given
+     * string column stored in the Add/Remove File action are truncated to the expected length.
+     */
+    def checkStringPrefixLengthInAction(
+        tableName: String,
+        version: Long,
+        action: String,
+        columnName: String,
+        expectedLength: Int,
+        minValueRowContent: String,
+        maxValueRowContent: String): Unit = {
+      val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))
+      val physicalColumnName = DeltaColumnMapping.getPhysicalName(
+        SchemaUtils.findNestedFieldIgnoreCase(snapshot.schema, Seq(columnName)).get)
+      val commit = spark.read.json(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toString)
+      val actionFile = commit.filter(col(action).isNotNull).select(s"$action.*")
+      val minMaxStatsSchema = StructType(Seq(
+        StructField("minValues", StructType(Seq(StructField(physicalColumnName, StringType)))),
+        StructField("maxValues", StructType(Seq(StructField(physicalColumnName, StringType))))
+      ))
+      val actionFileWithParsedStats = actionFile.withColumn(
+        "parsed_stats", from_json(col("stats"), minMaxStatsSchema))
+      val minValue = actionFileWithParsedStats
+        .select(col(s"parsed_stats.minValues.$physicalColumnName"))
+        .collect().last.getString(0)
+      val maxValue = actionFileWithParsedStats
+        .select(col(s"parsed_stats.maxValues.$physicalColumnName"))
+        .collect().last.getString(0)
+
+      assert(minValue == minValueRowContent.take(expectedLength))
+      assert(maxValue == maxValueRowContent.take(expectedLength) + ASCII_MAX_CHARACTER)
+    }
+
+    val tableName = "delta_table"
+    val strCol = "strCol"
+    withTable(tableName) {
+      // Create a table without table property override.
+      sql(s"create table $tableName ($strCol string) using delta")
+
+      val (a1000, b1000, c1000) = ("a" * 1000, "b" * 1000, "c" * 1000)
+
+      sql(s"insert into $tableName values ('$a1000'), ('$b1000'), ('$c1000')")
+      // [Add File] Min: "a" * 32, Max: "c" * 32
+      checkStringPrefixLengthInAction(
+        tableName,
+        version = 1,
+        action = "add",
+        columnName = strCol,
+        expectedLength = DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH.defaultValue.get,
+        minValueRowContent = a1000,
+        maxValueRowContent = c1000
+      )
+      sql(s"delete from $tableName where $strCol = '$b1000'")
+      // [Remove File] Min: "a" * 32, Max: "c" * 32
+      checkStringPrefixLengthInAction(
+        tableName,
+        version = 2,
+        action = "remove",
+        columnName = strCol,
+        expectedLength = DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH.defaultValue.get,
+        minValueRowContent = a1000,
+        maxValueRowContent = c1000
+      )
+
+      // Set the table property override.
+      sql(
+        s"""
+           | alter table $tableName set tblproperties
+           | ('${DeltaConfigs.DATA_SKIPPING_STRING_PREFIX_LENGTH.key}' = '64')
+           | """.stripMargin)
+
+      val (x1000, y1000, z1000) = ("x" * 1000, "y" * 1000, "z" * 1000)
+
+      sql(s"insert into $tableName values ('$x1000'), ('$y1000'), ('$z1000')")
+      // [Add File] Min: "x" * 64, Max: "z" * 64
+      checkStringPrefixLengthInAction(
+        tableName,
+        version = 4,
+        action = "add",
+        columnName = strCol,
+        expectedLength = 64,
+        minValueRowContent = x1000,
+        maxValueRowContent = z1000
+      )
+      sql(s"delete from $tableName where $strCol = '$y1000'")
+      // [Remove File] Min: "x" * 64, Max: "z" * 64
+      checkStringPrefixLengthInAction(
+        tableName,
+        version = 5,
+        action = "remove",
+        columnName = strCol,
+        expectedLength = 64,
+        minValueRowContent = x1000,
+        maxValueRowContent = z1000
+      )
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR provides a table property "delta.dataSkippingStringPrefixLength" that allows DBSQL users to override the prefix length table-wise.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
