### PR TITLE
Update publish_docs.yaml

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -23,9 +23,9 @@ jobs:
             ref: v4.0.1
             java: 17
             out_dir: docs/apis/_site/api
-          - name: 3.3.2
-            ref: v3.3.2
-            java: 8
+          - name: 4.0.0
+            ref: v4.0.0
+            java: 17
             out_dir: docs/apis/_site/api
 
     steps:


### PR DESCRIPTION
The older version of the docs should be 4.0.0 not 3.3.2.

#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Docs)

## Description
This changes the github workflow for publishing user facing docs

## How was this patch tested?
Running PR Build - this bumps doc publish release versions (latest: 4.0.1, last: 4.0.0)

## Does this PR introduce _any_ user-facing changes?
No. Docs only
