### PR TITLE
[Spark] Validate that non-null partition columns are not null in AddFile on commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -200,6 +200,15 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_NULL_PARTITION_CHECK_THROW_ENABLED =
+    buildConf("nullPartitionCheck.throwEnabled")
+      .internal()
+      .doc("When true, throws IllegalStateException if a commit contains AddFile actions with " +
+        "null partition values for columns that have NOT NULL constraints. " +
+        "When false, only logs. Logging always occurs regardless of this setting.")
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_SCHEMA_ON_READ_CHECK_ENABLED =
     buildConf("checkLatestSchemaOnRead")
       .doc("In Delta, we always try to give users the latest version of their data without " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConstraintEnforcementOnCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConstraintEnforcementOnCommitSuite.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.DeltaTestUtils.{filterUsageRecords, BOOLEAN_DOMAIN}
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+/**
+ * Tests for null partition value validation during commit.
+ * These tests verify that the sanity checks in OptimisticTransaction catch
+ * AddFile actions with null partition values for columns that have NOT NULL constraints.
+ */
+class ConstraintEnforcementOnCommitSuite extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest
+    with DeltaSQLTestUtils {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set(DeltaSQLConf.DELTA_NULL_PARTITION_CHECK_THROW_ENABLED.key, "true")
+  }
+
+  /**
+   * Creates a partitioned table with a NOT NULL partition column and returns the DeltaLog.
+   */
+  private def createPartitionedTableWithNotNullColumn(tempDir: java.io.File): DeltaLog = {
+    sql(s"CREATE TABLE delta.`${tempDir.getCanonicalPath()}` " +
+      s"(part String NOT NULL, value Int) using delta PARTITIONED BY (part)" )
+    DeltaLog.forTable(spark, tempDir.getCanonicalPath())
+  }
+
+  private def commit(
+    deltaLog: DeltaLog, addFile: AddFile, isCommitLarge: Boolean): Unit = {
+    val txn = deltaLog.startTransaction()
+    if (isCommitLarge) {
+      txn.commitLarge(
+        spark,
+        Seq(addFile).toIterator,
+        newProtocolOpt = None,
+        op = DeltaOperations.ManualUpdate,
+        context = Map.empty,
+        metrics = Map.empty
+      )
+    } else {
+      txn.commit(Seq(addFile), DeltaOperations.ManualUpdate)
+    }
+  }
+
+  BOOLEAN_DOMAIN.foreach { isCommitLarge =>
+    test(s"detect null partition value for NOT NULL column [isCommitLarge: $isCommitLarge]") {
+      withTempDir { tempDir =>
+        val deltaLog = createPartitionedTableWithNotNullColumn(tempDir)
+
+        // Create an AddFile with null partition value
+        val addFile = AddFile(
+          path = "part=__HIVE_DEFAULT_PARTITION__/file.parquet",
+          partitionValues = Map("part" -> null),
+          size = 100,
+          modificationTime = System.currentTimeMillis(),
+          dataChange = true,
+          stats = """{"numRecords": 1}"""
+        )
+
+        val e = intercept[IllegalStateException] {
+          commit(deltaLog, addFile, isCommitLarge)
+        }
+        assert(e.getMessage.contains("null partition value"))
+        assert(e.getMessage.contains("NOT NULL column 'part'"))
+      }
+    }
+
+    test(s"no error when partition value is not null [isCommitLarge: $isCommitLarge]") {
+      withTempDir { tempDir =>
+        val deltaLog = createPartitionedTableWithNotNullColumn(tempDir)
+
+        // Create an AddFile with valid (non-null) partition value
+        val addFile = AddFile(
+          path = "part=valid_value/file.parquet",
+          partitionValues = Map("part" -> "valid_value"),
+          size = 100,
+          modificationTime = System.currentTimeMillis(),
+          dataChange = true,
+          stats = """{"numRecords": 1}"""
+        )
+
+        // Should not throw
+        commit(deltaLog, addFile, isCommitLarge)
+      }
+    }
+
+    test(s"only log when throw is disabled [isCommitLarge: $isCommitLarge]") {
+      withTempDir { tempDir =>
+        withSQLConf(DeltaSQLConf.DELTA_NULL_PARTITION_CHECK_THROW_ENABLED.key -> "false") {
+          val deltaLog = createPartitionedTableWithNotNullColumn(tempDir)
+
+          // Create an AddFile with null partition value
+          val addFile = AddFile(
+            path = "part=__HIVE_DEFAULT_PARTITION__/file.parquet",
+            partitionValues = Map("part" -> null),
+            size = 100,
+            modificationTime = System.currentTimeMillis(),
+            dataChange = true,
+            stats = """{"numRecords": 1}"""
+          )
+
+          // Should not throw when flag is disabled, only log
+          val events = Log4jUsageLogger.track {
+            commit(deltaLog, addFile, isCommitLarge)
+          }
+
+          // Validate that the null partition violation event was emitted
+          val violationEvents =
+            filterUsageRecords(events, "delta.constraints.nullPartitionViolation")
+          assert(violationEvents.size == 1)
+
+          val eventBlob = JsonUtils.fromJson[Map[String, Any]](violationEvents.head.blob)
+          assert(eventBlob.contains("addFile"))
+          assert(eventBlob.contains("notNullPartitionCols"))
+          assert(eventBlob("notNullPartitionCols").toString == "part")
+          assert(eventBlob.contains("stackTrace"))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Validate that non-null partition columns are not null in AddFile on commit.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New suite


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the sanity check is only in validation mode right now