### PR TITLE
[Spark] Report numRows in estimateStatistics() using per-file stats

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -421,15 +421,19 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   private void planScanFiles() {
     final Engine tableEngine = DefaultEngine.create(hadoopConf);
     final String tablePath = getTablePath();
-    // Request stats to be included so we can populate numRows in estimateStatistics().
-    // ScanImpl.getScanFiles(engine, includeStats=true) reads the stats JSON field from the
-    // transaction log alongside the regular AddFile fields.
+    // TODO: Promote getScanFiles(Engine, boolean includeStats) to the public Scan interface to
+    // avoid coupling to the kernel-internal ScanImpl class. Until that API is available, this
+    // instanceof check is the only way to request per-file statistics from the kernel.
     final Iterator<FilteredColumnarBatch> scanFileBatches;
-    if (kernelScan instanceof ScanImpl) {
+    if (kernelScan instanceof ScanImpl && isRowStatsEnabled()) {
+      // Only parse stats JSON when the optimizer will use numRows (CBO or planStats enabled),
+      // matching V1's behavior (LogicalRelation.computeStats()) and avoiding unnecessary per-file
+      // stats JSON parsing cost on every scan.
       scanFileBatches = ((ScanImpl) kernelScan).getScanFiles(tableEngine, true /* includeStats */);
       rowCountKnown = true; // assume all files have stats; set to false on first miss
     } else {
-      // Fallback: stats will not be available, numRows() will return empty.
+      // Stats will not be collected: either kernel scan is not ScanImpl, or CBO/planStats is
+      // disabled. numRows() will return OptionalLong.empty().
       rowCountKnown = false;
       scanFileBatches = kernelScan.getScanFiles(tableEngine);
     }
@@ -506,10 +510,21 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
             runtimeFilteredPartitionedFiles.stream().mapToLong(PartitionedFile::fileSize).sum();
         this.estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(this.totalBytes);
         if (rowCountKnown) {
-          this.totalRows =
-              runtimeFilteredPartitionedFiles.stream()
-                  .mapToLong(pf -> fileRowCounts.getOrDefault(pf.filePath().toString(), 0L))
-                  .sum();
+          long newTotalRows = 0L;
+          for (PartitionedFile pf : runtimeFilteredPartitionedFiles) {
+            Long count = fileRowCounts.get(pf.filePath().toString());
+            if (count == null) {
+              // rowCountKnown=true guarantees every AddFile had numRecords in its stats JSON.
+              // A missing entry indicates a logic bug in planScanFiles().
+              throw new IllegalStateException(
+                  "Missing row count for file: "
+                      + pf.filePath()
+                      + ". This is a bug: when rowCountKnown=true every file must have an"
+                      + " entry in fileRowCounts.");
+            }
+            newTotalRows += count;
+          }
+          this.totalRows = newTotalRows;
         }
       }
     }
@@ -570,6 +585,21 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
       // Apply runtime predicates within the synchronized ensurePlanned method
       ensurePlanned(runtimePredicates);
     }
+  }
+
+  /**
+   * Returns whether row count statistics should be collected and reported.
+   *
+   * <p>Matches V1 behavior: {@code LogicalRelation.computeStats()} only reports numRows when {@code
+   * spark.sql.cbo.enabled} or {@code spark.sql.statistics.planStatsEnabled} is true. This gating
+   * avoids the cost of per-file stats JSON parsing on every scan when the optimizer would not use
+   * the statistics anyway.
+   */
+  private boolean isRowStatsEnabled() {
+    return sqlConf.cboEnabled()
+        || "true"
+            .equalsIgnoreCase(
+                sqlConf.getConfString("spark.sql.statistics.planStatsEnabled", "false"));
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -264,15 +264,11 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     ensurePlanned();
     final long plannedBytes = estimatedSizeInBytes;
 
-    // When catalog stats with numRows are available and CBO is enabled, combine table-level
-    // stats (for numRows/columnStats) with planned file stats (for sizeInBytes).
+    // When catalog stats are available and CBO is enabled, combine table-level stats
+    // (for columnStats) with planned file stats (for sizeInBytes and numRows).
     // This mirrors V1's LogicalRelation.computeStats() which gates column stats on
     // conf.cboEnabled || conf.planStatsEnabled.
-    // Catalog stats are typically all-or-nothing; having sizeInBytes without numRows is rare
-    // and not well-exercised in practice. For that case we fall through to the file-only path
-    // (planned file sizes), which aligns with V1's better-tested no-catalog-stats code path.
-    boolean useCatalogStats = sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
-    if (useCatalogStats && catalogStats.isPresent() && catalogStats.get().numRows().isPresent()) {
+    if (isRowStatsEnabled() && catalogStats.isPresent()) {
       final Statistics stats = catalogStats.get();
       return new Statistics() {
         @Override
@@ -283,9 +279,12 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
         @Override
         public OptionalLong numRows() {
-          // TODO: Use accurate row count from planned files (sum of AddFile.numRecords)
-          //  instead of catalog stats, which are stale (point-in-time from ANALYZE) and
-          //  not adjusted for partition pruning.
+          // Prefer per-file row count (sum of AddFile.numRecords) when available: it is
+          // partition-pruning-aware and always up-to-date. Fall back to catalog stats
+          // (from ANALYZE TABLE) only when per-file stats are unavailable.
+          if (rowCountKnown) {
+            return OptionalLong.of(totalRows);
+          }
           return stats.numRows();
         }
 
@@ -456,12 +455,18 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
           totalBytes += addFile.getSize();
           partitionedFiles.add(partitionedFile);
 
-          Optional<Long> numRecords = addFile.getNumRecords();
-          if (numRecords.isPresent()) {
-            totalRows += numRecords.get();
-            fileRowCounts.put(partitionedFile.filePath().toString(), numRecords.get());
-          } else {
-            rowCountKnown = false;
+          if (rowCountKnown) {
+            Optional<Long> numRecords = addFile.getNumRecords();
+            if (numRecords.isPresent()) {
+              totalRows += numRecords.get();
+              fileRowCounts.put(partitionedFile.filePath().toString(), numRecords.get());
+            } else {
+              // This file has no numRecords — row count is unknowable for the whole scan.
+              // Clear partial state and stop accumulating for all subsequent files.
+              rowCountKnown = false;
+              totalRows = 0;
+              fileRowCounts.clear();
+            }
           }
         }
       } catch (IOException e) {
@@ -525,6 +530,11 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
             newTotalRows += count;
           }
           this.totalRows = newTotalRows;
+          // fileRowCounts is no longer needed: partitionedFiles has been replaced with the
+          // filtered subset, and totalRows has been recomputed from it. Runtime filtering
+          // is applied at most once (partitionedFiles is overwritten, not accumulated), so
+          // this map will not be consulted again.
+          fileRowCounts.clear();
         }
       }
     }
