### PR TITLE
[Spark] Remove stale uncacheTable call from AlterTableAddColumnsDeltaCommand

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -20,8 +20,6 @@ package org.apache.spark.sql.delta.commands
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-import scala.util.control.NonFatal
-
 import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.skipping.clustering.ClusteringColumnInfo
 import org.apache.spark.sql.delta._
@@ -620,14 +618,6 @@ case class AlterTableAddColumnsDeltaCommand(
               case QualifiedColTypeWithPosition(_, column, _) => column
             }), true)(!_.nullable).nonEmpty) {
         throw DeltaErrors.operationNotSupportedException("NOT NULL in ALTER TABLE ADD COLUMNS")
-      }
-
-      // TODO: remove this after auto cache refresh is merged.
-      table.tableIdentifier.foreach { identifier =>
-        try sparkSession.catalog.uncacheTable(identifier) catch {
-          case NonFatal(e) =>
-            log.warn(s"Exception when attempting to uncache table $identifier", e)
-        }
       }
 
       val metadata = txn.metadata


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
`AlterTableAddColumnsDeltaCommand` already extends `IgnoreCachedData`, which handles cache invalidation after a successful commit. The manual `uncacheTable` block (added in 2020 with a TODO to remove it) is no longer needed.

The manual call also fires before `txn.commit`, so a failed commit still evicts the cache unnecessarily. `IgnoreCachedData` fires after `run()` returns, which is the correct ordering.

All other `AlterTable*DeltaCommand` classes in the same file are already consistent with no manual `uncacheTable` calls.

Changes:
- Removed the stale `uncacheTable` block
- Removed the now-unused `import scala.util.control.NonFatal`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.