### PR TITLE
[Delta-Spark] Extend stagingCatalog for non-Spark session catalog

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -251,7 +251,10 @@ class DeltaAnalysis(session: SparkSession)
           protocol
       }
       val newDeltaCatalog = new DeltaCatalogV1()
-      val existingTableOpt = newDeltaCatalog.getExistingTableIfExists(catalogTableTarget.identifier)
+      val existingTableOpt = newDeltaCatalog.getExistingTableIfExists(
+        catalogTableTarget.identifier,
+        identOpt = None,
+        operation = TableCreationModes.Create)
       val newTable = newDeltaCatalog
         .verifyTableAndSolidify(
           catalogTableTarget,
@@ -1583,4 +1586,3 @@ case class DeltaDynamicPartitionOverwriteCommand(
     ).run(sparkSession)
   }
 }
-

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -574,6 +574,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       "Cannot update the metadata in a transaction that has already written data.")
     assert(newMetadata.isEmpty,
       "Cannot change the metadata more than once in a transaction.")
+    updateMetadataInternal(proposedNewMetadata, ignoreDefaultProperties)
     // Temporary: block metadata changes on UC-managed CatalogOwned tables until Delta supports
     // propagating metadata updates to UC. UC is identified by catalog implementation class (handles
     // "spark_catalog" registration). New table creation is naturally excluded because
@@ -583,16 +584,36 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // catches Delta-internal additions (e.g. table-feature flags). This is acceptable for
     // a temporary kill switch - once Delta supports propagating metadata updates to UC,
     // this check will be removed entirely.
