### PR TITLE
[Spark][TEST-ONLY] Fix flaky timestamp test in DeltaCDCSuite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -277,7 +277,7 @@ abstract class DeltaCDCSuiteBase
       // version 0
       val currentTime = System.currentTimeMillis() - 5.days.toMillis
       modifyCommitTimestamp(deltaLog, 0, currentTime + 0)
-      val tsAfterV0 = dateFormat.format(new Date(currentTime + 1))
+      val tsV0 = dateFormat.format(new Date(currentTime))
 
       // version 1
       modifyCommitTimestamp(deltaLog, 1, currentTime + 1000)
@@ -286,7 +286,8 @@ abstract class DeltaCDCSuiteBase
       modifyCommitTimestamp(deltaLog, 2, currentTime + 3000)
 
       val readDf = cdcRead(
-        new TableName(tableName), StartingTimestamp(tsAfterV0), EndingTimestamp(tsAfterV1))
+        new TableName(tableName), StartingTimestamp(tsV0), EndingTimestamp(tsAfterV1))
+      // Answer should include version 0 and version 1, but not version 2.
       checkCDCAnswer(
         DeltaLog.forTable(spark, TableIdentifier(tableName)),
         readDf,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix a flaky test "changes - start and end are timestamps" in `DeltaCDCSuite`.

### Root Cause
The test was using `currentTime + 1` (1 millisecond offset) to create a timestamp "after" version 0:

```scala
  val tsAfterV0 = dateFormat.format(new Date(currentTime + 1))
```

However, dateFormat uses the format "yyyy-MM-dd HH:mm:ss Z" which has second precision only - no milliseconds.

When the formatted timestamp string is parsed back during CDC timestamp resolution, the milliseconds are lost. This causes flakiness:
- When currentTime does NOT end in 999ms: currentTime + 1 stays in the same second, formats and parses back to the same second as currentTime + 0. The starting version resolves to v0, test passes with 20 rows.
- When currentTime ends in 999ms: currentTime + 1 crosses a second boundary (e.g., ...999 → ...000), formats and parses back to a different second than v0's timestamp. The starting version resolves to v1 instead of v0, test fails with only 10 rows.

### Fix

Removed the misleading +1ms offset and renamed tsAfterV0 to tsV0 to reflect that it's intended to be at the same second as v0's timestamp, not after it.

## How was this patch tested?

Existing test - this PR fixes its flakiness.

## Does this PR introduce _any_ user-facing changes?

No