### PR TITLE
[Spark]Adding escape for the doc in UCCommitCoordinatorClient.java

### DIFF
--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -194,7 +194,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
 
   /**
    * Find the last known backfilled version by doing a listing of the last
-   * [[BACKFILL_LISTING_OFFSET]] commits. If no backfilled commits are found
+   * {@link #BACKFILL_LISTING_OFFSET} commits. If no backfilled commits are found
    * among those, a UC call is made to get the oldest tracked commit in UC.
    */
   public long getLastKnownBackfilledVersion(
@@ -716,7 +716,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
    *    delete the commit for v from its database.
    * 6. Now this client retries commit v (without conflict resolution since conflict=false
    *    in step 3).
-   * 7. UC rejects the commit because v <= latest_table_version and returns a retryable
+   * 7. UC rejects the commit because v {@literal <=} latest_table_version and returns a retryable
    *    conflict (retryable=true, conflict=true).
    *
    * Without this check, Delta's default response to retryable=true, conflict=true would be to
@@ -724,7 +724,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
    * commit the contents of v as v+2. This would result in duplicate data being written.
    *
    * This method prevents that by checking if the backfilled commit (v.json) has the same
-   * content as our retry attempt (v.<uuid>.json). If yes, we know our original commit
+   * content as our retry attempt (v.{@literal <uuid>}.json). If yes, we know our original commit
    * succeeded and can safely ignore the conflict and exit early without rebasing.
    *
    * Below is a concrete example of the failure and retry sequence:
@@ -733,9 +733,9 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
    * - Attempt 2: Try to commit v without conflict resolution since conflict=false in attempt-1.
    *              UC responds with retryable=true, conflict=true in the above scenario.
    *              (i.e. v is backfilled and latest version is v+1).
-   * - Fix: Compare v.<uuid>.json and v.json and *early exit* here.
+   * - Fix: Compare v.{@literal <uuid>}.json and v.json and *early exit* here.
    * - Attempt 3: [Without fix] Rebase, conflict-resolution + Try to commit v+2
-   *              => double-commit for contents of v => bug.
+   *              {@literal =>} double-commit for contents of v {@literal =>} bug.
    */
   protected boolean hasSameContent(
       LogStore logStore,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Java 17 have stricter requirement of java doc that we need to escape "<" this PR update the documentation for it

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No