### PR TITLE
[Spark] Rename tableId to unsafeVolatileTableId

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -110,7 +110,7 @@ class HudiConverter
                     try {
                       logInfo(log"Converting Delta table [path=" +
                         log"${MDC(DeltaLogKeys.PATH, log.logPath)}, " +
-                        log"tableId=${MDC(DeltaLogKeys.TABLE_ID, log.tableId)}, " +
+                        log"tableId=${MDC(DeltaLogKeys.TABLE_ID, log.unsafeVolatileTableId)}, " +
                         log"version=${MDC(DeltaLogKeys.VERSION, snapshotVal.version)}] into Hudi")
                       convertSnapshot(snapshotVal, prevTxn)
                     } catch {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -129,8 +129,9 @@ class IcebergConverter
                     try {
                       logInfo(log"Converting Delta table [path=" +
                         log"${MDC(DeltaLogKeys.PATH, log.logPath)}, " +
-                        log"tableId=${MDC(DeltaLogKeys.TABLE_ID, log.tableId)}, version=" +
-                        log"${MDC(DeltaLogKeys.VERSION, snapshotVal.version)}] into Iceberg")
+                        log"tableId=${MDC(DeltaLogKeys.TABLE_ID, log.unsafeVolatileTableId)}, " +
+                        log"version=${MDC(DeltaLogKeys.VERSION, snapshotVal.version)}] " +
+                        log"into Iceberg")
                       convertSnapshot(snapshotVal, prevTxn)
                     } catch {
                       case NonFatal(e) =>
@@ -227,7 +228,7 @@ class IcebergConverter
       txn.catalogTable match {
         case Some(table) => convertSnapshotWithRetry(snapshotToConvert, Some(txn), table)
         case _ =>
-          val msg = s"CatalogTable for table ${snapshotToConvert.deltaLog.tableId} " +
+          val msg = s"CatalogTable for table ${snapshotToConvert.deltaLog.unsafeVolatileTableId} " +
             s"is empty in txn. Skip iceberg conversion."
           throw DeltaErrors.universalFormatConversionFailedException(
             snapshotToConvert.version, "iceberg", msg)
@@ -514,7 +515,7 @@ class IcebergConverter
       if (needsExpireSnapshot) {
         logInfo(log"Committing iceberg snapshot expiration for uniform table " +
           log"[path = ${MDC(DeltaLogKeys.PATH, log.logPath)}] tableId=" +
-          log"${MDC(DeltaLogKeys.TABLE_ID, log.tableId)}]")
+          log"${MDC(DeltaLogKeys.TABLE_ID, log.unsafeVolatileTableId)}]")
         expireIcebergSnapshot(snapshotToConvert, icebergTxn)
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -474,7 +474,7 @@ trait Checkpoints extends DeltaLogging {
         .filterNot(cv => cv.version < 0 || cv.version == CheckpointInstance.MaxValue.version)
         .getOrElse {
           logInfo(
-            log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Try to " +
+            log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] Try to " +
             log"find Delta last complete checkpoint")
           eventData("listingFromZero") = true.toString
           return findLastCompleteCheckpoint()
@@ -484,8 +484,8 @@ trait Checkpoints extends DeltaLogging {
     eventData("upperBoundCheckpointType") = upperBoundCv.format.name
     var iterations: Long = 0L
     var numFilesScanned: Long = 0L
-    logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Try to find " +
-      log"Delta last complete checkpoint before version " +
+    logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] " +
+      log"Try to find Delta last complete checkpoint before version " +
       log"${MDC(DeltaLogKeys.VERSION, upperBoundCv.version)}")
     var listingEndVersion = upperBoundCv.version
 
@@ -530,7 +530,7 @@ trait Checkpoints extends DeltaLogging {
       eventData("numFilesScanned") = numFilesScanned.toString
       if (lastCheckpoint.isDefined) {
         logInfo(
-          log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Delta " +
+          log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] Delta " +
           log"checkpoint is found at version " +
           log"${MDC(DeltaLogKeys.VERSION, lastCheckpoint.get.version)}")
         return lastCheckpoint
@@ -538,7 +538,7 @@ trait Checkpoints extends DeltaLogging {
       listingEndVersion = listingEndVersion - 1000
     }
     logInfo(
-      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] No checkpoint " +
+      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] No checkpoint " +
       log"found for Delta table before version ${MDC(DeltaLogKeys.VERSION, upperBoundCv.version)}")
     None
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
@@ -134,7 +134,7 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
             duration.NANOSECONDS.toMillis(System.nanoTime() - startTime)
           logInfo(
             log"Validated Generated Column expressions on table " +
-            log"${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)} " +
+            log"${MDC(DeltaLogKeys.TABLE_ID, deltaLog.unsafeVolatileTableId)} " +
             log"in ${MDC(DeltaLogKeys.TIME_MS, durationMs)} ms"
           )
         } catch {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -158,22 +158,37 @@ class DeltaLog private(
         && spark.conf.get(DeltaSQLConf.INCREMENTAL_COMMIT_FORCE_VERIFY_IN_TESTS))
   }
 
