### PR TITLE
[Spark] Add `sqlState` for `MetadataMismatch` errors

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1789,6 +1789,42 @@
     ],
     "sqlState" : "2D521"
   },
+  "DELTA_METADATA_MISMATCH" : {
+    "message" : [
+      "A metadata mismatch was detected when writing to the Delta table."
+    ],
+    "subClass" : {
+      "OVERWRITE_REQUIRED" : {
+        "message" : [
+          "To overwrite your schema or change partitioning, please set: '.option(\"overwriteSchema\", \"true\")'.",
+          "Note that the schema can't be overwritten when using 'replaceWhere'."
+        ]
+      },
+      "PARTITIONING_MISMATCH" : {
+        "message" : [
+          "Partition columns do not match the partition columns of the table.",
+          "Given: <provided>",
+          "Table: <original>",
+          ""
+        ]
+      },
+      "SCHEMA_MISMATCH" : {
+        "message" : [
+          "A schema mismatch detected when writing to the Delta table (Table ID: <id>).",
+          "To enable schema migration using DataFrameWriter or DataStreamWriter, please set: '.option(\"mergeSchema\", \"true\")'.",
+          "For other operations, set the session configuration spark.databricks.delta.schema.autoMerge.enabled to \"true\". See the documentation specific to the operation for details.",
+          "",
+          "Table schema:",
+          "<tableSchema>",
+          "",
+          "Data schema:",
+          "<dataSchema>",
+          ""
+        ]
+      }
+    },
+    "sqlState" : "42KDG"
+  },
   "DELTA_MISSING_CHANGE_DATA" : {
     "message" : [
       "Error getting change data for range [<startVersion> , <endVersion>] as change data was not",
@@ -3330,11 +3366,6 @@
   "_LEGACY_ERROR_TEMP_DELTA_0006" : {
     "message" : [
       "Inconsistent IDENTITY metadata for column <colName> detected: <hasStart>, <hasStep>, <hasInsert>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_DELTA_0007" : {
-    "message" : [
-      "<message>"
     ]
   },
   "_LEGACY_ERROR_TEMP_DELTA_0008" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -4039,47 +4039,32 @@ class ConcurrentTransactionException(message: String)
 
 /** A helper class in building a helpful error message in case of metadata mismatches. */
 class MetadataMismatchErrorBuilder {
-  private var bits: Seq[String] = Nil
+  private var subErrors: Seq[(String, Array[String])] = Nil
 
   def addSchemaMismatch(original: StructType, data: StructType, id: String): Unit = {
-    bits ++=
-      s"""A schema mismatch detected when writing to the Delta table (Table ID: $id).
-         |To enable schema migration using DataFrameWriter or DataStreamWriter, please set:
-         |'.option("${DeltaOptions.MERGE_SCHEMA_OPTION}", "true")'.
-         |For other operations, set the session configuration
-         |${DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key} to "true". See the documentation
-         |specific to the operation for details.
-         |
-         |Table schema:
-         |${DeltaErrors.formatSchema(original)}
-         |
-         |Data schema:
-         |${DeltaErrors.formatSchema(data)}
-         """.stripMargin :: Nil
+    subErrors :+= ("SCHEMA_MISMATCH", Array(
+      id,
+      DeltaErrors.formatSchema(original),
+      DeltaErrors.formatSchema(data)
+    ))
   }
 
   def addPartitioningMismatch(original: Seq[String], provided: Seq[String]): Unit = {
-    bits ++=
-      s"""Partition columns do not match the partition columns of the table.
-         |Given: ${DeltaErrors.formatColumnList(provided)}
-         |Table: ${DeltaErrors.formatColumnList(original)}
-         """.stripMargin :: Nil
+    subErrors :+= ("PARTITIONING_MISMATCH", Array(
+      DeltaErrors.formatColumnList(provided),
+      DeltaErrors.formatColumnList(original)
+    ))
   }
 
   def addOverwriteBit(): Unit = {
-    bits ++=
-      s"""To overwrite your schema or change partitioning, please set:
-         |'.option("${DeltaOptions.OVERWRITE_SCHEMA_OPTION}", "true")'.
-         |
-           |Note that the schema can't be overwritten when using
-         |'${DeltaOptions.REPLACE_WHERE_OPTION}'.
-         """.stripMargin :: Nil
+    subErrors :+= ("OVERWRITE_REQUIRED", Array.empty[String])
   }
 
   def finalizeAndThrow(conf: SQLConf): Unit = {
-    throw new DeltaAnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
-      messageParameters = Array(bits.mkString("\n"))
+    throw new DeltaAnalysisExceptionWithSubErrors(
+      errorClass = "DELTA_METADATA_MISMATCH",
+      messageParameters = Array.empty[String],
+      subErrors = subErrors
     )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2684,6 +2684,7 @@ trait DeltaErrorsSuiteBase
         "colName" -> "col1", "hasStart" -> "true", "hasStep" -> "true", "hasInsert" -> "true"))
     }
     {
+      // Test MetadataMismatchErrorBuilder with single sub-error (schema mismatch)
       val errorBuilder = new MetadataMismatchErrorBuilder()
       val schema1 = StructType(Seq(StructField("c0", IntegerType)))
       val schema2 = StructType(Seq(StructField("c0", StringType)))
@@ -2691,7 +2692,78 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         errorBuilder.finalizeAndThrow(spark.sessionState.conf)
       }
-      assert(e.getErrorClass == "_LEGACY_ERROR_TEMP_DELTA_0007")
+      checkError(e, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+      // Verify complete message format with main message + sub-error bullet
+      val message = e.getMessage
+      assert(message.contains(
+        """[DELTA_METADATA_MISMATCH] A metadata mismatch was detected when writing to the Delta table.
+          |- A schema mismatch detected when writing to the Delta table (Table ID: id).
+          |To enable schema migration using DataFrameWriter or DataStreamWriter, please set: '.option("mergeSchema", "true")'.
+          |For other operations, set the session configuration spark.databricks.delta.schema.autoMerge.enabled to "true". See the documentation specific to the operation for details.
+          |
+          |Table schema:
+          |root
+          | |-- c0: integer (nullable = true)
+          |
+          |
+          |Data schema:
+          |root
+          | |-- c0: string (nullable = true)
+          |""".stripMargin))
+    }
+    // Test with multiple sub-errors
+    {
+      val errorBuilder = new MetadataMismatchErrorBuilder()
+      val schema1 = StructType(Seq(StructField("c0", IntegerType)))
+      val schema2 = StructType(Seq(StructField("c0", StringType)))
+      errorBuilder.addSchemaMismatch(schema1, schema2, "test-id")
+      errorBuilder.addPartitioningMismatch(Seq("part1"), Seq("part2"))
+      errorBuilder.addOverwriteBit()
+      val e = intercept[DeltaAnalysisException] {
+        errorBuilder.finalizeAndThrow(spark.sessionState.conf)
+      }
+      checkError(e, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+      // Verify complete message format with main message + three sub-error bullets
+      val message = e.getMessage
+      assert(message.contains(
+        """[DELTA_METADATA_MISMATCH] A metadata mismatch was detected when writing to the Delta table.
+          |- A schema mismatch detected when writing to the Delta table (Table ID: test-id).
+          |To enable schema migration using DataFrameWriter or DataStreamWriter, please set: '.option("mergeSchema", "true")'.
+          |For other operations, set the session configuration spark.databricks.delta.schema.autoMerge.enabled to "true". See the documentation specific to the operation for details.
+          |
+          |Table schema:
+          |root
+          | |-- c0: integer (nullable = true)
+          |
+          |
+          |Data schema:
+          |root
+          | |-- c0: string (nullable = true)
+          |
+          |
+          |- Partition columns do not match the partition columns of the table.
+          |Given: [`part2`]
+          |Table: [`part1`]
+          |
+          |- To overwrite your schema or change partitioning, please set: '.option("overwriteSchema", "true")'.
+          |Note that the schema can't be overwritten when using 'replaceWhere'.""".stripMargin))
+    }
+    // Test with partitioning mismatch only
+    {
+      val errorBuilder = new MetadataMismatchErrorBuilder()
+      errorBuilder.addPartitioningMismatch(Seq("year", "month"), Seq("date"))
+      val e = intercept[DeltaAnalysisException] {
+        errorBuilder.finalizeAndThrow(spark.sessionState.conf)
+      }
+      checkError(e, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+      // Verify complete message format with main message + one sub-error bullet
+      val message = e.getMessage
+      assert(message.contains(
+        """[DELTA_METADATA_MISMATCH] A metadata mismatch was detected when writing to the Delta table.
+          |- Partition columns do not match the partition columns of the table.
+          |Given: [`date`]
+          |Table: [`year`, `month`]
+          |""".stripMargin))
     }
     {
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -63,12 +63,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             .add("c", IntegerType))
       } else {
         ExpectedResult.Failure(ex => {
-          checkErrorMatchPVals(
-            ex,
-            "_LEGACY_ERROR_TEMP_DELTA_0007",
-            parameters = Map(
-              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
-            ))
+          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
         })
       },
       excludeInserts = Set(
@@ -97,12 +92,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             .add("c", IntegerType))
       } else {
         ExpectedResult.Failure(ex => {
-          checkErrorMatchPVals(
-            ex,
-            "_LEGACY_ERROR_TEMP_DELTA_0007",
-            parameters = Map(
-              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
-            ))
+          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
         })
       },
       includeInserts = insertsByPosition + StreamingInsert,
@@ -171,12 +161,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             ))
       } else {
         ExpectedResult.Failure(ex => {
-          checkErrorMatchPVals(
-            ex,
-            "_LEGACY_ERROR_TEMP_DELTA_0007",
-            parameters = Map(
-              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
-            ))
+          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
         })
       },
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
@@ -233,12 +218,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             ))
       } else {
         ExpectedResult.Failure(ex => {
-          checkErrorMatchPVals(
-            ex,
-            "_LEGACY_ERROR_TEMP_DELTA_0007",
-            parameters = Map(
-              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
-            ))
+          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
         })
       },
       includeInserts = insertsSQL ++ insertsByPosition + StreamingInsert -- Seq(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -330,13 +330,7 @@ class DeltaInsertIntoSQLSuite
           .format("delta")
           .insertInto(tableName)
       }
