### PR TITLE
Add a flag to force stats collection during query optimizations

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -470,6 +470,16 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_ALWAYS_COLLECT_STATS =
+    buildConf("alwaysCollectStats.enabled")
+      .internal()
+      .doc("When true, row counts are collected from file statistics even when there are no " +
+        "data filters. This is useful for ensuring PreparedDeltaFileIndex always has row count " +
+        "information available. Note: this may have a small performance overhead as it requires " +
+        "summing numRecords from all files.")
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_LIMIT_PUSHDOWN_ENABLED =
     buildConf("stats.limitPushdown.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/PreparedDeltaFileIndexRowCountSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/PreparedDeltaFileIndexRowCountSuite.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.stats
+
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTable}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Test suite to verify when preparedScan.scanned.rows is populated in PreparedDeltaFileIndex,
+ * and the behavior of the DELTA_ALWAYS_COLLECT_STATS flag.
+ */
+class PreparedDeltaFileIndexRowCountSuite
+    extends QueryTest
+    with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  private def getDeltaScan(df: DataFrame): DeltaScan = {
+    val scans = df.queryExecution.optimizedPlan.collect {
+      case DeltaTable(prepared: PreparedDeltaFileIndex) => prepared.preparedScan
+    }
+    assert(scans.size == 1, s"Expected 1 DeltaScan, found ${scans.size}")
+    scans.head
+  }
+
+  /**
+   * Test utility that creates a partitioned Delta table and verifies scanned.rows and
+   * scanned.logicalRows behavior.
+   *
+   * @param alwaysCollectStats value of the DELTA_ALWAYS_COLLECT_STATS flag
+   * @param queryTransform function to transform the base DataFrame (apply filters)
+   * @param expectedRowsDefined whether scanned.rows should be defined
+   * @param expectedRowCount expected row count if defined (None to skip validation)
+   * @param expectedLogicalRowsDefined whether scanned.logicalRows should be defined
+   *                                   (defaults to same as expectedRowsDefined)
+   * @param expectedLogicalRowCount expected logical row count if defined (None to skip validation)
+   */
+  private def testRowCountBehavior(
+      alwaysCollectStats: Boolean,
+      queryTransform: DataFrame => DataFrame,
+      expectedRowsDefined: Boolean,
+      expectedRowCount: Option[Long] = None,
+      expectedLogicalRowsDefined: Option[Boolean] = None,
+      expectedLogicalRowCount: Option[Long] = None): Unit = {
+    withTempDir { dir =>
+      withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "true") {
+        spark.range(100).toDF("id")
+          .withColumn("part", $"id" % 4)
+          .repartition(4)
+          .write.format("delta").partitionBy("part").save(dir.getAbsolutePath)
+      }
+
+      DeltaLog.clearCache()
+
+      withSQLConf(DeltaSQLConf.DELTA_ALWAYS_COLLECT_STATS.key -> alwaysCollectStats.toString) {
+        val df = spark.read.format("delta").load(dir.getAbsolutePath)
+        val scan = getDeltaScan(queryTransform(df))
+
+        if (expectedRowsDefined) {
+          assert(scan.scanned.rows.isDefined, "scanned.rows should be defined")
+          expectedRowCount.foreach { expected =>
+            assert(scan.scanned.rows.get == expected,
+              s"Expected $expected rows, got ${scan.scanned.rows.get}")
+          }
+        } else {
+          assert(scan.scanned.rows.isEmpty, "scanned.rows should be None")
+        }
+
+        // logicalRows should follow the same defined/undefined pattern as rows by default
+        val logicalDefined = expectedLogicalRowsDefined.getOrElse(expectedRowsDefined)
+        if (logicalDefined) {
+          assert(scan.scanned.logicalRows.isDefined, "scanned.logicalRows should be defined")
+          expectedLogicalRowCount.foreach { expected =>
+            assert(scan.scanned.logicalRows.get == expected,
+              s"Expected $expected logical rows, got ${scan.scanned.logicalRows.get}")
+          }
+        } else {
+          assert(scan.scanned.logicalRows.isEmpty, "scanned.logicalRows should be None")
+        }
+      }
+    }
+  }
+
+  // Define query cases: (name, transform function, always collects rows)
+  private val queryCases: Seq[(String, DataFrame => DataFrame, Boolean)] = Seq(
+    ("no filter", identity[DataFrame], false),
+    ("TrueLiteral filter", _.where(lit(true)), false),
+    ("partition filter only", _.where($"part" === 1), false),
+    ("data filter", _.where($"id" === 50), true),
+    ("partition + data filter", _.where($"part" === 1).where($"id" === 49), true)
+  )
+
+  // Grid test: all query cases x flag values
+  for {
+    (caseName, queryTransform, alwaysCollectsRows) <- queryCases
+    alwaysCollectStats <- Seq(false, true)
+  } {
+    val flagDesc = s"alwaysCollectStats=$alwaysCollectStats"
+    // If the query type always collects rows, rows is always defined; otherwise depends on flag
+    val expectedRowsDefined = alwaysCollectsRows || alwaysCollectStats
+
+    test(s"$caseName - $flagDesc") {
+      testRowCountBehavior(
+        alwaysCollectStats = alwaysCollectStats,
+        queryTransform = queryTransform,
+        expectedRowsDefined = expectedRowsDefined
+      )
+    }
+  }
+
+  test("alwaysCollectStats with missing stats returns None") {
+    withTempDir { dir =>
+      // Create table without stats
+      withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+        spark.range(100).toDF("id")
+          .write.format("delta").save(dir.getAbsolutePath)
+      }
+
+      DeltaLog.clearCache()
+
+      withSQLConf(DeltaSQLConf.DELTA_ALWAYS_COLLECT_STATS.key -> "true") {
+        val df = spark.read.format("delta").load(dir.getAbsolutePath)
+        val scan = getDeltaScan(df)
+        assert(scan.scanned.rows.isEmpty, "scanned.rows should be None when stats are missing")
+        assert(scan.scanned.logicalRows.isEmpty,
+          "scanned.logicalRows should be None when stats are missing")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR adds a new Spark flag that will make all code paths in DataSkippingReader to collect stats.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
