### PR TITLE
Make CommitInfo string fields Optional to fix NPE on nullable columns

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -595,11 +595,11 @@ public class TransactionImpl implements Transaction {
     return new CommitInfo(
         generateInCommitTimestampForFirstCommitAttempt(engine, commitAttemptStartTime),
         commitAttemptStartTime, /* timestamp */
-        "Kernel-" + Meta.KERNEL_VERSION + "/" + engineInfo, /* engineInfo */
-        operation.getDescription(), /* description */
+        Optional.of("Kernel-" + Meta.KERNEL_VERSION + "/" + engineInfo), /* engineInfo */
+        Optional.of(operation.getDescription()), /* description */
         getOperationParameters(), /* operationParameters */
         isBlindAppend(), /* isBlindAppend */
-        txnId.toString(), /* txnId */
+        Optional.of(txnId.toString()), /* txnId */
         emptyMap() /* operationMetrics */);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -101,16 +101,18 @@ public class CommitInfo {
       children[i] = vector.getChild(i);
     }
 
+    checkArgument(!children[1].isNullAt(rowId), "CommitInfo is missing required timestamp field");
+
     return new CommitInfo(
         Optional.ofNullable(children[0].isNullAt(rowId) ? null : children[0].getLong(rowId)),
-        children[1].isNullAt(rowId) ? null : children[1].getLong(rowId),
-        children[2].isNullAt(rowId) ? null : children[2].getString(rowId),
-        children[3].isNullAt(rowId) ? null : children[3].getString(rowId),
+        children[1].getLong(rowId),
+        Optional.ofNullable(children[2].isNullAt(rowId) ? null : children[2].getString(rowId)),
+        Optional.ofNullable(children[3].isNullAt(rowId) ? null : children[3].getString(rowId)),
         children[4].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[4].getMap(rowId)),
         Optional.ofNullable(children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId)),
-        children[6].isNullAt(rowId) ? null : children[6].getString(rowId),
+        Optional.ofNullable(children[6].isNullAt(rowId) ? null : children[6].getString(rowId)),
         children[7].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[7].getMap(rowId)));
@@ -213,22 +215,22 @@ public class CommitInfo {
   //////////////////////////////////
 
   private final long timestamp;
-  private final String engineInfo;
-  private final String operation;
+  private final Optional<String> engineInfo;
+  private final Optional<String> operation;
   private final Map<String, String> operationParameters;
   private final Optional<Boolean> isBlindAppend;
-  private final String txnId;
+  private final Optional<String> txnId;
   private Optional<Long> inCommitTimestamp;
   private final Map<String, String> operationMetrics;
 
   public CommitInfo(
       Optional<Long> inCommitTimestamp,
       long timestamp,
-      String engineInfo,
-      String operation,
+      Optional<String> engineInfo,
+      Optional<String> operation,
       Map<String, String> operationParameters,
       Optional<Boolean> isBlindAppend,
-      String txnId,
+      Optional<String> txnId,
       Map<String, String> operationMetrics) {
     this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
     this.timestamp = timestamp;
@@ -244,11 +246,11 @@ public class CommitInfo {
     return timestamp;
   }
 
-  public String getEngineInfo() {
+  public Optional<String> getEngineInfo() {
     return engineInfo;
   }
 
-  public String getOperation() {
+  public Optional<String> getOperation() {
     return operation;
   }
 
@@ -260,7 +262,7 @@ public class CommitInfo {
     return isBlindAppend;
   }
 
-  public String getTxnId() {
+  public Optional<String> getTxnId() {
     return txnId;
   }
 
@@ -285,12 +287,12 @@ public class CommitInfo {
     Map<Integer, Object> commitInfo = new HashMap<>();
     commitInfo.put(COL_NAME_TO_ORDINAL.get("inCommitTimestamp"), inCommitTimestamp.orElse(null));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("timestamp"), timestamp);
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo);
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo.orElse(null));
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation.orElse(null));
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationParameters"), stringStringMapValue(operationParameters));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend.orElse(null));
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId.orElse(null));
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -285,12 +285,15 @@ public class ChecksumUtils {
 
             CommitInfo commitInfo = CommitInfo.fromColumnVector(commitInfoVector, i);
             if (commitInfo == null
-                || !INCREMENTAL_SUPPORTED_OPS.contains(commitInfo.getOperation())) {
+                || !commitInfo
+                    .getOperation()
+                    .filter(INCREMENTAL_SUPPORTED_OPS::contains)
+                    .isPresent()) {
               logger.info(
                   "Falling back to full replay after {}ms: "
                       + "unsupported operation '{}' for version {}",
                   System.currentTimeMillis() - startTime,
-                  commitInfo != null ? commitInfo.getOperation() : "null",
+                  commitInfo != null ? commitInfo.getOperation().orElse("null") : "null",
                   newVersion);
               return Optional.empty();
             }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -45,11 +45,11 @@ trait ActionUtils extends VectorTestUtils {
     new CommitInfo(
       if (ictEnabled) Optional.of(1L) else Optional.empty(), // ICT
       1L, // timestamp
-      "engineInfo",
-      "operation",
+      Optional.of("engineInfo"),
+      Optional.of("operation"),
       Collections.emptyMap(), // operationParameters
       Optional.of(false), // isBlindAppend
-      "txnId",
+      Optional.of("txnId"),
       Collections.emptyMap() // operationMetrics
     )
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)


## Description

When reading a Delta table whose commits were written by an external engine that omits `engineInfo`, `operation`, or `txnId` fields in the `commitInfo` action, `CommitInfo.fromColumnVector()` passes `null` to the constructor which calls `requireNonNull()`, causing a `NullPointerException`.

This PR makes `engineInfo`, `operation`, and `txnId` `Optional<String>` — consistent with how `isBlindAppend` and `inCommitTimestamp` are already handled — since these fields are not required by the Delta protocol.

## How was this patch tested?

Added 3 new tests in `DefaultJsonHandlerSuite`:

- **`fromColumnVector` handles null `engineInfo`, `operation`, and `txnId` without NPE** — commit JSON missing all three string fields
- **`fromColumnVector` with only timestamp field does not NPE** — minimal commit info
- **`CommitInfo` round-trips through `toRow` with nullable fields** — verifies `Optional.empty()` serializes as `null` in `Row`

## Does this PR introduce _any_ user-facing changes?

No. This is an internal bug fix. The `CommitInfo` class is in the internal package and not part of the public API. Tables with commits missing these fields will now be readable instead of throwing an NPE.

