### PR TITLE
Preserve exception cause chain when rethrowing wrapped exceptions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/storage/S3SingleDriverLogStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/storage/S3SingleDriverLogStore.scala
@@ -198,7 +198,9 @@ class S3SingleDriverLogStore(
     } catch {
       // Convert Hadoop's FileAlreadyExistsException to Java's FileAlreadyExistsException
       case e: org.apache.hadoop.fs.FileAlreadyExistsException =>
-          throw new java.nio.file.FileAlreadyExistsException(e.getMessage)
+          val converted = new java.nio.file.FileAlreadyExistsException(e.getMessage)
+          converted.initCause(e)
+          throw converted
     } finally {
       releasePathLock(lockedPath)
     }


### PR DESCRIPTION
## Description

When `S3SingleDriverLogStore` catches Hadoop's `FileAlreadyExistsException` and converts it to Java's `FileAlreadyExistsException`, the original exception cause was being lost. This makes debugging harder because the stack trace does not show the original Hadoop exception.

This change preserves the cause chain by calling `initCause(e)` on the converted exception before rethrowing.

## How was this patch tested?

Existing tests cover this code path. The change is purely additive (preserving exception metadata that was previously discarded).