### PR TITLE
[Kernel]Allow empty commit range when startVersion = latest+1

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
@@ -55,9 +55,16 @@ public class CommitRangeImpl implements CommitRange {
       long startVersion,
       long endVersion,
       List<ParsedDeltaData> deltas) {
-    checkArgument(startVersion <= endVersion, "must have startVersion <= endVersion");
-    checkArgument(
-        deltas.size() == endVersion - startVersion + 1, "deltaFiles size must match size of range");
+    if (deltas.isEmpty()) {
+      // Empty ranges are represented with endVersion < startVersion.
+      checkArgument(
+          endVersion < startVersion, "empty CommitRange must have endVersion < startVersion");
+    } else {
+      checkArgument(startVersion <= endVersion, "must have startVersion <= endVersion");
+      checkArgument(
+          deltas.size() == endVersion - startVersion + 1,
+          "deltaFiles size must match size of range");
+    }
     this.dataPath = requireNonNull(dataPath, "dataPath cannot be null");
     this.startBoundary = requireNonNull(startBoundary, "startBoundary cannot be null");
     this.endBoundaryOpt = requireNonNull(endBoundaryOpt, "endSpecOpt cannot be null");
@@ -122,8 +129,10 @@ public class CommitRangeImpl implements CommitRange {
     requireNonNull(engine, "engine cannot be null");
     requireNonNull(startSnapshot, "startSnapshot cannot be null");
     requireNonNull(actionSet, "actionSet cannot be null");
-    checkArgument(
-        startSnapshot.getVersion() == startVersion,
-        "startSnapshot must have version = startVersion");
+    if (!deltas.isEmpty()) {
+      checkArgument(
+          startSnapshot.getVersion() == startVersion,
+          "startSnapshot must have version = startVersion");
+    }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/CommitRangeBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/CommitRangeBuilderSuite.scala
@@ -239,6 +239,16 @@ class CommitRangeBuilderSuite extends AnyFunSuite with MockFileSystemClientUtils
     }
     // Now we query the file list, this is where we fail if the provided versions do not exist
     if (startBoundary.expectError) {
+      // Special case: when requesting startVersion -> latest (default end boundary),
+      // Kernel allows an empty range iff startVersion == latestVersion + 1.
+      if (
+        startBoundary.version.isDefined
+        && endBoundary.isInstanceOf[DefaultBoundaryDef]
+        && startBoundary.expectedVersion == endBoundary.expectedVersion + 1
+      ) {
+        return None
+      }
+
       // These either hit DeltaErrors.noCommitFilesFoundForVersionRange or
       // DeltaErrors.startVersionNotFound
       return Some(classOf[KernelException], s"no log file")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Kernel `TableManager.loadCommitRange(...).build(engine)` currently throws **CommitRangeNotFoundException** when the requested range is empty (no commit files found). This is problematic for streaming-style polling where it is valid for the next micro-batch to request:

Delta streaming connectors typically do something like:
- Keep an offset that points to “where to start reading table changes next time” i.e.., startingVersion = latestVersion + 1
- For each micro-batch, ask Delta for the commit JSONs (log files) in a version range starting at that offset.
- If there are no new commits, the batch should just return 0 changes and the query should idle.
- But in Kernel, when you try to build a commit range starting at a version that doesn’t exist yet, Kernel throws:
`KernelException: "Requested table changes between [x, Optional.empty] but no log files found in the requested version range"`

Fixes #5391

## How was this patch tested?

Added/updated unit test coverage in **CommitRangeBuilderSuite** for the “start=latest+1, default end ⇒ empty range” case.

**Ran:**
`build/sbt "project kernelApi" "testOnly io.delta.kernel.internal.CommitRangeBuilderSuite"`

## Does this PR introduce _any_ user-facing changes?

Yes.
**Previous behavior:** requesting loadCommitRange(path, atVersion(latest+1)) with default end (“to latest”) throws CommitRangeNotFoundException (“no log files found…”).

**New behavior**: the same request returns an empty CommitRange (no commits to read) to support streaming polling.
