### PR TITLE
[kernel-spark] Fix initial snapshot file filtering to include metadata checkpoint files

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -57,6 +57,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     // === Schema Evolution ===
     "restarting a query should pick up latest table schema and recover",
     "disallow to change schema after starting a streaming query",
+    "allow to change schema before starting a streaming query",
 
     // ========== startingVersion option tests ==========
     "startingVersion",
@@ -74,13 +75,12 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "maxBytesPerTrigger: change and restart",
     "maxBytesPerTrigger: invalid parameter",
     "maxBytesPerTrigger: max bytes and max files together",
-    "startingVersion should work with rate time"
+    "startingVersion should work with rate time",
+    "maxFilesPerTrigger: metadata checkpoint",
+    "maxBytesPerTrigger: metadata checkpoint"
   )
 
   private lazy val shouldFailTests = Set(
-    // === Schema Evolution ===
-    "allow to change schema before starting a streaming query",
-
     // === Null Type Column Handling ===
     "streaming delta source should not drop null columns",
     "streaming delta source should drop null columns without feature flag",
@@ -103,9 +103,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "fail on data loss - gaps of files with option off",
 
     // === Rate Limiting / Trigger Options ===
-    "maxFilesPerTrigger: metadata checkpoint",
     "maxFilesPerTrigger: Trigger.AvailableNow respects read limits",
-    "maxBytesPerTrigger: metadata checkpoint",
     "maxBytesPerTrigger: Trigger.AvailableNow respects read limits",
     "Trigger.AvailableNow with an empty table",
     "Rate limited Delta source advances with non-data inserts",

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
@@ -62,9 +62,9 @@ public class StreamingHelper {
     return batch.getColumnVector(versionColIdx).getLong(0);
   }
 
-  /** Get AddFile action from a batch at the specified row, if present and has dataChange=true. */
-  public static Optional<AddFile> getDataChangeAdd(ColumnarBatch batch, int rowId) {
-    int addIdx = getFieldIndex(batch, DeltaLogActionUtils.DeltaAction.ADD.colName);
+  /** Get AddFile action from a batch at the specified row, if present. */
+  public static Optional<AddFile> getAddFile(ColumnarBatch batch, int rowId) {
+    int addIdx = getFieldIndex(batch, "add");
     ColumnVector addVector = batch.getColumnVector(addIdx);
     if (addVector.isNullAt(rowId)) {
       return Optional.empty();
@@ -75,8 +75,12 @@ public class StreamingHelper {
         addFileRow != null,
         String.format("Failed to extract AddFile struct from batch at rowId=%d.", rowId));
 
-    AddFile addFile = new AddFile(addFileRow);
-    return addFile.getDataChange() ? Optional.of(addFile) : Optional.empty();
+    return Optional.of(new AddFile(addFileRow));
+  }
+
+  /** Get AddFile action from a batch at the specified row, if present and has dataChange=true. */
+  public static Optional<AddFile> getAddFileWithDataChange(ColumnarBatch batch, int rowId) {
+    return getAddFile(batch, rowId).filter(AddFile::getDataChange);
   }
 
   /**


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5845/files) to review incremental changes.
- [**stack/testaudit2**](https://github.com/delta-io/delta/pull/5845) [[Files changed](https://github.com/delta-io/delta/pull/5845/files)]
  - stack/testaudit3
  - stack/testaudit4

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Fixes a bug in V2 streaming where snapshot files were incorrectly filtered by `dataChange=true`, which excluded metadata checkpoint files (they have `dataChange=false`).

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
DeltaSourceDSv2Suite
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.