-    val existingMetadata = snapshot.metadata
-    if (isUCManagedTable &&
-        (proposedNewMetadata.schemaString != existingMetadata.schemaString ||
-         proposedNewMetadata.partitionColumns != existingMetadata.partitionColumns ||
-         proposedNewMetadata.description != existingMetadata.description ||
-         proposedNewMetadata.configuration != existingMetadata.configuration)) {
+    if (!isCreatingNewTable) {
+      throwIfUCManagedMetadataChanged(snapshot.metadata, context = "updateMetadata")
+    }
+  }
+
+  /**
+   * Returns true if the proposed metadata differs from the existing metadata for a UC-managed
+   * table.
+   */
+  private def hasUCManagedMetadataChange(
+      existingMetadata: Metadata,
+      proposedMetadata: Metadata): Boolean = {
+    proposedMetadata.schemaString != existingMetadata.schemaString ||
+      proposedMetadata.partitionColumns != existingMetadata.partitionColumns ||
+      proposedMetadata.description != existingMetadata.description ||
+      proposedMetadata.configuration != existingMetadata.configuration
+  }
+
+  private def throwIfUCManagedMetadataChanged(
+      existingMetadata: Metadata,
+      context: String): Unit = {
+    val proposedMetadata = newMetadata.getOrElse(existingMetadata)
+    if (isUCManagedTable && hasUCManagedMetadataChange(existingMetadata, proposedMetadata)) {
+      logWarning(log"Blocking UC-managed metadata update during " +
+        log"${MDC(DeltaLogKeys.OPERATION, context)} because metadata changed: " +
+        log"${MDC(DeltaLogKeys.METADATA_OLD, existingMetadata)} => " +
+        log"${MDC(DeltaLogKeys.METADATA_NEW, proposedMetadata)}")
       throw DeltaErrors.operationNotSupportedException(
         "Metadata changes on Unity Catalog managed tables")
     }
-    updateMetadataInternal(proposedNewMetadata, ignoreDefaultProperties)
   }
 
   /**
@@ -928,6 +949,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       CoordinatedCommitsUtils.getExplicitCCConfigurations(snapshot.metadata.configuration)
     val existingICTConfs =
       CoordinatedCommitsUtils.getExplicitICTConfigurations(snapshot.metadata.configuration)
+    val existingQoLConfs =
+      CoordinatedCommitsUtils.getExplicitQoLConfigurations(snapshot.metadata.configuration)
     val oldMappingMode = snapshot.metadata.columnMappingMode
     val newMappingMode = metadata.columnMappingMode
     val shouldReuseColumnMetadataForReplaceTable =
@@ -943,8 +966,11 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // to remove them and retain the Coordinated Commits configurations from the existing table.
     val newConfsWithoutCC = newMetadata.get.configuration --
       CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS
-    var newConfs: Map[String, String] = newConfsWithoutCC ++ existingCCConfs ++
-      existingUCTableIdConf
+    val existingQoLConfsToRetain = existingQoLConfs.filterNot { case (key, _) =>
+      newConfsWithoutCC.contains(key)
+    }
+    var newConfs: Map[String, String] =
+      newConfsWithoutCC ++ existingCCConfs ++ existingQoLConfsToRetain ++ existingUCTableIdConf
     // We also need to retain the existing ICT dependency configurations, but only when the
     // existing table does have Coordinated Commits configurations or Catalog-Owned enabled.
     // Otherwise, we treat the ICT configurations the same as any other configurations,
@@ -956,6 +982,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
       newConfs = newConfsWithoutICT ++ existingICTConfs
     }
     newMetadata = Some(newMetadata.get.copy(configuration = newConfs))
+    throwIfUCManagedMetadataChanged(
+      snapshot.metadata,
+      context = "updateMetadataForNewTableInReplace")
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -155,10 +155,20 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       Option(allTableProperties.get("location"))
     }
     val id = {
-      TableIdentifier(ident.name(), ident.namespace().lastOption)
+      // Preserve the catalog name in the V1 identifier for Unity Catalog because this `id`
+      // becomes `tableDesc.identifier` for the rest of the create/replace flow. Downstream
+      // catalog-update logic reads `table.identifier.catalog`; without it, the table looks like
+      // an unqualified V1 table and catalog updates route through the current/session catalog
+      // instead of the delegated Unity Catalog entry.
+      val base = TableIdentifier(ident.name(), ident.namespace().lastOption)
+      if (isUnityCatalog) {
+        base.copy(catalog = Some(name())) // `name()` here is the catalog name.
+      } else {
+        base
+      }
     }
     var locUriOpt = location.map(CatalogUtils.stringToURI)
-    val existingTableOpt = getExistingTableIfExists(id)
+    val existingTableOpt = getExistingTableIfExists(id, Some(ident), operation)
     // PROP_IS_MANAGED_LOCATION indicates that the table location is not user-specified but
     // system-generated. The table should be created as managed table in this case.
     val isManagedLocation = Option(allTableProperties.get(TableCatalog.PROP_IS_MANAGED_LOCATION))
@@ -558,8 +568,19 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       properties = validatedConfigurations)
   }
 
-  /** Checks if a table already exists for the provided identifier. */
-  def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+  /**
+   * Checks if a Delta table already exists for the provided identifier.
+   *
+   * This first goes through the legacy V1 SessionCatalog/HMS lookup using [[TableIdentifier]].
+   * For operations that target an existing Unity Catalog table, it then falls back to the
+   * delegated V2 catalog plugin lookup (for example Unity Catalog) when the V1 lookup does not
+   * surface the table entry.
+   */
+  def getExistingTableIfExists(
+      table: TableIdentifier,
+      identOpt: Option[Identifier],
+      operation: TableCreationModes.CreationMode)
+      : Option[CatalogTable] = {
     // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
     // will check the file system itself
     if (isPathIdentifier(table)) return None
@@ -573,6 +594,50 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         throw DeltaErrors.notADeltaTable(table.table)
       }
       Some(oldTable)
