### PR TITLE
[External Access PO Metrics] Apply prototype defaults for endpoint, auth, and timeout

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHookSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHookSuite.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.JsonUtils
 
@@ -39,7 +38,7 @@ import org.apache.spark.sql.types.StructType
  * Tests cover:
  * - buildRequest: file and row metric extraction without Delta infrastructure
  * - JSON payload structure matching the server contract (snake_case, nested)
- * - Hook enablement via configuration
+ * - Hook behavior and error handling
  * - Error handling (commits succeed even when HTTP fails)
  * - Basic mock server integration
  * - Smoke test: run() fires HTTP POST with correct payload for UC-managed table
@@ -47,6 +46,8 @@ import org.apache.spark.sql.types.StructType
 class UpdatePOMetricsHookSuite extends QueryTest
   with SharedSparkSession
   with DeltaSQLCommandTest {
+  private val UC_CATALOG_URI_CONF_KEY = "spark.sql.catalog.migration_bugbash.uri"
+  private val TEST_CATALOG_NAME = "test_catalog"
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf
@@ -271,11 +272,9 @@ class UpdatePOMetricsHookSuite extends QueryTest
   // Hook lifecycle tests
   // ---------------------------------------------------------------------------
 
-  test("hook disabled by config - skips execution") {
+  test("path-based table writes continue without PO hook registration") {
     withTempDir { dir =>
       val tablePath = dir.getCanonicalPath
-
-      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENABLED.key, "false")
 
       // Create and append - if hook ran it would fail (no endpoint configured)
       spark.range(10).write.format("delta").save(tablePath)
@@ -292,10 +291,8 @@ class UpdatePOMetricsHookSuite extends QueryTest
       mockServer.setResponseCode(500)
       mockServer.start()
 
-      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key,
-        s"http://localhost:${mockServer.getPort()}/metrics")
-      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key, "test-token")
-      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_TIMEOUT_MS.key, "1000")
+      spark.conf.set(UC_CATALOG_URI_CONF_KEY, s"http://localhost:${mockServer.getPort()}")
+      spark.conf.set(s"spark.sql.catalog.$TEST_CATALOG_NAME.token", "test-token")
 
       val request = ReportDeltaMetricsRequest(
         tableId = "test-id",
@@ -303,7 +300,7 @@ class UpdatePOMetricsHookSuite extends QueryTest
       )
       // Client should throw on 5xx; the hook catches and logs this as a warning
       intercept[RuntimeException] {
-        POMetricsClient.sendMetrics(spark, request)
+        POMetricsClient.sendMetrics(spark, request, catalogName = Some(TEST_CATALOG_NAME))
       }
       assert(mockServer.getRequestCount() == 1, "Expected 1 HTTP request even on error")
     } finally {
@@ -317,10 +314,8 @@ class UpdatePOMetricsHookSuite extends QueryTest
       mockServer.setResponseCode(200)
       mockServer.start()
 
-      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key,
-        s"http://localhost:${mockServer.getPort()}/metrics")
-      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key, "test-token-123")
-      spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_TIMEOUT_MS.key, "5000")
+      spark.conf.set(UC_CATALOG_URI_CONF_KEY, s"http://localhost:${mockServer.getPort()}")
+      spark.conf.set(s"spark.sql.catalog.$TEST_CATALOG_NAME.token", "test-token-123")
 
       val request = ReportDeltaMetricsRequest(
         tableId = "abc-123",
@@ -330,7 +325,7 @@ class UpdatePOMetricsHookSuite extends QueryTest
           numRowsInserted = Some(100L)
         ))
       )
-      POMetricsClient.sendMetrics(spark, request)
+      POMetricsClient.sendMetrics(spark, request, catalogName = Some(TEST_CATALOG_NAME))
 
       assert(mockServer.getRequestCount() == 1, "Expected 1 HTTP request")
 
@@ -363,10 +358,8 @@ class UpdatePOMetricsHookSuite extends QueryTest
         val deltaLog = DeltaLog.forTable(spark, dir.getCanonicalPath)
         val snapshot = deltaLog.snapshot
 
