### PR TITLE
[Spark] Add sanity check in getBatch to detect missing trailing commits

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -179,6 +179,17 @@ object DeltaV2SourceSuite {
     // V2 only tolerates missing start versions with failOnDataLoss=false; mid-log gaps still
     // throw InvalidTableException because non-contiguous versions are not a log-retention scenario.
     "incremental: commit file gap between versions, failOnDataLoss=false succeeds",
+    // These tests directly use DeltaSource, not applicable to the v2 path.
+    "fail on missing trailing commit - trailing commit disappears between latestOffset and" +
+      " getBatch readChangeFeed=true midVersionEndOffset=true",
+    "fail on missing trailing commit - trailing commit disappears between latestOffset and" +
+      " getBatch readChangeFeed=true midVersionEndOffset=false",
+    "fail on missing trailing commit - trailing commit disappears between latestOffset and" +
+      " getBatch readChangeFeed=false midVersionEndOffset=true",
+    "fail on missing trailing commit - trailing commit disappears between latestOffset and" +
+      " getBatch readChangeFeed=false midVersionEndOffset=false",
+    "fail on missing trailing commit - empty batch from startIndex >= endIndex is not a" +
+      " false positive",
 
     // === Misc ===
     // TODO(#5900): fix exception mismatch

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -189,7 +189,9 @@ object DeltaV2SourceSuite {
     "fail on missing trailing commit - trailing commit disappears between latestOffset and" +
       " getBatch readChangeFeed=false midVersionEndOffset=false",
     "fail on missing trailing commit - empty batch from startIndex >= endIndex is not a" +
-      " false positive",
+      " false positive readChangeFeed=true",
+    "fail on missing trailing commit - empty batch from startIndex >= endIndex is not a" +
+      " false positive readChangeFeed=false",
 
     // === Misc ===
     // TODO(#5900): fix exception mismatch

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2883,6 +2883,14 @@
     ],
     "sqlState" : "KD007"
   },
+  "DELTA_STREAMING_TRAILING_COMMIT_MISSING" : {
+    "message" : [
+      "The connector discovered commits up to version <expectedVersion>, but when reading the",
+      "data, commits after version <seenVersion> are missing. The trailing commit files may",
+      "have been deleted or be transiently invisible in the _delta_log directory."
+    ],
+    "sqlState" : "XXKDS"
+  },
   "DELTA_TABLE_ALREADY_CONTAINS_CDC_COLUMNS" : {
     "message" : [
       "Unable to enable Change Data Capture on the table. The table already contains",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -509,6 +509,15 @@ trait DeltaErrorsBase
     )
   }
 
+  def streamingTrailingCommitMissing(
+      expectedVersion: Long,
+      seenVersion: Long): DeltaIllegalStateException = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_STREAMING_TRAILING_COMMIT_MISSING",
+      messageParameters = Array(s"$expectedVersion", s"$seenVersion")
+    )
+  }
+
   def staticPartitionsNotSupportedException: Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_STATIC_PARTITIONS",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1921,6 +1921,14 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val STREAMING_TRAILING_COMMIT_VALIDATION =
+    buildConf("streaming.trailingCommitValidation.enabled")
+      .internal()
+      .doc("Whether to validate that trailing commits have not gone missing " +
+        "when reading data for a streaming micro-batch.")
+      .booleanConf
+      .createWithDefault(true)
+
   val LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS =
     buildConf("loadFileSystemConfigsFromDataFrameOptions")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -324,6 +324,9 @@ trait DeltaSourceBase extends Source
 
         if (spark.sessionState.conf.getConf(DeltaSQLConf.STREAMING_TRAILING_COMMIT_VALIDATION) &&
             maxVersionSeen < lastExpectedVersion) {
+          recordTrailingCommitMissingEvent(
+            startVersion, startIndex, isInitialSnapshot, endOffset,
+            lastExpectedVersion, maxVersionSeen, isStreamingCDC = false)
           throw DeltaErrors.streamingTrailingCommitMissing(
             lastExpectedVersion, maxVersionSeen)
         }
@@ -339,6 +342,32 @@ trait DeltaSourceBase extends Source
         fileActionsIter.close()
       }
     }
