### PR TITLE
[Kernel] Add column ID and physical name uniqueness validation

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionMetadataFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionMetadataFactory.java
@@ -544,6 +544,8 @@ public class TransactionMetadataFactory {
     if (columnMappingMetadata.isPresent()) {
       newMetadata = columnMappingMetadata;
     }
+    // Validate column ID and physical name uniqueness as a safety check against metadata corruption
+    ColumnMapping.checkColumnIdAndPhysicalNameAssignments(getEffectiveMetadata());
     // We also resolve the user provided clustering columns here using the updated schema
     StructType updatedSchema = getEffectiveMetadata().getSchema();
     this.physicalNewClusteringColumns =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -21,6 +21,7 @@ import static java.util.Collections.singletonMap;
 
 import io.delta.kernel.data.Row;
 import io.delta.kernel.exceptions.InvalidConfigurationValueException;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
@@ -234,6 +235,42 @@ public class ColumnMapping {
     }
   }
 
+  /**
+   * Validates that column IDs and physical names are unique across the entire schema, and that
+   * maxColumnId is at least as large as the maximum column ID in the schema.
+   *
+   * <p>The Delta protocol requires globally unique physical names and unique column IDs with
+   * monotonically increasing maxColumnId. This is a last-defense safety check on the commit path to
+   * prevent corrupted metadata from being written, analogous to Spark's
+   * checkColumnIdAndPhysicalNameAssignments() in DeltaColumnMapping.scala.
+   *
+   * @param metadata The metadata to validate
+   */
+  public static void checkColumnIdAndPhysicalNameAssignments(Metadata metadata) {
+    ColumnMappingMode mode = getColumnMappingMode(metadata.getConfiguration());
+    if (mode == ColumnMappingMode.NONE) {
+      return;
+    }
+
+    StructType schema = metadata.getSchema();
+    Set<Integer> columnIds = new HashSet<>();
+    Set<String> physicalNames = new HashSet<>();
+    validateColumnMappingUniqueness(schema, "", columnIds, physicalNames);
+
+    // Validate maxColumnId >= max field ID in schema
+    int maxColumnId =
+        Integer.parseInt(
+            metadata.getConfiguration().getOrDefault(COLUMN_MAPPING_MAX_COLUMN_ID_KEY, "0"));
+    int fieldMaxId = findMaxColumnId(schema);
+    if (maxColumnId < fieldMaxId) {
+      throw new KernelException(
+          String.format(
+              "delta.columnMapping.maxColumnId (%d) is less than the max column ID "
+                  + "in the schema (%d)",
+              maxColumnId, fieldMaxId));
+    }
+  }
+
   ////////////////////////////
   // Private Helper Methods //
   ////////////////////////////
@@ -288,6 +325,48 @@ public class ColumnMapping {
     }
 
     return new Tuple2<>(new Column(outputNameParts.toArray(new String[0])), currentType);
+  }
+
+  /**
+   * Recursively validates that all column IDs and physical names in the schema are unique. Column
+   * IDs must be globally unique. Physical names must be unique within their full path context
+   * (i.e., sibling fields at the same nesting level cannot share physical names).
+   */
+  private static void validateColumnMappingUniqueness(
+      DataType dataType, String parentPath, Set<Integer> columnIds, Set<String> physicalNames) {
+    if (dataType instanceof StructType) {
+      StructType structType = (StructType) dataType;
+      for (StructField field : structType.fields()) {
+        int columnId = getColumnId(field);
+        if (!columnIds.add(columnId)) {
+          throw new KernelException(
+              String.format(
+                  "Duplicate column mapping ID %d found in the schema at field '%s'",
+                  columnId, field.getName()));
+        }
+        String physicalName = getPhysicalName(field);
+        String fullPhysicalPath =
+            parentPath.isEmpty() ? physicalName : parentPath + "." + physicalName;
+        if (!physicalNames.add(fullPhysicalPath)) {
+          throw new KernelException(
+              String.format(
+                  "Duplicate physical name '%s' found in the schema at field '%s'",
+                  fullPhysicalPath, field.getName()));
+        }
+        validateColumnMappingUniqueness(
+            field.getDataType(), fullPhysicalPath, columnIds, physicalNames);
+      }
+    } else if (dataType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) dataType;
+      validateColumnMappingUniqueness(
+          arrayType.getElementType(), parentPath + ".element", columnIds, physicalNames);
+    } else if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      validateColumnMappingUniqueness(
+          mapType.getKeyType(), parentPath + ".key", columnIds, physicalNames);
+      validateColumnMappingUniqueness(
+          mapType.getValueType(), parentPath + ".value", columnIds, physicalNames);
+    }
   }
 
   /** Visible for testing */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/ColumnMappingSuite.scala
