### PR TITLE
[Kernel] Make FileStatus Serializable for cross-executor usage

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableFileStatus.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableFileStatus.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import io.delta.kernel.utils.FileStatus;
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Serializable wrapper for Kernel's {@link FileStatus}, which is a public API class that we avoid
+ * modifying. This wrapper is used to serialize snapshot state (LogSegment contents) from the driver
+ * to executors.
+ */
+public final class SerializableFileStatus implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String path;
+  private final long size;
+  private final long modificationTime;
+
+  public SerializableFileStatus(String path, long size, long modificationTime) {
+    this.path = path;
+    this.size = size;
+    this.modificationTime = modificationTime;
+  }
+
+  public static SerializableFileStatus from(FileStatus fs) {
+    return new SerializableFileStatus(fs.getPath(), fs.getSize(), fs.getModificationTime());
+  }
+
+  public FileStatus toFileStatus() {
+    return FileStatus.of(path, size, modificationTime);
+  }
+
+  public static List<SerializableFileStatus> fromList(List<FileStatus> list) {
+    return list.stream().map(SerializableFileStatus::from).collect(Collectors.toList());
+  }
+
+  public static List<FileStatus> toFileStatusList(List<SerializableFileStatus> list) {
+    return list.stream().map(SerializableFileStatus::toFileStatus).collect(Collectors.toList());
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableFileStatusTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableFileStatusTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.delta.kernel.utils.FileStatus;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+public class SerializableFileStatusTest {
+
+  @Test
+  public void testSerializationRoundTrip() throws Exception {
+    FileStatus original = FileStatus.of("/table/_delta_log/00000.json", 1234L, 9999L);
+    SerializableFileStatus sfs = SerializableFileStatus.from(original);
+
+    byte[] bytes;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(sfs);
+      bytes = baos.toByteArray();
+    }
+
+    SerializableFileStatus deserialized;
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(bais)) {
+      deserialized = (SerializableFileStatus) ois.readObject();
+    }
+
+    FileStatus result = deserialized.toFileStatus();
+    assertEquals(original.getPath(), result.getPath());
+    assertEquals(original.getSize(), result.getSize());
+    assertEquals(original.getModificationTime(), result.getModificationTime());
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6134/files) to review incremental changes.
- [**stack/streaming_phase0_pr1**](https://github.com/delta-io/delta/pull/6134) [[Files changed](https://github.com/delta-io/delta/pull/6134/files)]
  - [stack/streaming_phase0_pr2](https://github.com/delta-io/delta/pull/6135) [[Files changed](https://github.com/delta-io/delta/pull/6135/files/f545c72443224f9ca09bab57111cbe128720047e..e210a3fa26c36748119deadb65048a40167a34c1)]
    - [stack/streaming_phase0_pr3](https://github.com/delta-io/delta/pull/6136) [[Files changed](https://github.com/delta-io/delta/pull/6136/files/e210a3fa26c36748119deadb65048a40167a34c1..d6049a8fc5dc6a747d5826c657e149135aa3f268)]
      - [stack/streaming_phase0_pr4](https://github.com/delta-io/delta/pull/6137) [[Files changed](https://github.com/delta-io/delta/pull/6137/files/d6049a8fc5dc6a747d5826c657e149135aa3f268..d30e7e8c74706f563ca0e13acd4152d98600d1cb)]

---------
FileStatus is a simple POJO (path, size, modificationTime) that needs
to be serializable for shipping LogSegment data to Spark executors in
the V2 streaming connector's DataFrame-based initial snapshot path.

Made-with: Cursor

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
