### PR TITLE
[Spark] Reorganise DML tests

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -115,6 +115,35 @@ case class TestGroup(
 )
 
 object SuiteGeneratorConfig {
+  /**
+   * Common import patterns reused across test groups.
+   */
+  private object Imports {
+    // Base DML imports used by nearly all test groups
+    val BASE_DML: List[Importer] = List(
+      importer"org.apache.spark.sql.delta._",
+      importer"org.apache.spark.sql.delta.dml.delete._",
+      importer"org.apache.spark.sql.delta.dml.merge._",
+      importer"org.apache.spark.sql.delta.dml.update._"
+    )
+
+    // Common test imports - BASE_DML plus frequently used packages
+    val COMMON_TEST: List[Importer] = BASE_DML ++ List(
+      importer"org.apache.spark.sql.delta.cdc._",
+      importer"org.apache.spark.sql.delta.columnmapping._",
+      importer"org.apache.spark.sql.delta.deletionvectors._",
+      importer"org.apache.spark.sql.delta.rowid._",
+      importer"org.apache.spark.sql.delta.rowtracking._"
+    )
+
+    // Additional imports that can be added to the common sets
+    val MST = importer"org.apache.spark.sql.delta.mst._"
+    val STATS = importer"org.apache.spark.sql.delta.stats._"
+    val STORAGE_DV = importer"org.apache.spark.sql.delta.storage.dv._"
+    val CONCURRENCY = importer"org.apache.spark.sql.delta.concurrency._"
+    val DML = importer"org.apache.spark.sql.delta.dml._"
+  }
+
   private object Dims {
     // Just to improve readability of the test configurations a bit.
     // `Dims.NONE` is clearer than just `Nil`.
@@ -355,9 +384,7 @@ object SuiteGeneratorConfig {
     ),
     TestGroup(
       name = "InsertSuites",
-      imports = List(
-        importer"org.apache.spark.sql.delta._"
-      ),
+      imports = Imports.BASE_DML,
       testConfigs = List(
         TestConfig(
           List("DeltaInsertIntoImplicitCastTests", "DeltaInsertIntoImplicitCastStreamingWriteTests"),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -23,7 +23,7 @@ import java.util.{ConcurrentModificationException, UUID}
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBySpec}
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.commands.{AlterTableDropFeatureDeltaCommand, DeltaGenerateCommand}
 import org.apache.spark.sql.delta.constraints.Constraints

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
@@ -22,6 +22,7 @@ import java.io.File
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.commands.optimize._
 import org.apache.spark.sql.delta.hooks.{AutoCompact, AutoCompactType}
 import org.apache.spark.sql.delta.optimize.CompactionTestHelperForAutoCompaction

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -26,8 +26,9 @@ import scala.concurrent.duration._
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
-import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestData
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LocalLogStore
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
@@ -584,7 +585,8 @@ class CheckpointsSuite
   test("checkpoint with DVs") {
     for (v2Checkpoint <- Seq(true, false))
     withTempDir { tempDir =>
-      val source = new File(DeletionVectorsSuite.table1Path) // this table has DVs in two versions
+      // This table has DVs in two versions.
+      val source = new File(DeletionVectorsTestData.table1Path)
       val targetName = s"insertTest_${UUID.randomUUID().toString.replace("-", "")}"
       val target = new File(tempDir, targetName)
 
@@ -619,7 +621,7 @@ class CheckpointsSuite
       import testImplicits._
       checkAnswer(
         spark.sql(s"SELECT * FROM delta.`${target.getAbsolutePath}`"),
-        (DeletionVectorsSuite.expectedTable1DataV4 ++ newData).toSeq.toDF())
+        (DeletionVectorsTestData.expectedTable1DataV4 ++ newData).toSeq.toDF())
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumDVMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumDVMetricsSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.{DeletedRecordCountsHistogram, DeletedRecordCountsHistogramUtils}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.delta
 import scala.collection.immutable.NumericRange
 
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
 import org.apache.hadoop.fs.Path

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.time.LocalDate
 
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import org.apache.hadoop.fs.Path
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -21,9 +21,11 @@ import java.time.LocalDate
 
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, Metadata, Protocol, RemoveFile, SetTransaction, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsTestUtils
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.util.FileNames.{isCheckpointFile, unsafeDeltaFile}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
@@ -24,6 +24,7 @@ import scala.jdk.CollectionConverters._
 import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.commands.{CloneDeltaSource, CloneSource, CloneSourceFormat}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames.unsafeDeltaFile

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.sql.{QueryTest, SaveMode}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictResolutionTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictResolutionTestUtils.scala
@@ -23,6 +23,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.apache.spark.sql.delta.concurrency.{PhaseLockingTestMixin, TransactionExecutionTestMixin}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.fuzzer.{PhaseLockingTransactionExecutionObserver => TransactionObserver}
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import org.apache.spark.sql.util.ScalaExtensions.OptionExt

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.apache.spark.sql.delta.DeltaConfigs.CHECKPOINT_INTERVAL
 import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -20,6 +20,7 @@ import java.util.Date
 
 import org.apache.spark.sql.delta.DeltaTestUtils.modifyCommitTimestamp
 import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTableUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -24,7 +24,9 @@ import scala.language.implicitConversions
 
 import org.apache.spark.sql.delta.DeltaTestUtils.modifyCommitTimestamp
 import org.apache.spark.sql.delta.actions.AddCDCFile
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.{DeltaSourceOffset, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.DeltaTestUtils.{modifyCommitTimestamp, BOOLEAN
 import org.apache.spark.sql.delta.cdc.CDCEnabled
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCheckpointWithStructColsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCheckpointWithStructColsSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.schema.InvariantViolationException
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.hadoop.fs.Path

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.scalatest.BeforeAndAfter
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescri
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.AlterTableUnsetPropertiesDeltaCommand
 import org.apache.spark.sql.delta.commands.DeltaReorgTableCommand
-import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.deletionvectors.{DeletionVectorsTestUtils, RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -22,6 +22,7 @@ import java.net.URI
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaOperations.Delete
 import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -22,6 +22,7 @@ import java.util.TimeZone
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.schema.InvariantViolationException
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.delta
 import com.databricks.spark.util.DatabricksLogging
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.StatsUtils
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, ScanReportHelper}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.DataFrameUtils
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.{AlterTableDropFeatureDeltaCommand, AlterTableSetPropertiesDeltaCommand, AlterTableUnsetPropertiesDeltaCommand}
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.coordinatedcommits._
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.redirect.{PathBasedRedirectSpec, RedirectReaderWriter, RedirectWriterOnly, TableRedirect}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.CommitInfo
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
 import org.apache.spark.sql.delta.sources.{DeltaSink, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.Relocated.StreamExecution
 import org.apache.spark.sql.delta.sources.{DeltaSource, DeltaSQLConf}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.Relocated.StreamExecution
+import org.apache.spark.sql.delta.deletionvectors.{DeletionVectorsTestUtils, PersistentDVEnabled}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.hadoop.fs.Path
 import org.scalatest.concurrent.Eventually

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceFastDropFeatureSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 
 import org.apache.spark.sql.delta.cdc.CDCEnabled
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -23,6 +23,7 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.sources._
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.util.JsonUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.delta.DataFrameUtils
 import org.apache.spark.sql.delta.DeltaTestUtils.modifyCommitTimestamp
 import org.apache.spark.sql.delta.Relocated
 import org.apache.spark.sql.delta.actions.{AddFile, Protocol}
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSQLConf, DeltaSource, DeltaSourceOffset}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.{Action, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.delta.commands.VacuumCommand
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedCommitCoordinatorProvider
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.coordinatedcommits.TrackingInMemoryCommitCoordinatorBuilder
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaWithNewTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaWithNewTransactionSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.DeltaTestUtils._
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, Metadata
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DescribeDeltaHistoryCommand
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}
+import org.apache.spark.sql.delta.dml.merge.MergeIntoMetricsBase
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnDMLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnDMLSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.GeneratedAsIdentityType.{GeneratedAlways, GeneratedByDefault}
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.merge.MergeStats
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnIngestionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnIngestionSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.PrintWriter
 
 import org.apache.spark.sql.delta.GeneratedAsIdentityType.{GeneratedAlways, GeneratedByDefault}
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.MemoryStream
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSuite.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable.ListBuffer
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.GeneratedAsIdentityType.{GeneratedAlways, GeneratedAsIdentityType, GeneratedByDefault}
 import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.util.JsonUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSyncSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSyncSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.GeneratedAsIdentityType.GeneratedByDefault
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 
 import org.apache.spark.sql.{AnalysisException, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -20,7 +20,7 @@ import java.util.ConcurrentModificationException
 
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, Metadata, RemoveFile}
-import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
+import org.apache.spark.sql.delta.deletionvectors.{DeletionVectorsTestUtils, RoaringBitmapArray}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSQLSuite.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableScalaSuite.scala
@@ -25,6 +25,7 @@ import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.test.DeltaExcludedTestMixin
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TightBoundsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TightBoundsSuite.scala
@@ -20,6 +20,8 @@ import scala.collection.mutable.ArrayBuffer
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingEnableIdMode
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DeltaStatistics.{MIN, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS}
 import org.apache.spark.sql.delta.stats.StatisticsCollection

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCEnabled.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCEnabled.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.cdc
+
+import org.apache.spark.sql.delta.DeltaConfigs
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Mixin trait that enables Change Data Feed (CDC) for tests.
+ */
+trait CDCEnabled extends SharedSparkSession {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -24,8 +24,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.Delete
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile}
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.files.DelayedCommitProtocol
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCWorkloadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCWorkloadSuite.scala
@@ -17,6 +17,9 @@
 package org.apache.spark.sql.delta.cdc
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.sql.QueryTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
@@ -21,6 +21,9 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf._
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
@@ -19,7 +19,12 @@ package org.apache.spark.sql.delta.cdc
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.deletionvectors.MergePersistentDVDisabled
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -32,16 +37,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 
-trait CDCEnabled extends SharedSparkSession {
-  override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
-}
-
-trait MergeCDCMixin extends SharedSparkSession
-  with MergeIntoSQLTestUtils
-  with DeltaColumnMappingTestUtils
-  with DeltaSQLCommandTest
-  with MergePersistentDVDisabled
+// CDCEnabled trait is now in tahoe/cdc/CDCEnabled.scala (shared_test_utilities)
+// MergeCDCMixin trait is now in dml/merge/MergeCDCMixin.scala (dml:shared_test)
 
 /**
  * Tests for MERGE INTO in CDC output mode.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
@@ -20,7 +20,11 @@ package org.apache.spark.sql.delta.cdc
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, RemoveFile}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql.Row

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DeltaColumnMappingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DeltaColumnMappingTestUtils.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.columnmapping
 
 import java.io.File
 
 import scala.collection.mutable
 
+import org.apache.spark.sql.delta.{Checkpoints, ColumnMappingTableFeature, DeltaColumnMapping, DeltaColumnMappingMode, DeltaConfigs, DeltaErrors, DeltaLog, IdMapping, NameMapping, NoMapping, Snapshot}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
@@ -21,6 +21,9 @@ import java.util.concurrent.TimeUnit
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaConfigs._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.sources.DeltaSQLConf._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.delta.columnmapping
 import io.delta.tables.DeltaTable
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.schema.DeltaInvariantViolationException
 import org.apache.spark.sql.delta.sources.DeltaSQLConf._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuiteUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuiteUtils.scala
@@ -20,6 +20,9 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.RemoveColumnMapping
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf._
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillConflictsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillConflictsSuite.scala
@@ -25,6 +25,9 @@ import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.concurrency.{PhaseLockingTestMixin, TransactionExecutionTestMixin}
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.fuzzer.{OptimisticTransactionPhases, PhaseLockingTransactionExecutionObserver}
 import org.apache.spark.sql.delta.fuzzer.AtomicBarrier.State
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionObserverSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionObserverSuite.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.delta.concurrency
 import scala.concurrent.duration._
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.fuzzer.{AtomicBarrier, IllegalStateTransitionException, OptimisticTransactionPhases, PhaseLockingTransactionExecutionObserver}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import io.delta.tables.{DeltaTable => IODeltaTable}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -21,6 +21,9 @@ import java.util.UUID
 
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.JsonUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
@@ -21,6 +21,9 @@ import java.util.UUID
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
@@ -23,8 +23,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata, Protocol}
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.storage.{LogStore, LogStoreProvider}
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsEnablementSuite.scala
@@ -17,6 +17,9 @@
 package org.apache.spark.sql.delta.coordinatedcommits
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 
 class CoordinatedCommitsEnablementSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, CheckpointPolicy, DeltaConfigs, DeltaLog, DeltaTestUtilsBase, Snapshot}
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.deletionvectors
 import java.io.{File, FileNotFoundException}
 import java.net.URISyntaxException
 
-import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeletionVectorsTestUtils, DeltaChecksumException, DeltaConfigs, DeltaLog, DeltaMetricsUtils, DeltaTestUtilsForTempViews}
+import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeltaChecksumException, DeltaConfigs, DeltaLog, DeltaMetricsUtils, DeltaTestUtilsForTempViews}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor.EMPTY
@@ -821,43 +821,32 @@ class DeletionVectorsSuite extends QueryTest
 }
 
 object DeletionVectorsSuite {
-  val table1Path = "src/test/resources/delta/table-with-dv-large"
-  // Table at version 0: contains [0, 2000)
-  val expectedTable1DataV0 = Seq.range(0, 2000)
-  // Table at version 1: removes rows with id = 0, 180, 300, 700, 1800
-  val v1Removed = Set(0, 180, 300, 700, 1800)
-  val expectedTable1DataV1 = expectedTable1DataV0.filterNot(e => v1Removed.contains(e))
-  // Table at version 2: inserts rows with id = 300, 700
-  val v2Added = Set(300, 700)
-  val expectedTable1DataV2 = expectedTable1DataV1 ++ v2Added
-  // Table at version 3: removes rows with id = 300, 250, 350, 900, 1353, 1567, 1800
-  val v3Removed = Set(300, 250, 350, 900, 1353, 1567, 1800)
-  val expectedTable1DataV3 = expectedTable1DataV2.filterNot(e => v3Removed.contains(e))
-  // Table at version 4: inserts rows with id = 900, 1567
-  val v4Added = Set(900, 1567)
-  val expectedTable1DataV4 = expectedTable1DataV3 ++ v4Added
+  // Delegate to shared test data object
+  val table1Path = DeletionVectorsTestData.table1Path
+  val expectedTable1DataV0 = DeletionVectorsTestData.expectedTable1DataV0
+  val v1Removed = DeletionVectorsTestData.v1Removed
+  val expectedTable1DataV1 = DeletionVectorsTestData.expectedTable1DataV1
+  val v2Added = DeletionVectorsTestData.v2Added
+  val expectedTable1DataV2 = DeletionVectorsTestData.expectedTable1DataV2
+  val v3Removed = DeletionVectorsTestData.v3Removed
+  val expectedTable1DataV3 = DeletionVectorsTestData.expectedTable1DataV3
+  val v4Added = DeletionVectorsTestData.v4Added
+  val expectedTable1DataV4 = DeletionVectorsTestData.expectedTable1DataV4
 
-  val table2Path = "src/test/resources/delta/table-with-dv-small"
-  // Table at version 0: contains 0 - 9
-  val expectedTable2DataV0 = Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-  // Table at version 1: removes rows 0 and 9
-  val expectedTable2DataV1 = Seq(1, 2, 3, 4, 5, 6, 7, 8)
+  val table2Path = DeletionVectorsTestData.table2Path
+  val expectedTable2DataV0 = DeletionVectorsTestData.expectedTable2DataV0
+  val expectedTable2DataV1 = DeletionVectorsTestData.expectedTable2DataV1
 
-  val table3Path = "src/test/resources/delta/partitioned-table-with-dv-large"
-  // Table at version 0: contains [0, 2000)
-  val expectedTable3DataV0 = Seq.range(0, 2000)
-  // Table at version 1: removes rows with id = (0, 180, 308, 225, 756, 1007, 1503)
-  val table3V1Removed = Set(0, 180, 308, 225, 756, 1007, 1503)
-  val expectedTable3DataV1 = expectedTable3DataV0.filterNot(e => table3V1Removed.contains(e))
-  // Table at version 2: inserts rows with id = 308, 756
-  val table3V2Added = Set(308, 756)
-  val expectedTable3DataV2 = expectedTable3DataV1 ++ table3V2Added
-  // Table at version 3: removes rows with id = (300, 257, 399, 786, 1353, 1567, 1800)
-  val table3V3Removed = Set(300, 257, 399, 786, 1353, 1567, 1800)
-  val expectedTable3DataV3 = expectedTable3DataV2.filterNot(e => table3V3Removed.contains(e))
-  // Table at version 4: inserts rows with id = 1353, 1567
-  val table3V4Added = Set(1353, 1567)
-  val expectedTable3DataV4 = expectedTable3DataV3 ++ table3V4Added
+  val table3Path = DeletionVectorsTestData.table3Path
+  val expectedTable3DataV0 = DeletionVectorsTestData.expectedTable3DataV0
+  val table3V1Removed = DeletionVectorsTestData.table3V1Removed
+  val expectedTable3DataV1 = DeletionVectorsTestData.expectedTable3DataV1
+  val table3V2Added = DeletionVectorsTestData.table3V2Added
+  val expectedTable3DataV2 = DeletionVectorsTestData.expectedTable3DataV2
+  val table3V3Removed = DeletionVectorsTestData.table3V3Removed
+  val expectedTable3DataV3 = DeletionVectorsTestData.expectedTable3DataV3
+  val table3V4Added = DeletionVectorsTestData.table3V4Added
+  val expectedTable3DataV4 = DeletionVectorsTestData.expectedTable3DataV4
 
   // Table with DV table feature as supported but no DVs
   val table4Path = "src/test/resources/delta/table-with-dv-feature-enabled"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsTestData.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsTestData.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.deletionvectors
+
+/**
+ * Test data constants for deletion vector test tables.
+ * These are used by multiple test suites across packages.
+ */
+object DeletionVectorsTestData {
+  val table1Path = "src/test/resources/delta/table-with-dv-large"
+  // Table at version 0: contains [0, 2000)
+  val expectedTable1DataV0 = Seq.range(0, 2000)
+  // Table at version 1: removes rows with id = 0, 180, 300, 700, 1800
+  val v1Removed = Set(0, 180, 300, 700, 1800)
+  val expectedTable1DataV1 = expectedTable1DataV0.filterNot(e => v1Removed.contains(e))
+  // Table at version 2: inserts rows with id = 300, 700
+  val v2Added = Set(300, 700)
+  val expectedTable1DataV2 = expectedTable1DataV1 ++ v2Added
+  // Table at version 3: removes rows with id = 300, 250, 350, 900, 1353, 1567, 1800
+  val v3Removed = Set(300, 250, 350, 900, 1353, 1567, 1800)
+  val expectedTable1DataV3 = expectedTable1DataV2.filterNot(e => v3Removed.contains(e))
+  // Table at version 4: inserts rows with id = 900, 1567
+  val v4Added = Set(900, 1567)
+  val expectedTable1DataV4 = expectedTable1DataV3 ++ v4Added
+
+  val table2Path = "src/test/resources/delta/table-with-dv-small"
+  // Table at version 0: contains 0 - 9
+  val expectedTable2DataV0 = Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+  // Table at version 1: removes rows 0 and 9
+  val expectedTable2DataV1 = Seq(1, 2, 3, 4, 5, 6, 7, 8)
+
+  val table3Path = "src/test/resources/delta/partitioned-table-with-dv-large"
+  // Table at version 0: contains [0, 2000)
+  val expectedTable3DataV0 = Seq.range(0, 2000)
+  // Table at version 1: removes rows with id = (0, 180, 308, 225, 756, 1007, 1503)
+  val table3V1Removed = Set(0, 180, 308, 225, 756, 1007, 1503)
+  val expectedTable3DataV1 = expectedTable3DataV0.filterNot(e => table3V1Removed.contains(e))
+  // Table at version 2: inserts rows with id = 308, 756
+  val table3V2Added = Set(308, 756)
+  val expectedTable3DataV2 = expectedTable3DataV1 ++ table3V2Added
+  // Table at version 3: removes rows with id = (300, 257, 399, 786, 1353, 1567, 1800)
+  val table3V3Removed = Set(300, 257, 399, 786, 1353, 1567, 1800)
+  val expectedTable3DataV3 = expectedTable3DataV2.filterNot(e => table3V3Removed.contains(e))
+  // Table at version 4: inserts rows with id = 1353, 1567
+  val table3V4Added = Set(1353, 1567)
+  val expectedTable3DataV4 = expectedTable3DataV3 ++ table3V4Added
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsTestUtils.scala
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.deletionvectors
 
 import java.io.File
 import java.util.UUID
 
+import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeltaConfigs, DeltaLog, DeltaOperations}
 import org.apache.spark.sql.delta.DeltaOperations.Truncate
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.{AlterTableDropFeatureDeltaCommand, DeletionVectorUtils}
-import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteMetricsSuite.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.delete
 
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.DatabricksLogging
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, RemoveFile}
 import org.apache.spark.sql.delta.commands.DeleteMetric

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteSQLSuite.scala
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.delete
 
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaExcludedTestMixin, DeltaSQLCommandTest}
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteScalaSuite.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.delete
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
 
 import org.apache.spark.sql.{functions, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/delete/DeleteSuiteBase.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.delete
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.{SparkThrowable, SparkUnsupportedOperationException}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeCDCMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeCDCMixin.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.dml.merge
+
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
+import org.apache.spark.sql.delta.deletionvectors.MergePersistentDVDisabled
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Mixin trait for Merge CDC tests.
+ * Extracted from MergeCDCSuite.scala to break circular dependencies.
+ */
+trait MergeCDCMixin extends SharedSparkSession
+  with MergeIntoSQLTestUtils
+  with DeltaColumnMappingTestUtils
+  with DeltaSQLCommandTest
+  with MergePersistentDVDisabled

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoDVsSuite.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
-import org.apache.spark.sql.delta.cdc.MergeCDCMixin
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.{DeletionVectorBitmapGenerator, DMLWithDeletionVectorsHelper}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
 
 import org.apache.spark.SparkException

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoMaterializeSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoMaterializeSourceSuite.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 import scala.collection.mutable
 import scala.concurrent.duration._
@@ -22,6 +22,7 @@ import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils._
 import org.apache.spark.sql.delta.commands.merge.{MergeIntoMaterializeSourceError, MergeIntoMaterializeSourceErrorType, MergeIntoMaterializeSourceReason, MergeStats}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoMetricsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoMetricsBase.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoNotMatchedBySourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoNotMatchedBySourceSuite.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.Row

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoSQLSuite.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.scalatest.matchers.must.Matchers.be

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoScalaSuite.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 import java.util.Locale
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.SetTransaction
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
@@ -47,6 +48,7 @@ trait MergeIntoScalaMixin extends MergeIntoSuiteBaseMixin
   )
 
   // scalastyle:off argcount
+import org.apache.spark.sql.delta._
   override def testNestedDataSupport(name: String, namePrefix: String = "nested data support")(
       source: String,
       target: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoSchemaEvolutionSuite.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 import scala.language.implicitConversions
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoStructEvolutionNullnessSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoStructEvolutionNullnessSuite.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 import scala.language.implicitConversions
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import com.fasterxml.jackson.annotation.JsonInclude.Include

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoSuiteBase.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 import java.io.File
 import java.lang.{Integer => JInt}
@@ -22,6 +22,7 @@ import java.lang.{Integer => JInt}
 import scala.language.implicitConversions
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.MergeIntoCommand
 import org.apache.spark.sql.delta.commands.merge.MergeStats
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoTestUtils.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import io.delta.tables._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoTimestampConsistencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/merge/MergeIntoTimestampConsistencySuite.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.merge
 
 import java.sql.Timestamp
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateMetricsSuite.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.update
 
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.DatabricksLogging
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateSQLSuite.scala
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.update
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateScalaSuite.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.update
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandTest}
 
 import org.apache.spark.sql.{functions, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/dml/update/UpdateSuiteBase.scala
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.delta.dml.update
 
 // scalastyle:off import.ordering.noEmptyLine
 import java.util.Locale
 
 import scala.language.implicitConversions
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.shims.UnsupportedTableOperationErrorShims

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteBaseTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteBaseTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class DeleteBaseSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteCDCTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteCDCTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class DeleteCDCSQLPathBasedCDCOnSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteSQLTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteSQLTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class DeleteSQLSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteScalaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteScalaTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class DeleteScalaScalaSuite extends DeleteScalaTests with DeleteScalaMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteTempViewTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesDeleteTempViewTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class DeleteTempViewSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesRowTrackingDeleteDvBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesRowTrackingDeleteDvBase.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class RowTrackingDeleteDvBaseCDCOnDVOnColMapIdModeSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesRowTrackingDeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/DeleteSuitesRowTrackingDeleteSuiteBase.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class RowTrackingDeleteSuiteBaseCDCOnDVOffSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/InsertSuitesDeltaInsertIntoImplicitCastStreamingWriteTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/InsertSuitesDeltaInsertIntoImplicitCastStreamingWriteTests.scala
@@ -29,6 +29,9 @@
 package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 
 class DeltaInsertIntoImplicitCastStreamingWriteSuite
   extends DeltaInsertIntoImplicitCastStreamingWriteTests

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/InsertSuitesDeltaInsertIntoImplicitCastTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/InsertSuitesDeltaInsertIntoImplicitCastTests.scala
@@ -29,4 +29,8 @@
 package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
+
 class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoImplicitCastTests

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeCDCTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeCDCTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeCDCSQLPathBasedCDCOnDVsPredPushOffSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoAnalysisExceptionTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoAnalysisExceptionTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoAnalysisExceptionSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoBasicTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoBasicTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoBasicSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoDVsTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoDVsTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoDVsSQLPathBasedCDCOnDVsPredPushOffSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoExtendedSyntaxTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoExtendedSyntaxTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoExtendedSyntaxSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoMaterializeSourceErrorTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoMaterializeSourceErrorTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoMaterializeSourceErrorMergePersistentDVOffSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoMaterializeSourceTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoMaterializeSourceTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoMaterializeSourceMergePersistentDVOffSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedArrayStructEvolutionNullnessTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedArrayStructEvolutionNullnessTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNestedArrayStructEvolutionNullnessSQLNameBasedColMapIdModePreserveNullSourceOffPreservG4SCW5ASuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedDataTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedDataTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNestedDataSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedMapStructEvolutionNullnessTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedMapStructEvolutionNullnessTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNestedMapStructEvolutionNullnessSQLNameBasedColMapIdModePreserveNullSourceOffPreserveN4NGDUBYSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructEvolutionInsertTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructEvolutionInsertTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNestedStructEvolutionInsertSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructEvolutionNullnessTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructEvolutionNullnessTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNestedStructEvolutionNullnessSQLNameBasedColMapIdModePreserveNullSourceOffPreserveNullXPVWNHQSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructEvolutionUpdateOnlyTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructEvolutionUpdateOnlyTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNestedStructEvolutionUpdateOnlySQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructInMapEvolutionTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNestedStructInMapEvolutionTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNestedStructInMapEvolutionSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNotMatchedBySourceCDCPart1Tests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNotMatchedBySourceCDCPart1Tests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNotMatchedBySourceCDCPart1SQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNotMatchedBySourceCDCPart2Tests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNotMatchedBySourceCDCPart2Tests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNotMatchedBySourceCDCPart2SQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNotMatchedBySourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoNotMatchedBySourceSuite.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoNotMatchedBySourceSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSQLNondeterministicOrderTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSQLNondeterministicOrderTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSQLNondeterministicOrderSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSQLTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSQLTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSQLSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoScalaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoScalaTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoScalaScalaSuite extends MergeIntoScalaTests with MergeIntoScalaMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvoStoreAssignmentPolicyTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvoStoreAssignmentPolicyTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSchemaEvoStoreAssignmentPolicySQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionBaseExistingColumnTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionBaseExistingColumnTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSchemaEvolutionBaseExistingColumnSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionBaseNewColumnTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionBaseNewColumnTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSchemaEvolutionBaseNewColumnSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionCoreTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionCoreTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSchemaEvolutionCoreSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionNotMatchedBySourceTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSchemaEvolutionNotMatchedBySourceTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSchemaEvolutionNotMatchedBySourceSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoStructEvolutionNullnessMultiClauseTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoStructEvolutionNullnessMultiClauseTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoStructEvolutionNullnessMultiClauseSQLNameBasedColMapIdModePreserveNullSourceOffPreserv23BA7GQSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSuiteBaseMiscTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoSuiteBaseMiscTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoSuiteBaseMiscSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTempViewsTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTempViewsTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoTempViewsSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTopLevelArrayStructEvolutionNullnessTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTopLevelArrayStructEvolutionNullnessTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoTopLevelArrayStructEvolutionNullnessSQLNameBasedColMapIdModePreserveNullSourceOffPrese53B5UFQSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTopLevelMapStructEvolutionNullnessTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTopLevelMapStructEvolutionNullnessTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoTopLevelMapStructEvolutionNullnessSQLNameBasedColMapIdModePreserveNullSourceOffPreservIVRBZBASuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTopLevelStructEvolutionNullnessTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoTopLevelStructEvolutionNullnessTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoTopLevelStructEvolutionNullnessSQLNameBasedColMapIdModePreserveNullSourceOffPreserveNuHUY7GZQSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoUnlimitedMergeClausesTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoUnlimitedMergeClausesTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class MergeIntoUnlimitedMergeClausesSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesRowTrackingMergeCommonTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesRowTrackingMergeCommonTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 
 class RowTrackingMergeCommonNameBasedCDCOnDVOffMergePersistentDVOffSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesRowTrackingUpdateCommonTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesRowTrackingUpdateCommonTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateBaseMiscTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateBaseMiscTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateBaseTempViewTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateBaseTempViewTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateCDCTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateCDCTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateCDCWithDeletionVectorsTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateCDCWithDeletionVectorsTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateSQLTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateSQLTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateSQLWithDeletionVectorsTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateSQLWithDeletionVectorsTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateScalaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/UpdateSuitesUpdateScalaTests.scala
@@ -30,6 +30,11 @@ package org.apache.spark.sql.delta.generatedsuites
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
+import org.apache.spark.sql.delta.columnmapping._
+import org.apache.spark.sql.delta.deletionvectors._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid._
 import org.apache.spark.sql.delta.rowtracking._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
@@ -16,9 +16,10 @@
 
 package org.apache.spark.sql.delta.optimize
 
-import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaColumnMapping, DeltaLog}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaLog}
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.commands.VacuumCommand.generateCandidateFileMap
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.DeltaFileOperations

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -24,6 +24,11 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
@@ -20,6 +20,10 @@ package org.apache.spark.sql.delta.optimize
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.optimize.{FileSizeStats, OptimizeMetrics, ZOrderStats}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeZOrderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeZOrderSuite.scala
@@ -18,7 +18,11 @@ package org.apache.spark.sql.delta.optimize
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf._
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils, TestsStatistics}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
@@ -24,6 +24,9 @@ import scala.util.matching.Regex
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.{DELTA_COLLECT_STATS, GENERATED_COLUMN_PARTITION_FILTER_OPTIMIZATION_ENABLED}
 import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -18,8 +18,10 @@ package org.apache.spark.sql.delta.perf
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaLog, DeltaTestUtils}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTestUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
 import org.apache.spark.sql.delta.stats.StatisticsCollection

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
@@ -25,6 +25,9 @@ import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.concurrency.PhaseLockingTestMixin
 import org.apache.spark.sql.delta.concurrency.TransactionExecutionTestMixin
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql.{QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingBackfillSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingBackfillSuite.scala
@@ -27,6 +27,9 @@ import org.apache.spark.sql.delta.actions.{AddFile, Protocol, TableFeatureProtoc
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.AlterTableSetPropertiesDeltaCommand
 import org.apache.spark.sql.delta.commands.backfill.{BackfillBatch, BackfillBatchStats, BackfillCommandStats, RowTrackingBackfillBatch, RowTrackingBackfillCommand, RowTrackingBackfillExecutor}
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.JsonUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingCompactionSuite.scala
@@ -19,7 +19,12 @@ package org.apache.spark.sql.delta.rowid
 import java.io.File
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
+import org.apache.spark.sql.delta.deletionvectors.PersistentDVEnabled
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.hooks.AutoCompact
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingDeleteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingDeleteSuite.scala
@@ -18,6 +18,10 @@ package org.apache.spark.sql.delta.rowid
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.deletionvectors.PersistentDVEnabled
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingMergeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingMergeSuite.scala
@@ -19,6 +19,10 @@ package org.apache.spark.sql.delta.rowid
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{Dataset, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingUpdateSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingUpdateSuite.scala
@@ -18,6 +18,10 @@ package org.apache.spark.sql.delta.rowid
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowtracking.RowTrackingEnabled
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -21,7 +21,10 @@ import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.actions.{Metadata, RemoveFile}
 import org.apache.spark.sql.delta.commands.backfill.{BackfillCommandStats, RowTrackingBackfillExecutor}
-import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
+import org.apache.spark.sql.delta.deletionvectors.{DeletionVectorsTestUtils, RoaringBitmapArray}
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -20,9 +20,10 @@ import java.io.File
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
-import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaAnalysisException, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaConfigs, DeltaLog, DeltaUnsupportedOperationException, NoMapping}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaAnalysisException, DeltaConfigs, DeltaLog, DeltaUnsupportedOperationException, NoMapping}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.hooks.UpdateCatalog
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -20,7 +20,11 @@ import java.io.File
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.metering.ScanReport
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/PartitionLikeDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/PartitionLikeDataSkippingSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.delta.stats
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
-import org.apache.spark.sql.delta.{DeltaColumnMappingEnableIdMode, DeltaLog}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingEnableIdMode
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.scalatest.BeforeAndAfter

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -24,6 +24,11 @@ import java.time.LocalDateTime
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.columnmapping.{DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaColumnMappingTestUtils}
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestUtils
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.StatisticsCollection.{ASCII_MAX_CHARACTER, UTF8_MAX_CHARACTER}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
-import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite
+import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsTestData
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.commons.io.FileUtils
@@ -70,7 +70,7 @@ class DeletionVectorFileSizeSuite extends QueryTest
 
   test("Bin Packing should take the size of existing DVs into account") {
     withTempDir { tempDir =>
-      val source = new File(DeletionVectorsSuite.table1Path)
+      val source = new File(DeletionVectorsTestData.table1Path)
       val target = new File(tempDir, "deleteTest")
 
       // Copy the source table with existing table layout to a temporary directory

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
@@ -18,7 +18,8 @@ package org.apache.spark.sql.delta.test
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.{DeltaColumnMappingTestUtils, DeltaConfigs, NoMapping}
+import org.apache.spark.sql.delta.{DeltaConfigs, NoMapping}
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtils
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.scalactic.source.Position
 import org.scalatest.Tag

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
@@ -21,8 +21,9 @@ import java.util.UUID
 
 import scala.util.Random
 
-import org.apache.spark.sql.delta.{DeltaColumnMappingTestUtilsBase, DeltaLog, DeltaTable, Snapshot, TableFeature}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTable, Snapshot, TableFeature}
 import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.columnmapping.DeltaColumnMappingTestUtilsBase
 import org.apache.spark.sql.delta.stats.{DeltaStatistics, PreparedDeltaFileIndex}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.delta.typewidening
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql.delta.typewidening
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningGeneratedColumnsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningGeneratedColumnsSuite.scala
@@ -17,6 +17,9 @@
 package org.apache.spark.sql.delta.typewidening
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionBasicSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionBasicSuite.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.delta.typewidening
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
@@ -17,6 +17,9 @@
 package org.apache.spark.sql.delta.typewidening
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
@@ -17,6 +17,9 @@
 package org.apache.spark.sql.delta.typewidening
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMetadataSuite.scala
@@ -20,6 +20,9 @@ import java.io.File
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.propertyKey
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.JsonUtils
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStatsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStatsSuite.scala
@@ -17,6 +17,9 @@
 package org.apache.spark.sql.delta.typewidening
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSinkSuite.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql.delta.typewidening
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.Relocated.StreamExecution
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.{DeltaSink, DeltaSQLConf}
 
 import org.apache.spark.sql.Row

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -20,6 +20,9 @@ import java.io.File
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.util.ScalaExtensions._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
@@ -22,6 +22,9 @@ import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.propertyKey
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.rowtracking.RowTrackingTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
@@ -20,6 +20,9 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{RemoveFile, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.AlterTableDropFeatureDeltaCommand
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.DeltaFileOperations

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
@@ -19,6 +19,9 @@ package org.apache.spark.sql.delta.uniform
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.dml.delete._
+import org.apache.spark.sql.delta.dml.merge._
+import org.apache.spark.sql.delta.dml.update._
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Simplifies the large `spark/Test` target by moving the DML test suites into different subpackages and separating out more CDC and deletion vector utility classes into separate packages as well.
This structure is more logical and has the nice side effect of making the compiler's job a little bit easier, resulting in about 0.5-1s improved (clean) build speeds on my machine at least.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.
