### PR TITLE
fix: Java Kernel data skipping uses case-sensitive column matching

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -162,13 +162,14 @@ public class StatsSchemaHelper {
         logicalToPhysicalColumnAndDataType.entrySet().stream()
             .collect(
                 Collectors.toMap(
-                    Map.Entry::getKey, e -> e.getValue()._1 // map to just the column
+                    e -> normalizeColumn(e.getKey()), e -> e.getValue()._1 // map to just the column
                     ));
     this.logicalToDataType =
         logicalToPhysicalColumnAndDataType.entrySet().stream()
             .collect(
                 Collectors.toMap(
-                    Map.Entry::getKey, e -> e.getValue()._2 // map to just the data type
+                    e -> normalizeColumn(e.getKey()),
+                    e -> e.getValue()._2 // map to just the data type
                     ));
   }
 
@@ -209,7 +210,7 @@ public class StatsSchemaHelper {
         column,
         collationIdentifier.isPresent() ? (" for collation " + collationIdentifier) : "",
         dataSchema);
-    DataType dataType = logicalToDataType.get(column);
+    DataType dataType = logicalToDataType.get(normalizeColumn(column));
     Column maxColumn = getStatsColumn(column, MAX, collationIdentifier);
 
     // If this is a column of type Timestamp or TimestampNTZ
@@ -250,8 +251,8 @@ public class StatsSchemaHelper {
    * column exists, is a leaf column, and is of a skipping-eligible data-type.
    */
   public boolean isSkippingEligibleMinMaxColumn(Column column) {
-    return logicalToDataType.containsKey(column)
-        && isSkippingEligibleDataType(logicalToDataType.get(column));
+    return logicalToDataType.containsKey(normalizeColumn(column))
+        && isSkippingEligibleDataType(logicalToDataType.get(normalizeColumn(column)));
   }
 
   /**
@@ -259,7 +260,7 @@ public class StatsSchemaHelper {
    * the column exists and is a leaf column as we only collect stats for leaf columns.
    */
   public boolean isSkippingEligibleNullCountColumn(Column column) {
-    return logicalToPhysicalColumn.containsKey(column);
+    return logicalToPhysicalColumn.containsKey(normalizeColumn(column));
   }
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -386,11 +387,11 @@ public class StatsSchemaHelper {
   private Column getStatsColumn(
       Column column, String statType, Optional<CollationIdentifier> collationIdentifier) {
     checkArgument(
-        logicalToPhysicalColumn.containsKey(column),
+        logicalToPhysicalColumn.containsKey(normalizeColumn(column)),
         "%s is not a valid leaf column for data schema: %s",
         column,
         dataSchema);
-    Column physicalColumn = logicalToPhysicalColumn.get(column);
+    Column physicalColumn = logicalToPhysicalColumn.get(normalizeColumn(column));
     // Use binary stats if collation is not specified or if it is the default Spark collation.
     if (collationIdentifier.isPresent()
         && collationIdentifier.get() != CollationIdentifier.SPARK_UTF8_BINARY) {
@@ -456,5 +457,13 @@ public class StatsSchemaHelper {
     newNames[0] = preElem;
     System.arraycopy(arr, 0, newNames, 1, arr.length);
     return newNames;
+  }
+
+  /** Returns a copy of the column with all name parts lowercased, for case insensitive lookups. */
+  private static Column normalizeColumn(final Column column) {
+    String[] newNames =
+        Arrays.stream(column.getNames()).map(String::toLowerCase).toArray(String[]::new);
+
+    return new Column(newNames);
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
@@ -17,6 +17,7 @@ package io.delta.kernel.internal.skipping
 
 import scala.collection.JavaConverters.setAsJavaSetConverter
 
+import io.delta.kernel.expressions.Column
 import io.delta.kernel.types.{ArrayType, BinaryType, BooleanType, ByteType, CollationIdentifier, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
 
 import org.scalatest.funsuite.AnyFunSuite
@@ -391,6 +392,44 @@ class StatsSchemaHelperSuite extends AnyFunSuite {
 
     val statsSchema = StatsSchemaHelper.getStatsSchema(dataSchema, collations.asJava)
     assert(statsSchema == expectedStatsSchema)
+  }
+
+  test("case-insensitive column lookup for skipping eligibility") {
+    // Schema uses mixed-case column names
+    val schema = new StructType()
+      .add("Value", IntegerType.INTEGER)
+      .add("Name", StringType.STRING)
+
+    val helper = new StatsSchemaHelper(schema)
+
+    // Exact case should work
+    assert(helper.isSkippingEligibleMinMaxColumn(new Column("Value")))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column("Value")))
+
+    // Different casing should also work, this would have failed before the fix
+    assert(helper.isSkippingEligibleMinMaxColumn(new Column("value")))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column("value")))
+    assert(helper.isSkippingEligibleMinMaxColumn(new Column("VALUE")))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column("VALUE")))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column("name")))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column("NAME")))
+  }
+
+  test("case-insensitive nested column lookup for skipping eligibility") {
+    val schema = new StructType()
+      .add("Outer", new StructType().add("Inner", IntegerType.INTEGER))
+
+    val helper = new StatsSchemaHelper(schema)
+
+    // Exact case
+    assert(helper.isSkippingEligibleMinMaxColumn(new Column(Array("Outer", "Inner"))))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column(Array("Outer", "Inner"))))
+
+    // Different casing would have failed before the fix
+    assert(helper.isSkippingEligibleMinMaxColumn(new Column(Array("outer", "inner"))))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column(Array("outer", "inner"))))
+    assert(helper.isSkippingEligibleMinMaxColumn(new Column(Array("OUTER", "INNER"))))
+    assert(helper.isSkippingEligibleNullCountColumn(new Column(Array("OUTER", "INNER"))))
   }
 
   test("check getStatsSchema with collations - no eligible string columns") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description
Resolves #6247 
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The protocol spec states that columns should be case insensitive. However, `StatsSchemaHelper` was case sensitive. This PR addresses this issue by making columns case insensitive in `StatsSchemaHelper` by normalizing the columns.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added additional tests with varying case patterns to ensure that the code is case insensitive. The older unit tests still pass.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No