### PR TITLE
[kernel-spark] Support ignoreChanges read option in dsv2

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
@@ -44,33 +44,33 @@ class DeltaV2SourceDeletionVectorsSuite
     "allow to delete files before staring a streaming query without checkpoint",
     "multiple deletion vectors per file with initial snapshot",
     "deleting files fails query if ignoreDeletes = false",
+    "deleting files when ignoreChanges = true doesn't fail the query",
     "allow to delete files after staring a streaming query when ignoreDeletes is true",
     "updating the source table causes failure when ignoreChanges = false - using DELETE",
+    "allow to update the source table when ignoreChanges = true - using DELETE",
     "updating source table when ignoreDeletes = true fails the query - using DELETE",
     "subsequent DML commands are processed correctly in a batch - DELETE->DELETE - List()",
     "subsequent DML commands are processed correctly in a batch - DELETE->DELETE" +
       " - List((ignoreDeletes,true))",
     "subsequent DML commands are processed correctly in a batch - DELETE->DELETE" +
       " - List((skipChangeCommits,true))",
+    "subsequent DML commands are processed correctly in a batch - DELETE->DELETE" +
+      " - List((ignoreChanges,true))",
     "subsequent DML commands are processed correctly in a batch - INSERT->DELETE - List()",
     "subsequent DML commands are processed correctly in a batch - INSERT->DELETE" +
       " - List((ignoreDeletes,true))",
     "subsequent DML commands are processed correctly in a batch - INSERT->DELETE" +
-      " - List((skipChangeCommits,true))"
+      " - List((skipChangeCommits,true))",
+    "subsequent DML commands are processed correctly in a batch - INSERT->DELETE" +
+      " - List((ignoreChanges,true))",
+    "multiple deletion vectors per file - List((ignoreChanges,true))"
   )
 
   private lazy val shouldFailTests = Set(
     // TODO(#5319): enable these tests after ignoreChanges/ignoreFileDeletion read options
     //  are supported by the V2 connector.
     "allow to delete files after staring a streaming query when ignoreFileDeletion is true",
-    "allow to update the source table when ignoreChanges = true - using DELETE",
-    "deleting files when ignoreChanges = true doesn't fail the query",
-    "subsequent DML commands are processed correctly in a batch - DELETE->DELETE" +
-      " - List((ignoreChanges,true))",
-    "subsequent DML commands are processed correctly in a batch - INSERT->DELETE" +
-      " - List((ignoreChanges,true))",
-    "multiple deletion vectors per file - List((ignoreFileDeletion,true))",
-    "multiple deletion vectors per file - List((ignoreChanges,true))"
+    "multiple deletion vectors per file - List((ignoreFileDeletion,true))"
   )
 
   override protected def shouldFail(testName: String): Boolean = {

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -54,11 +54,6 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "SC-11561: can consume new data without update",
     "Delta sources don't write offsets with null json",
 
-    // === read options ===
-    "streaming with ignoreDeletes = true skips delete-only commits",
-    "streaming with ignoreDeletes = true still fails on change commits",
-    "streaming with skipChangeCommits = true skips both delete and change commits",
-
     // === Schema Evolution ===
     "add column: restarting with new DataFrame should recover",
     "add column: restarting with stale DataFrame should fail",
@@ -77,6 +72,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "streaming with ignoreDeletes = true skips delete-only commits",
     "streaming with ignoreDeletes = true still fails on change commits",
     "streaming with skipChangeCommits = true skips both delete and change commits",
+    "streaming with ignoreChanges = true allows both delete and change commits",
 
     // ========== startingVersion option tests ==========
     "startingVersion",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -2019,6 +2019,57 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
+  test("streaming with ignoreChanges = true allows both delete and change commits") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      Seq(1, 2, 3).toDF("x").write.format("delta").save(inputDir.toString)
+
+      val df = loadStreamWithOptions(
+        inputDir.toString, Map(DeltaOptions.IGNORE_CHANGES_OPTION -> "true"))
+
+      val q = df.writeStream
+        .format("delta")
+        .option("checkpointLocation", checkpointDir.toString)
+        .start(outputDir.toString)
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.toString),
+          Seq(1, 2, 3).map(Row(_)))
+
+        // Delete all rows: delete-only commit, allowed by ignoreChanges
+        io.delta.tables.DeltaTable.forPath(spark, inputDir.getAbsolutePath).delete()
+
+        // The delete commit is skipped (no AddFiles)
+        Seq(4, 5).toDF("x").write.format("delta").mode("append").save(inputDir.toString)
+        q.processAllAvailable()
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.toString),
+          Seq(1, 2, 3, 4, 5).map(Row(_)))
+
+        // Overwrite produces both AddFile and RemoveFile actions (change commit).
+        // Unlike skipChangeCommits which skips the commit, ignoreChanges lets the
+        // AddFiles through (potentially duplicating data).
+        Seq(6, 7, 8).toDF("x")
+          .write
+          .mode("overwrite")
+          .format("delta")
+          .save(inputDir.toString)
+
+        Seq(9, 10).toDF("x").write.format("delta").mode("append").save(inputDir.toString)
+
+        q.processAllAvailable()
+
+        // The overwrite commit's AddFiles ARE emitted (unlike skipChangeCommits). The
+        // result includes the overwrite's new rows.
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.toString),
+          Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).map(Row(_)))
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
   test("fail on data loss - starting from missing files") {
     withTempDirs { (srcData, targetData, chkLocation) =>
       def addData(): Unit = {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -347,14 +347,6 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
           assertInvalidStreamOption(
               tableName, r -> r.option("startingVersion", -1), "startingVersion");
           assertInvalidStreamOption(tableName, r -> r.option("startingVersion", 999999), "999999");
-
-          if (tableType == TableType.MANAGED) {
-            assertInvalidStreamOption(
-                tableName,
-                r -> r.option("ignoreChanges", "true"),
-                "not supported",
-                "ignoreChanges");
-          }
         });
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -935,10 +935,13 @@ public class SparkMicroBatchStream
       }
     }
 
