### PR TITLE
[PROTOCOL RFC] Document SHREDDING_STATE tag in variant-shredding.md

### DIFF
--- a/protocol_rfcs/variant-shredding.md
+++ b/protocol_rfcs/variant-shredding.md
@@ -37,7 +37,7 @@ typed_value | * | (optional) This can be any Parquet type, representing the data
 
 When Variant Shredding is supported (`writerFeatures` field of a table's `protocol` action contains `variantShredding`), writers:
 - must respect the `delta.enableVariantShredding` table property configuration. If `delta.enableVariantShredding=false`, a column of type `variant` must not be written as a shredded Variant, but as an unshredded Variant. If `delta.enableVariantShredding=true`, the writer can choose to shred a Variant column according to the [Parquet Variant Shredding specification](https://github.com/apache/parquet-format/blob/master/VariantShredding.md)
-- may set the `SHREDDING_STATE` tag to `1` in `AddFile`s.
+- may set the `SHREDDING_STATE` tag to `1` in `AddFile`s if `delta.enableVariantShredding=true`.
 - may set the `SHREDDING_STATE` tag to `0` in `AddFile`s corresponding data that does not contain any shredded Variant data. The `SHREDDING_STATE` may not be `0` in an `AddFile` if the data corresponding to it contains any shredded Variant data.
 - may not set the `SHREDDING_STATE` tag in `AddFile`s to any value other than `0` or `1`. It is legal for the writer to not set the `SHREDDING_STATE` tag at all in `AddFile`s.
 The `SHREDDING_STATE` tag may be present in `AddFile`s in tables not supporting the 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol RFC)

## Description

This PR proposes the `SHREDDING_STATE` tag which can be used to identify which `AddFile` records correspond to files containing shredded Variant data.

## How was this patch tested?

NA

## Does this PR introduce _any_ user-facing changes?

No
