### PR TITLE
[Server-Side Planning] Add columnarSupportMode() override

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
@@ -250,6 +250,10 @@ class ServerSidePlannedScan(
 
   override def toBatch: Batch = this
 
+  override def columnarSupportMode(): Scan.ColumnarSupportMode = {
+    Scan.ColumnarSupportMode.UNSUPPORTED
+  }
+
   // Convert pushed filters to a single Spark Filter for the API call.
   // If no filters, pass None. If filters exist, combine them into a single filter.
   private val combinedFilter: Option[Filter] = {


### PR DESCRIPTION
## Summary
Add `columnarSupportMode()` override to `ServerSidePlannedScan` declaring `UNSUPPORTED` since it returns row-based batches, not columnar ones.

## Details
ServerSidePlannedScan extended Scan but didn't override columnarSupportMode(), which defaults to PARTITION_DEFINED. When Spark checks supportsColumnar during DML physical planning, it accesses inputPartitions, triggering planInputPartitions() prematurely. Returning UNSUPPORTED prevents Spark from accessing inputPartitions during DML planning phase. DML commands (DELETE/UPDATE/MERGE) no longer trigger unnecessary scan plan API calls

## Test plan
- Existing tests should pass
- Verify batches are read correctly with non-columnar mode