### PR TITLE
fix: skip creating FilteredColumnarBatch when no active AddFiles

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
@@ -266,6 +266,12 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
         scanAddFiles.withNewColumn(
             1, InternalScanFileUtils.TABLE_ROOT_STRUCT_FIELD, tableRootVector);
 
+    // Skip batch if no AddFiles are selected (all unselected)
+    if (numSelectedRows == 0) {
+      prepareNext();
+      return;
+    }
+
     Optional<ColumnVector> selectionColumnVector = Optional.empty();
     if (atLeastOneUnselected) {
       selectionColumnVector =
@@ -277,7 +283,6 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
                           .createSelectionVector(selectionVectorBuffer, 0, addsVector.getSize()),
                   "Create selection vector for selected scan files"));
     }
-    // TODO: skip batch if all AddFiles are unselected; issue #4941
     next =
         Optional.of(
             new FilteredColumnarBatch(


### PR DESCRIPTION
When all AddFiles in a batch are unselected (numSelectedRows == 0), skip creating the FilteredColumnarBatch and move to the next batch. This avoids returning empty batches from Scan::getScanFiles.

Fixes #4941