+  }
+
+  /** Records a Delta event when a trailing commit goes missing, for fleet visibility before we
+   * throw, mirroring [[DeltaFileProviderUtils.getDeltaFilesInVersionRange]]. */
+  protected def recordTrailingCommitMissingEvent(
+      startVersion: Long,
+      startIndex: Long,
+      isInitialSnapshot: Boolean,
+      endOffset: DeltaSourceOffset,
+      lastExpectedVersion: Long,
+      maxVersionSeen: Long,
+      isStreamingCDC: Boolean): Unit = {
+    recordDeltaEvent(
+      deltaLog,
+      opType = "delta.exceptions.streamingTrailingCommitMissing",
+      data = Map(
+        "stackTrace" -> Thread.currentThread().getStackTrace.tail.mkString("\n\t"),
+        "startVersion" -> startVersion,
+        "startIndex" -> startIndex,
+        "isInitialSnapshot" -> isInitialSnapshot,
+        "endOffsetReservoirVersion" -> endOffset.reservoirVersion,
+        "endOffsetIndex" -> endOffset.index,
+        "lastExpectedVersion" -> lastExpectedVersion,
+        "maxVersionSeen" -> maxVersionSeen,
+        "isStreamingCDC" -> isStreamingCDC
+      ))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -298,13 +298,34 @@ trait DeltaSourceBase extends Source
         endOffset = Some(endOffset)
       )
       try {
+        // Versions before startVersion have already been processed, so we treat
+        // startVersion - 1 as already "seen".
+        var maxVersionSeen = startVersion - 1
+        // The last commit version we expect the iterator to cover.
+        // If endOffset.index < 0, we don't need to read any file from
+        // endOffset.reservoirVersion, so the last version we must see is one before it.
+        // Similarly if start >= end (no data to read from that version), subtract 1.
+        val lastExpectedVersion = if (endOffset.index >= 0 &&
+          (startVersion < endOffset.reservoirVersion || startIndex < endOffset.index)) {
+          endOffset.reservoirVersion
+        } else {
+          endOffset.reservoirVersion - 1
+        }
+        // iterator will be materialized during createDataFrame
         val filteredIndexedFiles = fileActionsIter.filter { indexedFile =>
+          maxVersionSeen = indexedFile.version
           indexedFile.getFileAction != null &&
             excludeRegex.forall(_.findFirstIn(indexedFile.getFileAction.path).isEmpty)
         }
 
         val (result, duration) = Utils.timeTakenMs {
           createDataFrame(filteredIndexedFiles)
+        }
+
+        if (spark.sessionState.conf.getConf(DeltaSQLConf.STREAMING_TRAILING_COMMIT_VALIDATION) &&
+            maxVersionSeen < lastExpectedVersion) {
+          throw DeltaErrors.streamingTrailingCommitMissing(
+            lastExpectedVersion, maxVersionSeen)
         }
         logInfo(log"Getting dataFrame for delta_log_path=" +
           log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} with " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
@@ -203,8 +203,23 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
     val changes = getFileChangesForCDC(
       startVersion, startIndex, isInitialSnapshot, limits = None, Some(endOffset))
 
+    // Versions before startVersion have already been processed, so we treat
+    // startVersion - 1 as already "seen".
+    var maxVersionSeen = startVersion - 1
+    // The last commit version we expect the iterator to cover.
+    // If endOffset.index < 0, we don't need to read any file from
+    // endOffset.reservoirVersion, so the last version we must see is one before it.
+    // Similarly if start >= end (no data to read from that version), subtract 1.
+    val lastExpectedVersion = if (endOffset.index >= 0 &&
+      (startVersion < endOffset.reservoirVersion || startIndex < endOffset.index)) {
+      endOffset.reservoirVersion
+    } else {
+      endOffset.reservoirVersion - 1
+    }
+    // iterator will be materialized during CDCReader.changesToDF
     val groupedFileAndCommitInfoActions =
       changes.map { case (v, indexFiles, commitInfoOpt) =>
+        maxVersionSeen = v
         (v, indexFiles.filter(_.hasFileAction).map(_.getFileAction).toSeq ++ commitInfoOpt)
       }
 
@@ -227,6 +242,11 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
         case e: FileNotFoundException =>
           throw DeltaErrors.logFileNotFoundExceptionForStreamingSource(e)
       }