-    // TODO(#5319): Implement ignoreChanges & ignoreFileDeletion (deprecated)
-    // A check on the source table that disallows changes on the source data.
-    boolean shouldAllowChanges = skipChangeCommits;
-    // A check on the source table that disallows commits that only include deletes to the data.
+    // TODO(#5319): Implement ignoreFileDeletion (deprecated)
+    // "Changes" are commits that contain both AddFile and RemoveFile actions (e.g. UPDATE,
+    // MERGE that rewrites data files). Allowing changes means these commits won't cause failures.
+    boolean shouldAllowChanges = options.ignoreChanges() || skipChangeCommits;
+    // "Deletes" are commits that contain only RemoveFile actions without any AddFile actions
+    // (e.g. DELETE that purely removes data). This is a subset of changes, so allowing changes
+    // implies allowing deletes.
     boolean shouldAllowDeletes = shouldAllowChanges || options.ignoreDeletes();
 
     boolean hasFileAdd = false;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -70,22 +70,22 @@ public class SparkScan
               DeltaOptions.STARTING_TIMESTAMP_OPTION(),
               DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION(),
               DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION(),
+              DeltaOptions.IGNORE_CHANGES_OPTION(),
               DeltaOptions.IGNORE_DELETES_OPTION(),
               DeltaOptions.SKIP_CHANGE_COMMITS_OPTION(),
               DeltaOptions.EXCLUDE_REGEX_OPTION()));
 
   /**
    * Block list of DeltaOptions that are not supported for streaming in V2 connector. Only
-   * startingVersion, startingTimestamp, maxFilesPerTrigger, maxBytesPerTrigger, ignoreDeletes,
-   * skipChangeCommits, and excludeRegex are supported. User-defined custom options (not in
-   * DeltaOptions) are allowed to pass through.
+   * startingVersion, startingTimestamp, maxFilesPerTrigger, maxBytesPerTrigger, ignoreChanges,
+   * ignoreDeletes, skipChangeCommits, and excludeRegex are supported. User-defined custom options
+   * (not in DeltaOptions) are allowed to pass through.
    */
   private static final Set<String> UNSUPPORTED_STREAMING_OPTIONS =
       Collections.unmodifiableSet(
           new HashSet<>(
               Arrays.asList(
                   DeltaOptions.IGNORE_FILE_DELETION_OPTION().toLowerCase(),
-                  DeltaOptions.IGNORE_CHANGES_OPTION().toLowerCase(),
                   DeltaOptions.FAIL_ON_DATA_LOSS_OPTION().toLowerCase(),
                   DeltaOptions.CDC_READ_OPTION().toLowerCase(),
                   DeltaOptions.CDC_READ_OPTION_LEGACY().toLowerCase(),

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -972,32 +972,35 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   // ================================================================================================
-  // Tests for ignoreDeletes parity between DSv1 and DSv2
+  // Shared helpers for ignoreDeletes / skipChangeCommits / ignoreChanges parity tests
   // ================================================================================================
 
   /**
-   * Verifies that with ignoreDeletes=true, both DSv1 and DSv2 produce the same file changes for
-   * delete-only commits (commits with only RemoveFile actions, no AddFile actions). The delete-only
-   * commit should be silently skipped (only sentinels emitted, no data files).
+   * Runs a parity test: verifies that DSv1 and DSv2 produce identical file changes for the given
+   * option and scenario.
    */
-  @ParameterizedTest
-  @MethodSource("deleteOnlyScenarios")
-  public void testGetFileChanges_withIgnoreDeletes_deleteOnlyParity(
+  private void runFileChangeParityTest(
       ScenarioSetup scenarioSetup,
       boolean isInitialSnapshot,
       String testDescription,
-      @TempDir File tempDir)
+      File tempDir,
+      String optionName,
+      boolean usePartitionedTable)
       throws Exception {
     String testTablePath = tempDir.getAbsolutePath();
     String testTableName =
-        "test_ignore_deletes_" + Math.abs(testDescription.hashCode()) + "_" + System.nanoTime();
-    createEmptyPartitionedTestTable(testTablePath, testTableName);
+        "test_" + optionName + "_" + Math.abs(testDescription.hashCode()) + "_" + System.nanoTime();
+    if (usePartitionedTable) {
+      createEmptyPartitionedTestTable(testTablePath, testTableName);
+    } else {
+      createEmptyTestTable(testTablePath, testTableName);
+    }
 
     scenarioSetup.setup(testTableName, tempDir);
 
     long fromVersion = 0L;
     long fromIndex = DeltaSourceOffset.BASE_INDEX();
-    DeltaOptions options = createDeltaOptions("ignoreDeletes", "true");
+    DeltaOptions options = createDeltaOptions(optionName, "true");
 
     // DSv1
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
@@ -1029,24 +1032,19 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   /**
-   * Verifies that with ignoreDeletes=true, both DSv1 and DSv2 still throw on commits containing
-   * both adds and removes (e.g., UPDATE, MERGE), since ignoreDeletes only suppresses delete-only
-   * commits.
+   * Runs a throws-parity test: verifies that both DSv1 and DSv2 throw UnsupportedOperationException
+   * after the same number of next() calls.
    */
-  @ParameterizedTest
-  @MethodSource("changeCommitScenarios")
-  public void testGetFileChanges_withIgnoreDeletes_changeCommitStillThrows(
+  private void runFileChangeThrowsParityTest(
       ScenarioSetup scenarioSetup,
       boolean isInitialSnapshot,
       String testDescription,
-      @TempDir File tempDir)
+      File tempDir,
+      String optionName)
       throws Exception {
     String testTablePath = tempDir.getAbsolutePath();
     String testTableName =
-        "test_ignore_deletes_change_"
-            + Math.abs(testDescription.hashCode())
-            + "_"
-            + System.nanoTime();
+        "test_" + optionName + "_" + Math.abs(testDescription.hashCode()) + "_" + System.nanoTime();
     createEmptyTestTable(testTablePath, testTableName);
 
     scenarioSetup.setup(testTableName, tempDir);
@@ -1054,7 +1052,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     long fromVersion = 0L;
     long fromIndex = DeltaSourceOffset.BASE_INDEX();
     Option<DeltaSourceOffset> endOffset = Option.empty();
-    DeltaOptions options = createDeltaOptions("ignoreDeletes", "true");
+    DeltaOptions options = createDeltaOptions(optionName, "true");
 
     // DSv1
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
@@ -1081,7 +1079,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
           }
         },
         String.format(
-            "DSv1 should throw on change commit with ignoreDeletes for: %s", testDescription));
+            "DSv1 should throw on change commit with %s for: %s", optionName, testDescription));
 
     // DSv2
     Configuration hadoopConf = new Configuration();
