### PR TITLE
[Spark] Improve logging snapshot upon snapshot update

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1089,13 +1089,15 @@ trait SnapshotManagement { self: DeltaLog =>
     val doAsync = stalenessAcceptable && !isCurrentlyStale(capturedSnapshot.updateTimestamp)
     if (!doAsync) {
       recordFrameProfile("Delta", "SnapshotManagement.update") {
-        withSnapshotLockInterruptibly {
+        val snapshot = withSnapshotLockInterruptibly {
           val newSnapshot = updateInternal(
             isAsync = false,
             catalogTableOpt)
           sendEvent(newSnapshot = newSnapshot)
           newSnapshot
         }
+        logCurrentSnapshot()
+        snapshot
       }
     } else {
       // Kick off an async update, if one is not already obviously running. Intentionally racy.
@@ -1118,6 +1120,7 @@ trait SnapshotManagement { self: DeltaLog =>
             recordDeltaEvent(this, "delta.snapshot.asyncUpdateFailed", data = Map("exception" -> e))
         }
       }
+      logCurrentSnapshot()
       currentSnapshot.snapshot
     }
   }
@@ -1279,7 +1282,6 @@ trait SnapshotManagement { self: DeltaLog =>
           catalogTableOpt = catalogTableOpt,
           checksumOpt = None)
         previousSnapshotOpt.foreach(logMetadataTableIdChange(_, newSnapshot))
-        logInfo(log"Updated snapshot to ${MDC(DeltaLogKeys.SNAPSHOT, newSnapshot)}")
         newSnapshot
       }
     }.getOrElse {
@@ -1327,6 +1329,28 @@ trait SnapshotManagement { self: DeltaLog =>
         "nextSnapshotVersion" -> newSnapshot.version,
         "nextSnapshotMetadata" -> newSnapshot.metadata))
     }
