### PR TITLE
[DO NOT REVIEW] [Spark] Handle UC version lag in streaming reads

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -779,7 +779,8 @@ public class SparkMicroBatchStream
       commitRange = snapshotManager.getTableChanges(engine, startVersion, endVersionOpt);
     } catch (io.delta.kernel.exceptions.CommitRangeNotFoundException e) {
       // If the requested version range doesn't exist (e.g., we're asking for version 6 when
-      // the table only has versions 0-5).
+      // the table only has versions 0-5). For UC-managed tables, the snapshot manager maps
+      // version-not-yet-ratified errors to this exception as well.
       return Utils.toCloseableIterator(Collections.emptyIterator());
     }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.CommitRangeNotFoundException;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
@@ -168,13 +169,29 @@ public class UCManagedTableSnapshotManager implements DeltaSnapshotManager {
    */
   @Override
   public CommitRange getTableChanges(Engine engine, long startVersion, Optional<Long> endVersion) {
-    return ucCatalogManagedClient.loadCommitRange(
-        engine,
-        tableId,
-        tablePath,
-        Optional.of(startVersion) /* startVersionOpt */,
-        Optional.empty() /* startTimestampOpt */,
-        endVersion /* endVersionOpt */,
-        Optional.empty() /* endTimestampOpt */);
+    try {
+      return ucCatalogManagedClient.loadCommitRange(
+          engine,
+          tableId,
+          tablePath,
+          Optional.of(startVersion) /* startVersionOpt */,
+          Optional.empty() /* startTimestampOpt */,
+          endVersion /* endVersionOpt */,
+          Optional.empty() /* endTimestampOpt */);
+    } catch (IllegalArgumentException e) {
+      // UC-managed tables can temporarily have a Delta log version on the filesystem that has
+      // not yet been ratified by UC (version lag). UCCatalogManagedClient throws
+      // IllegalArgumentException with "ratified by UC" in the message for this case.
+      // Map it to CommitRangeNotFoundException so SparkMicroBatchStream treats it as
+      // "no new data yet" and retries on the next micro-batch.
+      String msg = e.getMessage();
+      if (msg != null && msg.contains("ratified by UC")) {
+        CommitRangeNotFoundException mapped =
+            new CommitRangeNotFoundException(tablePath, startVersion, endVersion);
+        mapped.initCause(e);
+        throw mapped;
+      }
+      throw e;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- UC-managed Delta tables can temporarily have a commit on the filesystem that UC has not yet ratified (version lag). When this happens, `UCCatalogManagedClient.validateVersionBoundariesExist()` throws `IllegalArgumentException`, which crashes the streaming query.
- This PR catches the version-lag `IllegalArgumentException` in `UCManagedTableSnapshotManager.getTableChanges()` and maps it to `CommitRangeNotFoundException`, which `SparkMicroBatchStream.filterDeltaLogs()` already handles by returning an empty iterator — causing the stream to retry on the next micro-batch.
- Keeps catalog-specific logic in the snapshot manager layer (not in `SparkMicroBatchStream`), addressing review feedback from @huan233usc on #6023.

Fixes the `allTableTypesTestsFactory` / `testStreamingContinuous(MANAGED)` flaky CI failure seen in PRs like #6255.

Supersedes #6023 (which included debug instrumentation and test modifications that are not needed for the fix).

## Test plan
- [ ] Existing `UCDeltaTableDataFrameStreamingTest.allTableTypesTestsFactory` tests should now pass without flakiness — the streaming query will retry when UC version lag is encountered instead of failing.
- [ ] Verify that non-ratification `IllegalArgumentException`s from `UCCatalogManagedClient` are still propagated (the catch only matches messages containing "ratified by UC").

This pull request was AI-assisted by Isaac.