### PR TITLE
[Build] Fix the Spark-4.2.0-SNAPSHOT building issue

### DIFF
--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -152,11 +152,12 @@ class CrossSparkPublishTest:
         """Runs an SBT command and returns True if successful."""
         print(f"  {description}")
         try:
+            # Run command with output going to console (inherit parent's stdout/stderr)
             subprocess.run(command, cwd=self.delta_root, check=True,
-                          stdout=subprocess.STDOUT, stderr=subprocess.STDOUT)
+                          stdout=None, stderr=None)
             return True
-        except subprocess.CalledProcessError:
-            print(f"  ✗ Command failed: {' '.join(command)}")
+        except subprocess.CalledProcessError as e:
+            print(f"  ✗ Command failed with exit code {e.returncode}: {' '.join(command)}")
             return False
 
     def validate_jars(self, expected: Set[str], test_name: str) -> bool:


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

We are encountering the failure when building the Spark-4.2.0-SNAPSHOT with publishing, but it does not show what's the specific root cause. 

```
======================================================================
TEST: Cross-Spark Workflow (all Spark versions)
======================================================================
Cleaning Maven cache: /home/runner/.m2/repository/io/delta
✓ Maven cache cleaned

  Step 1: build/sbt publishM2 (Spark 4.0.1 - all modules)
  Step 2: build/sbt -DsparkVersion=4.1.0 "runOnlyForReleasableSparkModules publishM2" (Spark 4.1.0 - Spark-dependent only)
  Step 2: build/sbt -DsparkVersion=4.2.0-SNAPSHOT "runOnlyForReleasableSparkModules publishM2" (Spark 4.2.0-SNAPSHOT - Spark-dependent only)
  ✗ Command failed: build/sbt -DsparkVersion=4.2.0-SNAPSHOT runOnlyForReleasableSparkModules publishM2

======================================================================
TEST SUMMARY
======================================================================

Part 1: Spark Versions Script Tests
  JSON Format:                            ✓ PASSED
  All Spark Versions Output:              ✓ PASSED
  Released Spark Versions Output:         ✓ PASSED
  Get Field Functionality:                ✓ PASSED

Part 2: Cross-Spark Build Tests
  Default publishM2:                      ✓ PASSED
  runOnlyForReleasableSparkModules:       ✓ PASSED
  Cross-Spark Workflow:                   ✗ FAILED
======================================================================

✗ SOME TESTS FAILED
```

Let's add a log message to show the error message and see what's the root cause.

## How was this patch tested?

The github CI will be happy if the thing is fixed. 

## Does this PR introduce _any_ user-facing changes?

No.
