### PR TITLE
[Experimental] Use Collections.singletonMap() in SingleAction factory methods

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
@@ -19,8 +19,6 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.types.StructType;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 public class SingleAction {
   /**
@@ -80,33 +78,23 @@ public class SingleAction {
   private static final int DOMAIN_METADATA_ORDINAL = FULL_SCHEMA.indexOf("domainMetadata");
 
   public static Row createAddFileSingleAction(Row addFile) {
-    Map<Integer, Object> singleActionValueMap = new HashMap<>();
-    singleActionValueMap.put(ADD_FILE_ORDINAL, addFile);
-    return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    return new GenericRow(FULL_SCHEMA, Collections.singletonMap(ADD_FILE_ORDINAL, addFile));
   }
 
   public static Row createProtocolSingleAction(Row protocol) {
-    Map<Integer, Object> singleActionValueMap = new HashMap<>();
-    singleActionValueMap.put(PROTOCOL_ORDINAL, protocol);
-    return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    return new GenericRow(FULL_SCHEMA, Collections.singletonMap(PROTOCOL_ORDINAL, protocol));
   }
 
   public static Row createMetadataSingleAction(Row metadata) {
-    Map<Integer, Object> singleActionValueMap = new HashMap<>();
-    singleActionValueMap.put(METADATA_ORDINAL, metadata);
-    return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    return new GenericRow(FULL_SCHEMA, Collections.singletonMap(METADATA_ORDINAL, metadata));
   }
 
   public static Row createRemoveFileSingleAction(Row remove) {
-    Map<Integer, Object> singleActionValueMap = new HashMap<>();
-    singleActionValueMap.put(REMOVE_FILE_ORDINAL, remove);
-    return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    return new GenericRow(FULL_SCHEMA, Collections.singletonMap(REMOVE_FILE_ORDINAL, remove));
   }
 
   public static Row createCommitInfoSingleAction(Row commitInfo) {
-    Map<Integer, Object> singleActionValueMap = new HashMap<>();
-    singleActionValueMap.put(COMMIT_INFO_ORDINAL, commitInfo);
-    return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    return new GenericRow(FULL_SCHEMA, Collections.singletonMap(COMMIT_INFO_ORDINAL, commitInfo));
   }
 
   public static Row createDomainMetadataSingleAction(Row domainMetadata) {
@@ -115,8 +103,6 @@ public class SingleAction {
   }
 
   public static Row createTxnSingleAction(Row txn) {
-    Map<Integer, Object> singleActionValueMap = new HashMap<>();
-    singleActionValueMap.put(TXN_ORDINAL, txn);
-    return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    return new GenericRow(FULL_SCHEMA, Collections.singletonMap(TXN_ORDINAL, txn));
   }
 }


### PR DESCRIPTION
## Problem
6 of 7 factory methods in SingleAction.java create a `new HashMap<>()` (default capacity 16) for a single entry. One method (`createDomainMetadataSingleAction`) already uses `Collections.singletonMap()`, showing the preferred pattern.

## Fix
Replace `new HashMap<>()` with `Collections.singletonMap()` in all 6 remaining factory methods, matching the existing pattern. Also removed the now-unused `HashMap` and `Map` imports.

## Validation
- Confirmed by reading SingleAction.java: 6 methods used HashMap, 1 used singletonMap.
- All 2715 existing kernelApi tests pass — the change is purely mechanical with identical semantics.
- `GenericRow` stores the map reference and only reads via `get()` — it never mutates the map, so the immutable `singletonMap` is safe.

## Regression Prevention
Existing test coverage validates the behavior. The fix makes the code consistent with the already-established pattern.