### PR TITLE
Fix Spark Connect test flakiness by waiting for server readiness

### DIFF
--- a/spark-connect/client/src/test/scala/io/delta/connect/tables/RemoteSparkSession.scala
+++ b/spark-connect/client/src/test/scala/io/delta/connect/tables/RemoteSparkSession.scala
@@ -38,7 +38,8 @@
 
 package io.delta.tables
 
-import java.io.File
+import java.io.{BufferedReader, File, InputStreamReader}
+import java.util.concurrent.TimeUnit
 
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
@@ -117,13 +118,58 @@ trait RemoteSparkSession extends BeforeAndAfterAll { self: Suite =>
     builder.environment().put("SPARK_LOCAL_IP", "127.0.0.1")
     builder.directory(new File(sparkHome))
     builder.redirectError(ProcessBuilder.Redirect.INHERIT)
-    builder.redirectOutput(ProcessBuilder.Redirect.INHERIT)
     builder.start()
+  }
+
+  private val SERVER_READY_TIMEOUT_SECONDS = 120
+
+  /**
+   * Wait for the server process to print "Ready for client connections." to stdout,
+   * indicating the gRPC port is bound and accepting connections.
+   */
+  private def waitForServerReady(process: Process): Unit = {
+    val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(SERVER_READY_TIMEOUT_SECONDS)
+    var ready = false
+    var line: String = null
+    while (!ready && System.nanoTime() < deadline) {
+      line = reader.readLine()
+      if (line == null) {
+        throw new RuntimeException(
+          "Spark Connect server process exited before becoming ready. " +
+            s"Exit code: ${process.exitValue()}")
+      }
+      // Mirror to stdout so server logs are still visible in test output.
+      // scalastyle:off println
+      println(line)
+      // scalastyle:on println
+      if (line.contains("Ready for client connections.")) {
+        ready = true
+      }
+    }
+    if (!ready) {
+      process.destroy()
+      throw new RuntimeException(
+        s"Spark Connect server did not become ready within $SERVER_READY_TIMEOUT_SECONDS seconds")
+    }
+    // Continue forwarding server stdout in background so the process doesn't block on a full
+    // output buffer.
+    val forwarder = new Thread(() => {
+      var l: String = null
+      while ({ l = reader.readLine(); l != null }) {
+        // scalastyle:off println
+        println(l)
+        // scalastyle:on println
+      }
+    })
+    forwarder.setDaemon(true)
+    forwarder.start()
   }
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    server
+    val process = server
+    waitForServerReady(process)
     spark = SparkSession.builder().remote(s"sc://localhost:$serverPort").create()
   }
 


### PR DESCRIPTION
## Summary

Fixes flaky `DeltaTableBuilderSuite` failures on CI (e.g. [#6223](https://github.com/delta-io/delta/actions/runs/22846185614/job/66263200141?pr=6223), [#6216](https://github.com/delta-io/delta/actions/runs/22787617169/job/66107799566?pr=6216)) caused by a **gRPC server startup race condition** in `RemoteSparkSession`.

### Root cause

`RemoteSparkSession.beforeAll()` starts the Spark Connect server as a subprocess and **immediately** attempts to create a `SparkSession` via gRPC — without waiting for the server to be ready:

```scala
// Before (race condition)
server                    // spawns the process
spark = SparkSession.builder().remote(s"sc://localhost:$serverPort").create()
// ^ connects immediately — server may not be listening yet
```

The only safety net was the gRPC client's internal retry/backoff, which provides roughly a ~4 second window (50ms → 200ms → 800ms → 3340ms). On CI runners under load, the server can take longer to start, exhausting retries and producing:

- `UNAVAILABLE: io exception` — server not yet listening
- `SESSION_CHANGED` — server crashed/restarted after partial initialization
- `No active or default Spark session found` — session not established

### Fix

Instead of relying on the gRPC retry budget, we now **wait for the server to signal readiness** before connecting. The server already prints `"Ready for client connections."` to stdout (via `SimpleDeltaConnectService.main()`) after SparkSession creation and gRPC port binding — we just weren't reading it.

Changes to `RemoteSparkSession`:

1. **Capture server stdout** (removed `redirectOutput(INHERIT)`) so we can read it programmatically
2. **Block in `beforeAll()` until we see the ready message**, with a 120-second timeout
3. **Forward server stdout via a background daemon thread** to keep logs visible and prevent the server from blocking on a full pipe buffer
4. **Fail fast** with a clear error if the server process exits unexpectedly or times out

### Verification

**Before fix** — gRPC retries visible at every test run:
```
WARN GrpcRetryHandler: UNAVAILABLE: io exception, retrying (wait=50 ms, currentRetryNum=1)
WARN GrpcRetryHandler: UNAVAILABLE: io exception, retrying (wait=200 ms, currentRetryNum=2)
WARN GrpcRetryHandler: UNAVAILABLE: io exception, retrying (wait=800 ms, currentRetryNum=3)
WARN GrpcRetryHandler: UNAVAILABLE: io exception, retrying (wait=3340 ms, currentRetryNum=4)
Ready for client connections.
```

**After fix** — clean startup, zero retries:
```
Ready for client connections.
[info] - create table with existing schema and extra column  ← first test starts immediately
```

All 29 tests pass with the fix applied.

## Test plan

- [x] `connectClient/testOnly io.delta.tables.DeltaTableBuilderSuite` — 29/29 passed, zero gRPC retry warnings
- [ ] Full `sparkGroup/test` CI run to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)