### PR TITLE
[Experimental] [Kernel] Add case-insensitive column name normalization on write path

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -24,6 +24,7 @@ import static io.delta.kernel.internal.util.PartitionUtils.getTargetDirectory;
 import static io.delta.kernel.internal.util.PartitionUtils.validateAndSanitizePartitionValues;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.SchemaUtils.findColIndex;
+import static io.delta.kernel.internal.util.SchemaUtils.normalizeColumnNames;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.annotation.Experimental;
@@ -201,8 +202,12 @@ public interface Transaction {
           }
 
           ColumnarBatch data = filteredBatch.getData();
-          if (!data.getSchema().isWriteCompatible(tableSchema)) {
-            throw dataSchemaMismatch(tablePath, tableSchema, data.getSchema());
+          // The Delta protocol requires column names to be unique regardless of casing.
+          // Normalize data column names to table schema casing before the compatibility
+          // check so that writes are not rejected solely due to a case mismatch.
+          StructType normalizedDataSchema = normalizeColumnNames(data.getSchema(), tableSchema);
+          if (!normalizedDataSchema.isWriteCompatible(tableSchema)) {
+            throw dataSchemaMismatch(tablePath, tableSchema, normalizedDataSchema);
           }
           for (String partitionColName : partitionColNames) {
             int partitionColIndex = findColIndex(data.getSchema(), partitionColName);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -311,6 +311,46 @@ public class SchemaUtils {
   }
 
   /**
+   * Normalizes column names in the data schema to match the casing of the table schema. The Delta
+   * protocol requires that column names are unique regardless of casing, so writes should not be
+   * rejected solely due to a case mismatch between data and table column names.
+   *
+   * <p>Only column names are normalized; each field's data type, nullability, and metadata are
+   * preserved from the data schema.
+   *
+   * @param dataSchema the schema of the data being written
+   * @param tableSchema the schema of the target table
+   * @return a new StructType with column names matching the table schema casing
+   * @throws KernelException if a data column cannot be found in the table schema
+   */
+  public static StructType normalizeColumnNames(StructType dataSchema, StructType tableSchema) {
+    Map<String, StructField> tableFieldMap = new HashMap<>();
+    for (StructField field : tableSchema.fields()) {
+      tableFieldMap.put(field.getName().toLowerCase(Locale.ROOT), field);
+    }
+
+    List<StructField> normalizedFields = new ArrayList<>();
+    for (StructField dataField : dataSchema.fields()) {
+      StructField tableField = tableFieldMap.get(dataField.getName().toLowerCase(Locale.ROOT));
+      if (tableField == null) {
+        throw new KernelException(
+            String.format(
+                "Cannot resolve column '%s' in the table schema. Available columns: %s",
+                dataField.getName(), tableSchema.fieldNames()));
+      }
+      DataType normalizedType =
+          normalizeDataType(dataField.getDataType(), tableField.getDataType());
+      normalizedFields.add(
+          new StructField(
+              tableField.getName(),
+              normalizedType,
+              dataField.isNullable(),
+              dataField.getMetadata()));
+    }
+    return new StructType(normalizedFields);
+  }
+
+  /**
    * Search (case-insensitive) for the given {@code colName} in the {@code schema} and return its
    * position in the {@code schema}.
    *
@@ -357,6 +397,32 @@ public class SchemaUtils {
   /////////////////////////////////////////////////////////////////////////////////////////////////
   /// Private methods                                                                           ///
   /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Recursively normalizes nested data types. For struct types, normalizes column names. For array
+   * and map types, normalizes their element/key/value types.
+   */
+  private static DataType normalizeDataType(DataType dataType, DataType tableType) {
+    if (dataType instanceof StructType && tableType instanceof StructType) {
+      return normalizeColumnNames((StructType) dataType, (StructType) tableType);
+    }
+    if (dataType instanceof ArrayType && tableType instanceof ArrayType) {
+      ArrayType dataArray = (ArrayType) dataType;
+      ArrayType tableArray = (ArrayType) tableType;
+      DataType normalizedElement =
+          normalizeDataType(dataArray.getElementType(), tableArray.getElementType());
+      return new ArrayType(normalizedElement, dataArray.containsNull());
+    }
+    if (dataType instanceof MapType && tableType instanceof MapType) {
+      MapType dataMap = (MapType) dataType;
+      MapType tableMap = (MapType) tableType;
+      DataType normalizedKey = normalizeDataType(dataMap.getKeyType(), tableMap.getKeyType());
+      DataType normalizedValue = normalizeDataType(dataMap.getValueType(), tableMap.getValueType());
+      return new MapType(normalizedKey, normalizedValue, dataMap.isValueContainsNull());
+    }
+    // For leaf types, return as-is
+    return dataType;
+  }
 
   /**
    * Compute the SchemaChanges using field IDs

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -29,7 +29,7 @@ import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.{TableFeature, TableFeatures}
 import io.delta.kernel.internal.types.DataTypeJsonSerDe
 import io.delta.kernel.internal.util.ColumnMapping.{COLUMN_MAPPING_ID_KEY, COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_PHYSICAL_NAME_KEY}
-import io.delta.kernel.internal.util.SchemaUtils.{computeSchemaChangesById, validateUpdatedSchemaAndGetUpdatedSchema}
+import io.delta.kernel.internal.util.SchemaUtils.{computeSchemaChangesById, normalizeColumnNames, validateUpdatedSchemaAndGetUpdatedSchema}
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
 import io.delta.kernel.types.{ArrayType, ByteType, DataType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructField, StructType, TypeChange, VariantType}
 import io.delta.kernel.types.IntegerType.INTEGER
@@ -2097,5 +2097,155 @@ class SchemaUtilsSuite extends AnyFunSuite {
       dummyProtocol,
       emptySet(),
       false)
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // normalizeColumnNames Tests
+  ///////////////////////////////////////////////////////////////////////////
+
+  test(
+    "normalizeColumnNames - case-mismatched names normalized, nullability and metadata preserved") {
+    val dataMetadata = FieldMetadata.builder().putString("custom", "value").build()
+    val dataSchema = new StructType(
+      java.util.Arrays.asList(
+        new StructField("userId", IntegerType.INTEGER, false /* non-nullable */, dataMetadata),
+        new StructField("name", StringType.STRING, true)))
+    val tableSchema = new StructType()
+      .add("UserId", IntegerType.INTEGER)
+      .add("Name", StringType.STRING)
+
+    val result = normalizeColumnNames(dataSchema, tableSchema)
+
+    assert(result.length() == 2)
+    // Names come from table schema
+    assert(result.at(0).getName == "UserId")
+    assert(result.at(1).getName == "Name")
+    // Nullability and metadata are preserved from data schema
+    assert(!result.at(0).isNullable)
+    assert(result.at(0).getMetadata.getString("custom") == "value")
+    assert(result.at(1).isNullable)
+  }
+
+  test("normalizeColumnNames - exact match is a no-op") {
+    val dataSchema = new StructType()
+      .add("id", IntegerType.INTEGER)
+      .add("name", StringType.STRING)
+    val tableSchema = new StructType()
+      .add("id", IntegerType.INTEGER)
+      .add("name", StringType.STRING)
+
+    val result = normalizeColumnNames(dataSchema, tableSchema)
+
+    assert(result.length() == 2)
+    assert(result.at(0).getName == "id")
+    assert(result.at(1).getName == "name")
+  }
+
+  test("normalizeColumnNames - columns in different order are resolved by name") {
+    val dataSchema = new StructType()
+      .add("name", StringType.STRING)
+      .add("id", IntegerType.INTEGER)
+    val tableSchema = new StructType()
+      .add("Id", IntegerType.INTEGER)
+      .add("Name", StringType.STRING)
+
+    val result = normalizeColumnNames(dataSchema, tableSchema)
+
+    // Result follows data schema ordering, with table schema casing
+    assert(result.at(0).getName == "Name")
+    assert(result.at(1).getName == "Id")
+  }
+
+  test("normalizeColumnNames - missing column error includes available columns") {
+    val dataSchema = new StructType()
+      .add("id", IntegerType.INTEGER)
+      .add("unknown", StringType.STRING)
+    val tableSchema = new StructType()
+      .add("id", IntegerType.INTEGER)
+      .add("name", StringType.STRING)
+
+    val e = intercept[KernelException] {
+      normalizeColumnNames(dataSchema, tableSchema)
+    }
+    assert(e.getMessage.contains("unknown"))
+    assert(e.getMessage.contains("Available columns"))
+  }
+
+  test("normalizeColumnNames - nested struct normalization") {
+    val dataSchema = new StructType()
+      .add(
+        "address",
+        new StructType()
+          .add("city", StringType.STRING)
+          .add("state", StringType.STRING))
+    val tableSchema = new StructType()
+      .add(
+        "Address",
+        new StructType()
+          .add("City", StringType.STRING)
+          .add("State", StringType.STRING))
+
+    val result = normalizeColumnNames(dataSchema, tableSchema)
+
+    assert(result.at(0).getName == "Address")
+    val nestedStruct = result.at(0).getDataType.asInstanceOf[StructType]
+    assert(nestedStruct.at(0).getName == "City")
+    assert(nestedStruct.at(1).getName == "State")
+  }
+
+  test("normalizeColumnNames - array of struct normalization") {
+    val dataSchema = new StructType()
+      .add(
+        "items",
+        new ArrayType(
+          new StructType()
+            .add("productId", IntegerType.INTEGER)
+            .add("quantity", IntegerType.INTEGER),
+          true))
+    val tableSchema = new StructType()
+      .add(
+        "Items",
+        new ArrayType(
+          new StructType()
+            .add("ProductId", IntegerType.INTEGER)
+            .add("Quantity", IntegerType.INTEGER),
+          true))
+
+    val result = normalizeColumnNames(dataSchema, tableSchema)
+
+    assert(result.at(0).getName == "Items")
+    val arrayType = result.at(0).getDataType.asInstanceOf[ArrayType]
+    val elementStruct = arrayType.getElementType.asInstanceOf[StructType]
+    assert(elementStruct.at(0).getName == "ProductId")
+    assert(elementStruct.at(1).getName == "Quantity")
+  }
+
+  test("normalizeColumnNames - map value struct normalization") {
+    val dataSchema = new StructType()
+      .add(
+        "lookup",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("firstName", StringType.STRING)
+            .add("lastName", StringType.STRING),
+          true))
+    val tableSchema = new StructType()
+      .add(
+        "Lookup",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("FirstName", StringType.STRING)
+            .add("LastName", StringType.STRING),
+          true))
+
+    val result = normalizeColumnNames(dataSchema, tableSchema)
+
+    assert(result.at(0).getName == "Lookup")
+    val mapType = result.at(0).getDataType.asInstanceOf[MapType]
+    val valueStruct = mapType.getValueType.asInstanceOf[StructType]
+    assert(valueStruct.at(0).getName == "FirstName")
+    assert(valueStruct.at(1).getName == "LastName")
   }
 }


