### PR TITLE
[kernel-spark] Support ignoreFileDeletion read option in dsv2

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
@@ -46,6 +46,7 @@ class DeltaV2SourceDeletionVectorsSuite
     "deleting files fails query if ignoreDeletes = false",
     "deleting files when ignoreChanges = true doesn't fail the query",
     "allow to delete files after staring a streaming query when ignoreDeletes is true",
+    "allow to delete files after staring a streaming query when ignoreFileDeletion is true",
     "updating the source table causes failure when ignoreChanges = false - using DELETE",
     "allow to update the source table when ignoreChanges = true - using DELETE",
     "updating source table when ignoreDeletes = true fails the query - using DELETE",
@@ -63,15 +64,11 @@ class DeltaV2SourceDeletionVectorsSuite
       " - List((skipChangeCommits,true))",
     "subsequent DML commands are processed correctly in a batch - INSERT->DELETE" +
       " - List((ignoreChanges,true))",
-    "multiple deletion vectors per file - List((ignoreChanges,true))"
-  )
-
-  private lazy val shouldFailTests = Set(
-    // TODO(#5319): enable these tests after ignoreChanges/ignoreFileDeletion read options
-    //  are supported by the V2 connector.
-    "allow to delete files after staring a streaming query when ignoreFileDeletion is true",
+    "multiple deletion vectors per file - List((ignoreChanges,true))",
     "multiple deletion vectors per file - List((ignoreFileDeletion,true))"
   )
