### PR TITLE
[External Access PO Metrics] Add core PO metrics post-commit hook and tests

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHookSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHookSuite.scala
@@ -1,0 +1,467 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+import java.io.{BufferedReader, InputStreamReader, PrintWriter}
+import java.net.{ServerSocket, Socket}
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Test suite for UpdatePOMetricsHook functionality.
+ *
+ * Tests cover:
+ * - buildRequest: file and row metric extraction without Delta infrastructure
+ * - JSON payload structure matching the server contract (snake_case, nested)
+ * - Hook enablement via configuration
+ * - Error handling (commits succeed even when HTTP fails)
+ * - Basic mock server integration
+ * - Smoke test: run() fires HTTP POST with correct payload for UC-managed table
+ */
+class UpdatePOMetricsHookSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.databricks.delta.properties.defaults.enableChangeDataFeed", "false")
+  }
+
+  // ---------------------------------------------------------------------------
+  // buildRequest tests - no reflection, no Delta infrastructure
+  // ---------------------------------------------------------------------------
+
+  test("buildRequest: file metrics from synthetic AddFile/RemoveFile actions") {
+    val hook = UpdatePOMetricsHook(None)
+
+    val plain1 = AddFile("plain1.parquet", Map.empty, 1024L,
+      System.currentTimeMillis(), dataChange = true)
+    val plain2 = AddFile("plain2.parquet", Map.empty, 2048L,
+      System.currentTimeMillis(), dataChange = true)
+    val clustered = AddFile("clustered.parquet", Map.empty, 4096L,
+      System.currentTimeMillis(), dataChange = true,
+      clusteringProvider = Some("liquid"))
+    val removed = RemoveFile("old.parquet", Some(System.currentTimeMillis()),
+      dataChange = true, size = Some(512L))
+
+    val actions: Seq[Action] = Seq(plain1, plain2, clustered, removed)
+    val request = hook.buildRequest("tbl-123", actions, committedVersion = 7L)
+    val report = request.report.commitReport
+
+    assert(request.tableId == "tbl-123")
+    assert(report.numFilesAdded == Some(3L), "3 AddFiles")
+    assert(report.numFilesRemoved == Some(1L), "1 RemoveFile")
+    assert(report.numBytesAdded == Some(1024L + 2048L + 4096L), "sum of add sizes")
+    assert(report.numBytesRemoved == Some(512L), "sum of remove sizes")
+    assert(report.numClusteredBytesAdded == Some(4096L), "only the clustered file")
+
+    val hist = report.fileSizeHistogram.getOrElse(fail("histogram must be present"))
+    assert(hist.commitVersion == Some(7L), "commit_version must be set")
+    assert(hist.sortedBinBoundaries.head == 0L, "bins must start at 0")
+    assert(hist.fileCounts.sum == 3L, "histogram covers all AddFiles")
+    assert(hist.totalBytes.sum == 1024L + 2048L + 4096L, "histogram totalBytes")
+  }
+
+  test("buildRequest: row metrics prefer operationMetrics over file stats") {
+    val hook = UpdatePOMetricsHook(None)
+
+    // Sub-case 1: operationMetrics present - must win over file-level numLogicalRecords
+    val addFileWithStats = AddFile("f.parquet", Map.empty, 1000L,
+      System.currentTimeMillis(), dataChange = true,
+      stats = """{"numRecords": 999}""")
+    val commitInfoWithMetrics = CommitInfo(
+      version = Some(0L),
+      inCommitTimestamp = None,
+      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
+      userId = None, userName = None,
+      operation = "WRITE",
+      operationParameters = Map.empty,
+      job = None, notebook = None, clusterId = None,
+      readVersion = None, isolationLevel = None,
+      isBlindAppend = Some(true),
+      operationMetrics = Some(Map("numOutputRows" -> "100")),
+      userMetadata = None, tags = None, engineInfo = None, txnId = None)
+
+    val req1 = hook.buildRequest("t1", Seq(commitInfoWithMetrics, addFileWithStats), 0L)
+    assert(req1.report.commitReport.numRowsInserted == Some(100L),
+      "operationMetrics wins over file stats")
+
+    // Sub-case 2: no operationMetrics - falls back to numLogicalRecords from file stats
+    val commitInfoNoMetrics = CommitInfo(
+      version = Some(1L),
+      inCommitTimestamp = None,
+      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
+      userId = None, userName = None,
+      operation = "WRITE",
+      operationParameters = Map.empty,
+      job = None, notebook = None, clusterId = None,
+      readVersion = None, isolationLevel = None,
+      isBlindAppend = Some(true),
+      operationMetrics = None,
+      userMetadata = None, tags = None, engineInfo = None, txnId = None)
+
+    val req2 = hook.buildRequest("t2", Seq(commitInfoNoMetrics, addFileWithStats), 1L)
+    assert(req2.report.commitReport.numRowsInserted == Some(999L),
+      "fallback to numLogicalRecords from file stats")
+
+    // Sub-case 3: no CommitInfo at all - falls back to numLogicalRecords
+    val req3 = hook.buildRequest("t3", Seq(addFileWithStats), 2L)
+    assert(req3.report.commitReport.numRowsInserted == Some(999L),
+      "fallback works with no CommitInfo in actions")
+  }
+
+  // ---------------------------------------------------------------------------
+  // JSON payload structure tests - validates server contract
+  // ---------------------------------------------------------------------------
+
+  test("JSON payload validation - matches server contract (snake_case, nested)") {
+    val request = ReportDeltaMetricsRequest(
+      tableId = "test-table-id-123",
+      report = CommitReportEnvelope(CommitReport(
+        numFilesAdded = Some(10L),
+        numFilesRemoved = Some(2L),
+        numBytesAdded = Some(10000L),
+        numBytesRemoved = Some(2000L),
+        numClusteredBytesAdded = Some(5000L),
+        numRowsInserted = Some(1000L),
+        numRowsRemoved = Some(200L),
+        numRowsUpdated = Some(50L),
+        fileSizeHistogram = Some(FileSizeHistogramPayload(
+          sortedBinBoundaries = Seq(0L, 1024L),
+          fileCounts = Seq(5L, 5L),
+          totalBytes = Seq(2000L, 8000L),
+          commitVersion = Some(42L)
+        ))
+      ))
+    )
+
+    val json = JsonUtils.toJson(request)
+
+    // Server expects snake_case field names
+    assert(json.contains(""""table_id":"test-table-id-123""""),
+      "table_id must be snake_case")
+    assert(json.contains(""""commit_report""""),
+      "must have nested commit_report key")
+    assert(json.contains(""""num_files_added":10"""),
+      "num_files_added must be snake_case")
+    assert(json.contains(""""num_rows_inserted":1000"""),
+      "must use num_rows_inserted (not num_rows_added)")
+    assert(json.contains(""""num_clustered_bytes_added":5000"""),
+      "clustered bytes must be present")
+    assert(json.contains(""""commit_version":42"""),
+      "commit_version required for server staleness check")
+
+    // Must NOT have camelCase keys
+    assert(!json.contains(""""tableId""""), "no camelCase tableId")
+    assert(!json.contains(""""numFilesAdded""""), "no camelCase numFilesAdded")
+    assert(!json.contains(""""numRowsAdded""""), "no old numRowsAdded field")
+  }
+
+  test("JSON payload: optional fields are omitted when None") {
+    val request = ReportDeltaMetricsRequest(
+      tableId = "some-id",
+      report = CommitReportEnvelope(CommitReport(
+        numFilesAdded = Some(1L)
+        // all other fields None
+      ))
+    )
+
+    val json = JsonUtils.toJson(request)
+    assert(!json.contains(""""num_rows_inserted""""),
+      "None fields should be absent from JSON")
+    assert(!json.contains(""""num_rows_updated""""),
+      "None fields should be absent from JSON")
+    assert(!json.contains(""""num_clustered_bytes_removed""""),
+      "clustered_bytes_removed must never appear")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hook lifecycle tests
+  // ---------------------------------------------------------------------------
+
+  test("hook disabled by config - skips execution") {
+    withTempDir { dir =>
+      val tablePath = dir.getCanonicalPath
+
+      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENABLED.key, "false")
+
+      // Create and append - if hook ran it would fail (no endpoint configured)
+      spark.range(10).write.format("delta").save(tablePath)
+      spark.range(10, 20).write.format("delta").mode("append").save(tablePath)
+
+      val deltaLog = DeltaLog.forTable(spark, tablePath)
+      assert(deltaLog.snapshot.version == 1, "Expected 2 commits")
+    }
+  }
+
+  test("POMetricsClient: throws RuntimeException on HTTP 5xx response") {
+    val mockServer = new SimpleMockServer(0)
+    try {
+      mockServer.setResponseCode(500)
+      mockServer.start()
+
+      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key,
+        s"http://localhost:${mockServer.getPort()}/metrics")
+      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key, "test-token")
+      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_TIMEOUT_MS.key, "1000")
+
+      val request = ReportDeltaMetricsRequest(
+        tableId = "test-id",
+        report = CommitReportEnvelope(CommitReport(numFilesAdded = Some(1L)))
+      )
+      // Client should throw on 5xx; the hook catches and logs this as a warning
+      intercept[RuntimeException] {
+        POMetricsClient.sendMetrics(spark, request)
+      }
+      assert(mockServer.getRequestCount() == 1, "Expected 1 HTTP request even on error")
+    } finally {
+      mockServer.stop()
+    }
+  }
+
+  test("POMetricsClient: sends correct Authorization header and JSON body") {
+    val mockServer = new SimpleMockServer(0)
+    try {
+      mockServer.setResponseCode(200)
+      mockServer.start()
+
+      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key,
+        s"http://localhost:${mockServer.getPort()}/metrics")
+      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key, "test-token-123")
+      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_TIMEOUT_MS.key, "5000")
+
+      val request = ReportDeltaMetricsRequest(
+        tableId = "abc-123",
+        report = CommitReportEnvelope(CommitReport(
+          numFilesAdded = Some(5L),
+          numBytesAdded = Some(5000L),
+          numRowsInserted = Some(100L)
+        ))
+      )
+      POMetricsClient.sendMetrics(spark, request)
+
+      assert(mockServer.getRequestCount() == 1, "Expected 1 HTTP request")
+
+      val authHeader = mockServer.getLastHeaders().get("Authorization")
+      assert(authHeader.isDefined, "Authorization header should be present")
+      assert(authHeader.get == "Bearer test-token-123", "Auth token must match")
+
+      val body = mockServer.getLastRequestBody()
+      assert(body.contains(""""table_id":"abc-123""""), "body must contain table_id")
+      assert(body.contains(""""num_files_added":5"""), "body must contain num_files_added")
+      assert(body.contains(""""num_rows_inserted":100"""), "body must contain num_rows_inserted")
+    } finally {
+      mockServer.stop()
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Smoke test - exercises run() end-to-end with a real DeltaLog + mock server
+  // ---------------------------------------------------------------------------
+
+  test("run(): fires HTTP POST with correct payload for UC-managed table") {
+    val mockServer = new SimpleMockServer(0)
+    try {
+      mockServer.setResponseCode(200)
+      mockServer.start()
+
+      withTempDir { dir =>
+        // Real DeltaLog so tableId is a valid UUID
+        spark.range(10).write.format("delta").save(dir.getCanonicalPath)
+        val deltaLog = DeltaLog.forTable(spark, dir.getCanonicalPath)
+        val snapshot = deltaLog.snapshot
+
+        spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENABLED.key, "true")
+        spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key,
+          s"http://localhost:${mockServer.getPort()}/metrics")
+        spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key, "smoke-token")
+
+        // catalog identifier causes isUCManagedTable to return true
+        val catalogTable = CatalogTable(
+          identifier = TableIdentifier("t", Some("default"), Some("spark_catalog")),
+          tableType = CatalogTableType.MANAGED,
+          storage = CatalogStorageFormat.empty,
+          schema = new StructType()
+        )
+
+        val addFile = AddFile("f1.parquet", Map.empty, 4096L, 0L, dataChange = true,
+          stats = """{"numRecords":50}""")
+        val commitInfo = CommitInfo(
+          version = Some(0L),
+          inCommitTimestamp = None,
+          timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
+          userId = None, userName = None,
+          operation = "WRITE",
+          operationParameters = Map.empty,
+          job = None, notebook = None, clusterId = None,
+          readVersion = None, isolationLevel = None,
+          isBlindAppend = Some(true),
+          operationMetrics = Some(Map("numOutputRows" -> "50")),
+          userMetadata = None, tags = None, engineInfo = None, txnId = None)
+
+        val txn = CommittedTransaction(
+          txnId = "smoke-txn",
+          deltaLog = deltaLog,
+          catalogTable = Some(catalogTable),
+          readSnapshot = snapshot,
+          committedVersion = 0L,
+          committedActions = Seq(commitInfo, addFile),
+          postCommitSnapshot = snapshot,
+          postCommitHooks = Seq.empty,
+          txnExecutionTimeMs = 0L,
+          needsCheckpoint = false,
+          partitionsAddedToOpt = None,
+          isBlindAppend = true
+        )
+
+        UpdatePOMetricsHook(Some(catalogTable)).run(spark, txn)
+
+        assert(mockServer.getRequestCount() == 1, "Expected exactly 1 HTTP POST")
+        val body = mockServer.getLastRequestBody()
+        assert(body.contains(s""""table_id":"${deltaLog.tableId}""""),
+          "payload must contain the table's UUID")
+        assert(body.contains(""""num_files_added":1"""), "1 AddFile committed")
+        assert(body.contains(""""num_rows_inserted":50"""),
+          "numOutputRows from operationMetrics")
+        assert(body.contains(""""commit_version":0"""),
+          "commit_version required for server staleness check")
+      }
+    } finally {
+      mockServer.stop()
+    }
+  }
+}
+
+/**
+ * Simple mock HTTP server for testing.
+ *
+ * Accepts one connection at a time, returns a configurable status code,
+ * and captures request headers and body for assertion.
+ */
+class SimpleMockServer(port: Int) {
+  private var serverSocket: ServerSocket = _
+  private var serverThread: Thread = _
+  private var running = false
+  private var responseCode = 200
+  private val requestCount = new AtomicInteger(0)
+  private var lastRequestBody = ""
+  private var lastHeaders = Map[String, String]()
+  private var actualPort = port
+
+  def setResponseCode(code: Int): Unit = { responseCode = code }
+
+  def getPort(): Int = actualPort
+
+  def getRequestCount(): Int = requestCount.get()
+
+  def getLastRequestBody(): String = lastRequestBody
+
+  def getLastHeaders(): Map[String, String] = lastHeaders
+
+  def start(): Unit = {
+    serverSocket = new ServerSocket(port)
+    actualPort = serverSocket.getLocalPort
+    running = true
+
+    serverThread = new Thread(new Runnable {
+      override def run(): Unit = {
+        while (running) {
+          try {
+            val clientSocket = serverSocket.accept()
+            handleRequest(clientSocket)
+          } catch {
+            case _: java.net.SocketException if !running => // expected on stop()
+            case e: Exception => e.printStackTrace()
+          }
+        }
+      }
+    })
+    serverThread.setDaemon(true)
+    serverThread.start()
+
+    Thread.sleep(100) // allow server to bind
+  }
+
+  private def handleRequest(clientSocket: Socket): Unit = {
+    try {
+      val in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream))
+      val out = new PrintWriter(clientSocket.getOutputStream, true)
+
+      in.readLine() // request line
+
+      val headers = scala.collection.mutable.Map[String, String]()
+      var contentLength = 0
+      var line = in.readLine()
+      while (line != null && line.nonEmpty) {
+        val parts = line.split(":", 2)
+        if (parts.length == 2) {
+          val key = parts(0).trim
+          val value = parts(1).trim
+          headers(key) = value
+          if (key.equalsIgnoreCase("Content-Length")) contentLength = value.toInt
+        }
+        line = in.readLine()
+      }
+
+      val body = new Array[Char](contentLength)
+      if (contentLength > 0) in.read(body, 0, contentLength)
+
+      requestCount.incrementAndGet()
+      lastRequestBody = new String(body)
+      lastHeaders = headers.toMap
+
+      out.println(s"HTTP/1.1 $responseCode ${statusMessage(responseCode)}")
+      out.println("Content-Type: application/json")
+      out.println("Content-Length: 2")
+      out.println()
+      out.println("{}")
+      out.flush()
+
+      clientSocket.close()
+    } catch {
+      case e: Exception => e.printStackTrace()
+    }
+  }
+
+  private def statusMessage(code: Int): String = code match {
+    case 200 => "OK"
+    case 400 => "Bad Request"
+    case 500 => "Internal Server Error"
+    case _ => "Unknown"
+  }
+
+  def stop(): Unit = {
+    running = false
+    if (serverSocket != null && !serverSocket.isClosed) serverSocket.close()
+    if (serverThread != null) {
+      serverThread.interrupt()
+      serverThread.join(1000)
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.constraints.{Constraints, Invariants}
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.files._
-import org.apache.spark.sql.delta.hooks.{CheckpointHook, ChecksumHook, GenerateSymlinkManifest, HudiConverterHook, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
+import org.apache.spark.sql.delta.hooks.{CheckpointHook, ChecksumHook, GenerateSymlinkManifest, HudiConverterHook, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory, UpdatePOMetricsHook}
 import org.apache.spark.sql.delta.implicits.addFileEncoder
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -448,6 +448,11 @@ trait OptimisticTransactionImpl extends TransactionHelper
   registerPostCommitHook(ChecksumHook)
   catalogTable.foreach { ct =>
     registerPostCommitHook(UpdateCatalogFactory.getUpdateCatalogHook(ct, spark))
+
+    // Register PO metrics hook for UC-managed tables
+    if (spark.conf.get(DeltaSQLConf.DELTA_PO_METRICS_ENABLED)) {
+      registerPostCommitHook(UpdatePOMetricsHook(Some(ct)))
+    }
   }
   // The CheckpointHook will only checkpoint if necessary, so always register it to run.
   registerPostCommitHook(CheckpointHook)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/POMetricsClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/POMetricsClient.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.http.HttpHeaders
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.{ContentType, StringEntity}
+import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
+import org.apache.http.util.EntityUtils
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Top-level request body for POST /api/2.1/unity-catalog/delta/preview/metrics.
+ *
+ * @param tableId UUID of the UC-managed Delta table
+ * @param report  The commit metrics, wrapped in a typed report envelope
+ */
+case class ReportDeltaMetricsRequest(
+    @JsonProperty("table_id") tableId: String,
+    @JsonProperty("report") report: CommitReportEnvelope)
+
+/**
+ * Envelope that matches the server's @JsonSubTypes WRAPPER_OBJECT format.
+ * Serializes as: { "commit_report": { ... } }
+ */
+case class CommitReportEnvelope(
+    @JsonProperty("commit_report") commitReport: CommitReport)
+
+/**
+ * Commit-level file and row metrics.
+ *
+ * All fields are optional - the server validates they are non-negative if present.
+ * num_clustered_bytes_removed is intentionally omitted: RemoveFile carries no
+ * clusteringProvider, so we cannot compute it from the commit log alone.
+ *
+ * commit_version is conveyed via file_size_histogram.commit_version and is
+ * required by the server to validate the payload is not stale.
+ */
+case class CommitReport(
+    @JsonProperty("num_files_added") numFilesAdded: Option[Long] = None,
+    @JsonProperty("num_files_removed") numFilesRemoved: Option[Long] = None,
+    @JsonProperty("num_bytes_added") numBytesAdded: Option[Long] = None,
+    @JsonProperty("num_bytes_removed") numBytesRemoved: Option[Long] = None,
+    @JsonProperty("num_clustered_bytes_added") numClusteredBytesAdded: Option[Long] = None,
+    // num_clustered_bytes_removed omitted: not derivable from RemoveFile (no clusteringProvider)
+    @JsonProperty("num_rows_inserted") numRowsInserted: Option[Long] = None,
+    @JsonProperty("num_rows_removed") numRowsRemoved: Option[Long] = None,
+    @JsonProperty("num_rows_updated") numRowsUpdated: Option[Long] = None,
+    @JsonProperty("file_size_histogram") fileSizeHistogram: Option[FileSizeHistogramPayload] = None)
+
+/**
+ * File size distribution for the added files in this commit.
+ * commit_version is also used by the server to validate payload freshness.
+ */
+case class FileSizeHistogramPayload(
+    @JsonProperty("sorted_bin_boundaries") sortedBinBoundaries: Seq[Long],
+    @JsonProperty("file_counts") fileCounts: Seq[Long],
+    @JsonProperty("total_bytes") totalBytes: Seq[Long],
+    @JsonProperty("commit_version") commitVersion: Option[Long] = None)
+
+/**
+ * HTTP client for sending commit metrics to the UC PO endpoint.
+ *
+ * Endpoint: POST /api/2.1/unity-catalog/delta/preview/metrics
+ *
+ * The server (ReportDeltaMetricsHandler) will:
+ *  1. Look up the table via getTableById to fetch PO-enable status and latest version
+ *  2. Validate commit_version is within validCommitVersionWindow of the latest version
+ *  3. Validate all numeric fields are non-negative
+ *  4. Forward the metrics to PO via PredictiveOptimizationClient.pushExternalDeltaCommitMetrics
+ */
+object POMetricsClient {
+
+  /**
+   * Sends commit metrics to the PO endpoint synchronously.
+   *
+   * @param spark   The SparkSession (used to read configuration)
+   * @param request The fully-constructed request payload
+   * @throws Exception if the HTTP request fails (caller should catch and log)
+   */
+  def sendMetrics(spark: SparkSession, request: ReportDeltaMetricsRequest): Unit = {
+    val endpointUrl = getEndpointUrl(spark)
+    val authToken = getAuthToken(spark)
+    val timeoutMs = getTimeoutMs(spark)
+
+    val requestConfig = RequestConfig.custom()
+      .setConnectTimeout(timeoutMs.toInt)
+      .setSocketTimeout(timeoutMs.toInt)
+      .setConnectionRequestTimeout(timeoutMs.toInt)
+      .build()
+
+    val httpClient: CloseableHttpClient = HttpClientBuilder.create()
+      .setDefaultRequestConfig(requestConfig)
+      .build()
+
+    try {
+      val httpPost = new HttpPost(endpointUrl)
+      httpPost.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType)
+      httpPost.setHeader(HttpHeaders.AUTHORIZATION, s"Bearer $authToken")
+
+      val jsonPayload = JsonUtils.toJson(request)
+      httpPost.setEntity(new StringEntity(jsonPayload, ContentType.APPLICATION_JSON))
+
+      val response = httpClient.execute(httpPost)
+      try {
+        val statusCode = response.getStatusLine.getStatusCode
+        if (statusCode < 200 || statusCode >= 300) {
+          val responseBody = if (response.getEntity != null) {
+            EntityUtils.toString(response.getEntity)
+          } else {
+            "<no response body>"
+          }
+          throw new RuntimeException(
+            s"PO metrics endpoint returned error status $statusCode: $responseBody")
+        }
+      } finally {
+        response.close()
+      }
+    } finally {
+      httpClient.close()
+    }
+  }
+
+  private def getEndpointUrl(spark: SparkSession): String = {
+    spark.conf.getOption(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key) match {
+      case Some(url) if url.nonEmpty => url
+      case _ =>
+        val key = DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key
+        throw new IllegalArgumentException(
+          s"PO metrics endpoint URL not configured. Set $key")
+    }
+  }
+
+  private def getAuthToken(spark: SparkSession): String = {
+    spark.conf.getOption(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key)
+      .orElse(Option(System.getenv("DATABRICKS_TOKEN"))) match {
+      case Some(token) if token.nonEmpty => token
+      case _ =>
+        val key = DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key
+        throw new IllegalArgumentException(
+          s"PO metrics auth token not configured. Set $key or " +
+          "DATABRICKS_TOKEN environment variable")
+    }
+  }
+
+  private def getTimeoutMs(spark: SparkSession): Long = {
+    spark.conf.get(DeltaSQLConf.DELTA_PO_METRICS_TIMEOUT_MS)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHook.scala
@@ -1,0 +1,242 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.FileSizeHistogram
+
+import org.apache.spark.internal.MDC
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * Post-commit hook that sends commit metrics to the PO (Predictive Optimization) endpoint
+ * for Unity Catalog managed Delta tables.
+ *
+ * Endpoint: POST /api/2.1/unity-catalog/delta/preview/metrics
+ *
+ * The server validates:
+ *  - table_id must match a known UC Delta table
+ *  - commit_version (in file_size_histogram) must be within validCommitVersionWindow of
+ *    the latest table version tracked by UC
+ *  - All numeric fields must be non-negative
+ *
+ * This hook is best-effort: failures are logged as warnings but never fail the commit.
+ *
+ * @param catalogTable The catalog table metadata (required to identify UC-managed tables)
+ */
+case class UpdatePOMetricsHook(catalogTable: Option[CatalogTable])
+    extends PostCommitHook with DeltaLogging {
+
+  override val name: String = "Update PO Metrics"
+
+  // Default bin boundaries for the file size histogram (in bytes).
+  // Must start at 0. Boundaries cover the typical Parquet file size range.
+  private val FILE_SIZE_BIN_BOUNDARIES: IndexedSeq[Long] = IndexedSeq(
+    0L,
+    8L * 1024, // 8 KB
+    64L * 1024, // 64 KB
+    512L * 1024, // 512 KB
+    1L << 20, // 1 MB
+    4L << 20, // 4 MB
+    8L << 20, // 8 MB
+    16L << 20, // 16 MB
+    32L << 20, // 32 MB
+    64L << 20, // 64 MB
+    128L << 20, // 128 MB
+    256L << 20, // 256 MB
+    512L << 20, // 512 MB
+    1L << 30 // 1 GB
+  )
+
+  override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
+    if (!spark.conf.get(DeltaSQLConf.DELTA_PO_METRICS_ENABLED)) return
+
+    if (!isUCManagedTable(txn.deltaLog, catalogTable)) return
+
+    if (!spark.conf.getOption(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key).exists(_.nonEmpty)) {
+      logInfo("PO metrics endpoint not configured, skipping")
+      return
+    }
+
+    try {
+      val tableId = txn.deltaLog.tableId
+      if (tableId.isEmpty) {
+        throw new IllegalStateException("UC-managed table must have a table ID")
+      }
+
+      val request = buildRequest(tableId, txn.committedActions, txn.committedVersion)
+      POMetricsClient.sendMetrics(spark, request)
+
+      logInfo(
+        log"Successfully sent PO metrics for table " +
+        log"${MDC(DeltaLogKeys.PATH, txn.deltaLog.logPath)} " +
+        log"version ${MDC(DeltaLogKeys.VERSION, txn.committedVersion)}")
+
+    } catch {
+      case e: Exception =>
+        logWarning(
+          log"Failed to send PO metrics for table " +
+          log"${MDC(DeltaLogKeys.PATH, txn.deltaLog.logPath)} " +
+          log"version ${MDC(DeltaLogKeys.VERSION, txn.committedVersion)}: " +
+          log"${MDC(DeltaLogKeys.ERROR, e.getMessage)}", e)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Request builder - package-private for direct testing without Delta infrastructure
+  // ---------------------------------------------------------------------------
+
+  private[hooks] def buildRequest(
+      tableId: String,
+      committedActions: Seq[Action],
+      committedVersion: Long): ReportDeltaMetricsRequest = {
+    val commitInfo = committedActions.collectFirst { case ci: CommitInfo => ci }
+    val opMetrics = commitInfo.flatMap(_.operationMetrics).getOrElse(Map.empty)
+
+    val addFiles = committedActions.collect { case a: AddFile => a }
+    val removeFiles = committedActions.collect { case r: RemoveFile => r }
+
+    val commitReport = CommitReport(
+      numFilesAdded = Some(addFiles.size.toLong),
+      numFilesRemoved = Some(removeFiles.size.toLong),
+      numBytesAdded = Some(addFiles.map(_.size).sum),
+      numBytesRemoved = Some(removeFiles.flatMap(_.size).sum),
+      numClusteredBytesAdded = Some(
+        addFiles.filter(_.clusteringProvider.isDefined).map(_.size).sum),
+      // num_clustered_bytes_removed: not available - RemoveFile has no clusteringProvider
+      numRowsInserted = extractRowsInserted(opMetrics, addFiles),
+      numRowsRemoved = extractRowsRemoved(opMetrics, removeFiles),
+      numRowsUpdated = extractRowsUpdated(opMetrics),
+      fileSizeHistogram = Some(buildFileSizeHistogram(addFiles, committedVersion))
+    )
+
+    ReportDeltaMetricsRequest(
+      tableId = tableId,
+      report = CommitReportEnvelope(commitReport)
+    )
+  }
+
+  override def handleError(spark: SparkSession, error: Throwable, version: Long): Unit = {
+    logWarning(
+      log"PO metrics hook failed for version ${MDC(DeltaLogKeys.VERSION, version)}: " +
+      log"${MDC(DeltaLogKeys.ERROR, error.getMessage)}", error)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row metric extraction - prefer operationMetrics for accuracy; fall back to
+  // file-level numLogicalRecords when operationMetrics are absent (e.g. external
+  // writers that don't emit CommitInfo, or simple WRITE operations).
+  // ---------------------------------------------------------------------------
+
+  /**
+   * numRowsInserted:
+   *  - MERGE  -&gt; numTargetRowsInserted
+   *  - WRITE / STREAMING_UPDATE -&gt; numOutputRows
+   *  - fallback -&gt; sum of AddFile.numLogicalRecords
+   */
+  private def extractRowsInserted(
+      opMetrics: Map[String, String],
+      addFiles: Seq[AddFile]): Option[Long] = {
+    opMetrics.get("numTargetRowsInserted")
+      .orElse(opMetrics.get("numOutputRows"))
+      .flatMap(toLong)
+      .orElse {
+        val fromStats = addFiles.flatMap(_.numLogicalRecords)
+        if (fromStats.nonEmpty) Some(fromStats.sum) else None
+      }
+  }
+
+  /**
+   * numRowsRemoved:
+   *  - MERGE  -&gt; numTargetRowsDeleted
+   *  - DELETE -&gt; numDeletedRows
+   *  - fallback -&gt; sum of RemoveFile.numLogicalRecords
+   */
+  private def extractRowsRemoved(
+      opMetrics: Map[String, String],
+      removeFiles: Seq[RemoveFile]): Option[Long] = {
+    opMetrics.get("numTargetRowsDeleted")
+      .orElse(opMetrics.get("numDeletedRows"))
+      .flatMap(toLong)
+      .orElse {
+        val fromStats = removeFiles.flatMap(_.numLogicalRecords)
+        if (fromStats.nonEmpty) Some(fromStats.sum) else None
+      }
+  }
+
+  /**
+   * numRowsUpdated:
+   *  - MERGE  -&gt; numTargetRowsUpdated
+   *  - UPDATE -&gt; numUpdatedRows
+   *  - No file-level fallback (updated rows are indistinguishable from inserts in file stats)
+   */
+  private def extractRowsUpdated(opMetrics: Map[String, String]): Option[Long] = {
+    opMetrics.get("numTargetRowsUpdated")
+      .orElse(opMetrics.get("numUpdatedRows"))
+      .flatMap(toLong)
+  }
+
+  private def toLong(s: String): Option[Long] =
+    try Some(s.toLong)
+    catch { case _: NumberFormatException => None }
+
+  // ---------------------------------------------------------------------------
+  // File size histogram
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a file-size histogram from the AddFiles in this commit.
+   * commit_version is required by the server to validate the payload is not stale.
+   */
+  private def buildFileSizeHistogram(
+      addFiles: Seq[AddFile],
+      committedVersion: Long): FileSizeHistogramPayload = {
+    val histogram = FileSizeHistogram(FILE_SIZE_BIN_BOUNDARIES)
+    addFiles.foreach(f => histogram.insert(f.size))
+    FileSizeHistogramPayload(
+      sortedBinBoundaries = histogram.sortedBinBoundaries,
+      fileCounts = histogram.fileCounts.toSeq,
+      totalBytes = histogram.totalBytes.toSeq,
+      commitVersion = Some(committedVersion)
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // UC table detection
+  // ---------------------------------------------------------------------------
+
+  private def isUCManagedTable(
+      deltaLog: DeltaLog,
+      catalogTable: Option[CatalogTable]): Boolean = {
+    if (deltaLog.tableId.isEmpty) return false
+
+    catalogTable match {
+      case Some(ct) =>
+        ct.identifier.catalog.isDefined ||
+        (ct.properties.get("provider").exists(
+          _.toLowerCase(java.util.Locale.ROOT) == "delta") &&
+          deltaLog.tableId.nonEmpty)
+      case None => false
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -127,6 +127,35 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_PO_METRICS_ENABLED =
+    buildConf("po.metrics.enabled")
+      .internal()
+      .doc("When true, commit metrics are sent to the PO endpoint for UC-managed tables.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DELTA_PO_METRICS_ENDPOINT =
+    buildConf("po.metrics.endpoint")
+      .internal()
+      .doc("Base URL for the Unity Catalog PO metrics endpoint.")
+      .stringConf
+      .createOptional
+
+  val DELTA_PO_METRICS_AUTH_TOKEN =
+    buildConf("po.metrics.authToken")
+      .internal()
+      .doc("Bearer token for authenticating to the PO metrics endpoint. " +
+        "Falls back to DATABRICKS_TOKEN env var if not set.")
+      .stringConf
+      .createOptional
+
+  val DELTA_PO_METRICS_TIMEOUT_MS =
+    buildConf("po.metrics.timeoutMs")
+      .internal()
+      .doc("HTTP request timeout for PO metrics endpoint calls (milliseconds).")
+      .longConf
+      .createWithDefault(5000L)
+
   val DELTA_CONVERT_USE_METADATA_LOG =
     buildConf("convert.useMetadataLog")
       .doc(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6152/files) to review all changes.

**Stack:**
- **[[External Access PO Metrics] Add core PO metrics post-commit hook and tests](https://github.com/delta-io/delta/pull/6152)** [[Files changed](https://github.com/delta-io/delta/pull/6152/files)] ⬅️ _This PR_
  - [[External Access PO Metrics] Harden UC table ID resolution for PO metrics](https://github.com/delta-io/delta/pull/6153) [[Files changed](https://github.com/delta-io/delta/pull/6153/files/b329f0c72be63df7cf53e30ca79143c8a710d072..2eed19ba7ab5e0403832cf0d3ecb985609236234)]
    - [[External Access PO Metrics] Apply prototype defaults for endpoint, auth, and timeout](https://github.com/delta-io/delta/pull/6154) [[Files changed](https://github.com/delta-io/delta/pull/6154/files/2eed19ba7ab5e0403832cf0d3ecb985609236234..466e4e0bdcf0713321c4cc026b2bd59f4354a717)]

---

## Summary
- add the core PO metrics post-commit hook, request payload models, and HTTP client wiring
- register the hook in post-commit flow for catalog-backed transactions and include baseline unit/smoke tests
- keep delivery best-effort so commit success is never blocked by metrics transport failures

## Test plan
- [x] build/sbt \"spark/testOnly *UpdatePOMetricsHookSuite\"