### PR TITLE
[UniForm] Use UnityCatalog as Iceberg committing catalog instead of HiveCatalog for Delta UniForm

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -22,6 +22,7 @@ import java.util.function.Consumer
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.jdk.OptionConverters._
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DummySnapshot, IcebergConstants, NoMapping, Snapshot}
@@ -33,11 +34,12 @@ import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
-import shadedForDelta.org.apache.iceberg.{AppendFiles, DataFile, DeleteFiles, ExpireSnapshots, OverwriteFiles, PartitionSpec, PendingUpdate, RewriteFiles, Schema => IcebergSchema, Transaction => IcebergTransaction}
+import shadedForDelta.org.apache.iceberg.{AppendFiles, BaseTransaction, DataFile, DeleteFiles, ExpireSnapshots, OverwriteFiles, PartitionSpec, PendingUpdate, RewriteFiles, Schema => IcebergSchema, TableMetadata, Transaction => IcebergTransaction}
 import shadedForDelta.org.apache.iceberg.MetadataUpdate
 import shadedForDelta.org.apache.iceberg.MetadataUpdate.{AddPartitionSpec, AddSchema}
 import shadedForDelta.org.apache.iceberg.mapping.MappingUtil
 import shadedForDelta.org.apache.iceberg.mapping.NameMappingParser
+import shadedForDelta.org.apache.iceberg.unityCatalog.{UnityCatalog, UnityCatalogTableOperations}
 import shadedForDelta.org.apache.iceberg.util.LocationUtil
 
 import org.apache.spark.internal.MDC
