### PR TITLE
[Spark] Check NullType inside UDTs

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -109,6 +109,24 @@ object SchemaUtils extends DeltaLogging {
       Some(other).filter(f)
   }
 
+  /**
+   * Checks if a given data type contains a NullType, including inside UDTs.
+   * `typeExistsRecursively` does not recurse into UDT sqlTypes, so this method
+   * explicitly handles that case.
+   */
+  def nullTypeExistsRecursively(
+      t: DataType
+  ): Boolean = {
+    typeExistsRecursively(t) {
+      case _: NullType =>
+        true
+      case udt: UserDefinedType[_] =>
+        nullTypeExistsRecursively(udt.sqlType)
+      case _ =>
+        false
+    }
+  }
+
   /** Turns the data types to nullable in a recursive manner for nested columns. */
   def typeAsNullable(dt: DataType): DataType = dt match {
     case s: StructType => s.asNullable
@@ -130,14 +148,8 @@ object SchemaUtils extends DeltaLogging {
    */
   def dropNullTypeColumns(df: DataFrame): DataFrame = {
     val schema = df.schema
-    def hasNullType(t: DataType): Boolean =
-      typeExistsRecursively(t) {
-        case _: NullType => true
-        case udt: UserDefinedType[_] => hasNullType(udt.sqlType)
-        case _ => false
-      }
+    if (!nullTypeExistsRecursively(schema)) return df
 
-    if (!hasNullType(schema)) return df
     def generateSelectExpr(sf: StructField, nameStack: Seq[String]): Column = sf.dataType match {
       case st: StructType =>
         val nested = st.fields.flatMap { f =>
@@ -151,17 +163,17 @@ object SchemaUtils extends DeltaLogging {
         when(col(colName).isNull, null)
           .otherwise(struct(nested: _*))
           .alias(sf.name)
-      case a: ArrayType if hasNullType(a) =>
+      case a: ArrayType if nullTypeExistsRecursively(a) =>
         val colName = UnresolvedAttribute.apply(nameStack :+ sf.name).sql
         throw new DeltaAnalysisException(
           errorClass = "DELTA_COMPLEX_TYPE_COLUMN_CONTAINS_NULL_TYPE",
           messageParameters = Array(colName, "ArrayType"))
-      case m: MapType if hasNullType(m) =>
+      case m: MapType if nullTypeExistsRecursively(m) =>
         val colName = UnresolvedAttribute.apply(nameStack :+ sf.name).sql
         throw new DeltaAnalysisException(
           errorClass = "DELTA_COMPLEX_TYPE_COLUMN_CONTAINS_NULL_TYPE",
           messageParameters = Array(colName, "MapType"))
-        case udt: UserDefinedType[_] if hasNullType(udt.sqlType) =>
+        case udt: UserDefinedType[_] if nullTypeExistsRecursively(udt.sqlType) =>
           val colName = UnresolvedAttribute.apply(nameStack :+ sf.name).sql
         throw new DeltaAnalysisException(
           errorClass = "DELTA_USER_DEFINED_TYPE_COLUMN_CONTAINS_NULL_TYPE",
@@ -275,7 +287,7 @@ object SchemaUtils extends DeltaLogging {
       return nullFields.headOption
     }
 
-    if (typeExistsRecursively(schema)(_.isInstanceOf[NullType])) {
+    if (nullTypeExistsRecursively(schema)) {
       findNullTypeColumnRec(schema, Seq.empty)
     } else {
       None

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.streaming.OutputMode
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, NullType, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 import org.apache.spark.util.Utils
 
 /**
@@ -114,7 +114,7 @@ case class DeltaSink(
     val txn = deltaLog.startTransaction(catalogTable)
     assert(queryId != null)
 
-    if (SchemaUtils.typeExistsRecursively(data.schema)(_.isInstanceOf[NullType])) {
+    if (SchemaUtils.nullTypeExistsRecursively(data.schema)) {
       throw DeltaErrors.streamWriteNullTypeException
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -655,6 +655,31 @@ class DeltaSinkSuite
         "deltaLog should not be initialized after constructor")
     }
   }
+
+  test("DeltaSink rejects DataFrame with UDT containing NullType") {
+    failAfter(streamingTimeout) {
+      withTempDirs { (outputDir, checkpointDir) =>
+        val inputData = MemoryStream[Int]
+        val ds = inputData.toDS()
+        val dsWriter =
+          ds.map(i => (i, new NullData()))
+            .toDF("id", "value")
+            .writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .format("delta")
+
+        val wrapperException = intercept[StreamingQueryException] {
+          val q = dsWriter.start(outputDir.getCanonicalPath)
+          inputData.addData(42)
+          q.processAllAvailable()
+        }
+        assert(wrapperException.cause.isInstanceOf[AnalysisException])
+        checkError(
+          wrapperException.cause.asInstanceOf[AnalysisException],
+          "DELTA_NULL_SCHEMA_IN_STREAMING_WRITE")
+      }
+    }
+  }
 }
 
 // Batch sizes 1, 2, and 100 exercise different backfill behaviors in the commit coordinator.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Follow-up to #6254. This PR improves the check for NullType in schema for streaming to also consider UDTs.

## How was this patch tested?

New unit tests.

## Does this PR introduce _any_ user-facing changes?

No.
