### PR TITLE
[Kernel]Propagate interrupt-related IOExceptions as UncheckedIOException instead of KernelEngineException in Kernel Default implementation

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -36,6 +36,7 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.LogStore;
 import java.io.*;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
@@ -113,6 +114,12 @@ public class DefaultJsonHandler implements JsonHandler {
           }
           return nextLine != null;
         } catch (IOException ex) {
+          // Propagate interrupt-related exceptions as UncheckedIOException so that
+          // Spark's StreamExecution.isInterruptionException() can recognize them
+          // during stream shutdown. Wrapping in KernelEngineException would mask them.
+          if (ex instanceof ClosedByInterruptException || ex instanceof InterruptedIOException) {
+            throw new UncheckedIOException(ex);
+          }
           throw new KernelEngineException(
               format("Error reading JSON file: %s", currentFile.getPath()), ex);
         }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -31,6 +31,9 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.UncheckedIOException;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.*;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.filter2.compat.FilterCompat;
@@ -91,6 +94,12 @@ public class ParquetFileReader {
           hasNotConsumedNextElement = next != null;
           return hasNotConsumedNextElement;
         } catch (IOException ex) {
+          // Propagate interrupt-related exceptions as UncheckedIOException so that
+          // Spark's StreamExecution.isInterruptionException() can recognize them
+          // during stream shutdown. Wrapping in KernelEngineException would mask them.
+          if (ex instanceof ClosedByInterruptException || ex instanceof InterruptedIOException) {
+            throw new UncheckedIOException(ex);
+          }
           throw new KernelEngineException(
               "Error reading Parquet file: " + fileStatus.getPath(), ex);
         }
@@ -158,6 +167,12 @@ public class ParquetFileReader {
 
           } catch (IOException e) {
             Utils.closeCloseablesSilently(fileReader, reader);
+            // Propagate interrupt-related exceptions as UncheckedIOException so that
+            // Spark's StreamExecution.isInterruptionException() can recognize them
+            // during stream shutdown. Wrapping in KernelEngineException would mask them.
+            if (e instanceof ClosedByInterruptException || e instanceof InterruptedIOException) {
+              throw new UncheckedIOException(e);
+            }
             throw new KernelEngineException(
                 "Error reading Parquet file: " + fileStatus.getPath(), e);
           }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
@@ -15,7 +15,9 @@
  */
 package io.delta.kernel.defaults.engine
 
+import java.io.UncheckedIOException
 import java.math.{BigDecimal => JBigDecimal}
+import java.nio.channels.ClosedByInterruptException
 import java.nio.file.FileAlreadyExistsException
 import java.util.Optional
 
@@ -24,9 +26,12 @@ import scala.collection.JavaConverters._
 import io.delta.kernel.data.ColumnVector
 import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO
 import io.delta.kernel.defaults.utils.{DefaultVectorTestUtils, TestRow, TestUtils}
+import io.delta.kernel.exceptions.KernelEngineException
 import io.delta.kernel.internal.actions.CommitInfo
 import io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector
+import io.delta.kernel.internal.util.Utils.singletonCloseableIterator
 import io.delta.kernel.types._
+import io.delta.kernel.utils.FileStatus
 
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.funsuite.AnyFunSuite
@@ -553,5 +558,23 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
     assert(commitInfo.getIsBlindAppend === Optional.empty())
     assert(commitInfo.getInCommitTimestamp === Optional.empty())
     assert(commitInfo.getTimestamp === 1740009523401L)
+  }
+
+  test("ClosedByInterruptException propagates as UncheckedIOException, not KernelEngineException") {
+    val handler = new DefaultJsonHandler(throwingFileIO(new ClosedByInterruptException()))
+    val fileIter = singletonCloseableIterator(
+      FileStatus.of("file:///fake/_delta_log/00000000000000000000.json", 100, 0))
+    val iter = handler.readJsonFiles(
+      fileIter,
+      new StructType().add("value", StringType.STRING),
+      Optional.empty())
+
+    val ex = intercept[UncheckedIOException] {
+      iter.hasNext()
+    }
+    assert(
+      ex.getCause.isInstanceOf[ClosedByInterruptException],
+      s"Expected ClosedByInterruptException cause, got: ${ex.getCause.getClass}")
+    assert(!ex.isInstanceOf[KernelEngineException])
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -15,14 +15,17 @@
  */
 package io.delta.kernel.defaults.internal.parquet
 
+import java.io.UncheckedIOException
 import java.math.BigDecimal
-import java.util.TimeZone
+import java.nio.channels.ClosedByInterruptException
+import java.util.{Optional, TimeZone}
 
 import io.delta.golden.GoldenTableUtils.{goldenTableFile, goldenTablePath}
 import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow}
