### PR TITLE
[DSv2] Add concrete batch WriteBuilder construction layer

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/SparkTable.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/SparkTable.java
@@ -243,13 +243,7 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite {
   public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
     requireNonNull(info, "write info is null");
     return new SparkParquetWriteBuilder(
-        tablePath,
-        hadoopConf,
-        initialSnapshot,
-        info.schema(),
-        info.queryId(),
-        info.options().asCaseSensitiveMap(),
-        schemaProvider.getPartitionColumnNames());
+        tablePath, hadoopConf, initialSnapshot, info, schemaProvider.getPartitionColumnNames());
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/SparkParquetBatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/SparkParquetBatchWrite.java
@@ -17,6 +17,7 @@ package io.delta.spark.internal.v2.write;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.delta.kernel.Snapshot;
 import java.util.Collections;
 import java.util.List;
@@ -75,30 +76,37 @@ public class SparkParquetBatchWrite implements BatchWrite {
   @Override
   public void abort(WriterCommitMessage[] messages) {}
 
+  @VisibleForTesting
   String getTablePath() {
     return tablePath;
   }
 
+  @VisibleForTesting
   Configuration getHadoopConf() {
     return hadoopConf;
   }
 
+  @VisibleForTesting
   Snapshot getInitialSnapshot() {
     return initialSnapshot;
   }
 
+  @VisibleForTesting
   StructType getWriteSchema() {
     return writeSchema;
   }
 
+  @VisibleForTesting
   String getQueryId() {
     return queryId;
   }
 
+  @VisibleForTesting
   Map<String, String> getOptions() {
     return options;
   }
 
+  @VisibleForTesting
   List<String> getPartitionColumnNames() {
     return partitionColumnNames;
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/SparkParquetWriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/SparkParquetWriteBuilder.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.types.StructType;
 
@@ -41,17 +42,21 @@ public class SparkParquetWriteBuilder implements WriteBuilder {
       String tablePath,
       Configuration hadoopConf,
       Snapshot initialSnapshot,
-      StructType writeSchema,
-      String queryId,
-      Map<String, String> options,
+      LogicalWriteInfo writeInfo,
       List<String> partitionColumnNames) {
     this.tablePath = requireNonNull(tablePath, "table path is null");
     this.hadoopConf = requireNonNull(hadoopConf, "hadoop conf is null");
     this.initialSnapshot = requireNonNull(initialSnapshot, "initial snapshot is null");
-    this.writeSchema = requireNonNull(writeSchema, "write schema is null");
-    this.queryId = requireNonNull(queryId, "query id is null");
+    LogicalWriteInfo nonNullWriteInfo = requireNonNull(writeInfo, "write info is null");
+    this.writeSchema = requireNonNull(nonNullWriteInfo.schema(), "write schema is null");
+    this.queryId = requireNonNull(nonNullWriteInfo.queryId(), "query id is null");
     this.options =
-        Collections.unmodifiableMap(new HashMap<>(requireNonNull(options, "options is null")));
+        Collections.unmodifiableMap(
+            new HashMap<>(
+                requireNonNull(
+                    requireNonNull(nonNullWriteInfo.options(), "write options are null")
+                        .asCaseSensitiveMap(),
+                    "options is null")));
     this.partitionColumnNames =
         Collections.unmodifiableList(
             new ArrayList<>(

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/SparkTableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/SparkTableTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.write.SparkParquetWriteBuilder;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -44,6 +45,7 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.delta.catalog.DeltaTableV2;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -489,16 +491,17 @@ public class SparkTableTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testNewWriteBuilderThrowsUnsupported(@TempDir File tempDir) throws Exception {
+  public void testNewWriteBuilderCreatesSparkParquetWriteBuilder(@TempDir File tempDir)
+      throws Exception {
     String path = tempDir.getAbsolutePath();
     spark.sql(
         String.format(
-            "CREATE TABLE test_write_builder_unsupported (id INT) USING delta LOCATION '%s'",
+            "CREATE TABLE test_write_builder_construction (id INT) USING delta LOCATION '%s'",
             path));
 
     SparkTable table =
         new SparkTable(
-            Identifier.of(new String[] {"default"}, "test_write_builder_unsupported"), path);
+            Identifier.of(new String[] {"default"}, "test_write_builder_construction"), path);
     LogicalWriteInfo writeInfo =
         new LogicalWriteInfo() {
           @Override
@@ -517,10 +520,21 @@ public class SparkTableTest extends DeltaV2TestBase {
           }
         };
 
-    UnsupportedOperationException ex =
-        assertThrows(UnsupportedOperationException.class, () -> table.newWriteBuilder(writeInfo));
-    assertEquals(
-        "Batch write for Delta tables via the DSv2 connector is not yet supported.",
-        ex.getMessage());
+    WriteBuilder writeBuilder = table.newWriteBuilder(writeInfo);
+    assertTrue(writeBuilder instanceof SparkParquetWriteBuilder);
+  }
+
+  @Test
+  public void testNewWriteBuilderRejectsNullWriteInfo(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE test_write_builder_null_info (id INT) USING delta LOCATION '%s'", path));
+
+    SparkTable table =
+        new SparkTable(
+            Identifier.of(new String[] {"default"}, "test_write_builder_null_info"), path);
+
+    assertThrows(NullPointerException.class, () -> table.newWriteBuilder(null));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/SparkParquetWriteBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/SparkParquetWriteBuilderTest.java
@@ -31,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -64,9 +66,7 @@ public class SparkParquetWriteBuilderTest extends DeltaV2TestBase {
             tablePath,
             hadoopConf,
             initialSnapshot,
-            writeSchema,
-            queryId,
-            options,
+            logicalWriteInfo(queryId, writeSchema, options),
             partitionColumnNames);
 
     SparkParquetBatchWrite batchWrite = builder.buildForBatch();
@@ -106,5 +106,25 @@ public class SparkParquetWriteBuilderTest extends DeltaV2TestBase {
     assertThrows(
         UnsupportedOperationException.class, () -> batchWrite.createBatchWriterFactory(null));
     assertThrows(UnsupportedOperationException.class, () -> batchWrite.commit(null));
+  }
+
+  private static LogicalWriteInfo logicalWriteInfo(
+      String queryId, StructType schema, Map<String, String> options) {
+    return new LogicalWriteInfo() {
+      @Override
+      public String queryId() {
+        return queryId;
+      }
+
+      @Override
+      public StructType schema() {
+        return schema;
+      }
+
+      @Override
+      public CaseInsensitiveStringMap options() {
+        return new CaseInsensitiveStringMap(options);
+      }
+    };
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6120/files) to review all changes in this PR.

**Stack:**
- **[[DSv2] Add concrete batch WriteBuilder construction layer](https://github.com/delta-io/delta/pull/6120)** [[Files changed](https://github.com/delta-io/delta/pull/6120/files)] ⬅️ _This PR_
  - [[DSv2] Initialize driver transaction and write context for batch writes](https://github.com/delta-io/delta/pull/6131) [[Files changed](https://github.com/delta-io/delta/pull/6131/files/3e66a14274fb4198be42b9f9a96986cfc7637d07..2da2c81bc5becbe6390101c761cd85f274ddb18c)]
    - [[DSv2] Add serializable transaction/conf transport for batch write](https://github.com/delta-io/delta/pull/6132) [[Files changed](https://github.com/delta-io/delta/pull/6132/files/2da2c81bc5becbe6390101c761cd85f274ddb18c..6d2dcaad412199df68e9d6f02ed49322687aa1ea)]
      - [[DSv2] Move shared parquet glue to v2/parquet](https://github.com/delta-io/delta/pull/6169) [[Files changed](https://github.com/delta-io/delta/pull/6169/files/6d2dcaad412199df68e9d6f02ed49322687aa1ea..adcc1ecd9acdd4bf0b01fad61b3a37e88058ed65)]
        - [[DSv2] Add schema alignment and batch writer factory skeleton](https://github.com/delta-io/delta/pull/6170) [[Files changed](https://github.com/delta-io/delta/pull/6170/files/adcc1ecd9acdd4bf0b01fad61b3a37e88058ed65..bf99c236630485a4605ad242aee8175de73c3907)]
          - [[DSv2] Add executor writer row accounting and commit payload](https://github.com/delta-io/delta/pull/6171) [[Files changed](https://github.com/delta-io/delta/pull/6171/files/bf99c236630485a4605ad242aee8175de73c3907..89ba136548ddc59d6c415ae04aa6d2dbc726088b)]
            - [[DSv2] Wire driver commit-message decoding path](https://github.com/delta-io/delta/pull/6172) [[Files changed](https://github.com/delta-io/delta/pull/6172/files/89ba136548ddc59d6c415ae04aa6d2dbc726088b..408efcf8076c9b2cc2765ecb501358ca68f56936)]
              - [[DSv2] Add write-path hardening failure-path coverage](https://github.com/delta-io/delta/pull/6173) [[Files changed](https://github.com/delta-io/delta/pull/6173/files/408efcf8076c9b2cc2765ecb501358ca68f56936..fa3ff85abfe2f02b5f21eb05485899365061edef)]

---

## Summary
- Wire DSv2 batch write builder from `SparkTable.newWriteBuilder`.
- Add batch-write construction object and foundational unit coverage.

## Test plan
- [x] `build/sbt "sparkV2/testOnly *SparkParquetWriteBuilderTest"`