### PR TITLE
Upgrade Iceberg shaded version from 1.10.0 to 1.10.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1217,7 +1217,7 @@ lazy val iceberg = (project in file("iceberg"))
   )
 // scalastyle:on println
 
-val icebergShadedVersion = "1.10.0"
+val icebergShadedVersion = "1.10.1"
 lazy val icebergShaded = (project in file("icebergShaded"))
   .dependsOn(spark % "provided")
   .disablePlugins(JavaFormatterPlugin, ScalafmtPlugin)


### PR DESCRIPTION
## Summary

Upgrades Iceberg shaded version from **1.10.0** to **1.10.1** in `build.sbt` (`icebergShadedVersion`).

## Problem

Iceberg 1.10.0's parser had a format incompatibility and 1.10.1 aligns the parser with the REST spec (e.g. apache/iceberg#14658). Iceberg's `PlanTableScanResponseParser.fromJson()` uses newer keys in 1.10.1


## Testing

Existing unit tests.