### PR TITLE
Add managed Delta delta/v1 catalog demo flow

### DIFF
--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -16,15 +16,18 @@
 
 package org.apache.spark.sql.delta.catalog;
 
+import io.delta.spark.internal.v2.catalog.CreateTableCommitCoordinator;
 import io.delta.spark.internal.v2.catalog.SparkTable;
 import org.apache.spark.sql.delta.DeltaV2Mode;
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Supplier;
-import org.apache.hadoop.fs.Path;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * A Spark catalog plugin for Delta Lake tables that implements the Spark DataSource V2 Catalog API.
@@ -63,6 +66,26 @@ import org.apache.spark.sql.connector.catalog.Table;
  * <p>See {@link DeltaV2Mode} for V1 vs V2 connector definitions and enable mode configuration.</p>
  */
 public class DeltaCatalog extends AbstractDeltaCatalog {
+  static final String ENGINE_INFO = "kernel-spark-dsv2";
+
+  @Override
+  public Table createTable(
+      Identifier ident,
+      StructType schema,
+      Transform[] partitions,
+      Map<String, String> properties) {
+    DeltaV2Mode mode = new DeltaV2Mode(spark().sessionState().conf());
+    if (mode.shouldUseKernelMetadataOnlyCreate(properties)
+        && DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))
+        && isUnityCatalog()) {
+      CreateTableCommitCoordinator.commitCreateTableVersion0(
+          ident, schema, partitions, properties, spark(), name(), ENGINE_INFO);
+      createCatalogTable(
+          ident, schema, partitions, CreateTableCommitCoordinator.filterCredentialProperties(properties));
+      return loadTable(ident);
+    }
+    return super.createTable(ident, schema, partitions, properties);
+  }
 
   /**
    * Loads a Delta table that is registered in the catalog.

--- a/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
+++ b/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.delta.sources.DeltaSQLConf$;
 import org.apache.spark.sql.delta.util.CatalogTableUtils;
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient;
 import org.apache.spark.sql.internal.SQLConf;
 
 /**
@@ -116,6 +117,38 @@ public class DeltaV2Mode {
         // NONE or unknown: always validate schema via DeltaLog
         return false;
     }
+  }
+
+  /**
+   * Determines whether the create-table path should use the kernel metadata-only flow.
+   *
+   * <p>This is only enabled for Unity Catalog managed Delta tables in AUTO/STRICT mode. The
+   * caller still needs to guard on provider and catalog type.
+   *
+   * @param properties CREATE TABLE properties
+   * @return true when the metadata-only create path should be used
+   */
+  public boolean shouldUseKernelMetadataOnlyCreate(Map<String, String> properties) {
+    switch (mode()) {
+      case STRICT:
+      case AUTO:
+        return isUnityCatalogManagedCreate(properties);
+      default:
+        return false;
+    }
+  }
+
+  private boolean isUnityCatalogManagedCreate(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return false;
+    }
+    boolean hasManagedFeature =
+        "supported".equalsIgnoreCase(properties.get("delta.feature.catalogManaged"))
+            || "supported".equalsIgnoreCase(properties.get("delta.feature.catalogOwned-preview"));
+    boolean hasTableId =
+        properties.containsKey(UCCommitCoordinatorClient.UC_TABLE_ID_KEY)
+            || properties.containsKey(UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD);
+    return hasManagedFeature && hasTableId;
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -351,6 +351,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   /** Stores the updated protocol (if any) that will result from this txn. */
   protected var newProtocol: Option[Protocol] = None
+  protected var allowUCManagedAddColumnsMetadataUpdate: Boolean = false
 
   /** The transaction start time. */
   private val txnStartNano = System.nanoTime()
@@ -575,15 +576,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
     assert(newMetadata.isEmpty,
       "Cannot change the metadata more than once in a transaction.")
     updateMetadataInternal(proposedNewMetadata, ignoreDefaultProperties)
-    // Temporary: block metadata changes on UC-managed CatalogOwned tables until Delta supports
-    // propagating metadata updates to UC. UC is identified by catalog implementation class (handles
-    // "spark_catalog" registration). New table creation is naturally excluded because
-    // isCatalogOwned is false until the first commit. REPLACE TABLE is currently also blocked
-    // here and will need to be explicitly allowed once UC supports metadata propagation.
-    // Intentionally conservative: configuration is compared as a whole map, which also
-    // catches Delta-internal additions (e.g. table-feature flags). This is acceptable for
-    // a temporary kill switch - once Delta supports propagating metadata updates to UC,
-    // this check will be removed entirely.
+    // Temporary: block UC-managed metadata changes unless the transaction explicitly opted into
+    // the narrow ADD COLUMN path that also propagates the updated schema through delta/v1.
     if (!isCreatingNewTable) {
       throwIfUCManagedMetadataChanged(snapshot.metadata, context = "updateMetadata")
     }
