### PR TITLE
[kernel-spark] Add e2e tests for type widening and relaxing nullability

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -121,7 +121,9 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "excludeRegex works and doesn't mess up offsets across restarts - parquet version",
     "SC-46515: deltaSourceIgnoreChangesError contains removeFile, version, tablePath",
 
-    // === schema evolution ===
+    // === Schema Evolution ===
+    // TODO(#6232): enable the two tests after spark streaming engine supports leaf node projection
+    // for datasource v2 such that we can adopt the two schema changes without refresh the dataframe
     "relax nullability: restarting with stale DataFrame should recover",
     "type widening: restarting with stale DataFrame should recover",
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, StreamingQueryException, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
-import org.apache.spark.sql.types.{IntegerType, NullType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, LongType, NullType, StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{ManualClock, Utils}
 
@@ -2188,6 +2188,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           .writeStream
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
           .option("mergeSchema", "true")
+          // use delta sink because we need to check the result
           .format("delta")
           .start(outputDir.getCanonicalPath)
       }
@@ -2290,6 +2291,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           .writeStream
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
           .option("mergeSchema", "true")
+          // use delta sink because we need to check the result
           .format("delta")
           .start(outputDir.getCanonicalPath)
       }
@@ -2316,8 +2318,10 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         // Restarting the query with a new DataFrame should recover from the schema change
         q = startQuery()
         q.processAllAvailable()
-        checkAnswer(
-          spark.read.format("delta").load(outputDir.getCanonicalPath).orderBy("id"),
+        val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+        assert(outputDf.schema("id").nullable,
+          "Expected 'id' column to be nullable after relaxing nullability")
+        checkAnswer(outputDf.orderBy("id"),
           Seq(Row(null), Row("0"), Row("1")))
       } finally {
         q.stop()
@@ -2339,6 +2343,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       var q = df.writeStream
         .option("checkpointLocation", checkpointDir.getCanonicalPath)
         .option("mergeSchema", "true")
+        // use delta sink because we need to check the result
         .format("delta")
         .start(outputDir.getCanonicalPath)
       try {
@@ -2366,8 +2371,10 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           .format("delta")
           .start(outputDir.getCanonicalPath)
         q.processAllAvailable()
-        checkAnswer(
-          spark.read.format("delta").load(outputDir.getCanonicalPath).orderBy("id"),
+        val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+        assert(outputDf.schema("id").nullable,
+          "Expected 'id' column to be nullable after relaxing nullability")
+        checkAnswer(outputDf.orderBy("id"),
           Seq(Row(null), Row("0"), Row("1")))
       } finally {
         q.stop()
@@ -2394,6 +2401,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
             .writeStream
             .option("checkpointLocation", checkpointDir.getCanonicalPath)
             .option("mergeSchema", "true")
+            // use delta sink because we need to check the result
             .format("delta")
             .start(outputDir.getCanonicalPath)
         }
@@ -2420,8 +2428,11 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           // Restarting the query with a new DataFrame should recover from the schema change
           q = startQuery()
           q.processAllAvailable()
-          checkAnswer(
-            spark.read.format("delta").load(outputDir.getCanonicalPath).orderBy("id"),
+          val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+          assert(outputDf.schema("id").dataType === LongType,
+            s"Expected 'id' column to be LongType after type widening but got " +
+              s"${outputDf.schema("id").dataType}")
+          checkAnswer(outputDf.orderBy("id"),
             Seq(Row(0L), Row(1L), Row(2147483648L)))
         } finally {
           q.stop()
@@ -2448,6 +2459,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         var q = df.writeStream
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
           .option("mergeSchema", "true")
+          // use delta sink because we need to check the result
           .format("delta")
           .start(outputDir.getCanonicalPath)
         try {
@@ -2475,8 +2487,11 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
             .format("delta")
             .start(outputDir.getCanonicalPath)
           q.processAllAvailable()
-          checkAnswer(
-            spark.read.format("delta").load(outputDir.getCanonicalPath).orderBy("id"),
+          val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+          assert(outputDf.schema("id").dataType === LongType,
+            s"Expected 'id' column to be LongType after type widening but got " +
+              s"${outputDf.schema("id").dataType}")
+          checkAnswer(outputDf.orderBy("id"),
             Seq(Row(0L), Row(1L), Row(2147483648L)))
         } finally {
           q.stop()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6227/files) to review incremental changes.
- [**stack/type-nullability-e2e-test**](https://github.com/delta-io/delta/pull/6227) [[Files changed](https://github.com/delta-io/delta/pull/6227/files)]
  - [stack/forbid-schema-evolution-with-staleDF-v2](https://github.com/delta-io/delta/pull/6228) [[Files changed](https://github.com/delta-io/delta/pull/6228/files/58309c897e41296ee84b4f0714867c4a229b130b..781fa7a841d9f7dc1e6551426f12bf5fe90f8055)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Added schema evolution e2e tests for type widening and relax nullability for both refresh dataframe and stale dataframe cases.

Refresh dataframe cases work for both v1 & v2 connector, while stale dataframe cases only work for v1 connector.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
test-only PR
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
