### PR TITLE
[kernel] Eliminate redundant N.json cloud read for InCommitTimestamp …

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -84,8 +84,9 @@ public class SnapshotImpl implements Snapshot {
    * <ul>
    *   <li>Optional.empty(): if the ICT value is not yet known (i.e. has not yet been read from the
    *       CRC or CommitInfo)
-   *   <li>Optional.of(timestamp): if the ICT value has been read from the CRC or CommitInfo, or was
-   *       injected into this Snapshot at construction time (e.g. for a post-commit snapshot)
+   *   <li>Optional.of(timestamp): if the ICT value was pre-populated during snapshot construction
+   *       (e.g. captured during Protocol/Metadata log replay or injected for post-commit
+   *       snapshots), or has been lazily read from the CRC or CommitInfo
    * </ul>
    */
   private Optional<Long> inCommitTimestampOpt;
@@ -162,12 +163,17 @@ public class SnapshotImpl implements Snapshot {
    * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit in this Snapshot.
    *
    * <p>When InCommitTimestampTableFeature is enabled, the timestamp is retrieved from the
-   * CommitInfo of the latest commit in this Snapshot, which can result in an IO operation.
+   * CommitInfo of the latest commit in this Snapshot. In the common case this value is already
+   * available (populated during snapshot construction) and no IO is needed. If it was not captured
+   * during construction (e.g. when a CRC file at the exact snapshot version was used), a single
+   * cloud read is performed and the result is cached.
    *
    * <p>For non-ICT tables, this is the same as the file modification time of the latest commit in
    * this Snapshot.
+   *
+   * <p>TODO: Populate ICT from the CRC file when available so the CRC path also avoids the extra
+   * cloud read.
    */
-  // TODO: Support reading from CRC file if available
   @Override
   public long getTimestamp(Engine engine) {
     if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
@@ -28,6 +28,8 @@ import io.delta.kernel.internal.metrics.SnapshotMetrics;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.internal.util.InCommitTimestampUtils;
+import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
@@ -41,20 +43,63 @@ public class ProtocolMetadataLogReplay {
 
   private static final Logger logger = LoggerFactory.getLogger(ProtocolMetadataLogReplay.class);
 
-  /** Read schema when searching for the latest Protocol and Metadata. */
+  /**
+   * Minimal CommitInfo sub-schema containing only the {@code inCommitTimestamp} field. Using this
+   * instead of {@link io.delta.kernel.internal.actions.CommitInfo#FULL_SCHEMA} avoids reading
+   * fields that are not needed during Protocol/Metadata loading.
+   *
+   * <p>{@code inCommitTimestamp} must be at ordinal 0 here, matching its position in {@code
+   * CommitInfo.FULL_SCHEMA}, so that {@link
+   * InCommitTimestampUtils#tryExtractInCommitTimestamp(ColumnarBatch)} works correctly with both
+   * schemas.
+   */
+  private static final StructType COMMIT_INFO_ICT_READ_SCHEMA =
+      new StructType().add("inCommitTimestamp", LongType.LONG, true /* nullable */);
+
+  /**
+   * Read schema used for <b>delta JSON commit files</b> when searching for the latest Protocol,
+   * Metadata, and InCommitTimestamp. The {@code commitInfo} field uses a minimal sub-schema to
+   * avoid reading unnecessary fields.
+   *
+   * <p>This schema must NOT be used for Parquet checkpoint files; use {@link
+   * #PROTOCOL_METADATA_CHECKPOINT_READ_SCHEMA} for those instead, since Parquet readers may fail on
+   * columns that are absent from the file's physical schema.
+   */
   public static final StructType PROTOCOL_METADATA_READ_SCHEMA =
+      new StructType()
+          .add("protocol", Protocol.FULL_SCHEMA)
+          .add("metaData", Metadata.FULL_SCHEMA)
+          .add("commitInfo", COMMIT_INFO_ICT_READ_SCHEMA);
+
+  /**
+   * Read schema used for <b>checkpoint files</b> (Parquet or JSON v2 checkpoints) when searching
+   * for the latest Protocol and Metadata. Omits {@code commitInfo} because checkpoint files do not
+   * contain CommitInfo actions, and some Parquet implementations throw on missing columns.
+   */
+  private static final StructType PROTOCOL_METADATA_CHECKPOINT_READ_SCHEMA =
       new StructType().add("protocol", Protocol.FULL_SCHEMA).add("metaData", Metadata.FULL_SCHEMA);
 
-  /** Result of loading Protocol and Metadata from a LogSegment. */
+  /** Result of loading Protocol, Metadata, and (optionally) InCommitTimestamp from a LogSegment. */
   public static class Result {
     public final Protocol protocol;
     public final Metadata metadata;
     private final long numDeltaFilesRead;
+    /**
+     * The InCommitTimestamp read from the snapshot version's commit file during P/M loading, if
+     * available. Empty when the snapshot version's commit file was not read (e.g. when a CRC file
+     * at the exact snapshot version was used), or when the table does not have ICT enabled.
+     */
+    public final Optional<Long> inCommitTimestampOpt;
 
-    public Result(Protocol protocol, Metadata metadata, long numDeltaFilesRead) {
+    public Result(
+        Protocol protocol,
+        Metadata metadata,
+        long numDeltaFilesRead,
+        Optional<Long> inCommitTimestampOpt) {
       this.protocol = protocol;
       this.metadata = metadata;
       this.numDeltaFilesRead = numDeltaFilesRead;
+      this.inCommitTimestampOpt = inCommitTimestampOpt;
     }
   }
 
@@ -108,7 +153,8 @@ public class ProtocolMetadataLogReplay {
 
         final Protocol protocol = crcInfo.get().getProtocol();
         final Metadata metadata = crcInfo.get().getMetadata();
-        return new Result(protocol, metadata, 0 /* logFilesRead */);
+        // ICT is not stored in the CRC file; leave it empty so SnapshotImpl reads it lazily.
+        return new Result(protocol, metadata, 0 /* logFilesRead */, Optional.empty());
       }
     }
 
@@ -118,12 +164,20 @@ public class ProtocolMetadataLogReplay {
     long numDeltaFilesRead = 0;
     Protocol protocol = null;
     Metadata metadata = null;
+    // ICT captured from the snapshot version's commit file (the first file we encounter since we
+    // iterate in reverse). Empty if that file is not a regular commit file (e.g. log compaction).
+    Optional<Long> ictOpt = Optional.empty();
+    boolean ictExtractionAttempted = false;
 
+    // Use separate schemas for JSON delta files (which may contain commitInfo) and checkpoint
+    // files (which never contain commitInfo and may fail on unexpected columns).
     try (CloseableIterator<ActionWrapper> reverseIter =
         new ActionsIterator(
             engine,
             logSegment.allFilesWithCompactionsReversed(),
             PROTOCOL_METADATA_READ_SCHEMA,
+            PROTOCOL_METADATA_CHECKPOINT_READ_SCHEMA,
+            Optional.empty(),
             Optional.empty())) {
       while (reverseIter.hasNext()) {
         final ActionWrapper nextElem = reverseIter.next();
@@ -132,9 +186,26 @@ public class ProtocolMetadataLogReplay {
         // Load this lazily (as needed). We may be able to just use the CRC.
         ColumnarBatch columnarBatch = null;
 
-        if (protocol == null) {
+        // Opportunistically capture the ICT from the first commit file at the snapshot version.
+        // CommitInfo (containing ICT) is guaranteed to be the first action in commit files when
+        // ICT is enabled, so reading it here avoids a separate cloud read in getTimestamp().
+        // We skip log-compaction files because they do not contain CommitInfo actions.
+        if (!ictExtractionAttempted
+            && version == snapshotVersion
+            && !nextElem.isFromCheckpoint()
+            && FileNames.isCommitFile(nextElem.getFilePath())) {
+          ictExtractionAttempted = true;
           columnarBatch = nextElem.getColumnarBatch();
-          assert (columnarBatch.getSchema().equals(PROTOCOL_METADATA_READ_SCHEMA));
+          ictOpt = InCommitTimestampUtils.tryExtractInCommitTimestamp(columnarBatch);
+        }
+
+        if (protocol == null) {
+          if (columnarBatch == null) {
+            columnarBatch = nextElem.getColumnarBatch();
+          }
+          // protocol is always at ordinal 0 in both PROTOCOL_METADATA_READ_SCHEMA and
+          // PROTOCOL_METADATA_CHECKPOINT_READ_SCHEMA
+          assert (columnarBatch.getSchema().at(0).getName().equals("protocol"));
 
           final ColumnVector protocolVector = columnarBatch.getColumnVector(0);
 
@@ -144,7 +215,7 @@ public class ProtocolMetadataLogReplay {
 
               if (metadata != null) {
                 // Stop since we have found the latest Protocol and Metadata.
-                return new Result(protocol, metadata, numDeltaFilesRead);
+                return new Result(protocol, metadata, numDeltaFilesRead, ictOpt);
               }
 
               break; // We just found the protocol, exit this for-loop
@@ -155,7 +226,8 @@ public class ProtocolMetadataLogReplay {
         if (metadata == null) {
           if (columnarBatch == null) {
             columnarBatch = nextElem.getColumnarBatch();
-            assert (columnarBatch.getSchema().equals(PROTOCOL_METADATA_READ_SCHEMA));
+            // metaData is always at ordinal 1 in both read schemas
+            assert (columnarBatch.getSchema().at(1).getName().equals("metaData"));
           }
           final ColumnVector metadataVector = columnarBatch.getColumnVector(1);
 
@@ -165,7 +237,7 @@ public class ProtocolMetadataLogReplay {
 
               if (protocol != null) {
                 // Stop since we have found the latest Protocol and Metadata.
-                return new Result(protocol, metadata, numDeltaFilesRead);
+                return new Result(protocol, metadata, numDeltaFilesRead, ictOpt);
               }
 
               break; // We just found the metadata, exit this for-loop
@@ -188,7 +260,7 @@ public class ProtocolMetadataLogReplay {
               metadata = crcInfo.get().getMetadata();
             }
 
-            return new Result(protocol, metadata, numDeltaFilesRead);
+            return new Result(protocol, metadata, numDeltaFilesRead, ictOpt);
           }
         }
       }
@@ -206,7 +278,7 @@ public class ProtocolMetadataLogReplay {
           String.format("No metadata found at version %s", logSegment.getVersion()));
     }
 
-    return new Result(protocol, metadata, numDeltaFilesRead);
+    return new Result(protocol, metadata, numDeltaFilesRead, ictOpt);
   }
 
   private static void validateCrcInfoMatchesExpectedVersion(CRCInfo crcInfo, long expectedVersion) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -179,7 +179,7 @@ public class SnapshotManager {
             protocolMetadataResult.metadata,
             DefaultFileSystemManagedTableOnlyCommitter.INSTANCE,
             snapshotContext,
-            Optional.empty() /* inCommitTimestampOpt */);
+            protocolMetadataResult.inCommitTimestampOpt);
 
     return snapshot;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -192,6 +192,10 @@ public class SnapshotFactory {
 
     Protocol protocol;
     Metadata metadata;
+    // ICT captured during P/M loading to avoid a redundant cloud read in getTimestamp().
+    // Remains empty when protocolAndMetadataOpt is pre-populated (e.g. post-commit snapshots
+    // inject the ICT separately via the SnapshotImpl constructor).
+    Optional<Long> inCommitTimestampOpt = Optional.empty();
 
     if (ctx.protocolAndMetadataOpt.isPresent()) {
       protocol = ctx.protocolAndMetadataOpt.get()._1;
@@ -206,6 +210,7 @@ public class SnapshotFactory {
               snapshotCtx.getSnapshotMetrics());
       protocol = result.protocol;
       metadata = result.metadata;
+      inCommitTimestampOpt = result.inCommitTimestampOpt;
     }
 
     // We require maxCatalogVersion to be provided for catalogManaged tables. We cannot validate
@@ -224,7 +229,7 @@ public class SnapshotFactory {
         metadata,
         ctx.committerOpt.orElse(DefaultFileSystemManagedTableOnlyCommitter.INSTANCE),
         snapshotCtx,
-        Optional.empty() /* inCommitTimestampOpt */);
+        inCommitTimestampOpt);
   }
 
   private SnapshotQueryContext getSnapshotQueryContext() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -22,7 +22,6 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.TableConfig;
-import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,6 +66,10 @@ public class InCommitTimestampUtils {
    * delta file. This function assumes that this batch is the leading batch of a single delta file
    * and attempts to extract the commitInfo action from the first row. If the commitInfo action is
    * not present or does not contain an inCommitTimestamp, this function returns an empty Optional.
+   *
+   * <p>Works with both the full {@link io.delta.kernel.internal.actions.CommitInfo#FULL_SCHEMA} and
+   * minimal read schemas that contain only the {@code inCommitTimestamp} field, as long as {@code
+   * inCommitTimestamp} appears as the first child (ordinal 0) of the {@code commitInfo} column.
    */
   public static Optional<Long> tryExtractInCommitTimestamp(
       ColumnarBatch firstActionsBatchFromSingleDelta) {
@@ -78,10 +81,13 @@ public class InCommitTimestampUtils {
     ColumnVector commitInfoVector =
         firstActionsBatchFromSingleDelta.getColumnVector(commitInfoOrdinal);
     // CommitInfo is always the first action in the batch when inCommitTimestamp is enabled.
-    int expectedRowIdOfCommitInfo = 0;
-    CommitInfo commitInfo =
-        CommitInfo.fromColumnVector(commitInfoVector, expectedRowIdOfCommitInfo);
-    return commitInfo != null ? commitInfo.getInCommitTimestamp() : Optional.empty();
+    if (commitInfoVector.getSize() == 0 || commitInfoVector.isNullAt(0)) {
+      return Optional.empty();
+    }
+    // inCommitTimestamp is child ordinal 0 in both CommitInfo.FULL_SCHEMA and the minimal
+    // ICT-only sub-schema used in PROTOCOL_METADATA_READ_SCHEMA.
+    ColumnVector ictVector = commitInfoVector.getChild(0);
+    return ictVector.isNullAt(0) ? Optional.empty() : Optional.of(ictVector.getLong(0));
   }
 
   /** Returns true if the current transaction implicitly/explicitly enables ICT. */

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PostCommitSnapshotSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PostCommitSnapshotSuite.scala
@@ -182,6 +182,25 @@ class PostCommitSnapshotSuite
     }
   }
 
+  test("regular snapshot has ICT pre-loaded") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createEmptyTable(
+        engine,
+        tablePath,
+        testSchema,
+        tableProperties = Map(TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true"))
+      appendData(engine, tablePath, data = seqOfUnpartitionedDataBatch1)
+
+      // Load as a regular snapshot via the standard path (SnapshotFactory -> SnapshotImpl)
+      val snapshot = latestSnapshot(tablePath, engine).asInstanceOf[SnapshotImpl]
+
+      val failingEngine = mockEngine()
+
+      // ICT is captured during Protocol/Metadata loading; should *not* read the delta file again
+      snapshot.getTimestamp(failingEngine)
+    }
+  }
+
   // TODO: Test CRC is also pre-loaded. Requires
   //       (1) SnapshotImpl::getCurrentCrcInfo to take in an engine param
   //       (2) LogReplay to *not* be injected into SnapshotImpl constructor


### PR DESCRIPTION
Which Delta project/connector is this regarding?
                                                                                               
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)      
                                                                                               
Description     
                                                                                               
Eliminates a redundant N.json cloud read that previously occurred when calling getTimestamp() on an ICT-enabled snapshot.

Root cause: Loading a snapshot required two separate reads of the same commit file:

1. ProtocolMetadataLogReplay read N.json to find Protocol and Metadata.
2. SnapshotImpl.getTimestamp() read N.json again to fetch CommitInfo.inCommitTimestamp.

Fix: Capture the InCommitTimestamp (ICT) opportunistically during the existing Protocol/Metadata log replay scan — the N.json file is already open — and pre-populate SnapshotImpl.inCommitTimestampOpt at construction time. getTimestamp() then returns the cached value with no additional IO.

Key implementation details:

- A minimal COMMIT_INFO_ICT_READ_SCHEMA containing only the inCommitTimestamp field (vs. the full 8-field CommitInfo schema) is added to PROTOCOL_METADATA_READ_SCHEMA for JSON delta files.
- A separate PROTOCOL_METADATA_CHECKPOINT_READ_SCHEMA (without commitInfo) is used for Parquet checkpoint files, which don't contain CommitInfo and whose Parquet readers throw on unexpected missing columns.
- ICT extraction is skipped for log-compaction files (which don't contain CommitInfo) via FileNames.isCommitFile().
- When a CRC file at the exact snapshot version is used, P/M loading returns early without reading any delta files, so ICT remains unpopulated and getTimestamp() falls back to a single lazy read. Eliminating this remaining case is left as a follow-up TODO.

Resolves #4914

How was this patch tested?

- Existing test suites all pass: InCommitTimestampSuite (16 tests), LogReplaySuite, SnapshotChecksumStatisticsAndWriteSuite, SnapshotSuite, PostCommitSnapshotSuite, and the metrics suites (115 tests total across 11 suites).
- Added a new regression-guard test "regular snapshot has ICT pre-loaded" in PostCommitSnapshotSuite: it loads a regular snapshot on an ICT-enabled table and calls getTimestamp() using a mockEngine() that throws UnsupportedOperationException on any IO. The test fails if ICT was not pre-populated during snapshot construction, preventing future regressions.    

Does this PR introduce any user-facing changes?

No. This is a performance optimization internal to the Kernel. The behavior of all public APIs (getTimestamp(), etc.) is unchanged; only the number of cloud reads required is reduced.