+    } else if (operation != TableCreationModes.Create) {
+      identOpt match {
+        case Some(ident) => getExistingTableFromDelegatedCatalog(ident)
+        case None =>
+          logDebug(log"Delegated catalog lookup skipped because no V2 identifier was provided " +
+            log"for ${MDC(DeltaLogKeys.TABLE_NAME, table)} during ${MDC(DeltaLogKeys.OPERATION,
+              operation.toString)}.")
+          None
+      }
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Returns an existing Delta table by querying the delegated catalog for Unity Catalog paths
+   * where the V1 SessionCatalog lookup does not surface the existing table entry.
+   *
+   * [[getExistingTableIfExists]] first checks the V1 catalog using a [[TableIdentifier]]. For
+   * Unity Catalog, some staged create/replace paths need a delegated V2 catalog lookup on the
+   * original [[Identifier]] to recover the existing table metadata.
+   *
+   * Even though this goes through the delegated V2 catalog plugin, Spark can still surface the
+   * result as a [[V1Table]] wrapper when the delegated catalog is exposing V1-backed table
+   * metadata. In that case we unwrap the embedded [[CatalogTable]] and continue on the V1 Delta
+   * path.
+   */
+  private def getExistingTableFromDelegatedCatalog(ident: Identifier): Option[CatalogTable] = {
+    if (isUnityCatalog) {
+      try {
+        super.loadTable(ident) match {
+          case v1: V1Table if DeltaTableUtils.isDeltaTable(v1.catalogTable) =>
+            Some(v1.catalogTable)
+          case _ =>
+            logDebug(log"Delegated catalog lookup for ${MDC(DeltaLogKeys.TABLE_NAME, ident)} " +
+              log"did not return a Delta table.")
+            None
+        }
+      } catch {
+        case _: NoSuchTableException =>
+          logDebug(log"Delegated catalog lookup did not find an existing table for " +
+            log"${MDC(DeltaLogKeys.TABLE_NAME, ident)}.")
+          None
+      }
     } else {
       None
     }
@@ -617,11 +682,11 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   }
 
   /**
-   * The UC table ID property was renamed from an old name. In a transition period we need to
-   * translate the old UC table ID property name set by caller to new one. And in case both the new
-   * and old properties are set, remove the old one. Later in UC server it might throw error if it
-   * sees both.
-   * TODO: clean up once callers are migrated.
+   * Normalizes the deprecated UC table ID property key to the canonical key.
+   *
+   * This is temporary compatibility for callers that still send the old key during the rename
+   * transition. If both keys are present, we drop the old one and keep the canonical key only.
+   * TODO(issue #6296): remove once all callers stop sending the deprecated key.
    */
   private def translateUCTableIdProperty(props: util.Map[String, String]): Unit = {
     val oldTableIdProperty = Option(props.remove(UC_TABLE_ID_KEY_OLD))
@@ -654,6 +719,11 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         writeOptions = sqlWriteOptions
       }
       expandTableProps(props, writeOptions, conf)
+      if (isUnityCatalog) {
+        // Unity Catalog callers may still send the deprecated `ucTableId` property key.
+        // Normalize it here to the canonical `io.unitycatalog.tableId` key before create/replace.
+        translateUCTableIdProperty(props)
+      }
       createDeltaTable(
         ident,
         schema,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -786,6 +786,11 @@ case class CreateDeltaTableCommand(
         newMetadata.configuration,
         txn.snapshot)
       newMetadata = newMetadata.copy(configuration = updatedConfig)
+      if (allowCatalogManaged && txn.snapshot.isCatalogOwned) {
+        // Preserve the existing Delta metadata id across REPLACE. This is distinct from the
+        // Unity Catalog table id stored in `io.unitycatalog.tableId`.
+        newMetadata = newMetadata.copy(id = txn.snapshot.metadata.id)
+      }
       txn.updateMetadataForNewTableInReplace(newMetadata)
     }
   }
