### PR TITLE
[Spark] Deflake tearDown of test_deltatable

### DIFF
--- a/python/delta/testing/utils.py
+++ b/python/delta/testing/utils.py
@@ -54,7 +54,7 @@ class DeltaTestCase(ReusedSQLTestCase):
 
     def tearDown(self) -> None:
         super(DeltaTestCase, self).tearDown()
-        shutil.rmtree(self.tempPath)
+        shutil.rmtree(self.tempPath, ignore_errors=True)
 
     @contextmanager
     def tempTable(self) -> Generator[str, None, None]:


### PR DESCRIPTION
## Description

Add ignore_errors=True argument to the call that deletes the temporary directory used by python delta tests.

## How was this patch tested?
Test-only. I didn't manage to reproduce the flakiness locally (visible in internal CI), but the error clearly points at tearDown failing to delete a file that was already deleted, which this change will address:
```
======================================================================
ERROR [9.982s]: test_dropFeatureSupport (__main__.DeltaTableTests.test_dropFeatureSupport)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/python/delta/connect/testing/utils.py", line 53, in tearDown
    shutil.rmtree(self.tempPath)
  File "/usr/lib/python3.12/shutil.py", line 785, in rmtree
    _rmtree_safe_fd(fd, path, onexc)
  File "/usr/lib/python3.12/shutil.py", line 686, in _rmtree_safe_fd
    _rmtree_safe_fd(dirfd, fullname, onexc)
  File "/usr/lib/python3.12/shutil.py", line 686, in _rmtree_safe_fd
    _rmtree_safe_fd(dirfd, fullname, onexc)
  File "/usr/lib/python3.12/shutil.py", line 717, in _rmtree_safe_fd
    onexc(os.unlink, fullname, err)
  File "/usr/lib/python3.12/shutil.py", line 715, in _rmtree_safe_fd
    os.unlink(entry.name, dir_fd=topfd)
```