### PR TITLE
[Spark] Make txn readFiles and readTheWholeTable thread safe

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.delta
 import java.nio.file.FileAlreadyExistsException
 import java.time.Instant
 import java.util.{ConcurrentModificationException, Optional, UUID}
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit.{MINUTES, NANOSECONDS}
 
 import scala.collection.JavaConverters._
@@ -347,10 +348,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
     new java.util.concurrent.ConcurrentLinkedQueue[DeltaTableReadPredicate]
 
   /** Tracks specific files that have been seen by this transaction. */
-  protected val readFiles = new HashSet[AddFile]
+  protected val readFiles: java.util.Set[AddFile] = ConcurrentHashMap.newKeySet[AddFile]()
 
   /** Whether the whole table was read during the transaction. */
-  protected var readTheWholeTable = false
+  @volatile protected var readTheWholeTable = false
 
   /** Tracks if this transaction has already committed. */
   protected var committed: Option[CommittedTransaction] = None
@@ -1298,7 +1299,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   /** Mark the given files as read within this transaction. */
   def trackFilesRead(files: Seq[AddFile]): Unit = {
-    readFiles ++= files
+    readFiles.addAll(files.asJava)
   }
 
   /** Mark the predicates that have been queried by this transaction. */
@@ -1812,7 +1813,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(finalActions, protocol)
 
       isBlindAppend = {
-        val dependsOnFiles = !readPredicates.isEmpty || readFiles.nonEmpty
+        val dependsOnFiles = !readPredicates.isEmpty || !readFiles.isEmpty
         val onlyAddFiles =
           preparedActions.collect { case f: FileAction => f }.forall(_.isInstanceOf[AddFile])
         onlyAddFiles && !dependsOnFiles
@@ -1855,7 +1856,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       val currentTransactionInfo = CurrentTransactionInfo(
         txnId = txnId,
         readPredicates = readPredicates.asScala.toVector,
-        readFiles = readFiles.toSet,
+        readFiles = readFiles.asScala.toSet,
         readWholeTable = readTheWholeTable,
         readAppIds = readTxn.toSet,
         metadata = metadata,
@@ -2281,7 +2282,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val t = new OptimisticTransaction(deltaLog, catalogTable, snapshot)
     t.executionObserver = executionObserver.createChild()
     t.readPredicates.addAll(readPredicates)
-    t.readFiles ++= readFilesSubset
+    t.readFiles.addAll(readFilesSubset.asJava)
     t.readTxn ++= readTxn
     t
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.nio.file.FileAlreadyExistsException
 import java.time.Instant
-import java.util.{ConcurrentModificationException, Optional, UUID}
+import java.util.{ConcurrentModificationException, Optional, Set => JSet, UUID}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit.{MINUTES, NANOSECONDS}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.collection.mutable.{ArrayBuffer, HashSet}
+import scala.collection.mutable.ArrayBuffer
 import scala.jdk.OptionConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -348,7 +348,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     new java.util.concurrent.ConcurrentLinkedQueue[DeltaTableReadPredicate]
 
   /** Tracks specific files that have been seen by this transaction. */
-  protected val readFiles: java.util.Set[AddFile] = ConcurrentHashMap.newKeySet[AddFile]()
+  protected val readFiles: JSet[AddFile] = ConcurrentHashMap.newKeySet[AddFile]()
 
   /** Whether the whole table was read during the transaction. */
   @volatile protected var readTheWholeTable = false

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -19,6 +19,11 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.File
 import java.nio.file.FileAlreadyExistsException
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 
 import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
@@ -39,7 +44,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{EqualTo, Literal}
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types.{IntegerType, StructType, TimestampType}
-import org.apache.spark.util.ManualClock
+import org.apache.spark.util.{ManualClock, ThreadUtils}
 
 
 class OptimisticTransactionSuite
@@ -1653,6 +1658,112 @@ class OptimisticTransactionSuite
       assertPartitionColumns(pathOrTable, expected)
     } else {
       assertPartitionColumns(new TableIdentifier(pathOrTable), expected)
+    }
+  }
+
+  test("filesForScan is thread-safe when invoked concurrently on a single transaction") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getCanonicalPath
+      val log = DeltaLog.forTable(spark, tablePath)
+
+      // Set up a partitioned table with one file per partition.
+      log.startTransaction().commit(Seq(
+        Metadata(
+          schemaString = new StructType()
+            .add("part", IntegerType)
+            .add("value", IntegerType).json,
+          partitionColumns = Seq("part"))
+      ), ManualUpdate)
+
+      val numPartitions = 16
+      val seedFiles = (0 until numPartitions).map { i =>
+        AddFile(s"f$i", Map("part" -> i.toString), 1, 1, dataChange = true)
+      }
+      log.startTransaction().commit(seedFiles, ManualUpdate)
+
+      val txn = log.startTransaction()
+
+      // Sanity check: filesForScan returns expected files when called concurrently. Each
+      // worker queries a single partition and must observe its own file independently of
+      // the other threads racing to update the transaction's state.
+      val numThreads = 8
+      val scanPool = Executors.newFixedThreadPool(numThreads)
+      locally {
+        implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(scanPool)
+        try {
+          val scanLatch = new CountDownLatch(1)
+          val scanFutures = (0 until numPartitions).map { i =>
+            Future {
+              scanLatch.await()
+              val filter = EqualTo('part, Literal(i))
+              val scan = txn.filesForScan(filter :: Nil)
+              assert(scan.files.map(_.path).toSet === Set(s"f$i"))
+            }
+          }
+          scanLatch.countDown()
+          ThreadUtils.awaitResult(Future.sequence(scanFutures), 60.seconds)
+        } finally {
+          scanPool.shutdown()
+          scanPool.awaitTermination(60, TimeUnit.SECONDS)
+        }
+      }
+
+      // Stress the mutator path that filesForScan ultimately uses (trackFilesRead) with a
+      // large, evenly partitioned write load timed so all threads start simultaneously.
+      // With a non-thread-safe collection (e.g. mutable.HashSet) this deterministically
+      // loses entries or corrupts the table on the box this test ran on; with a
+      // ConcurrentHashMap-backed set every entry is observed.
+      val stressThreads = 32
+      val perThread = 1000
+      val totalExpected = stressThreads * perThread
+      val stressBatches = (0 until stressThreads).map { t =>
+        (0 until perThread).map { j =>
+          AddFile(s"stress-t${t}-j${j}", Map("part" -> "0"), 1, 1, dataChange = true)
+        }
+      }
+      val pool = Executors.newFixedThreadPool(stressThreads)
+      locally {
+        implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(pool)
+        try {
+          val startLatch = new CountDownLatch(1)
+          val readyLatch = new CountDownLatch(stressThreads)
+          val futures = stressBatches.map { batch =>
+            Future {
+              readyLatch.countDown()
+              startLatch.await()
+              txn.trackFilesRead(batch)
+            }
+          }
+          assert(readyLatch.await(60, TimeUnit.SECONDS),
+            "Timed out waiting for stress workers to reach the start barrier.")
+          startLatch.countDown()
+          ThreadUtils.awaitResult(Future.sequence(futures), 120.seconds)
+        } finally {
+          pool.shutdown()
+          pool.awaitTermination(60, TimeUnit.SECONDS)
+        }
+      }
+
+      // Access the protected `readFiles` field reflectively so the test is decoupled
+      // from whether the underlying collection is a Scala or Java Set.
+      val readFilesField = txn.getClass.getDeclaredFields
+        .find(_.getName.endsWith("readFiles"))
+        .getOrElse(fail("Could not locate readFiles field on the transaction class"))
+      readFilesField.setAccessible(true)
+      val tracked: Set[AddFile] = readFilesField.get(txn) match {
+        case javaSet: java.util.Collection[_] =>
+          javaSet.asScala.toSet.asInstanceOf[Set[AddFile]]
+        case scalaSet: scala.collection.Iterable[_] =>
+          scalaSet.toSet.asInstanceOf[Set[AddFile]]
+        case other => fail(s"Unexpected readFiles container type: ${other.getClass}")
+      }
+      // Tracked files = the files initially scanned (one per partition) plus every
+      // synthetic file added by the stress phase.
+      val expectedSize = numPartitions + totalExpected
+      assert(tracked.size === expectedSize,
+        s"Expected $expectedSize tracked read files, got ${tracked.size}. " +
+          s"This indicates lost updates from concurrent updates to readFiles, meaning " +
+          s"the underlying collection is not thread-safe.")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -1710,9 +1710,9 @@ class OptimisticTransactionSuite
 
       // Stress the mutator path that filesForScan ultimately uses (trackFilesRead) with a
       // large, evenly partitioned write load timed so all threads start simultaneously.
-      // With a non-thread-safe collection (e.g. mutable.HashSet) this deterministically
-      // loses entries or corrupts the table on the box this test ran on; with a
-      // ConcurrentHashMap-backed set every entry is observed.
+      // Without a thread-safe collection (e.g. mutable.HashSet) the concurrent updates
+      // race and lose entries or corrupt the table; with a ConcurrentHashMap-backed set
+      // every entry is observed.
       val stressThreads = 32
       val perThread = 1000
       val totalExpected = stressThreads * perThread


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Follow up of https://github.com/delta-io/delta/pull/3022

> OptimisticTransaction.readPredicates may be updated by multiple threads that call filesForScan. This commit turns it from an ArrayBuffer to a ConcurrentLinkedQueue to be thread safe.

This PR does the same to the other 2 fields used by `filesForScan`: `readFiles` and `readTheWholeTable` 

## How was this patch tested?
Existing tests

## Does this PR introduce _any_ user-facing changes?
No