### PR TITLE
Update delta protocol to specify remove file path must byte match add file path

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -546,6 +546,11 @@ This delay allows concurrent readers to continue to execute against a stale snap
 A `remove` action should remain in the state of the table as a _tombstone_ until it has expired.
 A tombstone expires when *current time* (according to the node performing the cleanup) exceeds the expiration threshold added to the `remove` action timestamp.
 
+Because it is possible to represent the same physical file name with many different URI layouts and
+URI encodings, all add and remove actions that refer to the same physical file must use the same (byte-identical) path
+string. For example, [Action Reconciliation](#action-reconciliation) will treat a relative path as
+distinct from an absolute path, and `a` as distinct from `%65`, because they are not byte-identical.
+
 In the following statements, `dvId` can refer to either the unique id of a specific Deletion Vector (`deletionVector.uniqueId`) or to `NULL`, indicating that no rows are invalidated. Since actions within a given Delta commit are not guaranteed to be applied in order, a **valid** version is restricted to contain at most one file action *of the same type* (i.e. `add`/`remove`) for any one combination of `path` and `dvId`. Moreover, for simplicity it is required that there is at most one file action of the same type for any `path` (regardless of `dvId`).
 That means specifically that for any commit…
 
@@ -562,7 +567,7 @@ The schema of the `add` action is as follows:
 
 Field Name | Data Type | Description | optional/required
 -|-|-|-
-path| String | A relative path to a data file from the root of the table or an absolute path to a file that should be added to the table. The path is a URI as specified by [RFC 2396 URI Generic Syntax](https://www.ietf.org/rfc/rfc2396.txt), which needs to be decoded to get the data file path. | required
+path| String | A relative path to a data file from the root of the table or an absolute path to a file that should be added to the table. The path is a URI as specified by [RFC 2396 URI Generic Syntax](https://www.ietf.org/rfc/rfc2396.txt), which needs to be decoded to get the data file path. The path must be a byte-identical copy of the corresponding `add.path`. | required
 partitionValues| Map[String, String] | A map from partition column to value for this logical file. See also [Partition Value Serialization](#Partition-Value-Serialization) | required
 size| Long | The size of this data file in bytes | required
 modificationTime | Long | The time this logical file was created, as milliseconds since the epoch | required
@@ -904,7 +909,7 @@ To achieve the requirements above, related actions from different delta files ne
  - For `txn` actions, the latest `version` seen for a given `appId` wins
  - For `domainMetadata`, the latest `domainMetadata` seen for a given `domain` wins. The actions with `removed=true` act as tombstones to suppress earlier versions. Snapshot reads do _not_ return removed `domainMetadata` actions.
  - For `commitInfo` actions, only the `commitInfo` from the commit at the snapshot version is included in the snapshot. [Checkpoints](#checkpoints) and [log compaction files](#log-compaction-files) do not preserve `commitInfo` actions, so this information must be read from the JSON commit file at the snapshot version.
- - Logical files in a table are identified by their `(path, deletionVector.uniqueId)` primary key. File actions (`add` or `remove`) reference logical files, and a log can contain any number of references to a single file.
+ - Logical files in a table are identified by their `(path, deletionVector.uniqueId)` primary key. File actions (`add` or `remove`) reference logical files, and a log can contain any number of references to a single file. Two file actions refer to the same file only if their path strings are byte-identical.
  - To replay the log, scan all file actions and keep only the newest reference for each logical file.
  - `add` actions in the result identify logical files currently present in the table (for queries). `remove` actions in the result identify tombstones of logical files no longer present in the table (for VACUUM).
  - [v2 checkpoint spec](#v2-spec) actions are not allowed in normal commit files, and do not participate in log replay.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here)

## Description

Update delta protocol to specify remove file path must string match add file path. The current spec doesn't actually say how to compare the paths from two string actions. An implementation could choose any of the following, with very different outcomes for ambiguous cases:

Do a raw string comparison. Not reliable because different URI encoding libraries could choose to encode a different subset of "illegal" characters. e.g. abc vs %65bc.
URI-decode the strings before comparing them. Moderately expensive, but still not reliable, e.g. /path/to/table and /path//to//table refer to the same URI.
Construct a full URI from the string is the most expensive, and still not reliable, e.g. /path/to/table and /path/to/other/../table are not considered the same URI but some systems still treat them as the same path
In practice, all Delta clients we know of just copy whatever was in add.path as remove.path, so they should anyway compare byte-equal. Many Delta clients already perform raw string comparisons.

Since none of the approaches is reliable, and raw string comparisons are already used in practice, hereby we just update the spec to make that the required behavior.

## How was this patch tested?

NA

## Does this PR introduce _any_ user-facing changes?

No