### PR TITLE
[CatalogManaged] Add CCv2 streaming test coverage and remove CCv1 from DeltaSource suites

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -390,6 +390,14 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
   test("cdc streams with noop merge") {
     withSQLConf(
+      // When DeletionVectors are enabled (e.g., via CatalogManaged QoL features), a truly no-op
+      // merge (all WHEN conditions false) produces empty actions (no FileActions) because
+      // writeUnmodifiedRows=false in the DV path. The default table isolation level (Serializable)
+      // allows canDowngradeToSnapshotIsolation to succeed (noDataChanged=true is sufficient), so
+      // the transaction runs at SnapshotIsolation and skipRecordingEmptyCommitAllowed returns
+      // true, causing commitIfNeeded to skip the commit entirely. This test requires version 1
+      // to exist for streaming, so we force the classic copy-on-write merge path.
+      DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS.key -> "false",
       cdcConfig.defaultTablePropertyKey -> "true"
     ) {
       withTempDirs { (srcDir, targetDir, checkpointDir) =>
@@ -1063,19 +1071,27 @@ class DeltaCDCStreamDeletionVectorSuite extends DeltaCDCStreamSuite
 }
 
 class DeltaCDCStreamSuite extends DeltaCDCStreamSuiteBase
-class DeltaCDCStreamWithCoordinatedCommitsBatch1Suite
+// Batch sizes 1, 2, and 100 exercise different backfill behaviors in the commit coordinator.
+// Batch size 1 triggers a backfill on every commit (commitVersion % 1 == 0), testing the most
+// granular backfill path. Batch size 2 triggers backfill every other commit, testing the boundary
+// between backfilled and unbackfilled commits. Batch size 100 leaves most commits unbackfilled,
+// testing the production-like path where streaming must read from both the commit coordinator
+// and the filesystem. This follows the same pattern as other CatalogManaged (CCv2) test suites
+// (DeltaLogSuite, DeltaSourceSuite, etc.).
+
+class DeltaCDCStreamWithCatalogManagedBatch1Suite
   extends DeltaCDCStreamSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
 }
 
-class DeltaCDCStreamWithCoordinatedCommitsBatch10Suite
+class DeltaCDCStreamWithCatalogManagedBatch2Suite
   extends DeltaCDCStreamSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(10)
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
 }
 
-class DeltaCDCStreamWithCoordinatedCommitsBatch100Suite
+class DeltaCDCStreamWithCatalogManagedBatch100Suite
     extends DeltaCDCStreamSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }
 
 abstract class DeltaCDCStreamColumnMappingSuiteBase extends DeltaCDCStreamSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.Relocated.StreamExecution
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.{DeltaSource, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.DeltaColumnMappingSelectedTestMixin
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -32,6 +33,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.StreamingExecutionRelation
 import org.apache.spark.sql.streaming.{DataStreamReader, StreamTest}
@@ -752,4 +754,42 @@ class DeltaSourceNameColumnMappingSuite extends DeltaSourceSuite
 
   override protected def isCdcTest: Boolean = false
 
+}
+
+// Batch sizes 1, 2, and 100 exercise different backfill behaviors in the commit coordinator.
+// Batch size 1 triggers a backfill on every commit (commitVersion % 1 == 0), testing the most
+// granular backfill path. Batch size 2 triggers backfill every other commit, testing the boundary
+// between backfilled and unbackfilled commits. Batch size 100 leaves most commits unbackfilled,
+// testing the production-like path where streaming must read from both the commit coordinator
+// and the filesystem. This follows the same pattern as other CatalogManaged (CCv2) test suites
+// (DeltaLogSuite, DeltaCDCStreamSuite, etc.).
+
+class DeltaSourceIdColumnMappingWithCatalogManagedBatch1Suite
+    extends DeltaSourceIdColumnMappingSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class DeltaSourceIdColumnMappingWithCatalogManagedBatch2Suite
+    extends DeltaSourceIdColumnMappingSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class DeltaSourceIdColumnMappingWithCatalogManagedBatch100Suite
+    extends DeltaSourceIdColumnMappingSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
+}
+
+class DeltaSourceNameColumnMappingWithCatalogManagedBatch1Suite
+    extends DeltaSourceNameColumnMappingSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class DeltaSourceNameColumnMappingWithCatalogManagedBatch2Suite
+    extends DeltaSourceNameColumnMappingSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class DeltaSourceNameColumnMappingWithCatalogManagedBatch100Suite
+    extends DeltaSourceNameColumnMappingSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceLargeLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceLargeLogSuite.scala
@@ -18,18 +18,33 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
+import org.apache.spark.SparkConf
+
 class DeltaSourceLargeLogSuite extends DeltaSourceSuite {
   protected override def sparkConf = {
     super.sparkConf.set(DeltaSQLConf.LOG_SIZE_IN_MEMORY_THRESHOLD.key, "0")
   }
 }
 
-class DeltaSourceLargeLogWithCoordinatedCommitsBatch1Suite
+// Batch sizes 1, 2, and 100 exercise different backfill behaviors in the commit coordinator.
+// Batch size 1 triggers a backfill on every commit (commitVersion % 1 == 0), testing the most
+// granular backfill path. Batch size 2 triggers backfill every other commit, testing the boundary
+// between backfilled and unbackfilled commits. Batch size 100 leaves most commits unbackfilled,
+// testing the production-like path where streaming must read from both the commit coordinator
+// and the filesystem. This follows the same pattern as other CatalogManaged (CCv2) test suites
+// (DeltaLogSuite, DeltaCDCStreamSuite, etc.).
+
+class DeltaSourceLargeLogWithCatalogManagedBatch1Suite
     extends DeltaSourceLargeLogSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
 }
 
