### PR TITLE
Call out that deletion vectors are supported in IcebergCompatv3

### DIFF
--- a/protocol_rfcs/iceberg-compat-v3.md
+++ b/protocol_rfcs/iceberg-compat-v3.md
@@ -22,6 +22,8 @@ To support this feature:
 
 This table feature is enabled when the table property `delta.enableIcebergCompatV3` is set to `true`.
 
+> **NOTE:** Unlike IcebergCompatV1 and IcebergCompatV2, this feature does _NOT_ forbid supporting and enabling Deletion Vectors on the table.
+
 ## Writer Requirements for IcebergCompatV3
 
 When this feature is supported and enabled, writers must:
@@ -37,5 +39,3 @@ When this feature is supported and enabled, writers must:
 - Block replacing partitioned tables with a differently-named partition spec
   - e.g. replacing a table partitioned by `part_a INT` with partition spec `part_b INT` must be blocked
   - e.g. replacing a table partitioned by `part_a INT` with partition spec `part_a LONG` is allowed
-
-> **NOTE:** Unlike IcebergCompatV1 and IcebergCompatV2, this feature does _NOT_ forbid supporting and enabling Deletion Vectors on the table.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (fill in here) RFC

## Description

RFC change to call out that deletion vectors are supported (but not required) in IcebergCompatv3

## How was this patch tested?
N/A

## Does this PR introduce _any_ user-facing changes?

No