-        spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENABLED.key, "true")
-        spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key,
-          s"http://localhost:${mockServer.getPort()}/metrics")
-        spark.conf.set(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key, "smoke-token")
+        spark.conf.set(UC_CATALOG_URI_CONF_KEY, s"http://localhost:${mockServer.getPort()}")
+        spark.conf.set("spark.sql.catalog.spark_catalog.token", "smoke-token")
 
         // catalog identifier causes isUCManagedTable to return true
         val catalogTable = CatalogTable(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -448,11 +448,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
   registerPostCommitHook(ChecksumHook)
   catalogTable.foreach { ct =>
     registerPostCommitHook(UpdateCatalogFactory.getUpdateCatalogHook(ct, spark))
-
-    // Register PO metrics hook for UC-managed tables
-    if (spark.conf.get(DeltaSQLConf.DELTA_PO_METRICS_ENABLED)) {
-      registerPostCommitHook(UpdatePOMetricsHook(Some(ct)))
-    }
+    registerPostCommitHook(UpdatePOMetricsHook(Some(ct)))
   }
   // The CheckpointHook will only checkpoint if necessary, so always register it to run.
   registerPostCommitHook(CheckpointHook)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/POMetricsClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/POMetricsClient.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.hooks
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.http.HttpHeaders
@@ -89,6 +88,11 @@ case class FileSizeHistogramPayload(
  *  4. Forward the metrics to PO via PredictiveOptimizationClient.pushExternalDeltaCommitMetrics
  */
 object POMetricsClient {
+  private val UC_CATALOG_URI_CONF_KEY = "spark.sql.catalog.migration_bugbash.uri"
+  private val CATALOG_TOKEN_CONF_PREFIX = "spark.sql.catalog."
+  private val CATALOG_TOKEN_CONF_SUFFIX = ".token"
+  private val PO_METRICS_ENDPOINT_SUFFIX = "/api/2.1/unity-catalog/delta/preview/metrics"
+  private val HTTP_TIMEOUT_MS = 5000L
 
   /**
    * Sends commit metrics to the PO endpoint synchronously.
@@ -97,15 +101,17 @@ object POMetricsClient {
    * @param request The fully-constructed request payload
    * @throws Exception if the HTTP request fails (caller should catch and log)
    */
-  def sendMetrics(spark: SparkSession, request: ReportDeltaMetricsRequest): Unit = {
+  def sendMetrics(
+      spark: SparkSession,
+      request: ReportDeltaMetricsRequest,
+      catalogName: Option[String] = None): Unit = {
     val endpointUrl = getEndpointUrl(spark)
-    val authToken = getAuthToken(spark)
-    val timeoutMs = getTimeoutMs(spark)
+    val authToken = getAuthToken(spark, catalogName)
 
     val requestConfig = RequestConfig.custom()
-      .setConnectTimeout(timeoutMs.toInt)
-      .setSocketTimeout(timeoutMs.toInt)
-      .setConnectionRequestTimeout(timeoutMs.toInt)
+      .setConnectTimeout(HTTP_TIMEOUT_MS.toInt)
+      .setSocketTimeout(HTTP_TIMEOUT_MS.toInt)
+      .setConnectionRequestTimeout(HTTP_TIMEOUT_MS.toInt)
       .build()
 
     val httpClient: CloseableHttpClient = HttpClientBuilder.create()
@@ -141,28 +147,32 @@ object POMetricsClient {
   }
 
   private def getEndpointUrl(spark: SparkSession): String = {
-    spark.conf.getOption(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key) match {
-      case Some(url) if url.nonEmpty => url
+    spark.conf.getOption(UC_CATALOG_URI_CONF_KEY) match {
+      case Some(uri) if uri.nonEmpty =>
+        s"${uri.stripSuffix("/")}$PO_METRICS_ENDPOINT_SUFFIX"
       case _ =>
-        val key = DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key
+        val key = UC_CATALOG_URI_CONF_KEY
         throw new IllegalArgumentException(
-          s"PO metrics endpoint URL not configured. Set $key")
+          s"UC catalog base URI not configured. Set $key")
     }
   }
 
-  private def getAuthToken(spark: SparkSession): String = {
-    spark.conf.getOption(DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key)
-      .orElse(Option(System.getenv("DATABRICKS_TOKEN"))) match {
+  private def getAuthToken(spark: SparkSession, catalogName: Option[String]): String = {
+    val token = catalogName
+      .map(name => s"$CATALOG_TOKEN_CONF_PREFIX$name$CATALOG_TOKEN_CONF_SUFFIX")
+      .flatMap(spark.conf.getOption)
+      .filter(_.nonEmpty)
+
+    token match {
       case Some(token) if token.nonEmpty => token
       case _ =>
-        val key = DeltaSQLConf.DELTA_PO_METRICS_AUTH_TOKEN.key
+        val keyHint = catalogName
+          .map(name => s"$CATALOG_TOKEN_CONF_PREFIX$name$CATALOG_TOKEN_CONF_SUFFIX")
+          .getOrElse(
+          s"$CATALOG_TOKEN_CONF_PREFIX<catalog>$CATALOG_TOKEN_CONF_SUFFIX")
         throw new IllegalArgumentException(
-          s"PO metrics auth token not configured. Set $key or " +
-          "DATABRICKS_TOKEN environment variable")
+          s"PO metrics auth token not configured. Set $keyHint")
     }
   }
 
-  private def getTimeoutMs(spark: SparkSession): Long = {
-    spark.conf.get(DeltaSQLConf.DELTA_PO_METRICS_TIMEOUT_MS)
-  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdatePOMetricsHook.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.FileSizeHistogram
 
 import org.apache.spark.internal.MDC
@@ -76,14 +75,7 @@ case class UpdatePOMetricsHook(catalogTable: Option[CatalogTable])
   )
 
   override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
-    if (!spark.conf.get(DeltaSQLConf.DELTA_PO_METRICS_ENABLED)) return
-
     if (!isUCManagedTable(txn.deltaLog, catalogTable)) return
-
-    if (!spark.conf.getOption(DeltaSQLConf.DELTA_PO_METRICS_ENDPOINT.key).exists(_.nonEmpty)) {
-      logInfo("PO metrics endpoint not configured, skipping")
-      return
-    }
 
     try {
       val tableId = resolveTableId(catalogTable, txn.deltaLog)
@@ -92,7 +84,8 @@ case class UpdatePOMetricsHook(catalogTable: Option[CatalogTable])
       }
 
       val request = buildRequest(tableId, txn.committedActions, txn.committedVersion)
-      POMetricsClient.sendMetrics(spark, request)
+      val catalogName = catalogTable.flatMap(_.identifier.catalog)
+      POMetricsClient.sendMetrics(spark, request, catalogName = catalogName)
 
       logInfo(
         log"Successfully sent PO metrics for table " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -127,35 +127,6 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
-  val DELTA_PO_METRICS_ENABLED =
-    buildConf("po.metrics.enabled")
-      .internal()
-      .doc("When true, commit metrics are sent to the PO endpoint for UC-managed tables.")
-      .booleanConf
-      .createWithDefault(false)
-
-  val DELTA_PO_METRICS_ENDPOINT =
-    buildConf("po.metrics.endpoint")
-      .internal()
-      .doc("Base URL for the Unity Catalog PO metrics endpoint.")
-      .stringConf
-      .createOptional
-
-  val DELTA_PO_METRICS_AUTH_TOKEN =
-    buildConf("po.metrics.authToken")
-      .internal()
-      .doc("Bearer token for authenticating to the PO metrics endpoint. " +
-        "Falls back to DATABRICKS_TOKEN env var if not set.")
-      .stringConf
-      .createOptional
-
-  val DELTA_PO_METRICS_TIMEOUT_MS =
-    buildConf("po.metrics.timeoutMs")
-      .internal()
-      .doc("HTTP request timeout for PO metrics endpoint calls (milliseconds).")
-      .longConf
-      .createWithDefault(5000L)
-
   val DELTA_CONVERT_USE_METADATA_LOG =
     buildConf("convert.useMetadataLog")
       .doc(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6154/files/2eed19ba7ab5e0403832cf0d3ecb985609236234..466e4e0bdcf0713321c4cc026b2bd59f4354a717) to review incremental changes.

**Stack:**
- [[External Access PO Metrics] Add core PO metrics post-commit hook and tests](https://github.com/delta-io/delta/pull/6152) [[Files changed](https://github.com/delta-io/delta/pull/6152/files)]
  - [[External Access PO Metrics] Harden UC table ID resolution for PO metrics](https://github.com/delta-io/delta/pull/6153) [[Files changed](https://github.com/delta-io/delta/pull/6153/files/b329f0c72be63df7cf53e30ca79143c8a710d072..2eed19ba7ab5e0403832cf0d3ecb985609236234)]
    - **[[External Access PO Metrics] Apply prototype defaults for endpoint, auth, and timeout](https://github.com/delta-io/delta/pull/6154)** [[Files changed](https://github.com/delta-io/delta/pull/6154/files/2eed19ba7ab5e0403832cf0d3ecb985609236234..466e4e0bdcf0713321c4cc026b2bd59f4354a717)] ⬅️ _This PR_

---

## Summary
- remove client-side PO metrics enable/endpoint/timeout confs in favor of prototype defaults
- derive endpoint from `spark.sql.catalog.migration_bugbash.uri` + fixed PO metrics suffix
- reuse `spark.sql.catalog.<catalog>.token` for auth and hardcode timeout to 5000ms

## Test plan
- [x] build/sbt \"spark/testOnly *UpdatePOMetricsHookSuite\"