### PR TITLE
[Spark] Refactors the Delta INSERT testing framework to use the explicit .option("mergeSchema") for DF INSERT APIs instead of the SQL Conf

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
@@ -53,7 +53,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           .add("b", IntegerType)
           .add("c", IntegerType)),
       includeInserts = insertsByName,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     testInserts(s"insert with missing nested field, schemaEvolution=$schemaEvolution")(
@@ -71,7 +71,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
             .add("y", IntegerType)
           )),
       includeInserts = insertsByName.intersect(insertsDataframe),
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     // Missing columns for all inserts by name and missing nested fields for dataframe inserts by
@@ -90,7 +90,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           .add("b", IntegerType)
           .add("c", IntegerType)),
       includeInserts = insertsByName.intersect(insertsSQL) + StreamingInsert,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     testInserts(s"insert with implicit cast and missing top-level column," +
@@ -111,7 +111,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           ))
       }),
       includeInserts = insertsByName.intersect(insertsDataframe) - StreamingInsert,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     testInserts(s"insert with implicit cast and missing nested field," +
@@ -134,7 +134,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           ))
       }),
       includeInserts = insertsByName.intersect(insertsDataframe) - StreamingInsert,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
   testInserts(s"insert with implicit cast and missing nested field," +
@@ -154,7 +154,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
             .add("x", IntegerType)
             .add("y", IntegerType))),
       includeInserts = Set(StreamingInsert),
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     // Missing columns for all inserts by position and missing nested fields for all inserts by
@@ -177,7 +177,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           ))
       }),
       includeInserts = insertsByPosition,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     testInserts(s"insert with implicit cast and missing top-level column," +
@@ -198,7 +198,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           ))
       }),
       includeInserts = insertsByPosition,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     testInserts(s"insert with missing nested field, schemaEvolution=$schemaEvolution")(
@@ -220,7 +220,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           ))
       }),
       includeInserts = insertsByPosition ++ insertsSQL,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
 
     testInserts(s"insert with implicit cast and missing nested field," +
@@ -243,7 +243,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           ))
       }),
       includeInserts = insertsByPosition ++ insertsSQL,
-      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+      withSchemaEvolution = schemaEvolution
     )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
@@ -28,11 +28,6 @@ class TypeWideningInsertSchemaEvolutionExtendedSuite
   with DeltaDMLTestUtils
   with TypeWideningTestMixin
   with TypeWideningInsertSchemaEvolutionExtendedTests {
-
-  protected override def sparkConf: SparkConf = {
-    super.sparkConf
-      .set(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key, "true")
-  }
 }
 
 trait TypeWideningInsertSchemaEvolutionExtendedTests
@@ -47,7 +42,8 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
     insertData = TestData("a int, b int", Seq("""{ "a": 1, "b": 4 }""")),
     expectedResult = ExpectedResult.Success(new StructType()
       .add("a", IntegerType)
-      .add("b", IntegerType))
+      .add("b", IntegerType)),
+    withSchemaEvolution = true
   )
 
   testInserts("top-level type evolution with column upcast")(
@@ -58,7 +54,8 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
     expectedResult = ExpectedResult.Success(new StructType()
       .add("a", IntegerType)
       .add("b", IntegerType)
-      .add("c", IntegerType))
+      .add("c", IntegerType)),
+    withSchemaEvolution = true
   )
 
   testInserts("top-level type evolution with schema evolution")(
@@ -71,7 +68,8 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
       .add("b", IntegerType)
       .add("c", IntegerType)),
     // SQL INSERT by name doesn't support schema evolution.
-    excludeInserts = insertsSQL.intersect(insertsByName)
+    excludeInserts = insertsSQL.intersect(insertsByName),
+    withSchemaEvolution = true
   )
 
 
@@ -90,7 +88,8 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
         .add("x", ShortType)
         .add("y", IntegerType))
       .add("m", MapType(StringType, IntegerType))
-      .add("a", ArrayType(IntegerType)))
+      .add("a", ArrayType(IntegerType))),
+    withSchemaEvolution = true
   )
 
 
@@ -110,7 +109,8 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
         .add("y", IntegerType)
         .add("z", IntegerType))
       .add("m", MapType(StringType, IntegerType))
-      .add("a", ArrayType(IntegerType)))
+      .add("a", ArrayType(IntegerType))),
+    withSchemaEvolution = true
   )
 
 
@@ -127,7 +127,8 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
       .add("key", IntegerType)
       .add("s", new StructType()
         .add("x", IntegerType)
-        .add("y", IntegerType)))
+        .add("y", IntegerType))),
+    withSchemaEvolution = true
   )
 
   // Interestingly, we introduced a special case to handle schema evolution / casting for structs
@@ -146,7 +147,8 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
       .add("key", IntegerType)
       .add("a", ArrayType(new StructType()
         .add("x", IntegerType)
-        .add("y", IntegerType))))
+        .add("y", IntegerType)))),
+    withSchemaEvolution = true
   )
 
   // maps now allow type evolution for INSERT by position and name in SQL and dataframe.
@@ -164,6 +166,7 @@ trait TypeWideningInsertSchemaEvolutionExtendedTests
       // Type evolution was applied in the map.
       .add("m", MapType(StringType, new StructType()
         .add("x", IntegerType)
-        .add("y", IntegerType))))
+        .add("y", IntegerType)))),
+    withSchemaEvolution = true
   )
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningUniformTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningUniformTests.scala
@@ -204,9 +204,11 @@ trait TypeWideningUniformTests extends QueryTest
           testCase.initialValuesDF.write.format("delta").saveAsTable("target")
           testCase.additionalValuesDF.write.format("delta").saveAsTable("source")
           enableIcebergUniform("target", IcebergCompatV2)
-          withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
-            insert.runInsert(columns = Seq("value"), whereCol = "value", whereValue = 1)
-          }
+          insert.runInsert(
+            columns = Seq("value"),
+            whereCol = "value",
+            whereValue = 1,
+            withSchemaEvolution = true)
           val result = sql(s"SELECT * FROM target")
           assert(result.schema("value").dataType === testCase.toType)
           checkAnswer(result, testCase.expectedResult)
@@ -231,10 +233,13 @@ trait TypeWideningUniformTests extends QueryTest
             .saveAsTable("source")
           enableIcebergUniform("target", IcebergCompatV2)
           withSQLConf(
-            DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true",
             DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key -> "true"
           ) {
-            insert.runInsert(columns = Seq("value"), whereCol = "value", whereValue = 1)
+            insert.runInsert(
+              columns = Seq("value"),
+              whereCol = "value",
+              whereValue = 1,
+              withSchemaEvolution = true)
           }
           val result = sql(s"SELECT * FROM target")
           val expected = testCase.initialValuesDF.union(testCase.initialValuesDF)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
- Refactors the Delta INSERT testing framework to use the explicit `.option("mergeSchema")` for DF INSERT APIs instead of the SQL Conf, but still use the SQL Conf for the SQL INSERT APIs.
- This is so that we can test the `WITH SCHEMA EVOLUTION` SQL Clause when we introduce it in the future for the SQL INSERT APIs (this clause was already introduced for `MERGE`).
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