+    }
+    if (spark.sessionState.conf.getConf(DeltaSQLConf.STREAMING_TRAILING_COMMIT_VALIDATION) &&
+        maxVersionSeen < lastExpectedVersion) {
+      throw DeltaErrors.streamingTrailingCommitMissing(
+        lastExpectedVersion, maxVersionSeen)
     }
     logInfo(log"Getting CDC dataFrame for delta_log_path=" +
       log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} with " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
@@ -245,6 +245,9 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
     }
     if (spark.sessionState.conf.getConf(DeltaSQLConf.STREAMING_TRAILING_COMMIT_VALIDATION) &&
         maxVersionSeen < lastExpectedVersion) {
+      recordTrailingCommitMissingEvent(
+        startVersion, startIndex, isInitialSnapshot, endOffset,
+        lastExpectedVersion, maxVersionSeen, isStreamingCDC = true)
       throw DeltaErrors.streamingTrailingCommitMissing(
         lastExpectedVersion, maxVersionSeen)
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -2271,46 +2271,57 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  test("fail on missing trailing commit - empty batch from startIndex >= endIndex is not a" +
-      " false positive") {
-    withSQLConf(DeltaSQLConf.STREAMING_TRAILING_COMMIT_VALIDATION.key -> "true") {
-      withTempDir { srcData =>
-        spark.range(10).coalesce(1).write.format("delta").mode("append")
-          .save(srcData.getCanonicalPath)
-        spark.range(10, 20).coalesce(1).write.format("delta").mode("append")
-          .save(srcData.getCanonicalPath)
-        // Version 2: three files so multiple in-version indices exist.
-        spark.range(20, 30).repartition(3).write.format("delta").mode("append")
-          .save(srcData.getCanonicalPath)
+  for {
+    readChangeFeed <- Seq(true, false)
+  } {
+    test("fail on missing trailing commit - empty batch from startIndex >= endIndex is not a" +
+        s" false positive readChangeFeed=$readChangeFeed") {
+      withSQLConf(
+          DeltaSQLConf.STREAMING_TRAILING_COMMIT_VALIDATION.key -> "true",
+          DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey -> readChangeFeed.toString) {
+        withTempDir { srcData =>
+          spark.range(10).coalesce(1).write.format("delta").mode("append")
+            .save(srcData.getCanonicalPath)
+          spark.range(10, 20).coalesce(1).write.format("delta").mode("append")
+            .save(srcData.getCanonicalPath)
+          // Version 2: three files so multiple in-version indices exist.
+          spark.range(20, 30).repartition(3).write.format("delta").mode("append")
+            .save(srcData.getCanonicalPath)
 
-        val srcLog = DeltaLog.forTable(spark, srcData)
-        srcLog.update()
+          val srcLog = DeltaLog.forTable(spark, srcData)
+          srcLog.update()
 
-        val source = DeltaSource(
-          spark,
-          srcLog,
-          catalogTableOpt = None,
-          new DeltaOptions(Map("startingVersion" -> "0"), spark.sessionState.conf),
-          srcLog.update(),
-          metadataPath = "")
+          val optionsMap = {
+            var m = Map("startingVersion" -> "0")
+            if (readChangeFeed) m += (DeltaOptions.CDC_READ_OPTION -> "true")
+            m
+          }
+          val source = DeltaSource(
+            spark,
+            srcLog,
+            catalogTableOpt = None,
+            new DeltaOptions(optionsMap, spark.sessionState.conf),
+            srcLog.update(),
+            metadataPath = "")
 
-        val reservoirId = srcLog.unsafeVolatileTableId
-        // isInitialSnapshot=true keeps endOffset unequal to each start offset, so getBatch's
-        // start == end early return is skipped and the check actually runs.
-        val endOffset = DeltaSourceOffset(
-          reservoirId, reservoirVersion = 2, index = 1, isInitialSnapshot = true)
+          val reservoirId = srcLog.unsafeVolatileTableId
+          // isInitialSnapshot=true keeps endOffset unequal to each start offset, so getBatch's
+          // start == end early return is skipped and the check actually runs.
+          val endOffset = DeltaSourceOffset(
+            reservoirId, reservoirVersion = 2, index = 1, isInitialSnapshot = true)
 
-        // getBatch runs the check eagerly, so returning instead of throwing is the assertion.
+          // getBatch runs the check eagerly, so returning instead of throwing is the assertion.
 
-        // startIndex == endIndex: pins the comparison as `<`, not `<=`.
-        val equalStart = DeltaSourceOffset(
-          reservoirId, reservoirVersion = 2, index = 1, isInitialSnapshot = false)
-        source.getBatch(Some(equalStart), endOffset)
+          // startIndex == endIndex: pins the comparison as `<`, not `<=`.
+          val equalStart = DeltaSourceOffset(
+            reservoirId, reservoirVersion = 2, index = 1, isInitialSnapshot = false)
+          source.getBatch(Some(equalStart), endOffset)
 
-        // startIndex > endIndex.
-        val greaterStart = DeltaSourceOffset(
-          reservoirId, reservoirVersion = 2, index = 2, isInitialSnapshot = false)
-        source.getBatch(Some(greaterStart), endOffset)
+          // startIndex > endIndex.
+          val greaterStart = DeltaSourceOffset(
+            reservoirId, reservoirVersion = 2, index = 2, isInitialSnapshot = false)
+          source.getBatch(Some(greaterStart), endOffset)
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -2181,6 +2181,140 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       expectedAfterOverwriteAppend = Right(Seq(1, 2, 3, 4, 5, 9, 10)))
   }
 
+  for {
+    readChangeFeed <- Seq(true, false)
+    midVersionEndOffset <- Seq(true, false)
+  } {
+    test("fail on missing trailing commit - trailing commit disappears between latestOffset" +
+        s" and getBatch readChangeFeed=$readChangeFeed" +
+        s" midVersionEndOffset=$midVersionEndOffset") {
+      withTempDir { srcData =>
+        withSQLConf(
+          DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey -> readChangeFeed.toString) {
+          // Version 0: exactly 1 file
+          spark.range(10).coalesce(1).write.format("delta").mode("append")
+            .save(srcData.getCanonicalPath)
+          // Version 1: exactly 1 file
+          spark.range(10, 20).coalesce(1).write.format("delta").mode("append")
+            .save(srcData.getCanonicalPath)
+          // Version 2: exactly 3 files so rate limiting can produce a mid-version offset
+          spark.range(20, 30).repartition(3).write.format("delta").mode("append")
+            .save(srcData.getCanonicalPath)
+
+          val srcLog = DeltaLog.forTable(spark, srcData)
+          srcLog.update()
+
+          // Construct a DeltaSource manually so we can call latestOffset and getBatch separately.
+          // When midVersionEndOffset=true, we use maxFilesPerTrigger to force latestOffset to
+          // stop mid-version, producing a non-BASE_INDEX offset where reservoirVersion is
+          // the actual version. When false, all versions are consumed and the offset is bumped
+          // to (version+1, BASE_INDEX).
+          val optionsMap = {
+            var m = Map("startingVersion" -> "0")
+            if (readChangeFeed) m += (DeltaOptions.CDC_READ_OPTION -> "true")
+            if (midVersionEndOffset) m += ("maxFilesPerTrigger" -> "3")
+            m
+          }
+          val source = DeltaSource(
+            spark,
+            srcLog,
+            catalogTableOpt = None,
+            new DeltaOptions(optionsMap, spark.sessionState.conf),
+            srcLog.update(),
+            metadataPath = "")
+
+          val latestOfs = source.latestOffset(null, source.getDefaultReadLimit)
+          assert(latestOfs != null)
+          val endOffset = DeltaSourceOffset(srcLog.unsafeVolatileTableId, latestOfs)
+
+          if (midVersionEndOffset) {
+            // maxFilesPerTrigger=3 admits version 0 (1 file) + version 1 (1 file) +
+            // version 2's first file (1 file) = 3 files, stopping mid-version 2.
+            assert(endOffset.reservoirVersion == 2,
+              s"Expected version 2 but got ${endOffset.reservoirVersion}")
+            assert(endOffset.index == 0)
+          } else {
+            // All versions consumed; offset is bumped to (version=3, BASE_INDEX).
+            assert(endOffset.reservoirVersion == 3)
+            assert(endOffset.index == DeltaSourceOffset.BASE_INDEX)
+          }
+
+          // Delete version 2's commit file to simulate it disappearing after latestOffset.
+          srcLog.checkpoint()
+          val commitFile = new File(FileNames.unsafeDeltaFile(srcLog.logPath, 2).toUri)
+          assert(commitFile.exists(), s"Commit file should exist: $commitFile")
+          assert(commitFile.delete(), s"Failed to delete commit file: $commitFile")
+
+          if (catalogOwnedDefaultCreationEnabledInTests) {
+            // With coordinated commits, manually deleting the commit file creates an
+            // inconsistency between the filesystem and the commit coordinator's state.
+            // SnapshotManagement detects this gap before the streaming layer's trailing
+            // commit check can fire, throwing an IllegalStateException.
+            val e = intercept[IllegalStateException] {
+              source.getBatch(startOffsetOption = None, endOffset)
+            }
+            assert(e.getMessage.contains(
+              "unexpectedly still requires additional file-system listing"))
+          } else {
+            // getBatch reads versions 0-1 (version 2 is gone), so maxVersionSeen = 1.
+            // lastExpectedVersion = 2 in both cases:
+            //   mid-version:  endOffset=(v2, index=0) -> lastExpectedVersion = 2
+            //   fully consumed: endOffset=(v3, BASE_INDEX) -> lastExpectedVersion = 3 - 1 = 2
+            val e = intercept[DeltaIllegalStateException] {
+              source.getBatch(startOffsetOption = None, endOffset)
+            }
+            assert(e.getMessage ===
+              DeltaErrors.streamingTrailingCommitMissing(2L, 1L).getMessage)
+          }
+        }
+      }
+    }
+  }
+
+  test("fail on missing trailing commit - empty batch from startIndex >= endIndex is not a" +
+      " false positive") {
+    withSQLConf(DeltaSQLConf.STREAMING_TRAILING_COMMIT_VALIDATION.key -> "true") {
+      withTempDir { srcData =>
+        spark.range(10).coalesce(1).write.format("delta").mode("append")
+          .save(srcData.getCanonicalPath)
+        spark.range(10, 20).coalesce(1).write.format("delta").mode("append")
+          .save(srcData.getCanonicalPath)
+        // Version 2: three files so multiple in-version indices exist.
+        spark.range(20, 30).repartition(3).write.format("delta").mode("append")
+          .save(srcData.getCanonicalPath)
+
+        val srcLog = DeltaLog.forTable(spark, srcData)
+        srcLog.update()
+
+        val source = DeltaSource(
+          spark,
+          srcLog,
+          catalogTableOpt = None,
+          new DeltaOptions(Map("startingVersion" -> "0"), spark.sessionState.conf),
+          srcLog.update(),
+          metadataPath = "")
+
+        val reservoirId = srcLog.unsafeVolatileTableId
+        // isInitialSnapshot=true keeps endOffset unequal to each start offset, so getBatch's
+        // start == end early return is skipped and the check actually runs.
+        val endOffset = DeltaSourceOffset(
+          reservoirId, reservoirVersion = 2, index = 1, isInitialSnapshot = true)
+
+        // getBatch runs the check eagerly, so returning instead of throwing is the assertion.
+
+        // startIndex == endIndex: pins the comparison as `<`, not `<=`.
+        val equalStart = DeltaSourceOffset(
+          reservoirId, reservoirVersion = 2, index = 1, isInitialSnapshot = false)
+        source.getBatch(Some(equalStart), endOffset)
+
+        // startIndex > endIndex.
+        val greaterStart = DeltaSourceOffset(
+          reservoirId, reservoirVersion = 2, index = 2, isInitialSnapshot = false)
+        source.getBatch(Some(greaterStart), endOffset)
+      }
+    }
+  }
+
   test("incremental: first commit file missing, fails") {
     withTempDirs { (srcData, targetData, chkLocation) =>
       def addData(): Unit = {
@@ -3298,9 +3432,6 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
   test("streaming processes 100 sequential single-value commits and contains all values 0 to 99") {
     withTempDirs { (inputDir, outputDir, checkpointDir) =>
-      // TODO(#6339): enable batch size 2 after fix PR merged
-      assume(!catalogOwnedCoordinatorBackfillBatchSize.contains(2),
-        "Test cannot pass with batch size 2 due to issue #6339")
       // Write the first value to initialize the Delta table
       Seq(0).toDF("x").write.format("delta").save(inputDir.toString)
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds a sanity check in `getBatch` to detect when a trailing commit file disappears between `latestOffset` and `getBatch`, which would otherwise cause silent, permanent data loss.

**Problem:** `latestOffset` and `getBatch` perform independent listings of the Delta log. If `latestOffset` discovers commit version N and sets it as the end offset, but commit N's file disappears before `getBatch` reads it (e.g., due to cloud storage inconsistency), `getBatch` silently returns data only up to version N-1. The streaming engine then commits offset N to the checkpoint, so the next micro-batch starts from N onward — permanently skipping version N's data.

The existing `failOnDataLoss` gap check in `getChangeLogFiles` only detects **interior gaps** (e.g., seeing version 6 after version 4). When the missing version is at the **tail** of the range, the iterator simply ends early with no subsequent version to reveal the gap.

**Fix:** After `getBatch` fully consumes the file action iterator, verify that the maximum version actually read (`maxVersionSeen`) reaches the expected end version (`lastExpectedVersion`). `maxVersionSeen` is initialized to `startVersion - 1` because versions before `startVersion` have already been processed — we treat them as already "seen" and don't care if they've been deleted. The expected version is derived from the end offset:
- If `endOffset.index < 0`: we don't need to read any file from `endOffset.reservoirVersion`, so the last version we must see is one before it (`reservoirVersion - 1`)
- If start >= end (no data to read from that version): similarly subtract 1
- Otherwise: `lastExpectedVersion = reservoirVersion` (the actual version)

If `maxVersionSeen < lastExpectedVersion`, a `DeltaIllegalStateException` with error class `DELTA_STREAMING_TRAILING_COMMIT_MISSING` is thrown.

The check is guarded by a SQL conf flag `spark.databricks.delta.streaming.trailingCommitValidation.enabled` (default `true`) so users can disable it if it turns out to be too strict due to some uncaught bug.

This check is applied to both the regular read path (`DeltaSource.getFileChangesAndCreateDataFrame`) and the CDC read path (`DeltaSourceCDCSupport.getCDCFileChangesAndCreateDataFrame`).

## How was this patch tested?

Added parameterized unit tests in `DeltaSourceSuite` covering 4 combinations:
- `readChangeFeed=true/false` × `midVersionEndOffset=true/false`

Each test:
1. Creates a Delta table with 3 versions (controlled file counts via `coalesce(1)` and `repartition(3)`)
2. Manually constructs a `DeltaSource` and calls `latestOffset`
3. Checkpoints the table, then deletes the trailing commit file
4. Calls `getBatch` and verifies `DeltaIllegalStateException` is thrown

The `midVersionEndOffset` parameter tests both offset types:
- `midVersionEndOffset=false`: offset is `(v3, BASE_INDEX)` — we don't need to read any file from v3, so `lastExpectedVersion = 3 - 1 = 2`
- `midVersionEndOffset=true`: offset is `(v2, index=0)` — we do need to read from v2, so `lastExpectedVersion = 2`

In both cases `maxVersionSeen = 1` (version 2's commit was deleted), triggering the check.

Also added a test verifying the check does **not** fire on a legitimately empty batch: when start and end share a version with `startIndex >= endOffset.index`, no files are read and `maxVersionSeen` stays at `startVersion - 1`, which must not be flagged as a missing trailing commit. It exercises both `startIndex == endOffset.index` (pinning the comparison as `<` rather than `<=`) and `startIndex > endOffset.index`, asserting `getBatch` returns an empty batch without throwing.

Tests are skipped for the V2 source suite since they directly construct `DeltaSource`, which is not applicable to the V2 path. They also handle the coordinated-commits case, where manually deleting the commit file triggers an `IllegalStateException` from `SnapshotManagement` before the streaming layer's check fires.

Also removed the #6339 skip in the "streaming processes 100 sequential single-value commits" test, as this PR resolves that issue.

## Does this PR introduce _any_ user-facing changes?

Yes. Previously, if a trailing commit file disappeared between `latestOffset` and `getBatch`, the data in that commit would be silently and permanently lost — even with `failOnDataLoss=true` (the default). After this change, the stream will throw a `DELTA_STREAMING_TRAILING_COMMIT_MISSING` error in this scenario. The check can be disabled via `spark.databricks.delta.streaming.trailingCommitValidation.enabled = false`.
