### PR TITLE
[Quick POC][Experimental Branch ONLY] Column mapping support for DSv2 connector

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -19,7 +19,6 @@ import static io.delta.kernel.internal.DeltaErrors.dataSchemaMismatch;
 import static io.delta.kernel.internal.DeltaErrors.partitionColumnMissingInData;
 import static io.delta.kernel.internal.TransactionImpl.getStatisticsColumns;
 import static io.delta.kernel.internal.data.TransactionStateRow.*;
-import static io.delta.kernel.internal.util.ColumnMapping.blockIfColumnMappingEnabled;
 import static io.delta.kernel.internal.util.PartitionUtils.getTargetDirectory;
 import static io.delta.kernel.internal.util.PartitionUtils.validateAndSanitizePartitionValues;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -43,6 +42,7 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdater;
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV3MetadataValidatorAndUpdater;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.SchemaIterable;
 import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.types.StructField;
@@ -191,13 +191,14 @@ public interface Transaction {
     Protocol protocol = getProtocol(transactionState);
     boolean materializePartitionColumnsEnabled =
         protocol.supportsFeature(TableFeatures.MATERIALIZE_PARTITION_COLUMNS_W_FEATURE);
-    blockIfColumnMappingEnabled(transactionState);
     blockIfVariantDataTypeIsDefined(tableSchema);
     // We recognize the AllowColumnDefaults feature for Iceberg v3
     // but do not support writing with it yet
     ColumnDefaults.blockWriteIfEnabled(transactionState);
 
-    // TODO: set the correct schema once writing into column mapping enabled table is supported.
+    ColumnMapping.ColumnMappingMode cmMode =
+        TransactionStateRow.getColumnMappingMode(transactionState);
+
     String tablePath = getTablePath(transactionState);
     return dataIter.map(
         filteredBatch -> {
@@ -233,8 +234,44 @@ public interface Transaction {
               data = data.withDeletedColumnAt(partitionColIndex);
             }
           }
+
+          // For column mapping enabled tables, rename data columns from logical to physical
+          // names so Parquet files are written with physical column names.
+          if (ColumnMapping.isColumnMappingModeEnabled(cmMode)) {
+            StructType physicalSchema =
+                ColumnMapping.convertToPhysicalSchema(data.getSchema(), tableSchema, cmMode);
+            data = renameColumnsToPhysical(data, physicalSchema);
+          }
+
           return new FilteredColumnarBatch(data, filteredBatch.getSelectionVector());
         });