@@ -1106,7 +1104,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
           }
         },
         String.format(
-            "DSv2 should throw on change commit with ignoreDeletes for: %s", testDescription));
+            "DSv2 should throw on change commit with %s for: %s", optionName, testDescription));
 
     assertEquals(
         dsv1SuccessfulCalls.get(),
@@ -1115,6 +1113,44 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             "DSv1 and DSv2 should throw after the same number of next() calls for: %s. "
                 + "DSv1=%d, DSv2=%d",
             testDescription, dsv1SuccessfulCalls.get(), dsv2SuccessfulCalls.get()));
+  }
+
+  // ================================================================================================
+  // Tests for ignoreDeletes parity between DSv1 and DSv2
+  // ================================================================================================
+
+  /**
+   * Verifies that with ignoreDeletes=true, both DSv1 and DSv2 produce the same file changes for
+   * delete-only commits (commits with only RemoveFile actions, no AddFile actions). The delete-only
+   * commit should be silently skipped (only sentinels emitted, no data files).
+   */
+  @ParameterizedTest
+  @MethodSource("deleteOnlyScenarios")
+  public void testGetFileChanges_withIgnoreDeletes_deleteOnlyParity(
+      ScenarioSetup scenarioSetup,
+      boolean isInitialSnapshot,
+      String testDescription,
+      @TempDir File tempDir)
+      throws Exception {
+    runFileChangeParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "ignoreDeletes", true);
+  }
+
+  /**
+   * Verifies that with ignoreDeletes=true, both DSv1 and DSv2 still throw on commits containing
+   * both adds and removes (e.g., UPDATE, MERGE), since ignoreDeletes only suppresses delete-only
+   * commits.
+   */
+  @ParameterizedTest
+  @MethodSource("changeCommitScenarios")
+  public void testGetFileChanges_withIgnoreDeletes_changeCommitStillThrows(
+      ScenarioSetup scenarioSetup,
+      boolean isInitialSnapshot,
+      String testDescription,
+      @TempDir File tempDir)
+      throws Exception {
+    runFileChangeThrowsParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "ignoreDeletes");
   }
 
   // ================================================================================================
