### PR TITLE
[Spark] [Cleanup] Remove obsolete .gitignore file from icebergShaded directory

### DIFF
--- a/icebergShaded/.gitignore
+++ b/icebergShaded/.gitignore
@@ -1,2 +1,0 @@
-iceberg_src
-lib


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Follow-up of #5325
Remove obsolete .gitignore file from icebergShaded directory. It was created when icebergShaded was pulling Iceberg source code and appling patches to create a custom JAR. Now it relies on Maven JAR

## How was this patch tested?
N/A

## Does this PR introduce _any_ user-facing changes?
No