### PR TITLE
[Kernel] Add serializeToBase64() to DeletionVectorDescriptor

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/DeletionVectorDescriptor.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/DeletionVectorDescriptor.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toMap;
 
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.deletionvectors.Base85Codec;
 import io.delta.kernel.internal.fs.Path;
@@ -29,6 +30,9 @@ import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
@@ -168,6 +172,34 @@ public class DeletionVectorDescriptor {
       return uniqueFileId + "@" + offset;
     } else {
       return uniqueFileId;
+    }
+  }
+
+  /**
+   * Serialize this DV descriptor to a base64 encoded string.
+   *
+   * <p>Format is compatible with Spark's DeletionVectorDescriptor.serializeToBase64().
+   */
+  public String serializeToBase64() {
+    try (ByteArrayOutputStream bs = new ByteArrayOutputStream();
+        DataOutputStream ds = new DataOutputStream(bs)) {
+      ds.writeLong(cardinality);
+      ds.writeInt(sizeInBytes);
+
+      byte[] storageTypeBytes = storageType.getBytes();
+      checkArgument(storageTypeBytes.length == 1, "Storage type must be 1 byte: " + storageType);
+      ds.writeByte(storageTypeBytes[0]);
+
+      // Inline DVs (storageType="i") have no offset
+      if (!storageType.equals(INLINE_DV_MARKER)) {
+        checkArgument(offset.isPresent(), "Non-inline DV must have offset");
+        ds.writeInt(offset.get());
+      }
+
+      ds.writeUTF(pathOrInlineDv);
+      return Base64.getEncoder().encodeToString(bs.toByteArray());
+    } catch (IOException e) {
+      throw new KernelException("Failed to serialize DeletionVectorDescriptor", e);
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/DeletionVectorDescriptorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/DeletionVectorDescriptorSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions
+
+import java.io.{ByteArrayInputStream, DataInputStream}
+import java.util.{Base64, Optional}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Tests for DeletionVectorDescriptor.serializeToBase64().
+ */
+class DeletionVectorDescriptorSuite extends AnyFunSuite {
+
+  // Test cases: (storageType, pathOrInlineDv, offset, sizeInBytes, cardinality)
+  private val testCases = Seq(
+    ("u", "ab^-aqEH.-t@S}K{vb[*k^", Some(4), 40, 2L),
+    ("p", "path/to/dv.bin", Some(100), 1024, 50L),
+    ("i", "inline_data_here", None, 16, 3L))
+
+  testCases.foreach { case (storageType, pathOrInlineDv, offset, sizeInBytes, cardinality) =>
+    test(s"serializeToBase64 - $storageType storage type") {
+      val dv = new DeletionVectorDescriptor(
+        storageType,
+        pathOrInlineDv,
+        offset.map(Integer.valueOf).map(Optional.of[Integer]).getOrElse(Optional.empty[Integer]()),
+        sizeInBytes,
+        cardinality)
+
+      val base64Result = dv.serializeToBase64()
+
+      // Decode and verify the serialization format
+      val bytes = Base64.getDecoder.decode(base64Result)
+      val dis = new DataInputStream(new ByteArrayInputStream(bytes))
+
+      assert(dis.readLong() === cardinality)
+      assert(dis.readInt() === sizeInBytes)
+      assert(dis.readByte().toChar.toString === storageType)
+
+      if (storageType != "i") {
+        assert(dis.readInt() === offset.get)
+      }
+
+      assert(dis.readUTF() === pathOrInlineDv)
+      dis.close()
+    }
+  }
+
+  test("serializeToBase64 throws for non-inline DV without offset") {
+    val ex = intercept[IllegalArgumentException] {
+      val dv = new DeletionVectorDescriptor(
+        "u",
+        "ab^-aqEH.-t@S}K{vb[*k^",
+        Optional.empty[Integer](),
+        40,
+        2L)
+      dv.serializeToBase64()
+    }
+    assert(ex.getMessage.contains("Non-inline DV must have offset"))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Add a method to serialize DeletionVectorDescriptor to base64 encoded string.
This is needed for V2 connector DV support to pass DV info through
PartitionedFile metadata.

Format is compatible with Spark's DeletionVectorDescriptor.serializeToBase64().
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
unit

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no