### PR TITLE
[Spark] Avoid race condition in RowTrackingBackfillConflictsSuite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBackfillConflictsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBackfillConflictsSuite.scala
@@ -73,6 +73,8 @@ class RowTrackingBackfillBackfillConflictsSuite extends RowTrackingBackfillConfl
           firstBackfillFuture.get()
         }
         assertAbortedBecauseOfMetadataChange(e)
+        // We need to remove that expected error or we'll fail below when checking the sink.
+        BackgroundErrorSink.clear()
         assert(!RowId.isEnabled(latestSnapshot.protocol, latestSnapshot.metadata))
 
         // Launch a second backfill to finish the aborted backfill.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Fix flaky RowTrackingBackfillConflictsSuite Scenarios 3 and 6 by making backfill batch ordering deterministic
- Add setDeterministicInsertionTimes() to explicitly set insertion times on files after table creation, ensuring partitions 0-1 are processed by batch 1 and partitions 2-3 by batch 2
- Update concurrent transactions (DELETE, UPDATE, MERGE, OPTIMIZE) to touch only partitions 1 and 2, leaving partition 3 untouched so batch 2 always has work
- Also add some tracking to allow busyWait routines to fail fast if the futures that normally get checked later already failed.

## How was this patch tested?

Test-only PR

## Does this PR introduce _any_ user-facing changes?

No
