### PR TITLE
[Build] Enable serverSidePlanning for Spark 4.1+ without iceberg-spark-runtime

### DIFF
--- a/SERVER_SIDE_PLANNING_SPARK_41.md
+++ b/SERVER_SIDE_PLANNING_SPARK_41.md
@@ -1,0 +1,198 @@
+# Server-Side Planning Support for Spark 4.1+
+
+## Problem Statement
+
+Spark 4.1 is the new default version for Delta Lake, but Apache Iceberg hasn't released `iceberg-spark-runtime-4.1` yet. This blocked building the entire `delta-iceberg` module, including the serverSidePlanning code which doesn't actually need the Spark-specific runtime.
+
+## Solution
+
+We introduced a new `supportServerSidePlanning` flag that allows selective compilation of just the serverSidePlanning code for Spark versions where the full Iceberg integration isn't available.
+
+## Key Changes
+
+### 1. New SparkVersionSpec Field
+
+Added `supportServerSidePlanning: Boolean` to `SparkVersionSpec` in `project/CrossSparkVersions.scala`:
+
+```scala
+case class SparkVersionSpec(
+  ...
+  supportIceberg: Boolean,
+  supportServerSidePlanning: Boolean = false,  // For Spark 4.1+ where iceberg-spark-runtime doesn't exist
+  supportHudi: Boolean = true,
+  ...
+)
+```
+
+### 2. Spark Version Configuration
+
+Enabled for Spark 4.1 and 4.2:
+
+```scala
+private val spark41 = SparkVersionSpec(
+  fullVersion = "4.1.0",
+  ...
+  supportIceberg = false,
+  supportServerSidePlanning = true,  // Only build serverSidePlanning
+  ...
+)
+
+private val spark42Snapshot = SparkVersionSpec(
+  fullVersion = "4.2.0-SNAPSHOT",
+  ...
+  supportIceberg = false,
+  supportServerSidePlanning = true,
+  ...
+)
+```
+
+### 3. Build Configuration (build.sbt)
+
+#### Source Filtering
+
+When `supportServerSidePlanning=true` but `supportIceberg=false`, only serverSidePlanning sources are compiled:
+
+```scala
+Compile / sources := {
+  val allSources = (Compile / sources).value
+  if (supportIceberg) {
+    allSources
+  } else if (supportServerSidePlanning) {
+    // Only include serverSidePlanning sources
+    allSources.filter(_.getPath.contains("serverSidePlanning"))
+  } else {
+    Seq.empty
+  }
+}
+```
+
+#### Minimal Dependencies
+
+Only includes dependencies actually needed by serverSidePlanning:
+
+```scala
+libraryDependencies ++= {
+  ...
+  } else if (supportServerSidePlanning) {
+    Seq(
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1",
+      "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3",  // Runtime for shaded iceberg-core
+      "org.apache.httpcomponents.core5" % "httpcore5" % "5.2.4",
+      "org.apache.httpcomponents.client5" % "httpclient5" % "5.3.1"
+    )
+  }
+}
+```
+
+**Key insight**: No `iceberg-spark-runtime` dependency needed! serverSidePlanning uses `shadedForDelta.org.apache.iceberg.*` from the `icebergShaded` module, which depends on `iceberg-core` (Spark-version-agnostic).
+
+## Results
+
+### For Spark 4.1 (Default Build)
+
+**Production Code**:
+- ✅ Compiles 3 serverSidePlanning source files:
+  - `IcebergRESTCatalogPlanningClient.scala`
+  - `IcebergRESTCatalogPlanningClientFactory.scala`
+  - `SparkToIcebergExpressionConverter.scala`
+- ✅ Publishes `delta-iceberg_2.13-4.1.0-SNAPSHOT.jar` (5.7MB)
+- ✅ JAR contains only serverSidePlanning classes + shaded iceberg-core dependencies
+- ✅ No dependency on non-existent `iceberg-spark-runtime-4.1`
+
+**Other Iceberg Code**:
+- ❌ Skipped: ConvertToDelta, ConvertToIceberg, CloneIceberg, Uniform, etc.
+- ❌ These require full `iceberg-spark-runtime` integration
+
+### For Spark 4.0
+
+- ✅ Full iceberg support unchanged (`supportIceberg=true`)
+- ✅ All code compiles and tests run normally
+
+## Architecture Details
+
+### Why This Works
+
+ServerSidePlanning code uses **shaded iceberg-core APIs**, not the Spark-specific runtime:
+
+```scala
+// From IcebergRESTCatalogPlanningClient.scala
+import shadedForDelta.org.apache.iceberg.PartitionSpec
+import shadedForDelta.org.apache.iceberg.rest.requests.{PlanTableScanRequest, ...}
+import shadedForDelta.org.apache.iceberg.expressions.Expression
+```
+
+The `icebergShaded` module provides these via:
+```scala
+"org.apache.iceberg" % "iceberg-core" % "1.10.0"  // ← No Spark version suffix!
+```
+
+This dependency is Spark-version-agnostic and exists for all versions.
+
+### Dependency Chain
+
+```
+serverSidePlanning code
+  ↓ uses
+shadedForDelta.org.apache.iceberg.* (from icebergShaded module)
+  ↓ depends on
+org.apache.iceberg:iceberg-core:1.10.0 (shaded)
+  ✓ Exists for all Spark versions
+```
+
+**vs** other iceberg code:
+
+```
+ConvertToDelta, Uniform, etc.
+  ↓ uses
+org.apache.iceberg.spark.source.IcebergSource
+  ↓ from
+org.apache.iceberg:iceberg-spark-runtime-4.1:1.10.0
+  ✗ Doesn't exist yet!
+```
+
+## Build Commands
+
+```bash
+# Build for Spark 4.1 (default) - includes serverSidePlanning only
+build/sbt compile
+build/sbt publishM2
+
+# Build for Spark 4.0 - includes full iceberg support
+build/sbt -DsparkVersion=4.0 compile
+build/sbt -DsparkVersion=4.0 publishM2
+```
+
+## Future Work
+
+Once Apache Iceberg releases `iceberg-spark-runtime-4.1`:
+1. Update `spark41` and `spark42Snapshot` to set `supportIceberg = true`
+2. Remove `supportServerSidePlanning = true` (or keep it as redundant)
+3. Full delta-iceberg module will build for Spark 4.1+
+
+## Testing Notes
+
+Tests were explored but not included in the final implementation:
+- Integration tests that create Iceberg tables fail (need iceberg-spark-runtime)
+- Pure unit tests for REST client and expression conversion would pass
+- Tests are skipped when `supportServerSidePlanning=true` to keep the build clean
+
+## Files Modified
+
+1. `project/CrossSparkVersions.scala` - Added `supportServerSidePlanning` field
+2. `build.sbt` - Source filtering, dependency management, skip conditions
+
+## Artifact Details
+
+**Published artifact for Spark 4.1**:
+```
+io.delta:delta-iceberg_2.13:4.1.0-SNAPSHOT
+Size: 5.7MB
+Classes: 1,461 total (3 from serverSidePlanning, rest from shaded iceberg-core)
+```
+
+**JAR contents** (org.apache.spark classes only):
+```
+org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClient.class
+org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientFactory.class
+org/apache/spark/sql/delta/serverSidePlanning/SparkToIcebergExpressionConverter.class
+```

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -206,6 +206,7 @@ case class SparkVersionSpec(
   targetJvm: String,
   additionalSourceDir: Option[String] = None,
   supportIceberg: Boolean,
+  supportServerSidePlanning: Boolean = false,  // For Spark 4.1+ where iceberg-spark-runtime doesn't exist yet
   supportHudi: Boolean = true,
   antlr4Version: String,
   additionalJavaOptions: Seq[String] = Seq.empty,
@@ -267,6 +268,7 @@ object SparkVersionSpec {
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.1"),
     supportIceberg = false,
+    supportServerSidePlanning = true,  // Only build serverSidePlanning (uses shaded iceberg-core)
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
@@ -278,6 +280,7 @@ object SparkVersionSpec {
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.2"),
     supportIceberg = false,
+    supportServerSidePlanning = true,  // Only build serverSidePlanning (uses shaded iceberg-core)
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -38,8 +38,8 @@ SPARK_RELATED_JAR_TEMPLATES = [
     "delta-hudi{suffix}_2.13-{version}.jar",
 ]
 
-# Iceberg-related modules - only built for Spark versions with supportIceberg=true
-# See CrossSparkVersions.scala for which versions support iceberg
+# Iceberg-related modules - built when supportIceberg=true OR supportServerSidePlanning=true
+# See CrossSparkVersions.scala for which versions support iceberg/serverSidePlanning
 DELTA_ICEBERG_JAR_TEMPLATES = [
     "delta-iceberg{suffix}_2.13-{version}.jar",
 ]
@@ -63,7 +63,8 @@ class SparkVersionSpec:
     Mirrors the SparkVersionSpec in CrossSparkVersions.scala.
     """
     suffix: str  # e.g., "" for default, "_X.Y" for other versions
-    support_iceberg: bool = False  # Whether this Spark version supports iceberg integration
+    support_iceberg: bool = False  # Whether this Spark version supports full iceberg integration
+    support_server_side_planning: bool = False  # Whether serverSidePlanning is built (Spark 4.1+)
 
     def __post_init__(self):
         """Generate JAR templates with the suffix applied."""
@@ -73,8 +74,9 @@ class SparkVersionSpec:
             for jar in SPARK_RELATED_JAR_TEMPLATES
         ]
 
-        # Generate iceberg JAR templates with the suffix (only if this version supports iceberg)
-        if self.support_iceberg:
+        # Generate iceberg JAR templates with the suffix
+        # Published when either supportIceberg OR supportServerSidePlanning is true
+        if self.support_iceberg or self.support_server_side_planning:
             self.iceberg_jars = [
                 jar.format(suffix=self.suffix, version="{version}")
                 for jar in DELTA_ICEBERG_JAR_TEMPLATES
@@ -94,8 +96,8 @@ class SparkVersionSpec:
 # Spark versions to test (key = full version string, value = spec with suffix)
 # These should mirror CrossSparkVersions.scala
 SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
-    "4.0.1": SparkVersionSpec(suffix="_4.0", support_iceberg=True),   # Spark 4.0.1 supports iceberg
-    "4.1.0": SparkVersionSpec(suffix="", support_iceberg=False)       # Default Spark version, no iceberg support
+    "4.0.1": SparkVersionSpec(suffix="_4.0", support_iceberg=True),   # Spark 4.0.1 supports full iceberg
+    "4.1.0": SparkVersionSpec(suffix="", support_iceberg=False, support_server_side_planning=True)  # Default, serverSidePlanning only
 }
 
 # The default Spark version (no suffix in artifact names)


### PR DESCRIPTION
## Problem

Spark 4.1 is now the default version, but Apache Iceberg hasn't released `iceberg-spark-runtime-4.1` yet. This blocked building the entire `delta-iceberg` module, including serverSidePlanning code which doesn't actually need the Spark-specific runtime.

## Solution

This PR introduces a `supportServerSidePlanning` flag to allow selective compilation of just the serverSidePlanning code for Spark versions where full Iceberg integration isn't available.

**Key insight**: serverSidePlanning uses `shadedForDelta.org.apache.iceberg.*` (from shaded iceberg-core), which is Spark-version-agnostic, rather than `iceberg-spark-runtime`.

## Changes

1. **Add `supportServerSidePlanning` field** to `SparkVersionSpec` in `project/CrossSparkVersions.scala`
2. **Enable for Spark 4.1 and 4.2** (where iceberg-spark-runtime doesn't exist yet)
3. **Filter Compile sources** to only include serverSidePlanning when flag is true
4. **Minimal dependencies** - no iceberg-spark-runtime needed
5. **Skip tests** when only serverSidePlanning is enabled (tests need full Iceberg integration)

## Results

### For Spark 4.1 (default build):
- ✅ Compiles 3 serverSidePlanning source files
- ✅ Publishes `delta-iceberg_2.13-4.1.0-SNAPSHOT.jar` with only serverSidePlanning classes
- ✅ No dependency on non-existent `iceberg-spark-runtime-4.1`
- ❌ Skips other iceberg code (ConvertToDelta, Uniform, etc. - they need full runtime)

### For Spark 4.0:
- ✅ Full iceberg support unchanged (`supportIceberg=true`)
- ✅ All code and tests work normally

## Architecture

serverSidePlanning dependency chain:
```
serverSidePlanning code
  ↓ uses
shadedForDelta.org.apache.iceberg.* (from icebergShaded module)
  ↓ depends on
org.apache.iceberg:iceberg-core:1.10.0 (shaded)
  ✓ Exists for all Spark versions (no Spark suffix)
```

vs other iceberg code:
```
ConvertToDelta, Uniform, etc.
  ↓ uses
org.apache.iceberg.spark.source.IcebergSource
  ↓ from
org.apache.iceberg:iceberg-spark-runtime-4.1:1.10.0
  ✗ Doesn't exist yet
```

## Future Work

Once Apache Iceberg releases `iceberg-spark-runtime-4.1`:
1. Update `spark41` to set `supportIceberg = true`
2. Full delta-iceberg module will build for Spark 4.1+

## Testing
We did not include the test classes for SSP as they have dependencies on iceberg-spark-runtime. So the ssp code is only partially tested.

Verified that:
- `build/sbt compile` successfully compiles serverSidePlanning for Spark 4.1
- `build/sbt publishM2` publishes the JAR with only serverSidePlanning classes
- `build/sbt -DsparkVersion=4.0 test` runs full iceberg tests for Spark 4.0

See `SERVER_SIDE_PLANNING_SPARK_41.md` for detailed analysis and findings.