### PR TITLE
Fix typo in catalog managed tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -571,9 +571,8 @@ abstract class DeltaHistoryManagerBase extends DeltaTimeTravelTests {
   }
 
   test("vacuumed version") {
-    if (catalogOwnedDefaultCreationEnabledInTests) {
-      cancel("VACUUM is not supported on catalog owned managed tables.")
-    }
+    assume(!catalogOwnedDefaultCreationEnabledInTests,
+      "VACUUM is blocked on catalog-managed tables")
 
     quietly {
       val tblName = "delta_table"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1725,9 +1725,8 @@ class DeltaSuite extends QueryTest
           Seq((2, 99), (5, 99)).toDF("key", "value")
         )
 
-        if (catalogOwnedDefaultCreationEnabledInTests) {
-          cancel("VACUUM is not supported on catalog owned managed tables")
-        }
+        assume(!catalogOwnedDefaultCreationEnabledInTests,
+          "VACUUM is blocked on catalog-managed tables")
 
         // VACUUM
         withSQLConf(DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -23,9 +23,9 @@ import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 
-import org.apache.spark.sql.delta.DeltaUnsupportedOperationException
 import org.apache.spark.sql.delta.DeltaOperations.{Delete, Write}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
+import org.apache.spark.sql.delta.DeltaUnsupportedOperationException
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.VacuumCommand
@@ -1538,7 +1538,7 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
     }
   }
 
-  test("running vacuum on a catalog owned managed table should fail") {
+  test("running vacuum on a catalog managed table should fail") {
     withCatalogManagedTable() { tableName =>
       checkError(
         intercept[DeltaUnsupportedOperationException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
@@ -301,7 +301,7 @@ class DeltaReorgSuite extends QueryTest
     }
   }
 
-  test("reorg on a catalog owned managed table should fail") {
+  test("reorg on a catalog managed table should fail") {
     withCatalogManagedTable() { tableName =>
       checkError(
         intercept[DeltaUnsupportedOperationException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -639,7 +639,7 @@ trait OptimizeCompactionSuiteBase extends QueryTest
     df.format("delta").mode("append").save(tablePath)
   }
 
-  test("optimize on a catalog owned managed table should fail") {
+  test("optimize on a catalog managed table should fail") {
     withCatalogManagedTable() { tableName =>
       checkError(
         intercept[DeltaUnsupportedOperationException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -725,9 +725,8 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("optimize clustered table and trigger regular compaction") {
-    if (catalogOwnedDefaultCreationEnabledInTests) {
-      cancel("OPTIMIZE is blocked on catalog-managed tables.")
-    }
+    assume(!catalogOwnedDefaultCreationEnabledInTests,
+      "OPTIMIZE is blocked on catalog-managed tables")
     withClusteredTable(testTable, "a INT, b STRING", "a, b") {
       val tableIdentifier = TableIdentifier(testTable)
       verifyClusteringColumns(tableIdentifier, Seq("a", "b"))
@@ -771,9 +770,8 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("optimize clustered table - error scenarios") {
-    if (catalogOwnedDefaultCreationEnabledInTests) {
-      cancel("OPTIMIZE is blocked on catalog-managed tables.")
-    }
+    assume(!catalogOwnedDefaultCreationEnabledInTests,
+      "OPTIMIZE is blocked on catalog-managed tables")
     withClusteredTable(testTable, "a INT, b STRING", "a") {
       // Specify partition predicate.
       val e = intercept[DeltaUnsupportedOperationException] {
@@ -881,9 +879,8 @@ trait ClusteredTableDDLSuiteBase
 
 
   test("validate CLONE on clustered table") {
-    if (catalogOwnedDefaultCreationEnabledInTests) {
-      cancel("OPTIMIZE is blocked on catalog-managed tables.")
-    }
+    assume(!catalogOwnedDefaultCreationEnabledInTests,
+      "OPTIMIZE is blocked on catalog-managed tables")
     import testImplicits._
     val srcTable = "SrcTbl"
     val dstTable1 = "DestTbl1"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Clean up some typos where we should use `catalog managed`.
And made all tests to use assume to align with all skipped tests.

## How was this patch tested?

existing tests.

## Does this PR introduce _any_ user-facing changes?
No.