+  }
+
+  private def logCurrentSnapshot(): Unit = {
+    val CapturedSnapshot(snapshot, updatedTimestamp) = currentSnapshot
+    var logLine = log"Updated snapshot to ${MDC(DeltaLogKeys.SNAPSHOT, snapshot)}. "
+    logLine += log"Updated at: ${MDC(DeltaLogKeys.TIMESTAMP, updatedTimestamp)}. "
+    // Only check table size when checksum is available to avoid triggering state reconstruction.
+    snapshot.checksumOpt.foreach { checksum =>
+      logLine += log"Number of files: ${MDC(DeltaLogKeys.NUM_FILES, checksum.numFiles)} files. "
+      logLine += log"Table size: ${MDC(DeltaLogKeys.NUM_BYTES, checksum.tableSizeBytes)} bytes. "
+      val threshold = spark.conf.get(DeltaSQLConf.DELTA_SNAPSHOT_LOGGING_MAX_FILES_THRESHOLD)
+      if (threshold > 0 && checksum.numFiles > threshold) {
+        logWarning(
+          log"Snapshot at ${MDC(DeltaLogKeys.PATH, logPath)}, " +
+          log"version ${MDC(DeltaLogKeys.VERSION, snapshot.version)} has too many files " +
+          log"(files: ${MDC(DeltaLogKeys.NUM_FILES, checksum.numFiles)}, " +
+          log"threshold: ${MDC(DeltaLogKeys.NUM_FILES, threshold)}). This generally happens " +
+          log"when the table is over-partitioned or have lots of small files. Consider fixing " +
+          log"the partitioning scheme or running OPTIMIZE on the table.")
+      }
+    }
+    logInfo(logLine)
   }
 
   /**
@@ -1452,7 +1476,7 @@ trait SnapshotManagement { self: DeltaLog =>
         installSnapshot(newSnapshot, updateTimestamp)
       }
       logMetadataTableIdChange(previousSnapshot, updatedSnapshot)
-      logInfo(log"Updated snapshot to ${MDC(DeltaLogKeys.SNAPSHOT, updatedSnapshot)}")
+      logCurrentSnapshot()
       updatedSnapshot
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -176,6 +176,15 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .stringConf
       .createWithDefault("MEMORY_AND_DISK_SER")
 
+  val DELTA_SNAPSHOT_LOGGING_MAX_FILES_THRESHOLD =
+    buildConf("snapshot.logging.maxFilesThreshold")
+      .internal()
+      .doc("Threshold for number of files in a snapshot. When exceeded, emits a warning with " +
+        "remediation hints. Set to 0 to disable snapshot logging completely.")
+      .longConf
+      .checkValue(_ >= 0, "must be non-negative")
+      .createWithDefault(500000L)
+
   val DELTA_PARTITION_COLUMN_CHECK_ENABLED =
     buildConf("partitionColumnValidity.enabled")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Unify all snapshot logging in one place.
- Add a warning if the number of files in the table is too large.


## How was this patch tested?
Run some tests and look at the output log. Example:
```
Updated snapshot to SnapshotEdge(path=file:/tmp/spark%dir%prefix-c80c867f-2823-47fa-b225-c27efd6654ef/_delta_log, version=0, logSegment=LogSegment(file:/tmp/spark%dir%prefix-c80c867f-2823-47fa-b225-c27efd6654ef/_delta_log,0,WrappedArray(),UninitializedV1OrV2ParquetCheckpointProvider(0,DeprecatedRawLocalFileStatus{path=file:/tmp/spark%dir%prefix-c80c867f-2823-47fa-b225-c27efd6654ef/_delta_log/00000000000000000000.checkpoint.parquet; isDirectory=false; length=19509; replication=1; blocksize=33554432; modification_time=1769560478493; access_time=1769560478465; owner=; group=; permission=rw-rw-rw-; isSymlink=false; hasAcl=false; isEncrypted=false; isErasureCoded=false},file:/tmp/spark%dir%prefix-c80c867f-2823-47fa-b225-c27efd6654ef/_delta_log,Some(LastCheckpointInfo(0,4,None,Some(19509),Some(2),Some(StructType(StructField(txn,StructType(StructField(appId,StringType,true),StructField(version,LongType,true),StructField(lastUpdated,LongType,true)),true),StructField(add,StructType(StructField(path,StringType,true),StructField(partitionValues,MapType(StringType,StringType,true),true),StructField(size,LongType,true),StructField(modificationTime,LongType,true),StructField(dataChange,BooleanType,true),StructField(tags,MapType(StringType,StringType,true),true),StructField(deletionVector,StructType(StructField(storageType,StringType,true),StructField(pathOrInlineDv,StringType,true),StructField(offset,IntegerType,true),StructField(sizeInBytes,IntegerType,true),StructField(cardinality,LongType,true),StructField(maxRowIndex,LongType,true)),true),StructField(baseRowId,LongType,true),StructField(defaultRowCommitVersion,LongType,true),StructField(clusteringProvider,StringType,true),StructField(stats,StringType,true),StructField(stats_parsed,StructType(StructField(numRecords,LongType,true),StructField(minValues,StructType(StructField(id,LongType,true)),true),StructField(maxValues,StructType(StructField(id,LongType,true)),true),StructField(nullCount,StructType(StructField(id,LongType,true)),true),StructField(tightBounds,BooleanType,true)),true)),true),StructField(remove,StructType(StructField(path,StringType,true),StructField(deletionTimestamp,LongType,true),StructField(dataChange,BooleanType,true),StructField(extendedFileMetadata,BooleanType,true),StructField(partitionValues,MapType(StringType,StringType,true),true),StructField(size,LongType,true),StructField(deletionVector,StructType(StructField(storageType,StringType,true),StructField(pathOrInlineDv,StringType,true),StructField(offset,IntegerType,true),StructField(sizeInBytes,IntegerType,true),StructField(cardinality,LongType,true),StructField(maxRowIndex,LongType,true)),true),StructField(baseRowId,LongType,true),StructField(defaultRowCommitVersion,LongType,true)),true),StructField(metaData,StructType(StructField(id,StringType,true),StructField(name,StringType,true),StructField(description,StringType,true),StructField(format,StructType(StructField(provider,StringType,true),StructField(options,MapType(StringType,StringType,true),true)),true),StructField(schemaString,StringType,true),StructField(partitionColumns,ArrayType(StringType,true),true),StructField(configuration,MapType(StringType,StringType,true),true),StructField(createdTime,LongType,true)),true),StructField(protocol,StructType(StructField(minReaderVersion,IntegerType,true),StructField(minWriterVersion,IntegerType,true),StructField(readerFeatures,ArrayType(StringType,true),true),StructField(writerFeatures,ArrayType(StringType,true),true)),true),StructField(domainMetadata,StructType(StructField(domain,StringType,true),StructField(configuration,StringType,true),StructField(removed,BooleanType,true)),true))),None,Some(List(SerializableFileStatus(00000000000000000000.checkpoint.parquet,19509,false,1769560478493))),None,Some(a979ee1939b78c37dd5b6a386eca47b6)))),1769560477873), schema=StructType(StructField(id,LongType,true)), checksumOptPresent=true, prefetchedCheckpointAndMetadataPresent=false, prefetchedDeltaPresent=false). Updated at: 1769560478537. Number of files: 2 files. Table size: 1039 bytes.
```

For the warning, temporarily change the config value to a smaller number to trigger it:
```
26/01/20 21:56:40 WARN DeltaLog: Snapshot at file:/tmp/spark%dir%prefix-c1fe8b29-bced-4918-85b4-c6624b815111/_delta_log, version 4 has too many files (files: 10, threshold: 5). This generally happens when the table is over-partitioned or have lots of small files. Consider fixing the partitioning scheme or running OPTIMIZE on the table.
```
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