@@ -53,6 +55,9 @@ sealed trait IcebergConversionMode  {
 }
 // Used by Post-commit Delta UniForm (Iceberg conversion in Delta post commit hook)
 case object UNIFORM_POST_COMMIT_MODE extends IcebergConversionMode {
+}
+// Used by atomic Delta UniForm
+case object UNIFORM_CC_MODE extends IcebergConversionMode {
 }
 /**
  * Used to prepare (convert) and then commit a set of Delta actions into the Iceberg table located
@@ -73,6 +78,7 @@ class IcebergConversionTransaction(
     protected val tableOp: IcebergTableOp = WRITE_TABLE,
     protected val lastConvertedIcebergSnapshotId: Option[Long] = None,
     protected val lastConvertedDeltaVersion: Option[Long] = None,
+    protected val lastConvertedIcebergMetadataPath: Option[String] = None,
     protected val metadataUpdates: java.util.ArrayList[MetadataUpdate] =
       new java.util.ArrayList[MetadataUpdate]()
     ) extends DeltaLogging {
@@ -456,30 +462,75 @@ class IcebergConversionTransaction(
     committed = true
   }
 
+  /**
+   * Retrieves the converted Iceberg metadata location and its current snapshot.
+   * This method should only be called after a successful table conversion operation
+   *
+   * @return A tuple containing:
+   *         - String: The path where the Iceberg metadata file was written
+   *         - IcebergMetadata: The converted Iceberg metadata
+   * @throws IllegalStateException if the Iceberg metadata has not been converted
+   * @throws UnsupportedOperationException if called on non-UnityCatalogTableOperations
+   */
+  def getConvertedIcebergMetadata: (String, TableMetadata) =
+    txn.asInstanceOf[BaseTransaction].underlyingOps() match {
+      case ops: UnityCatalogTableOperations =>
+        ops.getLastWrittenTableMetadataWithLocation.toScala match {
+          case Some((metadataPath, tableMetadata)) =>
+            (metadataPath, tableMetadata)
+          case _ => throw new IllegalStateException(
+            "Could not get converted Iceberg metadata: new written metadata not found")
+        }
+      case _ =>
+        throw new IllegalStateException(
+          "Could not get converted Iceberg metadata:" +
+            " underlying UnityCatalogTableOperations not found"
+        )
+    }
+
   ///////////////////////
   // Protected Methods //
   ///////////////////////
 
   protected def createIcebergTxn(tableOpOpt: Option[IcebergTableOp] = None):
       IcebergTransaction = {
-    val hiveCatalog = IcebergTransactionUtils.createHiveCatalog(conf, metadataUpdates)
-    val icebergTableId = IcebergTransactionUtils
-      .convertSparkTableIdentifierToIcebergHive(catalogTable.identifier)
+    val (commitToUC, baseMetadataPath) =
+      (tableOpOpt.getOrElse(tableOp), lastConvertedIcebergMetadataPath) match {
+        case (CREATE_TABLE, None) => (false, None)
+        case (CREATE_TABLE, Some(_)) =>
+          throw new IllegalStateException(
+            "Unexpected base metadata path for CREATE_TABLE operation")
+        case (op, None) =>
+          throw new IllegalStateException(s"Missing base metadata path for $op operation")
+        case (_, Some(path)) => (false, Some(path))
+      }
 
-    val tableExists = hiveCatalog.tableExists(icebergTableId)
+    val ucTable = new UnityCatalog(
+      metadataUpdates,
+      baseMetadataPath.toJava
+    )
+    ucTable.initialize(null, new java.util.HashMap[String, String]())
+    ucTable.setConf(conf)
+
+    val icebergIdentifier =
+      IcebergTransactionUtils.convertSparkTableIdentifierToIceberg(catalogTable.identifier)
+
+    val tableExists = ucTable.tableExists(icebergIdentifier)
 
     def tableBuilder = {
-      hiveCatalog
-        .buildTable(icebergTableId, icebergSchema)
+      val tableLocation = postCommitSnapshot.deltaLog.dataPath.toString
+      ucTable
+        .buildTable(icebergIdentifier, icebergSchema)
         .withPartitionSpec(partitionSpec)
         .withProperties(convert.properties.asJava)
+        .withLocation(tableLocation)
     }
 
-    tableOpOpt.getOrElse(tableOp) match {
+    val txn = tableOpOpt.getOrElse(tableOp) match {
       case WRITE_TABLE =>
         if (tableExists) {
           recordFrameProfile("IcebergConversionTransaction", "loadTable") {
-            hiveCatalog.loadTable(icebergTableId).newTransaction()
+            ucTable.loadTable(icebergIdentifier).newTransaction()
           }
         } else {
           throw new IllegalStateException(s"Cannot write to table $tablePath. Table doesn't exist.")
@@ -501,6 +552,7 @@ class IcebergConversionTransaction(
           throw new IllegalStateException(s"Cannot replace table $tablePath. Table doesn't exist.")
         }
     }
+    txn
   }
 
   ////////////////////

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -494,15 +494,15 @@ class IcebergConversionTransaction(
 
   protected def createIcebergTxn(tableOpOpt: Option[IcebergTableOp] = None):
       IcebergTransaction = {
-    val (commitToUC, baseMetadataPath) =
+    val baseMetadataPath =
       (tableOpOpt.getOrElse(tableOp), lastConvertedIcebergMetadataPath) match {
-        case (CREATE_TABLE, None) => (false, None)
+        case (CREATE_TABLE, None) => None
         case (CREATE_TABLE, Some(_)) =>
           throw new IllegalStateException(
             "Unexpected base metadata path for CREATE_TABLE operation")
         case (op, None) =>
           throw new IllegalStateException(s"Missing base metadata path for $op operation")
-        case (_, Some(path)) => (false, Some(path))
+        case (_, Some(path)) => Some(path)
       }
 
     val ucTable = new UnityCatalog(

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -180,7 +180,7 @@ class IcebergConverter
    *    Convert Iceberg Metadata for a complete snapshot. Used for conversion
    *    after delta commits and in create table
    */
-  private def convertSnapshotInternal(
+  protected def convertSnapshotInternal(
       snapshotToConvert: Snapshot,
       readSnapshotOpt: Option[Snapshot],
       lastConvertedInfo: LastConvertedIcebergInfo,
@@ -321,7 +321,6 @@ class IcebergConverter
       icebergTxn.commit()
       logInfo(s"icebergTxn committed for table ${Option(catalogTable).map(_.identifier)} " +
         s"with converted delta version ${snapshotToConvert.version}")
-      validateIcebergCommit(snapshotToConvert, catalogTable)
 
       recordDeltaEvent(
         snapshotToConvert.deltaLog,

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -241,6 +241,24 @@ object IcebergTransactionUtils
   }
 
   /**
+  * Encode Spark table identifier to Iceberg table identifier by putting "database" and "catalog"
+  * to the "namespace" in Iceberg table identifier
+  */
+  def convertSparkTableIdentifierToIceberg(
+      identifier: SparkTableIdentifier): IcebergTableIdentifier = {
+    val namespace = (identifier.database, identifier.catalog) match {
+      case (Some(database), Some(catalog)) => Namespace.of(database, catalog)
+      case (Some(database), None) => Namespace.of(database)
+      case (None, Some(catalog)) =>
+        throw new IllegalArgumentException(
+          "Spark does not allow the constructors to skip the `database` when `catalog` is used"
+        )
+      case (None, None) => Namespace.empty()
+    }
+    IcebergTableIdentifier.of(namespace, identifier.table)
+  }
+
+  /**
    * Encode Spark table identifier to Iceberg table identifier by putting
    * only "database" to the "namespace" in Iceberg table identifier.
    * See [[HiveCatalog.isValidateNamespace]]

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uniform
+
+import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.icebergShaded.{IcebergConverter, UNIFORM_CC_MODE}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class IcebergConverterForTest extends IcebergConverter {
+  def convertSnapshotAndReturnMetadataPath(
+      snapshotToConvert: Snapshot,
+      catalogTable: CatalogTable): String = {
+    val icebergTxn = convertSnapshotInternal(
+      snapshotToConvert,
+      readSnapshotOpt = None,
+      lastConvertedInfo = LastConvertedIcebergInfo(
+        icebergTable = None,
+        icebergSnapshotId = None,
+        deltaVersionConverted = None,
+        baseMetadataLocationOpt = None
+      ),
+      conversionContext = new ConversionContext(
+        conversionMode = UNIFORM_CC_MODE,
+        additionalDeltaActionsToCommit = None,
+        opType = "delta.iceberg.conversion.convertSnapshot"
+      ),
+      catalogTable
+    )
+    icebergTxn.getConvertedIcebergMetadata._1
+  }
+}
+
+class UniFormConverterSuite extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+  test("convertSnapshot writes Iceberg metadata and file count matches Delta snapshot") {
+    val tableName = "test_iceberg_converter"
+    withTable(tableName) {
+      spark.sql(
+        s"""CREATE TABLE $tableName (id INT, name STRING) USING DELTA
+           |TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      // Do write
+      spark.sql(s"INSERT INTO $tableName VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')")
+      val tableId = TableIdentifier(tableName)
+      val deltaLog = DeltaLog.forTable(spark, tableId)
+      val snapshot = deltaLog.update()
+      val catalogTable = spark.sessionState.catalog.getTableMetadata(tableId)
+      // Trigger conversion
+      val converter = new IcebergConverterForTest()
+      val metadataPath = converter.convertSnapshotAndReturnMetadataPath(snapshot, catalogTable)
+      // Check match
+      val icebergTable =
+        new HadoopTables(deltaLog.newDeltaHadoopConf()).load(metadataPath)
+      val numFilesInIceberg =
+        icebergTable.currentSnapshot().summary().get("total-data-files").toInt
+      assert(
+        numFilesInIceberg == snapshot.numOfFiles,
+        s"Iceberg total-data-files ($numFilesInIceberg) must equal " +
+          s"Delta numOfFiles (${snapshot.numOfFiles})")
+    }
+  }
+
+  test("convertSnapshot file count matches Delta snapshot after multiple inserts") {
+    val tableName = "test_iceberg_converter_multi"
+    withTable(tableName) {
+      spark.sql(
+        s"""CREATE TABLE $tableName (id INT) USING DELTA
+           |TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      // Do some writes
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      spark.sql(s"INSERT INTO $tableName VALUES (2)")
+      spark.sql(s"INSERT INTO $tableName VALUES (3)")
+      val tableId = TableIdentifier(tableName)
+      val deltaLog = DeltaLog.forTable(spark, tableId)
+      val snapshot = deltaLog.update()
+      val catalogTable = spark.sessionState.catalog.getTableMetadata(tableId)
+      assert(snapshot.numOfFiles == 3)
+      // Trigger conversion
+      val converter = new IcebergConverterForTest()
+      val metadataPath = converter.convertSnapshotAndReturnMetadataPath(snapshot, catalogTable)
+      // Check match
+      val icebergTable = new HadoopTables(deltaLog.newDeltaHadoopConf()).load(metadataPath)
+      val numFilesInIceberg =
+        icebergTable.currentSnapshot().summary().get("total-data-files").toInt
+      assert(
+        numFilesInIceberg == snapshot.numOfFiles,
+        s"Iceberg total-data-files ($numFilesInIceberg) must equal " +
+          s"Delta numOfFiles (${snapshot.numOfFiles})")
+    }
+  }
+}

--- a/icebergShaded/src/main/java/org/apache/iceberg/unityCatalog/UnityCatalog.java
+++ b/icebergShaded/src/main/java/org/apache/iceberg/unityCatalog/UnityCatalog.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.unityCatalog;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.Configurable;
+import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.FileIO;
+
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
+
+
+/**
+ * UnityCatalog manages delta table with iceberg metadata conversion in unity catalog
+ * Only newTableOps needs implementation as it is used to commit to Iceberg. All other methods are
+ * not required (eg, listTables, dropTable, renameTable) because the tables are managed by
+ * unity catalog outside of iceberg context.
+ */
+public class UnityCatalog extends BaseMetastoreCatalog implements Closeable, Configurable<Object> {
+    private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.hadoop.HadoopFileIO";
+
+
+    // Injectable factory for testing purposes.
+    static class FileIOFactory {
+        public FileIO newFileIO(String impl, Map<String, String> properties, Object hadoopConf) {
+            return CatalogUtil.loadFileIO(impl, properties, hadoopConf);
+        }
+    }
+
+    private Object conf;
+
+    private Map<String, String> catalogProperties;
+
+    private FileIOFactory fileIOFactory;
+
+    private CloseableGroup closeableGroup;
+
+    private List<MetadataUpdate> metadataUpdates;
+
+    // If set, all table option in this catalog will be built based on the snapshot baseMetadataLocation points to.
+    private final Optional<String> baseMetadataLocation;
+
+    public UnityCatalog(
+        List<MetadataUpdate> metadataUpdates
+        , Optional<String> baseMetadataLocation
+    ) {
+        this.metadataUpdates = metadataUpdates;
+        this.baseMetadataLocation = baseMetadataLocation;
+    }
+
+    @Override
+    protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+        FileIO fileIO = fileIOFactory.newFileIO(DEFAULT_FILE_IO_IMPL, catalogProperties, conf);
+        closeableGroup.addCloseable(fileIO);
+        return new UnityCatalogTableOperations(
+                fileIO
+                , tableIdentifier
+                , metadataUpdates
+                , baseMetadataLocation
+        );
+    }
+
+    @Override
+    public void initialize(String name, Map<String, String> properties) {
+        this.catalogProperties = properties;
+        this.fileIOFactory = new FileIOFactory();
+        this.closeableGroup = new CloseableGroup();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closeableGroup != null) {
+            closeableGroup.close();
+        }
+    }
+
+    @Override
+    protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+        throw new UnsupportedOperationException(
+                "UnityCatalog does not currently support defaultWarehouseLocation");
+    }
+
+    @Override
+    public void setConf(Object conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace) {
+        throw new UnsupportedOperationException("UnityCatalog does not currently support listTables");
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier, boolean purge) {
+        throw new UnsupportedOperationException("UnityCatalog does not currently support dropTable");
+    }
+
+    @Override
+    public void renameTable(TableIdentifier from, TableIdentifier to) {
+        throw new UnsupportedOperationException("UnityCatalog does not currently support renameTable");
+    }
+
+    // If the given metadataLocation is invalid, we also see it as the table doesn't exist
+    @Override
+    public boolean tableExists(TableIdentifier identifier) {
+        try {
+            loadTable(identifier);
+            return true;
+        } catch (NoSuchTableException | NotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/icebergShaded/src/main/java/org/apache/iceberg/unityCatalog/UnityCatalogTableOperations.java
+++ b/icebergShaded/src/main/java/org/apache/iceberg/unityCatalog/UnityCatalogTableOperations.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.unityCatalog;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.*;
+
+import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.Tuple2;
+
+/**
+ * UnityCatalogTableOperations supports load and commit to Iceberg metadata through unity catalog
+ */
+public class UnityCatalogTableOperations extends BaseMetastoreTableOperations {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UnityCatalogTableOperations.class);
+
+    /**
+     * Property to be set in translated Iceberg metadata files.
+     * Indicates the delta commit version # that it corresponds to.
+     */
+    public static final String DELTA_VERSION_PROPERTY = "delta-version";
+    public static final String DELTA_TIMESTAMP_PROPERTY = "delta-timestamp";
+    public static final String BASE_DELTA_VERSION_PROPERTY = "base-delta-version";
+    public static final String DELTA_HIGH_WATER_MARK_PROPERTY = "delta-high-water-mark";
+
+    public static final String DELTA_SQL_CONF_BYPASS_SEQUENCE_NUMBER_CHECK =
+            "spark.databricks.delta.uniform.bypassSnapshotSequenceNumberCheck";
+    public static final String DELTA_SQL_CONF_BYPASS_FORMAT_VERSION_DOWNGRAGDE_CHECK =
+            "spark.databricks.delta.uniform.bypassFormatVersionDowngradeCheck";
+
+    private final FileIO fileIO;
+    private final TableIdentifier tableIdentifier;
+    private final Optional<String> baseMetadataLocation;
+    private List<MetadataUpdate> metadataUpdates;
+    private Optional<Tuple2<String, TableMetadata>> lastWrittenTableMetadataWithLocation;
+
+    public UnityCatalogTableOperations(
+            FileIO fileIO
+            , TableIdentifier tableIdentifier
+            , List<MetadataUpdate> metadataUpdates
+            , Optional<String> baseMetadataLocation
+    ) {
+        this.fileIO = fileIO;
+        this.tableIdentifier = tableIdentifier;
+        this.metadataUpdates = metadataUpdates;
+        this.baseMetadataLocation = baseMetadataLocation;
+        this.lastWrittenTableMetadataWithLocation = Optional.empty();
+    }
+
+    @Override
+    public FileIO io() {
+        return fileIO;
+    }
+
+    @Override
+    protected String tableName() {
+        return tableIdentifier.toString();
+    }
+
+    @Override
+    public void doCommit(TableMetadata base, TableMetadata metadata) {
+        TableMetadata.Builder builder = TableMetadata.buildFrom(metadata);
+
+        // hasAddPartitionSpec indicates if the current commit attempt have added a new
+        // partition spec through metadata update.
+        boolean hasAddPartitionSpec = false;
+        boolean initialPartitionSpecExistsAndIsPartitioned = false;
+        for (PartitionSpec spec : metadata.specs()) {
+            if (spec.specId() == 0 && spec.isPartitioned()) {
+                initialPartitionSpecExistsAndIsPartitioned = true;
+            }
+        }
+        Long deltaVersion = Long.parseLong(
+                metadata.properties().get(DELTA_VERSION_PROPERTY));
+        String baseDeltaVersionStr =
+                metadata.properties().get(BASE_DELTA_VERSION_PROPERTY);
+
+        String deltaHighWaterMarkStr =
+                metadata.properties().get(DELTA_HIGH_WATER_MARK_PROPERTY);
+
+        Schema lastAddedSchema = metadata.schema();
+        for (MetadataUpdate update : metadataUpdates) {
+            // iceberg-core reassigns field id in its schema when firstly creates table metadata;
+            // we should always use the schema (with field ids assigned by delta) from MetadataUpdate
+            // because the parquet data files are already written with field ids assigned by Delta.
+            if (update instanceof MetadataUpdate.AddSchema) {
+                MetadataUpdate.AddSchema addSchema = (MetadataUpdate.AddSchema) update;
+                // lastColumnId must be monotonically increasing.
+                builder.setCurrentSchema(
+                  addSchema.schema(), Math.max(metadata.lastColumnId(), addSchema.lastColumnId()));
+                lastAddedSchema = addSchema.schema();
+            } else if (update instanceof MetadataUpdate.AddPartitionSpec) {
+                // Use the partition spec from MetadataUpdate because the partition spec contains
+                // the correct field ids assigned by Delta
+                PartitionSpec specToAdd = ((MetadataUpdate.AddPartitionSpec) update).spec().bind(lastAddedSchema);
+                if (!specToAdd.compatibleWith(metadata.spec())) {
+                    builder.setDefaultPartitionSpec(specToAdd);
+                    hasAddPartitionSpec = true;
+                }
+            } else {
+                update.applyTo(builder);
+            }
+        }
+
+        // Remove the initial partitioned partition spec (id=0) if new partition spec is added
+        // because the initial partition spec has field ids assigned by iceberg-core
+        // which may mismatch with field id assigned by Delta
+        if (hasAddPartitionSpec && initialPartitionSpecExistsAndIsPartitioned) {
+            MetadataUpdate.RemovePartitionSpecs removeSpecs = new MetadataUpdate.RemovePartitionSpecs(Set.of(0));
+            removeSpecs.applyTo(builder);
+        }
+
+        metadata = builder.build();
+
+        if (base != current()) {
+            throw new CommitFailedException("Cannot commit changes based on stale table metadata");
+        }
+        if (base == metadata) {
+            LOG.info("Nothing to commit.");
+            return;
+        }
+
+        final int newVersion = currentVersion() + 1;
+        String newMetadataLocation = writeNewMetadata(metadata, newVersion);
+        lastWrittenTableMetadataWithLocation = Optional.of(Tuple2.apply(newMetadataLocation, metadata));
+    }
+
+    @Override
+    public TableMetadata refresh() {
+        // during Delta to iceberg conversion, the table should always exist in catalog and the only
+        // case with NoSuchTableException is the very first metadata conversion where iceberg
+        // metadata and metadata location table prop does not exist yet.
+        try {
+            return super.refresh();
+        } catch (NoSuchTableException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void doRefresh() {
+        LOG.debug("Getting metadata location for table {}", tableIdentifier);
+        String location = loadTableMetadataLocation();
+        Preconditions.checkState(
+                location != null && !location.isEmpty(),
+                "Got null or empty location %s for table %s",
+                location,
+                tableIdentifier);
+        refreshFromMetadataLocation(location);
+    }
+
+    /**
+     * Returns both the location of the Iceberg metadata file and its corresponding table metadata.
+     *
+     * @return An Optional containing a tuple of:
+     *         - String: The path where the metadata file was written
+     *         - TableMetadata: The corresponding Iceberg table metadata
+     */
+    public Optional<Tuple2<String, TableMetadata>> getLastWrittenTableMetadataWithLocation() {
+        return lastWrittenTableMetadataWithLocation;
+    }
+
+    private String loadTableMetadataLocation() {
+        if (baseMetadataLocation.isPresent()) {
+            return baseMetadataLocation.get();
+        }
+        throw new NoSuchTableException("Cannot find iceberg table %s. Either the table does " +
+            "not exist or the corresponding Delta table has not been converted yet.",
+            tableIdentifier.toString());
+    }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Use UnityCatalog as Iceberg committing catalog instead of HiveCatalog for Delta UniForm


## How was this patch tested?
Add UTs
```
build/sbt -DsparkVersion=4.0 "iceberg/testOnly org.apache.spark.sql.delta.uniform.UniFormConverterSuite"
```