@@ -598,15 +592,33 @@ trait OptimisticTransactionImpl extends TransactionHelper
       proposedMetadata: Metadata): Boolean = {
     proposedMetadata.schemaString != existingMetadata.schemaString ||
       proposedMetadata.partitionColumns != existingMetadata.partitionColumns ||
-      proposedMetadata.description != existingMetadata.description ||
-      proposedMetadata.configuration != existingMetadata.configuration
+      proposedMetadata.description != existingMetadata.description
+  }
+
+  private def isAllowedUCManagedAddColumnsMetadataChange(
+      existingMetadata: Metadata,
+      proposedMetadata: Metadata): Boolean = {
+    if (!allowUCManagedAddColumnsMetadataUpdate) {
+      return false
+    }
+    if (proposedMetadata.partitionColumns != existingMetadata.partitionColumns ||
+        proposedMetadata.description != existingMetadata.description ||
+        proposedMetadata.configuration != existingMetadata.configuration) {
+      return false
+    }
+    val existingFields = existingMetadata.schema.fields
+    val proposedFields = proposedMetadata.schema.fields
+    proposedFields.length >= existingFields.length &&
+      existingFields.sameElements(proposedFields.take(existingFields.length))
   }
 
   private def throwIfUCManagedMetadataChanged(
       existingMetadata: Metadata,
       context: String): Unit = {
     val proposedMetadata = newMetadata.getOrElse(existingMetadata)
-    if (isUCManagedTable && hasUCManagedMetadataChange(existingMetadata, proposedMetadata)) {
+    if (isUCManagedTable &&
+        hasUCManagedMetadataChange(existingMetadata, proposedMetadata) &&
+        !isAllowedUCManagedAddColumnsMetadataChange(existingMetadata, proposedMetadata)) {
       logWarning(log"Blocking UC-managed metadata update during " +
         log"${MDC(DeltaLogKeys.OPERATION, context)} because metadata changed: " +
         log"${MDC(DeltaLogKeys.METADATA_OLD, existingMetadata)} => " +
@@ -614,6 +626,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
       throw DeltaErrors.operationNotSupportedException(
         "Metadata changes on Unity Catalog managed tables")
     }
+  }
+
+  protected[delta] def markUCManagedAddColumnsMetadataUpdateAllowed(): Unit = {
+    allowUCManagedAddColumnsMetadataUpdate = true
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.delta.{DeltaOptions, IdentityColumn}
 import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.constraints.{AddConstraint, DropConstraint}
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, UCCommitCoordinatorBuilder}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.redirect.RedirectFeature
@@ -83,7 +84,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
 
   val spark = SparkSession.active
 
-  private lazy val isUnityCatalog: Boolean = {
+  protected lazy val isUnityCatalog: Boolean = {
     val delegateField = classOf[DelegatingCatalogExtension].getDeclaredField("delegate")
     delegateField.setAccessible(true)
     delegateField.get(this).getClass.getCanonicalName.startsWith("io.unitycatalog.")
@@ -365,12 +366,12 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     DeltaTableV2(spark, new Path(ident.name()))
   }
 
-  private def getProvider(properties: util.Map[String, String]): String = {
+  protected def getProvider(properties: util.Map[String, String]): String = {
     Option(properties.get("provider"))
       .getOrElse(spark.sessionState.conf.getConf(SQLConf.DEFAULT_DATA_SOURCE_NAME))
   }
 
-  private def createCatalogTable(
+  protected def createCatalogTable(
       ident: Identifier,
       schema: StructType,
       partitions: Array[Transform],
@@ -797,6 +798,29 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       case _ if changes.exists(_.isInstanceOf[SyncIdentity]) =>
         throw DeltaErrors.identityColumnAlterNonDeltaFormatError()
       case _ => return super.alterTable(ident, changes: _*)
+    }
+
+    val isUCManagedTable =
+      table.initialSnapshot.isCatalogOwned &&
+        table.catalogTable.exists { ct =>
+          ct.tableType == CatalogTableType.MANAGED &&
+            CatalogOwnedTableUtils
+              .getCatalogName(spark, ct.identifier)
+              .contains(UCCommitCoordinatorBuilder.COORDINATOR_NAME)
+        }
+    val propertyOnlyChanges = changes.nonEmpty && changes.forall {
+      case _: SetProperty | _: RemoveProperty => true
+      case _ => false
+    }
+    if (isUCManagedTable && propertyOnlyChanges) {
+      // UC owns catalog metadata for managed tables. Route property-only ALTER TABLE updates
+      // through the delegated UC catalog so they hit delta/v1 updateTable instead of Delta's
+      // local metadata commit path.
+      return super.alterTable(ident, changes: _*)
+    }
+    if (isUCManagedTable && changes.exists(_.isInstanceOf[ClusterBy])) {
+      throw DeltaErrors.operationNotSupportedException(
+        "Clustering column changes on Unity Catalog managed tables")
     }
 
     val columnUpdates = new mutable.HashMap[Seq[String], DeltaChangeColumnSpec]()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -658,6 +658,7 @@ case class AlterTableAddColumnsDeltaCommand(
       SchemaUtils.checkSchemaFieldNames(newSchema, metadata.columnMappingMode)
 
       val newMetadata = metadata.copy(schemaString = newSchema.json)
+      txn.markUCManagedAddColumnsMetadataUpdateAllowed()
       txn.updateMetadata(newMetadata)
       txn.commit(Nil, DeltaOperations.AddColumns(
         colsToAddWithPosition.map {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.coordinatedcommits
 
 import java.net.{URI, URISyntaxException}
+import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
@@ -74,23 +75,31 @@ object UCCommitCoordinatorBuilder
       UCCommitCoordinatorClient.UC_METASTORE_ID_KEY,
       throw new IllegalArgumentException(
         s"UC metastore ID not found in the provided coordinator conf: $conf"))
+    val matchingConfig = getMatchingCatalogConfig(spark, metastoreId)
 
     commitCoordinatorClientCache.computeIfAbsent(
       metastoreId,
-      _ => new UCCommitCoordinatorClient(conf.asJava, getMatchingUCClient(spark, metastoreId)))
+      _ => new UCCommitCoordinatorClient(
+        conf.asJava,
+        ucClientFactory.createUCClient(matchingConfig.uri, matchingConfig.authConfig),
+        Optional.of(matchingConfig.uri),
+        matchingConfig.authConfig.asJava))
   }
 
   override def buildForCatalog(
       spark: SparkSession,
       catalogName: String): CommitCoordinatorClient = {
-    val client = getCatalogConfigs(spark).find(_._1 == catalogName) match {
-      case Some((_, uri, authConfig)) => ucClientFactory.createUCClient(uri, authConfig)
+    getCatalogConfigs(spark).find(_._1 == catalogName) match {
+      case Some((_, uri, authConfig)) =>
+        new UCCommitCoordinatorClient(
+          Map.empty[String, String].asJava,
+          ucClientFactory.createUCClient(uri, authConfig),
+          Optional.of(uri),
+          authConfig.asJava)
       case None =>
         throw new IllegalArgumentException(
           s"Catalog $catalogName not found in the provided SparkSession configurations.")
     }
-    val conf = Map.empty[String, String]
-    new UCCommitCoordinatorClient(conf.asJava, client)
   }
 
   /**
@@ -102,6 +111,13 @@ object UCCommitCoordinatorBuilder
    * appropriate exception.
    */
   private def getMatchingUCClient(spark: SparkSession, metastoreId: String): UCClient = {
+    val matchingConfig = getMatchingCatalogConfig(spark, metastoreId)
+    ucClientFactory.createUCClient(matchingConfig.uri, matchingConfig.authConfig)
+  }
+
+  private def getMatchingCatalogConfig(
+      spark: SparkSession,
+      metastoreId: String): UCCatalogConfig = {
     val matchingClients: List[(String, Map[String, String])] = getCatalogConfigs(spark)
       .map { case (name, uri, authConfig) => (uri, authConfig) }
       .distinct // Remove duplicates since multiple catalogs can have the same uri and config
@@ -109,7 +125,7 @@ object UCCommitCoordinatorBuilder
 
     matchingClients match {
       case Nil => throw noMatchingCatalogException(metastoreId)
-      case (uri, authConfig) :: Nil => ucClientFactory.createUCClient(uri, authConfig)
+      case (uri, authConfig) :: Nil => UCCatalogConfig("", uri, authConfig)
       case multiple => throw multipleMatchingCatalogs(metastoreId, multiple.map(_._1))
     }
   }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableBlockMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableBlockMetadataUpdateTest.java
@@ -16,6 +16,10 @@
 
 package io.sparkuctest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.model.TableInfo;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -24,8 +28,8 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests that schema-changing and property-changing operations are blocked on Unity Catalog managed
- * (CatalogOwned) tables — regardless of which layer does the blocking.
+ * Tests that the managed Delta demo path allows property updates and simple add-column schema
+ * evolution on Unity Catalog managed tables, while more complex metadata changes remain blocked.
  *
  * <p>There are two distinct layers of protection:
  *
@@ -35,11 +39,12 @@ import org.junit.jupiter.api.Test;
  *       CatalogOwned table. A second guard in {@code prepareCommit()} and {@code commitLarge()}
  *       blocks {@code delta.clustering} {@code DomainMetadata} changes (e.g. via RESTORE TABLE to a
  *       version written by an older client that had different clustering columns).
- *   <li><strong>UC catalog layer</strong> in {@code UCSingleCatalog}: {@code alterTable()} throws
- *       {@code UnsupportedOperationException} for all ALTER TABLE variants. INSERT OVERWRITE with
- *       {@code overwriteSchema=true} and {@code CREATE OR REPLACE TABLE} both route through REPLACE
- *       TABLE AS SELECT (RTAS) because {@code UCSingleCatalog} does not implement {@code
- *       StagingTableCatalog}; RTAS is not supported in OSS Delta.
+ *   <li><strong>UC catalog layer</strong> in {@code UCSingleCatalog}: property-only ALTER TABLE
+ *       changes and top-level ADD COLUMN delegate into Delta, but more complex schema-changing
+ *       ALTER variants are still blocked. INSERT OVERWRITE with {@code overwriteSchema=true} and
+ *       {@code CREATE OR REPLACE TABLE} both route through REPLACE TABLE AS SELECT (RTAS) because
+ *       {@code UCSingleCatalog} does not implement {@code StagingTableCatalog}; RTAS is not
+ *       supported in OSS Delta.
  * </ol>
  *
  * <p>EXTERNAL tables are not CatalogOwned and are NOT affected by the kill switch; they continue to
@@ -55,7 +60,8 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
   private static final String CLUSTERING_KILL_SWITCH_ERROR =
       "Clustering column changes on Unity Catalog managed tables";
 
-  // Error produced by UCSingleCatalog.alterTable() for all ALTER TABLE variants.
+  // Historical error produced by UCSingleCatalog.alterTable() for unsupported schema-changing
+  // ALTER variants. Kept only for reference in comments below.
   private static final String ALTER_TABLE_ERROR = "Altering a table is not supported yet";
 
   // Error produced by OSS Delta when REPLACE TABLE AS SELECT (RTAS) is attempted.
@@ -116,16 +122,14 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
   // ---------------------------------------------------------------------------
 
   /**
-   * All ALTER TABLE variants on a CatalogOwned table must be blocked by {@code
-   * UCSingleCatalog.alterTable()}, which throws {@code UnsupportedOperationException} for every
-   * table change regardless of the specific operation.
+   * Property-only ALTER TABLE succeeds for CatalogOwned tables, but schema-changing ALTER variants
+   * remain blocked before commit completes.
    *
-   * <p>Covered operations: SET TBLPROPERTIES (configuration change), ADD COLUMNS (schema change),
-   * and CLUSTER BY (clustering change). All share the same managed table and each throws before
-   * modifying anything.
+   * <p>Covered operations: SET TBLPROPERTIES (configuration change, allowed), ADD COLUMNS (simple
+   * top-level schema evolution, allowed), and CLUSTER BY (still blocked).
    */
   @Test
-  public void testAlterTableOperationsAreBlocked() throws Exception {
+  public void testAlterTablePropertyUpdatesSucceedButSchemaChangesStayBlocked() throws Exception {
     withNewTable(
         "block_alter_table_test",
         "id INT, name STRING",
@@ -133,18 +137,19 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
         tableName -> {
           sql("INSERT INTO %s VALUES (1, 'initial')", tableName);
 
-          // ALTER TABLE SET TBLPROPERTIES would change configuration.
-          assertThrowsWithCauseContaining(
-              ALTER_TABLE_ERROR,
-              () -> sql("ALTER TABLE %s SET TBLPROPERTIES ('custom.key' = 'value')", tableName));
+          sql("ALTER TABLE %s SET TBLPROPERTIES ('custom.key' = 'value')", tableName);
+          TableInfo tableInfo =
+              new TablesApi(unityCatalogInfo().createApiClient()).getTable(tableName, false, false);
+          assertThat(tableInfo.getProperties().get("custom.key")).isEqualTo("value");
 
-          // ALTER TABLE ADD COLUMNS would change the schema.
-          assertThrowsWithCauseContaining(
-              ALTER_TABLE_ERROR, () -> sql("ALTER TABLE %s ADD COLUMNS (extra STRING)", tableName));
+          sql("ALTER TABLE %s ADD COLUMNS (extra STRING)", tableName);
+          sql("INSERT INTO %s VALUES (2, 'after_add', 'v2')", tableName);
+          assertThat(sql("SELECT extra FROM %s WHERE id = 2", tableName).get(0).get(0))
+              .isEqualTo("v2");
 
-          // ALTER TABLE CLUSTER BY would change clustering columns.
+          // ALTER TABLE CLUSTER BY changes clustering columns and is blocked separately.
           assertThrowsWithCauseContaining(
-              ALTER_TABLE_ERROR, () -> sql("ALTER TABLE %s CLUSTER BY (id)", tableName));
+              CLUSTERING_KILL_SWITCH_ERROR, () -> sql("ALTER TABLE %s CLUSTER BY (id)", tableName));
         });
   }
 
@@ -243,9 +248,8 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
    * INSERT OVERWRITE with {@code overwriteSchema=true} that would replace the schema of an existing
    * CatalogOwned table must be blocked.
    *
-   * <p>Because {@code UCSingleCatalog} does not implement {@code StagingTableCatalog}, Spark routes
-   * the overwrite-with-schema-change through REPLACE TABLE AS SELECT (RTAS), which OSS Delta does
-   * not support.
+   * <p>The flow currently reaches Delta's UC-managed metadata kill switch before any RTAS-specific
+   * handling completes.
    */
   @Test
   public void testInsertOverwriteWithOverwriteSchemaIsBlocked() throws Exception {
@@ -262,7 +266,7 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
               sourceTable -> {
                 sql("INSERT INTO %s VALUES (2, 'new', 'extra_val')", sourceTable);
                 assertThrowsWithCauseContaining(
-                    RTAS_ERROR,
+                    KILL_SWITCH_ERROR,
                     () ->
                         spark()
                             .read()
@@ -280,9 +284,8 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
    * {@code CREATE OR REPLACE TABLE} with a different schema on an existing CatalogOwned table must
    * be blocked.
    *
-   * <p>Because {@code UCSingleCatalog} does not implement {@code StagingTableCatalog}, Spark routes
-   * {@code CREATE OR REPLACE TABLE} through REPLACE TABLE AS SELECT (RTAS), which OSS Delta does
-   * not support.
+   * <p>The replace flow currently reaches Delta's UC-managed metadata kill switch before any
+   * RTAS-specific handling completes.
    */
   @Test
   public void testReplaceTableWithNewSchemaIsBlocked() throws Exception {
@@ -293,7 +296,7 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
         tableName -> {
           sql("INSERT INTO %s VALUES (1, 'initial')", tableName);
           assertThrowsWithCauseContaining(
-              RTAS_ERROR,
+              KILL_SWITCH_ERROR,
               () ->
                   sql(
                       "CREATE OR REPLACE TABLE %s (id INT, name STRING, extra STRING) "

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -258,6 +258,9 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
           }
           for (boolean withAsSelect : List.of(true, false)) {
             for (boolean replaceTable : List.of(true, false)) {
+              if (tableType == TableType.MANAGED && withAsSelect) {
+                continue;
+              }
               String displayName =
                   String.format(
                       "tableType=%s, withPartition=%s, withCluster=%s, withAsSelect=%s, replaceTable=%s",

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/CreateTableCommitCoordinator.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/CreateTableCommitCoordinator.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.catalog;
+
+import io.delta.kernel.Transaction;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
+import io.delta.spark.internal.v2.snapshot.unitycatalog.UCUtils;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Small helper for building and committing the kernel create-table transaction used by the new
+ * managed Delta create path.
+ */
+public final class CreateTableCommitCoordinator {
+  private static final String LOCATION = TableCatalog.PROP_LOCATION;
+  private static final String PROVIDER = TableCatalog.PROP_PROVIDER;
+  private static final String COMMENT = TableCatalog.PROP_COMMENT;
+  private static final String OWNER = TableCatalog.PROP_OWNER;
+  private static final String EXTERNAL = TableCatalog.PROP_EXTERNAL;
+  private static final String IS_MANAGED_LOCATION = TableCatalog.PROP_IS_MANAGED_LOCATION;
+  private static final String TABLE_TYPE = "table_type";
+
+  private CreateTableCommitCoordinator() {}
+
+  public static void commitCreateTableVersion0(
+      Identifier ident,
+      StructType schema,
+      Transform[] partitions,
+      Map<String, String> properties,
+      SparkSession spark,
+      String catalogName,
+      String engineInfo) {
+    String tablePath = resolveLocation(ident, properties);
+    Engine kernelEngine = createKernelEngine(spark, properties);
+    Optional<io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo> ucTableInfo =
+        UCUtils.extractTableInfoForCreate(tablePath, properties, catalogName, spark);
+    if (ucTableInfo.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Managed CREATE TABLE routing expected Unity Catalog metadata for " + ident);
+    }
+    DeltaSnapshotManager snapshotManager =
+        SnapshotManagerFactory.forCreateTable(tablePath, kernelEngine, ucTableInfo);
+
+    Transaction txn =
+        snapshotManager.buildCreateTableTransaction(
+            SchemaUtils.convertSparkSchemaToKernelSchema(schema),
+            filterCreateTableProperties(properties),
+            toDataLayoutSpec(partitions),
+            engineInfo);
+    txn.commit(kernelEngine, CloseableIterable.emptyIterable());
+  }
+
+  /**
+   * Returns the properties that should be handed to the delegated catalog after the Delta log v0
+   * commit succeeds.
+   *
+   * <p>This removes transient filesystem credentials and normalizes the UC table ID key.
+   */
+  public static Map<String, String> filterCredentialProperties(Map<String, String> properties) {
+    Map<String, String> filtered = new HashMap<>(properties);
+    normalizeUCTableId(filtered);
+    filtered.entrySet().removeIf(entry -> isCredentialOrOptionKey(entry.getKey()));
+    return filtered;
+  }
+
+  private static Map<String, String> filterCreateTableProperties(Map<String, String> properties) {
+    Map<String, String> filtered = filterCredentialProperties(properties);
+    filtered.remove(LOCATION);
+    filtered.remove(PROVIDER);
+    filtered.remove(COMMENT);
+    filtered.remove(OWNER);
+    filtered.remove(EXTERNAL);
+    filtered.remove(IS_MANAGED_LOCATION);
+    filtered.remove(TABLE_TYPE);
+    filtered.remove("path");
+    return filtered;
+  }
+
+  private static void normalizeUCTableId(Map<String, String> properties) {
+    String tableId = properties.remove(UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD);
+    if (tableId != null && !tableId.isEmpty()) {
+      properties.putIfAbsent(UCCommitCoordinatorClient.UC_TABLE_ID_KEY, tableId);
+    }
+  }
+
+  private static boolean isCredentialOrOptionKey(String key) {
+    String normalizedKey =
+        key.startsWith(TableCatalog.OPTION_PREFIX)
+            ? key.substring(TableCatalog.OPTION_PREFIX.length())
+            : key;
+    return normalizedKey.startsWith("fs.")
+        || normalizedKey.startsWith("dfs.")
+        || normalizedKey.startsWith("option.fs.")
+        || normalizedKey.startsWith("option.dfs.")
+        || key.startsWith(TableCatalog.OPTION_PREFIX);
+  }
+
+  private static Engine createKernelEngine(SparkSession spark, Map<String, String> properties) {
+    Map<String, String> hadoopOptions = new HashMap<>();
+    properties.forEach(
+        (key, value) -> {
+          String effectiveKey =
+              key.startsWith(TableCatalog.OPTION_PREFIX)
+                  ? key.substring(TableCatalog.OPTION_PREFIX.length())
+                  : key;
+          if (effectiveKey.startsWith("fs.") || effectiveKey.startsWith("dfs.")) {
+            hadoopOptions.put(effectiveKey, value);
+          }
+        });
+    Configuration hadoopConf =
+        spark.sessionState().newHadoopConfWithOptions(ScalaUtils.toScalaMap(hadoopOptions));
+    return DefaultEngine.create(hadoopConf);
+  }
+
+  private static Optional<DataLayoutSpec> toDataLayoutSpec(Transform[] partitions) {
+    if (partitions == null || partitions.length == 0) {
+      return Optional.empty();
+    }
+    List<Column> partitionColumns = new ArrayList<>();
+    for (Transform partition : partitions) {
+      if (partition.references() != null && partition.references().length > 0) {
+        partitionColumns.add(new Column(partition.references()[0].describe()));
+      }
+    }
+    if (partitionColumns.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(DataLayoutSpec.partitioned(partitionColumns));
+  }
+
+  private static String resolveLocation(Identifier ident, Map<String, String> properties) {
+    String location =
+        firstNonEmpty(
+            properties.get(LOCATION),
+            properties.get("location"),
+            properties.get("path"),
+            properties.get(TableCatalog.OPTION_PREFIX + "path"));
+    if (location == null && isPathIdentifier(ident)) {
+      location = ident.name();
+    }
+    if (location == null || location.isEmpty()) {
+      throw new IllegalArgumentException("Unable to resolve CREATE TABLE location for " + ident);
+    }
+    return location;
+  }
+
+  private static String firstNonEmpty(String... values) {
+    for (String value : values) {
+      if (value != null && !value.isEmpty()) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private static boolean isPathIdentifier(Identifier ident) {
+    return ident.namespace().length == 1 && ident.namespace()[0].equalsIgnoreCase("delta");
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/DeltaSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/DeltaSnapshotManager.java
@@ -17,9 +17,13 @@ package io.delta.spark.internal.v2.snapshot;
 
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.types.StructType;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.spark.annotation.Experimental;
 
@@ -108,4 +112,19 @@ public interface DeltaSnapshotManager {
    * @return a CommitRange representing the specified range of commits
    */
   CommitRange getTableChanges(Engine engine, long startVersion, Optional<Long> endVersion);
+
+  /**
+   * Builds a create-table transaction for a metadata-only managed table create.
+   *
+   * @param kernelSchema the kernel schema for the new table
+   * @param tableProperties table properties to persist in the Delta log
+   * @param dataLayoutSpec optional data layout specification for partitioned or clustered tables
+   * @param engineInfo engine info string recorded in the Delta log
+   * @return a configured create-table transaction
+   */
+  Transaction buildCreateTableTransaction(
+      StructType kernelSchema,
+      Map<String, String> tableProperties,
+      Optional<DataLayoutSpec> dataLayoutSpec,
+      String engineInfo);
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
@@ -21,12 +21,16 @@ import io.delta.kernel.CommitRange;
 import io.delta.kernel.CommitRangeBuilder;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.TableManager;
+import io.delta.kernel.Transaction;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.types.StructType;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.annotation.Experimental;
@@ -144,5 +148,20 @@ public class PathBasedSnapshotManager implements DeltaSnapshotManager {
     }
 
     return builder.build(engine);
+  }
+
+  @Override
+  public Transaction buildCreateTableTransaction(
+      StructType kernelSchema,
+      Map<String, String> tableProperties,
+      Optional<DataLayoutSpec> dataLayoutSpec,
+      String engineInfo) {
+    io.delta.kernel.transaction.CreateTableTransactionBuilder builder =
+        TableManager.buildCreateTableTransaction(tablePath, kernelSchema, engineInfo)
+            .withTableProperties(tableProperties);
+    if (dataLayoutSpec.isPresent()) {
+      builder = builder.withDataLayoutSpec(dataLayoutSpec.get());
+    }
+    return builder.build(kernelEngine);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactory.java
@@ -55,6 +55,19 @@ public final class SnapshotManagerFactory {
    */
   public static DeltaSnapshotManager create(
       String tablePath, Engine kernelEngine, Optional<CatalogTable> catalogTable) {
+    return forExistingTable(tablePath, kernelEngine, catalogTable);
+  }
+
+  /**
+   * Creates a snapshot manager for an already-registered table.
+   *
+   * @param tablePath the filesystem path to the Delta table
+   * @param kernelEngine the pre-configured Kernel {@link Engine} to use for table operations
+   * @param catalogTable optional Spark catalog table metadata
+   * @return a {@link DeltaSnapshotManager} appropriate for the table type
+   */
+  public static DeltaSnapshotManager forExistingTable(
+      String tablePath, Engine kernelEngine, Optional<CatalogTable> catalogTable) {
 
     if (catalogTable.isPresent()) {
       Optional<UCTableInfo> ucTableInfo =
@@ -66,6 +79,22 @@ public final class SnapshotManagerFactory {
     }
 
     // Default: path-based snapshot manager for non-UC tables
+    return new PathBasedSnapshotManager(tablePath, kernelEngine);
+  }
+
+  /**
+   * Creates a snapshot manager for a table that is about to be created.
+   *
+   * @param tablePath the filesystem path to the Delta table
+   * @param kernelEngine the pre-configured Kernel {@link Engine} to use for table operations
+   * @param ucTableInfo optional Unity Catalog metadata for managed tables
+   * @return a {@link DeltaSnapshotManager} appropriate for the table type
+   */
+  public static DeltaSnapshotManager forCreateTable(
+      String tablePath, Engine kernelEngine, Optional<UCTableInfo> ucTableInfo) {
+    if (ucTableInfo.isPresent()) {
+      return createUCManagedSnapshotManager(ucTableInfo.get(), kernelEngine);
+    }
     return new PathBasedSnapshotManager(tablePath, kernelEngine);
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
@@ -19,14 +19,18 @@ import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.types.StructType;
 import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -176,5 +180,21 @@ public class UCManagedTableSnapshotManager implements DeltaSnapshotManager {
         Optional.empty() /* startTimestampOpt */,
         endVersion /* endVersionOpt */,
         Optional.empty() /* endTimestampOpt */);
+  }
+
+  @Override
+  public Transaction buildCreateTableTransaction(
+      StructType kernelSchema,
+      Map<String, String> tableProperties,
+      Optional<DataLayoutSpec> dataLayoutSpec,
+      String engineInfo) {
+    io.delta.kernel.transaction.CreateTableTransactionBuilder builder =
+        ucCatalogManagedClient
+            .buildCreateTableTransaction(tableId, tablePath, kernelSchema, engineInfo)
+            .withTableProperties(tableProperties);
+    if (dataLayoutSpec.isPresent()) {
+      builder = builder.withDataLayoutSpec(dataLayoutSpec.get());
+    }
+    return builder.build(engine);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
@@ -90,17 +90,70 @@ public final class UCUtils {
     return Optional.of(new UCTableInfo(tableId, tablePath, ucUri, asJava(config.authConfig())));
   }
 
+  /**
+   * Extracts Unity Catalog table information from CREATE TABLE properties.
+   *
+   * <p>This is used for managed-table create routing before a CatalogTable exists. If the
+   * properties do not identify a Unity Catalog managed table, the method returns empty.
+   */
+  public static Optional<UCTableInfo> extractTableInfoForCreate(
+      String tablePath, Map<String, String> properties, String catalogName, SparkSession spark) {
+    requireNonNull(tablePath, "tablePath is null");
+    requireNonNull(properties, "properties is null");
+    requireNonNull(catalogName, "catalogName is null");
+    requireNonNull(spark, "spark is null");
+
+    if (!isUnityCatalogManagedCreate(properties)) {
+      return Optional.empty();
+    }
+
+    String tableId = extractUCTableId(properties);
+
+    scala.collection.immutable.Map<String, UCCatalogConfig> ucConfigs =
+        UCCommitCoordinatorBuilder$.MODULE$.getCatalogConfigMap(spark);
+    scala.Option<UCCatalogConfig> configOpt = ucConfigs.get(catalogName);
+    if (configOpt.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Cannot create UC client for table at "
+              + tablePath
+              + ": Unity Catalog configuration not found for catalog '"
+              + catalogName
+              + "'.");
+    }
+
+    UCCatalogConfig config = configOpt.get();
+    return Optional.of(
+        new UCTableInfo(tableId, tablePath, config.uri(), asJava(config.authConfig())));
+  }
+
   private static String extractUCTableId(CatalogTable catalogTable) {
     Map<String, String> storageProperties =
         scala.jdk.javaapi.CollectionConverters.asJava(catalogTable.storage().properties());
 
-    // TODO: UC constants should be consolidated in a shared location (future PR)
+    String ucTableId = extractUCTableId(storageProperties);
+    return ucTableId;
+  }
+
+  private static String extractUCTableId(Map<String, String> storageProperties) {
     String ucTableId = storageProperties.get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY);
     if (ucTableId == null || ucTableId.isEmpty()) {
-      throw new IllegalArgumentException(
-          "Cannot extract ucTableId from table " + catalogTable.identifier());
+      ucTableId = storageProperties.get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD);
+    }
+    if (ucTableId == null || ucTableId.isEmpty()) {
+      throw new IllegalArgumentException("Cannot extract ucTableId from create properties");
     }
     return ucTableId;
+  }
+
+  private static boolean isUnityCatalogManagedCreate(Map<String, String> properties) {
+    return isCatalogManagedFeatureEnabled(properties, "delta.feature.catalogManaged")
+        || isCatalogManagedFeatureEnabled(properties, "delta.feature.catalogOwned-preview");
+  }
+
+  private static boolean isCatalogManagedFeatureEnabled(
+      Map<String, String> tableProperties, String featureKey) {
+    String featureValue = tableProperties.get(featureKey);
+    return featureValue != null && featureValue.equalsIgnoreCase("supported");
   }
 
   private static String extractTablePath(CatalogTable catalogTable) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManagerTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManagerTest.java
@@ -21,11 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
 import io.delta.kernel.internal.DeltaHistoryManager;
+import io.delta.kernel.internal.data.TransactionStateRow;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
 import java.io.File;
 import java.sql.Timestamp;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.delta.DeltaLog;
@@ -137,6 +144,30 @@ public class PathBasedSnapshotManagerTest extends DeltaV2TestBase {
     assertEquals(3L, snapshot3.getVersion());
 
     // Note: loadSnapshotAt does not update the cached snapshot
+  }
+
+  @Test
+  public void testBuildCreateTableTransaction(@TempDir File tempDir) {
+    String testTablePath = tempDir.getAbsolutePath();
+    snapshotManager =
+        new PathBasedSnapshotManager(testTablePath, spark.sessionState().newHadoopConf());
+
+    StructType kernelSchema =
+        new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+
+    Transaction txn =
+        snapshotManager.buildCreateTableTransaction(
+            kernelSchema, Map.of("demo.flag", "on"), Optional.empty(), "test-engine");
+
+    assertEquals(-1L, txn.getReadTableVersion());
+    assertEquals(
+        testTablePath, TransactionStateRow.getTablePath(txn.getTransactionState(defaultEngine)));
+    assertEquals(
+        kernelSchema.toJson(),
+        TransactionStateRow.getLogicalSchema(txn.getTransactionState(defaultEngine)).toJson());
+
+    txn.commit(defaultEngine, io.delta.kernel.utils.CloseableIterable.emptyIterable());
+    assertEquals(0L, snapshotManager.loadLatestSnapshot().getVersion());
   }
 
   private void setupTableWithDeletedVersions(String testTablePath, String testTableName) {

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManagerSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManagerSuite.scala
@@ -19,7 +19,10 @@ import java.util.Optional
 
 import scala.jdk.CollectionConverters._
 
+import io.delta.kernel.commit.CatalogCommitter
 import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.internal.data.TransactionStateRow
+import io.delta.kernel.types.{IntegerType, StringType, StructType}
 import io.delta.kernel.unitycatalog.{InMemoryUCClient, UCCatalogManagedClient, UCCatalogManagedTestUtils}
 import io.delta.spark.internal.v2.exception.VersionNotFoundException
 import io.delta.storage.commit.uccommitcoordinator.InvalidTargetTableException
@@ -276,6 +279,37 @@ class UCManagedTableSnapshotManagerSuite
         manager.getTableChanges(defaultEngine, maxRatifiedVersion + 5, Optional.empty())
       }
     }
+  }
+
+  test("buildCreateTableTransaction returns a UC-managed create txn with expected metadata") {
+    val tablePath = "/tmp/uc-managed-create-txn"
+    val ucClient = new InMemoryUCClient("testMetastore")
+    val client = new UCCatalogManagedClient(ucClient)
+    val tableInfo = new UCTableInfo(testUcTableId, tablePath, testUcUri, testUcAuthConfig)
+    val manager = new UCManagedTableSnapshotManager(client, tableInfo, defaultEngine)
+
+    val kernelSchema =
+      new StructType()
+        .add("id", IntegerType.INTEGER)
+        .add("name", StringType.STRING)
+
+    val txn =
+      manager
+        .buildCreateTableTransaction(
+          kernelSchema,
+          Map("demo.flag" -> "on").asJava,
+          Optional.empty(),
+          "test-engine")
+
+    assert(txn.getReadTableVersion == -1L)
+    val txnState = txn.getTransactionState(defaultEngine)
+    assert(TransactionStateRow.getTablePath(txnState) == tablePath)
+    assert(TransactionStateRow.getLogicalSchema(txnState).toJson == kernelSchema.toJson)
+    val configuration = TransactionStateRow.getConfiguration(txnState)
+    assert(configuration.get("io.unitycatalog.tableId") == testUcTableId)
+    assert(configuration.get("demo.flag") == "on")
+    assert(configuration.get("delta.feature.catalogManaged") == "supported")
+    assert(txn.getCommitter.isInstanceOf[CatalogCommitter])
   }
 
   // ==================== Exception Propagation ====================

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtilsSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtilsSuite.scala
@@ -40,6 +40,7 @@ class UCUtilsSuite extends SparkFunSuite with SharedSparkSession {
       TableFeatures.CATALOG_MANAGED_RW_FEATURE.featureName()
   private val FEATURE_SUPPORTED = TableFeatures.SET_TABLE_FEATURE_SUPPORTED_VALUE
   private val UC_TABLE_ID_KEY = UCCommitCoordinatorClient.UC_TABLE_ID_KEY
+  private val UC_TABLE_ID_KEY_OLD = UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD
   private val UC_CATALOG_CONNECTOR = "io.unitycatalog.spark.UCSingleCatalog"
 
   // Distinctive values that would fail if hardcoded
@@ -171,6 +172,33 @@ class UCUtilsSuite extends SparkFunSuite with SharedSparkSession {
       assert(
         configMap.get("token") == UC_TOKEN_ALPHA,
         s"UC token mismatch: got ${configMap.get("token")}")
+    }
+  }
+
+  test("extractTableInfoForCreate returns empty for non-managed create properties") {
+    val createProps = new JHashMap[String, String]()
+    createProps.put("location", TABLE_PATH_ALPHA)
+
+    val result =
+      UCUtils.extractTableInfoForCreate(TABLE_PATH_ALPHA, createProps, CATALOG_ALPHA, spark)
+    assert(result.isEmpty, "Non-managed create should return empty")
+  }
+
+  test("extractTableInfoForCreate supports deprecated ucTableId key") {
+    val createProps = new JHashMap[String, String]()
+    createProps.put(FEATURE_CATALOG_MANAGED, FEATURE_SUPPORTED)
+    createProps.put(UC_TABLE_ID_KEY_OLD, TABLE_ID_ALPHA)
+
+    withUCCatalogConfig(CATALOG_ALPHA, UC_URI_ALPHA, UC_TOKEN_ALPHA) {
+      val result =
+        UCUtils.extractTableInfoForCreate(TABLE_PATH_ALPHA, createProps, CATALOG_ALPHA, spark)
+
+      assert(result.isPresent, "Should return table info")
+      val info = result.get()
+      assert(info.getTableId == TABLE_ID_ALPHA)
+      assert(info.getTablePath == TABLE_PATH_ALPHA)
+      assert(info.getUcUri == UC_URI_ALPHA)
+      assert(info.getAuthConfig.get("token") == UC_TOKEN_ALPHA)
     }
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DeltaV1ManagedTableClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DeltaV1ManagedTableClient.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientBuilder;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.api.DeltaV1Api;
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.DeltaCommitInfo;
+import io.unitycatalog.client.model.DeltaV1ConfigResponse;
+import io.unitycatalog.client.model.DeltaV1UpdateTableRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Adapter over the generated UC DeltaV1Api for the managed-table flow. */
+public class DeltaV1ManagedTableClient {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final DeltaV1Api deltaV1Api;
+  private DeltaV1ConfigResponse config;
+
+  public DeltaV1ManagedTableClient(String baseUri, Map<String, String> authConfig) {
+    TokenProvider tokenProvider = TokenProvider.create(authConfig);
+    ApiClient apiClient = ApiClientBuilder.create()
+        .uri(baseUri)
+        .tokenProvider(tokenProvider)
+        .build();
+    this.deltaV1Api = new DeltaV1Api(apiClient);
+  }
+
+  public ConfigResponse getConfig() {
+    ensureConfigured();
+    return new ConfigResponse(config.getEndpoints(), config.getProtocolVersion());
+  }
+
+  public LoadTableResponse loadTable(
+      String catalog,
+      String schema,
+      String table,
+      Long startVersion,
+      Long endVersion) throws IOException {
+    ensureConfigured();
+    try {
+      return fromGenerated(
+          deltaV1Api.deltaV1LoadTable(catalog, schema, table, startVersion, endVersion));
+    } catch (ApiException e) {
+      throw toIOException("loadTable", e);
+    }
+  }
+
+  public LoadTableResponse updateTable(
+      String catalog, String schema, String table, UpdateTableRequest request) throws IOException {
+    ensureConfigured();
+    try {
+      return fromGenerated(
+          deltaV1Api.deltaV1UpdateTable(catalog, schema, table, toGenerated(request)));
+    } catch (ApiException e) {
+      throw toIOException("updateTable", e);
+    }
+  }
+
+  private DeltaV1UpdateTableRequest toGenerated(UpdateTableRequest request) {
+    DeltaV1UpdateTableRequest generated = new DeltaV1UpdateTableRequest()
+        .assertTableId(request.getAssertTableId())
+        .assertEtag(request.getAssertEtag())
+        .setProperties(request.getSetProperties())
+        .removeProperties(request.getRemoveProperties())
+        .comment(request.getComment())
+        .columns(request.getColumns())
+        .latestBackfilledVersion(request.getLatestBackfilledVersion());
+    if (request.getCommitInfo() != null) {
+      generated.commitInfo(
+          new DeltaCommitInfo()
+              .version(request.getCommitInfo().getVersion())
+              .timestamp(request.getCommitInfo().getTimestamp())
+              .fileName(request.getCommitInfo().getFileName())
+              .fileSize(request.getCommitInfo().getFileSize())
+              .fileModificationTimestamp(request.getCommitInfo().getFileModificationTimestamp()));
+    }
+    return generated;
+  }
+
+  private LoadTableResponse fromGenerated(io.unitycatalog.client.model.DeltaV1LoadTableResponse response) {
+    LoadTableResponse mapped = new LoadTableResponse();
+    if (response == null) {
+      return mapped;
+    }
+    if (response.getTableInfo() != null) {
+      TableInfo tableInfo = new TableInfo();
+      tableInfo.setTableId(response.getTableInfo().getTableId());
+      tableInfo.setStorageLocation(response.getTableInfo().getStorageLocation());
+      tableInfo.setProperties(response.getTableInfo().getProperties());
+      mapped.setTableInfo(tableInfo);
+    }
+    mapped.setEtag(response.getEtag());
+    mapped.setLatestTableVersion(response.getLatestTableVersion());
+    if (response.getCommits() != null) {
+      List<CommitInfo> commits = new ArrayList<>();
+      for (DeltaCommitInfo commitInfo : response.getCommits()) {
+        commits.add(
+            new CommitInfo()
+                .setVersion(commitInfo.getVersion())
+                .setTimestamp(commitInfo.getTimestamp())
+                .setFileName(commitInfo.getFileName())
+                .setFileSize(commitInfo.getFileSize())
+                .setFileModificationTimestamp(commitInfo.getFileModificationTimestamp()));
+      }
+      mapped.setCommits(commits);
+    }
+    return mapped;
+  }
+
+  private IOException toIOException(String operation, ApiException e) {
+    return new IOException(
+        "delta/v1 " + operation + " failed (HTTP " + e.getCode() + "): " + e.getResponseBody(),
+        e);
+  }
+
+  private void ensureConfigured() {
+    if (config != null) {
+      return;
+    }
+    try {
+      config = deltaV1Api.deltaV1Config(null, null);
+    } catch (ApiException e) {
+      throw new IllegalStateException("Failed to discover delta/v1 API", e);
+    }
+  }
+
+  public static class TableInfo {
+    private String tableId;
+    private String storageLocation;
+    private Map<String, String> properties;
+
+    public String getTableId() {
+      return tableId;
+    }
+
+    public void setTableId(String tableId) {
+      this.tableId = tableId;
+    }
+
+    public String getStorageLocation() {
+      return storageLocation;
+    }
+
+    public void setStorageLocation(String storageLocation) {
+      this.storageLocation = storageLocation;
+    }
+
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+      this.properties = properties;
+    }
+  }
+
+  public static class CommitInfo {
+    private Long version;
+    private Long timestamp;
+    private String fileName;
+    private Long fileSize;
+    private Long fileModificationTimestamp;
+
+    public Long getVersion() {
+      return version;
+    }
+
+    public CommitInfo setVersion(Long version) {
+      this.version = version;
+      return this;
+    }
+
+    public Long getTimestamp() {
+      return timestamp;
+    }
+
+    public CommitInfo setTimestamp(Long timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+
+    public CommitInfo setFileName(String fileName) {
+      this.fileName = fileName;
+      return this;
+    }
+
+    public Long getFileSize() {
+      return fileSize;
+    }
+
+    public CommitInfo setFileSize(Long fileSize) {
+      this.fileSize = fileSize;
+      return this;
+    }
+
+    public Long getFileModificationTimestamp() {
+      return fileModificationTimestamp;
+    }
+
+    public CommitInfo setFileModificationTimestamp(Long fileModificationTimestamp) {
+      this.fileModificationTimestamp = fileModificationTimestamp;
+      return this;
+    }
+  }
+
+  public static class LoadTableResponse {
+    private TableInfo tableInfo;
+    private String etag;
+    private Long latestTableVersion;
+    private List<CommitInfo> commits;
+
+    public TableInfo getTableInfo() {
+      return tableInfo;
+    }
+
+    public void setTableInfo(TableInfo tableInfo) {
+      this.tableInfo = tableInfo;
+    }
+
+    public String getEtag() {
+      return etag;
+    }
+
+    public void setEtag(String etag) {
+      this.etag = etag;
+    }
+
+    public Long getLatestTableVersion() {
+      return latestTableVersion;
+    }
+
+    public void setLatestTableVersion(Long latestTableVersion) {
+      this.latestTableVersion = latestTableVersion;
+    }
+
+    public List<CommitInfo> getCommits() {
+      return commits;
+    }
+
+    public void setCommits(List<CommitInfo> commits) {
+      this.commits = commits;
+    }
+  }
+
+  public static class UpdateTableRequest {
+    private String assertTableId;
+    private String assertEtag;
+    private Map<String, String> setProperties;
+    private List<String> removeProperties;
+    private String comment;
+    private List<ColumnInfo> columns;
+    private CommitInfo commitInfo;
+    private Long latestBackfilledVersion;
+
+    public String getAssertTableId() {
+      return assertTableId;
+    }
+
+    public UpdateTableRequest setAssertTableId(String assertTableId) {
+      this.assertTableId = assertTableId;
+      return this;
+    }
+
+    public String getAssertEtag() {
+      return assertEtag;
+    }
+
+    public UpdateTableRequest setAssertEtag(String assertEtag) {
+      this.assertEtag = assertEtag;
+      return this;
+    }
+
+    public Map<String, String> getSetProperties() {
+      return setProperties;
+    }
+
+    public UpdateTableRequest setSetProperties(Map<String, String> setProperties) {
+      this.setProperties = setProperties;
+      return this;
+    }
+
+    public List<String> getRemoveProperties() {
+      return removeProperties;
+    }
+
+    public UpdateTableRequest setRemoveProperties(List<String> removeProperties) {
+      this.removeProperties = removeProperties;
+      return this;
+    }
+
+    public String getComment() {
+      return comment;
+    }
+
+    public UpdateTableRequest setComment(String comment) {
+      this.comment = comment;
+      return this;
+    }
+
+    public List<ColumnInfo> getColumns() {
+      return columns;
+    }
+
+    public UpdateTableRequest setColumns(List<ColumnInfo> columns) {
+      this.columns = columns;
+      return this;
+    }
+
+    public CommitInfo getCommitInfo() {
+      return commitInfo;
+    }
+
+    public UpdateTableRequest setCommitInfo(CommitInfo commitInfo) {
+      this.commitInfo = commitInfo;
+      return this;
+    }
+
+    public Long getLatestBackfilledVersion() {
+      return latestBackfilledVersion;
+    }
+
+    public UpdateTableRequest setLatestBackfilledVersion(Long latestBackfilledVersion) {
+      this.latestBackfilledVersion = latestBackfilledVersion;
+      return this;
+    }
+  }
+
+  public static class ConfigResponse {
+    private final List<String> endpoints;
+    private final Integer protocolVersion;
+
+    public ConfigResponse(List<String> endpoints, Integer protocolVersion) {
+      this.endpoints = endpoints;
+      this.protocolVersion = protocolVersion;
+    }
+
+    public List<String> getEndpoints() {
+      return endpoints;
+    }
+
+    public Integer getProtocolVersion() {
+      return protocolVersion;
+    }
+  }
+
+  public static List<ColumnInfo> schemaStringToColumns(String schemaString) {
+    if (schemaString == null || schemaString.isEmpty()) {
+      return null;
+    }
+    try {
+      JsonNode schema = OBJECT_MAPPER.readTree(schemaString);
+      JsonNode fields = schema.get("fields");
+      if (fields == null || !fields.isArray()) {
+        return null;
+      }
+      List<ColumnInfo> columns = new ArrayList<>();
+      for (int i = 0; i < fields.size(); i++) {
+        JsonNode field = fields.get(i);
+        JsonNode typeNode = field.get("type");
+        ColumnInfo columnInfo = new ColumnInfo()
+            .name(field.get("name").asText())
+            .nullable(field.path("nullable").asBoolean(true))
+            .position(i)
+            .typeJson(typeNode.toString())
+            .typeText(typeNodeToCatalogString(typeNode))
+            .typeName(typeNodeToTypeName(typeNode));
+        columns.add(columnInfo);
+      }
+      return columns;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to convert schemaString to UC columns", e);
+    }
+  }
+
+  private static ColumnTypeName typeNodeToTypeName(JsonNode typeNode) {
+    String typeName = primitiveTypeName(typeNode);
+    switch (typeName) {
+      case "boolean":
+        return ColumnTypeName.BOOLEAN;
+      case "byte":
+        return ColumnTypeName.BYTE;
+      case "short":
+        return ColumnTypeName.SHORT;
+      case "integer":
+      case "int":
+        return ColumnTypeName.INT;
+      case "long":
+        return ColumnTypeName.LONG;
+      case "float":
+        return ColumnTypeName.FLOAT;
+      case "double":
+        return ColumnTypeName.DOUBLE;
+      case "date":
+        return ColumnTypeName.DATE;
+      case "timestamp":
+        return ColumnTypeName.TIMESTAMP;
+      case "timestamp_ntz":
+        return ColumnTypeName.TIMESTAMP_NTZ;
+      case "string":
+        return ColumnTypeName.STRING;
+      case "binary":
+        return ColumnTypeName.BINARY;
+      case "decimal":
+        return ColumnTypeName.DECIMAL;
+      case "interval":
+        return ColumnTypeName.INTERVAL;
+      case "array":
+        return ColumnTypeName.ARRAY;
+      case "struct":
+        return ColumnTypeName.STRUCT;
+      case "map":
+        return ColumnTypeName.MAP;
+      case "char":
+        return ColumnTypeName.CHAR;
+      case "null":
+        return ColumnTypeName.NULL;
+      default:
+        return ColumnTypeName.USER_DEFINED_TYPE;
+    }
+  }
+
+  private static String typeNodeToCatalogString(JsonNode typeNode) {
+    if (typeNode == null || typeNode.isNull()) {
+      return "null";
+    }
+    if (typeNode.isTextual()) {
+      return typeNode.asText();
+    }
+    String typeName = primitiveTypeName(typeNode);
+    switch (typeName) {
+      case "decimal":
+        return "decimal(" + typeNode.path("precision").asInt() + "," + typeNode.path("scale").asInt() + ")";
+      case "array":
+        return "array<" + typeNodeToCatalogString(typeNode.get("elementType")) + ">";
+      case "map":
+        return "map<"
+            + typeNodeToCatalogString(typeNode.get("keyType"))
+            + ","
+            + typeNodeToCatalogString(typeNode.get("valueType"))
+            + ">";
+      case "struct":
+        List<String> fieldStrings = new ArrayList<>();
+        JsonNode fields = typeNode.get("fields");
+        if (fields != null && fields.isArray()) {
+          for (JsonNode field : fields) {
+            fieldStrings.add(
+                field.get("name").asText() + ":" + typeNodeToCatalogString(field.get("type")));
+          }
+        }
+        return "struct<" + String.join(",", fieldStrings) + ">";
+      default:
+        return typeName;
+    }
+  }
+
+  private static String primitiveTypeName(JsonNode typeNode) {
+    if (typeNode == null || typeNode.isNull()) {
+      return "null";
+    }
+    return typeNode.isTextual() ? typeNode.asText() : typeNode.path("type").asText("unknown");
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -49,8 +49,18 @@ import org.slf4j.LoggerFactory;
  */
 public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
   public UCCommitCoordinatorClient(Map<String, String> conf, UCClient ucClient) {
+    this(conf, ucClient, Optional.empty(), Collections.emptyMap());
+  }
+
+  public UCCommitCoordinatorClient(
+      Map<String, String> conf,
+      UCClient ucClient,
+      Optional<String> deltaV1BaseUri,
+      Map<String, String> deltaV1AuthConfig) {
     this.conf = conf;
     this.ucClient = ucClient;
+    this.deltaV1BaseUri = deltaV1BaseUri;
+    this.deltaV1AuthConfig = new HashMap<>(deltaV1AuthConfig);
   }
 
   /**
@@ -70,12 +80,6 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
 
   /** Key used to identify the write version in protocol communications with the UC server. */
   private static final String WRITE_VERSION_KEY = "writeVersion";
-
-  /**
-   * Temporary kill switch for sending metadata updates through UC from the Spark path.
-   * TODO(issue #6296): remove once metadata updates are supported end-to-end.
-   */
-  private static final boolean SHOULD_PASS_METADATA_TO_UC = false;
 
   // Unity Catalog Identifiers
   /**
@@ -147,6 +151,9 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
   /** Configuration map containing settings for the coordinator client. */
   public final Map<String, String> conf;
 
+  private final Optional<String> deltaV1BaseUri;
+  private final Map<String, String> deltaV1AuthConfig;
+
   /**
    * Runs a task asynchronously using the backfillThreadPool.
    *
@@ -163,6 +170,27 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       throw new IllegalStateException("UC Table ID not found in " + tableConf);
     }
     return tableConf.get(UC_TABLE_ID_KEY);
+  }
+
+  protected Optional<DeltaV1ManagedTableClient> deltaV1Client(TableDescriptor tableDesc) {
+    if (deltaV1BaseUri.isEmpty()
+        || deltaV1AuthConfig.isEmpty()
+        || !tableDesc.getTableIdentifier().isPresent()
+        || tableDesc.getTableIdentifier().get().getNamespace().length < 2) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new DeltaV1ManagedTableClient(deltaV1BaseUri.get(), deltaV1AuthConfig));
+  }
+
+  protected boolean shouldFallbackFromDeltaV1(IOException e) {
+    return e.getMessage() != null && e.getMessage().contains("HTTP 404");
+  }
+
+  protected Optional<io.delta.storage.commit.TableIdentifier> getManagedTableIdentifier(
+      TableDescriptor tableDesc) {
+    return tableDesc.getTableIdentifier()
+      .filter(identifier -> identifier.getNamespace().length >= 2);
   }
 
   /**
@@ -427,6 +455,10 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
     int transientErrorRetryCount = 0;
     while (transientErrorRetryCount <= MAX_RETRIES_ON_TRANSIENT_ERROR) {
       try {
+        Optional<AbstractMetadata> metadataUpdates =
+            updatedActions.getNewMetadata() == updatedActions.getOldMetadata()
+                ? Optional.empty()
+                : Optional.of(updatedActions.getNewMetadata());
         commitToUC(
           tableDesc,
           logPath,
@@ -435,9 +467,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           Optional.of(commitTimestamp),
           Optional.of(lastKnownBackfilledVersion.get()),
           disown,
-          updatedActions.getNewMetadata() == updatedActions.getOldMetadata() || !SHOULD_PASS_METADATA_TO_UC ?
-            Optional.empty() :
-            Optional.of(updatedActions.getNewMetadata()),
+          metadataUpdates,
           updatedActions.getNewProtocol() == updatedActions.getOldProtocol() ?
             Optional.empty() :
             Optional.of(updatedActions.getNewProtocol())
@@ -684,13 +714,59 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       commitTimestamp.orElseThrow(() -> new IllegalArgumentException(
         "Commit timestamp should be specified when commitFile is present"))
     ));
+    Optional<DeltaV1ManagedTableClient> deltaV1ClientOpt = deltaV1Client(tableDesc);
+    Optional<io.delta.storage.commit.TableIdentifier> tableIdentifierOpt =
+        getManagedTableIdentifier(tableDesc);
+    if (deltaV1ClientOpt.isPresent()
+        && tableIdentifierOpt.isPresent()
+        && newProtocol.isEmpty()) {
+      io.delta.storage.commit.TableIdentifier tableIdentifier = tableIdentifierOpt.get();
+      String[] namespace = tableIdentifier.getNamespace();
+      String catalog = namespace[0];
+      String schema = namespace[1];
+      String table = tableIdentifier.getName();
+      DeltaV1ManagedTableClient deltaV1Client = deltaV1ClientOpt.get();
+      try {
+        DeltaV1ManagedTableClient.LoadTableResponse currentState =
+            deltaV1Client.loadTable(catalog, schema, table, 0L, null);
+        DeltaV1ManagedTableClient.UpdateTableRequest request =
+            new DeltaV1ManagedTableClient.UpdateTableRequest()
+                .setAssertTableId(extractUCTableId(tableDesc))
+                .setAssertEtag(currentState.getEtag())
+                .setLatestBackfilledVersion(lastKnownBackfilledVersion.orElse(null));
+        commit.ifPresent(
+            c ->
+                request.setCommitInfo(
+                    new DeltaV1ManagedTableClient.CommitInfo()
+                        .setVersion(c.getVersion())
+                        .setTimestamp(c.getCommitTimestamp())
+                        .setFileName(c.getFileStatus().getPath().getName())
+                        .setFileSize(c.getFileStatus().getLen())
+                        .setFileModificationTimestamp(c.getFileStatus().getModificationTime())));
+        if (newMetadata.isPresent()) {
+          MetadataDiff metadataDiff = buildMetadataDiff(newMetadata.get(), tableDesc);
+          request.setSetProperties(metadataDiff.setProperties);
+          request.setRemoveProperties(metadataDiff.removeProperties);
+          request.setComment(metadataDiff.comment);
+          request.setColumns(metadataDiff.columns);
+        }
+        deltaV1Client.updateTable(catalog, schema, table, request);
+        return;
+      } catch (IOException e) {
+        if (!shouldFallbackFromDeltaV1(e)) {
+          throw e;
+        }
+      }
+    }
+    Optional<AbstractMetadata> legacyMetadata =
+        deltaV1ClientOpt.isPresent() ? Optional.empty() : newMetadata;
     ucClient.commit(
       extractUCTableId(tableDesc),
       CoordinatedCommitsUtils.getTablePath(logPath).toUri(),
       commit,
       lastKnownBackfilledVersion,
       disown,
-      newMetadata,
+      legacyMetadata,
       newProtocol,
       Optional.empty() /* uniform */
     );
@@ -804,6 +880,51 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       TableDescriptor tableDesc,
       Optional<Long> startVersion,
       Optional<Long> endVersion) {
+    Optional<DeltaV1ManagedTableClient> deltaV1ClientOpt = deltaV1Client(tableDesc);
+    Optional<io.delta.storage.commit.TableIdentifier> tableIdentifierOpt =
+        getManagedTableIdentifier(tableDesc);
+    if (deltaV1ClientOpt.isPresent() && tableIdentifierOpt.isPresent()) {
+      try {
+        io.delta.storage.commit.TableIdentifier tableIdentifier = tableIdentifierOpt.get();
+        String[] namespace = tableIdentifier.getNamespace();
+        DeltaV1ManagedTableClient.LoadTableResponse response =
+            deltaV1ClientOpt
+                .get()
+                .loadTable(
+                    namespace[0],
+                    namespace[1],
+                    tableIdentifier.getName(),
+                    startVersion.orElse(null),
+                    endVersion.orElse(null));
+        List<Commit> commits = new ArrayList<>();
+        if (response.getCommits() != null) {
+          Path basePath =
+              CoordinatedCommitsUtils.commitDirPath(
+                  CoordinatedCommitsUtils.logDirPath(
+                      CoordinatedCommitsUtils.getTablePath(tableDesc.getLogPath())));
+          for (DeltaV1ManagedTableClient.CommitInfo commitInfo : response.getCommits()) {
+            commits.add(
+                new Commit(
+                    commitInfo.getVersion(),
+                    new FileStatus(
+                        commitInfo.getFileSize(),
+                        false,
+                        0,
+                        0,
+                        commitInfo.getFileModificationTimestamp(),
+                        new Path(basePath, commitInfo.getFileName())),
+                    commitInfo.getTimestamp()));
+          }
+        }
+        return new GetCommitsResponse(
+            commits,
+            response.getLatestTableVersion() == null ? 0L : response.getLatestTableVersion());
+      } catch (IOException e) {
+        if (!shouldFallbackFromDeltaV1(e)) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
     try {
       return ucClient.getCommits(
         extractUCTableId(tableDesc),
@@ -812,6 +933,50 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
         endVersion);
     } catch (IOException | UCCommitCoordinatorException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  protected MetadataDiff buildMetadataDiff(AbstractMetadata newMetadata, TableDescriptor tableDesc) {
+    Map<String, String> oldProperties = tableDesc.getTableConf();
+    Map<String, String> newProperties = newMetadata.getConfiguration();
+    Map<String, String> setProperties = new HashMap<>();
+    List<String> removeProperties = new ArrayList<>();
+    if (newProperties != null) {
+      for (Map.Entry<String, String> entry : newProperties.entrySet()) {
+        if (!Objects.equals(oldProperties.get(entry.getKey()), entry.getValue())) {
+          setProperties.put(entry.getKey(), entry.getValue());
+        }
+      }
+      for (String key : oldProperties.keySet()) {
+        if (!newProperties.containsKey(key)
+            && !UC_TABLE_ID_KEY.equals(key)
+            && !UC_TABLE_ID_KEY_OLD.equals(key)) {
+          removeProperties.add(key);
+        }
+      }
+    }
+    return new MetadataDiff(
+        setProperties,
+        removeProperties,
+        newMetadata.getDescription(),
+        DeltaV1ManagedTableClient.schemaStringToColumns(newMetadata.getSchemaString()));
+  }
+
+  protected static class MetadataDiff {
+    final Map<String, String> setProperties;
+    final List<String> removeProperties;
+    final String comment;
+    final List<io.unitycatalog.client.model.ColumnInfo> columns;
+
+    MetadataDiff(
+        Map<String, String> setProperties,
+        List<String> removeProperties,
+        String comment,
+        List<io.unitycatalog.client.model.ColumnInfo> columns) {
+      this.setProperties = setProperties;
+      this.removeProperties = removeProperties;
+      this.comment = comment;
+      this.columns = columns;
     }
   }
 

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClientDeltaV1Suite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClientDeltaV1Suite.scala
@@ -1,0 +1,237 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.util.{Collections, Optional}
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.Commit
+import io.delta.storage.commit.{GetCommitsResponse, TableDescriptor, TableIdentifier}
+import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.uniform.UniformMetadata
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.scalatest.funsuite.AnyFunSuite
+
+class UCCommitCoordinatorClientDeltaV1Suite extends AnyFunSuite {
+
+  private class RecordingUCClient extends UCClient {
+    var commitCalls: Int = 0
+
+    override def getMetastoreId(): String = "metastore-id"
+
+    override def commit(
+        tableId: String,
+        tableUri: java.net.URI,
+        commit: Optional[Commit],
+        lastKnownBackfilledVersion: Optional[java.lang.Long],
+        disown: Boolean,
+        newMetadata: Optional[AbstractMetadata],
+        newProtocol: Optional[AbstractProtocol],
+        uniform: Optional[UniformMetadata]): Unit = {
+      commitCalls += 1
+    }
+
+    override def getCommits(
+        tableId: String,
+        tableUri: java.net.URI,
+        startVersion: Optional[java.lang.Long],
+        endVersion: Optional[java.lang.Long]): GetCommitsResponse = {
+      new GetCommitsResponse(Collections.emptyList(), -1L)
+    }
+
+    override def close(): Unit = {}
+  }
+
+  private class RecordingDeltaV1Client extends DeltaV1ManagedTableClient(
+        "http://localhost:8080", Map("type" -> "static", "token" -> "token").asJava) {
+    var loadResponse: DeltaV1ManagedTableClient.LoadTableResponse = _
+    var updateResponse: DeltaV1ManagedTableClient.LoadTableResponse =
+      new DeltaV1ManagedTableClient.LoadTableResponse()
+    var lastLoadArgs: (String, String, String, java.lang.Long, java.lang.Long) = _
+    var lastUpdateArgs:
+      (String, String, String, DeltaV1ManagedTableClient.UpdateTableRequest) = _
+
+    override def loadTable(
+        catalog: String,
+        schema: String,
+        table: String,
+        startVersion: java.lang.Long,
+        endVersion: java.lang.Long): DeltaV1ManagedTableClient.LoadTableResponse = {
+      lastLoadArgs = (catalog, schema, table, startVersion, endVersion)
+      loadResponse
+    }
+
+    override def updateTable(
+        catalog: String,
+        schema: String,
+        table: String,
+        request: DeltaV1ManagedTableClient.UpdateTableRequest)
+        : DeltaV1ManagedTableClient.LoadTableResponse = {
+      lastUpdateArgs = (catalog, schema, table, request)
+      updateResponse
+    }
+  }
+
+  private class TestClient(ucClient: UCClient, deltaV1ManagedTableClient: DeltaV1ManagedTableClient)
+      extends UCCommitCoordinatorClient(
+        Collections.emptyMap[String, String](),
+        ucClient,
+        Optional.of("http://localhost:8080"),
+        Map("type" -> "static", "token" -> "token").asJava) {
+
+    override protected def deltaV1Client(
+        tableDesc: TableDescriptor): Optional[DeltaV1ManagedTableClient] = {
+      Optional.of(deltaV1ManagedTableClient)
+    }
+
+    def commitToUCTest(
+        tableDesc: TableDescriptor,
+        commitFile: Optional[FileStatus],
+        commitVersion: Optional[java.lang.Long],
+        commitTimestamp: Optional[java.lang.Long],
+        lastKnownBackfilledVersion: Optional[java.lang.Long],
+        newMetadata: Optional[AbstractMetadata],
+        newProtocol: Optional[AbstractProtocol]): Unit = {
+      super.commitToUC(
+        tableDesc,
+        tableDesc.getLogPath,
+        commitFile,
+        commitVersion,
+        commitTimestamp,
+        lastKnownBackfilledVersion,
+        false,
+        newMetadata,
+        newProtocol)
+    }
+
+    def getCommitsFromUCTest(
+        tableDesc: TableDescriptor,
+        startVersion: Optional[java.lang.Long],
+        endVersion: Optional[java.lang.Long]): GetCommitsResponse = {
+      super.getCommitsFromUCImpl(tableDesc, startVersion, endVersion)
+    }
+  }
+
+  private def createMetadata(
+      description: String,
+      configuration: Map[String, String]): AbstractMetadata = new AbstractMetadata {
+    override def getId: String = "id"
+    override def getName: String = "name"
+    override def getDescription: String = description
+    override def getProvider: String = "delta"
+    override def getFormatOptions: java.util.Map[String, String] = Collections.emptyMap()
+    override def getSchemaString: String = """{"type":"struct","fields":[]}"""
+    override def getPartitionColumns: java.util.List[String] = Collections.emptyList()
+    override def getConfiguration: java.util.Map[String, String] = configuration.asJava
+    override def getCreatedTime: java.lang.Long = 0L
+  }
+
+  private def createTableDescriptor(tableConf: Map[String, String]): TableDescriptor = {
+    new TableDescriptor(
+      new Path("file:///tmp/table/_delta_log"),
+      Optional.of(new TableIdentifier(Array("main", "db"), "tbl")),
+      tableConf.asJava)
+  }
+
+  test("commitToUC uses delta v1 managed-table path for metadata and commit updates") {
+    val ucClient = new RecordingUCClient
+    val deltaV1Client = new RecordingDeltaV1Client
+    val currentState = new DeltaV1ManagedTableClient.LoadTableResponse()
+    currentState.setEtag("etag-1")
+    deltaV1Client.loadResponse = currentState
+
+    val client = new TestClient(ucClient, deltaV1Client)
+    val tableDesc =
+      createTableDescriptor(
+        Map(
+          UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> "table-id",
+          "unchanged" -> "same",
+          "updated" -> "old",
+          "removed" -> "gone"))
+    val commitFile = new FileStatus(
+      128L,
+      false,
+      1,
+      4096L,
+      123456789L,
+      new Path("file:///tmp/table/_delta_log/_staged_commits/00000000000000000001.uuid.json"))
+    val metadata =
+      createMetadata(
+        description = "updated comment",
+        configuration = Map("unchanged" -> "same", "updated" -> "new", "added" -> "value"))
+
+    client.commitToUCTest(
+      tableDesc,
+      Optional.of(commitFile),
+      Optional.of(java.lang.Long.valueOf(1L)),
+      Optional.of(java.lang.Long.valueOf(123456789L)),
+      Optional.of(java.lang.Long.valueOf(0L)),
+      Optional.of(metadata),
+      Optional.empty())
+
+    assert(deltaV1Client.lastLoadArgs === ("main", "db", "tbl", 0L, null))
+    assert(deltaV1Client.lastUpdateArgs._1 === "main")
+    assert(deltaV1Client.lastUpdateArgs._2 === "db")
+    assert(deltaV1Client.lastUpdateArgs._3 === "tbl")
+    assert(ucClient.commitCalls === 0)
+
+    val request = deltaV1Client.lastUpdateArgs._4
+    assert(request.getAssertTableId === "table-id")
+    assert(request.getAssertEtag === "etag-1")
+    assert(request.getLatestBackfilledVersion === 0L)
+    assert(request.getSetProperties.asScala === Map("updated" -> "new", "added" -> "value"))
+    assert(request.getRemoveProperties.asScala === Seq("removed"))
+    assert(request.getComment === "updated comment")
+    assert(request.getCommitInfo.getVersion === 1L)
+    assert(request.getCommitInfo.getTimestamp === 123456789L)
+    assert(request.getCommitInfo.getFileName === "00000000000000000001.uuid.json")
+    assert(request.getCommitInfo.getFileSize === 128L)
+    assert(request.getCommitInfo.getFileModificationTimestamp === 123456789L)
+  }
+
+  test("getCommitsFromUCImpl maps delta v1 commit response to storage commits") {
+    val ucClient = new RecordingUCClient
+    val deltaV1Client = new RecordingDeltaV1Client
+    val loadResponse = new DeltaV1ManagedTableClient.LoadTableResponse()
+    loadResponse.setLatestTableVersion(9L)
+    loadResponse.setCommits(
+      List(
+        new DeltaV1ManagedTableClient.CommitInfo()
+          .setVersion(7L)
+          .setTimestamp(1000L)
+          .setFileName("00000000000000000007.uuid.json")
+          .setFileSize(256L)
+          .setFileModificationTimestamp(1001L)).asJava)
+    deltaV1Client.loadResponse = loadResponse
+
+    val client = new TestClient(ucClient, deltaV1Client)
+    val response = client.getCommitsFromUCTest(
+      createTableDescriptor(Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> "table-id")),
+      Optional.of(java.lang.Long.valueOf(7L)),
+      Optional.empty())
+
+    assert(deltaV1Client.lastLoadArgs === ("main", "db", "tbl", 7L, null))
+    assert(response.getLatestTableVersion === 9L)
+    assert(response.getCommits.size() === 1)
+    assert(response.getCommits.get(0).getVersion === 7L)
+    assert(response.getCommits.get(0).getCommitTimestamp === 1000L)
+    assert(response.getCommits.get(0).getFileStatus.getLen === 256L)
+    assert(response.getCommits.get(0).getFileStatus.getModificationTime === 1001L)
+    assert(response.getCommits.get(0).getFileStatus.getPath.getName === "00000000000000000007.uuid.json")
+  }
+}


### PR DESCRIPTION
## Summary
This PR wires Delta into the new UC `delta/v1` managed-table flow for the hackathon demo.

It adds:
- metadata-only managed `CREATE TABLE` that writes version 0 before UC final registration
- managed commit-coordinator integration against `GET/POST /delta/v1/.../tables/{table}`
- managed schema-evolution support for `ALTER TABLE ... ADD COLUMNS`
- snapshot-manager and UC utility updates needed for the managed create/read/write path
- focused tests for the new managed-table path

## Demo CUJ
This PR is intended to support the following end-to-end flow when paired with the corresponding UC OSS PR:
- `CREATE TABLE unity.db.demo ... USING DELTA`
- `INSERT`
- `SELECT`
- `ALTER TABLE ... SET TBLPROPERTIES`
- `ALTER TABLE ... ADD COLUMNS`
- `INSERT`
- `SELECT`

## Testing
- `build/sbt -DsparkVersion=4.0.1 "++2.13.17" 'storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClientDeltaV1Suite'`
- `build/sbt -DsparkVersion=4.0.1 "++2.13.17" 'sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableBlockMetadataUpdateTest'`
- local `spark-sql` end-to-end demo against locally published UC + Delta artifacts

## Companion PR
- UC OSS companion PR: https://github.com/unitycatalog/unitycatalog/pull/1408
