### PR TITLE
Delta Error Followup for Logging all operations that try to illegally repartition the table's columns

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3143,9 +3143,7 @@
   },
   "DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE" : {
     "message" : [
-      "Cannot change partition columns during <operation> operation.",
-      "- Old partition columns: <oldPartitionColumns>.",
-      "- New partition columns: <newPartitionColumns>."
+      "Cannot change partition columns during <operation> operation (old: <oldPartitionColumns>, new: <newPartitionColumns>)."
     ],
     "sqlState" : "42P10"
   },

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -1198,16 +1198,22 @@ class OptimisticTransactionSuite
 
           val logRecords = Log4jUsageLogger.track {
             exceptionClassOpt match {
-              case Some(exceptionClass) =>
-                val ex = intercept[Throwable] {
-                  txn.commit(
-                    Seq(newMetadata),
-                    DeltaOperations.Update(predicate = Some(EqualTo(Literal(1), Literal(1))))
+              case Some(_) =>
+                checkError(
+                  intercept[DeltaAnalysisException] {
+                    txn.commit(
+                      Seq(newMetadata),
+                      DeltaOperations.Update(predicate = Some(EqualTo(Literal(1), Literal(1))))
+                    )
+                  },
+                  condition = "DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE",
+                  sqlState = "42P10",
+                  parameters = Map(
+                    "operation" -> "UPDATE",
+                    "oldPartitionColumns" -> "col1",
+                    "newPartitionColumns" -> "col2"
                   )
-                }
-                assert(ex.getClass == exceptionClass)
-                assert(ex.asInstanceOf[DeltaAnalysisException].getErrorClass ==
-                  "DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE")
+                )
               case None =>
                 // Should succeed without throwing
                 txn.commit(
@@ -1245,41 +1251,49 @@ class OptimisticTransactionSuite
       val txn = deltaLog.startTransaction()
       val newMetadata = txn.metadata.copy(partitionColumns = Seq("col2"))
 
-      val ex = intercept[DeltaAnalysisException] {
-        txn.commit(
-          Seq(newMetadata),
-          DeltaOperations.Update(predicate = Some(EqualTo(Literal(1), Literal(1))))
+      checkError(
+        intercept[DeltaAnalysisException] {
+          txn.commit(
+            Seq(newMetadata),
+            DeltaOperations.Update(predicate = Some(EqualTo(Literal(1), Literal(1))))
+          )
+        },
+        condition = "DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE",
+        sqlState = "42P10",
+        parameters = Map(
+          "operation" -> "UPDATE",
+          "oldPartitionColumns" -> "col1",
+          "newPartitionColumns" -> "col2"
         )
-      }
-      assert(ex.getErrorClass == "DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE")
+      )
       assertPartitionColumns(tablePath, Seq("col1"))
     }
   }
 
   Seq(
     // Recreation of running DFv1 .save() overwrite changing partition cols.
-    ("blocked for Write(Overwrite, partitionBy)",
+    ("blocked for Write(Overwrite, partitionBy)", "WRITE",
       (_: Metadata) => DeltaOperations.Write(SaveMode.Overwrite, partitionBy = Some(Seq("col2")))),
 
     // Recreation of running DFv1 .save() replaceWhere changing partition cols.
-    ("blocked for Write(Overwrite, partitionBy, predicate)",
+    ("blocked for Write(Overwrite, partitionBy, predicate)", "WRITE",
       (_: Metadata) => DeltaOperations.Write(SaveMode.Overwrite, partitionBy = Some(Seq("col2")),
         predicate = Some("col1=0"))),
 
     // Recreation of running DFv1 .save() DPO changing partition cols.
-    ("blocked for Write(Overwrite, partitionBy, DPO)",
+    ("blocked for Write(Overwrite, partitionBy, DPO)", "WRITE",
       (_: Metadata) => DeltaOperations.Write(SaveMode.Overwrite, partitionBy = Some(Seq("col2")),
         isDynamicPartitionOverwrite = Some(true))),
 
     // Recreation of running DFv1 .saveAsTable() overwrite changing partition cols.
-    ("blocked for ReplaceTable(isV1SaveAsTableOverwrite=true)",
+    ("blocked for ReplaceTable(isV1SaveAsTableOverwrite=true)", "CREATE OR REPLACE TABLE AS SELECT",
       (newMeta: Metadata) => DeltaOperations.ReplaceTable(
         metadata = newMeta,
         isManaged = true,
         orCreate = true,
         asSelect = true,
         isV1SaveAsTableOverwrite = Some(true)))
-  ).foreach { case (testSuffix, mkOp) =>
+  ).foreach { case (testSuffix, expectedOpName, mkOp) =>
     test(s"partition column changes $testSuffix") {
       withTempDir { tempDir =>
         val tablePath = tempDir.getAbsolutePath
@@ -1289,10 +1303,18 @@ class OptimisticTransactionSuite
         val txn = deltaLog.startTransaction()
         val newMetadata = txn.metadata.copy(partitionColumns = Seq("col2"))
 
-        val ex = intercept[DeltaAnalysisException] {
-          txn.commit(Seq(newMetadata), mkOp(newMetadata))
-        }
-        assert(ex.getErrorClass == "DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE")
+        checkError(
+          intercept[DeltaAnalysisException] {
+            txn.commit(Seq(newMetadata), mkOp(newMetadata))
+          },
+          condition = "DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE",
+          sqlState = "42P10",
+          parameters = Map(
+            "operation" -> expectedOpName,
+            "oldPartitionColumns" -> "col1",
+            "newPartitionColumns" -> "col2"
+          )
+        )
         assertPartitionColumns(tablePath, Seq("col1"))
       }
     }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
- Updated partition column change tests in `OptimisticTransactionSuite` to use `checkError` instead of calling `ex.getErrorClass` directly
- Each `checkError` call now verifies the error condition (`DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE`), SQLSTATE (`42P10`), and named parameter values (`operation`, `oldPartitionColumns`, `newPartitionColumns`)
- Added expected operation name to the parameterized blocked-operations test cases to support per-case parameter verification
- Collapsed the `DELTA_UNSUPPORTED_PARTITION_COLUMN_CHANGE` error message from three lines into a single line in `delta-error-classes.json`, `databricks-error-classes.json`, and `delta-error-classes-data-classification.json` (the multi-line split was not justified as the column lists render as single-line comma-separated strings)


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
No new tests added. Existing tests in `OptimisticTransactionSuite` covering partition column change validation were updated to use `checkError` as required by the error message review guidelines.

## Does this PR introduce _any_ user-facing changes?
N/A
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
