### PR TITLE
[Spark] Double DELTA_STREAMING_INITIAL_SNAPSHOT_MAX_FILES default from 50000 to 100000

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3166,7 +3166,7 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .internal()
       .doc("Maximum number of files allowed in initial snapshot for V2 streaming.")
       .intConf
-      .createWithDefault(50000)
+      .createWithDefault(100000)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Double the default value of `DELTA_STREAMING_INITIAL_SNAPSHOT_MAX_FILES` from 50,000 to 100,000 to better support larger tables for V2 streaming initial snapshots out of the box.

## How was this patch tested?

Existing tests continue to pass since this is a default-value-only change. Tests that explicitly set this config (e.g., `SparkMicroBatchStreamTest`) are unaffected.

## Does this PR introduce _any_ user-facing changes?

Yes. The default maximum number of files allowed in the initial snapshot for V2 streaming is increased from 50,000 to 100,000. Users with tables between 50k–100k files will no longer hit the limit without explicitly raising the config. This change only affects the unreleased master branch and the future release.