### PR TITLE
[Build] Disable the hudi integration tests for spark 4.1 

### DIFF
--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -277,6 +277,7 @@ object SparkVersionSpec {
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.1"),
     supportIceberg = false,
+    supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
     jacksonVersion = "2.18.2"
@@ -287,6 +288,7 @@ object SparkVersionSpec {
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.2"),
     supportIceberg = false,
+    supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
     jacksonVersion = "2.18.2",

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -106,7 +106,7 @@ class SparkVersionSpec:
 # These should mirror CrossSparkVersions.scala
 SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
     "4.0.1": SparkVersionSpec(suffix="_4.0", support_iceberg=True, support_hudi=True),
-    "4.1.0": SparkVersionSpec(suffix="_4.1", support_iceberg=False, support_hudi=True)
+    "4.1.0": SparkVersionSpec(suffix="_4.1", support_iceberg=False, support_hudi=False)
 }
 
 # The default Spark version


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here)

## Description

This revert the #6090 , since seems like there are some CI failures.


## How was this patch tested?

Github CI.

## Does this PR introduce _any_ user-facing changes?

No.