-class DeltaSourceLargeLogWithCoordinatedCommitsBatch100Suite
+class DeltaSourceLargeLogWithCatalogManagedBatch2Suite
     extends DeltaSourceLargeLogSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class DeltaSourceLargeLogWithCatalogManagedBatch100Suite
+    extends DeltaSourceLargeLogSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
 import org.scalatest.time.{Seconds, Span}
 
-import org.apache.spark.SparkThrowable
+import org.apache.spark.{SparkConf, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.IntervalUtils
@@ -858,8 +858,12 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         StopStream,
         AssertOnQuery { _ =>
           Utils.deleteRecursively(inputDir)
-          if (coordinatedCommitsEnabledInTests) {
-            deleteTableFromCommitCoordinator(tablePath)
+          // This test deletes and recreates a table at the same path. The InMemoryCommitCoordinator
+          // keys on logPath, so stale coordinator state from the old table must be cleared before
+          // the new table is created. In production, UC handles table lifecycle management, so
+          // explicit coordinator cleanup is not needed.
+          if (catalogOwnedDefaultCreationEnabledInTests) {
+            deleteCatalogOwnedTableFromCommitCoordinator(tablePath)
           }
           val deltaLog = DeltaLog.forTable(spark, tablePath)
           // All Delta tables in tests use the same tableId by default. Here we pass a new tableId
@@ -897,7 +901,11 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
       def writeFile(name: String, content: String): AddFile = {
         FileUtils.write(new File(inputDir, name), content)
-        AddFile(name, Map.empty, content.length, System.currentTimeMillis(), dataChange = true)
+        // CatalogManaged (CCv2) tables auto-enable row tracking, which requires numRecords in
+        // AddFile stats to assign base row IDs. Without numRecords, the commit fails with
+        // DELTA_ROW_ID_ASSIGNMENT_WITHOUT_STATS.
+        AddFile(name, Map.empty, content.length, System.currentTimeMillis(), dataChange = true,
+          stats = s"""{"numRecords": 1}""")
       }
 
       def commitFiles(files: AddFile*): Unit = {
@@ -2380,14 +2388,22 @@ object MonotonicallyIncreasingTimestampFS {
   val scheme = s"MonotonicallyIncreasingTimestampFS"
 }
 
-class DeltaSourceWithCoordinatedCommitsBatch1Suite extends DeltaSourceSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
+// Batch sizes 1, 2, and 100 exercise different backfill behaviors in the commit coordinator.
+// Batch size 1 triggers a backfill on every commit (commitVersion % 1 == 0), testing the most
+// granular backfill path. Batch size 2 triggers backfill every other commit, testing the boundary
+// between backfilled and unbackfilled commits. Batch size 100 leaves most commits unbackfilled,
+// testing the production-like path where streaming must read from both the commit coordinator
+// and the filesystem. This follows the same pattern as other CatalogManaged (CCv2) test suites
+// (DeltaLogSuite, DeltaCDCStreamSuite, etc.).
+
+class DeltaSourceWithCatalogManagedBatch1Suite extends DeltaSourceSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
 }
 
-class DeltaSourceWithCoordinatedCommitsBatch10Suite extends DeltaSourceSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(10)
+class DeltaSourceWithCatalogManagedBatch2Suite extends DeltaSourceSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
 }
 
-class DeltaSourceWithCoordinatedCommitsBatch100Suite extends DeltaSourceSuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
+class DeltaSourceWithCatalogManagedBatch100Suite extends DeltaSourceSuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.File
 
 import org.apache.spark.sql.delta.actions.Format
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 
@@ -51,7 +51,7 @@ trait DeltaSourceConnectorTrait {
 
 trait DeltaSourceSuiteBase extends StreamTest
   with DeltaSQLTestUtils
-  with CoordinatedCommitsBaseSuite
+  with CatalogOwnedTestBaseSuite
   with DeltaSourceConnectorTrait {
 
   /**
@@ -119,10 +119,17 @@ trait DeltaSourceSuiteBase extends StreamTest
     val updatedSchema = copyOverMetadata(
       schema, baseMetadata.schema,
       baseMetadata.columnMappingMode)
-    // Configure coordinated commits
-    val updatedConfiguration = if (coordinatedCommitsEnabledInTests) {
+    // Configure CatalogManaged (CCv2) table settings.
+    val updatedConfiguration = if (catalogOwnedDefaultCreationEnabledInTests) {
+      // This withMetadata helper calls txn.commit(Metadata, ManualUpdate) directly, bypassing
+      // the normal CREATE TABLE path (CreateDeltaTableCommand, DeltaTestImplicits.commitActions)
+      // that populates newProtocol with CatalogOwnedTableFeature and auto-enables ICT. Without
+      // ICT, the CatalogManaged commit coordinator rejects the commit because it requires
+      // commitTimestamp on every version. This is a test-only issue: txn.commit is not a
+      // user-facing table creation API, and production tables always go through the full DDL
+      // path. We enable ICT manually here as the simplest fix.
       baseMetadata.configuration +
-        (DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.key -> defaultCommitsCoordinatorName)
+        (DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")
     } else {
       baseMetadata.configuration
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
as titled.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
through newly added suites.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
no.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