+  }
+
+  /**
+   * Renames columns in a {@link ColumnarBatch} from logical names to physical names for column
+   * mapping enabled tables. The data (column vectors) is unchanged; only the schema field names and
+   * metadata are updated to match the physical schema.
+   *
+   * @param data The batch with logical column names.
+   * @param physicalSchema The physical schema with physical column names (same column count and
+   *     order as data).
+   * @return A new batch with physical column names.
+   */
+  private static ColumnarBatch renameColumnsToPhysical(
+      ColumnarBatch data, StructType physicalSchema) {
+    checkArgument(
+        data.getSchema().length() == physicalSchema.length(),
+        "Schema length mismatch: data has %s columns, physical schema has %s columns",
+        data.getSchema().length(),
+        physicalSchema.length());
+    // Replace each column's field with the corresponding physical field (same vector, new name).
+    // Process from last to first to keep stable indices during delete+insert.
+    for (int i = data.getSchema().length() - 1; i >= 0; i--) {
+      ColumnVector vec = data.getColumnVector(i);
+      data = data.withDeletedColumnAt(i);
+      data = data.withNewColumn(i, physicalSchema.at(i), vec);
+    }
+    return data;
   }
 
   /**
@@ -266,7 +303,6 @@ public interface Transaction {
    */
   static DataWriteContext getWriteContext(
       Engine engine, Row transactionState, Map<String, Literal> partitionValues) {
-    blockIfColumnMappingEnabled(transactionState);
     StructType tableSchema = getLogicalSchema(transactionState);
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
 

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingWithV2ConnectorSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingWithV2ConnectorSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.test.V2ForceTest
+
+/**
+ * Test suite that runs DeltaColumnMappingSuite with Delta V2 connector mode forced to STRICT.
+ *
+ * Tests that are expected to fail with the V2 connector are listed in `shouldFailTests` and
+ * converted to ignored tests. This list should be updated as V2 connector support improves.
+ */
+class DeltaColumnMappingWithV2ConnectorSuite
+  extends DeltaColumnMappingSuite
+  with V2ForceTest {
+
+  override protected def shouldFail(testName: String): Boolean = {
+    shouldFailTests.contains(testName)
+  }
+
+  // Note: must be lazy val to avoid NPE during superclass constructor initialization,
+  // since V2ForceTest.test() is called before subclass fields are initialized.
+  // Tests expected to fail because they use V1-specific internals, unsupported DDL,
+  // or features not yet implemented in the V2 connector.
+  private lazy val shouldFailTests = Set(
+    // --- V1 internal API tests (DeltaLog, DeltaTableV2, internal properties) ---
+    "Enable column mapping with schema change on table with no schema",
+    "update column mapped table invalid max id property is blocked",
+    "should block CM upgrade when commit has FileActions and CDF enabled",
+    "upgrade with dot column name should not be blocked",
+    "explicit id matching",
+    "verify internal table properties only if property exists in spec and existing metadata",
+    "DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES exception should include column names",
+    "enabling column mapping disallowed if column mapping metadata already exists",
+    "unit test physical name assigning is case-insensitive",
+    "Illegal null value specified for delta.columnMapping.mode option",
+    "try modifying restricted max id property should fail",
+    "isColumnMappingReadCompatible",
+    "is drop/rename column operation",
+    "getPhysicalNameFieldMap",
+
+    // --- Table creation tests (V1 DeltaLog-based schema checking) ---
+    "create table through raw schema API should auto bump the version and retain input metadata",
+    "create table through dataframe should auto bumps the version and rebuild " +
+      "schema metadata/drop dataframe metadata",
+    "create table with none mode",
+    "create table in column mapping mode without defining ids explicitly",
+
+    // --- Schema evolution / ALTER TABLE tests (V1-specific internal paths) ---
+    "alter column order in schema on new protocol",
+    "add column in schema on new protocol",
+    "add nested column in schema on new protocol",
+    "change mode on new protocol table",
+    "upgrade first and then change mode",
+    "upgrade and change mode in one ALTER TABLE cmd",
+    "illegal mode changes",
+    "column mapping upgrade with table features",
+
+    // --- Write/merge/overwrite tests that use V1-specific partitioned write paths ---
+    "write/merge df to table",
+    "overwrite a column mapping table should preserve column mapping metadata",
+
+    // --- CONVERT TO DELTA not supported in V2 ---
+    "block CONVERT TO DELTA",
+
+    // --- CDF + column mapping interaction (V1 internals) ---
+    "CDF and Column Mapping: should block when CDF=true",
+    "CDF and Column Mapping: should not block when CDF=false",
+
+    // --- RESTORE not supported in V2 ---
+    "restore Delta table with name column mapping enabled",
+
+    // --- External table / REPLACE TABLE operations not supported in V2 ---
+    "drop and recreate external Delta table with name column mapping enabled",
+    "replace external Delta table with name column mapping enabled",
+    "replace delta table will reuse the field id only when column name and type unchanged",
+    "replace delta table will not reuse the field id when name mapping mode changed",
+
+    // --- Read path tests that depend on V1-specific filter push-down or streaming internals ---
+    "filters pushed down to parquet use physical names",
+    "stream read from column mapping does not leak metadata",
+
+    // --- Column mapping metadata stripping tests (V1 internals) ---
+    "column mapping metadata are stripped when feature is disabled - name",
+    "column mapping metadata are stripped when feature is disabled - id"
+  )
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
@@ -60,6 +60,54 @@ public class V2ReadTest extends V2TestBase {
   }
 
   @Test
+  public void testColumnMappingReadAfterRename(@TempDir File deltaTablePath) {
+    String tablePath = deltaTablePath.getAbsolutePath();
+
+    // Create table with column mapping name mode
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, user_name STRING) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            tablePath));
+
+    // Insert data using original column name
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'Alice'), (2, 'Bob')", tablePath));
+
+    // Rename column via V1 path
+    spark.sql(str("ALTER TABLE delta.`%s` RENAME COLUMN user_name TO full_name", tablePath));
+
+    // Read through V2 with the new column name
+    check(
+        str("SELECT id, full_name FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice"), row(2, "Bob")));
+  }
+
+  @Test
+  public void testColumnMappingReadAfterDrop(@TempDir File deltaTablePath) {
+    String tablePath = deltaTablePath.getAbsolutePath();
+
+    // Create table with column mapping name mode
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, user_name STRING, extra INT) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            tablePath));
+
+    // Insert data
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'Alice', 10), (2, 'Bob', 20)", tablePath));
+
+    // Drop column via V1 path
+    spark.sql(str("ALTER TABLE delta.`%s` DROP COLUMN extra", tablePath));
+
+    // Read through V2 — dropped column should be gone
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice"), row(2, "Bob")));
+  }
+
+  @Test
   public void testDeletionVectorRead(@TempDir File tempDir) throws Exception {
     // Create a directory with space in the name to test URL encoding handling
     File dirWithSpace = new File(tempDir, "my table");

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2WriteColumnMappingTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2WriteColumnMappingTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2;
+
+import java.io.File;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for write operations on column-mapping-enabled Delta tables using the V2 connector.
+ *
+ * <p>Tables are created via the V1 path ({@code delta.`path`}), then writes and DML are executed
+ * via the V2 catalog ({@code dsv2.delta.`path`}).
+ */
+public class V2WriteColumnMappingTest extends V2TestBase {
+
+  // ---------- Append tests ----------
+
+  @Test
+  public void testAppendToNameModeTable(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+
+    // Create table with column mapping name mode via V1
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id BIGINT, data STRING) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            path));
+
+    // Insert initial data via V1
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b')", path));
+
+    // Append via V2 connector
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (3, 'c'), (4, 'd')", path));
+
+    // Read back and verify all data is present
+    check(
+        str("SELECT id, data FROM dsv2.delta.`%s` ORDER BY id", path),
+        List.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d")));
+  }
+
+  @Test
+  public void testAppendToIdModeTable(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+
+    // Create table with column mapping id mode via V1
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id BIGINT, data STRING) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'id')",
+            path));
+
+    // Insert initial data via V1
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b')", path));
+
+    // Append via V2 connector
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (3, 'c'), (4, 'd')", path));
+
+    // Read back and verify
+    check(
+        str("SELECT id, data FROM dsv2.delta.`%s` ORDER BY id", path),
+        List.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d")));
+  }
+
+  @Test
+  public void testWriteAfterColumnRename(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+
+    // Create table with column mapping name mode
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id BIGINT, old_name STRING) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            path));
+
+    // Insert data with original column name
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'before')", path));
+
+    // Rename column
+    spark.sql(str("ALTER TABLE delta.`%s` RENAME COLUMN old_name TO new_name", path));
+
+    // Write new data via V2 using the renamed column
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (2, 'after')", path));
+
+    // Verify both old and new data readable with new column name
+    check(
+        str("SELECT id, new_name FROM dsv2.delta.`%s` ORDER BY id", path),
+        List.of(row(1L, "before"), row(2L, "after")));
+  }
+
+  @Test
+  public void testWriteAfterColumnDrop(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+
+    // Create table with column mapping name mode
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id BIGINT, data STRING, extra INT) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            path));
+
+    // Insert data with all columns
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'a', 10)", path));
+
+    // Drop column
+    spark.sql(str("ALTER TABLE delta.`%s` DROP COLUMN extra", path));
+
+    // Write new data via V2 (without dropped column)
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (2, 'b')", path));
+
+    // Verify all data readable
+    check(
+        str("SELECT id, data FROM dsv2.delta.`%s` ORDER BY id", path),
+        List.of(row(1L, "a"), row(2L, "b")));
+  }
+
+  // ---------- COW DML on column mapping tables ----------
+
+  @Test
+  public void testDeleteOnColumnMappingTable(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id BIGINT, data STRING) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            path));
+    spark.sql(
+        str(
+            "INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')",
+            path));
+
+    // DELETE via V2
+    spark.sql(str("DELETE FROM dsv2.delta.`%s` WHERE id = 3", path));
+
+    check(
+        str("SELECT id, data FROM dsv2.delta.`%s` ORDER BY id", path),
+        List.of(row(1L, "a"), row(2L, "b"), row(4L, "d"), row(5L, "e")));
+  }
+
+  @Test
+  public void testUpdateOnColumnMappingTable(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id BIGINT, data STRING) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            path));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b'), (3, 'c')", path));
+
+    // UPDATE via V2
+    spark.sql(str("UPDATE dsv2.delta.`%s` SET data = 'updated' WHERE id = 2", path));
+
+    check(
+        str("SELECT id, data FROM dsv2.delta.`%s` ORDER BY id", path),
+        List.of(row(1L, "a"), row(2L, "updated"), row(3L, "c")));
+  }
+
+  @Test
+  public void testMergeOnColumnMappingTable(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id BIGINT, data STRING) "
+                + "USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            path));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b'), (3, 'c')", path));
+
+    // MERGE via V2: update existing + insert new
+    spark.sql(
+        str(
+            "MERGE INTO dsv2.delta.`%s` t "
+                + "USING (SELECT * FROM VALUES (2, 'updated'), (4, 'new') AS s(id, data)) s "
+                + "ON t.id = s.id "
+                + "WHEN MATCHED THEN UPDATE SET t.data = s.data "
+                + "WHEN NOT MATCHED THEN INSERT (id, data) VALUES (s.id, s.data)",
+            path));
+
+    check(
+        str("SELECT id, data FROM dsv2.delta.`%s` ORDER BY id", path),
+        List.of(row(1L, "a"), row(2L, "updated"), row(3L, "c"), row(4L, "new")));
+  }
+}


### PR DESCRIPTION
## Summary

- Unblocks writes to column-mapping-enabled tables through the Kernel-based V2 connector
- Removes `blockIfColumnMappingEnabled()` from `Transaction.transformLogicalData()` and `Transaction.getWriteContext()`
- Adds logical-to-physical column renaming in `transformLogicalData()` after partition column handling, using existing `ColumnMapping.convertToPhysicalSchema()` utility
- No changes needed in the DSv2 write layer — renaming is handled at the Kernel Transaction level

## Test plan

- [x] `DeltaColumnMappingWithV2ConnectorSuite` — V2ForceTest suite extending DeltaColumnMappingSuite (8 passing, 38 ignored for V1-only tests)
- [ ] `V2ReadTest` — read-after-rename, read-after-drop with column mapping (JUnit 5, needs IDE/CI runner)
- [ ] `V2WriteColumnMappingTest` — append (name/id modes), write-after-rename, write-after-drop, COW DELETE/UPDATE/MERGE on column mapping tables (JUnit 5, needs IDE/CI runner)
- [x] Existing write tests unaffected (non-column-mapping tables)