@@ -591,15 +601,12 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
    * Returns whether row count statistics should be collected and reported.
    *
    * <p>Matches V1 behavior: {@code LogicalRelation.computeStats()} only reports numRows when {@code
-   * spark.sql.cbo.enabled} or {@code spark.sql.statistics.planStatsEnabled} is true. This gating
-   * avoids the cost of per-file stats JSON parsing on every scan when the optimizer would not use
-   * the statistics anyway.
+   * spark.sql.cbo.enabled} or {@code spark.sql.cbo.planStats.enabled} is true. This gating avoids
+   * the cost of per-file stats JSON parsing on every scan when the optimizer would not use the
+   * statistics anyway.
    */
   private boolean isRowStatsEnabled() {
-    return sqlConf.cboEnabled()
-        || "true"
-            .equalsIgnoreCase(
-                sqlConf.getConfString("spark.sql.statistics.planStatsEnabled", "false"));
+    return sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -113,11 +113,9 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   private List<PartitionedFile> partitionedFiles = new ArrayList<>();
   private long totalBytes = 0L;
   private long totalRows = 0L;
-  // true iff every AddFile in the scan had numRecords in its stats JSON
+  // true iff every AddFile in the scan had numRecords in its stats JSON AND no runtime
+  // partition filter has been applied (runtime filtering invalidates the cached totalRows).
   private boolean rowCountKnown = false;
-  // per-file row counts, keyed by filePath; populated during planning for use after runtime
-  // filtering
-  private Map<String, Long> fileRowCounts = new HashMap<>();
   // Estimated size in bytes accounting for column projection, used for query optimizer cost
   // estimation
   private long estimatedSizeInBytes = 0L;
@@ -279,13 +277,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
         @Override
         public OptionalLong numRows() {
-          // Prefer per-file row count (sum of AddFile.numRecords) when available: it is
-          // partition-pruning-aware and always up-to-date. Fall back to catalog stats
-          // (from ANALYZE TABLE) only when per-file stats are unavailable.
-          if (rowCountKnown) {
-            return OptionalLong.of(totalRows);
+          // Prefer catalog stats when available: ANALYZE TABLE counts are typically fresh
+          // enough for the optimizer, and using them lets us skip per-file stats JSON parsing
+          // during planning. Fall back to per-file row count only when the catalog lacks it.
+          if (stats.numRows().isPresent()) {
+            return stats.numRows();
           }
-          return stats.numRows();
+          return rowCountKnown ? OptionalLong.of(totalRows) : OptionalLong.empty();
         }
 
         @Override
@@ -423,16 +421,20 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     // TODO: Promote getScanFiles(Engine, boolean includeStats) to the public Scan interface to
     // avoid coupling to the kernel-internal ScanImpl class. Until that API is available, this
     // instanceof check is the only way to request per-file statistics from the kernel.
+    //
+    // Only parse stats JSON when all of:
+    //  - the optimizer will use numRows (CBO or planStats enabled), matching V1's behavior
+    //    (LogicalRelation.computeStats())
+    //  - the catalog does not already provide numRows (otherwise catalog value is preferred in
+    //    estimateStatistics(), so per-file parsing would be wasted work)
+    //  - the kernel scan is ScanImpl (the only path that supports includeStats)
+    final boolean includeStats =
+        kernelScan instanceof ScanImpl && isRowStatsEnabled() && !catalogHasNumRows();
     final Iterator<FilteredColumnarBatch> scanFileBatches;
-    if (kernelScan instanceof ScanImpl && isRowStatsEnabled()) {
-      // Only parse stats JSON when the optimizer will use numRows (CBO or planStats enabled),
-      // matching V1's behavior (LogicalRelation.computeStats()) and avoiding unnecessary per-file
-      // stats JSON parsing cost on every scan.
+    if (includeStats) {
       scanFileBatches = ((ScanImpl) kernelScan).getScanFiles(tableEngine, true /* includeStats */);
       rowCountKnown = true; // assume all files have stats; set to false on first miss
     } else {
-      // Stats will not be collected: either kernel scan is not ScanImpl, or CBO/planStats is
-      // disabled. numRows() will return OptionalLong.empty().
       rowCountKnown = false;
       scanFileBatches = kernelScan.getScanFiles(tableEngine);
     }
@@ -459,13 +461,11 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
             Optional<Long> numRecords = addFile.getNumRecords();
             if (numRecords.isPresent()) {
               totalRows += numRecords.get();
-              fileRowCounts.put(partitionedFile.filePath().toString(), numRecords.get());
             } else {
               // This file has no numRecords — row count is unknowable for the whole scan.
               // Clear partial state and stop accumulating for all subsequent files.
               rowCountKnown = false;
               totalRows = 0;
-              fileRowCounts.clear();
             }
           }
         }
@@ -514,28 +514,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
         this.totalBytes =
             runtimeFilteredPartitionedFiles.stream().mapToLong(PartitionedFile::fileSize).sum();
         this.estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(this.totalBytes);
-        if (rowCountKnown) {
-          long newTotalRows = 0L;
-          for (PartitionedFile pf : runtimeFilteredPartitionedFiles) {
-            Long count = fileRowCounts.get(pf.filePath().toString());
-            if (count == null) {
-              // rowCountKnown=true guarantees every AddFile had numRecords in its stats JSON.
-              // A missing entry indicates a logic bug in planScanFiles().
-              throw new IllegalStateException(
-                  "Missing row count for file: "
-                      + pf.filePath()
-                      + ". This is a bug: when rowCountKnown=true every file must have an"
-                      + " entry in fileRowCounts.");
-            }
-            newTotalRows += count;
-          }
-          this.totalRows = newTotalRows;
-          // fileRowCounts is no longer needed: partitionedFiles has been replaced with the
-          // filtered subset, and totalRows has been recomputed from it. Runtime filtering
-          // is applied at most once (partitionedFiles is overwritten, not accumulated), so
-          // this map will not be consulted again.
-          fileRowCounts.clear();
-        }
+        // Per-file row counts are not retained, so we cannot recompute totalRows over the
+        // filtered subset. Invalidate rowCountKnown so numRows() returns OptionalLong.empty()
+        // rather than a stale pre-filter count. Retaining per-file counts just for this case
+        // would cost O(n) memory on every scan; the trade-off is losing numRows after runtime
+        // partition filtering fires.
+        rowCountKnown = false;
+        totalRows = 0L;
       }
     }
   }
