### PR TITLE
Fix path ambiguity with MERGE w/ deletion vectors 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -308,6 +308,9 @@ object DeletionVectorBitmapGenerator {
   final val DELETED_ROW_INDEX_BITMAP = "deletedRowIndexSet"
   final val DELETED_ROW_INDEX_COUNT = "deletedRowIndexCount"
   final val MAX_ROW_INDEX_COL = "maxRowIndexCol"
+  // Used to avoid colliding with user columns (e.g. a target column named `path`) when joining
+  // with `FileToDvDescriptor` which also has a `path` column.
+  private final val DV_FILE_PATH_JOIN_COL = "__delta_dv_file_path"
 
   private class DeletionVectorSet(
     spark: SparkSession,
@@ -428,13 +431,20 @@ object DeletionVectorBitmapGenerator {
       }
       val filePathToDVDf = sparkSession.createDataset(filePathToDV)
 
-      val joinExpr = filePathToDVDf("path") === matchedRowsDf(FILE_NAME_COL)
+      // Avoid duplicate column names: the target table can legitimately have a column named `path`,
+      // and a DataFrame join would then produce multiple `path` columns. If we later rename `path`
+      // to `filePath` we'd end up with multiple `filePath` columns which triggers ambiguous
+      // references (see delta-io/delta#5296).
+      val filePathToDVDfWithUniquePathCol =
+        filePathToDVDf.withColumnRenamed("path", DV_FILE_PATH_JOIN_COL)
+      val joinExpr = filePathToDVDfWithUniquePathCol(DV_FILE_PATH_JOIN_COL) ===
+        matchedRowsDf(FILE_NAME_COL)
       // Perform leftOuter join to make sure we do not eliminate any rows because of path
       // encoding issues. If there is such an issue we will detect it during the aggregation
       // of the bitmaps.
-      val joinedDf = matchedRowsDf.join(filePathToDVDf, joinExpr, "leftOuter")
+      val joinedDf = matchedRowsDf.join(filePathToDVDfWithUniquePathCol, joinExpr, "leftOuter")
         .drop(FILE_NAME_COL)
-        .withColumnRenamed("path", FILE_NAME_COL)
+        .withColumnRenamed(DV_FILE_PATH_JOIN_COL, FILE_NAME_COL)
       joinedDf
     } else {
       // When the table has no DVs, just add a column to indicate that the existing dv is null

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -21,8 +21,9 @@ import org.apache.spark.sql.delta.commands.{DeletionVectorBitmapGenerator, DMLWi
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
 
 import org.apache.spark.SparkException
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, expr}
 
 trait MergeIntoDVsMixin extends MergeIntoSQLMixin with DeletionVectorsTestUtils {
 
@@ -84,6 +85,39 @@ trait MergeIntoDVsTests extends MergeIntoDVsMixin {
       mergeMetrics.getOrElse("numTargetDeletionVectorsRemoved", -1) === numDeletionVectorsRemoved)
     assert(
       mergeMetrics.getOrElse("numTargetDeletionVectorsUpdated", -1) === numDeletionVectorsUpdated)
+  }
+
+  test("Merge with DVs: target column named `path` should not cause ambiguous `filePath`") {
+    withTempDir { dir =>
+      val targetPath = s"$dir/target"
+
+      Seq(("test_old", "old_hash")).toDF("path", "hash_key")
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(targetPath)
+
+      // Make sure DVs are enabled on the table to exercise the DV merge path.
+      enableDeletionVectorsInTable(new Path(targetPath), enable = true)
+
+      val target = io.delta.tables.DeltaTable.forPath(spark, targetPath)
+      val sourceDf = Seq(("test_old", "new_hash")).toDF("path", "hash_key")
+
+      // Force a match + update to exercise DV update code paths.
+      target.as("target")
+        .merge(
+          sourceDf.as("source"),
+          expr("concat_ws('|', source.`path`) = concat_ws('|', target.`path`)"))
+        .whenMatched(expr("target.hash_key != source.hash_key"))
+        .updateExpr(Map("hash_key" -> "source.hash_key"))
+        .whenNotMatched()
+        .insertAll()
+        .execute()
+
+      checkAnswer(
+        spark.read.format("delta").load(targetPath),
+        Seq(("test_old", "new_hash")).toDF("path", "hash_key"))
+    }
   }
 
   test(s"Merge with DVs metrics - Incremental Updates") {


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?


- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When performing a Delta merge operation on a table that:
    1. Has deletion vectors enabled, AND
    2. Contains a column named "path" in the schema
    
An ambiguous reference error occurs because Delta internally renames "path" to "filePath"  during the merge execution plan, but then tries to reference both names.

Fixes #5296 

## How was this patch tested?

Added a test suite which tests this ambiguity and also did a manual testing 

## Does this PR introduce _any_ user-facing changes?

Yes it failed previously and now it succeeds