### PR TITLE
[Spark] Add In filter pushdown to ExpressionUtils

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ExpressionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ExpressionUtils.java
@@ -18,6 +18,7 @@ package io.delta.spark.internal.v2.utils;
 import static org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.delta.kernel.expressions.AlwaysFalse;
 import io.delta.kernel.expressions.And;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.In;
@@ -141,10 +142,10 @@ public final class ExpressionUtils {
     }
     if (filter instanceof org.apache.spark.sql.sources.In) {
       org.apache.spark.sql.sources.In f = (org.apache.spark.sql.sources.In) filter;
-      // An empty IN list can never match; skip pushdown rather than pushing ALWAYS_FALSE so
-      // that Spark still evaluates the filter and returns the correct empty result.
+      // An empty IN list can never match any row. Push ALWAYS_FALSE so the kernel skips
+      // all files entirely, rather than scanning every file only to discard every row.
       if (f.values().length == 0) {
-        return new ConvertedPredicate(Optional.empty());
+        return new ConvertedPredicate(Optional.of(AlwaysFalse.ALWAYS_FALSE));
       }
       List<io.delta.kernel.expressions.Expression> literals = new ArrayList<>();
       for (Object value : f.values()) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/ExpressionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/ExpressionUtilsTest.java
@@ -169,7 +169,9 @@ public class ExpressionUtilsTest {
     ExpressionUtils.ConvertedPredicate result =
         ExpressionUtils.convertSparkFilterToKernelPredicate(filter);
 
-    assertFalse(result.isPresent(), "In filter with empty values should not be pushed down");
+    // Empty IN list always evaluates to FALSE; push ALWAYS_FALSE so the kernel skips all files.
+    assertTrue(result.isPresent(), "In filter with empty values should push ALWAYS_FALSE");
+    assertEquals("ALWAYS_FALSE", result.get().getName());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Spark's In(attribute, values[]) filter was not converted to a Kernel predicate, meaning WHERE col IN (...) queries had no filter pushdown in the V2 connector. The Kernel's IN predicate accepts a column followed by one or more typed literals as children.

The conversion builds the children list by calling convertValueToKernelLiteral on each value; if any value cannot be converted (null, unsupported type) or the values array is empty the whole filter is left for post-scan evaluation rather than producing an incorrect partially-pushed predicate.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No