### PR TITLE
[Kernel] Fix long overflow when parsing far-future timestamp stats

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
@@ -212,6 +212,17 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
       TestRow(2524636800000000L, 23423523000L, -315583200000000L, null))
   }
 
+  test("parse timestamp type with large values") {
+    // Timestamps far in the future should not cause overflow.
+    // ChronoUnit.MICROS.between() internally computes nanoseconds first, which overflows
+    // for timestamps more than ~292 years from epoch.
+    testJsonParserForSingleType(
+      jsonString = """{"col1":"9999-12-31T23:59:59.000+00:00"}""",
+      dataType = TimestampType.TIMESTAMP,
+      numColumns = 1,
+      TestRow(253402300799000000L))
+  }
+
   test("parse null input") {
     val schema = new StructType()
       .add("nested_struct", new StructType().add("foo", IntegerType.INTEGER))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/5927/files) to review incremental changes.
- [**stack/kernel_long_overflow_timestamp_stats_col_bug**](https://github.com/delta-io/delta/pull/5927) [[Files changed](https://github.com/delta-io/delta/pull/5927/files)]

---------

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

ChronoUnit.MICROS.between() internally computes (seconds * 1_000_000_000) / 1000,
where the intermediate nanoseconds value overflows for timestamps beyond ~292
years from epoch. Fix by computing seconds * 1_000_000 directly.

## How was this patch tested?

New UTs.

## Does this PR introduce _any_ user-facing changes?

No
