### PR TITLE
[Spark] Don't print Java objects in SnapshotManagement

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -269,10 +269,10 @@ trait SnapshotManagement { self: DeltaLog =>
       // the additional listing.
       val eventData = Map(
         "initialCommitVersionsFromFsListingOpt" ->
-          initialLogTuplesFromFsListingOpt.map(_.map(_._3)),
+          initialLogTuplesFromFsListingOpt.map(_.map(_._3).toSeq),
         "initialMaxDeltaVersionSeen" -> initialMaxDeltaVersionSeen,
         "additionalCommitVersionsFromFsListingOpt" ->
-          additionalLogTuplesFromFsListingOpt.map(_.map(_._3)),
+          additionalLogTuplesFromFsListingOpt.map(_.map(_._3).toSeq),
         "maxDeltaVersionSeen" -> maxDeltaVersionSeen,
         "unbackfilledCommitVersions" ->
           unbackfilledCommitsResponse.getCommits.asScala.map(commit => commit.getVersion),


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR fixes an issue where we accidentally print Java objects because we're printing `Option[Array[T]]`, where Array is a Java array. Call `.toSeq` to convert to Scala and prevent Java array object references (e.g., `"[J@1a2b3c4d"`) in event data.

## How was this patch tested?
Existing tests pass. Manual testing since I encountered this while debugging an issue.

## Does this PR introduce _any_ user-facing changes?

No.