@@ -1134,44 +1170,8 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       String testDescription,
       @TempDir File tempDir)
       throws Exception {
-    String testTablePath = tempDir.getAbsolutePath();
-    String testTableName =
-        "test_skip_change_del_" + Math.abs(testDescription.hashCode()) + "_" + System.nanoTime();
-    createEmptyPartitionedTestTable(testTablePath, testTableName);
-
-    scenarioSetup.setup(testTableName, tempDir);
-
-    long fromVersion = 0L;
-    long fromIndex = DeltaSourceOffset.BASE_INDEX();
-    DeltaOptions options = createDeltaOptions("skipChangeCommits", "true");
-
-    // DSv1
-    DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
-    DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath, options);
-    Option<DeltaSourceOffset> endOffset = Option.empty();
-    ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> deltaChanges =
-        deltaSource.getFileChanges(
-            fromVersion, fromIndex, isInitialSnapshot, endOffset, /* verifyMetadataAction= */ true);
-    List<org.apache.spark.sql.delta.sources.IndexedFile> deltaFilesList = new ArrayList<>();
-    while (deltaChanges.hasNext()) {
-      deltaFilesList.add(deltaChanges.next());
-    }
-    deltaChanges.close();
-
-    // DSv2
-    Configuration hadoopConf = new Configuration();
-    PathBasedSnapshotManager snapshotManager =
-        new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
-        createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
-    try (CloseableIterator<IndexedFile> kernelChanges =
-        stream.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, Optional.empty())) {
-      List<IndexedFile> kernelFilesList = new ArrayList<>();
-      while (kernelChanges.hasNext()) {
-        kernelFilesList.add(kernelChanges.next());
-      }
-      compareFileChanges(deltaFilesList, kernelFilesList);
-    }
+    runFileChangeParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "skipChangeCommits", true);
   }
 
   /**
@@ -1187,53 +1187,56 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       String testDescription,
       @TempDir File tempDir)
       throws Exception {
-    String testTablePath = tempDir.getAbsolutePath();
-    String testTableName =
-        "test_skip_change_chg_" + Math.abs(testDescription.hashCode()) + "_" + System.nanoTime();
-    createEmptyTestTable(testTablePath, testTableName);
-
-    scenarioSetup.setup(testTableName, tempDir);
-
-    long fromVersion = 0L;
-    long fromIndex = DeltaSourceOffset.BASE_INDEX();
-    DeltaOptions options = createDeltaOptions("skipChangeCommits", "true");
-
-    // DSv1
-    DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
-    DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath, options);
-    Option<DeltaSourceOffset> endOffset = Option.empty();
-    ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> deltaChanges =
-        deltaSource.getFileChanges(
-            fromVersion, fromIndex, isInitialSnapshot, endOffset, /* verifyMetadataAction= */ true);
-    List<org.apache.spark.sql.delta.sources.IndexedFile> deltaFilesList = new ArrayList<>();
-    while (deltaChanges.hasNext()) {
-      deltaFilesList.add(deltaChanges.next());
-    }
-    deltaChanges.close();
-
-    // DSv2
-    Configuration hadoopConf = new Configuration();
-    PathBasedSnapshotManager snapshotManager =
-        new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
-        createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
-    try (CloseableIterator<IndexedFile> kernelChanges =
-        stream.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, Optional.empty())) {
-      List<IndexedFile> kernelFilesList = new ArrayList<>();
-      while (kernelChanges.hasNext()) {
-        kernelFilesList.add(kernelChanges.next());
-      }
-      compareFileChanges(deltaFilesList, kernelFilesList);
-    }
+    runFileChangeParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "skipChangeCommits", false);
   }
 
   // ================================================================================================