-  /** The unique identifier for this table. */
-  def tableId: String = unsafeVolatileMetadata.id // safe because table id never changes
+  /**
+   * The unique identifier for this table.
+   *
+   * WARNING: This value is volatile and can change during the lifetime of a DeltaLog instance,
+   * e.g., when the snapshot is updated and the new snapshot has a different table id. Use with
+   * care.
+   */
+  def unsafeVolatileTableId: String = unsafeVolatileMetadata.id
 
   /** Returns the truncated table ID for logging purposes. */
-  private[delta] def truncatedTableId: String = tableId.split("-").head
+  private[delta] def truncatedUnsafeVolatileTableId: String =
+    unsafeVolatileTableId.split("-").head
+
+  /**
+   * WARNING: This API is unsafe and deprecated. It will be removed in future versions.
+   * Use the above unsafeVolatileTableId to get the most recently cached table id.
+   */
+  @deprecated("This method is deprecated and will be removed in future versions. " +
+    "Use unsafeVolatileTableId instead", "18.0")
+  def tableId: String = unsafeVolatileTableId
 
   def getInitialCatalogTable: Option[CatalogTable] = initialCatalogTable
   /**
-   * Combines the tableId with the path of the table to ensure uniqueness. Normally `tableId`
+   * Combines the table id with the path of the table to ensure uniqueness. Normally the table id
    * should be globally unique, but nothing stops users from copying a Delta table directly to
-   * a separate location, where the transaction log is copied directly, causing the tableIds to
+   * a separate location, where the transaction log is copied directly, causing the table ids to
    * match. When users mutate the copied table, and then try to perform some checks joining the
-   * two tables, optimizations that depend on `tableId` alone may not be correct. Hence we use a
+   * two tables, optimizations that depend on the table id alone may not be correct. Hence we use a
    * composite id.
    */