@@ -607,6 +592,11 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
    */
   private boolean isRowStatsEnabled() {
     return sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
+  }
+
+  /** Returns whether the catalog-provided statistics include a numRows value. */
+  private boolean catalogHasNumRows() {
+    return catalogStats.isPresent() && catalogStats.get().numRows().isPresent();
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -23,6 +23,7 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.utils.CloseableIterator;
@@ -111,6 +112,12 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   // Planned input files and stats
   private List<PartitionedFile> partitionedFiles = new ArrayList<>();
   private long totalBytes = 0L;
+  private long totalRows = 0L;
+  // true iff every AddFile in the scan had numRecords in its stats JSON
+  private boolean rowCountKnown = false;
+  // per-file row counts, keyed by filePath; populated during planning for use after runtime
+  // filtering
+  private Map<String, Long> fileRowCounts = new HashMap<>();
   // Estimated size in bytes accounting for column projection, used for query optimizer cost
   // estimation
   private long estimatedSizeInBytes = 0L;
@@ -300,8 +307,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
       @Override
       public OptionalLong numRows() {
-        // Row count is unknown without catalog stats
-        return OptionalLong.empty();
+        return rowCountKnown ? OptionalLong.of(totalRows) : OptionalLong.empty();
       }
     };
   }
@@ -415,7 +421,18 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   private void planScanFiles() {
     final Engine tableEngine = DefaultEngine.create(hadoopConf);
     final String tablePath = getTablePath();
-    final Iterator<FilteredColumnarBatch> scanFileBatches = kernelScan.getScanFiles(tableEngine);
+    // Request stats to be included so we can populate numRows in estimateStatistics().
+    // ScanImpl.getScanFiles(engine, includeStats=true) reads the stats JSON field from the
+    // transaction log alongside the regular AddFile fields.
+    final Iterator<FilteredColumnarBatch> scanFileBatches;
+    if (kernelScan instanceof ScanImpl) {
+      scanFileBatches = ((ScanImpl) kernelScan).getScanFiles(tableEngine, true /* includeStats */);
+      rowCountKnown = true; // assume all files have stats; set to false on first miss
+    } else {
+      // Fallback: stats will not be available, numRows() will return empty.
+      rowCountKnown = false;
+      scanFileBatches = kernelScan.getScanFiles(tableEngine);
+    }
 
     final String[] locations = new String[0];
     final scala.collection.immutable.Map<String, Object> otherConstantMetadataColumnValues =
@@ -434,6 +451,14 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
           totalBytes += addFile.getSize();
           partitionedFiles.add(partitionedFile);
+
+          Optional<Long> numRecords = addFile.getNumRecords();
+          if (numRecords.isPresent()) {
+            totalRows += numRecords.get();
+            fileRowCounts.put(partitionedFile.filePath().toString(), numRecords.get());
+          } else {
+            rowCountKnown = false;
+          }
         }
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -473,13 +498,19 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
         }
       }
 
