### PR TITLE
[Spark] Add streaming tests for startingTimestamp, skipChangeCommits

### DIFF
--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -364,6 +364,90 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
   }
 
   /**
+   * Verifies that {@code startingTimestamp} streams only from the commit at-or-after the given
+   * timestamp, excluding rows from earlier commits.
+   *
+   * <p>The timestamp of the second commit is captured after both inserts complete. Delta resolves
+   * this to that commit (inclusive), so only rows from the second insert are delivered.
+   */
+  @TestAllTableTypes
+  public void testStreamingStartingTimestamp(TableType tableType) throws Exception {
+    withNewTable(
+        "streaming_ts_test",
+        "id INT",
+        tableType,
+        tableName -> {
+          sql("INSERT INTO %s VALUES (1), (2), (3)", tableName); // commit 1 — before the cutoff
+          sql("INSERT INTO %s VALUES (4), (5)", tableName); // commit 2 — the starting point
+          String commitTimestamp = currentTimestamp(tableName); // timestamp of commit 2
+
+          List<Integer> result = new ArrayList<>();
+          spark()
+              .readStream()
+              .format("delta")
+              .option("startingTimestamp", commitTimestamp)
+              .table(tableName)
+              .writeStream()
+              .trigger(Trigger.AvailableNow())
+              .option("checkpointLocation", checkpoint())
+              .foreachBatch((VoidFunction2<Dataset<Row>, Long>) (df, id) -> result.addAll(ids(df)))
+              .start()
+              .awaitTermination();
+          assertThat(result).containsExactlyInAnyOrder(4, 5);
+        });
+  }
+
+  /**
+   * Verifies that {@code skipChangeCommits=true} skips commits that contain deletions, allowing the
+   * stream to continue on subsequent insert commits.
+   *
+   * <p>EXTERNAL tables (V1 connector): the delete commit is skipped; follow-up inserts arrive.
+   * MANAGED tables (V2 connector): the option is not yet supported and the stream fails.
+   */
+  @TestAllTableTypes
+  public void testStreamingSkipChangeCommits(TableType tableType) throws Exception {
+    withNewTable(
+        "streaming_skip_changes_test",
+        "id INT",
+        tableType,
+        tableName -> {
+          if (tableType == TableType.EXTERNAL) {
+            verifySkipChangeCommitsExternal(tableName);
+          } else {
+            assertInvalidStreamOption(
+                tableName, r -> r.option("skipChangeCommits", "true"), "valid version");
+          }
+        });
+  }
+
+  private void verifySkipChangeCommitsExternal(String tableName) throws Exception {
+    sql("INSERT INTO %s VALUES (1), (2), (3)", tableName);
+    List<Integer> result = new ArrayList<>();
+    StreamingQuery query =
+        spark()
+            .readStream()
+            .format("delta")
+            .option("skipChangeCommits", "true")
+            .table(tableName)
+            .writeStream()
+            .option("checkpointLocation", checkpoint())
+            .foreachBatch((VoidFunction2<Dataset<Row>, Long>) (df, id) -> result.addAll(ids(df)))
+            .start();
+    try {
+      query.processAllAvailable();
+      assertThat(result).containsExactlyInAnyOrder(1, 2, 3);
+
+      sql("DELETE FROM %s WHERE id = 1", tableName); // change commit — skipped by the option
+      sql("INSERT INTO %s VALUES (4)", tableName);
+      query.processAllAvailable();
+
+      assertThat(result).containsExactlyInAnyOrder(1, 2, 3, 4);
+    } finally {
+      query.stop();
+    }
+  }
+
+  /**
    * Starts a streaming read with options applied by {@code configure}, then asserts the stream
    * fails with a message containing all {@code fragments} (case-insensitive).
    */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Cover three streaming read options in the io.sparkuctest DataFrame streaming suite:
- startingTimestamp: uses ICT for deterministic timestamps; verifies only post-boundary rows arrive
- skipChangeCommits: delete commit is skipped for EXTERNAL (V1); MANAGED (V2) rejects with error

## How was this patch tested?

Unit test and Remote test.

## Does this PR introduce _any_ user-facing changes?

No.
