### PR TITLE
[SPARK] Improve check for V2WriteCommand with fallback to V1 in PrepareDeltaScan

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -37,7 +37,9 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.PROJECT
+import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback
 import org.apache.spark.sql.execution.datasources.{FileIndex, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -194,8 +196,17 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
     val updatedPlan = if (shouldPrepareDeltaScan) {
       // Should not be applied to subqueries to avoid duplicate delta jobs.
       val isSubquery = isSubqueryRoot(plan)
+      // Should not be applied to DataSourceV2 write plans, because they'll be planned later
+      // through a V1 fallback and only that later planning takes place within the transaction.
+      val targetHasV1Fallback = plan match {
+        case v2: V2WriteCommand => v2.table match {
+          case r: DataSourceV2Relation => r.table.isInstanceOf[V2TableWithV1Fallback]
+          case _ => false
+        }
+        case _ => false
+      }
 
-      if (isSubquery) {
+      if (isSubquery || targetHasV1Fallback) {
         return plan
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -194,10 +194,8 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
     val updatedPlan = if (shouldPrepareDeltaScan) {
       // Should not be applied to subqueries to avoid duplicate delta jobs.
       val isSubquery = isSubqueryRoot(plan)
-      // Should not be applied to DataSourceV2 write plans, because they'll be planned later
-      // through a V1 fallback and only that later planning takes place within the transaction.
-      val isDataSourceV2 = plan.isInstanceOf[V2WriteCommand]
-      if (isSubquery || isDataSourceV2) {
+
+      if (isSubquery) {
         return plan
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.PROJECT
-import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback
+import org.apache.spark.sql.connector.catalog.TableCapability
 import org.apache.spark.sql.execution.datasources.{FileIndex, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.StructType
@@ -198,13 +198,7 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       val isSubquery = isSubqueryRoot(plan)
       // Should not be applied to DataSourceV2 write plans, because they'll be planned later
       // through a V1 fallback and only that later planning takes place within the transaction.
-      val targetHasV1Fallback = plan match {
-        case v2: V2WriteCommand => v2.table match {
-          case r: DataSourceV2Relation => r.table.isInstanceOf[V2TableWithV1Fallback]
-          case _ => false
-        }
-        case _ => false
-      }
+      val targetHasV1Fallback = writeWillFallBackToV1(plan)
 
       if (isSubquery || targetHasV1Fallback) {
         return plan
@@ -218,6 +212,29 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       prepareDeltaScanWithoutFileSkipping(plan)
     }
     updatedPlan
+  }
+
+  /**
+   * Returns true iff `plan` is a [[V2WriteCommand]] that will be re-planned through Spark's
+   * V1 batch write fallback path. For such plans [[PrepareDeltaScan]] is skipped now so that
+   * the V1 fallback planning (which runs inside the OptimisticTransaction) prepares the
+   * scan instead. For V2 write plans that do NOT fall back to V1 (e.g. noop, Iceberg) we
+   * must run [[PrepareDeltaScan]] now, otherwise the TahoeLogFileIndex will never be
+   * replaced with a PreparedDeltaFileIndex and PreprocessTableWithDVs will fail with
+   * "Cannot work with a non-pinned table snapshot".
+   *
+   * V1 fallback is detected via the V1_BATCH_WRITE table capability, which is the same gate
+   * Spark itself uses in DataSourceV2Strategy: a V2 table advertising this capability is
+   * contractually required to return a V1Write from its WriteBuilder and is routed to V1
+   * write nodes (e.g. AppendDataExecV1).
+   */
+  private def writeWillFallBackToV1(plan: LogicalPlan): Boolean = plan match {
+    case v2: V2WriteCommand => v2.table match {
+      case r: DataSourceV2Relation =>
+        r.table.capabilities().contains(TableCapability.V1_BATCH_WRITE)
+      case _ => false
+    }
+    case _ => false
   }
 
   protected def prepareDeltaScanWithoutFileSkipping(plan: LogicalPlan): LogicalPlan = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -37,7 +37,9 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.PROJECT
+import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback
 import org.apache.spark.sql.execution.datasources.{FileIndex, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -199,8 +201,17 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
     val updatedPlan = if (shouldPrepareDeltaScan) {
       // Should not be applied to subqueries to avoid duplicate delta jobs.
       val isSubquery = isSubqueryRoot(plan)
+      // Should not be applied to DataSourceV2 write plans, because they'll be planned later
+      // through a V1 fallback and only that later planning takes place within the transaction.
+      val targetHasV1Fallback = plan match {
+        case v2: V2WriteCommand => v2.table match {
+          case r: DataSourceV2Relation => r.table.isInstanceOf[V2TableWithV1Fallback]
+          case _ => false
+        }
+        case _ => false
+      }
 
-      if (isSubquery) {
+      if (isSubquery || targetHasV1Fallback) {
         return plan
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -199,10 +199,8 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
     val updatedPlan = if (shouldPrepareDeltaScan) {
       // Should not be applied to subqueries to avoid duplicate delta jobs.
       val isSubquery = isSubqueryRoot(plan)
-      // Should not be applied to DataSourceV2 write plans, because they'll be planned later
-      // through a V1 fallback and only that later planning takes place within the transaction.
-      val isDataSourceV2 = plan.isInstanceOf[V2WriteCommand]
-      if (isSubquery || isDataSourceV2) {
+
+      if (isSubquery) {
         return plan
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.PROJECT
-import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback
+import org.apache.spark.sql.connector.catalog.TableCapability
 import org.apache.spark.sql.execution.datasources.{FileIndex, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.StructType
@@ -203,13 +203,7 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       val isSubquery = isSubqueryRoot(plan)
       // Should not be applied to DataSourceV2 write plans, because they'll be planned later
       // through a V1 fallback and only that later planning takes place within the transaction.
-      val targetHasV1Fallback = plan match {
-        case v2: V2WriteCommand => v2.table match {
-          case r: DataSourceV2Relation => r.table.isInstanceOf[V2TableWithV1Fallback]
-          case _ => false
-        }
-        case _ => false
-      }
+      val targetHasV1Fallback = writeWillFallBackToV1(plan)
 
       if (isSubquery || targetHasV1Fallback) {
         return plan
@@ -223,6 +217,29 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       prepareDeltaScanWithoutFileSkipping(plan)
     }
     updatedPlan
+  }
+
+  /**
+   * Returns true iff `plan` is a [[V2WriteCommand]] that will be re-planned through Spark's
+   * V1 batch write fallback path. For such plans [[PrepareDeltaScan]] is skipped now so that
+   * the V1 fallback planning (which runs inside the OptimisticTransaction) prepares the
+   * scan instead. For V2 write plans that do NOT fall back to V1 (e.g. noop, Iceberg) we
+   * must run [[PrepareDeltaScan]] now, otherwise the TahoeLogFileIndex will never be
+   * replaced with a PreparedDeltaFileIndex and PreprocessTableWithDVs will fail with
+   * "Cannot work with a non-pinned table snapshot".
+   *
+   * V1 fallback is detected via the V1_BATCH_WRITE table capability, which is the same gate
+   * Spark itself uses in DataSourceV2Strategy: a V2 table advertising this capability is
+   * contractually required to return a V1Write from its WriteBuilder and is routed to V1
+   * write nodes (e.g. AppendDataExecV1).
+   */
+  private def writeWillFallBackToV1(plan: LogicalPlan): Boolean = plan match {
+    case v2: V2WriteCommand => v2.table match {
+      case r: DataSourceV2Relation =>
+        r.table.capabilities().contains(TableCapability.V1_BATCH_WRITE)
+      case _ => false
+    }
+    case _ => false
   }
 
   protected def prepareDeltaScanWithoutFileSkipping(plan: LogicalPlan): LogicalPlan = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -161,6 +161,19 @@ class DeletionVectorsSuite extends QueryTest
     assert(deltaLog.createDataFrame(snapshot, selectFiles).count() == rowCount - deletedRowCount)
   }
 
+  test("read Delta table with DV, write to Data Source V2") {
+    withTempDir { dirName =>
+      val df = spark.read
+        .format("delta")
+        .load(table2Path)
+
+      df.write
+        .format("noop")
+        .mode("overwrite")
+        .save()
+    }
+  }
+
   for (optimizeMetadataQuery <- BOOLEAN_DOMAIN)
     test("read Delta tables with DVs in subqueries: " +
       s"metadataQueryOptimizationEnabled=$optimizeMetadataQuery") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -161,7 +161,40 @@ class DeletionVectorsSuite extends QueryTest
     assert(deltaLog.createDataFrame(snapshot, selectFiles).count() == rowCount - deletedRowCount)
   }
 
+  // ---------------------------------------------------------------------------------------------
+  // Regression tests for https://github.com/delta-io/delta/issues/4794
+  //
+  // Bug: When reading a Delta table that has Deletion Vectors and writing the result through the
+  // DataSource V2 write path (e.g. `df.write.format("noop").save()` or `df.writeTo(...).append()`
+  // / DataFrameWriterV2), the query failed with:
+  //
+  //   java.lang.IllegalArgumentException: requirement failed:
+  //   Cannot work with a non-pinned table snapshot of the TahoeFileIndex
+  //
+  // (raised by PreprocessTableWithDVs.ScanWithDeletionVectors.dvEnabledScanFor).
+  //
+  // Root cause: PrepareDeltaScan unconditionally skipped every V2WriteCommand plan. That skip was
+  // originally added so that Delta-to-Delta V2 writes are re-planned via Spark's V1 batch write
+  // fallback inside the OptimisticTransaction (preserving isBlindAppend semantics - see commit
+  // 8553b1c2). However, for V2 sinks that do NOT fall back to V1 (e.g. `noop`, Iceberg), nothing
+  // else replaces the TahoeLogFileIndex with a PreparedDeltaFileIndex, so PreprocessTableWithDVs
+  // hit a non-pinned file index and threw.
+  //
+  // Fix: PrepareDeltaScan now skips a V2WriteCommand only when its target DataSourceV2Relation
+  // advertises the V1_BATCH_WRITE capability - i.e. when Spark will actually re-plan the write
+  // through the V1 fallback (the same gate DataSourceV2Strategy uses). Delta-to-Delta V2 writes
+  // still get skipped (DeltaTableV2 declares V1_BATCH_WRITE), while V2 sinks like noop/Iceberg
+  // now correctly flow through PrepareDeltaScan.
+  //
+  // All tests below exercise this fix from slightly different angles.
+  // ---------------------------------------------------------------------------------------------
+
   test("read Delta table with DV, write to Data Source V2") {
+    // Original repro from the bug report: a plain DataFrame read from a DV-enabled Delta table
+    // piped into a V2 sink without V1 fallback (`format("noop")`). Before the fix this threw
+    // "Cannot work with a non-pinned table snapshot of the TahoeFileIndex" because the V2 write
+    // plan was incorrectly skipped by PrepareDeltaScan and PreprocessTableWithDVs subsequently
+    // saw a TahoeLogFileIndex instead of a PreparedDeltaFileIndex.
     withTempDir { dirName =>
       val df = spark.read
         .format("delta")
@@ -173,6 +206,62 @@ class DeletionVectorsSuite extends QueryTest
         .save()
     }
   }
+
+  test("read Delta table with DV, write to Data Source V2 - append mode") {
+    // Same scenario as above with a different SaveMode. The bug being fixed is unrelated to
+    // mode, so this provides additional coverage that PrepareDeltaScan correctly pins the
+    // TahoeLogFileIndex for any V2 write whose target does not advertise V1_BATCH_WRITE.
+    spark.read.format("delta").load(table2Path)
+      .write.format("noop").mode("append").save()
+  }
+
+  test("read partitioned Delta table with DV, write to Data Source V2") {
+    // Exercises the fix with a partitioned source that has DVs, ensuring the partition
+    // pruning paths still work end-to-end when the target is a V2 sink without V1 fallback.
+    spark.read.format("delta").load(table3Path)
+      .write.format("noop").mode("overwrite").save()
+  }
+
+  test("read Delta table with DV via temp view, write to Data Source V2") {
+    // Routes the DV-enabled source through SQL / temp view resolution, exercising a
+    // slightly different logical plan shape (SubqueryAlias above the relation) than the
+    // direct DataFrame read above.
+    withTempView("dv_source_view") {
+      spark.read.format("delta").load(table2Path)
+        .createOrReplaceTempView("dv_source_view")
+      sql("SELECT value FROM dv_source_view WHERE value % 2 = 0")
+        .write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  test("read Delta table with DV with filter, write to Data Source V2") {
+    // Sanity-check that DV filtering of the source still produces the expected rows after
+    // PrepareDeltaScan runs on this V2 plan: table2 has 0 and 9 deleted via DV, leaving
+    // (1..8); the additional WHERE keeps only odd values, so 4 rows should remain.
+    val df = spark.read.format("delta").load(table2Path).where("value % 2 = 1")
+    assert(df.count() === 4)
+    df.write.format("noop").mode("overwrite").save()
+  }
+
+  test("read DV-enabled Delta source, V2 write to a separate Delta target") {
+    // Delta-to-Delta V2 writes go through Spark's V1 batch write fallback because
+    // DeltaTableV2 advertises V1_BATCH_WRITE. PrepareDeltaScan must still skip these V2
+    // write plans so that the V1-fallback planning inside the OptimisticTransaction records
+    // the scan and sets commit metadata (e.g. isBlindAppend) correctly. This regression
+    // test confirms the new capability-based skip preserves that behavior with a DV source.
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      withTable("dv_v2_target") {
+        sql(s"CREATE TABLE dv_v2_target(value INT) USING delta LOCATION '$path'")
+        spark.read.format("delta").load(table2Path)
+          .writeTo("dv_v2_target").append()
+        checkAnswer(spark.table("dv_v2_target"), expectedTable2DataV1.toDF())
+      }
+    }
+  }
+  // ---------------------------------------------------------------------------------------------
+  // End of regression tests for https://github.com/delta-io/delta/issues/4794
+  // ---------------------------------------------------------------------------------------------
 
   for (optimizeMetadataQuery <- BOOLEAN_DOMAIN)
     test("read Delta tables with DVs in subqueries: " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -164,6 +164,19 @@ class DeletionVectorsSuite extends QueryTest
     assert(deltaLog.createDataFrame(snapshot, selectFiles).count() == rowCount - deletedRowCount)
   }
 
+  test("read Delta table with DV, write to Data Source V2") {
+    withTempDir { dirName =>
+      val df = spark.read
+        .format("delta")
+        .load(table2Path)
+
+      df.write
+        .format("noop")
+        .mode("overwrite")
+        .save()
+    }
+  }
+
   for (optimizeMetadataQuery <- BOOLEAN_DOMAIN)
     test("read Delta tables with DVs in subqueries: " +
       s"metadataQueryOptimizationEnabled=$optimizeMetadataQuery") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -164,7 +164,40 @@ class DeletionVectorsSuite extends QueryTest
     assert(deltaLog.createDataFrame(snapshot, selectFiles).count() == rowCount - deletedRowCount)
   }
 
+  // ---------------------------------------------------------------------------------------------
+  // Regression tests for https://github.com/delta-io/delta/issues/4794
+  //
+  // Bug: When reading a Delta table that has Deletion Vectors and writing the result through the
+  // DataSource V2 write path (e.g. `df.write.format("noop").save()` or `df.writeTo(...).append()`
+  // / DataFrameWriterV2), the query failed with:
+  //
+  //   java.lang.IllegalArgumentException: requirement failed:
+  //   Cannot work with a non-pinned table snapshot of the TahoeFileIndex
+  //
+  // (raised by PreprocessTableWithDVs.ScanWithDeletionVectors.dvEnabledScanFor).
+  //
+  // Root cause: PrepareDeltaScan unconditionally skipped every V2WriteCommand plan. That skip was
+  // originally added so that Delta-to-Delta V2 writes are re-planned via Spark's V1 batch write
+  // fallback inside the OptimisticTransaction (preserving isBlindAppend semantics - see commit
+  // 8553b1c2). However, for V2 sinks that do NOT fall back to V1 (e.g. `noop`, Iceberg), nothing
+  // else replaces the TahoeLogFileIndex with a PreparedDeltaFileIndex, so PreprocessTableWithDVs
+  // hit a non-pinned file index and threw.
+  //
+  // Fix: PrepareDeltaScan now skips a V2WriteCommand only when its target DataSourceV2Relation
+  // advertises the V1_BATCH_WRITE capability - i.e. when Spark will actually re-plan the write
+  // through the V1 fallback (the same gate DataSourceV2Strategy uses). Delta-to-Delta V2 writes
+  // still get skipped (DeltaTableV2 declares V1_BATCH_WRITE), while V2 sinks like noop/Iceberg
+  // now correctly flow through PrepareDeltaScan.
+  //
+  // All tests below exercise this fix from slightly different angles.
+  // ---------------------------------------------------------------------------------------------
+
   test("read Delta table with DV, write to Data Source V2") {
+    // Original repro from the bug report: a plain DataFrame read from a DV-enabled Delta table
+    // piped into a V2 sink without V1 fallback (`format("noop")`). Before the fix this threw
+    // "Cannot work with a non-pinned table snapshot of the TahoeFileIndex" because the V2 write
+    // plan was incorrectly skipped by PrepareDeltaScan and PreprocessTableWithDVs subsequently
+    // saw a TahoeLogFileIndex instead of a PreparedDeltaFileIndex.
     withTempDir { dirName =>
       val df = spark.read
         .format("delta")
@@ -176,6 +209,62 @@ class DeletionVectorsSuite extends QueryTest
         .save()
     }
   }
+
+  test("read Delta table with DV, write to Data Source V2 - append mode") {
+    // Same scenario as above with a different SaveMode. The bug being fixed is unrelated to
+    // mode, so this provides additional coverage that PrepareDeltaScan correctly pins the
+    // TahoeLogFileIndex for any V2 write whose target does not advertise V1_BATCH_WRITE.
+    spark.read.format("delta").load(table2Path)
+      .write.format("noop").mode("append").save()
+  }
+
+  test("read partitioned Delta table with DV, write to Data Source V2") {
+    // Exercises the fix with a partitioned source that has DVs, ensuring the partition
+    // pruning paths still work end-to-end when the target is a V2 sink without V1 fallback.
+    spark.read.format("delta").load(table3Path)
+      .write.format("noop").mode("overwrite").save()
+  }
+
+  test("read Delta table with DV via temp view, write to Data Source V2") {
+    // Routes the DV-enabled source through SQL / temp view resolution, exercising a
+    // slightly different logical plan shape (SubqueryAlias above the relation) than the
+    // direct DataFrame read above.
+    withTempView("dv_source_view") {
+      spark.read.format("delta").load(table2Path)
+        .createOrReplaceTempView("dv_source_view")
+      sql("SELECT value FROM dv_source_view WHERE value % 2 = 0")
+        .write.format("noop").mode("overwrite").save()
+    }
+  }
+
+  test("read Delta table with DV with filter, write to Data Source V2") {
+    // Sanity-check that DV filtering of the source still produces the expected rows after
+    // PrepareDeltaScan runs on this V2 plan: table2 has 0 and 9 deleted via DV, leaving
+    // (1..8); the additional WHERE keeps only odd values, so 4 rows should remain.
+    val df = spark.read.format("delta").load(table2Path).where("value % 2 = 1")
+    assert(df.count() === 4)
+    df.write.format("noop").mode("overwrite").save()
+  }
+
+  test("read DV-enabled Delta source, V2 write to a separate Delta target") {
+    // Delta-to-Delta V2 writes go through Spark's V1 batch write fallback because
+    // DeltaTableV2 advertises V1_BATCH_WRITE. PrepareDeltaScan must still skip these V2
+    // write plans so that the V1-fallback planning inside the OptimisticTransaction records
+    // the scan and sets commit metadata (e.g. isBlindAppend) correctly. This regression
+    // test confirms the new capability-based skip preserves that behavior with a DV source.
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      withTable("dv_v2_target") {
+        sql(s"CREATE TABLE dv_v2_target(value INT) USING delta LOCATION '$path'")
+        spark.read.format("delta").load(table2Path)
+          .writeTo("dv_v2_target").append()
+        checkAnswer(spark.table("dv_v2_target"), expectedTable2DataV1.toDF())
+      }
+    }
+  }
+  // ---------------------------------------------------------------------------------------------
+  // End of regression tests for https://github.com/delta-io/delta/issues/4794
+  // ---------------------------------------------------------------------------------------------
 
   for (optimizeMetadataQuery <- BOOLEAN_DOMAIN)
     test("read Delta tables with DVs in subqueries: " +


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Fix #4794.
Previous code was assuming the write is always to a Delta table (or that all V2 fallback to V1), which is not always true.
For example:

```
val df = spark.read
  .format("delta")
  .load("....")

df
  .write
  .format("iceberg") // or noop
  .mode("overwrite")
  .saveAsTable("IcebergTable01")
```

I tracked related changes:

1. The reason the assert exists:

https://github.com/delta-io/delta/issues/2443#issuecomment-1887612294

> The reason for the assert is because `TahoeLogFileIndex` is unstable that is not yet pinned to a particular version of the table snapshot. According to [@ryan-johnson-databricks](https://github.com/ryan-johnson-databricks) , if it has`isTimeTravel=true`, then it is stable. There is a special case in PrepareDeltaScan when data skipping is disabled, it generates `TahoeLogFileIndex` with `isTimeTravel=fasle`.
> 
> More on this assert: We have a rule PreprocessTablesWithDVs that alters the query scan with an additional (filePath to DV) broadcast map for reading DVs. This rules immediately after the PrepareDeltaScan rule [here](https://github.com/delta-io/delta/blob/24f2d935cef6e7bd574af17e6bcfadb7bfd4cb1f/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala#L218). In PreprocessTablesWithDVs, we enforce a [requirement](https://github.com/delta-io/delta/blob/24f2d935cef6e7bd574af17e6bcfadb7bfd4cb1f/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableWithDVs.scala#L88) that the scan shouldn’t have TahoeLogFileIndex as it is not stable as it is not yet pinned. However when data skipping is disabled, we keep the TahoeLogFileIndex with isTimeTravel=false. This fails the assert in PreprocessTablesWithDVs.

2. ActiveOptimisticTransactionRule.scala‎ first created by https://github.com/delta-io/delta/commit/cd3047bdd1fa9625e7810c1554c7a24f911bb009 doesn't contain the check. It fixes https://github.com/delta-io/delta/issues/550

3. The check for `V2WriteCommand` was first introduced here:

https://github.com/delta-io/delta/commit/8553b1c27dd7286ce626b10c66b02a006a7e5cac

The comment says:

    // Skip this rule for V2 write commands - it will be evaluated later when the V1 fallback
    // is planned. We don't want to pin the file index yet because we're not in the transaction.

With this PR change, the behavior is closer to what is described in the comment

4. ActiveOptimisticTransactionRule.scala has been deleted and code moved to PrepareDeltaScan.scala: https://github.com/delta-io/delta/commit/0ed90b5822cd23c3d44b1a685d90f66cc741362e

## How was this patch tested?
Manually tested in Spark with Iceberg

## Does this PR introduce _any_ user-facing changes?
Bug fix only