### PR DESCRIPTION
## Summary
- Add `normalizeColumnNames()` utility in `SchemaUtils.java` that rewrites data column names to match table schema casing (case-insensitive lookup, recursive through nested structs/arrays/maps)
- Integrate into the write path in `Transaction.transformLogicalData()` before the `isWriteCompatible()` check
- Add 7 unit tests covering: case-mismatch normalization with nullability/metadata preservation, exact match no-op, different column ordering, missing column error with available columns, nested structs, arrays of structs, and map value structs

## Motivation
The Delta protocol requires column names to be unique regardless of casing (Protocol L2155). Spark normalizes incoming data column names to match the table schema casing before writing (`SchemaUtils.normalizeColumnNamesInDataType`), so a write with column `userId` against a table with column `UserId` succeeds. Java Kernel uses case-sensitive name comparison in `StructType.isWriteCompatible()` and rejects such writes, creating a behavioral incompatibility where writes that succeed on Spark fail on Kernel-based connectors.

## Test plan
- [x] Case-mismatched column names are normalized, nullability and metadata preserved
- [x] Exact match is a no-op
- [x] Columns in different order are resolved by name
- [x] Missing column throws with actionable error including available columns
- [x] Nested struct normalization
- [x] Array of struct normalization
- [x] Map value struct normalization
- [x] All 66 tests in `SchemaUtilsSuite` pass

This pull request was AI-assisted by Isaac.