@@ -802,7 +807,7 @@ case class CreateDeltaTableCommand(
       deltaLog: DeltaLog,
       tableWithLocation: CatalogTable,
       snapshotOpt: Option[Snapshot] = None): OptimisticTransaction = {
-    val txn = deltaLog.startTransaction(None, snapshotOpt)
+    val txn = deltaLog.startTransaction(existingTableOpt, snapshotOpt)
     validatePrerequisitesForClusteredTable(txn.snapshot.protocol, txn.deltaLog)
 
     // During CREATE (not REPLACE/overwrites), we synchronously run conversion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
@@ -107,15 +107,26 @@ trait CreateDeltaTableLike extends SQLConfHelper {
         }
       case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
         if existingTableOpt.isDefined =>
-        UpdateCatalogFactory.getUpdateCatalogHook(table, spark).updateSchema(spark, snapshot)
+        // Catalog-managed / CC tables are owned by the delegated V2 catalog plugin (for example
+        // Unity Catalog), so SessionCatalog's post-commit UpdateCatalogHook must not run.
+        if (!allowCatalogManaged) {
+          UpdateCatalogFactory.getUpdateCatalogHook(table, spark).updateSchema(spark, snapshot)
+        }
       case TableCreationModes.Replace =>
         val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
         throw DeltaErrors.cannotReplaceMissingTableException(ident)
       case TableCreationModes.CreateOrReplace =>
-      spark.sessionState.catalog.createTable(
-        cleaned,
-        ignoreIfExists = false,
-        validateLocation = false)
+        createTableFunc match {
+          case Some(createFunc) =>
+            // This is the new missing-table path where creation is delegated through the V2
+            // catalog plugin (for example Unity Catalog) instead of SessionCatalog.createTable().
+            createFunc(cleaned)
+          case None =>
+            spark.sessionState.catalog.createTable(
+              cleaned,
+              ignoreIfExists = false,
+              validateLocation = false)
+        }
     }
     if (conf.getConf(DeltaSQLConf.HMS_FORCE_ALTER_TABLE_DATA_SCHEMA)) {
       spark.sessionState.catalog.alterTableDataSchema(cleaned.identifier, cleaned.schema)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -772,6 +772,18 @@ object CoordinatedCommitsUtils extends DeltaLogging {
   }
 
   /**
+   * Extracts the explicit QoL configurations from the provided properties.
+   *
+   * These are preserved across catalog-managed REPLACE when the existing table already has the
+   * QoL defaults materialized in metadata, so a no-op REPLACE does not accidentally drop them
+   * while rebuilding the configuration map.
+   */
+  def getExplicitQoLConfigurations(properties: Map[String, String]): Map[String, String] = {
+    val qolKeys = CatalogOwnedTableUtils.QOL_TABLE_FEATURES_AND_PROPERTIES.map(_._2.key).toSet
+    properties.filter { case (k, _) => qolKeys.contains(k) }
+  }
+
+  /**
    * Fetches the SparkSession default configurations for ICT. The `withDefaultKey`
    * flag controls whether the keys in the returned map should have the default prefix or not.
    */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
@@ -17,12 +17,15 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
-import java.net.URI
 import java.util.UUID
 
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
-import org.apache.spark.sql.delta.commands.{CreateDeltaTableCommand, TableCreationModes}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.commands.{
+  CreateDeltaTableCommand,
+  CreateDeltaTableLike,
+  TableCreationModes
+}
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.sql.QueryTest
@@ -35,7 +38,8 @@ import org.apache.spark.sql.types.StructType
 
 class DeltaCreateTableLikeSuite extends QueryTest
   with SharedSparkSession
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with DeltaSQLTestUtils {
 
   def checkTableEmpty(tblName: String): Boolean = {
     val numRows = spark.sql(s"SELECT * FROM $tblName")
@@ -289,7 +293,7 @@ class DeltaCreateTableLikeSuite extends QueryTest
       withTable("t") {
         def getCatalogTable: CatalogTable = {
           val storage = CatalogStorageFormat.empty.copy(
-            locationUri = Some(new URI(s"$dir/${UUID.randomUUID().toString}")))
+            locationUri = Some(dir.toPath.resolve(UUID.randomUUID().toString).toUri))
           val catalogTableTarget = CatalogTable(
             identifier = TableIdentifier("t"),
             tableType = CatalogTableType.MANAGED,
@@ -316,6 +320,102 @@ class DeltaCreateTableLikeSuite extends QueryTest
           query = None,
           operation = TableCreationModes.Create).run(spark)
         assert(spark.sessionState.catalog.tableExists(TableIdentifier("t")))
+      }
+    }
+  }
+
+  test("catalog-managed CREATE OR REPLACE creates missing tables") {
+    withTempDir { dir =>
+      withTable("t") {
+        val storage = CatalogStorageFormat.empty.copy(
+          locationUri = Some(dir.toPath.resolve(UUID.randomUUID().toString).toUri))
+        val catalogTableTarget = CatalogTable(
+          identifier = TableIdentifier("t"),
+          tableType = CatalogTableType.MANAGED,
+          storage = storage,
+          provider = Some("delta"),
+          schema = new StructType().add("id", "long"))
+        val command = CreateDeltaTableCommand(
+          new DeltaCatalog().verifyTableAndSolidify(
+            tableDesc = catalogTableTarget,
+            query = None,
+            maybeClusterBySpec = None),
+          existingTableOpt = None,
+          mode = SaveMode.ErrorIfExists,
+          query = None,
+          operation = TableCreationModes.CreateOrReplace,
+          allowCatalogManaged = true,
+          createTableFunc = None)
+
+        command.run(spark)
+        assert(spark.sessionState.catalog.tableExists(TableIdentifier("t")))
+      }
+    }
+  }
+
+  test("catalog-managed CREATE OR REPLACE skips catalog create callback " +
+      "when metadata is unchanged") {
+    withCatalogManagedTable(createTable = false) { tableName =>
+      spark.sql(
+        s"""CREATE TABLE $tableName (id LONG) USING DELTA
+           |TBLPROPERTIES ('delta.feature.catalogManaged' = 'supported')
+           |""".stripMargin)
+
+      val existingTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
+      val snapshot = DeltaLog.forTable(spark, existingTable).update()
+      var createCallbackCalls = 0
+
+      val command = new CreateDeltaTableLike {
+        override val table: CatalogTable = existingTable
+        override val existingTableOpt: Option[CatalogTable] = Some(existingTable)
+        override val operation: TableCreationModes.CreationMode =
+          TableCreationModes.CreateOrReplace
+        override val mode: SaveMode = SaveMode.ErrorIfExists
+        override val allowCatalogManaged: Boolean = true
+
+        def runUpdateCatalog(): Unit = {
+          updateCatalog(
+            spark,
+            table,
+            snapshot,
+            query = None,
+            didNotChangeMetadata = true,
+            createTableFunc = Some((_: CatalogTable) => {
+              createCallbackCalls += 1
+            }))
+        }
+      }
+
+      command.runUpdateCatalog()
+      assert(createCallbackCalls === 0)
+    }
+  }
+
+  test("catalog-managed CREATE OR REPLACE rejects query-derived nullable schema") {
+    withCatalogManagedTable(createTable = false) { tableName =>
+      withTable("source") {
+        spark.sql(
+          s"""CREATE TABLE $tableName (id LONG NOT NULL) USING DELTA
+             |TBLPROPERTIES ('delta.feature.catalogManaged' = 'supported')
+             |""".stripMargin)
+        spark.sql(s"INSERT INTO $tableName VALUES (1)")
+        spark.sql("CREATE TABLE source (id LONG) USING DELTA")
+        spark.sql("INSERT INTO source VALUES (2)")
+
+        val existingTable =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
+        val versionBefore = DeltaLog.forTable(spark, existingTable).update().version
+        val query = spark.sql("SELECT id FROM source").logicalPlan
+        val err = intercept[AssertionError] {
+          new DeltaCatalog().verifyTableAndSolidify(
+            tableDesc = existingTable.copy(schema = query.schema.asNullable),
+            query = Some(query),
+            maybeClusterBySpec = None)
+        }
+
+        assert(err.getMessage.contains("Can't specify table schema in CTAS."))
+        assert(DeltaLog.forTable(spark, existingTable).update().version === versionBefore)
+        checkAnswer(spark.sql(s"SELECT * FROM $tableName"), Seq(org.apache.spark.sql.Row(1L)))
       }
     }
   }
@@ -370,7 +470,7 @@ class DeltaCreateTableLikeSuite extends QueryTest
   test("CREATE TABLE LIKE where target table is a named external table") {
     val srcTbl = "srcTbl"
     val targetTbl = "targetTbl"
-    withTempDir { dir =>
+    withTempDir(prefix = "sparkdirprefix") { dir =>
       withTable(srcTbl) {
         createTable(srcTbl)
         spark.sql(s"CREATE TABLE $targetTbl LIKE $srcTbl LOCATION '${dir.toURI.toString}'")
@@ -385,7 +485,7 @@ class DeltaCreateTableLikeSuite extends QueryTest
       withTable(srcTbl) {
         createTable(srcTbl)
         spark.sql(s"CREATE TABLE delta.`${dir.toURI.toString}` LIKE $srcTbl")
-        checkTableCopyDelta(srcTbl, dir.toString, checkTargetTableByPath = true
+        checkTableCopyDelta(srcTbl, dir.toURI.toString, checkTargetTableByPath = true
         )
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
@@ -116,6 +116,11 @@ class CatalogOwnedPropertySuite extends QueryTest
     ucTableId.get
   }
 
+  private def getSnapshotVersion(tableName: String): Long = {
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, new TableIdentifier(tableName))
+    snapshot.version
+  }
+
   private def validateInCommitTimestampTableFeature(tableName: String, expected: Boolean): Unit = {
     val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, new TableIdentifier(tableName))
     val writerFeatureNames = snapshot.protocol.writerFeatureNames
@@ -241,6 +246,7 @@ class CatalogOwnedPropertySuite extends QueryTest
       // CatalogManaged enabled table.
       createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
       val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
 
       // Specifying CatalogManaged on an already CatalogManaged table should succeed.
       // The CatalogManaged properties are treated as a no-op.
@@ -251,6 +257,7 @@ class CatalogOwnedPropertySuite extends QueryTest
       validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
       val ucTableIdAfter = getUCTableIdFromTable(tableName = "t1")
       assert(ucTableIdBefore === ucTableIdAfter)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore + 1)
     }
   }
 
@@ -280,6 +287,7 @@ class CatalogOwnedPropertySuite extends QueryTest
       // CatalogManaged enabled table.
       createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
       val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
 
       // Source RTAS table.
       createTableAndValidateCatalogOwned(tableName = "t2", withCatalogOwned = false)
@@ -294,6 +302,48 @@ class CatalogOwnedPropertySuite extends QueryTest
       validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
       val ucTableIdAfter = getUCTableIdFromTable(tableName = "t1")
       assert(ucTableIdBefore === ucTableIdAfter)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore + 1)
+      checkAnswer(sql("SELECT * FROM t1"), Seq(Row(1), Row(2)))
+    }
+  }
+
+  test("[RTAS] failed replace preserves existing catalog-managed table data and version") {
+    withTable("t1") {
+      createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
+      val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
+      sql("INSERT INTO t1 VALUES (1), (2)")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
+
+      intercept[Exception] {
+        sql(
+          """REPLACE TABLE t1 USING delta AS
+            |SELECT IF(id = 2L, CAST(raise_error('boom') AS BIGINT), id) AS id
+            |FROM VALUES (1L), (2L) AS src(id)
+            |""".stripMargin)
+      }
+
+      validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
+      assert(getUCTableIdFromTable(tableName = "t1") === ucTableIdBefore)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore)
+      checkAnswer(sql("SELECT * FROM t1"), Seq(Row(1), Row(2)))
+    }
+  }
+
+  test("[RTAS] replacing an existing catalog-managed table preserves UC identity") {
+    withTable("t1", "t2") {
+      createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
+      val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
+      sql("INSERT INTO t1 VALUES (10)")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
+
+      createTableAndValidateCatalogOwned(tableName = "t2", withCatalogOwned = false)
+      sql("INSERT INTO t2 VALUES (1), (2)")
+
+      sql("REPLACE TABLE t1 USING delta AS SELECT * FROM t2")
+
+      validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
+      assert(getUCTableIdFromTable(tableName = "t1") === ucTableIdBefore)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore + 1)
       checkAnswer(sql("SELECT * FROM t1"), Seq(Row(1), Row(2)))
     }
   }
