### PR TITLE
[Protocol] Merging the catalog-managed tables to delta protocol

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1411,7 +1411,7 @@ round-trips, yet it lets the client decide — early and unambiguously — wheth
 The following is an example of a possible API which a Java-based Delta client might require catalog
 implementations to target:
 
-```java
+```scala
 
 interface CatalogManagedTable {
     /**
@@ -2278,11 +2278,8 @@ The following steps could be used to do cleanup of the DeltaLog directory:
 1. Identify a threshold (in days) uptil which we want to preserve the deltaLog. Let's refer to
 midnight UTC of that day as `cutOffTimestamp`. The newest commit not newer than the `cutOffTimestamp` is
 the `cutoffCommit`, because a commit exactly at midnight is an acceptable cutoff. We want to retain everything including and after the `cutoffCommit`.
-2. Identify the newest checkpoint that is not newer than the `cutOffCommit`. A checkpoint at the
-   `cutOffCommit` is ideal, but an older one will do. Let's call it `cutOffCheckpoint`. We need to
-   preserve the `cutOffCheckpoint` and all published commits after it, because we need
-   them to enable time travel for commits between `cutOffCheckpoint` and the next available
-   checkpoint.
+2. Identify the newest checkpoint that is not newer than the `cutOffCommit`. A checkpoint at the `cutOffCommit` is ideal, but an older one will do. Let's call it `cutOffCheckpoint`.
+We need to preserve the `cutOffCheckpoint` (both the checkpoint file and the JSON commit file at that version) and all published commits after it. The JSON commit file at the `cutOffCheckpoint` version must be preserved because checkpoints do not preserve [commit provenance information](#commit-provenance-information) (e.g., `commitInfo` actions), which may be required by table features such as [In-Commit Timestamps](#in-commit-timestamps). All published commits after `cutOffCheckpoint` must be preserved to enable time travel for commits between `cutOffCheckpoint` and the next available checkpoint.
     - If no `cutOffCheckpoint` can be found, do not proceed with metadata cleanup as there is
       nothing to cleanup.
 3. Delete all [delta log entries](#delta-log-entries), [checkpoint files](#checkpoints), and

--- a/protocol_rfcs/README.md
+++ b/protocol_rfcs/README.md
@@ -30,10 +30,10 @@ Here is the history of all the RFCs propose/accepted/rejected since Feb 6, 2024,
 
 | Date proposed | Date accepted | RFC file | Github issue | RFC title |
 |:-|:-|:-|:-|:-|
-| 2025-04-07    | 2026-02-17    |[catalog-managed.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/catalog-managed.md)            | https://github.com/delta-io/delta/issues/4381 | Catalog-Managed Tables         |
-| 2023-02-28    | 2023-03-26    |[vacuum-protocol-check.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/vacuum-protocol-check.md)| https://github.com/delta-io/delta/issues/2630 | Enforce Vacuum Protocol Check  |
-| 2023-02-02    | 2023-07-24    |[in-commit-timestamps.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/in-commit-timestamps.md)  | https://github.com/delta-io/delta/issues/2532 | In-Commit Timestamps           |
-| 2023-02-09    | 2025-01-28    |[type-widening.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/type-widening.md)                | https://github.com/delta-io/delta/issues/2623 | Type Widening                  |
+| 2025-04-07    | 2026-02-17    |[catalog-managed.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/accepted/catalog-managed.md)            | https://github.com/delta-io/delta/issues/4381 | Catalog-Managed Tables         |
+| 2023-02-28    | 2023-03-26    |[vacuum-protocol-check.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/accepted/vacuum-protocol-check.md)| https://github.com/delta-io/delta/issues/2630 | Enforce Vacuum Protocol Check  |
+| 2023-02-02    | 2023-07-24    |[in-commit-timestamps.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/accepted/in-commit-timestamps.md)  | https://github.com/delta-io/delta/issues/2532 | In-Commit Timestamps           |
+| 2023-02-09    | 2025-01-28    |[type-widening.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/accepted/type-widening.md)                | https://github.com/delta-io/delta/issues/2623 | Type Widening                  |
 
 ### Rejected RFCs
 

--- a/protocol_rfcs/accepted/catalog-managed.md
+++ b/protocol_rfcs/accepted/catalog-managed.md
@@ -477,7 +477,7 @@ round-trips, yet it lets the client decide — early and unambiguously — wheth
 The following is an example of a possible API which a Java-based Delta client might require catalog
 implementations to target:
 
-```java
+```scala
 
 interface CatalogManagedTable {
     /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Accept the Catalog-Managed Tables RFC by merging the content into the `PROTOCOL.md`.
Moved the proposed `catalog-managed.mk` to accepted folder.
Updated the `README.md` to the current state.

## How was this patch tested?

Doc only

## Does this PR introduce _any_ user-facing changes?

Added a new table feature in docs. No other API user facing changes.