-  // Shared scenario providers for ignoreDeletes and skipChangeCommits tests
+  // Tests for ignoreChanges parity between DSv1 and DSv2
+  // ================================================================================================
+
+  /**
+   * Verifies that with ignoreChanges=true, both DSv1 and DSv2 produce the same file changes for
+   * delete-only commits. Since ignoreChanges implies shouldAllowDeletes, these commits should be
+   * silently skipped (only sentinels emitted, no data files).
+   */
+  @ParameterizedTest
+  @MethodSource("deleteOnlyScenarios")
+  public void testGetFileChanges_withIgnoreChanges_deleteOnlyParity(
+      ScenarioSetup scenarioSetup,
+      boolean isInitialSnapshot,
+      String testDescription,
+      @TempDir File tempDir)
+      throws Exception {
+    runFileChangeParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "ignoreChanges", true);
+  }
+
+  /**
+   * Verifies that with ignoreChanges=true, both DSv1 and DSv2 produce the same file changes for
+   * change commits (commits containing both AddFile and RemoveFile actions). Unlike ignoreDeletes,
+   * ignoreChanges allows these commits through and emits their AddFiles.
+   */
+  @ParameterizedTest
+  @MethodSource("changeCommitScenarios")
+  public void testGetFileChanges_withIgnoreChanges_changeCommitParity(
+      ScenarioSetup scenarioSetup,
+      boolean isInitialSnapshot,
+      String testDescription,
+      @TempDir File tempDir)
+      throws Exception {
+    runFileChangeParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "ignoreChanges", false);
+  }
+
+  // TODO(#5319): test the combinations of ignoreDeletes, skipChangeCommits, and ignoreChanges
+  // ================================================================================================
+  // Shared scenario providers for ignoreDeletes, skipChangeCommits, and ignoreChanges tests
   // ================================================================================================
 
   /**
    * Provides delete-only scenarios: commits with only RemoveFile actions and no AddFile actions.
-   * Used by both ignoreDeletes and skipChangeCommits tests.
+   * Used by ignoreDeletes, skipChangeCommits, and ignoreChanges tests.
    *
    * <p>Arguments: (ScenarioSetup, isInitialSnapshot, testDescription)
    */
