### PR TITLE
[Spark] Add delta write options tests to commit stats logging

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -19,8 +19,11 @@ package org.apache.spark.sql.delta
 import java.util.Locale
 
 // scalastyle:off import.ordering.noEmptyLine
+import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
+
 import org.apache.spark.sql.delta.DeltaOptions.{OVERWRITE_SCHEMA_OPTION, PARTITION_OVERWRITE_MODE_OPTION}
 import org.apache.spark.sql.delta.actions.{Action, FileAction}
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -36,7 +39,8 @@ import org.apache.spark.util.Utils
 
 class DeltaOptionSuite extends QueryTest
   with SharedSparkSession
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with WriteOptionsTestBase {
 
   import testImplicits._
 
@@ -432,6 +436,72 @@ class DeltaOptionSuite extends QueryTest
         .saveAsTable("temp")
       assert(spark.read.format("delta").table("temp").count() == 2,
         "Table should keep the original partition with DPO mode enabled.")
+    }
+  }
+
+  override def executePathWriteTest(
+      write: String => Unit)(assertions: WriteOptionsAssertion): Unit = {
+    withTempDir { tempDir =>
+      val path = createPartitionedTable(tempDir)
+      executeAndValidateWriteOptions(write(path), assertions)
+    }
+  }
+
+  override def executeTableWriteTest(
+      write: String => Unit)(assertions: WriteOptionsAssertion): Unit = {
+    withTable("test_table") {
+      // Create initial partitioned table
+      Seq((1, 1, "event1"), (2, 2, "event2"), (3, 1, "event3"))
+        .toDF("id", "part", "event_name")
+        .write.format("delta").partitionBy("part").saveAsTable("test_table")
+
+      executeAndValidateWriteOptions(write("test_table"), assertions)
+    }
+  }
+
+  private def executeAndValidateWriteOptions(
+    writeOp: => Unit,
+    assertions: WriteOptionsAssertion
+  ): Unit = {
+    val events = Log4jUsageLogger.track {
+      writeOp
+    }
+    val usageLog = getWriteOptionsEvents(events).lastOption
+      .getOrElse(fail("No usage log event found"))
+
+    // Validate the usage log contains correct write options
+    assertWriteOptionsInCommitStats(
+      usageLog.blob,
+      assertions
+    )
+  }
+
+  protected def getWriteOptionsEvents(events: Seq[UsageRecord]): Seq[UsageRecord] = {
+    events.filter { e =>
+      e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+        e.tags.get("opType").contains(DeltaLogging.DELTA_COMMIT_STATS_OPTYPE)
+    }
+  }
+
+  private def assertWriteOptionsInCommitStats(
+    blob: String,
+    assertions: WriteOptionsAssertion
+  ): Unit = {
+    def assertContainsWithOptionalParens(field: String, value: Option[String]): Unit = {
+      val plainValue = value.map(s => "\"" + s + "\"").getOrElse("")
+      val valueWithParens = value.map(s => "\"(" + s + ")\"").getOrElse("")
+      assert(blob.contains(s""""$field":$plainValue""") ||
+        blob.contains(s""""$field":$valueWithParens"""))
+    }
+
+    if (assertions.mode != "") assert(blob.contains(s"""mode":"${assertions.mode}"""))
+    if (assertions.canOverwriteSchema) assert(blob.contains("\"canOverwriteSchema\":true"))
+    if (assertions.canMergeSchema) assert(blob.contains("\"canMergeSchema\":true"))
+    if (assertions.isDynamicPartitionOverwrite) {
+      assert(blob.contains("\"isDynamicPartitionOverwrite\":true"))
+    }
+    assertions.predicate.foreach { pred =>
+      assertContainsWithOptionalParens("predicate", Some(pred))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds unit tests that ensure that the telemetry for Delta write operations ([introduced here](https://github.com/delta-io/delta/pull/5939)) is being captured in Delta commit stats logging.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
**Unit tests in `DeltaOptionSuite`:**
- Regular overwrite operations
- Dynamic partition overwrite via SQL, DFv1, and DFv2 APIs
- replaceWhere via SQL, DFv1, and DFv2 APIs
- overwriteSchema and mergeSchema options
- Combinations of options (e.g., replaceWhere + overwriteSchema)
- SQL autoMerge config triggering mergeSchema flag
- INSERT REPLACE USING with full/partial partition columns using legacy code path
- Validates both telemetry events (via `Log4jUsageLogger.track`) and commit info persistence
- New `WriteOptionsTestBase` trait with reusable test helpers

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
