### PR TITLE
[kernel-spark] Refactor DeltaSourceSuite such that both dsv1 and dsv2 code paths are tested 

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.delta.DeltaSourceSuite
 /**
  * Test suite that runs DeltaSourceSuite using the V2 connector (V2_ENABLE_MODE=STRICT).
  */
-class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
+class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
 
   override protected def useDsv2: Boolean = true
 
@@ -77,37 +77,22 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
     // === Schema Evolution ===
     "allow to change schema before starting a streaming query",
     "restarting a query should pick up latest table schema and recover",
-    "handling nullability schema changes",
-    "allow user specified schema if consistent: v1 source",
-    "disallow user specified schema",
-    "createSource should create source with empty or matching table schema provided",
+    "disallow to change schema after starting a streaming query",
 
     // === Null Type Column Handling ===
     "streaming delta source should not drop null columns",
     "streaming delta source should drop null columns without feature flag",
-    "DeltaLog.createDataFrame should drop null columns with feature flag",
-    "DeltaLog.createDataFrame should not drop null columns without feature flag",
 
     // === read options ===
     "skip change commits",
     "excludeRegex works and doesn't mess up offsets across restarts - parquet version",
+    "excludeRegex throws good error on bad regex pattern",
     "startingVersion: user defined start works with mergeSchema",
     "startingVersion latest calls update when starting",
     "startingVersion should be ignored when restarting from a checkpoint, withRowTracking = true",
     "startingVersion should be ignored when restarting from a checkpoint, withRowTracking = false",
     "startingTimestamp",
     "startingVersion and startingTimestamp are both set",
-
-    // === Other tests that bypass V2 by not using loadStreamWithOptions ===
-    "disallow to change schema after starting a streaming query",
-    "recreate the reservoir should fail the query",
-    "excludeRegex throws good error on bad regex pattern",
-    "SC-46515: deltaSourceIgnoreChangesError contains removeFile, version, tablePath",
-    "SC-46515: deltaSourceIgnoreDeleteError contains removeFile, version, tablePath",
-    "Delta sources should verify the protocol reader version",
-    "can delete old files of a snapshot without update",
-    "Delta source advances with non-data inserts and generates empty dataframe for " +
-      "non-data operations",
 
     // === Data Loss Detection ===
     "fail on data loss - starting from missing files",
@@ -124,25 +109,41 @@ class DeltaSourceDSv2Suite extends DeltaSourceSuite with V2ForceTest {
     "Rate limited Delta source advances with non-data inserts",
     "ES-445863: delta source should not hang or reprocess data when using AvailableNow",
 
-    // === Source Offset / Version Handling ===
-    "unknown sourceVersion value",
-    "invalid sourceVersion value",
-    "missing sourceVersion",
-    "unmatched reservoir id",
-    "isInitialSnapshot serializes as isStartingVersion",
-    "DeltaSourceOffset deserialization",
-    "DeltaSourceOffset deserialization error",
-    "DeltaSourceOffset serialization",
-    "DeltaSourceOffset.validateOffsets",
-
     // === Misc ===
     "no schema should throw an exception",
-    "Delta source advances with non-data inserts and generates empty dataframe for addl files",
     "a fast writer should not starve a Delta source",
+    "recreate the reservoir should fail the query",
+    "SC-46515: deltaSourceIgnoreChangesError contains removeFile, version, tablePath",
+    "SC-46515: deltaSourceIgnoreDeleteError contains removeFile, version, tablePath",
+    "Delta sources should verify the protocol reader version",
+    "can delete old files of a snapshot without update",
+    "Delta source advances with non-data inserts and generates empty dataframe for " +
+      "non-data operations",
+    "Delta source advances with non-data inserts and generates empty dataframe for addl files",
     "start from corrupt checkpoint",
-    "make sure that the delta sources works fine",
     "should not attempt to read a non exist version",
-    "self union a Delta table should pass the catalog table assert"
+
+    // === Tests that bypass V2 by not using loadStreamWithOptions ===
+    "disallow user specified schema", // Uses .schema() directly
+    "make sure that the delta sources works fine", // Uses .delta() directly
+    "self union a Delta table should pass the catalog table assert", // Uses .table() directly
+    "handling nullability schema changes", // Uses .table() directly
+    "allow user specified schema if consistent: v1 source", // Uses DataSource directly
+    // Calls deltaSource.createSource() directly
+    "createSource should create source with empty or matching table schema provided",
+    // Unit test for internal API
+    "DeltaLog.createDataFrame should drop null columns with feature flag",
+    // Unit test for internal API
+    "DeltaLog.createDataFrame should not drop null columns without feature flag",
+    "unknown sourceVersion value", // Unit test for DeltaSourceOffset
+    "invalid sourceVersion value", // Unit test for DeltaSourceOffset
+    "missing sourceVersion", // Unit test for DeltaSourceOffset
+    "unmatched reservoir id", // Unit test for DeltaSourceOffset
+    "isInitialSnapshot serializes as isStartingVersion", // Unit test for DeltaSourceOffset
+    "DeltaSourceOffset deserialization", // Unit test for DeltaSourceOffset
+    "DeltaSourceOffset deserialization error", // Unit test for DeltaSourceOffset
+    "DeltaSourceOffset serialization", // Unit test for DeltaSourceOffset
+    "DeltaSourceOffset.validateOffsets" // Unit test for DeltaSourceOffset
   )
 
   override protected def shouldFail(testName: String): Boolean = {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5810/files) to review incremental changes.
- [stack/cache](https://github.com/delta-io/delta/pull/5811) [[Files changed](https://github.com/delta-io/delta/pull/5811/files)]
- stack/deletionfix
- stack/snapshot
- [**stack/testrefactor**](https://github.com/delta-io/delta/pull/5810) [[Files changed](https://github.com/delta-io/delta/pull/5810/files)]
  - [stack/testaudit](https://github.com/delta-io/delta/pull/5819) [[Files changed](https://github.com/delta-io/delta/pull/5819/files/5eecc27e9e77e1a608a1555a5ca024165c335b1c..53c18d82de68afa15c1ef2dae62d6a765078a0d1)]
  - [stack/testaudit2](https://github.com/delta-io/delta/pull/5845) [[Files changed](https://github.com/delta-io/delta/pull/5845/files/5eecc27e9e77e1a608a1555a5ca024165c335b1c..6800336508bc911435cad784dce821e843500cbb)]
    - stack/testaudit3

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Refactor `DeltaSourceSuite` to use the `loadStreamWithOptions` helper method
* This ensures tests properly respect the `useDsv2` configuration and test both DSv1 and DSv2 code paths
Reorganize the shouldFailTests list in `DeltaSourceDSv2Suite`. 

Also had to fix a bunch of scalastyle issues (started failing after https://github.com/delta-io/delta/pull/5699). 

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

DeltaSourceSuite & DSv2DeltaSourceSuite

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
