### PR TITLE
[BUILD] Speed up Delta Spark CI with faster runners and increased parallelism

### DIFF
--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -66,12 +66,12 @@ jobs:
         # These Scala versions must match those in the build.sbt
         scala: [2.13.16]
         # Important: This list of shards must be [0..NUM_SHARDS - 1]
-        shard: ${{ fromJson(needs.generate-matrix.outputs.use_faster_tests == 'true' && '[0,1,2,3,4,5,6,7]' || '[0,1,2,3]') }}
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
       SPARK_VERSION: ${{ matrix.spark_version }}
       # Important: This must be the same as the length of shards in matrix
-      NUM_SHARDS: ${{ needs.generate-matrix.outputs.use_faster_tests == 'true' && 8 || 4 }}
+      NUM_SHARDS: 8
     steps:
       - uses: actions/checkout@v3
       - name: Get Spark version details


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add support for the `faster-tests` PR label to opt into faster CI runs for Delta Spark tests.

- When `faster-tests` is set: use 16-core runners in the `delta-spark-tests-runner-group`, 8 test shards, and `TEST_PARALLELISM_COUNT=8`
- When `faster-tests` is not set: use standard `ubuntu-24.04` runners, 4 test shards, and `TEST_PARALLELISM_COUNT=4` (unchanged from current behavior)
- Add concurrency group to auto-cancel previous in-progress runs on the same PR, avoiding wasted runner time

## How was this patch tested?

- Verified CI tests run successfully on standard GitHub-hosted runners (no `faster-tests` label)
- Verified CI tests use the custom runner group with 8 shards when `faster-tests` label is added
- Verified concurrency group cancels previous runs when new commits are pushed

## Does this PR introduce _any_ user-facing changes?

No.