### PR TITLE
[kernel-spark][Part 2] CDC commit processing (convert delta log actions to IndexedFiles)

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/CDCDataFile.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/CDCDataFile.java
@@ -15,30 +15,80 @@
  */
 package io.delta.spark.internal.v2.read;
 
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.actions.AddCDCFile;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.RemoveFile;
+import javax.annotation.Nullable;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 
-/** Wrapper for inferred CDF files. */
+/**
+ * Wrapper for all CDC file variants: inferred from AddFile (insert/update), inferred from
+ * RemoveFile (delete), or explicit AddCDCFile actions.
+ */
 public class CDCDataFile {
-  private final AddFile addFile;
-  private final String changeType;
+  @Nullable private final AddFile addFile;
+  @Nullable private final RemoveFile removeFile;
+  private final boolean isAddCDCFile;
+  @Nullable private final String changeType;
   private final long commitTimestamp;
+  private final long fileSize;
 
-  /** Creates a CDC file representing an insert (initial snapshot or new AddFile). */
-  public static CDCDataFile fromAddFile(AddFile addFile, long commitTimestamp) {
-    return new CDCDataFile(addFile, CDCReader.CDC_TYPE_INSERT(), commitTimestamp);
-  }
-
-  private CDCDataFile(AddFile addFile, String changeType, long commitTimestamp) {
+  private CDCDataFile(
+      @Nullable AddFile addFile,
+      @Nullable RemoveFile removeFile,
+      boolean isAddCDCFile,
+      @Nullable String changeType,
+      long commitTimestamp,
+      long fileSize) {
     this.addFile = addFile;
+    this.removeFile = removeFile;
+    this.isAddCDCFile = isAddCDCFile;
     this.changeType = changeType;
     this.commitTimestamp = commitTimestamp;
+    this.fileSize = fileSize;
   }
 
+  /** Create a CDCDataFile inferred from an AddFile action (always "insert"). */
+  public static CDCDataFile fromAddFile(AddFile addFile, long commitTimestamp) {
+    return new CDCDataFile(
+        addFile,
+        /* removeFile= */ null,
+        /* isAddCDCFile= */ false,
+        CDCReader.CDC_TYPE_INSERT(),
+        commitTimestamp,
+        addFile.getSize());
+  }
+
+  /** Create a CDCDataFile inferred from a RemoveFile action (always "delete"). */
+  public static CDCDataFile fromRemoveFile(RemoveFile removeFile, long commitTimestamp) {
+    return new CDCDataFile(
+        /* addFile= */ null,
+        removeFile,
+        /* isAddCDCFile= */ false,
+        CDCReader.CDC_TYPE_DELETE_STRING(),
+        commitTimestamp,
+        removeFile.getSize().orElse(0L));
+  }
+
+  /** Create a CDCDataFile for an explicit AddCDCFile action. */
+  public static CDCDataFile fromAddCDCFile(Row cdcRow, long commitTimestamp) {
+    long size = cdcRow.getLong(AddCDCFile.FULL_SCHEMA.indexOf("size"));
+    return new CDCDataFile(
+        /* addFile= */ null,
+        /* removeFile= */ null,
+        /* isAddCDCFile= */ true,
+        /* changeType= */ null,
+        commitTimestamp,
+        size);
+  }
+
+  @Nullable
   public AddFile getAddFile() {
     return addFile;
   }
 
+  @Nullable
   public String getChangeType() {
     return changeType;
   }
@@ -48,14 +98,27 @@ public class CDCDataFile {
   }
 
   public long getFileSize() {
-    return addFile.getSize();
+    return fileSize;
+  }
+
+  /** Returns true if this is an explicit CDC file (from AddCDCFile action). */
+  public boolean isAddCDCFile() {
+    return isAddCDCFile;
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("CDCDataFile{");
-    sb.append("addFile=").append(addFile);
-    sb.append(", changeType='").append(changeType).append("'");
+    if (addFile != null) {
+      sb.append("addFile=").append(addFile);
+    } else if (removeFile != null) {
+      sb.append("removeFile=").append(removeFile);
+    } else {
+      sb.append("explicit=true");
+    }
+    if (changeType != null) {
+      sb.append(", changeType='").append(changeType).append("'");
+    }
     sb.append(", commitTimestamp=").append(commitTimestamp);
     sb.append("}");
     return sb.toString();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/IndexedFile.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/IndexedFile.java
@@ -32,29 +32,30 @@ public class IndexedFile implements AdmittableFile {
   private final long version;
   private final long index;
   @Nullable private final AddFile addFile;
-  @Nullable private final CDCDataFile cdcFile;
+  @Nullable private final CDCDataFile cdcDataFile;
 
   /** Creates a sentinel IndexedFile (no file action) for offset tracking boundaries. */
   public static IndexedFile sentinel(long version, long index) {
-    return new IndexedFile(version, index, /* addFile= */ null, /* cdcFile= */ null);
+    return new IndexedFile(version, index, /* addFile= */ null, /* cdcDataFile= */ null);
   }
 
   /** Creates a CDC IndexedFile wrapping a CDCDataFile. */
-  public static IndexedFile cdc(long version, long index, CDCDataFile cdcFile) {
-    return new IndexedFile(version, index, /* addFile= */ null, cdcFile);
+  public static IndexedFile cdc(long version, long index, CDCDataFile cdcDataFile) {
+    return new IndexedFile(version, index, /* addFile= */ null, cdcDataFile);
   }
 
   /** Creates an IndexedFile for a non-CDC AddFile action. */
   public static IndexedFile addFile(long version, long index, AddFile addFile) {
-    return new IndexedFile(version, index, addFile, /* cdcFile= */ null);
+    return new IndexedFile(version, index, addFile, /* cdcDataFile= */ null);
   }
 
-  private IndexedFile(long version, long index, AddFile addFile, CDCDataFile cdcFile) {
-    checkState(addFile == null || cdcFile == null, "At most one of addFile, cdcFile can be set");
+  private IndexedFile(long version, long index, AddFile addFile, CDCDataFile cdcDataFile) {
+    checkState(
+        addFile == null || cdcDataFile == null, "At most one of addFile, cdcDataFile can be set");
     this.version = version;
     this.index = index;
     this.addFile = addFile;
-    this.cdcFile = cdcFile;
+    this.cdcDataFile = cdcDataFile;
   }
 
   public long getVersion() {
@@ -71,21 +72,26 @@ public class IndexedFile implements AdmittableFile {
   }
 
   @Nullable
-  public CDCDataFile getCDCFile() {
-    return cdcFile;
+  public CDCDataFile getCDCDataFile() {
+    return cdcDataFile;
+  }
+
+  /** Returns true if this IndexedFile wraps an explicit AddCDCFile action. */
+  public boolean isAddCDCFile() {
+    return cdcDataFile != null && cdcDataFile.isAddCDCFile();
   }
 
   @Override
   public boolean hasFileAction() {
-    return addFile != null || cdcFile != null;
+    return addFile != null || cdcDataFile != null;
   }
 
   @Override
   public long getFileSize() {
     if (addFile != null) {
       return addFile.getSize();
-    } else if (cdcFile != null) {
-      return cdcFile.getFileSize();
+    } else if (cdcDataFile != null) {
+      return cdcDataFile.getFileSize();
     }
     throw new IllegalStateException("check hasFileAction() before calling getFileSize()");
   }
@@ -99,8 +105,8 @@ public class IndexedFile implements AdmittableFile {
     if (addFile != null) {
       sb.append(", addFile=").append(addFile);
     }
-    if (cdcFile != null) {
-      sb.append(", cdcFile=").append(cdcFile);
+    if (cdcDataFile != null) {
+      sb.append(", cdcDataFile=").append(cdcDataFile);
     }
     sb.append('}');
     return sb.toString();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -31,6 +31,7 @@ import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.RemoveFile;
 import io.delta.kernel.internal.util.ColumnMapping;
@@ -815,13 +816,7 @@ public class SparkMicroBatchStream
   }
 
   private void validateCDFEnabledOnTable() {
-    String cdcEnabled =
-        snapshotAtSourceInit
-            .getMetadata()
-            .getConfiguration()
-            .getOrDefault("delta.enableChangeDataFeed", "false");
-
-    if (!cdcEnabled.equalsIgnoreCase("true")) {
+    if (!isCDFEnabled(snapshotAtSourceInit.getMetadata())) {
       long version = snapshotAtSourceInit.getVersion();
       // DeltaErrors.changeDataNotRecordedException returns a DeltaAnalysisException (checked),
       // so we wrap it to propagate through the streaming pipeline.
@@ -1059,22 +1054,14 @@ public class SparkMicroBatchStream
           // Track Metadata for read-incompatible schema changes.
           Optional<Metadata> metadataOpt = StreamingHelper.getMetadata(batch, rowId);
           if (metadataOpt.isPresent()) {
-            Metadata metadata = metadataOpt.get();
-            Preconditions.checkArgument(
-                metadataAction == null,
-                "Should not encounter two metadata actions in the same commit of version %d",
-                version);
-            metadataAction = metadata;
-            Long batchEndVersion =
-                endOffsetOpt.map(DeltaSourceOffset::reservoirVersion).orElse(null);
-            if (verifyMetadataAction) {
-              checkReadIncompatibleSchemaChanges(
-                  metadata,
-                  version,
-                  batchStartVersion,
-                  batchEndVersion,
-                  /* validatedDuringStreamStart */ false);
-            }
+            metadataAction =
+                validateMetadata(
+                    metadataOpt.get(),
+                    metadataAction,
+                    version,
+                    batchStartVersion,
+                    endOffsetOpt,
+                    verifyMetadataAction);
           }
         }
       }
@@ -1477,5 +1464,194 @@ public class SparkMicroBatchStream
 
     return new InitialSnapshotCache(
         version, Collections.unmodifiableList(indexedFiles), commitTimestamp);
+  }
+
+  /**
+   * Process a CDC commit into IndexedFiles. Validates metadata, collects CDC actions, and builds
+   * IndexedFiles.
+   *
+   * <p>Package-private for testing.
+   */
+  CloseableIterator<IndexedFile> processCommitToIndexedFilesForCDC(
+      CommitActions commit, long startVersion, Optional<DeltaSourceOffset> endOffsetOpt) {
+    try {
+      long version = commit.getVersion();
+      long timestamp = commit.getTimestamp();
+
+      if (isEndOffsetAtBaseIndex(endOffsetOpt, version)) {
+        Utils.closeCloseables(commit);
+        return Utils.toCloseableIterator(
+            Arrays.asList(
+                    IndexedFile.sentinel(version, DeltaSourceOffset.BASE_INDEX()),
+                    IndexedFile.sentinel(version, DeltaSourceOffset.END_INDEX()))
+                .iterator());
+      }
+
+      List<IndexedFile> result =
+          collectAndBuildCDCIndexedFiles(commit, version, timestamp, startVersion, endOffsetOpt);
+
+      result.add(IndexedFile.sentinel(version, DeltaSourceOffset.END_INDEX()));
+      Utils.closeCloseables(commit);
+      return Utils.toCloseableIterator(result.iterator());
+    } catch (IOException e) {
+      Utils.closeCloseables(commit);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Scans a commit's actions in a single pass: validates metadata, checks CDF is enabled, detects
+   * no-op MERGEs, and collects CDC/Add/Remove files into IndexedFiles.
+   */
+  private List<IndexedFile> collectAndBuildCDCIndexedFiles(
+      CommitActions commit,
+      long version,
+      long timestamp,
+      long startVersion,
+      Optional<DeltaSourceOffset> endOffsetOpt)
+      throws IOException {
+    // Phase 1: scan actions to validate metadata and collect CDC/Add/Remove files.
+    List<CDCDataFile> cdcFiles = new ArrayList<>();
+    // Single ordered list for inferred CDC files, preserving delta-log action ordering.
+    // DSv1 assigns IndexedFile.index via zipWithIndex on the original action sequence.
+    List<CDCDataFile> inferredCdcFiles = new ArrayList<>();
+    boolean shouldSkip = false;
+    Metadata metadataAction = null;
+
+    try (CloseableIterator<ColumnarBatch> actionsIter = commit.getActions()) {
+      while (actionsIter.hasNext()) {
+        ColumnarBatch batch = actionsIter.next();
+        for (int rowId = 0; rowId < batch.getSize(); rowId++) {
+          // Metadata: check schema changes + CDF still enabled
+          Optional<Metadata> metadataOpt = StreamingHelper.getMetadata(batch, rowId);
+          if (metadataOpt.isPresent()) {
+            metadataAction =
+                validateMetadata(
+                    metadataOpt.get(),
+                    metadataAction,
+                    version,
+                    startVersion,
+                    endOffsetOpt,
+                    /* verifyMetadataAction= */ true);
+            if (!isCDFEnabled(metadataAction)) {
+              throw new RuntimeException(
+                  DeltaErrors.changeDataNotRecordedException(
+                      version,
+                      startVersion,
+                      endOffsetOpt.map(DeltaSourceOffset::reservoirVersion).orElse(version)));
+            }
+          }
+
+          // CommitInfo: detect no-op MERGEs where the operation rewrites files without
+          // changing logical data. These produce file actions that cancel out; inferred CDC
+          // actions will be discarded after the scan to avoid emitting spurious changes.
+          Optional<CommitInfo> commitInfoOpt = StreamingHelper.getCommitInfo(batch, rowId);
+          if (commitInfoOpt.isPresent()) {
+            shouldSkip = shouldSkipFileActionsInCommit(commitInfoOpt.get());
+          }
+
+          // Explicit CDC files
+          Optional<CDCDataFile> cdcOpt = StreamingHelper.getCDCFile(batch, rowId, timestamp);
+          if (cdcOpt.isPresent()) {
+            cdcFiles.add(cdcOpt.get());
+            continue;
+          }
+
+          // RemoveFile(dataChange=true): collect for inferred CDC
+          Optional<RemoveFile> removeOpt = StreamingHelper.getDataChangeRemove(batch, rowId);
+          if (removeOpt.isPresent()) {
+            inferredCdcFiles.add(CDCDataFile.fromRemoveFile(removeOpt.get(), timestamp));
+            continue;
+          }
+
+          // AddFile(dataChange=true)
+          Optional<AddFile> addOpt = StreamingHelper.getAddFileWithDataChange(batch, rowId);
+          if (addOpt.isPresent()) {
+            inferredCdcFiles.add(CDCDataFile.fromAddFile(addOpt.get(), timestamp));
+          }
+        }
+      }
+    }
+
+    // No-op MERGE: discard inferred actions (DSv1's isValidIndexedFile / shouldSkip).
+    // shouldSkip doesn't apply to explicit CDC files — only inferred Add/Remove.
+    if (shouldSkip) {
+      inferredCdcFiles.clear();
+    }
+
+    // Phase 2: build IndexedFiles from collected actions.
+    List<IndexedFile> result = new ArrayList<>();
+    result.add(IndexedFile.sentinel(version, DeltaSourceOffset.BASE_INDEX()));
+    long fileIndex = 0;
+
+    // Explicit CDC files and inferred files are mutually exclusive: if a commit contains any
+    // AddCDCFile actions, only those are emitted and AddFile/RemoveFile are ignored.
+    if (!cdcFiles.isEmpty()) {
+      for (CDCDataFile cdcFile : cdcFiles) {
+        result.add(IndexedFile.cdc(version, fileIndex++, cdcFile));
+      }
+    } else {
+      for (CDCDataFile cdcFile : inferredCdcFiles) {
+        result.add(IndexedFile.cdc(version, fileIndex++, cdcFile));
+      }
+    }
+
+    return result;
+  }
+
+  /** Detects no-op MERGEs whose file actions should be skipped for CDC. */
+  private static boolean shouldSkipFileActionsInCommit(CommitInfo commitInfo) {
+    boolean isMerge = commitInfo.getOperation().filter("MERGE"::equals).isPresent();
+    if (!isMerge) {
+      return false;
+    }
+    Map<String, String> metrics = commitInfo.getOperationMetrics();
+    return "0".equals(metrics.get("numTargetRowsInserted"))
+        && "0".equals(metrics.get("numTargetRowsUpdated"))
+        && "0".equals(metrics.get("numTargetRowsDeleted"));
+  }
+
+  private static boolean isCDFEnabled(Metadata metadata) {
+    return metadata
+        .getConfiguration()
+        .getOrDefault("delta.enableChangeDataFeed", "false")
+        .equalsIgnoreCase("true");
+  }
+
+  /** Checks if the endOffset is at BASE_INDEX for the given version (early exit condition). */
+  private static boolean isEndOffsetAtBaseIndex(
+      Optional<DeltaSourceOffset> endOffsetOpt, long version) {
+    return endOffsetOpt.isPresent()
+        && endOffsetOpt.get().reservoirVersion() == version
+        && endOffsetOpt.get().index() == DeltaSourceOffset.BASE_INDEX();
+  }
+
+  /**
+   * Validates a metadata action: checks for duplicates and read-incompatible schema changes.
+   *
+   * @return the validated metadata (for assignment back to the caller's tracking variable)
+   */
+  private Metadata validateMetadata(
+      Metadata metadata,
+      Metadata existing,
+      long version,
+      long startVersion,
+      Optional<DeltaSourceOffset> endOffsetOpt,
+      boolean verifyMetadataAction) {
+    Preconditions.checkArgument(
+        existing == null,
+        "Should not encounter two metadata actions in the same commit of version %d",
+        version);
+    // TODO(#5319): don't verify metadata action when schema tracking is enabled
+    if (verifyMetadataAction) {
+      Long batchEndVersion = endOffsetOpt.map(DeltaSourceOffset::reservoirVersion).orElse(null);
+      checkReadIncompatibleSchemaChanges(
+          metadata,
+          version,
+          startVersion,
+          batchEndVersion,
+          /* validatedDuringStreamStart= */ false);
+    }
+    return metadata;
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
@@ -26,12 +26,14 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.RemoveFile;
 import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.internal.data.StructRow;
 import io.delta.kernel.internal.util.Preconditions;
 import io.delta.kernel.utils.CloseableIterator;
+import io.delta.spark.internal.v2.read.CDCDataFile;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import java.io.IOException;
 import java.util.*;
@@ -231,6 +233,34 @@ public class StreamingHelper {
     }
 
     return versionToMetadata;
+  }
+
+  /** Get explicit CDC file (AddCDCFile) from a batch at the specified row, if present. */
+  public static Optional<CDCDataFile> getCDCFile(
+      ColumnarBatch batch, int rowId, long commitTimestamp) {
+    int cdcIdx = getFieldIndex(batch, DeltaLogActionUtils.DeltaAction.CDC.colName);
+    ColumnVector cdcVector = batch.getColumnVector(cdcIdx);
+    if (cdcVector.isNullAt(rowId)) {
+      return Optional.empty();
+    }
+
+    Row cdcRow = StructRow.fromStructVector(cdcVector, rowId);
+    checkState(
+        cdcRow != null,
+        String.format("Failed to extract CDC struct from batch at rowId=%d.", rowId));
+
+    return Optional.of(CDCDataFile.fromAddCDCFile(cdcRow, commitTimestamp));
+  }
+
+  /** Get CommitInfo action from a batch at the specified row, if present. */
+  public static Optional<CommitInfo> getCommitInfo(ColumnarBatch batch, int rowId) {
+    int commitInfoIdx = getFieldIndex(batch, DeltaLogActionUtils.DeltaAction.COMMITINFO.colName);
+    ColumnVector commitInfoVector = batch.getColumnVector(commitInfoIdx);
+    if (commitInfoVector.isNullAt(rowId)) {
+      return Optional.empty();
+    }
+    CommitInfo commitInfo = CommitInfo.fromColumnVector(commitInfoVector, rowId);
+    return Optional.ofNullable(commitInfo);
   }
 
   /** Private constructor to prevent instantiation of this utility class. */

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/CDCDataFileTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/CDCDataFileTest.java
@@ -17,10 +17,17 @@ package io.delta.spark.internal.v2.read;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.actions.AddCDCFile;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.GenerateIcebergCompatActionUtils;
+import io.delta.kernel.internal.actions.RemoveFile;
+import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.StructType;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 import org.junit.jupiter.api.Test;
@@ -46,6 +53,32 @@ public class CDCDataFileTest {
             /* stats= */ Optional.empty()));
   }
 
+  private static RemoveFile createTestRemoveFile(String path, long size) {
+    Row row =
+        GenerateIcebergCompatActionUtils.createRemoveFileRowWithExtendedFileMetadata(
+            path,
+            /* deletionTimestamp= */ 100L,
+            /* dataChange= */ true,
+            VectorUtils.stringStringMapValue(Collections.emptyMap()),
+            size,
+            /* stats= */ Optional.empty(),
+            /* physicalSchema= */ null,
+            /* baseRowId= */ Optional.empty(),
+            /* defaultRowCommitVersion= */ Optional.empty(),
+            /* deletionVector= */ Optional.empty());
+    return new RemoveFile(row);
+  }
+
+  private static Row createCDCRow(long size) {
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(AddCDCFile.FULL_SCHEMA.indexOf("path"), "cdc-file.parquet");
+    fieldMap.put(
+        AddCDCFile.FULL_SCHEMA.indexOf("partitionValues"),
+        VectorUtils.stringStringMapValue(Collections.emptyMap()));
+    fieldMap.put(AddCDCFile.FULL_SCHEMA.indexOf("size"), size);
+    return new GenericRow(AddCDCFile.FULL_SCHEMA, fieldMap);
+  }
+
   @Test
   public void testFromAddFile() {
     AddFile addFile = createTestAddFile("file1.parquet", 2048, 100L);
@@ -55,9 +88,30 @@ public class CDCDataFileTest {
     assertEquals(CDCReader.CDC_TYPE_INSERT(), cdcFile.getChangeType());
     assertEquals(12345L, cdcFile.getCommitTimestamp());
     assertEquals(2048, cdcFile.getFileSize());
+    assertFalse(cdcFile.isAddCDCFile());
+  }
 
-    String str = cdcFile.toString();
-    assertTrue(str.startsWith("CDCDataFile{addFile=AddFile{"));
-    assertTrue(str.contains("changeType='insert', commitTimestamp=12345}"));
+  @Test
+  public void testFromRemoveFile() {
+    RemoveFile removeFile = createTestRemoveFile("removed.parquet", 4096);
+    CDCDataFile cdcFile = CDCDataFile.fromRemoveFile(removeFile, /* commitTimestamp= */ 99999L);
+
+    assertNull(cdcFile.getAddFile());
+    assertEquals(CDCReader.CDC_TYPE_DELETE_STRING(), cdcFile.getChangeType());
+    assertEquals(99999L, cdcFile.getCommitTimestamp());
+    assertEquals(4096, cdcFile.getFileSize());
+    assertFalse(cdcFile.isAddCDCFile());
+  }
+
+  @Test
+  public void testFromAddCDCFile() {
+    Row cdcRow = createCDCRow(/* size= */ 8192);
+    CDCDataFile cdcFile = CDCDataFile.fromAddCDCFile(cdcRow, /* commitTimestamp= */ 55555L);
+
+    assertNull(cdcFile.getAddFile());
+    assertNull(cdcFile.getChangeType());
+    assertEquals(55555L, cdcFile.getCommitTimestamp());
+    assertEquals(8192, cdcFile.getFileSize());
+    assertTrue(cdcFile.isAddCDCFile());
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/IndexedFileTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/IndexedFileTest.java
@@ -17,10 +17,15 @@ package io.delta.spark.internal.v2.read;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.actions.AddCDCFile;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.StructType;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +50,16 @@ public class IndexedFileTest {
             /* stats= */ Optional.empty()));
   }
 
+  private static Row createCDCRow(long size) {
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(AddCDCFile.FULL_SCHEMA.indexOf("path"), "cdc-file.parquet");
+    fieldMap.put(
+        AddCDCFile.FULL_SCHEMA.indexOf("partitionValues"),
+        VectorUtils.stringStringMapValue(Collections.emptyMap()));
+    fieldMap.put(AddCDCFile.FULL_SCHEMA.indexOf("size"), size);
+    return new GenericRow(AddCDCFile.FULL_SCHEMA, fieldMap);
+  }
+
   @Test
   public void testSentinel() {
     IndexedFile sentinel = IndexedFile.sentinel(/* version= */ 5L, /* index= */ -1L);
@@ -53,7 +68,8 @@ public class IndexedFileTest {
     assertEquals(-1L, sentinel.getIndex());
     assertFalse(sentinel.hasFileAction());
     assertNull(sentinel.getAddFile());
-    assertNull(sentinel.getCDCFile());
+    assertNull(sentinel.getCDCDataFile());
+    assertFalse(sentinel.isAddCDCFile());
     assertThrows(IllegalStateException.class, sentinel::getFileSize);
     assertEquals("IndexedFile{version=5, index=-1}", sentinel.toString());
   }
@@ -67,7 +83,8 @@ public class IndexedFileTest {
     assertEquals(7L, indexed.getIndex());
     assertTrue(indexed.hasFileAction());
     assertSame(addFile, indexed.getAddFile());
-    assertNull(indexed.getCDCFile());
+    assertNull(indexed.getCDCDataFile());
+    assertFalse(indexed.isAddCDCFile());
     assertEquals(4096, indexed.getFileSize());
 
     String str = indexed.toString();
@@ -76,18 +93,25 @@ public class IndexedFileTest {
 
   @Test
   public void testCdc() {
+    // Inferred CDC (from AddFile)
     AddFile addFile = createTestAddFile("file.parquet", 3072);
-    CDCDataFile cdcFile = CDCDataFile.fromAddFile(addFile, /* commitTimestamp= */ 999L);
-    IndexedFile indexed = IndexedFile.cdc(/* version= */ 2L, /* index= */ 0L, cdcFile);
+    CDCDataFile inferredCdc = CDCDataFile.fromAddFile(addFile, /* commitTimestamp= */ 999L);
+    IndexedFile inferred = IndexedFile.cdc(/* version= */ 2L, /* index= */ 0L, inferredCdc);
 
-    assertEquals(2L, indexed.getVersion());
-    assertEquals(0L, indexed.getIndex());
-    assertTrue(indexed.hasFileAction());
-    assertNull(indexed.getAddFile());
-    assertSame(cdcFile, indexed.getCDCFile());
-    assertEquals(3072, indexed.getFileSize());
+    assertTrue(inferred.hasFileAction());
+    assertNull(inferred.getAddFile());
+    assertSame(inferredCdc, inferred.getCDCDataFile());
+    assertFalse(inferred.isAddCDCFile());
+    assertEquals(3072, inferred.getFileSize());
 
-    String str = indexed.toString();
-    assertTrue(str.startsWith("IndexedFile{version=2, index=0, cdcFile=CDCDataFile{"));
+    String str = inferred.toString();
+    assertTrue(str.startsWith("IndexedFile{version=2, index=0, cdcDataFile=CDCDataFile{"));
+
+    // Explicit CDC (from AddCDCFile row)
+    Row cdcRow = createCDCRow(/* size= */ 5000);
+    CDCDataFile explicitCdc = CDCDataFile.fromAddCDCFile(cdcRow, /* commitTimestamp= */ 888L);
+    IndexedFile explicit = IndexedFile.cdc(/* version= */ 4L, /* index= */ 1L, explicitCdc);
+    assertTrue(explicit.isAddCDCFile());
+    assertEquals(5000, explicit.getFileSize());
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
@@ -17,14 +17,20 @@ package io.delta.spark.internal.v2.read;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.delta.kernel.CommitActions;
+import io.delta.kernel.CommitRange;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
+import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.StreamingHelper;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -35,6 +41,7 @@ import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.sources.DeltaSource;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
+import org.apache.spark.sql.delta.sources.DeltaSourceOffset$;
 import org.apache.spark.sql.delta.storage.ClosableIterator;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
@@ -173,26 +180,171 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     assertCDCFileChangesMatch(dsv1Files, dsv2Files);
   }
 
-  /**
-   * Compare CDC file changes between DSv1 and DSv2. Reuses {@link #compareFileChanges} for
-   * version/index/path comparison, then verifies CDC metadata on DSv2 data files.
-   */
-  private void assertCDCFileChangesMatch(
-      List<org.apache.spark.sql.delta.sources.IndexedFile> dsv1Files, List<IndexedFile> dsv2Files) {
-    compareFileChanges(dsv1Files, dsv2Files);
+  private static final Set<DeltaAction> CDC_ACTION_SET =
+      Set.of(
+          DeltaAction.ADD,
+          DeltaAction.REMOVE,
+          DeltaAction.METADATA,
+          DeltaAction.CDC,
+          DeltaAction.COMMITINFO);
 
-    // CDC metadata (only on DSv2 data files, not sentinels)
-    for (int i = 0; i < dsv2Files.size(); i++) {
-      IndexedFile d2 = dsv2Files.get(i);
-      if (d2.getCDCFile() != null) {
-        assertNull(d2.getAddFile(), "CDC IndexedFile should not have a raw addFile at index " + i);
-        assertEquals(
-            "insert", d2.getCDCFile().getChangeType(), "changeType mismatch at index " + i);
-        assertTrue(
-            d2.getCDCFile().getCommitTimestamp() > 0,
-            "commitTimestamp should be > 0 at index " + i);
+  @Test
+  public void testProcessCommit_inferredInsert(@TempDir File tempDir) throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_insert_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName);
+    sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);
+
+    long commitVersion = 2;
+    SparkMicroBatchStream stream = createStream(tablePath);
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+
+    List<IndexedFile> files;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit, /* startVersion= */ commitVersion, /* endOffsetOpt= */ Optional.empty())) {
+      files = collectAll(iter);
+    }
+
+    assertTrue(files.size() >= 3, "Expected at least BEGIN + data + END, got " + files.size());
+
+    IndexedFile begin = files.get(0);
+    assertEquals(commitVersion, begin.getVersion());
+    assertEquals(DeltaSourceOffset.BASE_INDEX(), begin.getIndex());
+    assertNull(begin.getCDCDataFile());
+
+    IndexedFile end = files.get(files.size() - 1);
+    assertEquals(commitVersion, end.getVersion());
+    assertEquals(DeltaSourceOffset.END_INDEX(), end.getIndex());
+    assertNull(end.getCDCDataFile());
+
+    List<IndexedFile> dataFiles = new ArrayList<>();
+    for (IndexedFile f : files) {
+      if (f.getCDCDataFile() != null) dataFiles.add(f);
+    }
+    assertFalse(dataFiles.isEmpty(), "Expected at least one data file");
+
+    for (IndexedFile f : dataFiles) {
+      assertNotNull(f.getCDCDataFile(), "Data file should have a CDCDataFile");
+      assertEquals("insert", f.getCDCDataFile().getChangeType(), "Change type should be 'insert'");
+      assertTrue(
+          f.getCDCDataFile().getCommitTimestamp() > 0, "Commit timestamp should be positive");
+      assertEquals(commitVersion, f.getVersion());
+    }
+  }
+
+  @Test
+  public void testProcessCommit_explicitCDCFromDelete(@TempDir File tempDir) throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_delete_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName);
+    sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);
+    sql("DELETE FROM %s WHERE id = 1", tableName);
+
+    long commitVersion = 3;
+    SparkMicroBatchStream stream = createStream(tablePath);
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+
+    List<IndexedFile> files;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit, /* startVersion= */ commitVersion, /* endOffsetOpt= */ Optional.empty())) {
+      files = collectAll(iter);
+    }
+
+    assertTrue(files.size() >= 3, "Expected at least BEGIN + data + END, got " + files.size());
+
+    List<IndexedFile> dataFiles = new ArrayList<>();
+    for (IndexedFile f : files) {
+      if (f.getCDCDataFile() != null) dataFiles.add(f);
+    }
+    assertFalse(dataFiles.isEmpty(), "Expected at least one data file from DELETE");
+
+    for (IndexedFile f : dataFiles) {
+      assertTrue(f.isAddCDCFile(), "Data file should be a CDC file");
+      assertNotNull(f.getCDCDataFile(), "CDCDataFile should be present");
+      assertTrue(f.getCDCDataFile().isAddCDCFile(), "Should be an explicit CDC file");
+      assertEquals(commitVersion, f.getVersion());
+    }
+  }
+
+  @Test
+  public void testProcessCommit_noopMergeSkipsInferredFiles(@TempDir File tempDir)
+      throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_noop_merge_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName);
+    sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);
+
+    // Spark optimizes away truly no-op MERGEs (no commit produced), so we write a
+    // synthetic commit that simulates what a copy-on-write no-op MERGE looks like:
+    // AddFile + RemoveFile (file rewrite) with CommitInfo showing zero rows changed.
+    long commitVersion = 3;
+    writeSyntheticNoopMergeCommit(tablePath, commitVersion);
+
+    SparkMicroBatchStream stream = createStream(tablePath);
+
+    // Verify the commit has file actions (the synthetic commit has Add + Remove).
+    CommitActions rawCommit = getCommitActions(tablePath, commitVersion);
+    int addFileCount = 0;
+    try (CloseableIterator<ColumnarBatch> iter = rawCommit.getActions()) {
+      while (iter.hasNext()) {
+        ColumnarBatch batch = iter.next();
+        for (int rowId = 0; rowId < batch.getSize(); rowId++) {
+          if (StreamingHelper.getAddFileWithDataChange(batch, rowId).isPresent()) {
+            addFileCount++;
+          }
+        }
       }
     }
+    assertTrue(addFileCount > 0, "Synthetic commit should have AddFile actions");
+
+    // Process through CDC — no-op MERGE should discard all inferred files.
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+    List<IndexedFile> files;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit, /* startVersion= */ commitVersion, /* endOffsetOpt= */ Optional.empty())) {
+      files = collectAll(iter);
+    }
+
+    assertEquals(2, files.size(), "Expected only BEGIN + END sentinels for no-op merge");
+    assertEquals(DeltaSourceOffset.BASE_INDEX(), files.get(0).getIndex());
+    assertEquals(DeltaSourceOffset.END_INDEX(), files.get(1).getIndex());
+    assertNull(files.get(0).getCDCDataFile());
+    assertNull(files.get(1).getCDCDataFile());
+  }
+
+  @Test
+  public void testProcessCommit_endOffsetAtBaseIndex(@TempDir File tempDir) throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_baseindex_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName);
+    sql("INSERT INTO %s VALUES (1, 'User1')", tableName);
+
+    long commitVersion = 2;
+    SparkMicroBatchStream stream = createStream(tablePath);
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+
+    DeltaSourceOffset endOffset =
+        DeltaSourceOffset$.MODULE$.apply(
+            "test-reservoir",
+            commitVersion,
+            DeltaSourceOffset.BASE_INDEX(),
+            /* isInitialSnapshot= */ false);
+
+    List<IndexedFile> files;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit, /* startVersion= */ commitVersion, Optional.of(endOffset))) {
+      files = collectAll(iter);
+    }
+
+    assertEquals(2, files.size(), "Expected exactly BEGIN + END sentinels");
+    assertEquals(DeltaSourceOffset.BASE_INDEX(), files.get(0).getIndex());
+    assertEquals(DeltaSourceOffset.END_INDEX(), files.get(1).getIndex());
+    assertNull(files.get(0).getCDCDataFile());
+    assertNull(files.get(1).getCDCDataFile());
   }
 
   private static void sql(String query, Object... args) {
@@ -201,6 +353,11 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
   private DeltaOptions emptyDeltaOptions() {
     return new DeltaOptions(Map$.MODULE$.empty(), spark.sessionState().conf());
+  }
+
+  private void createCDFEnabledTable(String tablePath, String tableName) {
+    createEmptyTestTable(tablePath, tableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')", tableName);
   }
 
   private Optional<DeltaSource.AdmissionLimits> createAdmissionLimits(
@@ -251,55 +408,108 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         /* scalaOptions= */ scala.collection.immutable.Map$.MODULE$.empty());
   }
 
+  private SparkMicroBatchStream createStream(String tablePath) {
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    return createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
+  }
+
+  private CommitActions getCommitActions(String tablePath, long version) {
+    Configuration hadoopConf = new Configuration();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
+
+    CommitRange commitRange =
+        snapshotManager.getTableChanges(engine, version, Optional.of(version));
+
+    try (CloseableIterator<CommitActions> iter =
+        StreamingHelper.getCommitActionsFromRangeUnsafe(
+            engine, (CommitRangeImpl) commitRange, tablePath, CDC_ACTION_SET)) {
+      assertTrue(iter.hasNext(), "Expected at least one commit at version " + version);
+      return iter.next();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to get commit actions at version " + version, e);
+    }
+  }
+
+  private static List<IndexedFile> collectAll(CloseableIterator<IndexedFile> iter) {
+    List<IndexedFile> result = new ArrayList<>();
+    while (iter.hasNext()) {
+      result.add(iter.next());
+    }
+    return result;
+  }
+
   /**
-   * Compares file changes between DSv1 and DSv2 including sentinels. Both DSv1 and DSv2 emit
-   * BEGIN/END sentinels for initial snapshots (DSv1 via addBeginAndEndIndexOffsetsForVersion, DSv2
-   * via loadAndValidateSnapshot).
+   * Writes a synthetic delta log commit that simulates a copy-on-write no-op MERGE: the commit has
+   * AddFile + RemoveFile actions (file rewrite) but CommitInfo metrics show zero rows changed.
+   *
+   * <p>We write this directly because Spark optimizes away truly no-op MERGEs (skips the commit
+   * when no data changes).
    */
-  private void compareFileChanges(
-      List<org.apache.spark.sql.delta.sources.IndexedFile> deltaSourceFiles,
-      List<IndexedFile> kernelFiles) {
-    assertEquals(
-        deltaSourceFiles.size(),
-        kernelFiles.size(),
-        String.format(
-            "Number of file changes should match between dsv1 (%d) and dsv2 (%d)",
-            deltaSourceFiles.size(), kernelFiles.size()));
+  private void writeSyntheticNoopMergeCommit(String tablePath, long version) throws Exception {
+    String logDir = tablePath + "/_delta_log";
+    String filename = String.format("%020d.json", version);
+    java.nio.file.Path commitFile = java.nio.file.Paths.get(logDir, filename);
 
-    for (int i = 0; i < deltaSourceFiles.size(); i++) {
-      org.apache.spark.sql.delta.sources.IndexedFile deltaFile = deltaSourceFiles.get(i);
-      IndexedFile kernelFile = kernelFiles.get(i);
+    String commitInfo =
+        "{\"commitInfo\":{"
+            + "\"timestamp\":"
+            + System.currentTimeMillis()
+            + ","
+            + "\"operation\":\"MERGE\","
+            + "\"operationParameters\":{},"
+            + "\"isBlindAppend\":false,"
+            + "\"operationMetrics\":{"
+            + "\"numTargetRowsInserted\":\"0\","
+            + "\"numTargetRowsUpdated\":\"0\","
+            + "\"numTargetRowsDeleted\":\"0\","
+            + "\"numTargetFilesAdded\":\"1\","
+            + "\"numTargetFilesRemoved\":\"1\""
+            + "}}}";
+    String remove =
+        "{\"remove\":{"
+            + "\"path\":\"noop-merge-old.parquet\","
+            + "\"deletionTimestamp\":"
+            + System.currentTimeMillis()
+            + ","
+            + "\"dataChange\":true,"
+            + "\"partitionValues\":{},"
+            + "\"size\":100"
+            + "}}";
+    String add =
+        "{\"add\":{"
+            + "\"path\":\"noop-merge-new.parquet\","
+            + "\"partitionValues\":{},"
+            + "\"size\":100,"
+            + "\"modificationTime\":"
+            + System.currentTimeMillis()
+            + ","
+            + "\"dataChange\":true"
+            + "}}";
 
-      assertEquals(
-          deltaFile.version(),
-          kernelFile.getVersion(),
-          String.format(
-              "Version mismatch at index %d: dsv1=%d, dsv2=%d",
-              i, deltaFile.version(), kernelFile.getVersion()));
+    java.nio.file.Files.writeString(commitFile, commitInfo + "\n" + remove + "\n" + add + "\n");
+  }
 
-      assertEquals(
-          deltaFile.index(),
-          kernelFile.getIndex(),
-          String.format(
-              "Index mismatch at index %d: dsv1=%d, dsv2=%d",
-              i, deltaFile.index(), kernelFile.getIndex()));
+  /**
+   * Compare CDC file changes between DSv1 and DSv2. Delegates to {@link
+   * SparkMicroBatchStreamTest#compareFileChanges} for version/index/path comparison, then verifies
+   * CDC metadata on DSv2 data files.
+   */
+  private void assertCDCFileChangesMatch(
+      List<org.apache.spark.sql.delta.sources.IndexedFile> dsv1Files, List<IndexedFile> dsv2Files) {
+    SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
 
-      // For CDC files, the AddFile is inside the CDCDataFile wrapper.
-      String deltaAddPath = deltaFile.add() != null ? deltaFile.add().path() : null;
-      String kernelAddPath = null;
-      if (kernelFile.getAddFile() != null) {
-        kernelAddPath = kernelFile.getAddFile().getPath();
-      } else if (kernelFile.getCDCFile() != null && kernelFile.getCDCFile().getAddFile() != null) {
-        kernelAddPath = kernelFile.getCDCFile().getAddFile().getPath();
-      }
-
-      if (deltaAddPath != null || kernelAddPath != null) {
+    // CDC metadata (only on DSv2 data files, not sentinels)
+    for (int i = 0; i < dsv2Files.size(); i++) {
+      IndexedFile d2 = dsv2Files.get(i);
+      if (d2.getCDCDataFile() != null) {
+        assertNull(d2.getAddFile(), "CDC IndexedFile should not have a raw addFile at index " + i);
         assertEquals(
-            deltaAddPath,
-            kernelAddPath,
-            String.format(
-                "AddFile path mismatch at index %d: dsv1=%s, dsv2=%s",
-                i, deltaAddPath, kernelAddPath));
+            "insert", d2.getCDCDataFile().getChangeType(), "changeType mismatch at index " + i);
+        assertTrue(
+            d2.getCDCDataFile().getCommitTimestamp() > 0,
+            "commitTimestamp should be > 0 at index " + i);
       }
     }
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -604,7 +604,8 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             "InitialSnapshot_Version2_MaxBytes"));
   }
 
-  private void compareFileChanges(
+  /** Package-private so CDC tests can reuse without duplication. */
+  static void compareFileChanges(
       List<org.apache.spark.sql.delta.sources.IndexedFile> deltaSourceFiles,
       List<IndexedFile> kernelFiles) {
     assertEquals(
@@ -637,8 +638,9 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       String kernelPath = null;
       if (kernelFile.getAddFile() != null) {
         kernelPath = kernelFile.getAddFile().getPath();
-      } else if (kernelFile.getCDCFile() != null && kernelFile.getCDCFile().getAddFile() != null) {
-        kernelPath = kernelFile.getCDCFile().getAddFile().getPath();
+      } else if (kernelFile.getCDCDataFile() != null
+          && kernelFile.getCDCDataFile().getAddFile() != null) {
+        kernelPath = kernelFile.getCDCDataFile().getAddFile().getPath();
       }
 
       if (deltaPath != null || kernelPath != null) {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6076/files) to review incremental changes.
- [**stack/cdf2**](https://github.com/delta-io/delta/pull/6076) [[Files changed](https://github.com/delta-io/delta/pull/6076/files)]
  - [stack/cdf3](https://github.com/delta-io/delta/pull/6336) [[Files changed](https://github.com/delta-io/delta/pull/6336/files/726b361d519c504c643d1617c720a02fff8a86a5..1f7e05373bef713e8c230aa05c7f096c620606fa)]
    - [stack/cdf4](https://github.com/delta-io/delta/pull/6359) [[Files changed](https://github.com/delta-io/delta/pull/6359/files/1f7e05373bef713e8c230aa05c7f096c620606fa..6a167bb960040ddc781941e65848d08831d0a23a)]
      - [stack/cdf5](https://github.com/delta-io/delta/pull/6362) [[Files changed](https://github.com/delta-io/delta/pull/6362/files/6a167bb960040ddc781941e65848d08831d0a23a..f4ed6dfb06dfa1d565c242804e4f3ac6caee2437)]
        - [stack/cdf6](https://github.com/delta-io/delta/pull/6363) [[Files changed](https://github.com/delta-io/delta/pull/6363/files/f4ed6dfb06dfa1d565c242804e4f3ac6caee2437..568a3bb8de4beaedd2696c89068b369e6f8064e8)]
          - [stack/cdf-outofrange](https://github.com/delta-io/delta/pull/6388) [[Files changed](https://github.com/delta-io/delta/pull/6388/files/568a3bb8de4beaedd2696c89068b369e6f8064e8..52ba63f855fc3ea7c4d3525ef16460dc0f5343b8)]
            - [stack/cdf7](https://github.com/delta-io/delta/pull/6370) [[Files changed](https://github.com/delta-io/delta/pull/6370/files/52ba63f855fc3ea7c4d3525ef16460dc0f5343b8..571d7f62202e675a2a4036348c596a6afaafc39c)]

---------
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Add delta log CDC commit processing to SparkMicroBatchStream. This implements
`processCommitToIndexedFilesForCDC` and `collectAndBuildCDCIndexedFiles`, which
convert delta log commit actions (AddFile, RemoveFile, AddCDCFile) into
CDC-typed IndexedFiles with change type and commit timestamp metadata.

Admission limits (rate-limiting CDC file output) are added in the next PR (#6391).

## How was this patch tested?

Unit tests in `SparkMicroBatchStreamCDCTest`

## Does this PR introduce _any_ user-facing changes?

No