### PR TITLE
[sharing][test-only] Fix delta format CDF suite to not set large retention period

### DIFF
--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -866,15 +866,10 @@ trait DeltaSharingDataSourceDeltaSuiteBase
   test("DeltaSharingDataSource able to read data for simple cdf query") {
     withTempDir { tempDir =>
       val deltaTableName = "delta_table_cdf"
-      // Set the deletedFileRetentionDuration and logRetentionDuration to a large value so that
-      // older versions can be accessed
-      val largeRetentionHours = 2 * System.currentTimeMillis().millis.toHours
       withTable(deltaTableName) {
         sql(s"""
                |CREATE TABLE $deltaTableName (c1 INT, c2 STRING) USING DELTA PARTITIONED BY (c2)
-               |TBLPROPERTIES (delta.enableChangeDataFeed = true,
-               |'delta.deletedFileRetentionDuration' = '$largeRetentionHours hours',
-               |'delta.logRetentionDuration' = '$largeRetentionHours hours')
+               |TBLPROPERTIES (delta.enableChangeDataFeed = true)
                |""".stripMargin)
         // 2 inserts in version 1, 1 with c1=2
         sql(s"""INSERT INTO $deltaTableName VALUES (1, "one"), (2, "two")""")
@@ -1151,17 +1146,12 @@ trait DeltaSharingDataSourceDeltaSuiteBase
   test("DeltaSharingDataSource able to read cdf with special chars") {
     withTempDir { tempDir =>
       val deltaTableName = "delta_table_cdf_special"
-      // Set the deletedFileRetentionDuration and logRetentionDuration to a large value so that
-      // older versions can be accessed
-      val largeRetentionHours = 2 * System.currentTimeMillis().millis.toHours
       withTable(deltaTableName) {
         // scalastyle:off nonascii
         sql(s"""CREATE TABLE $deltaTableName (`第一列` INT, c2 STRING)
                |USING DELTA PARTITIONED BY (c2)
                |TBLPROPERTIES(
-               |delta.enableChangeDataFeed = true,
-               |'delta.deletedFileRetentionDuration' = '$largeRetentionHours hours',
-               |'delta.logRetentionDuration' = '$largeRetentionHours hours'
+               |delta.enableChangeDataFeed = true
                |)""".stripMargin)
         // The table operations take about 20~30 seconds.
         for (i <- 0 to 9) {

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingTestSparkUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingTestSparkUtils.scala
@@ -86,17 +86,10 @@ trait DeltaSharingTestSparkUtils extends DeltaSQLTestUtils {
   }
 
   protected def createSimpleTable(tableName: String, enableCdf: Boolean): Unit = {
-    // Set the deletedFileRetentionDuration and largeRetentionHours to a large value so that older
-    // versions can be accessed
-    val largeRetentionHours = 2 * System.currentTimeMillis().millis.toHours
     val tablePropertiesStr = if (enableCdf) {
       s"""TBLPROPERTIES (
         |delta.minReaderVersion=1,
         |delta.minWriterVersion=4,
-        |'delta.deletedFileRetentionDuration' =
-        |'$largeRetentionHours hours',
-        |'delta.logRetentionDuration' =
-        |'$largeRetentionHours hours',
         |delta.enableChangeDataFeed = true)""".stripMargin
     } else {
       ""
@@ -108,25 +101,15 @@ trait DeltaSharingTestSparkUtils extends DeltaSQLTestUtils {
   }
 
   protected def createCMIdTableWithCdf(tableName: String): Unit = {
-    // Set the deletedFileRetentionDuration and logRetentionDuration to a large value so that
-    // older versions can be accessed
-    val largeRetentionHours = 2 * System.currentTimeMillis().millis.toHours
     sql(s"""CREATE TABLE $tableName (c1 INT, c2 STRING) USING DELTA PARTITIONED BY (c2)
            |TBLPROPERTIES ('delta.columnMapping.mode' = 'id',
-           |'delta.deletedFileRetentionDuration' = '$largeRetentionHours hours',
-           |'delta.logRetentionDuration' = '$largeRetentionHours hours',
            |delta.enableChangeDataFeed = true)
            |""".stripMargin)
   }
 
   protected def createDVTableWithCdf(tableName: String): Unit = {
-    // Set the deletedFileRetentionDuration and logRetentionDuration to a large value so that
-    // older versions can be accessed
-    val largeRetentionHours = 2 * System.currentTimeMillis().millis.toHours
     sql(s"""CREATE TABLE $tableName (c1 INT, partition INT) USING DELTA PARTITIONED BY (partition)
            |TBLPROPERTIES (delta.enableDeletionVectors = true,
-           |'delta.deletedFileRetentionDuration' = '$largeRetentionHours hours',
-           |'delta.logRetentionDuration' = '$largeRetentionHours hours',
            |delta.enableChangeDataFeed = true)
            |""".stripMargin)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Now that we don't check log retention period for delta format shared tables (https://github.com/delta-io/delta/pull/5739), we can revert the adjustment made to the tests to set extra-large retention period as it is not needed. Setting a large retention period in the test was not the right move in the first place, as it wrongly changed the test suite instead of addressing the root cause.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
It is a test.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.