### PR TITLE
Make UniversalFormatConverter evaluate the currently active SparkSession upon every access

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -59,9 +59,9 @@ object HudiConverter {
 /**
  * This class manages the transformation of delta snapshots into their Hudi equivalent.
  */
-class HudiConverter(spark: SparkSession)
-    extends UniversalFormatConverter(spark)
-    with DeltaLogging {
+class HudiConverter
+  extends UniversalFormatConverter
+  with DeltaLogging {
 
   // Save an atomic reference of the snapshot being converted, and the txn that triggered
   // resulted in the specified snapshot

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -77,9 +77,9 @@ object IcebergConverter {
 /**
  * This class manages the transformation of delta snapshots into their Iceberg equivalent.
  */
-class IcebergConverter(spark: SparkSession)
-    extends UniversalFormatConverter(spark)
-    with DeltaLogging {
+class IcebergConverter
+  extends UniversalFormatConverter
+  with DeltaLogging {
 
   // Save an atomic reference of the snapshot being converted, and the txn that triggered
   // resulted in the specified snapshot

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ProvidesUniFormConverters.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ProvidesUniFormConverters.scala
@@ -20,7 +20,6 @@ import java.lang.reflect.InvocationTargetException
 
 import org.apache.commons.lang3.exception.ExceptionUtils
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.util.Utils
 
 trait ProvidesUniFormConverters { self: DeltaLog =>
@@ -30,10 +29,8 @@ trait ProvidesUniFormConverters { self: DeltaLog =>
    * shaded iceberg module.
    */
   protected lazy val _icebergConverter: UniversalFormatConverter = try {
-    val clazz =
-      Utils.classForName("org.apache.spark.sql.delta.icebergShaded.IcebergConverter")
-    val constructor = clazz.getConstructor(classOf[SparkSession])
-    constructor.newInstance(spark)
+    val clazz = Utils.classForName("org.apache.spark.sql.delta.icebergShaded.IcebergConverter")
+    clazz.getConstructor().newInstance()
   } catch {
     case e: ClassNotFoundException =>
       logError(log"Failed to find Iceberg converter class", e)
@@ -45,10 +42,8 @@ trait ProvidesUniFormConverters { self: DeltaLog =>
   }
 
   protected lazy val _hudiConverter: UniversalFormatConverter = try {
-    val clazz =
-      Utils.classForName("org.apache.spark.sql.delta.hudi.HudiConverter")
-    val constructor = clazz.getConstructor(classOf[SparkSession])
-    constructor.newInstance(spark)
+    val clazz = Utils.classForName("org.apache.spark.sql.delta.hudi.HudiConverter")
+    clazz.getConstructor().newInstance()
   } catch {
     case e: ClassNotFoundException =>
       logError(log"Failed to find Hudi converter class", e)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -292,7 +292,10 @@ object UniversalFormat extends DeltaLogging {
 }
 
 /** Class to facilitate the conversion of Delta into other table formats. */
-abstract class UniversalFormatConverter(spark: SparkSession) {
+abstract class UniversalFormatConverter {
+  /** The current Spark session. */
+  def spark: SparkSession = SparkSession.active
+
   /**
    * Perform an asynchronous conversion.
    *


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
For UniversalFormatConverter and all its subclasses, change the member value `spark` into a `def`. This prevents those classes from storing the Spark session, so that if the currently active Spark session changes, subsequent accesses to those classes will use the latest session.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
