### PR TITLE
[Protocol] Clarify ambiguity in string partition value serialization

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2575,6 +2575,11 @@ timestamp without timezone | Encoded as `{year}-{month}-{day} {hour}:{minute}:{s
 boolean | Encoded as the string "true" or "false"
 binary | Encoded as a string of escaped binary values. For example, `"\u0001\u0002\u0003"`
 
+Note: Readers should interpret empty strings in non-nullable string partition columns as empty
+strings (not as illegal NULL values that would trigger a query error), and writers are encouraged to
+block creation of nullable string partition columns in order to avoid ambiguity between `""` and
+`NULL` values. Otherwise, an empty string stored in a nullable string column will read back as NULL.
+
 Note: A timestamp value in a partition value may be stored in one of the following ways:
 1. Without a timezone, where the timestamp should be interpreted using the time zone of the system which wrote to the table.
 2. Adjusted to UTC and stored in ISO8601 format.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (protocol)

## Description

When reading partition column values, the Delta spec requires readers to deserialize the empty string `""` as `NULL`.

This policy works for most types, but causes problems for string partition columns that might actually attempt to store an empty string:
* If the column is nullable, the reader cannot determine whether the original value was `""` or `NULL`.
* If the column is non-nullable, the NULL value is illegal and would likely produce a query error.

Delta-spark addressed this ambiguity several years ago by deserializing `""` as the empty string, if stored in a non-nullable string partition column (avoiding the read path error), and by blocking the creation of nullable string partition columns (preventing the ambiguity at write time).

Update the Delta spec with a note reflecting this practical reality.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

Not directly, but the spec change empowers Delta clients to handle serialized string partition values more robustly.