-  private[delta] def compositeId: (String, Path) = tableId -> dataPath
+  private[delta] def compositeId: (String, Path) = unsafeVolatileTableId -> dataPath
 
   /**
    * Creates a [[LogicalRelation]] for a given [[DeltaLogFileIndex]], with all necessary file source

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
@@ -123,7 +123,7 @@ abstract class MaterializedRowTrackingColumn {
     }
 
     val materializedColumnName = getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.tableId)
+      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.unsafeVolatileTableId)
 
     val analyzedPlan = dataFrame.queryExecution.analyzed
     analyzedPlan.outputSet.view.find(attr => materializedColumnName == attr.name)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -84,8 +84,8 @@ trait MetadataCleanup extends DeltaLogging {
         truncateDate(clock.getTimeMillis() - retentionMillis, cutoffTruncationGranularity).getTime
       val formattedDate = fileCutOffTime.toGMTString
       logInfo(
-        log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Starting the deletion " +
-        log"of log files older than ${MDC(DeltaLogKeys.DATE, formattedDate)}")
+        log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] " +
+        log"Starting the deletion of log files older than ${MDC(DeltaLogKeys.DATE, formattedDate)}")
 
       if (!metadataCleanupAllowed(snapshotToCleanup, fileCutOffTime.getTime)) {
         logInfo("Metadata cleanup was skipped due to not satisfying the requirements " +
@@ -147,8 +147,8 @@ trait MetadataCleanup extends DeltaLogging {
           sidecarDeletionMetrics)
         logInfo(log"Sidecar deletion metrics: ${MDC(DeltaLogKeys.METRICS, sidecarDeletionMetrics)}")
       }
-      logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Deleted " +
-        log"${MDC(DeltaLogKeys.NUM_FILES, numDeleted.toLong)} log files and " +
+      logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] " +
+        log"Deleted ${MDC(DeltaLogKeys.NUM_FILES, numDeleted.toLong)} log files and " +
         log"${MDC(DeltaLogKeys.NUM_FILES2, numDeletedUnbackfilled.toLong)} unbackfilled commit " +
         log"files older than ${MDC(DeltaLogKeys.DATE, formattedDate)}")
     }
@@ -443,11 +443,11 @@ trait MetadataCleanup extends DeltaLogging {
       .filterNot(path => activeSidecarFiles.contains(path.getName))
     val sidecarDeletionStartTimeMs = System.currentTimeMillis()
     logInfo(
-      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Starting the deletion of " +
-      log"unreferenced sidecar files")
+      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] " +
+      log"Starting the deletion of unreferenced sidecar files")
     val count = deleteMultiple(fs, sidecarFilesToDelete)
 
-    logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Deleted " +
+    logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] Deleted " +
       log"${MDC(DeltaLogKeys.COUNT, count)} sidecar files")
     metrics.numSidecarFilesDeleted = count
     val endTimeMs = System.currentTimeMillis()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2498,7 +2498,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // Add to commit stats and consume the returned iterator.
     commitStatsComputer.addToCommitStats(actions.toIterator).foreach(_ => ())
     partitionsAddedToOpt = Some(commitStatsComputer.getPartitionsAddedByTransaction)
-    collectAutoOptimizeStatsAndFinalize(actions, deltaLog.tableId)
+    collectAutoOptimizeStatsAndFinalize(actions, deltaLog.unsafeVolatileTableId)
     val commitSizeBytes: Long = jsonActions.map(_.length.toLong).sum
     commitStatsComputer.finalizeAndEmitCommitStats(
       spark,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
@@ -54,7 +54,7 @@ object RowCommitVersion {
     }
 
     val materializedColumnName = MaterializedRowCommitVersion.getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.tableId)
+      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.unsafeVolatileTableId)
 
     val rowCommitVersionColumn =
       DeltaTableUtils.getFileMetadataColumn(dataFrame).getField(METADATA_STRUCT_FIELD_NAME)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -341,7 +341,7 @@ object RowId {
     }
 
     val materializedColumnName = MaterializedRowId.getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.tableId)
+      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.unsafeVolatileTableId)
 
     val rowIdColumn = DeltaTableUtils.getFileMetadataColumn(dataFrame).getField(ROW_ID)
     val shouldSetIcebergReservedFieldId = IcebergCompat.isGeqEnabled(snapshot.metadata, 3)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -719,24 +719,28 @@ class Snapshot(
 
 
   def logInfo(msg: MessageWithContext): Unit = {
-    super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext): Unit = {
-    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext, throwable: Throwable): Unit = {
-    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg,
-      throwable)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
   }
 
   def logError(msg: MessageWithContext): Unit = {
-    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logError(msg: MessageWithContext, throwable: Throwable): Unit = {
-    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg, throwable)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
   }
 
   override def toString: String =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -744,8 +744,8 @@ trait SnapshotManagement { self: DeltaLog =>
       log" starting from checkpoint version " +
       log"${MDC(DeltaLogKeys.START_VERSION, initSegment.checkpointProvider.version)}."
     } else log"."
-    logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedTableId)}] Loading version " +
-      log"${MDC(DeltaLogKeys.VERSION, initSegment.version)}" + startingFrom)
+    logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, truncatedUnsafeVolatileTableId)}] " +
+      log"Loading version ${MDC(DeltaLogKeys.VERSION, initSegment.version)}" + startingFrom)
     createSnapshotFromGivenOrEquivalentLogSegment(
         initSegment, tableCommitCoordinatorClientOpt, catalogTableOpt) { segment =>
       new Snapshot(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/Constraints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/Constraints.scala
@@ -147,7 +147,8 @@ object Constraints extends DeltaLogging {
       validateCheckConstraintsInternal(spark, constraints, schema)
       val durationMs = duration.NANOSECONDS.toMillis(System.nanoTime() - startTime)
       logInfo(
-        log"Validated CHECK constraints on table ${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)} " +
+        log"Validated CHECK constraints on table " +
+        log"${MDC(DeltaLogKeys.TABLE_ID, deltaLog.unsafeVolatileTableId)} " +
         log"in ${MDC(DeltaLogKeys.TIME_MS, durationMs)} ms and processed " +
         log"${MDC(DeltaLogKeys.NUM_PREDICATES, constraints.size)} constraints"
       )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -130,7 +130,7 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
 
     // Validate that write columns for Row IDs have the correct name.
     RowId.throwIfMaterializedRowIdColumnNameIsInvalid(
-      normalizedData, metadata, protocol, deltaLog.tableId)
+      normalizedData, metadata, protocol, deltaLog.unsafeVolatileTableId)
 
     val nullAsDefault = options.isDefined &&
       options.get.options.contains(ColumnWithDefaultExprUtils.USE_NULL_AS_DEFAULT_DELTA_OPTION)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -120,7 +120,7 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
       opType: String,
       maxDeletedRowsRatio: Option[Double]
   ): Seq[OptimizeMetrics] = {
-    val tableId = txn.deltaLog.tableId
+    val tableId = txn.deltaLog.unsafeVolatileTableId
     val autoCompactRequest = AutoCompactUtils.prepareAutoCompactRequest(
       spark,
       txn,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompactUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompactUtils.scala
@@ -136,7 +136,7 @@ object AutoCompactUtils extends DeltaLogging {
       isModifiedPartitionsOnlyAutoCompactEnabled(spark) && reservePartitionEnabled(spark)
     val freePartitions =
       if (shouldReservePartitions) {
-        filterFreePartitions(deltaLog.tableId, partitionsAddedToOpt.get)
+        filterFreePartitions(deltaLog.unsafeVolatileTableId, partitionsAddedToOpt.get)
       } else {
         partitionsAddedToOpt.get
       }
@@ -183,7 +183,8 @@ object AutoCompactUtils extends DeltaLogging {
 
     val numChosenPartitions = finalPartitions.size
     if (shouldReservePartitions) {
-      finalPartitions = tryReservePartitions(deltaLog.tableId, finalPartitions)
+      finalPartitions = tryReservePartitions(
+        deltaLog.unsafeVolatileTableId, finalPartitions)
     }
     // Abort if all chosen partitions were reserved by a concurrent thread.
     if (numChosenPartitions > 0 && finalPartitions.isEmpty) {
@@ -235,7 +236,7 @@ object AutoCompactUtils extends DeltaLogging {
         // files threshold; otherwise, use 0 to indicate that any partition is qualified.
         val minNumFilesPerPartition = if (partitionEarlySkippingEnabled) minNumFiles else 0L
         val pickedPartitions = tablePartitionStats.filterPartitionsWithSmallFiles(
-          deltaLog.tableId,
+          deltaLog.unsafeVolatileTableId,
           freePartitionsAddedTo,
           minNumFilesPerPartition)
         if (pickedPartitions.isEmpty) {
@@ -250,7 +251,7 @@ object AutoCompactUtils extends DeltaLogging {
       } else if (partitionEarlySkippingEnabled) {
         // If only early skipping is enabled, then check whether there is any partition with more
         // files than minNumFiles.
-        val maxNumFiles = tablePartitionStats.maxNumFilesInTable(deltaLog.tableId)
+        val maxNumFiles = tablePartitionStats.maxNumFilesInTable(deltaLog.unsafeVolatileTableId)
         val shouldCompact = maxNumFiles >= minNumFiles
         if (shouldCompact) {
           ChosenPartitionsResult(shouldRunAC = true,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -257,9 +257,9 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .internal()
       .doc(
         """
-          |Include the deltaLog.tableId field in equals and hashCode for TahoeLogFileIndex.
-          |The field is unstable, so including it can lead semantic violations for equals and
-          |hashCode.""".stripMargin)
+          |Include the deltaLog.unsafeVolatileTableId field in equals and hashCode for
+          |TahoeLogFileIndex. The field is unstable, so including it can lead semantic violations
+          |for equals and hashCode.""".stripMargin)
       .booleanConf
       // TODO: Phase this out towards `false` eventually remove the flag altogether again.
       .createWithDefault(true)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -415,7 +415,7 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
         changedMetadataOpt, changedProtocolOpt, version)) {
 
       val schemaToPersist = PersistedMetadata(
-        deltaLog.tableId,
+        deltaLog.unsafeVolatileTableId,
         version,
         changedMetadataOpt.getOrElse(readSnapshotDescriptor.metadata),
         changedProtocolOpt.getOrElse(readSnapshotDescriptor.protocol),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataTrackingLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataTrackingLog.scala
@@ -95,8 +95,9 @@ case class PersistedMetadata(
     protocolJson.map(Action.fromJson).map(_.asInstanceOf[Protocol])
 
   def validateAgainstSnapshot(snapshot: SnapshotDescriptor): Unit = {
-    if (snapshot.deltaLog.tableId != tableId) {
-      throw DeltaErrors.incompatibleSchemaLogDeltaTable(tableId, snapshot.deltaLog.tableId)
+    if (snapshot.deltaLog.unsafeVolatileTableId != tableId) {
+      throw DeltaErrors.incompatibleSchemaLogDeltaTable(
+        tableId, snapshot.deltaLog.unsafeVolatileTableId)
     }
   }
 
@@ -256,7 +257,7 @@ object DeltaSourceMetadataTrackingLog extends Logging {
     val options = new CaseInsensitiveStringMap(parameters.asJava)
     val sourceTrackingId = Option(options.get(DeltaOptions.STREAMING_SOURCE_TRACKING_ID))
     val metadataTrackingLocation = fullMetadataTrackingLocation(
-      rootMetadataLocation, sourceSnapshot.deltaLog.tableId, sourceTrackingId)
+      rootMetadataLocation, sourceSnapshot.deltaLog.unsafeVolatileTableId, sourceTrackingId)
     val log = new DeltaSourceMetadataTrackingLog(
       sparkSession,
       metadataTrackingLocation,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -476,7 +476,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       DeltaSQLConf.DELTA_STREAMING_SCHEMA_TRACKING_METADATA_PATH_CHECK_ENABLED.key -> "false") {
       // Schema log's schema is respected
       val schemaLog = getDefaultSchemaLog()
-      val newSchema = PersistedMetadata(log.tableId, 0,
+      val newSchema = PersistedMetadata(log.unsafeVolatileTableId, 0,
         makeMetadata(
           new StructType().add("a", StringType, true)
             .add("b", StringType, true)
@@ -656,7 +656,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       Execute { _ => addData(10 until 15) },
       ExpectMetadataEvolutionException,
       AssertOnQuery { q =>
-        val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+        val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
         offset.index == indexWhenSchemaLogIsUpdated
       }
     )
@@ -735,7 +735,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       ProcessAllAvailable(),
       CheckAnswer((10 until 15).map(i => (i.toString, i.toString)): _*),
       AssertOnQuery { q =>
-        val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+        val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
         // bumped from file action, no pending schema change
         offset.reservoirVersion == v1 + 1 &&
           offset.index == DeltaSourceOffset.BASE_INDEX &&
@@ -753,7 +753,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       // No more new data
       CheckAnswer((10 until 15).map(i => (i.toString, i.toString)): _*),
       AssertOnQuery { q =>
-        val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+        val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
         // latest offset should have a schema attached and evolved set to true
         // note the reservoir version has not changed
         offset.reservoirVersion == v1 + 1 &&
@@ -1170,7 +1170,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTerminationIgnoreError,
         CheckAnswer((0 until 5).map(i => (i.toString, i.toString)): _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           // bumped from file action
           offset.reservoirVersion == schemaChangeVersion &&
             offset.index == DeltaSourceOffset.METADATA_CHANGE_INDEX &&
@@ -1188,7 +1188,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTerminationIgnoreError,
         CheckAnswer(Nil: _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           // still stuck, but the pending schema change is marked as evolved
           offset.reservoirVersion == schemaChangeVersion &&
             offset.index == DeltaSourceOffset.POST_METADATA_CHANGE_INDEX &&
@@ -1218,7 +1218,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTermination,
         CheckAnswer((5 until 10).map(i => (i.toString)): _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           // bumped by file action, and since it's an non schema change, just clear schema change
           offset.reservoirVersion == v2 + 1 &&
             offset.index == DeltaSourceOffset.BASE_INDEX
@@ -1239,7 +1239,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTermination,
         CheckAnswer(Nil: _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           offset.reservoirVersion == v2 + 1 &&
             offset.index == DeltaSourceOffset.METADATA_CHANGE_INDEX
         }
@@ -1253,7 +1253,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTerminationIgnoreError,
         CheckAnswer(Nil: _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           offset.reservoirVersion == v3 &&
             offset.index == DeltaSourceOffset.POST_METADATA_CHANGE_INDEX
         },
@@ -1301,7 +1301,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTerminationIgnoreError,
         CheckAnswer((0 until 5).map(_.toString).map(i => (i, i)): _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           offset.reservoirVersion == schemaChangeVersion &&
             // schema change marked as evolved
             offset.index == DeltaSourceOffset.POST_METADATA_CHANGE_INDEX
@@ -1321,7 +1321,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTermination,
         CheckAnswer((5 until 10).map(i => (i.toString)): _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           // schema change cleared because it's a non-schema change offset
           offset.reservoirVersion == latestVersion + 1 &&
             offset.index == DeltaSourceOffset.BASE_INDEX
@@ -1344,7 +1344,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AwaitTerminationIgnoreError,
         CheckAnswer(Nil: _*),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           offset.reservoirVersion == v3 &&
             offset.index == DeltaSourceOffset.POST_METADATA_CHANGE_INDEX
         },
@@ -1393,7 +1393,8 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         CheckAnswer(Seq(4).map(_.toString).map(i => (i, i)): _*),
         AssertOnQuery { q =>
           q.availableOffsets.size == 1 && {
-            val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.head)
+            val offset = DeltaSourceOffset(
+              log.unsafeVolatileTableId, q.availableOffsets.values.head)
             offset.reservoirVersion == v5 + 1 && offset.index == indexWhenSchemaLogIsUpdated
           }
         },
@@ -1409,7 +1410,8 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         AssertOnQuery { q =>
           // size is 1 because commit removes previous offset
           q.availableOffsets.size == 1 && {
-            val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.head)
+            val offset = DeltaSourceOffset(
+              log.unsafeVolatileTableId, q.availableOffsets.values.head)
             offset.reservoirVersion == v5 + 2 && offset.index == indexWhenSchemaLogIsUpdated
           }
         },
@@ -1424,7 +1426,8 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         ProcessAllAvailableIgnoreError,
         AssertOnQuery { q =>
           q.availableOffsets.size == 1 && {
-            val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.head)
+            val offset = DeltaSourceOffset(
+              log.unsafeVolatileTableId, q.availableOffsets.values.head)
             offset.reservoirVersion == v5 + 3 && offset.index == indexWhenSchemaLogIsUpdated
           }
         },
@@ -1439,7 +1442,8 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         ProcessAllAvailableIgnoreError,
         AssertOnQuery { q =>
           q.availableOffsets.size == 1 && {
-            val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.head)
+            val offset = DeltaSourceOffset(
+              log.unsafeVolatileTableId, q.availableOffsets.values.head)
             offset.reservoirVersion == v5 + 4 && offset.index == indexWhenSchemaLogIsUpdated
           }
         },
@@ -1486,7 +1490,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       CheckAnswer(Seq(4).map(_.toString).map(i => (i, i)): _*),
       AssertOnQuery { q =>
         q.availableOffsets.size == 1 && {
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.head)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.head)
           offset.reservoirVersion == v5 + 1 && offset.index == indexWhenSchemaLogIsUpdated
         }
       },
@@ -1522,7 +1526,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       CheckAnswer((0 until 5).map(_.toString).map(i => (i, i)): _*),
       AssertOnQuery { q =>
         assert(q.availableOffsets.size == 1)
-        val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+        val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
         offset.reservoirVersion == v0 + 1 &&
           offset.index == DeltaSourceOffset.BASE_INDEX
       }
@@ -1560,7 +1564,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
         ProcessAllAvailableIgnoreError,
         CheckAnswer(("5", "5")),
         AssertOnQuery { q =>
-          val offset = DeltaSourceOffset(log.tableId, q.availableOffsets.values.last)
+          val offset = DeltaSourceOffset(log.unsafeVolatileTableId, q.availableOffsets.values.last)
           offset.reservoirVersion == v2 &&
             offset.index == indexWhenSchemaLogIsUpdated
         },
@@ -1819,13 +1823,13 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       Some(getDefaultSchemaLog()))
 
     def getLatestOffset(source: DeltaSource, start: Option[Offset] = None): DeltaSourceOffset =
-      DeltaSourceOffset(log.tableId,
+      DeltaSourceOffset(log.unsafeVolatileTableId,
         source.latestOffset(start.orNull, source.getDefaultReadLimit))
 
     // Initialize the schema log to skip initialization failure
     getDefaultSchemaLog().writeNewMetadata(
       PersistedMetadata(
-        log.tableId,
+        log.unsafeVolatileTableId,
         0L,
         s0.metadata,
         s0.protocol,
@@ -1891,7 +1895,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       val s0 = log.update()
       val schemaLog = getDefaultSchemaLog()
       schemaLog.writeNewMetadata(
-        PersistedMetadata(log.tableId, s0.version, s0.metadata, s0.protocol,
+        PersistedMetadata(log.unsafeVolatileTableId, s0.version, s0.metadata, s0.protocol,
           sourceMetadataPath = "")
       )
 
@@ -2202,7 +2206,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       DeltaSQLConf.DELTA_STREAMING_SCHEMA_TRACKING_METADATA_PATH_CHECK_ENABLED.key -> "false") {
       // Schema log's schema is respected
       val schemaLog = getDefaultSchemaLog()
-      val s0 = PersistedMetadata(log.tableId, 0,
+      val s0 = PersistedMetadata(log.unsafeVolatileTableId, 0,
         makeMetadata(
           new StructType().add("a", StringType, true)
             .add("b", StringType, true)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1348,7 +1348,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
       // Create a checkpoint so that logs before checkpoint can be expired and deleted
       writersLog.checkpoint()
-      val tahoeId = deltaLog.tableId // This isn't stable, but it shouldn't change during the test.
+      // This isn't stable, but it shouldn't change during the test.
+      val tahoeId = deltaLog.unsafeVolatileTableId
 
       testStream(df)(
         StartStream(Trigger.ProcessingTime("10 seconds"), new StreamManualClock),
@@ -1449,7 +1450,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val deltaLog = DeltaLog.forTable(spark, inputDir.toString)
       def expectLatestOffset(offset: DeltaSourceOffset) {
           val lastOffset = DeltaSourceOffset(
-            deltaLog.tableId,
+            deltaLog.unsafeVolatileTableId,
             SerializedOffset(stream.lastProgress.sources.head.endOffset)
           )
 
@@ -1459,17 +1460,26 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       try {
         stream.processAllAvailable()
         expectLatestOffset(DeltaSourceOffset(
-          deltaLog.tableId, 1, DeltaSourceOffset.BASE_INDEX, isInitialSnapshot = false))
+          deltaLog.unsafeVolatileTableId,
+          reservoirVersion = 1,
+          DeltaSourceOffset.BASE_INDEX,
+          isInitialSnapshot = false))
 
         deltaLog.startTransaction().commit(Seq(), DeltaOperations.ManualUpdate)
         stream.processAllAvailable()
         expectLatestOffset(DeltaSourceOffset(
-          deltaLog.tableId, 2, DeltaSourceOffset.BASE_INDEX, isInitialSnapshot = false))
+          deltaLog.unsafeVolatileTableId,
+          reservoirVersion = 2,
+          DeltaSourceOffset.BASE_INDEX,
+          isInitialSnapshot = false))
 
         deltaLog.startTransaction().commit(Seq(), DeltaOperations.ManualUpdate)
         stream.processAllAvailable()
         expectLatestOffset(DeltaSourceOffset(
-          deltaLog.tableId, 3, DeltaSourceOffset.BASE_INDEX, isInitialSnapshot = false))
+          deltaLog.unsafeVolatileTableId,
+          reservoirVersion = 3,
+          DeltaSourceOffset.BASE_INDEX,
+          isInitialSnapshot = false))
       } finally {
         stream.stop()
       }
@@ -1493,7 +1503,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         def waitForOffset(offset: DeltaSourceOffset) {
           eventually(timeout(streamingTimeout)) {
             val lastOffset = DeltaSourceOffset(
-              deltaLog.tableId,
+              deltaLog.unsafeVolatileTableId,
               SerializedOffset(stream.lastProgress.sources.head.endOffset)
             )
 
@@ -1504,7 +1514,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         // Process the initial snapshot (version 0) and end up at the start of version 1 which
         // does not exist yet.
         stream.processAllAvailable()
-        waitForOffset(DeltaSourceOffset(deltaLog.tableId, 1, DeltaSourceOffset.BASE_INDEX, false))
+        waitForOffset(DeltaSourceOffset(
+          deltaLog.unsafeVolatileTableId, 1, DeltaSourceOffset.BASE_INDEX, false))
 
         // Add Versions 1, 2, 3, and 4
         for(i <- 1 to 4) {
@@ -1516,7 +1527,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         // v4[END_INDEX] which is then rounded up to v5[BASE_INDEX] even though v5 does not exist
         // yet.
         stream.processAllAvailable()
-        waitForOffset(DeltaSourceOffset(deltaLog.tableId, 5, DeltaSourceOffset.BASE_INDEX, false))
+        waitForOffset(
+          DeltaSourceOffset(deltaLog.unsafeVolatileTableId, 5, DeltaSourceOffset.BASE_INDEX, false))
 
         // Add Version 5
         deltaLog.startTransaction().commit(Seq(), DeltaOperations.ManualUpdate)
@@ -1525,7 +1537,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         // versions of the code we did not have END_INDEX. In that case the stream would not have
         // moved forward from v5, because there were no indexes after v5[BASE_INDEX].
         stream.processAllAvailable()
-        waitForOffset(DeltaSourceOffset(deltaLog.tableId, 6, DeltaSourceOffset.BASE_INDEX, false))
+        waitForOffset(
+          DeltaSourceOffset(deltaLog.unsafeVolatileTableId, 6, DeltaSourceOffset.BASE_INDEX, false))
       } finally {
         stream.stop()
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingCompactionSuite.scala
@@ -73,11 +73,11 @@ trait RowTrackingCompactionTestsBase
       val deltaLog = DeltaLog.forTable(spark, dir)
       val snapshot = deltaLog.update()
       val materializedRowIdColName = MaterializedRowId.getMaterializedColumnNameOrThrow(
-        snapshot.protocol, snapshot.metadata, deltaLog.tableId)
+        snapshot.protocol, snapshot.metadata, deltaLog.unsafeVolatileTableId)
       df = df.withMaterializedRowIdColumn(materializedRowIdColName, col("value"))
       val materializedRowCommitVersionColName =
         MaterializedRowCommitVersion.getMaterializedColumnNameOrThrow(
-          snapshot.protocol, snapshot.metadata, deltaLog.tableId)
+          snapshot.protocol, snapshot.metadata, deltaLog.unsafeVolatileTableId)
       df = df.withMaterializedRowCommitVersionColumn(
         materializedRowCommitVersionColName, col("value"))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -281,7 +281,8 @@ trait AppendSaveModeTests extends BatchWriterTest {
           spark.range(10).withColumn("part", 'id + 1).write.append(dir)
         }
         assert(e.getMessage.contains("schema mismatch detected"))
-        assert(e.getMessage.contains(s"Table ID: ${DeltaLog.forTable(spark, dir).tableId}"))
+        assert(e.getMessage.contains(
+          s"Table ID: ${DeltaLog.forTable(spark, dir).unsafeVolatileTableId}"))
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Renames `DeltaLog.tableId` to `DeltaLog.unsafeVolatileTableId` and `DeltaLog.truncatedTableId` to `DeltaLog.truncatedUnsafeVolatileTableId` across the codebase.

The table ID accessed via `DeltaLog` is derived from `unsafeVolatileMetadata`, meaning it can change during the lifetime of a `DeltaLog` instance (e.g., when the snapshot is updated and the new snapshot has a different table ID). The previous name `tableId` gave a false impression of stability. The new name `unsafeVolatileTableId` makes the volatile nature explicit and encourages callers to use the value with care.

This is a purely mechanical rename with no behavioral changes. All 65 modified files (source and test) simply update references from `tableId`/`truncatedTableId` to `unsafeVolatileTableId`/`truncatedUnsafeVolatileTableId`. The related SQL conf doc string referencing `deltaLog.tableId` is also updated.
## How was this patch tested?

CI testing

## Does this PR introduce _any_ user-facing changes?

No