### PR TITLE
Update UniForm comment to include Hudi support

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -808,7 +808,7 @@ trait DeltaConfigsBase extends DeltaLogging {
 
   /**
    * Convert the table's metadata into other storage formats after each Delta commit.
-   * Only Iceberg is supported for now
+   * Supports both Iceberg and Hudi formats.
    */
   val UNIVERSAL_FORMAT_ENABLED_FORMATS = buildConfig[Seq[String]](
     "universalFormat.enabledFormats",


### PR DESCRIPTION
## Description

Fixes #3252

The comment in DeltaConfig.scala stated 'Only Iceberg is supported for now' but UniForm now supports both Iceberg and Hudi formats. This PR updates the comment to accurately reflect the current capabilities.

## Changes

- Updated comment in UNIVERSAL_FORMAT_ENABLED_FORMATS config from 'Only Iceberg is supported for now' to 'Supports both Iceberg and Hudi formats.'

## Does this PR introduce any user-facing change?

No, this is just a documentation comment update.