@@ -319,6 +369,7 @@ class CatalogOwnedPropertySuite extends QueryTest
       createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
       val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
       sql("INSERT INTO t1 VALUES (1)")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
 
       // CREATE OR REPLACE with CatalogManaged on existing CatalogManaged table should succeed.
       sql("CREATE OR REPLACE TABLE t1 (id LONG) USING delta TBLPROPERTIES " +
@@ -328,6 +379,65 @@ class CatalogOwnedPropertySuite extends QueryTest
       validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
       val ucTableIdAfter = getUCTableIdFromTable(tableName = "t1")
       assert(ucTableIdBefore === ucTableIdAfter)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore + 1)
+    }
+  }
+
+  test("[CREATE OR REPLACE] replacing an existing catalog-managed table is atomic") {
+    withTable("t1") {
+      createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
+      val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
+      sql("INSERT INTO t1 VALUES (1)")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
+
+      sql("CREATE OR REPLACE TABLE t1 USING delta TBLPROPERTIES " +
+        s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported') AS " +
+        "SELECT 2 AS id")
+
+      validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
+      assert(getUCTableIdFromTable(tableName = "t1") === ucTableIdBefore)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore + 1)
+      checkAnswer(sql("SELECT * FROM t1"), Seq(Row(2)))
+    }
+  }
+
+  test("[REPLACE] replacing an existing catalog-managed table preserves UC identity") {
+    withTable("t1") {
+      createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
+      val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
+      sql("INSERT INTO t1 VALUES (1)")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
+
+      sql("REPLACE TABLE t1 (id LONG) USING delta")
+
+      validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
+      assert(getUCTableIdFromTable(tableName = "t1") === ucTableIdBefore)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore + 1)
+      checkAnswer(sql("SELECT * FROM t1"), Seq.empty)
+    }
+  }
+
+  test("[CREATE OR REPLACE] specifying table UUID for existing catalog-managed table " +
+      "should be blocked") {
+    withTable("t1") {
+      createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = true)
+      val ucTableIdBefore = getUCTableIdFromTable(tableName = "t1")
+      sql("INSERT INTO t1 VALUES (1)")
+      val versionBefore = getSnapshotVersion(tableName = "t1")
+
+      val error = intercept[DeltaUnsupportedOperationException] {
+        sql("CREATE OR REPLACE TABLE t1 USING delta TBLPROPERTIES " +
+          s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported', " +
+          s"'${UCCommitCoordinatorClient.UC_TABLE_ID_KEY}' = '${UUID.randomUUID().toString}') " +
+          "AS SELECT 2 AS id")
+      }
+      checkError(error, "DELTA_CANNOT_MODIFY_TABLE_PROPERTY", "42939",
+        Map("prop" -> "io.unitycatalog.tableId"))
+
+      validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
+      assert(getUCTableIdFromTable(tableName = "t1") === ucTableIdBefore)
+      assert(getSnapshotVersion(tableName = "t1") === versionBefore)
+      checkAnswer(sql("SELECT * FROM t1"), Seq(Row(1)))
     }
   }
 
