### PR TITLE
[Spark] Fix timestamp overflow in dataskipping

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -232,6 +232,27 @@ private[delta] object DataSkippingReader {
     Option(ExpressionEncoder[java.lang.Long]()),
     Option(ExpressionEncoder[java.lang.Long]()),
     Option(ExpressionEncoder[java.lang.Long]()))
+
+  /**
+   * For timestamps, JSON serialization will truncate to milliseconds. This means
+   * that we must adjust 1 millisecond upwards for max stats, or we will incorrectly skip
+   * records that differ only in microsecond precision. (For example, a file containing only
+   * 01:02:03.456789 will be written with min == max == 01:02:03.456, so we must consider it
+   * to contain the range from 01:02:03.456 to 01:02:03.457.)
+   *
+   * To avoid overflow when the timestamp is near Long.MAX_VALUE, we check if adding 1
+   * millisecond would overflow. If so, we saturate to Long.MAX_VALUE to ensure the max stat
+   * is >= all actual values in the file while avoiding arithmetic overflow.
+   */
+  def getAdjustedTimestamp(col: Column, tsType: DataType): Column = {
+    val maxTimestampLiteral = Literal(Long.MaxValue, tsType)
+    val overflowThresholdLiteral = Literal(Long.MaxValue - 1000, tsType)
+    val adjustedExpr = If(
+      GreaterThan(col.expr, overflowThresholdLiteral),
+      maxTimestampLiteral,
+      TimestampAdd("MILLISECOND", Literal(1L, LongType), col.expr))
+    Column(Cast(adjustedExpr, tsType))
+  }
 }
 
 /**
@@ -1087,27 +1108,9 @@ trait DataSkippingReaderBase
       .filterNot(_._2.isInstanceOf[StructType])
       .map {
         case (statCol, TimestampType, _) if pathToStatType.head == MAX =>
-          // SC-22824: For timestamps, JSON serialization will truncate to milliseconds. This means
-          // that we must adjust 1 millisecond upwards for max stats, or we will incorrectly skip
-          // records that differ only in microsecond precision. (For example, a file containing only
-          // 01:02:03.456789 will be written with min == max == 01:02:03.456, so we must consider it
-          // to contain the range from 01:02:03.456 to 01:02:03.457.)
-          //
-          // There is a longer term task SC-22825 to fix the serialization problem that caused this.
-          // But we need the adjustment in any case to correctly read stats written by old versions.
-          // TimeAdd is removed in Spark 4.1, using TimestampAdd instead
-          Column(Cast(TimestampAdd(
-            "MILLISECOND",
-            new Literal(1L, LongType),
-            statCol.expr), TimestampType))
+          getAdjustedTimestamp(statCol, TimestampType)
         case (statCol, TimestampNTZType, _) if pathToStatType.head == MAX =>
-          // We also apply the same adjustment of max stats that was applied to Timestamp
-          // for TimestampNTZ because these 2 types have the same precision in terms of time.
-          // TimeAdd is removed in Spark 4.1, using TimestampAdd instead
-          Column(Cast(TimestampAdd(
-            "MILLISECOND",
-            new Literal(1L, LongType),
-            statCol.expr), TimestampNTZType))
+          getAdjustedTimestamp(statCol, TimestampNTZType)
         case (statCol, _, _) =>
           statCol
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -1671,41 +1671,92 @@ trait DataSkippingDeltaTestsBase extends QueryTest
           s"STRUCT(CAST(strTs AS $timestampType) AS ts) AS nested")
 
       val tempDir = Utils.createTempDir()
-      val r = DeltaLog.forTable(spark, tempDir)
-      df.coalesce(1).write.format("delta").save(r.dataPath.toString)
+      val log = DeltaLog.forTable(spark, tempDir)
+      df.coalesce(1).write.format("delta").save(log.dataPath.toString)
 
-      // Check to ensure that the value actually in the file is always in range queries.
-      val hits = Seq(
-        s"""ts >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
-        s"""ts <= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
-        s"""nested.ts >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
-        s"""nested.ts <= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
-        s"""TS >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
-        s"""nEstED.tS >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""")
+      checkSkipping(
+        log,
+        // Check to ensure that the value actually in the file is always in range queries.
+        hits = Seq(
+          s"""ts >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+          s"""ts <= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+          s"""nested.ts >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+          s"""nested.ts <= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+          s"""TS >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+          s"""nEstED.tS >= cast("2019-09-09 01:02:03.456789" AS $timestampType)"""),
+        // Check the range of values that are far enough away to be data skipped. Note that the
+        // values are aligned with millisecond boundaries because of the JSON serialization
+        // truncation.
+        misses = Seq(
+          s"""ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+          s"""ts <= cast("2019-09-04 01:02:03.455999" AS $timestampType)""",
+          s"""nested.ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+          s"""nested.ts <= cast("2019-09-09 01:02:03.455999" AS $timestampType)""",
+          s"""TS >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+          s"""nEstED.tS >= cast("2019-09-09 01:02:03.457001" AS $timestampType)"""),
+        data = data,
+        checkEmptyUnusedFiltersForHits = false)
+    }
+  }
 
-      // Check the range of values that are far enough away to be data skipped. Note that the values
-      // are aligned with millisecond boundaries because of the JSON serialization truncation.
-      val misses = Seq(
-        s"""ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
-        s"""ts <= cast("2019-09-04 01:02:03.455999" AS $timestampType)""",
-        s"""nested.ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
-        s"""nested.ts <= cast("2019-09-09 01:02:03.455999" AS $timestampType)""",
-        s"""TS >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
-        s"""nEstED.tS >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""")
+  for (timestampType <- Seq("TIMESTAMP", "TIMESTAMP_NTZ")) {
+    test(s"data skipping on $timestampType with Long.MaxValue") {
+      val maxVal = "294247-01-10 04:00:54.775807Z"
+      val tempDir = Utils.createTempDir()
+      val log = DeltaLog.forTable(spark, tempDir)
+      Seq(maxVal).toDF("strTs")
+        .selectExpr(s"CAST(strTs AS $timestampType) AS ts")
+        .coalesce(1)
+        .write
+        .format("delta")
+        .save(log.dataPath.toString)
 
-      hits.foreach { predicate =>
-        Given(predicate)
-        if (filesRead(r, predicate) != 1) {
-          failPretty(s"Expected hit but got miss for $predicate", predicate, data)
-        }
-      }
+      checkSkipping(
+        log,
+        hits = Seq(
+          s"""ts >= cast("$maxVal" AS $timestampType)""",
+          s"""ts >= "$maxVal"""",
+          s"""ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+          // This still hits because of JSON truncation to milliseconds
+          s"""ts < cast("$maxVal" AS $timestampType)""".stripMargin),
+        misses = Seq(
+          s"""ts <= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+          s"""ts > cast("$maxVal" AS $timestampType)"""),
+        data = maxVal,
+        checkEmptyUnusedFiltersForHits = false)
+    }
+  }
 
-      misses.foreach { predicate =>
-        Given(predicate)
-        if (filesRead(r, predicate) != 0) {
-          failPretty(s"Expected miss but got hit for $predicate", predicate, data)
-        }
-      }
+  for (timestampType <- Seq("TIMESTAMP", "TIMESTAMP_NTZ")) {
+    test(s"data skipping on $timestampType near Long.MaxValue") {
+      val tempDir = Utils.createTempDir()
+      val log = DeltaLog.forTable(spark, tempDir)
+
+      val nearMaxMicros = Long.MaxValue - 999L
+
+      // Create DataFrame with the near-max timestamp value
+      Seq(nearMaxMicros).toDF("microsSinceEpoch")
+        .selectExpr(s"TIMESTAMP_MICROS(microsSinceEpoch) AS ts")
+        .selectExpr(s"CAST(ts AS $timestampType) AS ts")
+        .coalesce(1)
+        .write
+        .format("delta")
+        .save(log.dataPath.toString)
+
+      checkSkipping(
+        log,
+        // maxValue of the stats on ts will be saturated to Long.MaxValue instead
+        // of being added 1000 microseconds, which will cause a long overflow.
+        hits = Seq(
+          s"ts >= TIMESTAMP_MICROS($nearMaxMicros)",
+          s"ts >= TIMESTAMP_MICROS(${nearMaxMicros - 100})",
+          s"""ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+          s"ts >= TIMESTAMP_MICROS(${Long.MaxValue - 1000})",
+          s"ts < TIMESTAMP_MICROS($nearMaxMicros)"),
+        misses = Seq(
+          s"""ts <= cast("2019-09-09 01:02:03.457001" AS $timestampType)"""),
+        data = nearMaxMicros.toString,
+        checkEmptyUnusedFiltersForHits = false)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

During data-skipping, we add one millisecond to timestamp max stats to compensate for the fact that JSON serialization will truncate them to milliseconds. This has the consequence that if the data contains a timestamp within the range (Long.MaxValue - 1000, Long.MaxValue], then the addition will throw an overflow exception.

This PR fixes this by adding a check for if the stats is within that range, then we saturate the stats to Long.MaxValue instead of adding 1000 to it.

## How was this patch tested?
Unit test

## Does this PR introduce _any_ user-facing changes?

No