@@ -31,6 +31,140 @@ import org.assertj.core.util.Maps
 import org.scalatest.funsuite.AnyFunSuite
 
 class ColumnMappingSuite extends AnyFunSuite with ColumnMappingSuiteBase {
+
+  ///////////////////////////////////////////////////////////
+  // Tests for checkColumnIdAndPhysicalNameAssignments      //
+  ///////////////////////////////////////////////////////////
+
+  /** Helper to create a StructField with column mapping metadata. */
+  private def cmField(
+      name: String,
+      dataType: DataType,
+      id: Long,
+      physicalName: String): StructField = {
+    new StructField(
+      name,
+      dataType,
+      true,
+      FieldMetadata.builder()
+        .putLong(COLUMN_MAPPING_ID_KEY, id)
+        .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, physicalName)
+        .build())
+  }
+
+  /** Helper to create metadata with column mapping enabled and a given maxColumnId. */
+  private def cmMetadata(schema: StructType, maxId: String): Metadata = {
+    testMetadata(schema).withColumnMappingEnabled("name")
+      .withMergedConfiguration(
+        Maps.newHashMap(ColumnMapping.COLUMN_MAPPING_MAX_COLUMN_ID_KEY, maxId))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: duplicate column ID detected") {
+    val schema = new StructType()
+      .add(cmField("a", StringType.STRING, 1L, "phys_a"))
+      .add(cmField("b", IntegerType.INTEGER, 1L, "phys_b")) // duplicate ID
+
+    val ex = intercept[KernelException] {
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(cmMetadata(schema, "2"))
+    }
+    assert(ex.getMessage.contains("Duplicate column mapping ID 1"))
+    assert(ex.getMessage.contains("field 'b'"))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: duplicate physical name detected") {
+    val schema = new StructType()
+      .add(cmField("a", StringType.STRING, 1L, "same_name"))
+      .add(cmField("b", IntegerType.INTEGER, 2L, "same_name")) // duplicate physical name
+
+    val ex = intercept[KernelException] {
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(cmMetadata(schema, "2"))
+    }
+    assert(ex.getMessage.contains("Duplicate physical name 'same_name'"))
+    assert(ex.getMessage.contains("field 'b'"))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: nested struct duplicate column ID detected") {
+    val innerStruct = new StructType()
+      .add(cmField("c", IntegerType.INTEGER, 1L, "phys_c")) // duplicate of top-level "a"
+
+    val schema = new StructType()
+      .add(cmField("a", StringType.STRING, 1L, "phys_a"))
+      .add(cmField("b", innerStruct, 2L, "phys_b"))
+
+    val ex = intercept[KernelException] {
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(cmMetadata(schema, "3"))
+    }
+    assert(ex.getMessage.contains("Duplicate column mapping ID 1"))
+    assert(ex.getMessage.contains("field 'c'"))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: duplicate ID in array element struct") {
+    // Validates traversal into ArrayType elements
+    val elementStruct = new StructType()
+      .add(cmField("inner", IntegerType.INTEGER, 1L, "phys_inner")) // duplicate of "a"
+
+    val schema = new StructType()
+      .add(cmField("a", StringType.STRING, 1L, "phys_a"))
+      .add(cmField("arr", new ArrayType(elementStruct, false), 2L, "phys_arr"))
+
+    val ex = intercept[KernelException] {
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(cmMetadata(schema, "3"))
+    }
+    assert(ex.getMessage.contains("Duplicate column mapping ID 1"))
+    assert(ex.getMessage.contains("field 'inner'"))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: duplicate ID in map value struct") {
+    // Validates traversal into MapType values
+    val valueStruct = new StructType()
+      .add(cmField("inner", IntegerType.INTEGER, 1L, "phys_inner")) // duplicate of "a"
+
+    val schema = new StructType()
+      .add(cmField("a", StringType.STRING, 1L, "phys_a"))
+      .add(cmField(
+        "m",
+        new MapType(StringType.STRING, valueStruct, false),
+        2L,
+        "phys_m"))
+
+    val ex = intercept[KernelException] {
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(cmMetadata(schema, "3"))
+    }
+    assert(ex.getMessage.contains("Duplicate column mapping ID 1"))
+    assert(ex.getMessage.contains("field 'inner'"))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: maxColumnId too small") {
+    val schema = new StructType()
+      .add(cmField("a", StringType.STRING, 5L, "phys_a"))
+      .add(cmField("b", IntegerType.INTEGER, 10L, "phys_b"))
+
+    val ex = intercept[KernelException] {
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(cmMetadata(schema, "7"))
+    }
+    assert(ex.getMessage.contains("delta.columnMapping.maxColumnId (7)"))
+    assert(ex.getMessage.contains("less than the max column ID in the schema (10)"))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: valid schema passes") {
+    val schema = new StructType()
+      .add(cmField("a", StringType.STRING, 1L, "phys_a"))
+      .add(cmField("b", IntegerType.INTEGER, 2L, "phys_b"))
+
+    assertThatNoException.isThrownBy(() =>
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(cmMetadata(schema, "2")))
+  }
+
+  test("checkColumnIdAndPhysicalNameAssignments: no-op for NONE mode") {
+    // Fields without column mapping metadata - validation should skip entirely
+    val schema = new StructType()
+      .add("a", StringType.STRING, true)
+      .add("b", IntegerType.INTEGER, true)
+
+    assertThatNoException.isThrownBy(() =>
+      ColumnMapping.checkColumnIdAndPhysicalNameAssignments(testMetadata(schema)))
+  }
+
   test("column mapping is only enabled on known mapping modes") {
     assertThat(ColumnMapping.isColumnMappingModeEnabled(null)).isFalse
     assertThat(ColumnMapping.isColumnMappingModeEnabled(NONE)).isFalse


### PR DESCRIPTION
## Summary
- Add `checkColumnIdAndPhysicalNameAssignments()` validation on the commit path in `ColumnMapping.java` to detect duplicate column IDs, duplicate physical names, and `maxColumnId` inconsistencies before they are written
- Recursively validates uniqueness across nested structs, arrays, and maps
- Called from `TransactionMetadataFactory` after column mapping metadata is assigned

## Why
Spark validates column ID and physical name uniqueness on every commit as a "last defense" against corrupted metadata (`DeltaColumnMapping.scala:382-425`). Java Kernel assigns column IDs and physical names during schema processing but **never validates that the resulting assignments are unique**. A buggy connector or manual metadata manipulation could produce duplicate IDs or names, silently corrupting the table for all readers.

The protocol explicitly requires globally unique physical names and unique column IDs with monotonically increasing `maxColumnId`.

## What
- **`ColumnMapping.checkColumnIdAndPhysicalNameAssignments(Metadata)`**: New public validation method that checks column mapping mode, then delegates to recursive traversal
- **`ColumnMapping.validateColumnMappingUniqueness(...)`**: Private recursive helper that walks StructType/ArrayType/MapType collecting IDs and physical names into sets, throwing `KernelException` with field context on duplicates
- **`TransactionMetadataFactory`**: Calls the new validation after `updateColumnMappingMetadataIfNeeded()` returns
- **8 new tests** in `ColumnMappingSuite`: duplicate column ID, duplicate physical name, nested struct/array/map duplicates, maxColumnId validation, valid schema passes, NONE mode no-op

## Test plan
- [x] All 70 tests in `ColumnMappingSuite` pass (62 existing + 8 new)
- [x] `build/sbt "kernelApi/testOnly io.delta.kernel.internal.util.ColumnMappingSuite"` passes
- [x] Checkstyle, javafmt, scalafmt all pass
- [ ] Verify no regressions in broader `kernelApi/test` suite

This pull request was AI-assisted by Isaac.