### PR TITLE
[Kernel] Fix last checkpoint search issue

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -216,8 +216,11 @@ public class Checkpointer {
           } else if (FileNames.isCheckpointFile(fileName)) {
             currentFileVersion = FileNames.checkpointVersion(fileName);
           } else {
-            // allow all other types of files.
-            currentFileVersion = currentVersion;
+            // Skip unrecognized file types (e.g. .crc files). If we assigned
+            // them a version, they could prematurely trigger the break condition
+            // below and cause us to miss recent checkpoints.
+            numberOfFilesSearched++;
+            continue;
           }
 
           boolean shouldContinue =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

- findLastCompleteCheckpointBefore searches backwards through the delta log in 1000-version windows. It uses a shouldContinue check to stop when a file's version exceeds
   the current window.
- Unrecognized files (e.g. .crc checksum files) don't have a version. The old code assigned them currentFileVersion = currentVersion, which equals version on the first
  window. This made the shouldContinue check (currentFileVersion < version) evaluate to false, immediately breaking the loop.
- The first search window was always abandoned after hitting its first .crc file, causing the search to fall back to an older window and miss nearby checkpoints.
- The fix skips unrecognized files entirely so they don't trigger the window boundary check.

## How was this patch tested?

- Test added


```
Without fix: finds the wrong checkpoint (not the last)
[info] CheckpointerSuite:
[info] - findLastCompleteCheckpointBefore - checksum files don't break first search iteration *** FAILED ***
[info]   1000 did not equal 2000 Incorrect checkpoint version before version=2100 (CheckpointerSuite.scala:240)
[info]   org.scalatest.exceptions.TestFailedException:

With fix:
passes
```

## Does this PR introduce _any_ user-facing changes?

No

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