+import io.delta.kernel.exceptions.KernelEngineException
 import io.delta.kernel.test.VectorTestUtils
 import io.delta.kernel.types._
-import io.delta.kernel.utils.MetadataColumnTestUtils
+import io.delta.kernel.utils.{FileStatus, MetadataColumnTestUtils}
 
 import org.apache.spark.sql.internal.SQLConf
 import org.scalatest.funsuite.AnyFunSuite
@@ -384,5 +387,22 @@ class ParquetFileReaderSuite extends AnyFunSuite
     checkAnswer(
       readParquetFilesUsingKernel(parquetFilePath, readSchema), /* actual */
       readParquetFilesUsingSpark(parquetFilePath, readSchema) /* expected */ )
+  }
+
+  test("ClosedByInterruptException propagates as UncheckedIOException, not KernelEngineException") {
+    val reader = new ParquetFileReader(throwingFileIO(new ClosedByInterruptException()))
+    val fileStatus = FileStatus.of("file:///fake/test.parquet", 100, 0)
+    val iter = reader.read(
+      fileStatus,
+      new StructType().add("value", StringType.STRING),
+      Optional.empty())
+
+    val ex = intercept[UncheckedIOException] {
+      iter.hasNext()
+    }
+    assert(
+      ex.getCause.isInstanceOf[ClosedByInterruptException],
+      s"Expected ClosedByInterruptException cause, got: ${ex.getCause.getClass}")
+    assert(!ex.isInstanceOf[KernelEngineException])
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -28,6 +28,7 @@ import io.delta.golden.GoldenTableUtils
 import io.delta.kernel.{Scan, Snapshot, Table, TransactionCommitResult}
 import io.delta.kernel.data._
 import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.defaults.engine.fileio.{FileIO, InputFile, OutputFile, SeekableInputStream}
 import io.delta.kernel.defaults.internal.data.vector.{DefaultGenericVector, DefaultStructVector}
 import io.delta.kernel.defaults.test.{AbstractTableManagerAdapter, LegacyTableManagerAdapter, TableManagerAdapter}
 import io.delta.kernel.engine.Engine
@@ -986,6 +987,28 @@ trait AbstractTestUtils
     option match {
       case Some(value) => Optional.of(value)
       case None => Optional.empty()
+    }
+  }
+
+  /**
+   * Creates a FileIO whose newInputFile().newStream() always throws the given exception.
+   * Useful for testing error handling in handlers.
+   */
+  def throwingFileIO(exception: => Exception): FileIO = {
+    new FileIO {
+      override def newInputFile(path: String, fileSize: Long): InputFile = new InputFile {
+        override def length(): Long = fileSize
+        override def path(): String = path
+        override def newStream(): SeekableInputStream = throw exception
+      }
+      override def listFrom(filePath: String): CloseableIterator[FileStatus] = null
+      override def getFileStatus(path: String): FileStatus = null
+      override def resolvePath(path: String): String = null
+      override def mkdirs(path: String): Boolean = false
+      override def newOutputFile(path: String): OutputFile = null
+      override def delete(path: String): Boolean = false
+      override def getConf(confKey: String): Optional[String] = Optional.empty()
+      override def copyFileAtomically(src: String, dst: String, overwrite: Boolean): Unit = {}
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

In the integration with Spark using Kernel's default engine impl, we found an issue in error propagation:

When a Spark Structured Streaming query stops, the micro-batch thread is interrupted. If the
kernel is performing I/O (reading JSON delta log files or Parquet data files) at that moment,
a `ClosedByInterruptException` or `InterruptedIOException` is thrown. 

Previously, these were
wrapped in `KernelEngineException`, which Spark's `StreamExecution.isInterruptionException()`
does not recognize -- causing a spurious `StreamingQueryException` on clean stream shutdown
(flaky "basic" test in `DeltaSourceV2Suite`).

This PR changes the kernel's `DefaultJsonHandler` and `ParquetFileReader` to wrap
interrupt-related `IOException`s in `java.io.UncheckedIOException` instead. Spark's interrupt
detection explicitly recurses into `UncheckedIOException.getCause()`, so the underlying
`ClosedByInterruptException` is properly recognized and the stream shuts down cleanly.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No