### PR TITLE
[Spark] Revert "[Spark] Skip applying UDFs as Partition Filters in Delta queries (#5964)"

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -184,13 +184,6 @@ object DeltaTableUtils extends PredicateHelper
       new Path(tableIdent.table).isAbsolute
   }
 
-  // Helper function to detect UDF expressions
-  def exprContainsUdf(expr: Expression): Boolean = {
-    expr.exists {
-      case _: UserDefinedExpression => true
-      case _ => false
-    }
-  }
   /** Find the root of a Delta table from the provided path. */
   def findDeltaTableRoot(
       spark: SparkSession,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1745,19 +1745,6 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .intConf
       .createWithDefault(8)
 
-  val DELTA_DATASKIPPING_SKIP_UDF_FILTERS =
-    buildConf("skipping.udfFilters.skip")
-      .doc(
-        """
-           |If true, filters containing User Defined Functions (UDFs) will not be used for
-           |data skipping. UDFs are excluded because users may not correctly mark them as
-           |non-deterministic, which could lead to incorrect data skipping results if a
-           |non-deterministic UDF is evaluated against file statistics.
-           |""".stripMargin)
-      .internal()
-      .booleanConf
-      .createWithDefault(true)
-
   /**
    * The below confs have a special prefix `spark.databricks.io` because this is the conf value
    * already used by Databricks' data skipping implementation. There's no benefit to making OSS

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -1356,18 +1356,12 @@ trait DataSkippingReaderBase
     import DeltaTableUtils._
     val partitionColumns = metadata.partitionColumns
 
-    // Check if UDF filters should be skipped for data skipping
-    val skipUdfFilters = spark.conf.get(DeltaSQLConf.DELTA_DATASKIPPING_SKIP_UDF_FILTERS)
-
     // For data skipping, avoid using the filters that either:
     // 1. involve subqueries.
     // 2. are non-deterministic.
-    // 3. involve file metadata struct fields.
-    // 4. contain UDFs (when spark.databricks.delta.skipping.udfFilters.skip is true).
+    // 3. involve file metadata struct fields
     var (ineligibleFilters, eligibleFilters) = filters.partition {
-      case f => containsSubquery(f) || !f.deterministic ||
-        (skipUdfFilters && DeltaTableUtils.exprContainsUdf(f)) ||
-        f.exists {
+      case f => containsSubquery(f) || !f.deterministic || f.exists {
         case MetadataAttribute(_) => true
         case _ => false
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -36,7 +36,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, LessThan, Literal, PredicateHelper, ScalaUDF, UserDefinedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, PredicateHelper}
 import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.internal.SQLConf
@@ -2131,83 +2131,6 @@ trait DataSkippingDeltaTestsBase extends QueryTest
         .filesForScan(predicates)
       assert(scanResult.unusedFilters.nonEmpty,
         "Expected predicate to be ineligible for data skipping")
-    }
-  }
-
-  // Test UDF filter handling in data skipping. Creates a table with 10 files and applies
-  // a UDF predicate (udf(col) < 5). Expected behavior:
-  //   - skipUdfFilters=true: UDF excluded from skipping, all 10 files scanned
-  //   - skipUdfFilters=false, partition col: UDF used for partition pruning, 4 files scanned
-  //   - skipUdfFilters=false, data col: UDF can't convert to stats predicate, 10 files scanned
-  Seq(true, false).foreach { skipUdfFilters =>
-    Seq(true, false).foreach { usePartitionColumn =>
-      test(s"UDF filters in data skipping - " +
-          s"skipUdfFilters=$skipUdfFilters, usePartitionColumn=$usePartitionColumn") {
-        val tableName = s"tbl_udf"
-        withTable(tableName) {
-          val df = spark.range(1000).withColumn("part_col", ($"id" / 100).cast("long"))
-          df.write.partitionBy("part_col").format("delta").saveAsTable(tableName)
-
-          val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
-          val snapshot = deltaLog.update()
-          val totalFiles = snapshot.allFiles.count().toInt
-          assert(totalFiles == 10, s"Expected 10 files, got $totalFiles")
-
-          val targetColName = if (usePartitionColumn) "part_col" else "id"
-          val targetCol = snapshot.metadata.schema.fields.find(_.name == targetColName).get
-          val targetAttr = AttributeReference(targetCol.name, targetCol.dataType)()
-
-          val udfExpr = ScalaUDF(
-            function = (x: Long) => x + 1,
-            dataType = LongType,
-            children = Seq(targetAttr),
-            inputEncoders = Nil,
-            outputEncoder = None,
-            udfName = Some("testAddOneUdf"),
-            nullable = true,
-            udfDeterministic = true)
-
-          val udfPredicate = LessThan(udfExpr, Literal(5L))
-          assert(udfPredicate.exists(_.isInstanceOf[UserDefinedExpression]),
-            "Test setup error: expected UDF in predicate")
-          assert(udfExpr.deterministic, "Test setup error: UDF should be deterministic")
-
-          withSQLConf(
-              DeltaSQLConf.DELTA_DATASKIPPING_SKIP_UDF_FILTERS.key -> skipUdfFilters.toString) {
-            val scanResult = {
-              deltaLog.update().filesForScan(Seq(udfPredicate))
-            }
-
-            val unusedContainsUdf = scanResult.unusedFilters.exists(
-              _.exists(_.isInstanceOf[UserDefinedExpression]))
-            val partitionFiltersContainUdf = scanResult.partitionFilters.exists(
-              _.exists(_.isInstanceOf[UserDefinedExpression]))
-
-            if (skipUdfFilters) {
-              assert(unusedContainsUdf,
-                "UDF predicate should be in unusedFilters when skipUdfFilters=true")
-              assert(!partitionFiltersContainUdf,
-                "UDF predicate should NOT be in partitionFilters when skipUdfFilters=true")
-              assert(scanResult.files.size == totalFiles,
-                s"Expected all $totalFiles files, got: ${scanResult.files.size}")
-            } else if (usePartitionColumn) {
-              assert(partitionFiltersContainUdf,
-                "UDF predicate on partition column should be in partitionFilters")
-              assert(!unusedContainsUdf,
-                "UDF predicate on partition column should NOT be in unusedFilters")
-              assert(scanResult.files.size == 4,
-                s"Expected 4 files after partition pruning, got: ${scanResult.files.size}")
-            } else {
-              assert(unusedContainsUdf,
-                "UDF predicate on data column should be in unusedFilters")
-              assert(!partitionFiltersContainUdf,
-                "UDF predicate on data column should NOT be in partitionFilters")
-              assert(scanResult.files.size == totalFiles,
-                s"Expected all $totalFiles files, got: ${scanResult.files.size}")
-            }
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This reverts commit 9997fd86714b308b9853df9a7110d77c916b5bc3 because it has a correctness bug around metadata-only queries i.e. queries referencing UDFs which don't reference any columns.

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No
