### PR TITLE
[Spark] Add test util `getAllDeltaOperations`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.delta
 
-import scala.reflect.runtime.universe._
-
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.util.JsonUtils
@@ -210,26 +208,7 @@ class CommitInfoSerializerSuite extends QueryTest with SharedSparkSession {
   )
 
   test("all operations should be tested in this suite") {
-    val mirror = runtimeMirror(getClass.getClassLoader)
-    val moduleSymbol =
-      mirror.staticModule("org.apache.spark.sql.delta.DeltaOperations")
-    val moduleMirror = mirror.reflectModule(moduleSymbol)
-    val instance = moduleMirror.instance
-
-    val instanceMirror = mirror.reflect(instance)
-    val symbol = instanceMirror.symbol
-    val traitOperation =
-      typeOf[org.apache.spark.sql.delta.DeltaOperations.Operation].typeSymbol
-
-    val allOperations = symbol.typeSignature.members.flatMap {
-      case cls: ClassSymbol
-          if cls.isCaseClass && cls.isPublic && cls.toType.baseClasses.contains(traitOperation) =>
-        Some(cls.name.toString)
-      case obj: ModuleSymbol
-          if obj.isPublic && obj.moduleClass.asType.toType.baseClasses.contains(traitOperation) =>
-        Some(obj.name.toString)
-      case _ => None
-    }.toSet
+    val allOperations = DeltaTestUtils.getAllDeltaOperations
     assert(
       (allOperations -- ignoredOperationClasses) == trackedOperationClasses.keySet,
       s"if you add a new operation, please add a new test case in this suite " +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

It adds util `getAllDeltaOperations` to discovers all `DeltaOperations.Operation` subclasses using reflection. This is useful for tests that need to ensure exhaustive coverage of all operations.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Test-only.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
