### PR TITLE
[kernel-spark] Extract starting timestamp utility from v1 connector

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -1474,14 +1474,12 @@ object DeltaSource extends DeltaLogging {
   }
 
   /**
-   * - If a commit version exactly matches the provided timestamp, we return it.
-   * - Otherwise, we return the earliest commit version
-   *   with a timestamp greater than the provided one.
-   * - If the provided timestamp is larger than the timestamp
-   *   of any committed version, and canExceedLatest is disabled we throw an error.
-   * - If the provided timestamp is larger than the timestamp
-   *   of any committed version, and canExceedLatest is enabled we return a version that is greater
-   *   than deltaLog.snapshot.version by one
+   * Returns the earliest commit version whose timestamp is >= the provided timestamp.
+   *
+   * This method fetches the commit at the given timestamp via
+   * [[DeltaLog.history.getActiveCommitAtTime]], computes the starting version using
+   * [[DeltaStreamUtils.getStartingVersionFromCommitAtTimestamp]], and validates the protocol
+   * at the returned version.
    *
    * @param spark - current spark session
    * @param deltaLog - Delta log of the table for which we find the version.
@@ -1489,6 +1487,8 @@ object DeltaSource extends DeltaLogging {
    * @param timestamp - user specified timestamp
    * @param canExceedLatest - if true, version can be greater than the latest snapshot commit
    * @return - corresponding version number for timestamp
+   * @see [[DeltaStreamUtils.getStartingVersionFromCommitAtTimestamp]] for the core version
+   *      computation logic
    */
   def getStartingVersionFromTimestamp(
       spark: SparkSession,
@@ -1503,31 +1503,20 @@ object DeltaSource extends DeltaLogging {
       canReturnLastCommit = true,
       mustBeRecreatable = false,
       canReturnEarliestCommit = true)
-    if (commit.timestamp >= timestamp.getTime) {
-      validateProtocolAt(spark, deltaLog, catalogTableOpt, commit.version)
-      // Find the commit at the `timestamp` or the earliest commit
-      commit.version
-    } else {
-      // commit.timestamp is not the same, so this commit is a commit before the timestamp and
-      // the next version if exists should be the earliest commit after the timestamp.
-      // Note: `getActiveCommitAtTime` has called `update`, so we don't need to call it again.
-      //
-      // Note2: In the use case of [[CDCReader]] timestamp passed in can exceed the latest commit
-      // timestamp, caller doesn't expect exception, and can handle the non-existent version.
-      val latestNotExceeded = commit.version + 1 <= deltaLog.unsafeVolatileSnapshot.version
-      if (latestNotExceeded || canExceedLatest) {
-        if (latestNotExceeded) {
-          validateProtocolAt(spark, deltaLog, catalogTableOpt, commit.version + 1)
-        }
-        commit.version + 1
-      } else {
-        val commitTs = new Timestamp(commit.timestamp)
-        val timestampFormatter = TimestampFormatter(DateTimeUtils.getTimeZone(tz))
-        val tsString = DateTimeUtils.timestampToString(
-          timestampFormatter, DateTimeUtils.fromJavaTimestamp(commitTs))
-        throw DeltaErrors.timestampGreaterThanLatestCommit(timestamp, commitTs, tsString)
-      }
+    // Note: `getActiveCommitAtTime` has called `update`, so we don't need to call it again.
+    val latestVersion = deltaLog.unsafeVolatileSnapshot.version
+    val startingVersion = DeltaStreamUtils.getStartingVersionFromCommitAtTimestamp(
+      timeZone = tz,
+      commitTimestamp = commit.timestamp,
+      commitVersion = commit.version,
+      latestVersion = latestVersion,
+      timestamp = timestamp,
+      canExceedLatest = canExceedLatest
+    )
+    if (startingVersion <= latestVersion) {
+      validateProtocolAt(spark, deltaLog, catalogTableOpt, startingVersion)
     }
+    startingVersion
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaStreamUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaStreamUtils.scala
@@ -16,14 +16,18 @@
 
 package org.apache.spark.sql.delta.sources
 
+import java.sql.Timestamp
+
 import scala.collection.mutable
 
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.delta.DataFrameUtils
+import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.Relocated._
 import org.apache.spark.sql.delta.TypeWideningMode
 import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.util.{DateTimeUtils, TimestampFormatter}
 
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.apache.spark.sql.classic.ClassicConversions._
@@ -252,6 +256,53 @@ object DeltaStreamUtils {
       }
     } else {
       SchemaCompatibilityResult.Compatible
+    }
+  }
+
+  /**
+   * - If commitVersion exactly matches the provided timestamp, we return it.
+   * - Otherwise, we return the earliest commit version
+   *   with a timestamp greater than the provided one.
+   * - If the provided timestamp is larger than the timestamp
+   *   of any committed version, and canExceedLatest is disabled we throw an error.
+   * - If the provided timestamp is larger than the timestamp
+   *   of any committed version, and canExceedLatest is enabled we return a version that is greater
+   *   than commitVersion by one
+   *
+   * @param timeZone - time zone for formatting error messages
+   * @param commitTimestamp - timestamp of the commit
+   * @param commitVersion - version of the commit
+   * @param latestVersion - latest snapshot version
+   * @param timestamp - user specified timestamp
+   * @param canExceedLatest - if true, version can be greater than the latest snapshot commit
+   * @return - corresponding version number for timestamp
+   */
+  def getStartingVersionFromCommitAtTimestamp(
+      timeZone: String,
+      commitTimestamp: Long,
+      commitVersion: Long,
+      latestVersion: Long,
+      timestamp: Timestamp,
+      canExceedLatest: Boolean = false): Long = {
+    if (commitTimestamp >= timestamp.getTime) {
+      // Find the commit at the `timestamp` or the earliest commit
+      commitVersion
+    } else {
+      // commitTimestamp is not the same, so this commit is a commit before the timestamp and
+      // the next version if exists should be the earliest commit after the timestamp.
+      //
+      // Note: In the use case of [[CDCReader]] timestamp passed in can exceed the latest commit
+      // timestamp, caller doesn't expect exception, and can handle the non-existent version.
+      val latestNotExceeded = commitVersion + 1 <= latestVersion
+      if (latestNotExceeded || canExceedLatest) {
+        commitVersion + 1
+      } else {
+        val commitTs = new Timestamp(commitTimestamp)
+        val timestampFormatter = TimestampFormatter(DateTimeUtils.getTimeZone(timeZone))
+        val tsString = DateTimeUtils.timestampToString(
+          timestampFormatter, DateTimeUtils.fromJavaTimestamp(commitTs))
+        throw DeltaErrors.timestampGreaterThanLatestCommit(timestamp, commitTs, tsString)
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This is part of stacked PR that support starting timestamp read option in dsv2
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing test
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
