### PR TITLE
docs: add timestamp_ntz type name to protocol documentation

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1584,11 +1584,12 @@ The identifiers for the nested fields are stored in the metadata as follows:
 ]
 ```
 # Timestamp without timezone (TimestampNtz)
-This feature introduces a new data type to support timestamps without timezone information. For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456`.
+This feature introduces a new data type (`timestamp_ntz`) to support timestamps without timezone information. For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456`.
+The type name used in JSON schema serialization is `timestamp_ntz`. The human-readable description "timestamp without timezone" (or "timestamp without time zone") refers to this same type.
 The serialization method is described in Sections [Partition Value Serialization](#partition-value-serialization) and [Schema Serialization Format](#schema-serialization-format).
 
 To support this feature:
-- To have a column of TimestampNtz type in a table, the table must have Reader Version 3 and Writer Version 7. A feature name `timestampNtz` must exist in the table's `readerFeatures` and `writerFeatures`.
+- To have a column of `timestamp_ntz` type in a table, the table must have Reader Version 3 and Writer Version 7. A feature name `timestampNtz` must exist in the table's `readerFeatures` and `writerFeatures`.
 
 
 # V2 Checkpoint Table Feature
@@ -2571,7 +2572,7 @@ string | No translation required
 numeric types | The string representation of the number
 date | Encoded as `{year}-{month}-{day}`. For example, `1970-01-01`
 timestamp | Encoded as `{year}-{month}-{day} {hour}:{minute}:{second}` or `{year}-{month}-{day} {hour}:{minute}:{second}.{microsecond}`. For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456`. Timestamps may also be encoded as an ISO8601 formatted timestamp adjusted to UTC timestamp such as `1970-01-01T00:00:00.123456Z`
-timestamp without timezone | Encoded as `{year}-{month}-{day} {hour}:{minute}:{second}` or `{year}-{month}-{day} {hour}:{minute}:{second}.{microsecond}` For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456` To use this type, a table must support a feature `timestampNtz`. See section [Timestamp without timezone (TimestampNtz)](#timestamp-without-timezone-timestampNtz) for more information.
+timestamp_ntz (timestamp without timezone) | Encoded as `{year}-{month}-{day} {hour}:{minute}:{second}` or `{year}-{month}-{day} {hour}:{minute}:{second}.{microsecond}` For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456` To use this type, a table must support a feature `timestampNtz`. See section [Timestamp without timezone (TimestampNtz)](#timestamp-without-timezone-timestampNtz) for more information.
 boolean | Encoded as the string "true" or "false"
 binary | Encoded as a string of escaped binary values. For example, `"\u0001\u0002\u0003"`
 
@@ -2603,7 +2604,7 @@ boolean| `true` or `false`
 binary| A sequence of binary data.
 date| A calendar date, represented as a year-month-day triple without a timezone.
 timestamp| Microsecond precision timestamp elapsed since the Unix epoch, 1970-01-01 00:00:00 UTC. When this is stored in a parquet file, its `isAdjustedToUTC` must be set to `true`.
-timestamp without time zone | Microsecond precision timestamp in a local timezone elapsed since the Unix epoch, 1970-01-01 00:00:00. It doesn't have the timezone information, and a value of this type can map to multiple physical time instants. It should always be displayed in the same way, regardless of the local time zone in effect. When this is stored in a parquet file, its `isAdjustedToUTC` must be set to `false`. To use this type, a table must support a feature `timestampNtz`. See section [Timestamp without timezone (TimestampNtz)](#timestamp-without-timezone-timestampNtz) for more information.
+timestamp_ntz (timestamp without time zone) | Microsecond precision timestamp in a local timezone elapsed since the Unix epoch, 1970-01-01 00:00:00. It doesn't have the timezone information, and a value of this type can map to multiple physical time instants. It should always be displayed in the same way, regardless of the local time zone in effect. When this is stored in a parquet file, its `isAdjustedToUTC` must be set to `false`. To use this type, a table must support a feature `timestampNtz`. See section [Timestamp without timezone (TimestampNtz)](#timestamp-without-timezone-timestampNtz) for more information.
 
 See Parquet [timestamp type](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp) for more details about timestamp and `isAdjustedToUTC`.
 
@@ -2960,7 +2961,7 @@ int| `int32` | `INT(bitwidth = 32, signed = true)`
 long| `int64` | `INT(bitwidth = 64, signed = true)`
 date| `int32` | `DATE`
 timestamp| `int96` or `int64` | `TIMESTAMP(isAdjustedToUTC = true, units = microseconds)`
-timestamp without time zone| `int96` or `int64` | `TIMESTAMP(isAdjustedToUTC = false, units = microseconds)`
+timestamp_ntz (timestamp without time zone)| `int96` or `int64` | `TIMESTAMP(isAdjustedToUTC = false, units = microseconds)`
 float| `float` |
 double| `double` |
 decimal| `int32`, `int64` or `fixed_length_binary` | `DECIMAL(scale, precision)`


### PR DESCRIPTION
## Summary

Closes #2065

The Protocol document described the timestamp without timezone type using verbose phrases ("timestamp without timezone" and "timestamp without time zone") but never mentioned the actual type name `timestamp_ntz` that writers use in JSON schema serialization.

This inconsistency is confusing for implementors who need to know the exact string to use when writing Delta table schemas.

## Changes

- In **Partition Value Serialization** table: `timestamp without timezone` → `timestamp_ntz (timestamp without timezone)`
- In **Schema Serialization Format** primitive types table: `timestamp without time zone` → `timestamp_ntz (timestamp without time zone)`
- In **Parquet type mapping** table: `timestamp without time zone` → `timestamp_ntz (timestamp without time zone)`
- In the **Timestamp without timezone (TimestampNtz)** feature section: added a sentence explicitly stating that the JSON schema type name is `timestamp_ntz` and that the verbose English descriptions refer to this same type. Also updated the reference from "TimestampNtz type" to `` `timestamp_ntz` type ``.

## Test plan

Documentation-only change. No code changes.

Made with [Cursor](https://cursor.com)