-      // Update partitionedFiles, totalBytes, and estimatedSizeInBytes if any partition is
-      // filtered out
+      // Update partitionedFiles, totalBytes, totalRows, and estimatedSizeInBytes if any partition
+      // is filtered out
       if (runtimeFilteredPartitionedFiles.size() < this.partitionedFiles.size()) {
         this.partitionedFiles = runtimeFilteredPartitionedFiles;
         this.totalBytes =
             runtimeFilteredPartitionedFiles.stream().mapToLong(PartitionedFile::fileSize).sum();
         this.estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(this.totalBytes);
+        if (rowCountKnown) {
+          this.totalRows =
+              runtimeFilteredPartitionedFiles.stream()
+                  .mapToLong(pf -> fileRowCounts.getOrDefault(pf.filePath().toString(), 0L))
+                  .sum();
+        }
       }
     }
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -260,13 +260,19 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   @Override
   public Statistics estimateStatistics() {
     ensurePlanned();
+    // Capture mutable scan state as final locals so the returned Statistics object reflects a
+    // consistent snapshot. A subsequent filter() call mutates rowCountKnown and totalRows
+    // (see ensurePlanned(runtimePredicates)), and we don't want those mutations to leak into a
+    // Statistics instance the caller is still holding.
     final long plannedBytes = estimatedSizeInBytes;
+    final boolean rowCountKnownSnapshot = rowCountKnown;
+    final long totalRowsSnapshot = totalRows;
 
     // When catalog stats are available and CBO is enabled, combine table-level stats
     // (for columnStats) with planned file stats (for sizeInBytes and numRows).
     // This mirrors V1's LogicalRelation.computeStats() which gates column stats on
     // conf.cboEnabled || conf.planStatsEnabled.
-    if (isRowStatsEnabled() && catalogStats.isPresent()) {
+    if (arePlanStatsEnabled() && catalogStats.isPresent()) {
       final Statistics stats = catalogStats.get();
       return new Statistics() {
         @Override
@@ -283,7 +289,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
           if (stats.numRows().isPresent()) {
             return stats.numRows();
           }
-          return rowCountKnown ? OptionalLong.of(totalRows) : OptionalLong.empty();
+          return rowCountKnownSnapshot ? OptionalLong.of(totalRowsSnapshot) : OptionalLong.empty();
         }
 
         @Override
@@ -304,7 +310,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
       @Override
       public OptionalLong numRows() {
-        return rowCountKnown ? OptionalLong.of(totalRows) : OptionalLong.empty();
+        return rowCountKnownSnapshot ? OptionalLong.of(totalRowsSnapshot) : OptionalLong.empty();
       }
     };
   }
@@ -429,7 +435,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     //    estimateStatistics(), so per-file parsing would be wasted work)
     //  - the kernel scan is ScanImpl (the only path that supports includeStats)
     final boolean includeStats =
-        kernelScan instanceof ScanImpl && isRowStatsEnabled() && !catalogHasNumRows();
+        kernelScan instanceof ScanImpl && arePlanStatsEnabled() && !catalogHasNumRows();
     final Iterator<FilteredColumnarBatch> scanFileBatches;
     if (includeStats) {
       scanFileBatches = ((ScanImpl) kernelScan).getScanFiles(tableEngine, true /* includeStats */);
@@ -583,14 +589,24 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   }
 
   /**
-   * Returns whether row count statistics should be collected and reported.
+   * Returns whether plan-time statistics should be collected and reported. Matches V1 behavior:
+   * {@code LogicalRelation.computeStats()} only surfaces stats when {@code spark.sql.cbo.enabled}
+   * or {@code spark.sql.cbo.planStats.enabled} is true.
    *
-   * <p>Matches V1 behavior: {@code LogicalRelation.computeStats()} only reports numRows when {@code
-   * spark.sql.cbo.enabled} or {@code spark.sql.cbo.planStats.enabled} is true. This gating avoids
-   * the cost of per-file stats JSON parsing on every scan when the optimizer would not use the
-   * statistics anyway.
+   * <p>Despite the row-count-flavored framing in V1, this gate controls multiple things in the V2
+   * scan path:
+   *
+   * <ul>
+   *   <li>whether {@code numRows()} is reported in {@link #estimateStatistics()}
+   *   <li>whether the catalog-stats branch is entered (which also governs {@code columnStats}
+   *       propagation from the catalog)
+   *   <li>whether per-file stats JSON is parsed in {@link #planScanFiles()} (gated together with
+   *       {@code !catalogHasNumRows()} to avoid wasted parsing when the catalog already has it)
+   * </ul>
+   *
+   * Future readers touching any of these paths should treat this helper as load-bearing.
    */
-  private boolean isRowStatsEnabled() {
+  private boolean arePlanStatsEnabled() {
     return sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -553,6 +553,65 @@ public class SparkScanTest extends DeltaV2TestBase {
     return (long) field.get(scan);
   }
 
+  private static long getTotalRows(SparkScan scan) throws Exception {
+    scan.estimateStatistics(); // ensurePlanned
+    Field field = SparkScan.class.getDeclaredField("totalRows");
+    field.setAccessible(true);
+    return (long) field.get(scan);
+  }
+
+  private static boolean isRowCountKnown(SparkScan scan) throws Exception {
+    scan.estimateStatistics(); // ensurePlanned
+    Field field = SparkScan.class.getDeclaredField("rowCountKnown");
+    field.setAccessible(true);
+    return (boolean) field.get(scan);
+  }
+
+  // ================================================================================================
+  // Tests for numRows statistics
+  // ================================================================================================
+
+  @Test
+  public void testNumRowsInStatistics() throws Exception {
+    // Table has 5 rows inserted as 5 separate partitions (1 row each), all with stats.
+    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    SparkScan scan = (SparkScan) builder.build();
+
+    assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
+    assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
+    assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+    assertEquals(5L, scan.estimateStatistics().numRows().getAsLong());
+  }
+
+  @Test
+  public void testNumRowsAfterRuntimeFiltering() throws Exception {
+    // city=hz matches 2 partitions: (date=20180520, city=hz) and (date=20180718, city=hz)
+    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    SparkScan scan = (SparkScan) builder.build();
+
+    assertEquals(5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
+
+    scan.filter(new Predicate[] {cityPredicate}); // city=hz
+
+    assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+    assertEquals(
+        2L, scan.estimateStatistics().numRows().getAsLong(), "2 rows after city=hz filter");
+  }
+
+  @Test
+  public void testNumRowsZeroAfterFilteringOutAllFiles() throws Exception {
+    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    SparkScan scan = (SparkScan) builder.build();
+
+    scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
+
+    assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+    assertEquals(
+        0L,
+        scan.estimateStatistics().numRows().getAsLong(),
+        "0 rows after filtering out all files");
+  }
+
   // ================================================================================================
   // Tests for streaming options validation
   // ================================================================================================

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -572,44 +572,110 @@ public class SparkScanTest extends DeltaV2TestBase {
   // ================================================================================================
 
   @Test
-  public void testNumRowsInStatistics() throws Exception {
-    // Table has 5 rows inserted as 5 separate partitions (1 row each), all with stats.
+  public void testNumRowsEmptyWhenStatsDisabled() throws Exception {
+    // With CBO and planStats disabled (the default), numRows() should return empty even when all
+    // files have stats, matching V1 behavior (LogicalRelation.computeStats()).
     SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
     SparkScan scan = (SparkScan) builder.build();
 
-    assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
-    assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
-    assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-    assertEquals(5L, scan.estimateStatistics().numRows().getAsLong());
+    assertFalse(
+        isRowCountKnown(scan), "rowCountKnown should be false when CBO and planStats are disabled");
+    assertFalse(
+        scan.estimateStatistics().numRows().isPresent(),
+        "numRows() should be empty when CBO and planStats are disabled");
+  }
+
+  @Test
+  public void testNumRowsInStatistics() throws Exception {
+    // Table has 5 rows inserted as 5 separate partitions (1 row each), all with stats.
+    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
+    try {
+      SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+      SparkScan scan = (SparkScan) builder.build();
+
+      assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
+      assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
+      assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+      assertEquals(5L, scan.estimateStatistics().numRows().getAsLong());
+    } finally {
+      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
+    }
   }
 
   @Test
   public void testNumRowsAfterRuntimeFiltering() throws Exception {
     // city=hz matches 2 partitions: (date=20180520, city=hz) and (date=20180718, city=hz)
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
+    try {
+      SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+      SparkScan scan = (SparkScan) builder.build();
 
-    assertEquals(5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
+      assertEquals(5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
 
-    scan.filter(new Predicate[] {cityPredicate}); // city=hz
+      scan.filter(new Predicate[] {cityPredicate}); // city=hz
 
-    assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-    assertEquals(
-        2L, scan.estimateStatistics().numRows().getAsLong(), "2 rows after city=hz filter");
+      assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+      assertEquals(
+          2L, scan.estimateStatistics().numRows().getAsLong(), "2 rows after city=hz filter");
+    } finally {
+      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
+    }
   }
 
   @Test
   public void testNumRowsZeroAfterFilteringOutAllFiles() throws Exception {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
+    try {
+      SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+      SparkScan scan = (SparkScan) builder.build();
 
-    scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
+      scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
 
-    assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-    assertEquals(
-        0L,
-        scan.estimateStatistics().numRows().getAsLong(),
-        "0 rows after filtering out all files");
+      assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+      assertEquals(
+          0L,
+          scan.estimateStatistics().numRows().getAsLong(),
+          "0 rows after filtering out all files");
+    } finally {
+      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
+    }
+  }
+
+  @Test
+  public void testNumRowsUnknownWhenSomeFilesLackStats(@TempDir File testDir) throws Exception {
+    // Older Delta tables or tables written with stats collection disabled will have AddFile entries
+    // without numRecords. When even one file lacks stats, rowCountKnown must be false so that
+    // numRows() returns OptionalLong.empty() rather than an incorrect partial count.
+    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
+    String tblName = "test_mixed_stats_numrows";
+    try {
+      String path = testDir.getAbsolutePath();
+      // First write: stats are collected by default (numRecords is present in AddFile stats JSON).
+      spark.sql(
+          "CREATE TABLE " + tblName + " (id INT, city STRING) USING delta LOCATION '" + path + "'");
+      spark.sql("INSERT INTO " + tblName + " VALUES (1, 'hz')");
+
+      // Disable stats collection via session config so the second AddFile has no numRecords.
+      spark.sql("SET spark.databricks.delta.stats.collect=false");
+      spark.sql("INSERT INTO " + tblName + " VALUES (2, 'sh')");
+
+      // Table now has two AddFile entries: one with stats (first insert), one without (second).
+      SparkTable mixedStatsTable =
+          new SparkTable(
+              Identifier.of(new String[] {"spark_catalog", "default"}, tblName), path, options);
+      SparkScanBuilder builder = (SparkScanBuilder) mixedStatsTable.newScanBuilder(options);
+      SparkScan scan = (SparkScan) builder.build();
+
+      assertFalse(
+          isRowCountKnown(scan), "rowCountKnown should be false when some files lack stats");
+      assertFalse(
+          scan.estimateStatistics().numRows().isPresent(),
+          "numRows() should be OptionalLong.empty() when row count is unknown");
+    } finally {
+      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
+      spark.sql("RESET spark.databricks.delta.stats.collect");
+      spark.sql("DROP TABLE IF EXISTS " + tblName);
+    }
   }
 
   // ================================================================================================

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -604,7 +604,9 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testNumRowsAfterRuntimeFiltering() throws Exception {
-    // city=hz matches 2 partitions: (date=20180520, city=hz) and (date=20180718, city=hz)
+    // Runtime partition filtering invalidates the cached totalRows: per-file row counts are
+    // not retained (to avoid O(n) memory on every scan), so numRows() returns empty after
+    // filtering rather than a recomputed value.
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
         "true",
@@ -617,14 +619,16 @@ public class SparkScanTest extends DeltaV2TestBase {
 
           scan.filter(new Predicate[] {cityPredicate}); // city=hz
 
-          assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-          assertEquals(
-              2L, scan.estimateStatistics().numRows().getAsLong(), "2 rows after city=hz filter");
+          assertFalse(
+              scan.estimateStatistics().numRows().isPresent(),
+              "numRows should be empty after runtime filtering invalidates row count");
         });
   }
 
   @Test
-  public void testNumRowsZeroAfterFilteringOutAllFiles() throws Exception {
+  public void testNumRowsEmptyAfterFilteringOutAllFiles() throws Exception {
+    // Same reasoning as testNumRowsAfterRuntimeFiltering: runtime filtering invalidates the
+    // cached totalRows regardless of how many files remain.
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
         "true",
@@ -634,11 +638,9 @@ public class SparkScanTest extends DeltaV2TestBase {
 
           scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
 
-          assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-          assertEquals(
-              0L,
-              scan.estimateStatistics().numRows().getAsLong(),
-              "0 rows after filtering out all files");
+          assertFalse(
+              scan.estimateStatistics().numRows().isPresent(),
+              "numRows should be empty after runtime filtering (even when all files filtered)");
         });
   }
 
@@ -1155,7 +1157,7 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // Should have numRows from per-file stats (not stale catalog stats)
+          // numRows comes from catalog stats (per-file parsing is skipped when catalog has it)
           assertTrue(stats.numRows().isPresent(), "numRows should be present with CBO enabled");
           assertEquals(2L, stats.numRows().getAsLong(), "numRows should be 2");
 
@@ -1181,25 +1183,25 @@ public class SparkScanTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testPerFileNumRowsPrefersOverStaleCatalogStats(@TempDir File tempDir)
-      throws Exception {
-    // Verifies that per-file numRows (from AddFile.numRecords) takes precedence over stale catalog
-    // stats (from ANALYZE TABLE). Catalog stats are a point-in-time snapshot and not adjusted for
-    // partition pruning; per-file stats are always up-to-date.
+  public void testCatalogNumRowsPreferredOverPerFile(@TempDir File tempDir) throws Exception {
+    // Verifies that catalog numRows (from ANALYZE TABLE) is preferred over per-file numRows
+    // when both are available. This lets us skip per-file stats JSON parsing during planning,
+    // trading off freshness for planning cost. If the catalog value is stale, the user is
+    // expected to re-run ANALYZE TABLE.
     String path = tempDir.getAbsolutePath();
-    String tblName = "stats_per_file_wins";
+    String tblName = "stats_catalog_wins";
     spark.sql(
         String.format(
             "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
     spark.sql(String.format("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tblName));
 
-    // Inject stale catalog stats claiming 999 rows (simulating stats collected before a deletion)
-    CatalogStatistics staleCatalogStats =
+    // Inject catalog stats claiming 999 rows (distinguishable from the actual per-file count of 2)
+    CatalogStatistics catalogStats =
         new CatalogStatistics(
             scala.math.BigInt.apply(1024L),
-            scala.Option.apply(scala.math.BigInt.apply(999L)), // stale — actual count is 2
+            scala.Option.apply(scala.math.BigInt.apply(999L)),
             buildColStatsMap(new String[] {}, new CatalogColumnStat[] {}));
-    CatalogTable catalogTable = injectCatalogStats(tblName, staleCatalogStats);
+    CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
 
     withSQLConf(
         "spark.sql.cbo.enabled",
@@ -1213,12 +1215,12 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // Per-file stats show 2 rows; the stale catalog claim of 999 should be ignored.
+          // Catalog numRows wins; per-file parsing is skipped entirely.
           assertTrue(stats.numRows().isPresent(), "numRows should be present");
           assertEquals(
-              2L,
+              999L,
               stats.numRows().getAsLong(),
-              "numRows should be 2 from per-file stats, not 999 from stale catalog");
+              "numRows should come from catalog (999), not per-file (2)");
         });
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -1279,7 +1279,7 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.cbo.enabled",
         "true",
         () -> {
-          // Path-based table — no catalog table, no stats
+          // Path-based table — no catalog table, no ANALYZE TABLE stats
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           SparkTable sparkTable = new SparkTable(id, path);
 
@@ -1289,8 +1289,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // Without catalog stats, numRows should be empty
-          assertFalse(stats.numRows().isPresent(), "numRows should be empty for path-based table");
+          // Per-file Delta stats (numRecords in the transaction log) are available even without
+          // catalog stats from ANALYZE TABLE, so numRows should be present.
+          assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
+          assertEquals(1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
           assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
           assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
         });
@@ -1480,8 +1482,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // Without catalog stats, we fall back to file-only stats
-          assertFalse(stats.numRows().isPresent(), "numRows should be empty without catalog stats");
+          // Per-file Delta stats (numRecords in the transaction log) provide numRows even when
+          // ANALYZE TABLE has not been run and no catalog stats exist.
+          assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
+          assertEquals(1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
           assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
           assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
         });

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -588,57 +588,58 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testNumRowsInStatistics() throws Exception {
     // Table has 5 rows inserted as 5 separate partitions (1 row each), all with stats.
-    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
-    try {
-      SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-      SparkScan scan = (SparkScan) builder.build();
+    withSQLConf(
+        "spark.sql.cbo.planStats.enabled",
+        "true",
+        () -> {
+          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+          SparkScan scan = (SparkScan) builder.build();
 
-      assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
-      assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
-      assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-      assertEquals(5L, scan.estimateStatistics().numRows().getAsLong());
-    } finally {
-      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
-    }
+          assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
+          assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
+          assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+          assertEquals(5L, scan.estimateStatistics().numRows().getAsLong());
+        });
   }
 
   @Test
   public void testNumRowsAfterRuntimeFiltering() throws Exception {
     // city=hz matches 2 partitions: (date=20180520, city=hz) and (date=20180718, city=hz)
-    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
-    try {
-      SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-      SparkScan scan = (SparkScan) builder.build();
+    withSQLConf(
+        "spark.sql.cbo.planStats.enabled",
+        "true",
+        () -> {
+          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+          SparkScan scan = (SparkScan) builder.build();
 
-      assertEquals(5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
+          assertEquals(
+              5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
 
-      scan.filter(new Predicate[] {cityPredicate}); // city=hz
+          scan.filter(new Predicate[] {cityPredicate}); // city=hz
 
-      assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-      assertEquals(
-          2L, scan.estimateStatistics().numRows().getAsLong(), "2 rows after city=hz filter");
-    } finally {
-      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
-    }
+          assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+          assertEquals(
+              2L, scan.estimateStatistics().numRows().getAsLong(), "2 rows after city=hz filter");
+        });
   }
 
   @Test
   public void testNumRowsZeroAfterFilteringOutAllFiles() throws Exception {
-    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
-    try {
-      SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-      SparkScan scan = (SparkScan) builder.build();
+    withSQLConf(
+        "spark.sql.cbo.planStats.enabled",
+        "true",
+        () -> {
+          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+          SparkScan scan = (SparkScan) builder.build();
 
-      scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
+          scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
 
-      assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-      assertEquals(
-          0L,
-          scan.estimateStatistics().numRows().getAsLong(),
-          "0 rows after filtering out all files");
-    } finally {
-      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
-    }
+          assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
+          assertEquals(
+              0L,
+              scan.estimateStatistics().numRows().getAsLong(),
+              "0 rows after filtering out all files");
+        });
   }
 
   @Test
@@ -646,7 +647,6 @@ public class SparkScanTest extends DeltaV2TestBase {
     // Older Delta tables or tables written with stats collection disabled will have AddFile entries
     // without numRecords. When even one file lacks stats, rowCountKnown must be false so that
     // numRows() returns OptionalLong.empty() rather than an incorrect partial count.
-    spark.sql("SET spark.sql.statistics.planStatsEnabled=true");
     String tblName = "test_mixed_stats_numrows";
     try {
       String path = testDir.getAbsolutePath();
@@ -663,16 +663,21 @@ public class SparkScanTest extends DeltaV2TestBase {
       SparkTable mixedStatsTable =
           new SparkTable(
               Identifier.of(new String[] {"spark_catalog", "default"}, tblName), path, options);
-      SparkScanBuilder builder = (SparkScanBuilder) mixedStatsTable.newScanBuilder(options);
-      SparkScan scan = (SparkScan) builder.build();
 
-      assertFalse(
-          isRowCountKnown(scan), "rowCountKnown should be false when some files lack stats");
-      assertFalse(
-          scan.estimateStatistics().numRows().isPresent(),
-          "numRows() should be OptionalLong.empty() when row count is unknown");
+      withSQLConf(
+          "spark.sql.cbo.planStats.enabled",
+          "true",
+          () -> {
+            SparkScanBuilder builder = (SparkScanBuilder) mixedStatsTable.newScanBuilder(options);
+            SparkScan scan = (SparkScan) builder.build();
+
+            assertFalse(
+                isRowCountKnown(scan), "rowCountKnown should be false when some files lack stats");
+            assertFalse(
+                scan.estimateStatistics().numRows().isPresent(),
+                "numRows() should be OptionalLong.empty() when row count is unknown");
+          });
     } finally {
-      spark.sql("RESET spark.sql.statistics.planStatsEnabled");
       spark.sql("RESET spark.databricks.delta.stats.collect");
       spark.sql("DROP TABLE IF EXISTS " + tblName);
     }
@@ -1150,7 +1155,7 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // Should have numRows from catalog stats
+          // Should have numRows from per-file stats (not stale catalog stats)
           assertTrue(stats.numRows().isPresent(), "numRows should be present with CBO enabled");
           assertEquals(2L, stats.numRows().getAsLong(), "numRows should be 2");
 
@@ -1172,6 +1177,48 @@ public class SparkScanTest extends DeltaV2TestBase {
           assertTrue(idStats.max().isPresent(), "id max should be present");
           assertEquals(1, idStats.min().get(), "id min should be 1");
           assertEquals(2, idStats.max().get(), "id max should be 2");
+        });
+  }
+
+  @Test
+  public void testPerFileNumRowsPrefersOverStaleCatalogStats(@TempDir File tempDir)
+      throws Exception {
+    // Verifies that per-file numRows (from AddFile.numRecords) takes precedence over stale catalog
+    // stats (from ANALYZE TABLE). Catalog stats are a point-in-time snapshot and not adjusted for
+    // partition pruning; per-file stats are always up-to-date.
+    String path = tempDir.getAbsolutePath();
+    String tblName = "stats_per_file_wins";
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tblName));
+
+    // Inject stale catalog stats claiming 999 rows (simulating stats collected before a deletion)
+    CatalogStatistics staleCatalogStats =
+        new CatalogStatistics(
+            scala.math.BigInt.apply(1024L),
+            scala.Option.apply(scala.math.BigInt.apply(999L)), // stale — actual count is 2
+            buildColStatsMap(new String[] {}, new CatalogColumnStat[] {}));
+    CatalogTable catalogTable = injectCatalogStats(tblName, staleCatalogStats);
+
+    withSQLConf(
+        "spark.sql.cbo.enabled",
+        "true",
+        () -> {
+          Identifier id = Identifier.of(new String[] {"default"}, tblName);
+          SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+          SparkScanBuilder builder =
+              (SparkScanBuilder)
+                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+          SparkScan scan = (SparkScan) builder.build();
+          Statistics stats = scan.estimateStatistics();
+
+          // Per-file stats show 2 rows; the stale catalog claim of 999 should be ignored.
+          assertTrue(stats.numRows().isPresent(), "numRows should be present");
+          assertEquals(
+              2L,
+              stats.numRows().getAsLong(),
+              "numRows should be 2 from per-file stats, not 999 from stale catalog");
         });
   }
 
@@ -1496,9 +1543,9 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEstimateStatisticsWithCatalogStats_noNumRows(@TempDir File tempDir)
       throws Exception {
-    // Catalog stats with sizeInBytes but no numRows should be treated the same as no catalog
-    // stats: fall through to post-pruned/filtered file sizes instead of using the stale
-    // catalog sizeInBytes.
+    // Catalog stats with sizeInBytes but no numRows: when per-file stats are available,
+    // numRows should still be reported from per-file numRecords (not from catalog stats).
+    // sizeInBytes should come from planned files, not the stale catalog value.
     String path = tempDir.getAbsolutePath();
     String tblName = "stats_no_numrows";
     spark.sql(
@@ -1528,10 +1575,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // Should behave like no catalog stats: numRows empty, sizeInBytes from planned files
-          assertFalse(
-              stats.numRows().isPresent(),
-              "numRows should be empty when catalog stats have no numRows");
+          // Per-file stats provide numRows even when catalog stats lack it
+          assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
+          assertEquals(
+              2L, stats.numRows().getAsLong(), "numRows should reflect per-file row count");
           assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
           assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
 
@@ -1541,10 +1588,10 @@ public class SparkScanTest extends DeltaV2TestBase {
               stats.sizeInBytes().getAsLong(),
               "sizeInBytes should come from planned files, not catalog stats");
 
-          // columnStats should be empty (not inheriting from catalog stats)
+          // columnStats should be empty (catalog stats had no column stats)
           assertTrue(
               stats.columnStats().isEmpty(),
-              "columnStats should be empty when catalog stats have no numRows");
+              "columnStats should be empty when catalog stats have no column stats");
         });
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -1292,7 +1292,8 @@ public class SparkScanTest extends DeltaV2TestBase {
           // Per-file Delta stats (numRecords in the transaction log) are available even without
           // catalog stats from ANALYZE TABLE, so numRows should be present.
           assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
-          assertEquals(1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
+          assertEquals(
+              1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
           assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
           assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
         });
@@ -1485,7 +1486,8 @@ public class SparkScanTest extends DeltaV2TestBase {
           // Per-file Delta stats (numRecords in the transaction log) provide numRows even when
           // ANALYZE TABLE has not been run and no catalog stats exist.
           assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
-          assertEquals(1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
+          assertEquals(
+              1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
           assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
           assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
         });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

SparkScan.estimateStatistics().numRows() previously always returned OptionalLong.empty(), leaving Spark's cost-based optimizer without row count information for joins, broadcast decisions, etc.

Each AddFile in the Delta transaction log carries a stats JSON blob with numRecords. This change requests stats inclusion via ScanImpl.getScanFiles(engine, includeStats=true) during scan planning, accumulates numRecords across all files into totalRows, and exposes it through numRows(). A per-file fileRowCounts map allows totalRows to be recomputed correctly after DPP runtime partition filtering narrows the file set. rowCountKnown degrades gracefully to empty when any file lacks stats.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
