### PR TITLE
[Spark] Fix CDC non-constant argument detection for correlated subquery expressions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
@@ -26,10 +26,11 @@ import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaDataSource
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistryBase, NamedRelation, TableFunctionRegistry, UnresolvedLeafNode, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExpressionInfo, Literal, StringLiteral, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExpressionInfo, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, UnaryNode}
 import org.apache.spark.sql.connector.catalog.V1Table
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -114,12 +115,11 @@ trait CDCStatementBase extends DeltaTableValueFunction {
         val fakePlan = util.AnalysisHelper.FakeLogicalPlan(Seq(value), Nil)
         val timestampExpression =
           org.apache.spark.sql.catalyst.optimizer.ComputeCurrentTime(fakePlan).expressions.head
-        if (timestampExpression.isInstanceOf[Unevaluable]) {
-          throw DeltaErrors.cdcNonConstantArgument(fnName, keyPrefix, position, value)
-        }
         timestampExpression.eval().toString
       } catch {
         case _: NullPointerException => throw DeltaErrors.nullRangeBoundaryInCDCRead()
+        case e: SparkException if e.getErrorClass == "INTERNAL_ERROR" =>
+          throw DeltaErrors.cdcNonConstantArgument(fnName, keyPrefix, position, value)
       }
       value.dataType match {
         // We dont need to explicitly handle ShortType as it is parsed as IntegerType.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -294,6 +294,36 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
     }
   }
 
+  test("negative case - table_changes in correlated subquery with OuterReference") {
+    // When table_changes() is used inside a correlated subquery with an expression that
+    // wraps an OuterReference (e.g. `o.version + 0`), the top-level node is not Unevaluable
+    // (Add is evaluable) but its child OuterReference is. The old isInstanceOf[Unevaluable]
+    // check on the top-level expression misses this case and .eval() throws INTERNAL_ERROR.
+    // We instead catch that SparkException and re-throw as DELTA_CDC_NON_CONSTANT_ARGUMENT.
+    val tbl = "tbl"
+    val otherTbl = "other_tbl"
+    withTable(tbl, otherTbl) {
+      spark.range(10).write.format("delta").saveAsTable(tbl)
+      spark.range(5).toDF("version").write.format("delta").saveAsTable(otherTbl)
+
+      val q = s"""
+        SELECT * FROM $otherTbl o WHERE EXISTS (
+          SELECT 1 FROM table_changes('$tbl', o.version + 0)
+        )
+      """
+      checkErrorMatchPVals(
+        intercept[AnalysisException] { sql(q) },
+        "DELTA_CDC_NON_CONSTANT_ARGUMENT",
+        parameters = Map(
+          "argumentName" -> "`starting`",
+          "pos" -> "2",
+          "functionName" -> "`table_changes`",
+          "sqlExpr" -> ".*"
+        )
+      )
+    }
+  }
+
   test("resolve expression for timestamp function") {
     val tbl = "tbl"
     withDefaultTimeZone(UTC) {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When table_changes() is used inside a correlated subquery with an expression referencing an outer column (e.g. o.version + 0), the top-level expression node (Add) is not Unevaluable — but its child OuterReference  is. The previous guard only checked isInstanceOf[Unevaluable] on the top-level node, so it passed through, and the subsequent .eval() call threw a SparkException with error class INTERNAL_ERROR instead of the expected user-facing error.

This PR replaces the upfront Unevaluable check with a catch on SparkException(INTERNAL_ERROR), which correctly handles this case and re-throws it as DELTA_CDC_NON_CONSTANT_ARGUMENT.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Added a new negative test in DeltaCDCSQLSuite — "negative case - table_changes in correlated subquery with OuterReference" — which verifies that the query throws DELTA_CDC_NON_CONSTANT_ARGUMENT with the correct  parameters instead of an internal Spark error.

## Does this PR introduce _any_ user-facing changes?

No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
