### PR TITLE
Make blindAppend Optional in CommitInfo

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -359,11 +359,11 @@ public class TransactionImpl implements Transaction {
     return maxRetries + 1; // +1 because the first attempt is a try, not a retry.
   }
 
-  private boolean isBlindAppend() {
+  private Optional<Boolean> isBlindAppend() {
     // TODO: for now we hard code this to false to avoid erroneously setting this to true for a
     //  non-blind-append operation. We should revisit how to safely set this to true for actual
     //  blind appends.
-    return false;
+    return Optional.of(false);
   }
 
   private void updateMetadata(Metadata metadata) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -109,7 +109,7 @@ public class CommitInfo {
         children[4].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[4].getMap(rowId)),
-        children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId),
+        Optional.ofNullable(children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId)),
         children[6].isNullAt(rowId) ? null : children[6].getString(rowId),
         children[7].isNullAt(rowId)
             ? Collections.emptyMap()
@@ -216,7 +216,7 @@ public class CommitInfo {
   private final String engineInfo;
   private final String operation;
   private final Map<String, String> operationParameters;
-  private final boolean isBlindAppend;
+  private final Optional<Boolean> isBlindAppend;
   private final String txnId;
   private Optional<Long> inCommitTimestamp;
   private final Map<String, String> operationMetrics;
@@ -227,7 +227,7 @@ public class CommitInfo {
       String engineInfo,
       String operation,
       Map<String, String> operationParameters,
-      boolean isBlindAppend,
+      Optional<Boolean> isBlindAppend,
       String txnId,
       Map<String, String> operationMetrics) {
     this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
@@ -235,7 +235,7 @@ public class CommitInfo {
     this.engineInfo = requireNonNull(engineInfo);
     this.operation = requireNonNull(operation);
     this.operationParameters = Collections.unmodifiableMap(requireNonNull(operationParameters));
-    this.isBlindAppend = isBlindAppend;
+    this.isBlindAppend = requireNonNull(isBlindAppend);
     this.txnId = requireNonNull(txnId);
     this.operationMetrics = Collections.unmodifiableMap(requireNonNull(operationMetrics));
   }
@@ -256,7 +256,7 @@ public class CommitInfo {
     return operationParameters;
   }
 
-  public boolean getIsBlindAppend() {
+  public Optional<Boolean> getIsBlindAppend() {
     return isBlindAppend;
   }
 
@@ -289,7 +289,7 @@ public class CommitInfo {
     commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationParameters"), stringStringMapValue(operationParameters));
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend.orElse(null));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId);
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -48,7 +48,7 @@ trait ActionUtils extends VectorTestUtils {
       "engineInfo",
       "operation",
       Collections.emptyMap(), // operationParameters
-      false, // isBlindAppend
+      Optional.of(false), // isBlindAppend
       "txnId",
       Collections.emptyMap() // operationMetrics
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

- CommitInfo.fromColumnVector method throws a NullPointerException (Cannot invoke "java.lang.Boolean.booleanValue()") when reading Delta commit JSON files where the optional isBlindAppend field is absent/null, because it attempts to auto-unbox a null Java Boolean into a primitive boolean.
- The schema correctly declares isBlindAppend as nullable, but the constructor and field type use a primitive boolean, creating an inconsistency with every other nullable field in the Delta Kernel actions codebase. (classic java bug)
- Changed isBlindAppend from primitive boolean to Optional<Boolean> to fix this

## How was this patch tested?

- Added tests in DefaultJsonHandlerSuite to verify that fromColumnVector correctly produces Optional.empty() for absent isBlindAppend without throwing.


## Does this PR introduce _any_ user-facing changes?

No
