### PR TITLE
[Spark] Use parsed_stats from checkpoints in loadActions when available

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.util.{Locale, TimeZone}
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta.actions._
@@ -38,10 +39,14 @@ import org.apache.spark.sql.delta.util.StateCache
 import org.apache.spark.sql.util.ScalaExtensions._
 import io.delta.storage.commit.CommitCoordinatorClient
 import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
+import org.apache.parquet.hadoop.Footer
+import org.apache.parquet.hadoop.ParquetFileReader
 
 import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetToSparkSchemaConverter}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
@@ -528,11 +533,51 @@ class Snapshot(
    * when sorted in ascending order, will order older actions before newer ones, as required by
    * [[InMemoryLogReplay]]); and [[ADD_STATS_TO_USE_COL_NAME]] (to handle certain combinations of
    * config settings for delta.checkpoint.writeStatsAsJson and delta.checkpoint.writeStatsAsStruct).
+   * When we see a V2 checkpoint without the old stats column, but the stats_parsed column, we
+   * json encode the stats_parsed column back as "stats" again. This is a temporary correctness
+   * hack.
    */
   protected def loadActions: DataFrame = {
-    fileIndices.map(deltaLog.loadIndex(_))
-      .reduceOption(_.union(_)).getOrElse(emptyDF)
-      .withColumn(ADD_STATS_TO_USE_COL_NAME, col("add.stats"))
+    if (fileIndices.isEmpty) return emptyDF
+
+    // Augment the schema with a NullType add.stats_parsed column, as a place-holder for
+    // compatibility with the checkpoint parquet. Both deltas and checkpoints generally use this
+    // schema. HOWEVER, IF (and only if) a checkpoint actually exists, AND it provides an
+    // add.stats_parsed column AND it lacks an add.stats column, THEN (and only then) the checkpoint
+    // DF includes the actual add.stats_parsed column -- not a NullType placeholder -- from which we
+    // generate the add_stats_to_use column (add.stats is unused in that case). Meanwhile, JSON
+    // deltas always map add.stats to add_stats_to_use, and always use the placeholder.
+    val logSchemaToUse = Action.logSchema
+    val jsonStatsCol = col("add.stats")
+    val deltas = deltaFileIndexOpt.map(deltaLog.loadIndex(_, logSchemaToUse))
+      .map(_.withColumn(ADD_STATS_TO_USE_COL_NAME, jsonStatsCol))
+
+    val checkpointDataframes = checkpointProvider
+      .allActionsFileIndexesAndSchemas(spark, deltaLog)
+      .map { case (index, schema) =>
+        val addSchema = schema("add").dataType.asInstanceOf[StructType]
+        val (checkpointSchemaToUse, checkpointStatsColToUse) =
+          if (addSchema.exists(_.name == "stats_parsed") && !addSchema.exists(_.name == "stats")) {
+            val checkpointSchemaToUse =
+              Action.logSchemaWithAddStatsParsed(addSchema("stats_parsed"))
+            (
+              checkpointSchemaToUse,
+              to_json(
+                col("add.stats_parsed")
+              )
+            )
+          } else {
+            // Normal (JSON-like) schema suffices
+            (logSchemaToUse, jsonStatsCol)
+          }
+
+        // For schema compat, make sure to discard add.stats_parsed (if present)
+        deltaLog.loadIndex(index, checkpointSchemaToUse)
+          .withColumn(COMMIT_VERSION_COLUMN, lit(checkpointProvider.version))
+          .withColumn(ADD_STATS_TO_USE_COL_NAME, checkpointStatsColToUse)
+          .withColumn("add", col("add").dropFields("stats_parsed"))
+      }
+      (checkpointDataframes ++ deltas).reduce(_.union(_))
   }
 
   /**
@@ -816,6 +861,30 @@ object Snapshot extends DeltaLogging {
     } else {
       base
     }
+  }
+
+  /**
+   * Gets the schema of a single parquet file by reading its footer. Code here is copied from
+   * ParquetFileFormat.
+   */
+  private[delta] def getParquetFileSchemaAndRowCount(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      file: FileStatus): (StructType, Long) = {
+    // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`
+    val converter = new ParquetToSparkSchemaConverter(
+      assumeBinaryIsString = spark.sessionState.conf.isParquetBinaryAsString,
+      assumeInt96IsTimestamp = spark.sessionState.conf.isParquetINT96AsTimestamp)
+
+    val conf = deltaLog.newDeltaHadoopConf()
+
+    val parquetMetadata = {
+      ParquetFileReader.readFooter(deltaLog.newDeltaHadoopConf(), file.getPath)
+    }
+    val rowCount = parquetMetadata.getBlocks.asScala.map(_.getRowCount).sum
+
+    val footer = new Footer(file.getPath(), parquetMetadata)
+    (ParquetFileFormat.readSchemaFromFooter(footer, converter), rowCount)
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -115,6 +115,18 @@ object Action {
 
   lazy val logSchema = ExpressionEncoder[SingleAction]().schema
   lazy val addFileSchema = logSchema("add").dataType.asInstanceOf[StructType]
+
+  /**
+   * Same as [[logSchema]], but with a user-specified add.stats_parsed column. This is useful for
+   * reading parquet checkpoint files that provide add.stats_parsed instead of add.stats.
+   */
+  def logSchemaWithAddStatsParsed(statsParsed: StructField): StructType = {
+    val logAddSchema = logSchema("add").dataType.asInstanceOf[StructType]
+    val fields = logSchema.map { f =>
+      if (f.name == "add") f.copy(dataType = logAddSchema.add(statsParsed)) else f
+    }
+    StructType(fields)
+  }
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1254,6 +1254,14 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .intConf
       .createWithDefault(30)
 
+  val USE_CHECKPOINT_SCHEMA_FROM_CHECKPOINT_METADATA =
+    buildConf("checkpointSchema.useFromCheckpointMetadata")
+      .internal()
+      .doc("If enabled, use checkpoint schema from checkpoint metadata file instead of reading it" +
+        " from the checkpoint file")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_WRITE_CHECKSUM_ENABLED =
     buildConf("writeChecksumFile.enabled")
       .doc("Whether the checksum file can be written.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Updates loadActions so that it fetches stats from parsed_stats and emits them in the stats column for further usage. This also helps maintain stats in the checkpoint when some table has statsAsJson disabled and statsAsStruct enabled.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
DeltaCheckpointWithStructColsSuite

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No