@@ -352,7 +462,7 @@ class CatalogOwnedPropertySuite extends QueryTest
     }
   }
 
-  test("[CREATE OR REPLACE] continuous CREATE OR REPLACE with CatalogManaged " +
+  test("[CREATE OR REPLACE] repeated same-schema CREATE OR REPLACE with CatalogManaged " +
       "should succeed repeatedly") {
     withTable("t1") {
       // First CREATE OR REPLACE creates the table.
@@ -372,16 +482,16 @@ class CatalogOwnedPropertySuite extends QueryTest
       val ucTableIdSecond = getUCTableIdFromTable(tableName = "t1")
       assert(ucTableIdFirst === ucTableIdSecond)
 
-      // Third CREATE OR REPLACE should also succeed.
-      sql("CREATE OR REPLACE TABLE t1 (id LONG, name STRING) USING delta TBLPROPERTIES " +
+      // Third CREATE OR REPLACE should also succeed when the metadata is unchanged.
+      sql("CREATE OR REPLACE TABLE t1 (id LONG) USING delta TBLPROPERTIES " +
         s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
       validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
       val ucTableIdThird = getUCTableIdFromTable(tableName = "t1")
       assert(ucTableIdFirst === ucTableIdThird)
 
       // Verify table is functional.
-      sql("INSERT INTO t1 VALUES (1, 'a'), (2, 'b')")
-      checkAnswer(sql("SELECT * FROM t1"), Seq(Row(1, "a"), Row(2, "b")))
+      sql("INSERT INTO t1 VALUES (2)")
+      checkAnswer(sql("SELECT * FROM t1"), Seq(Row(2)))
     }
   }
   test("[CREATE LIKE] Specifying table UUID should be blocked") {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -71,6 +71,12 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
   /** Key used to identify the write version in protocol communications with the UC server. */
   private static final String WRITE_VERSION_KEY = "writeVersion";
 
+  /**
+   * Temporary kill switch for sending metadata updates through UC from the Spark path.
+   * TODO(issue #6296): remove once metadata updates are supported end-to-end.
+   */
+  private static final boolean SHOULD_PASS_METADATA_TO_UC = false;
+
   // Unity Catalog Identifiers
   /**
    * Key for identifying Unity Catalog table ID in `delta.coordinatedCommits.tableConf{-preview}`.
@@ -429,7 +435,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           Optional.of(commitTimestamp),
           Optional.of(lastKnownBackfilledVersion.get()),
           disown,
-          updatedActions.getNewMetadata() == updatedActions.getOldMetadata() ?
+          updatedActions.getNewMetadata() == updatedActions.getOldMetadata() || !SHOULD_PASS_METADATA_TO_UC ?
             Optional.empty() :
             Optional.of(updatedActions.getNewMetadata()),
           updatedActions.getNewProtocol() == updatedActions.getOldProtocol() ?


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6166/files) to review incremental changes.
- [**atomic-rtas**](https://github.com/delta-io/delta/pull/6166) [[Files changed](https://github.com/delta-io/delta/pull/6166/files)]
  - [atomic-rtas-ci](https://github.com/delta-io/delta/pull/6233) [[Files changed](https://github.com/delta-io/delta/pull/6233/files/a85f6ff586dc587fa09bfc3f94b0b930631a40a9..0606404eb15233b4744f487a4cba428baf6a3118)]

---------
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
**Unity Catalog side PR:** https://github.com/unitycatalog/unitycatalog/pull/1373

Currently, `REPLACE TABLE` and `REPLACE TABLE AS SELECT` through the `stagingTable` only works for the default Spark Session Catalog (HMS for OSS). However, we want to make this REPLACE path be able to talk to non-Spark session catalogs such as UC.

This PR enables this communication to non-Spark session catalogs.

We configure the spark shell like this:
```sh
"$SPARK_HOME/bin/spark-shell" --master "local[*]" \
  --jars "$KERNEL_UC_JAR" \
  --packages "$DELTA_PKGS" \
  --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
  --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
  --conf "spark.sql.catalog.main=io.unitycatalog.spark.UCSingleCatalog" \
  --conf "spark.sql.catalog.main.uri=${UC_URI%/}" \
  --conf "spark.sql.catalog.main.token=${UC_TOKEN}" \
  --conf "spark.sql.defaultCatalog=main" \
```

**note:** the `"spark.sql.catalog.main=io.unitycatalog.spark.UCSingleCatalog"`

if we run the following REPLACE operation
```sql
REPLACE TABLE main.demo_zh.t_rtas USING DELTA
TBLPROPERTIES ('delta.feature.catalogManaged'='supported')
AS SELECT 2 AS i, 'new' AS s;
```
this operation will fail because it is not looking at the specified catalog `main`. See here where it tries to get the existing table we want to replace: [AbstractDeltaCatalog.scala#L161](https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala#L161)
```scala
    val existingTableOpt = getExistingTableIfExists(id)
```

and it is asking `catalog: SessionCatalog` for this information: https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala#L991
```scala
  protected lazy val catalog: SessionCatalog = spark.sessionState.catalog
```

So this PR ensures that if the `SessionCatalog` doesn't have the CatalogTable information of the table we want to replace, it will query `UCProxy` -> UC server for this information (containing tableId, location, credentials).
> it asks the delegated catalog to materialize the existing target as a CatalogTable, and then uses that existing table metadata to drive replace.

Then, with a CatalogTable filled with the properties like tableId, location, credentials, it can perform the remaining operations for REPLACE.

**TLDR:** Enable staged Delta `REPLACE TABLE`, `REPLACE TABLE AS SELECT`, and `CREATE OR REPLACE TABLE` to resolve the existing target from delegated catalogs such as Unity Catalog when `SessionCatalog` is insufficient, and preserve existing UC table metadata/location during replace, including a narrow UC external Delta replace path.

## How was this patch tested?
 - Preserve UC-managed table identity across REPLACE, RTAS, and CREATE OR REPLACE.
 - Route existing-table replace flows through the delegated catalog instead of falling back to the V1 session catalog.
 - Block illegal UC-managed metadata changes while allowing same-metadata replace operations.
 - Preserve catalog-owned / coordinated-commit state that must survive managed replace.
 - Add repo-local coverage for managed replace atomicity, identity preservation, and kill-switch behavior.

## Does this PR introduce _any_ user-facing changes?

Yes.

Compared to the target branch, existing catalog-managed Delta tables can now support atomic data-only replace without redefining table metadata. Metadata-changing replace remains unsupported, and `CREATE OR REPLACE TABLE` on a missing catalog-managed table now fails instead of behaving like create.

