### PR TITLE
[SPARK] Enable faster bit interleaving algorithm by default

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2037,7 +2037,7 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .internal()
       .doc("When true, a faster version of the bit interleaving algorithm is used.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val INTERNAL_UDF_OPTIMIZATION_ENABLED =
     buildConf("internalUdfOptimization.enabled")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Fix #5815

More context: https://github.com/delta-io/delta/pull/1160#discussion_r893746168.

The plan was to enable it by default after a couple releases (after 2.0/2.1), but I think we completely forgot it.

`Given this is a new approach, should we set the default to false and make it default to true after the couple of releases and more confidence?` - https://github.com/delta-io/delta/pull/1160#discussion_r893746168

The PR says perf is around 30% better: #1160

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
Config default