### PR TITLE
[Spark] Fix CharType/VarcharType pattern matching for Spark master

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -163,8 +163,8 @@ object TypeWidening {
       // Implementations shouldn't record these type changes in the table metadata per the Delta
       // spec, but in case that happen we really shouldn't block reading the table.
       case (_, TypeChange(_,
-        _: StringType | CharType(_) | VarcharType(_),
-        _: StringType | CharType(_) | VarcharType(_), _)) =>
+        _: StringType | _: CharType | _: VarcharType,
+        _: StringType | _: CharType | _: VarcharType, _)) =>
       case (fieldPath, TypeChange(_, from: AtomicType, to: AtomicType, _))
         if stableFeatureCanReadTypeChange(from, to) =>
         val featureName = if (protocol.isFeatureSupported(TypeWideningPreviewTableFeature)) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
@@ -253,8 +253,8 @@ private[delta] object TypeWideningMetadata extends DeltaLogging {
   /** Returns whether the given type change is Char/Varchar/String or collation type change. */
   private def isStringTypeChange(from: AtomicType, to: AtomicType): Boolean = (from, to) match {
     case (
-      _: StringType | CharType(_) | VarcharType(_),
-      _: StringType | CharType(_) | VarcharType(_)) => true
+      _: StringType | _: CharType | _: VarcharType,
+      _: StringType | _: CharType | _: VarcharType) => true
     case _ => false
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Update pattern matching for CharType and VarcharType to use type tests (`_: CharType`, `_: VarcharType`) instead of extractors (`CharType(_)`, `VarcharType(_)`).

This is needed because Spark master (apache/spark@192327f) added collation support to char/varchar types, introducing an additional constructor parameter that breaks the previous pattern matching.

## How was this patch tested?

Builds now.

## Does this PR introduce _any_ user-facing changes?

No

Generated-By: Claude Opus 4.5