+
+  private lazy val shouldFailTests = Set.empty[String]
 
   override protected def shouldFail(testName: String): Boolean = {
     val inPassList = shouldPassTests.contains(testName)

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -54,12 +54,6 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "SC-11561: can consume new data without update",
     "Delta sources don't write offsets with null json",
 
-    // === read options ===
-    "streaming with ignoreDeletes = true skips delete-only commits",
-    "streaming with ignoreDeletes = true still fails on change commits",
-    "streaming with skipChangeCommits = true skips both delete and change commits",
-    "streaming with ignoreChanges = true allows both delete and change commits",
-
     // === Schema Evolution ===
     "add column: restarting with new DataFrame should recover",
     "add column: restarting with stale DataFrame should fail",
@@ -79,6 +73,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "streaming with ignoreDeletes = true still fails on change commits",
     "streaming with skipChangeCommits = true skips both delete and change commits",
     "streaming with ignoreChanges = true allows both delete and change commits",
+    "streaming with ignoreFileDeletion = true allows both delete and change commits",
 
     // ========== startingVersion option tests ==========
     "startingVersion",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -2070,6 +2070,56 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
+  test("streaming with ignoreFileDeletion = true allows both delete and change commits") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      Seq(1, 2, 3).toDF("x").write.format("delta").save(inputDir.toString)
+
+      val df = loadStreamWithOptions(
+        inputDir.toString, Map(DeltaOptions.IGNORE_FILE_DELETION_OPTION -> "true"))
+
+      val q = df.writeStream
+        .format("delta")
+        .option("checkpointLocation", checkpointDir.toString)
+        .start(outputDir.toString)
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.toString),
+          Seq(1, 2, 3).map(Row(_)))
+
+        // Delete all rows: delete-only commit
+        io.delta.tables.DeltaTable.forPath(spark, inputDir.getAbsolutePath).delete()
+
+        // The delete commit is skipped (no AddFiles)
+        Seq(4, 5).toDF("x").write.format("delta").mode("append").save(inputDir.toString)
+        q.processAllAvailable()
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.toString),
+          Seq(1, 2, 3, 4, 5).map(Row(_)))
+
+        // Overwrite produces both AddFile and RemoveFile actions (change commit).
+        // ignoreFileDeletion behaves like ignoreChanges - AddFiles are emitted.
+        Seq(6, 7, 8).toDF("x")
+          .write
+          .mode("overwrite")
+          .format("delta")
+          .save(inputDir.toString)
+
+        Seq(9, 10).toDF("x").write.format("delta").mode("append").save(inputDir.toString)
+
+        q.processAllAvailable()
+
+        // The overwrite's AddFiles are emitted (same as ignoreChanges). This option is
+        // deprecated in favor of skipChangeCommits.
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.toString),
+          Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).map(Row(_)))
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
   test("fail on data loss - starting from missing files") {
     withTempDirs { (srcData, targetData, chkLocation) =>
       def addData(): Unit = {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -102,6 +102,7 @@ public class SparkMicroBatchStream
   private final Engine engine;
   private final DeltaSnapshotManager snapshotManager;
   private final DeltaOptions options;
+  private final boolean ignoreFileDeletion;
   private final boolean skipChangeCommits;
   private final SnapshotImpl snapshotAtSourceInit;
   private final String tableId;
@@ -188,6 +189,11 @@ public class SparkMicroBatchStream
     this.spark = Objects.requireNonNull(spark, "spark is null");
     this.engine = DefaultEngine.create(hadoopConf);
     this.options = Objects.requireNonNull(options, "options is null");
+    this.ignoreFileDeletion = this.options.ignoreFileDeletion();
+    // Deprecated. Please use `skipChangeCommits` from now on.
+    if (this.ignoreFileDeletion) {
+      logger.warn(DeltaErrors.ignoreStreamingUpdatesAndDeletesWarning(this.spark));
+    }
     this.skipChangeCommits = this.options.skipChangeCommits();
     // Normalize tablePath to ensure it ends with "/" for consistent path construction
     String normalizedTablePath = Objects.requireNonNull(tablePath, "tablePath is null");
@@ -935,10 +941,9 @@ public class SparkMicroBatchStream
       }
     }
 
-    // TODO(#5319): Implement ignoreFileDeletion (deprecated)
     // "Changes" are commits that contain both AddFile and RemoveFile actions (e.g. UPDATE,
     // MERGE that rewrites data files). Allowing changes means these commits won't cause failures.
-    boolean shouldAllowChanges = options.ignoreChanges() || skipChangeCommits;
+    boolean shouldAllowChanges = options.ignoreChanges() || ignoreFileDeletion || skipChangeCommits;
     // "Deletes" are commits that contain only RemoveFile actions without any AddFile actions
     // (e.g. DELETE that purely removes data). This is a subset of changes, so allowing changes
     // implies allowing deletes.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -72,6 +72,7 @@ public class SparkScan
               DeltaOptions.STARTING_TIMESTAMP_OPTION(),
               DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION(),
               DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION(),
+              DeltaOptions.IGNORE_FILE_DELETION_OPTION(),
               DeltaOptions.IGNORE_CHANGES_OPTION(),
               DeltaOptions.IGNORE_DELETES_OPTION(),
               DeltaOptions.SKIP_CHANGE_COMMITS_OPTION(),
@@ -79,15 +80,14 @@ public class SparkScan
 
   /**
    * Block list of DeltaOptions that are not supported for streaming in V2 connector. Only
-   * startingVersion, startingTimestamp, maxFilesPerTrigger, maxBytesPerTrigger, ignoreChanges,
-   * ignoreDeletes, skipChangeCommits, and excludeRegex are supported. User-defined custom options
-   * (not in DeltaOptions) are allowed to pass through.
+   * startingVersion, startingTimestamp, maxFilesPerTrigger, maxBytesPerTrigger, ignoreFileDeletion,
+   * ignoreChanges, ignoreDeletes, skipChangeCommits, and excludeRegex are supported. User-defined
+   * custom options (not in DeltaOptions) are allowed to pass through.
    */
   private static final Set<String> UNSUPPORTED_STREAMING_OPTIONS =
       Collections.unmodifiableSet(
           new HashSet<>(
               Arrays.asList(
-                  DeltaOptions.IGNORE_FILE_DELETION_OPTION().toLowerCase(),
                   DeltaOptions.FAIL_ON_DATA_LOSS_OPTION().toLowerCase(),
                   DeltaOptions.CDC_READ_OPTION().toLowerCase(),
                   DeltaOptions.CDC_READ_OPTION_LEGACY().toLowerCase(),

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -1229,14 +1229,53 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         scenarioSetup, isInitialSnapshot, testDescription, tempDir, "ignoreChanges", false);
   }
 
+  // ================================================================================================
+  // Tests for ignoreFileDeletion parity between DSv1 and DSv2
+  // ================================================================================================
+
+  /**
+   * Verifies that with ignoreFileDeletion=true, both DSv1 and DSv2 produce the same file changes
+   * for delete-only commits. Since ignoreFileDeletion implies shouldAllowDeletes, these commits
+   * should be silently skipped (only sentinels emitted, no data files).
+   */
+  @ParameterizedTest
+  @MethodSource("deleteOnlyScenarios")
+  public void testGetFileChanges_withIgnoreFileDeletion_deleteOnlyParity(
+      ScenarioSetup scenarioSetup,
+      boolean isInitialSnapshot,
+      String testDescription,
+      @TempDir File tempDir)
+      throws Exception {
+    runFileChangeParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "ignoreFileDeletion", true);
+  }
+
+  /**
+   * Verifies that with ignoreFileDeletion=true, both DSv1 and DSv2 produce the same file changes
+   * for change commits (commits containing both AddFile and RemoveFile actions). Unlike
+   * ignoreDeletes, ignoreFileDeletion allows these commits through and emits their AddFiles.
+   */
+  @ParameterizedTest
+  @MethodSource("changeCommitScenarios")
+  public void testGetFileChanges_withIgnoreFileDeletion_changeCommitParity(
+      ScenarioSetup scenarioSetup,
+      boolean isInitialSnapshot,
+      String testDescription,
+      @TempDir File tempDir)
+      throws Exception {
+    runFileChangeParityTest(
+        scenarioSetup, isInitialSnapshot, testDescription, tempDir, "ignoreFileDeletion", false);
+  }
+
   // TODO(#5319): test the combinations of ignoreDeletes, skipChangeCommits, and ignoreChanges
   // ================================================================================================
-  // Shared scenario providers for ignoreDeletes, skipChangeCommits, and ignoreChanges tests
+  // Shared scenario providers for ignoreDeletes, skipChangeCommits, ignoreChanges, and
+  // ignoreFileDeletion tests
   // ================================================================================================
 
   /**
    * Provides delete-only scenarios: commits with only RemoveFile actions and no AddFile actions.
-   * Used by ignoreDeletes, skipChangeCommits, and ignoreChanges tests.
+   * Used by ignoreDeletes, skipChangeCommits, ignoreChanges, and ignoreFileDeletion tests.
    *
    * <p>Arguments: (ScenarioSetup, isInitialSnapshot, testDescription)
    */
@@ -1295,9 +1334,10 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Provides change-commit scenarios: commits containing both AddFile and RemoveFile actions (e.g.,
-   * UPDATE, MERGE). Used by ignoreDeletes, skipChangeCommits, and ignoreChanges tests —
-   * ignoreDeletes expects these to throw, skipChangeCommits expects them to be silently skipped,
-   * and ignoreChanges expects them to pass through with AddFiles emitted.
+   * UPDATE, MERGE). Used by ignoreDeletes, skipChangeCommits, ignoreChanges, and ignoreFileDeletion
+   * tests — ignoreDeletes expects these to throw, skipChangeCommits expects them to be silently
+   * skipped, and ignoreChanges/ignoreFileDeletion expect them to pass through with AddFiles
+   * emitted.
    *
    * <p>Arguments: (ScenarioSetup, isInitialSnapshot, testDescription)
    */

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -588,7 +588,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     assertEquals(
         "The following streaming options are not supported: [readchangefeed]. "
             + "Supported options are: [startingVersion, startingTimestamp, maxFilesPerTrigger, "
-            + "maxBytesPerTrigger, ignoreChanges, ignoreDeletes, skipChangeCommits, excludeRegex].",
+            + "maxBytesPerTrigger, ignoreFileDeletion, ignoreChanges, ignoreDeletes, skipChangeCommits, excludeRegex].",
         exception.getMessage());
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6250/files/7e400f87189bef892d3b0022c0aede238a0c84de..af230590d0d9c1a5c37cc6a7b6af404025a6d415) to review incremental changes.
- [stack/ignoreDeletesV2](https://github.com/delta-io/delta/pull/6245) [[Files changed](https://github.com/delta-io/delta/pull/6245/files)]
  - [stack/skipChangeCommitsV2](https://github.com/delta-io/delta/pull/6246) [[Files changed](https://github.com/delta-io/delta/pull/6246/files/6e9962d4a30a63ed14786830bae2b668004a76c9..2e111cf6ac9d1e5f84d83d94412b05486f543613)]
    - [stack/ignoreChangesV2](https://github.com/delta-io/delta/pull/6249) [[Files changed](https://github.com/delta-io/delta/pull/6249/files/0d54da51e7eade47b8115d92aaf7be1e8e4c011f..7e400f87189bef892d3b0022c0aede238a0c84de)]
      - [**stack/ignoreFileDeletionV2**](https://github.com/delta-io/delta/pull/6250) [[Files changed](https://github.com/delta-io/delta/pull/6250/files/7e400f87189bef892d3b0022c0aede238a0c84de..af230590d0d9c1a5c37cc6a7b6af404025a6d415)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Support ignoreFileDeletion read option is DSv2, which skip a all remove file actions but keep the add file actions in the same commit. And also inform user that this read option has deprecated. 
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests that test parity between v1 and v2 connector on both pure deletes commit (only remove) and change commit (add + remove).

Integration tests:
 - streaming with ignoreFileDeletion = true allows both delete and change commits

DV tests:
 - multiple deletion vectors per file - List((ignoreFileDeletion,true))
 - allow to delete files after staring a streaming query when ignoreFileDeletion is true
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
