### PR TITLE
Add table property for skipping prefix string length

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -670,6 +670,18 @@ trait DeltaConfigsBase extends DeltaLogging {
       |collected.
       |""".stripMargin)
 
+  /**
+   * For string columns, how long prefix to store in the data skipping index.
+   * Note that the behavior from table property overrides the config:
+   * [[DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH]]
+   */
+  val DATA_SKIPPING_STRING_PREFIX_LENGTH = buildConfig[Option[Int]](
+    "dataSkippingStringPrefixLength",
+    null,
+    v => Option(v).map(_.toInt),
+    v => v.forall(_ >= 0),
+    "needs to be greater or equal to zero.")
+
   val SYMLINK_FORMAT_MANIFEST_ENABLED = buildConfig[Boolean](
     s"${hooks.GenerateSymlinkManifest.CONFIG_NAME_ROOT}.enabled",
     "false",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.commands.{DeletionVectorBitmapGenerator, DMLWi
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_TYPE_COLUMN_NAME, CDC_TYPE_NOT_CDC}
 import org.apache.spark.sql.delta.commands.merge.MergeOutputGeneration.{SOURCE_ROW_INDEX_COL, TARGET_ROW_INDEX_COL}
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
+import org.apache.spark.sql.delta.stats.StatsCollectionUtils
 import org.apache.spark.sql.delta.util.SetAccumulator
 
 import org.apache.spark.sql.{Column, Dataset, SparkSession}
@@ -552,7 +553,8 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
     val (dvActions, metricsMap) = DMLWithDeletionVectorsHelper.processUnmodifiedData(
       spark,
       touchedFilesWithDVs,
-      deltaTxn.snapshot)
+      deltaTxn.snapshot,
+      StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, deltaTxn.metadata))
 
     metrics("numTargetDeletionVectorsAdded")
       .set(metricsMap.getOrElse("numDeletionVectorsAdded", 0L))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.DELTA_COLLECT_STATS_USING_TABLE_SCHEMA
 import org.apache.spark.sql.delta.stats.{
   DeltaJobStatisticsTracker,
-  StatisticsCollection
+  StatisticsCollection,
+  StatsCollectionUtils
 }
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.Path
@@ -371,6 +372,8 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
         override val spark: SparkSession = data.sparkSession
         override val statsColumnSpec = StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
         override val protocol: Protocol = newProtocol.getOrElse(snapshot.protocol)
+        override def getDataSkippingStringPrefixLength: Int =
+          StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, metadata)
       }
       val (statsColExpr, newOutputStatsCollectionSchema) =
         getStatsColExpr(outputStatsCollectionSchema, statsCollection)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.stats.{DeltaStatistics, SkippingEligibleDataType, StatisticsCollection}
+import org.apache.spark.sql.delta.stats.{DeltaStatistics, SkippingEligibleDataType, StatisticsCollection, StatsCollectionUtils}
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
 import org.apache.spark.sql.{AnalysisException, SparkSession}
@@ -336,6 +336,8 @@ trait ClusteredTableUtilsBase extends DeltaLogging {
       override val statsColumnSpec = StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
       override val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
       override val protocol: Protocol = p
+      override def getDataSkippingStringPrefixLength: Int =
+        StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, metadata)
 
       override def spark: SparkSession = {
         throw new Exception("Method not used in statisticsCollectionFromMetadata")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -1135,6 +1135,10 @@ trait DataSkippingReaderBase
   final protected[delta] def getStatsColumnOrNullLiteral(stat: StatsColumn): Column =
     getStatsColumnOpt(stat.pathToStatType, stat.pathToColumn).getOrElse(lit(null))
 
+  /** Overload for delta table property override */
+  override protected def getDataSkippingStringPrefixLength: Int =
+    StatsCollectionUtils.getDataSkippingStringPrefixLength(spark, metadata)
+
   /**
    * Returns an expression that can be used to check that the required statistics are present for a
    * given file. If any required statistics are missing we must include the corresponding file.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -238,6 +238,13 @@ trait StatisticsCollection extends DeltaLogging {
   }
 
   /**
+   * Returns the prefix length of strings that should be used for data skipping.
+   * Intentionally left abstract to let implementation decide whether table property overrides
+   * need to be included.
+   */
+  protected def getDataSkippingStringPrefixLength: Int
+
+  /**
    * Returns a struct column that can be used to collect statistics for the current
    * schema of the table.
    * The types we keep stats on must be consistent with DataSkippingReader.SkippingEligibleLiteral.
@@ -245,8 +252,7 @@ trait StatisticsCollection extends DeltaLogging {
    * collect the NULL_COUNT stats for it as the number of rows.
    */
   lazy val statsCollector: Column = {
-    val stringPrefix =
-      spark.sessionState.conf.getConf(DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH)
+    val stringPrefix = getDataSkippingStringPrefixLength
 
     // On file initialization/stat recomputation TIGHT_BOUNDS is always set to true
     val tightBoundsColOpt =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR provides a table property "delta.dataSkippingStringPrefixLength" that allows users to override the prefix length table-wise. This helps with data-skipping performance on columns with long prefix that exceeds the default length (32), so that regular data-skipping does not work.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