@@ -1292,8 +1295,9 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Provides change-commit scenarios: commits containing both AddFile and RemoveFile actions (e.g.,
-   * UPDATE, MERGE). Used by both ignoreDeletes and skipChangeCommits tests — ignoreDeletes expects
-   * these to throw, while skipChangeCommits expects them to be silently skipped.
+   * UPDATE, MERGE). Used by ignoreDeletes, skipChangeCommits, and ignoreChanges tests —
+   * ignoreDeletes expects these to throw, skipChangeCommits expects them to be silently skipped,
+   * and ignoreChanges expects them to pass through with AddFiles emitted.
    *
    * <p>Arguments: (ScenarioSetup, isInitialSnapshot, testDescription)
    */

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -463,7 +463,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     assertEquals(
         "The following streaming options are not supported: [readchangefeed]. "
             + "Supported options are: [startingVersion, startingTimestamp, maxFilesPerTrigger, "
-            + "maxBytesPerTrigger, ignoreDeletes, skipChangeCommits, excludeRegex].",
+            + "maxBytesPerTrigger, ignoreChanges, ignoreDeletes, skipChangeCommits, excludeRegex].",
         exception.getMessage());
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6249/files/0d54da51e7eade47b8115d92aaf7be1e8e4c011f..7e400f87189bef892d3b0022c0aede238a0c84de) to review incremental changes.
- [stack/ignoreDeletesV2](https://github.com/delta-io/delta/pull/6245) [[Files changed](https://github.com/delta-io/delta/pull/6245/files)]
  - [stack/skipChangeCommitsV2](https://github.com/delta-io/delta/pull/6246) [[Files changed](https://github.com/delta-io/delta/pull/6246/files/6e9962d4a30a63ed14786830bae2b668004a76c9..2e111cf6ac9d1e5f84d83d94412b05486f543613)]
    - [**stack/ignoreChangesV2**](https://github.com/delta-io/delta/pull/6249) [[Files changed](https://github.com/delta-io/delta/pull/6249/files/0d54da51e7eade47b8115d92aaf7be1e8e4c011f..7e400f87189bef892d3b0022c0aede238a0c84de)]
      - [stack/ignoreFileDeletionV2](https://github.com/delta-io/delta/pull/6250) [[Files changed](https://github.com/delta-io/delta/pull/6250/files/7e400f87189bef892d3b0022c0aede238a0c84de..af230590d0d9c1a5c37cc6a7b6af404025a6d415)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Support ignoreChanges read option in DSv2, which skip all remove file actions but keep the add file actions in the same commit.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests that test parity between v1 and v2 connector on both pure deletes commit (only remove) and change commit (add + remove).

Integration tests:
 - streaming with ignoreChanges = true allows both delete and change commits
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
