### PR TITLE
[Spark] Improve the error messages for DELTA_METADATA_MISMATCH errors

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1796,7 +1796,7 @@
     "subClass" : {
       "OVERWRITE_REQUIRED" : {
         "message" : [
-          "To overwrite your schema or change partitioning, please set: '.option(\"overwriteSchema\", \"true\")'.",
+          "To overwrite your schema or change partitioning, set: '.option(\"overwriteSchema\", \"true\")'.",
           "Note that the schema can't be overwritten when using 'replaceWhere'."
         ]
       },
@@ -1810,8 +1810,8 @@
       },
       "SCHEMA_MISMATCH" : {
         "message" : [
-          "A schema mismatch detected when writing to the Delta table (Table ID: <id>).",
-          "To enable schema migration using DataFrameWriter or DataStreamWriter, please set: '.option(\"mergeSchema\", \"true\")'.",
+          "A schema mismatch was detected when writing to the Delta table (Table ID: <id>).",
+          "To enable schema migration using DataFrameWriter or DataStreamWriter, set: '.option(\"mergeSchema\", \"true\")'.",
           "For other operations, set the session configuration spark.databricks.delta.schema.autoMerge.enabled to \"true\". See the documentation specific to the operation for details.",
           "",
           "Table schema:",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2697,8 +2697,8 @@ trait DeltaErrorsSuiteBase
       val message = e.getMessage
       assert(message.contains(
         """[DELTA_METADATA_MISMATCH] A metadata mismatch was detected when writing to the Delta table.
-          |- A schema mismatch detected when writing to the Delta table (Table ID: id).
-          |To enable schema migration using DataFrameWriter or DataStreamWriter, please set: '.option("mergeSchema", "true")'.
+          |- A schema mismatch was detected when writing to the Delta table (Table ID: id).
+          |To enable schema migration using DataFrameWriter or DataStreamWriter, set: '.option("mergeSchema", "true")'.
           |For other operations, set the session configuration spark.databricks.delta.schema.autoMerge.enabled to "true". See the documentation specific to the operation for details.
           |
           |Table schema:
@@ -2727,8 +2727,8 @@ trait DeltaErrorsSuiteBase
       val message = e.getMessage
       assert(message.contains(
         """[DELTA_METADATA_MISMATCH] A metadata mismatch was detected when writing to the Delta table.
-          |- A schema mismatch detected when writing to the Delta table (Table ID: test-id).
-          |To enable schema migration using DataFrameWriter or DataStreamWriter, please set: '.option("mergeSchema", "true")'.
+          |- A schema mismatch was detected when writing to the Delta table (Table ID: test-id).
+          |To enable schema migration using DataFrameWriter or DataStreamWriter, set: '.option("mergeSchema", "true")'.
           |For other operations, set the session configuration spark.databricks.delta.schema.autoMerge.enabled to "true". See the documentation specific to the operation for details.
           |
           |Table schema:
@@ -2745,7 +2745,7 @@ trait DeltaErrorsSuiteBase
           |Given: [`part2`]
           |Table: [`part1`]
           |
-          |- To overwrite your schema or change partitioning, please set: '.option("overwriteSchema", "true")'.
+          |- To overwrite your schema or change partitioning, set: '.option("overwriteSchema", "true")'.
           |Note that the schema can't be overwritten when using 'replaceWhere'.""".stripMargin))
     }
     // Test with partitioning mismatch only

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SchemaValidationSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SchemaValidationSuite.scala
@@ -222,7 +222,7 @@ class SchemaValidationSuite
           .save(tblPath)
       }
       assert(e.getMessage.contains(
-        "A schema mismatch detected when writing to the Delta table"))
+        "A schema mismatch was detected when writing to the Delta table"))
     },
     concurrentChange = dropColFromSampleTable("col2")
   )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -280,7 +280,7 @@ trait AppendSaveModeTests extends BatchWriterTest {
         val e = intercept[AnalysisException] {
           spark.range(10).withColumn("part", 'id + 1).write.append(dir)
         }
-        assert(e.getMessage.contains("schema mismatch detected"))
+        assert(e.getMessage.contains("schema mismatch was detected"))
         assert(e.getMessage.contains(s"Table ID: ${DeltaLog.forTable(spark, dir).tableId}"))
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Minor error message improvements for DELTA_METADATA_MISMATCH errors.

## How was this patch tested?

Existing unit tests

## Does this PR introduce _any_ user-facing changes?

Minor changes to the error messages. No other API or behavior change.