### PR TITLE
[Build] Add CODEOWNERS to require approval for build-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS file for Delta Lake
+# This file defines code owners who must approve changes to specific files/directories.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Build configuration files and directories
+/build/                         @tdas
+/build.sbt                      @tdas
+/project/                       @tdas
+/version.sbt                    @tdas
+
+# All files in the root directory
+/*                              @tdas


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Build configuration)

## Description

Adds a CODEOWNERS file to require approval from @tdas for:
- Build configuration files and directories (`/build/`, `/build.sbt`, `/project/`, `/version.sbt`)
- All files added to the root directory (`/*`)

This ensures that critical build infrastructure changes are reviewed by the appropriate maintainer.

## How was this patch tested?

No tests needed - this is a GitHub configuration file that will be validated by GitHub when the PR is merged.

## Does this PR introduce _any_ user-facing changes?

No. This only affects the PR review process for contributors modifying build-related files.