### PR TITLE
[Experimental] [Kernel] Add type widening metadata removal and query methods

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -354,6 +354,43 @@ public class SchemaUtils {
     return field.withNewMetadata(metadata);
   }
 
+  /**
+   * Recursively checks if any field in the schema contains type widening metadata (non-empty type
+   * changes). This includes type changes on fields nested inside {@link ArrayType} and {@link
+   * MapType}.
+   *
+   * @param schema the schema to check
+   * @return true if any field in the schema tree has type widening metadata
+   */
+  public static boolean containsTypeWideningMetadata(StructType schema) {
+    for (StructField field : schema.fields()) {
+      if (containsTypeWideningMetadataInField(field)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Removes all type widening metadata ({@code delta.typeChanges}) from the schema. Returns a new
+   * schema with all type changes cleared. Required for DROP TABLE FEATURE (typeWidening).
+   *
+   * <p>If the schema contains no type widening metadata, the same schema object is returned.
+   *
+   * @param schema the schema to remove type widening metadata from
+   * @return a new schema with all type changes cleared, or the same schema if no changes existed
+   */
+  public static StructType removeTypeWideningMetadata(StructType schema) {
+    if (!containsTypeWideningMetadata(schema)) {
+      return schema;
+    }
+    List<StructField> cleanedFields = new ArrayList<>();
+    for (StructField field : schema.fields()) {
+      cleanedFields.add(removeTypeWideningMetadataFromField(field));
+    }
+    return new StructType(cleanedFields);
+  }
+
   /////////////////////////////////////////////////////////////////////////////////////////////////
   /// Private methods                                                                           ///
   /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -866,5 +903,75 @@ public class SchemaUtils {
     } else {
       throw unsupportedDataType(dataType);
     }
+  }
+
+  private static boolean containsTypeWideningMetadataInField(StructField field) {
+    if (!field.getTypeChanges().isEmpty()) {
+      return true;
+    }
+    return containsTypeWideningMetadataInDataType(field.getDataType());
+  }
+
+  private static boolean containsTypeWideningMetadataInDataType(DataType dataType) {
+    if (dataType instanceof StructType) {
+      return containsTypeWideningMetadata((StructType) dataType);
+    }
+    if (dataType instanceof ArrayType) {
+      return containsTypeWideningMetadataInField(((ArrayType) dataType).getElementField());
+    }
+    if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      return containsTypeWideningMetadataInField(mapType.getKeyField())
+          || containsTypeWideningMetadataInField(mapType.getValueField());
+    }
+    return false;
+  }
+
+  private static StructField removeTypeWideningMetadataFromField(StructField field) {
+    DataType cleanedType = removeTypeWideningMetadataFromDataType(field.getDataType());
+    boolean hasTypeChanges = !field.getTypeChanges().isEmpty();
+    boolean typeChanged = cleanedType != field.getDataType();
+
+    if (!hasTypeChanges && !typeChanged) {
+      return field;
+    }
+
+    FieldMetadata cleanedMetadata = removeTypeChangesFromMetadata(field.getMetadata());
+    return new StructField(field.getName(), cleanedType, field.isNullable(), cleanedMetadata);
+  }
+
+  private static DataType removeTypeWideningMetadataFromDataType(DataType dataType) {
+    if (dataType instanceof StructType) {
+      return removeTypeWideningMetadata((StructType) dataType);
+    }
+    if (dataType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) dataType;
+      StructField cleanedElement = removeTypeWideningMetadataFromField(arrayType.getElementField());
+      if (cleanedElement != arrayType.getElementField()) {
+        return new ArrayType(cleanedElement);
+      }
+      return dataType;
+    }
+    if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      StructField cleanedKey = removeTypeWideningMetadataFromField(mapType.getKeyField());
+      StructField cleanedValue = removeTypeWideningMetadataFromField(mapType.getValueField());
+      if (cleanedKey != mapType.getKeyField() || cleanedValue != mapType.getValueField()) {
+        return new MapType(cleanedKey, cleanedValue);
+      }
+      return dataType;
+    }
+    return dataType;
+  }
+
+  /** Removes the {@code delta.typeChanges} key from field metadata if present. */
+  private static FieldMetadata removeTypeChangesFromMetadata(FieldMetadata metadata) {
+    if (!metadata.contains(StructField.DELTA_TYPE_CHANGES_KEY)) {
+      return metadata;
+    }
+    return FieldMetadata.builder()
+        .fromMetadata(metadata)
+        .remove(StructField.DELTA_TYPE_CHANGES_KEY)
+        .build();
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -31,7 +31,7 @@ import io.delta.kernel.internal.types.DataTypeJsonSerDe
 import io.delta.kernel.internal.util.ColumnMapping.{COLUMN_MAPPING_ID_KEY, COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_PHYSICAL_NAME_KEY}
 import io.delta.kernel.internal.util.SchemaUtils.{computeSchemaChangesById, validateUpdatedSchemaAndGetUpdatedSchema}
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
-import io.delta.kernel.types.{ArrayType, ByteType, DataType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructField, StructType, TypeChange, VariantType}
+import io.delta.kernel.types.{ArrayType, ByteType, DataType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, ShortType, StringType, StructField, StructType, TypeChange, VariantType}
 import io.delta.kernel.types.IntegerType.INTEGER
 import io.delta.kernel.types.LongType.LONG
 import io.delta.kernel.types.TimestampType.TIMESTAMP
@@ -2097,5 +2097,163 @@ class SchemaUtilsSuite extends AnyFunSuite {
       dummyProtocol,
       emptySet(),
       false)
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Type Widening Metadata Lifecycle Tests
+  ///////////////////////////////////////////////////////////////////////////
+
+  test("containsTypeWideningMetadata - returns true for field with type changes") {
+    val typeChange = new TypeChange(IntegerType.INTEGER, LongType.LONG)
+    val field = new StructField("id", LongType.LONG, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val schema = new StructType(List(field).asJava)
+
+    assert(SchemaUtils.containsTypeWideningMetadata(schema))
+  }
+
+  test("containsTypeWideningMetadata - returns false for schema without type changes") {
+    val schema = new StructType()
+      .add("id", IntegerType.INTEGER)
+      .add("name", StringType.STRING)
+
+    assert(!SchemaUtils.containsTypeWideningMetadata(schema))
+  }
+
+  test("containsTypeWideningMetadata - returns true for nested struct with type changes") {
+    val typeChange = new TypeChange(IntegerType.INTEGER, LongType.LONG)
+    val innerField = new StructField("inner_id", LongType.LONG, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val innerStruct = new StructType(List(innerField).asJava)
+    val schema = new StructType().add("outer", innerStruct)
+
+    assert(SchemaUtils.containsTypeWideningMetadata(schema))
+  }
+
+  test("containsTypeWideningMetadata - returns true for array element with type changes") {
+    val typeChange = new TypeChange(ByteType.BYTE, IntegerType.INTEGER)
+    val elementField = new StructField("element", IntegerType.INTEGER, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val arrayType = new ArrayType(elementField)
+    val schema = new StructType().add("arr", arrayType)
+
+    assert(SchemaUtils.containsTypeWideningMetadata(schema))
+  }
+
+  test("containsTypeWideningMetadata - returns true for map value with type changes") {
+    val typeChange = new TypeChange(IntegerType.INTEGER, LongType.LONG)
+    val valueField = new StructField("value", LongType.LONG, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val keyField = new StructField("key", StringType.STRING, false)
+    val mapType = new MapType(keyField, valueField)
+    val schema = new StructType().add("map_col", mapType)
+
+    assert(SchemaUtils.containsTypeWideningMetadata(schema))
+  }
+
+  test("removeTypeWideningMetadata - removes type changes and preserves field properties") {
+    val customMetadata = FieldMetadata.builder()
+      .putString("comment", "user column")
+      .build()
+    val typeChange = new TypeChange(IntegerType.INTEGER, LongType.LONG)
+    val field = new StructField("id", LongType.LONG, false /* nullable */, customMetadata)
+      .withTypeChanges(List(typeChange).asJava)
+    val schema = new StructType(List(field).asJava)
+
+    val cleaned = SchemaUtils.removeTypeWideningMetadata(schema)
+
+    assert(!SchemaUtils.containsTypeWideningMetadata(cleaned))
+    val cleanedField = cleaned.get("id")
+    // Type changes and metadata key are removed
+    assert(cleanedField.getTypeChanges.isEmpty)
+    assert(!cleanedField.getMetadata.contains(StructField.DELTA_TYPE_CHANGES_KEY))
+    // Field properties are preserved
+    assert(cleanedField.getName == "id")
+    assert(cleanedField.getDataType == LongType.LONG)
+    assert(!cleanedField.isNullable)
+    assert(cleanedField.getMetadata.getString("comment") == "user column")
+  }
+
+  test("removeTypeWideningMetadata - returns same schema when no type changes") {
+    val schema = new StructType()
+      .add("id", IntegerType.INTEGER)
+      .add("name", StringType.STRING)
+
+    val cleaned = SchemaUtils.removeTypeWideningMetadata(schema)
+
+    assert(cleaned eq schema) // identity check - same object returned
+  }
+
+  test("removeTypeWideningMetadata - removes type changes from nested struct") {
+    val typeChange = new TypeChange(IntegerType.INTEGER, LongType.LONG)
+    val innerField = new StructField("inner_id", LongType.LONG, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val innerStruct = new StructType(List(innerField).asJava)
+    val schema = new StructType().add("outer", innerStruct)
+
+    val cleaned = SchemaUtils.removeTypeWideningMetadata(schema)
+
+    assert(!SchemaUtils.containsTypeWideningMetadata(cleaned))
+    val cleanedInner = cleaned.get("outer").getDataType.asInstanceOf[StructType]
+    assert(cleanedInner.get("inner_id").getTypeChanges.isEmpty)
+  }
+
+  test("removeTypeWideningMetadata - removes type changes from array elements") {
+    val typeChange = new TypeChange(ByteType.BYTE, IntegerType.INTEGER)
+    val elementField = new StructField("element", IntegerType.INTEGER, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val arrayType = new ArrayType(elementField)
+    val schema = new StructType().add("arr", arrayType)
+
+    val cleaned = SchemaUtils.removeTypeWideningMetadata(schema)
+
+    assert(!SchemaUtils.containsTypeWideningMetadata(cleaned))
+    val cleanedArray = cleaned.get("arr").getDataType.asInstanceOf[ArrayType]
+    assert(cleanedArray.getElementField.getTypeChanges.isEmpty)
+    assert(!cleaned.get("arr").getMetadata.contains(StructField.DELTA_TYPE_CHANGES_KEY))
+  }
+
+  test("removeTypeWideningMetadata - removes type changes from map value field") {
+    val typeChange = new TypeChange(IntegerType.INTEGER, LongType.LONG)
+    val valueField = new StructField("value", LongType.LONG, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val keyField = new StructField("key", StringType.STRING, false)
+    val mapType = new MapType(keyField, valueField)
+    val schema = new StructType().add("map_col", mapType)
+
+    val cleaned = SchemaUtils.removeTypeWideningMetadata(schema)
+
+    assert(!SchemaUtils.containsTypeWideningMetadata(cleaned))
+    val cleanedMap = cleaned.get("map_col").getDataType.asInstanceOf[MapType]
+    assert(cleanedMap.getValueField.getTypeChanges.isEmpty)
+    assert(!cleaned.get("map_col").getMetadata.contains(StructField.DELTA_TYPE_CHANGES_KEY))
+  }
+
+  test("removeTypeWideningMetadata - handles multiple type changes on same field") {
+    // Simulate byte -> int -> long widening history
+    val typeChanges = List(
+      new TypeChange(ByteType.BYTE, IntegerType.INTEGER),
+      new TypeChange(IntegerType.INTEGER, LongType.LONG)).asJava
+    val field = new StructField("id", LongType.LONG, true)
+      .withTypeChanges(typeChanges)
+    val schema = new StructType(List(field).asJava)
+
+    assert(SchemaUtils.containsTypeWideningMetadata(schema))
+    val cleaned = SchemaUtils.removeTypeWideningMetadata(schema)
+
+    assert(!SchemaUtils.containsTypeWideningMetadata(cleaned))
+    assert(cleaned.get("id").getTypeChanges.isEmpty)
+    assert(cleaned.get("id").getDataType == LongType.LONG)
+  }
+
+  test("removeTypeWideningMetadata - round trip: contains returns false after removal") {
+    val typeChange = new TypeChange(ByteType.BYTE, IntegerType.INTEGER)
+    val field = new StructField("id", IntegerType.INTEGER, true)
+      .withTypeChanges(List(typeChange).asJava)
+    val schema = new StructType(List(field).asJava)
+
+    assert(SchemaUtils.containsTypeWideningMetadata(schema))
+    val cleaned = SchemaUtils.removeTypeWideningMetadata(schema)
+    assert(!SchemaUtils.containsTypeWideningMetadata(cleaned))
   }
 }


### PR DESCRIPTION
## Summary
- Add `containsTypeWideningMetadata(StructType)` to recursively check if any field in a schema has type widening metadata
- Add `removeTypeWideningMetadata(StructType)` to strip all `delta.typeChanges` metadata from a schema
- Both methods correctly traverse ArrayType/MapType internal StructFields (not just DataTypes), and removal explicitly cleans the serialized metadata key

## Why
The Delta protocol (L1617-1618) requires removing all `delta.typeChanges` metadata when dropping the `typeWidening` feature. Java Kernel can add and preserve type change metadata during schema evolution, but has no way to remove or query it. These methods complete the type widening metadata lifecycle needed for DROP TABLE FEATURE support.

## Test plan
- [x] `containsTypeWideningMetadata` returns true for direct field type changes
- [x] `containsTypeWideningMetadata` returns false for schema without type changes
- [x] `containsTypeWideningMetadata` detects type changes in nested structs, array elements, and map values
- [x] `removeTypeWideningMetadata` clears type changes and preserves field properties (name, nullable, custom metadata)
- [x] `removeTypeWideningMetadata` returns same schema object when no type changes exist (identity optimization)
- [x] `removeTypeWideningMetadata` handles nested structs, array elements, and map values
- [x] `removeTypeWideningMetadata` handles multiple type changes on same field (byte→int→long)
- [x] Round-trip: `containsTypeWideningMetadata` returns false after `removeTypeWideningMetadata`
- [x] All 71 tests pass in `SchemaUtilsSuite`

This pull request was AI-assisted by Isaac.