### PR TITLE
[Protocol] Add documentation for data skipping statistics configuration properties

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -894,16 +894,16 @@ Delta tables support configuration through table properties stored in the `confi
 
 ## Statistics Collection Properties
 
-The following table properties control which columns have per-column statistics collected in [Per-file Statistics](#per-file-statistics):
+The following table properties specify which columns should have per-column statistics collected in [Per-file Statistics](#per-file-statistics). Writers are recommended to respect these properties when collecting statistics.
 
 Property | Description
 -|-
 `delta.dataSkippingStatsColumns` | A comma-separated list of column names for which to collect per-column statistics. Column names may refer to nested struct fields using dot notation (e.g., `a.b.c`), in which case statistics are collected for all leaf fields within that struct. Column names containing special characters (including commas, dots, or spaces) must be enclosed in backticks (e.g., `` `column.with" +special,chars` ``). When this property is set, it takes precedence over `delta.dataSkippingNumIndexedCols`. Partition columns cannot be specified.
 `delta.dataSkippingNumIndexedCols` | The number of leading leaf columns in the table schema for which to collect per-column statistics. Defaults to 32. This property is ignored if `delta.dataSkippingStatsColumns` is set. A negative value indicates that statistics should be collected for all columns.
 
-When neither property is set, statistics are collected for the first 32 leaf columns in the table schema (excluding partition columns).
+When neither property is set, statistics should be collected for the first 32 leaf columns in the table schema (excluding partition columns).
 
-For [clustered tables](#clustered-table), all clustering columns must be included in the set of columns for which statistics are collected, whether determined by `delta.dataSkippingStatsColumns`, `delta.dataSkippingNumIndexedCols`, or the default.
+For [clustered tables](#clustered-table), all clustering columns should be included in the set of columns for which statistics are collected, whether determined by `delta.dataSkippingStatsColumns`, `delta.dataSkippingNumIndexedCols`, or the default.
 
 # Column Mapping
 Delta can use column mapping to avoid any column naming restrictions, and to support the renaming and dropping of columns without having to rewrite all the data. There are two modes of column mapping, by `name` and by `id`. In both modes, every column - nested or leaf - is assigned a unique _physical_ name, and a unique 32-bit integer as an id. The physical name is stored as part of the column metadata with the key `delta.columnMapping.physicalName`. The column id is stored within the metadata with the key `delta.columnMapping.id`.
@@ -1368,7 +1368,7 @@ When the Clustered Table is supported (when the `writerFeatures` field of a tabl
 - Writers must track clustering column names in a `domainMetadata` action with `delta.clustering` as the `domain` and a `configuration` containing all clustering column names.
   If [Column Mapping](#column-mapping) is enabled, the physical column names should be used.
 - Writers must write out [per-file statistics](#per-file-statistics) and per-column statistics for clustering columns in `add` action.
-  Clustering columns must be included in the set of columns for which statistics are collected (see [Statistics Collection Properties](#statistics-collection-properties)).
+  Clustering columns should be included in the set of columns for which statistics are collected (see [Statistics Collection Properties](#statistics-collection-properties)).
   If a new column is included in the clustering columns list, it is required for all table files to have statistics for these added columns.
 - When a clustering implementation clusters files, writers must set the name of the clustering implementation in the `clusteringProvider` field when adding `add` actions for clustered files.
   - By default, a clustering implementation must only recluster files that have the field `clusteringProvider` set to the name of the same clustering implementation, or to the names of other clustering implementations that are superseded by the current clustering implementation. In addition, a clustering implementation may cluster any files with an unset `clusteringProvider` field (i.e., unclustered files).


### PR DESCRIPTION
## Description
This PR adds documentation to PROTOCOL.md for two table properties that control per-column statistics collection:
* delta.dataSkippingStatsColumns: Allows users to explicitly specify which columns should have statistics collected. Column names can refer to struct fields using dot notation (e.g., a.b.c), in which case all leaf fields within that struct are included.
* delta.dataSkippingNumIndexedCols: Specifies the number of leading leaf columns in the table schema for which to collect statistics. Defaults to 32.

This is implemented in Spark today. See https://github.com/delta-io/delta/blob/f86d5496ee5e1f18ee1c4affa9fc8d4f77c07221/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala#L637