-      checkErrorMatchPVals(
-        exception = err,
-        "_LEGACY_ERROR_TEMP_DELTA_0007",
-        parameters = Map(
-          "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
-        )
-      )
+      checkError(err, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
 
       // insert data with schema evolution
       withSQLConf("spark.databricks.delta.schema.autoMerge.enabled" -> "true") {
@@ -407,13 +401,7 @@ class DeltaInsertIntoSQLSuite
       val e = intercept[AnalysisException] {
         sql("INSERT INTO target SELECT * FROM source")
       }
-      checkErrorMatchPVals(
-        exception = e,
-        "_LEGACY_ERROR_TEMP_DELTA_0007",
-        parameters = Map(
-          "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
-        )
-      )
+      checkError(e, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
         sql("INSERT INTO target SELECT * FROM source")
@@ -448,13 +436,7 @@ class DeltaInsertIntoSQLSuite
       val e = intercept[AnalysisException] {
         sql("INSERT INTO target SELECT * FROM source")
       }
-      checkErrorMatchPVals(
-        exception = e,
-        "_LEGACY_ERROR_TEMP_DELTA_0007",
-        parameters = Map(
-          "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
-        )
-      )
+      checkError(e, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
         sql("INSERT INTO target SELECT * FROM source")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add sqlState for MetadataMismatch. Currently they are marked as DeltaAnalysisException with _LEGACY_ERROR_TEMP_DELTA_0007.
This PR replaces the legacy error code with a proper error code defined using multiple sub-classes.

## How was this patch tested?
Unit test and existing tests. Only error message improvement, expecting no real change to the original error.

## Does this PR introduce _any_ user-facing changes?

No.
