### PR TITLE
[kernel-spark] Refactor v1 connector to reuse schemaReadOptions constructor

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -94,7 +94,7 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
    * legacy mode), we will ignore the schema log.
    */
   protected def trackingMetadataChange: Boolean =
-    !allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
+    !schemaReadOptions.allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
       metadataTrackingLog.flatMap(_.getCurrentTrackedMetadata).nonEmpty
 
   /**
@@ -103,7 +103,7 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
    * should not rely on this state any more.
    */
   protected def readyToInitializeMetadataTrackingEagerly: Boolean =
-    !allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
+    !schemaReadOptions.allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
       metadataTrackingLog.exists { log =>
         log.getCurrentTrackedMetadata.isEmpty && log.initMetadataLogEagerly
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaStreamUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaStreamUtils.scala
@@ -100,7 +100,6 @@ object DeltaStreamUtils {
       enableSchemaTrackingForTypeWidening: Boolean
   )
 
-  // TODO(#5319): migrate v1 connector to reuse this utility
   object SchemaReadOptions {
     /**
      * Creates a SchemaReadOptions instance from SparkSession configuration settings.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Refactor v1 connector to reuse the schemaReadOptions constructor code to reduce the code duplication
## How was this patch tested?
Existing tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
