### PR TITLE
Update CharType/VarcharType pattern matches for Spark SPARK-54870 compatibility

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/CharVarcharConstraint.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/CharVarcharConstraint.scala
@@ -37,11 +37,11 @@ object CharVarcharConstraint {
   }
 
   private def checkStringLength(expr: Expression, dt: DataType): Option[Expression] = dt match {
-    case VarcharType(length) =>
-      Some(Or(IsNull(expr), LessThanOrEqual(Length(expr), Literal(length))))
+    case v: VarcharType =>
+      Some(Or(IsNull(expr), LessThanOrEqual(Length(expr), Literal(v.length))))
 
-    case CharType(length) =>
-      checkStringLength(expr, VarcharType(length))
+    case c: CharType =>
+      checkStringLength(expr, VarcharType(c.length))
 
     case StructType(fields) =>
       fields.zipWithIndex.flatMap { case (f, i) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed `CharType` and `VarcharType` pattern matches from extractor patterns to type patterns:
- `case VarcharType(length) =>` → `case v: VarcharType =>`
- `case CharType(length) =>` → `case c: CharType =>`

## Why are the changes needed?

In Apache Spark master branch, https://github.com/apache/spark/pull/53643 added collation support to `CharType` and `VarcharType`, which introduces a new field to these case classes. This breaks existing extractor pattern matches.

Using type patterns (`case c: CharType =>`) instead of extractor patterns (`case CharType(length) =>`) ensures compatibility with the updated Spark type hierarchy.

## Does this PR introduce any user-facing changes?

No.