### PR TITLE
[Spark][Prototype] Schema evolution in DSv2 INSERT

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -1452,7 +1452,7 @@ object DeltaRelation extends DeltaLogging {
 
 object AppendDelta {
   def unapply(a: AppendData): Option[(DataSourceV2Relation, DeltaTableV2)] = {
-    if (a.query.resolved) {
+    if (a.query.resolved && !a.needSchemaEvolution) {
       a.table match {
         case r: DataSourceV2Relation if r.table.isInstanceOf[DeltaTableV2] =>
           Some((r, r.table.asInstanceOf[DeltaTableV2]))
@@ -1466,7 +1466,7 @@ object AppendDelta {
 
 object OverwriteDelta {
   def unapply(o: OverwriteByExpression): Option[(DataSourceV2Relation, DeltaTableV2)] = {
-    if (o.query.resolved) {
+    if (o.query.resolved && !o.needSchemaEvolution) {
       o.table match {
         case r: DataSourceV2Relation if r.table.isInstanceOf[DeltaTableV2] =>
           Some((r, r.table.asInstanceOf[DeltaTableV2]))
@@ -1480,7 +1480,7 @@ object OverwriteDelta {
 
 object DynamicPartitionOverwriteDelta {
   def unapply(o: OverwritePartitionsDynamic): Option[(DataSourceV2Relation, DeltaTableV2)] = {
-    if (o.query.resolved) {
+    if (o.query.resolved && !o.needSchemaEvolution) {
       o.table match {
         case r: DataSourceV2Relation if r.table.isInstanceOf[DeltaTableV2] =>
           Some((r, r.table.asInstanceOf[DeltaTableV2]))
@@ -1509,6 +1509,7 @@ case class DeltaDynamicPartitionOverwriteCommand(
     isByName: Boolean,
     analyzedQuery: Option[LogicalPlan] = None) extends RunnableCommand with V2WriteCommand {
 
+  override val withSchemaEvolution: Boolean = false
   override def child: LogicalPlan = query
 
   override def withNewQuery(newQuery: LogicalPlan): DeltaDynamicPartitionOverwriteCommand = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, Ca
 import org.apache.spark.sql.catalyst.plans.logical.{AnalysisHelper, LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapability, TableCatalog, V2TableWithV1Fallback}
+import org.apache.spark.sql.connector.catalog.SupportsTypeEvolution
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog.V1Table
@@ -50,7 +51,7 @@ import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsDynamicOv
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.sources.{BaseRelation, Filter, InsertableRelation}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{AtomicType, DataType, NullType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.{Clock, SystemClock}
 
@@ -69,8 +70,19 @@ class DeltaTableV2 private(
     val options: Map[String, String])
   extends Table
   with SupportsWrite
+  with SupportsTypeEvolution
   with V2TableWithV1Fallback
   with DeltaLogging {
+
+  override def canChangeType(currentType: DataType, newType: DataType): Boolean =
+    (currentType, newType) match {
+      case (NullType, _: AtomicType) => true
+      case (currentType: AtomicType, newType: AtomicType) =>
+        TypeWidening.isEnabled(initialSnapshot.protocol, initialSnapshot.metadata) &&
+          TypeWidening.isTypeChangeSupported(currentType, newType,
+            uniformIcebergCompatibleOnly = UniversalFormat.icebergEnabled(initialSnapshot.metadata))
+      case _ => false
+  }
 
   case class PathInfo(
       rootPath: Path,
@@ -259,10 +271,17 @@ class DeltaTableV2 private(
     base.asJava
   }
 
-  override def capabilities(): ju.Set[TableCapability] = Set(
-    ACCEPT_ANY_SCHEMA, BATCH_READ,
-    V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE, OVERWRITE_DYNAMIC
-  ).asJava
+  override def capabilities(): ju.Set[TableCapability] = {
+    val baseCapabilities = mutable.Set(
+      ACCEPT_ANY_SCHEMA, BATCH_READ,
+      V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE, OVERWRITE_DYNAMIC)
+    // AUTOMATIC_SCHEMA_EVOLUTION tells Spark to use the schema evolution rules to evolve the
+    // table schema when new columns or type changes are detected.
+    if (spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_DML_USE_DSV2_SCHEMA_EVOLUTION)) {
+      baseCapabilities += AUTOMATIC_SCHEMA_EVOLUTION
+    }
+    baseCapabilities.asJava
+  }
 
   def tableExists: Boolean = deltaLog.tableExists
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -981,6 +981,18 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_DML_USE_DSV2_SCHEMA_EVOLUTION =
+    buildConf("dml.useDSv2SchemaEvolution")
+      .internal()
+      .doc(
+        """
+          |If enabled, DML operations on Delta tables will use Spark's DSv2 schema evolution
+          |rules (ResolveInsertSchemaEvolution / ResolveMergeIntoSchemaEvolution) to handle
+          |automatic schema evolution when new columns or type changes are detected.
+        """.stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val MERGE_FAIL_IF_SOURCE_CHANGED =
     buildConf("merge.failIfSourceChanged")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -1708,11 +1708,11 @@ abstract class DeltaInsertIntoTests(
           DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true",
           SQLConf.STORE_ASSIGNMENT_POLICY.key -> "strict") {
         // ordering should still match
-        intercept[AnalysisException] {
+        intercept[SparkException] {
           doInsert(t1, complexSchema.select("struct", "long"))
         }
 
-        intercept[AnalysisException] {
+        intercept[SparkException] {
           doInsert(t1, complexSchema.select("struct", "long", "string"))
         }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -291,7 +291,8 @@ trait DeltaTestUtilsBase {
 
   @deprecated("Use checkError() instead")
   protected def errorContains(errMsg: String, str: String): Unit = {
-    assert(errMsg.toLowerCase(Locale.ROOT).contains(str.toLowerCase(Locale.ROOT)))
+    assert(errMsg.toLowerCase(Locale.ROOT).contains(str.toLowerCase(Locale.ROOT)),
+      s"'$errMsg' did not contain '$str'")
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
@@ -34,6 +34,22 @@ class TypeWideningConstraintsSuite
 
 trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin =>
 
+  private def checkDependentTypeEvolutionError(body: => Unit, parameters: Map[String, String])
+    : Unit =
+    if (spark.conf.get(DeltaSQLConf.DELTA_DML_USE_DSV2_SCHEMA_EVOLUTION)) {
+      checkError(
+        intercept[DeltaAnalysisException] { body },
+        "DELTA_CONSTRAINT_DEPENDENT_COLUMN_CHANGE",
+        parameters = parameters.filterNot(p => Set("columnType", "dataType").contains(p._1))
+      )
+    } else {
+      checkError(
+        intercept[DeltaAnalysisException] { body },
+        "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+        parameters = parameters
+      )
+    }
+
   test("not null constraint with type change") {
     withTable("t") {
       sql("CREATE TABLE t (a byte NOT NULL) USING DELTA")
@@ -138,11 +154,8 @@ trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin 
       checkAnswer(sql("SELECT hash(a) FROM t"), Row(1765031574))
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
-        checkError(
-          intercept[DeltaAnalysisException] {
-            sql("INSERT INTO t VALUES (200)")
-          },
-          "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+        checkDependentTypeEvolutionError(
+          sql("INSERT INTO t VALUES (200)"),
           parameters = Map(
             "columnName" -> "a",
             "columnType" -> "TINYINT",
@@ -161,11 +174,8 @@ trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin 
       checkAnswer(sql("SELECT hash(a.x) FROM t"), Row(1765031574))
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
-        checkError(
-          intercept[DeltaAnalysisException] {
-            sql("INSERT INTO t (a) VALUES (named_struct('x', 200, 'y', CAST(5 AS byte)))")
-          },
-          "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+        checkDependentTypeEvolutionError(
+          sql("INSERT INTO t (a) VALUES (named_struct('x', 200, 'y', CAST(5 AS byte)))"),
           parameters = Map(
             "columnName" -> "a.x",
             "columnType" -> "TINYINT",
@@ -190,17 +200,14 @@ trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin 
       checkAnswer(sql("SELECT hash(a.x.z) FROM t"), Row(1765031574))
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
-        checkError(
-          intercept[DeltaAnalysisException] {
-            sql(
-              s"""
-                 | INSERT INTO t (a) VALUES (
-                 |   named_struct('x', named_struct('z', 200, 'h', 3), 'y', 4)
-                 | )
-                 |""".stripMargin
-            )
-          },
-          "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+        checkDependentTypeEvolutionError(
+          sql(
+            s"""
+               | INSERT INTO t (a) VALUES (
+               |   named_struct('x', named_struct('z', 200, 'h', 3), 'y', 4)
+               | )
+               |""".stripMargin
+          ),
           parameters = Map(
             "columnName" -> "a.x.z",
             "columnType" -> "TINYINT",
@@ -232,14 +239,11 @@ trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin 
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
         // Insert by name is not supported by type evolution.
-        checkError(
-          intercept[DeltaAnalysisException] {
-            // Migrate map's key to int type.
-            spark.createDataFrame(Seq(Tuple1(Tuple1(Array(Map(999999 -> 1, 3 -> 3))))))
-              .toDF("s").withColumn("s", col("s").cast("struct<arr:array<map<int,tinyint>>>"))
-              .write.format("delta").mode("append").saveAsTable("t")
-          },
-          "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+        checkDependentTypeEvolutionError(
+          // Migrate map's key to int type.
+          spark.createDataFrame(Seq(Tuple1(Tuple1(Array(Map(999999 -> 1, 3 -> 3))))))
+            .toDF("s").withColumn("s", col("s").cast("struct<arr:array<map<int,tinyint>>>"))
+            .write.format("delta").mode("append").saveAsTable("t"),
           parameters = Map(
             "columnName" -> "s.arr.element.key",
             "columnType" -> "TINYINT",
@@ -247,14 +251,11 @@ trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin 
             "constraints" -> "delta.constraints.ck -> s . arr [ 0 ] [ 3 ] = 3"
           )
         )
-        checkError(
-          intercept[DeltaAnalysisException] {
-            // Migrate map's value to int type.
-            spark.createDataFrame(Seq(Tuple1(Tuple1(Array(Map(1 -> 999999, 3 -> 3))))))
-              .toDF("s").withColumn("s", col("s").cast("struct<arr:array<map<tinyint,int>>>"))
-              .write.format("delta").mode("append").saveAsTable("t")
-          },
-          "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+        checkDependentTypeEvolutionError(
+          // Migrate map's value to int type.
+          spark.createDataFrame(Seq(Tuple1(Tuple1(Array(Map(1 -> 999999, 3 -> 3))))))
+            .toDF("s").withColumn("s", col("s").cast("struct<arr:array<map<tinyint,int>>>"))
+            .write.format("delta").mode("append").saveAsTable("t"),
           parameters = Map(
             "columnName" -> "s.arr.element.value",
             "columnType" -> "TINYINT",


### PR DESCRIPTION
## Description
This requires https://github.com/apache/spark/pull/54488 in Spark

Demonstrate using Spark DSv2 code path to handle schema evolution for INSERT operations instead of Delta.
That is: rely on the new rule `ResolveInsertSchemaEvolution` introduced in the linked Spark PR instead of `DeltaAnalysis`

Note: this actually goes one step further and includes changes for type evolution (see `SupportsTypeEvolution`), which I haven't pushed to Spark yet, so it won't build unless `SupportsTypeEvolution` / `canChangeType` are removed

## How was this patch tested?
Building locally together with https://github.com/apache/spark/pull/54488 and running tests.
After triaging them, all failures are somewhat expected - e.g. negative tests covering incorrect null struct expansion if the corresponding is disabled, or different error class returned.

 
