### PR TITLE
[Spark] Set delta.checkpoint.writeStatsAs* properties for UC managed tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -194,6 +194,16 @@ object CatalogOwnedTableUtils extends DeltaLogging {
     )
 
   /**
+   * QoL table property defaults for CatalogOwned tables that are not tied to a specific table
+   * feature. These are applied alongside [[QOL_TABLE_FEATURES_AND_PROPERTIES]] during table
+   * creation. User-set values (in table properties or session defaults) take precedence.
+   */
+  val QOL_TABLE_PROPERTIES: Seq[(DeltaConfig[_], String)] = Seq(
+    (DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON, "false"),
+    (DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT, "true")
+  )
+
+  /**
    * Return true if we should enable CatalogOwned either via default spark
    * session configuration during creating a new table,
    * or via the explicit table property overrides.
@@ -238,11 +248,13 @@ object CatalogOwnedTableUtils extends DeltaLogging {
   def updateMetadataForQoLFeatures(
       spark: SparkSession,
       metadata: Metadata): Metadata = {
-    val qoLConfigsToAdd = QOL_TABLE_FEATURES_AND_PROPERTIES.collect {
-      case (feature, config, targetValue) if
-          !isAlreadyConfigured(config, metadata.configuration, spark) =>
-        config.key -> targetValue
-    }.toMap
+    val qoLConfigsToAdd =
+      (QOL_TABLE_FEATURES_AND_PROPERTIES.map { case (_, config, value) => config -> value } ++
+        QOL_TABLE_PROPERTIES)
+      .collect {
+        case (config, targetValue) if !isAlreadyConfigured(config, metadata.configuration, spark) =>
+          config.key -> targetValue
+      }
     metadata.copy(configuration = metadata.configuration ++ qoLConfigsToAdd)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -963,6 +963,7 @@ class CheckpointsSuite
   for (checkpointFormat <- V2Checkpoint.Format.ALL)
   test(s"All actions in V2 manifest [v2CheckpointFormat: ${checkpointFormat.name}]") {
     withSQLConf(
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON.defaultTablePropertyKey -> "true",
       DeltaConfigs.CHECKPOINT_POLICY.defaultTablePropertyKey -> CheckpointPolicy.V2.name) {
       withTempDir { dir =>
         spark.range(10).write.format("delta").save(dir.getAbsolutePath)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -201,6 +201,8 @@ trait DescribeDeltaHistorySuiteBase
         case (feature, config, value)
         => config.key -> value
       }.toMap ++
+      CatalogOwnedTableUtils.QOL_TABLE_PROPERTIES
+        .map { case (config, value) => config.key -> value }.toMap ++
       // DV is explicitly disabled here b/c the current suite is incompatible
       // w/ DV, and we automatically enable it as part of CatalogOwned QoL features.
       Map(s"${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key}" -> "false")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -257,7 +257,9 @@ trait CatalogOwnedTestBaseSuite
           case (feature, config, value)
           => config.key -> value
         }
-        .toMap
+        .toMap ++
+        CatalogOwnedTableUtils.QOL_TABLE_PROPERTIES
+          .map { case (config, value) => config.key -> value }.toMap
       // RowTracking specific properties.
       qolConfs ++ Map(
         MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP ->
@@ -290,6 +292,7 @@ trait CatalogOwnedTestBaseSuite
           .filterNot(Set(
             DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key
           )) ++
+          CatalogOwnedTableUtils.QOL_TABLE_PROPERTIES.map { case (config, _) => config.key } ++
           Seq(
             MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP,
             MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -645,6 +645,8 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
               : ImmutableMap.of();
       final Map<String, String> expectedOtherProperties =
           ImmutableMap.<String, String>builder()
+              .put("delta.checkpoint.writeStatsAsJson", "false")
+              .put("delta.checkpoint.writeStatsAsStruct", "true")
               .put("delta.checkpointPolicy", "v2")
               .put("delta.enableDeletionVectors", "true")
               .put("delta.enableInCommitTimestamps", "true")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Set the following properties for UC managed tables:
```
delta.checkpoint.writeStatsAsJson=false
delta.checkpoint.writeStatsAsStruct=true
```

## How was this patch tested?
Integration test

## Does this PR introduce _any_ user-facing changes?
No.