### PR TITLE
[Kernel] Make WorkloadBenchmark configurable using command line arguments

### DIFF
--- a/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmark.java
+++ b/kernel/kernel-benchmarks/src/test/java/io/delta/kernel/benchmarks/WorkloadBenchmark.java
@@ -71,11 +71,77 @@ public class WorkloadBenchmark<T> {
     runner.executeAsBenchmark(blackhole);
   }
 
+  /** Configuration class for benchmark command line arguments. */
+  private static class BenchmarkConfig {
+    String includeTest = null;
+    int warmupIterations = 3;
+    int measurementIterations = 5;
+    int warmupTimeSeconds = 1;
+    int measurementTimeSeconds = 1;
+    int forks = 1;
+
+    static BenchmarkConfig parseArgs(String[] args) {
+      BenchmarkConfig config = new BenchmarkConfig();
+      for (int i = 0; i < args.length; i++) {
+        switch (args[i]) {
+          case "--include-test":
+            if (i + 1 < args.length) {
+              config.includeTest = args[++i];
+            }
+            break;
+          case "--warmup-iterations":
+            if (i + 1 < args.length) {
+              config.warmupIterations = Integer.parseInt(args[++i]);
+            }
+            break;
+          case "--measurement-iterations":
+            if (i + 1 < args.length) {
+              config.measurementIterations = Integer.parseInt(args[++i]);
+            }
+            break;
+          case "--warmup-time":
+            if (i + 1 < args.length) {
+              config.warmupTimeSeconds = Integer.parseInt(args[++i]);
+            }
+            break;
+          case "--measurement-time":
+            if (i + 1 < args.length) {
+              config.measurementTimeSeconds = Integer.parseInt(args[++i]);
+            }
+            break;
+          case "--forks":
+            if (i + 1 < args.length) {
+              config.forks = Integer.parseInt(args[++i]);
+            }
+            break;
+          default:
+            System.err.println("Unknown argument: " + args[i]);
+            printUsage();
+            System.exit(1);
+        }
+      }
+      return config;
+    }
+
+    static void printUsage() {
+      System.out.println("Usage: WorkloadBenchmark [options]");
+      System.out.println("Options:");
+      System.out.println("  --include-test <substring>     Filter workload specs by name (substring match)");
+      System.out.println("  --warmup-iterations <n>        Number of warmup iterations (default: 3)");
+      System.out.println("  --measurement-iterations <n>   Number of measurement iterations (default: 5)");
+      System.out.println("  --warmup-time <seconds>        Warmup time in seconds (default: 1)");
+      System.out.println("  --measurement-time <seconds>   Measurement time in seconds (default: 1)");
+      System.out.println("  --forks <n>                    Number of forks (default: 1)");
+    }
+  }
+
   /**
    * TODO: In the future, this can be extracted so that new benchmarks with custom BenchmarkStates
    * can be easily constructed.
    */
   public static void main(String[] args) throws RunnerException, IOException {
+    BenchmarkConfig config = BenchmarkConfig.parseArgs(args);
+
     // Get workload specs from the workloads directory
     List<WorkloadSpec> workloadSpecs = BenchmarkUtils.loadAllWorkloads(WORKLOAD_SPECS_DIR);
     if (workloadSpecs.isEmpty()) {
@@ -83,11 +149,21 @@ public class WorkloadBenchmark<T> {
           "No workloads found. Please add workload specs to the workloads directory.");
     }
 
-    // Parse the Json specs from the json paths
+    // Parse the Json specs from the json paths and apply filtering
     List<WorkloadSpec> filteredSpecs = new ArrayList<>();
     for (WorkloadSpec spec : workloadSpecs) {
-      // TODO(#5420): In the future, we can filter specific workloads using command line args here.
-      filteredSpecs.addAll(spec.getWorkloadVariants());
+      for (WorkloadSpec variant : spec.getWorkloadVariants()) {
+        // Apply substring filter if specified
+        if (config.includeTest == null
+            || variant.getFullName().toLowerCase().contains(config.includeTest.toLowerCase())) {
+          filteredSpecs.add(variant);
+        }
+      }
+    }
+
+    if (filteredSpecs.isEmpty()) {
+      throw new RunnerException(
+          "No workloads matched the filter criteria: " + config.includeTest);
     }
 
     // Convert paths into a String array for JMH. JMH requires that parameters be of type String[].
@@ -102,12 +178,11 @@ public class WorkloadBenchmark<T> {
             .param("workloadSpecJson", workloadSpecsArray)
             // TODO: In the future, this can be extended to support multiple engines.
             .param("engineName", "default")
-            // TODO(#5420): Allow configuring forks, warmup, and measurement via command line args.
-            .forks(1)
-            .warmupIterations(3) // Proper warmup for production benchmarks
-            .measurementIterations(5) // Proper measurement iterations for production benchmarks
-            .warmupTime(TimeValue.seconds(1))
-            .measurementTime(TimeValue.seconds(1))
+            .forks(config.forks)
+            .warmupIterations(config.warmupIterations)
+            .measurementIterations(config.measurementIterations)
+            .warmupTime(TimeValue.seconds(config.warmupTimeSeconds))
+            .measurementTime(TimeValue.seconds(config.measurementTimeSeconds))
             .addProfiler(KernelMetricsProfiler.class)
             .build();
 


### PR DESCRIPTION
## Overview
This PR makes the kernel benchmark framework configurable via command line arguments.

## Motivation
The kernel benchmarking framework currently hardcodes benchmark parameters. Users need flexibility to configure:
* Filtering benchmark specs by name
* Number of warmup iterations
* Number of measurement iterations
* Warmup and measurement time
* Number of forks

## Changes
Added a `BenchmarkConfig` class that parses command line arguments:
- `--include-test <substring>` - Filter workload specs by name (case-insensitive substring match)
- `--warmup-iterations <n>` - Number of warmup iterations (default: 3)
- `--measurement-iterations <n>` - Number of measurement iterations (default: 5)
- `--warmup-time <seconds>` - Warmup time in seconds (default: 1)
- `--measurement-time <seconds>` - Measurement time in seconds (default: 1)
- `--forks <n>` - Number of forks (default: 1)

Resolves #5420