### PR TITLE
[UC Commit Metrics] Add feature flag and async dispatch

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
@@ -17,19 +17,24 @@
 package org.apache.spark.sql.delta.hooks.metrics
 
 // scalastyle:off import.ordering.noEmptyLine
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 
 import org.apache.spark.sql.delta.CommittedTransaction
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
-import org.apache.spark.sql.delta.stats.FileSizeHistogram
 import org.apache.spark.sql.delta.coordinatedcommits.UCCommitCoordinatorBuilder
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.FileSizeHistogram
 import org.apache.spark.sql.delta.util.{CatalogTableUtils, JsonUtils}
+import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
 
 import io.unitycatalog.client.auth.TokenProvider
 import org.apache.http.HttpHeaders
@@ -42,7 +47,7 @@ import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
-// Payload case classes (JSON-serialized via Jackson @JsonProperty)
+// Payload case classes
 
 case class ReportDeltaMetricsRequest(
     @JsonProperty("table_id") tableId: String,
@@ -77,8 +82,9 @@ case class FileSizeHistogramPayload(
  * Post-commit hook that sends commit metrics to Unity Catalog
  * for UC-managed Delta tables.
  *
- * Best-effort: failures are logged as warnings and never fail
- * the commit.
+ * Metrics are dispatched asynchronously to a background thread
+ * pool and never block or fail the commit. Gated by
+ * [[DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED]].
  *
  * @param catalogTable catalog metadata for UC-managed detection
  */
@@ -90,6 +96,10 @@ case class UpdateMetricsHook(catalogTable: Option[CatalogTable])
   override def run(
       spark: SparkSession,
       txn: CommittedTransaction): Unit = {
+    if (!spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED)) {
+      return
+    }
     val ct = catalogTable.orNull
     if (ct == null ||
         !CatalogTableUtils.isUnityCatalogManagedTable(ct)) {
@@ -97,33 +107,78 @@ case class UpdateMetricsHook(catalogTable: Option[CatalogTable])
     }
     val tableId = ct.storage.properties(
       UCCommitCoordinatorClient.UC_TABLE_ID_KEY)
+    sendMetricsAsync(spark, tableId, ct, txn)
+  }
 
-    try {
+  private def sendMetricsAsync(
+      spark: SparkSession,
+      tableId: String,
+      ct: CatalogTable,
+      txn: CommittedTransaction): Unit = {
+    val catalogName = ct.identifier.catalog
+    val actions = txn.committedActions
+    val version = txn.committedVersion
+    val logPath = txn.deltaLog.logPath
+
+    implicit val ec: ExecutionContext =
+      UpdateMetricsHook.getOrCreateExecutionContext(spark)
+    UpdateMetricsHook.activeRequests.incrementAndGet()
+    Future {
       val request = UpdateMetricsHook.buildRequest(
-        tableId, txn.committedActions, txn.committedVersion)
-      val catalogName = ct.identifier.catalog
+        tableId, actions, version)
       UpdateMetricsHook.sendMetrics(
-        spark, request, catalogName = catalogName)
-
+        spark, request, catalogName)
       logDebug(
         log"Successfully sent UC metrics for table " +
-        log"${MDC(DeltaLogKeys.PATH, txn.deltaLog.logPath)} " +
+        log"${MDC(DeltaLogKeys.PATH, logPath)} " +
         log"version " +
-        log"${MDC(DeltaLogKeys.VERSION, txn.committedVersion)}")
-
-    } catch {
+        log"${MDC(DeltaLogKeys.VERSION, version)}")
+    }.recover {
       case e: Exception =>
         logWarning(
           log"Failed to send UC metrics for table " +
-          log"${MDC(DeltaLogKeys.PATH, txn.deltaLog.logPath)} " +
+          log"${MDC(DeltaLogKeys.PATH, logPath)} " +
           log"version " +
-          log"${MDC(DeltaLogKeys.VERSION, txn.committedVersion)}" +
-          log": ${MDC(DeltaLogKeys.ERROR, e.getMessage)}", e)
+          log"${MDC(DeltaLogKeys.VERSION, version)}" +
+          log": ${MDC(DeltaLogKeys.ERROR, e.getMessage)}",
+          e)
+    }.onComplete { _ =>
+      UpdateMetricsHook.activeRequests.decrementAndGet()
     }
   }
 }
 
+// Follows the same async dispatch pattern as UpdateCatalog.
 object UpdateMetricsHook {
+
+  // -- Async thread pool --
+
+  @volatile private var tp: ExecutionContext = _
+
+  private def getOrCreateExecutionContext(
+      spark: SparkSession): ExecutionContext = synchronized {
+    if (tp == null) {
+      val poolSize = spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_UC_COMMIT_METRICS_THREAD_POOL_SIZE)
+      tp = ExecutionContext.fromExecutorService(
+        DeltaThreadPool.newDaemonCachedThreadPool(
+          "uc-metrics-sender", poolSize))
+    }
+    tp
+  }
+
+  private[metrics] val activeRequests = new AtomicInteger(0)
+
+  // Test only.
+  private[metrics] def awaitCompletion(
+      timeoutMs: Long): Boolean = {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (activeRequests.get() > 0 &&
+           System.currentTimeMillis() < deadline) {
+      Thread.sleep(50)
+    }
+    activeRequests.get() == 0
+  }
 
   // -- Payload builder --
 
@@ -135,7 +190,6 @@ object UpdateMetricsHook {
       committedActions.collectFirst { case ci: CommitInfo => ci }
     val opMetrics =
       commitInfo.flatMap(_.operationMetrics).getOrElse(Map.empty)
-
     val addFiles =
       committedActions.collect { case a: AddFile => a }
     val removeFiles =
@@ -252,7 +306,6 @@ object UpdateMetricsHook {
       val httpPost = new HttpPost(endpointUrl)
       httpPost.setHeader(
         HttpHeaders.AUTHORIZATION, s"Bearer $authToken")
-
       val jsonPayload = JsonUtils.toJson(request)
       httpPost.setEntity(
         new StringEntity(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -825,6 +825,23 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .checkValue(_ > 0, "threadPoolSize must be positive")
       .createWithDefault(20)
 
+  val DELTA_UC_COMMIT_METRICS_ENABLED =
+    buildConf("commitMetrics.enabled")
+      .doc("When enabled, Delta sends commit metrics to Unity Catalog " +
+        "for UC-managed tables. Metrics are sent asynchronously and " +
+        "never block or fail commits.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DELTA_UC_COMMIT_METRICS_THREAD_POOL_SIZE =
+    buildStaticConf("commitMetrics.threadPoolSize")
+      .internal()
+      .doc("The number of threads for sending commit metrics " +
+        "to Unity Catalog asynchronously.")
+      .intConf
+      .checkValue(_ > 0, "threadPoolSize must be positive")
+      .createWithDefault(20)
+
   val COORDINATED_COMMITS_GET_COMMITS_THREAD_POOL_SIZE =
     buildStaticConf("coordinatedCommits.getCommits.threadPoolSize")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
@@ -24,6 +24,7 @@ import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 
 import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.{CatalogTableUtils, JsonUtils}
 
@@ -39,6 +40,22 @@ class UpdateMetricsHookSuite extends QueryTest
   with DeltaSQLCommandTest {
   private val TEST_CATALOG_NAME = "test_catalog"
   private val TEST_UC_TABLE_ID = "uc-table-id-abc"
+  private val CONF_KEY = DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED.key
+
+  private def makeTxn(
+      deltaLog: DeltaLog,
+      catalogTable: CatalogTable,
+      actions: Seq[Action] = Seq.empty): CommittedTransaction = {
+    CommittedTransaction(
+      txnId = "test-txn", deltaLog = deltaLog,
+      catalogTable = Some(catalogTable),
+      readSnapshot = deltaLog.snapshot,
+      committedVersion = 0L, committedActions = actions,
+      postCommitSnapshot = deltaLog.snapshot,
+      postCommitHooks = Seq.empty, txnExecutionTimeMs = 0L,
+      needsCheckpoint = false, partitionsAddedToOpt = None,
+      isBlindAppend = true)
+  }
 
   private def ucStorageFormat(ucTableId: String = TEST_UC_TABLE_ID): CatalogStorageFormat = {
     CatalogStorageFormat(
@@ -52,6 +69,41 @@ class UpdateMetricsHookSuite extends QueryTest
         "delta.feature.catalogManaged" -> "supported"
       )
     )
+  }
+
+  private def withMockMetricsServer(
+      responseCode: Int = 200,
+      responseDelay: Int = 0,
+      enableFlag: Boolean = true)(
+      testBody: (SimpleMockServer, DeltaLog, CatalogTable) => Unit): Unit = {
+    val mockServer = new SimpleMockServer(0)
+    mockServer.setResponseCode(responseCode)
+    if (responseDelay > 0) { mockServer.setResponseDelay(responseDelay) }
+    mockServer.start()
+    try {
+      spark.conf.set(CONF_KEY, enableFlag.toString)
+      spark.conf.set("spark.sql.catalog.spark_catalog",
+        "io.unitycatalog.spark.UCSingleCatalog")
+      spark.conf.set("spark.sql.catalog.spark_catalog.uri",
+        s"http://localhost:${mockServer.getPort()}")
+      spark.conf.set("spark.sql.catalog.spark_catalog.token",
+        "test-token")
+      withTempDir { dir =>
+        spark.range(1).write.format("delta")
+          .save(dir.getCanonicalPath)
+        val deltaLog = DeltaLog.forTable(
+          spark, dir.getCanonicalPath)
+        val ct = CatalogTable(
+          identifier = TableIdentifier(
+            "t", Some("d"), Some("spark_catalog")),
+          tableType = CatalogTableType.MANAGED,
+          storage = ucStorageFormat(), schema = new StructType())
+        testBody(mockServer, deltaLog, ct)
+      }
+    } finally {
+      spark.conf.set(CONF_KEY, "false")
+      mockServer.stop()
+    }
   }
 
   override protected def sparkConf: SparkConf = {
@@ -432,179 +484,117 @@ class UpdateMetricsHookSuite extends QueryTest
     }
   }
 
-  test("run(): fires HTTP POST for UC-managed table") {
-    val mockServer = new SimpleMockServer(0)
-    try {
-      mockServer.setResponseCode(200)
-      mockServer.start()
+  // Async dispatch tests: verify end-to-end send with payload
+  // validation, feature-flag gating, non-blocking
+  // behavior, error resilience, and skip logic for non-UC /
+  // missing-table-ID tables.
 
-      withTempDir { dir =>
-        spark.range(10).write.format("delta").save(dir.getCanonicalPath)
-        val deltaLog = DeltaLog.forTable(spark, dir.getCanonicalPath)
-        val snapshot = deltaLog.snapshot
-
-        spark.conf.set(
-          "spark.sql.catalog.spark_catalog",
-          "io.unitycatalog.spark.UCSingleCatalog")
-        spark.conf.set(
-          "spark.sql.catalog.spark_catalog.uri",
-          s"http://localhost:${mockServer.getPort()}")
-        spark.conf.set(
-          "spark.sql.catalog.spark_catalog.token", "smoke-token")
-
-        val catalogTable = CatalogTable(
-          identifier = TableIdentifier(
-            "t", Some("default"), Some("spark_catalog")),
-          tableType = CatalogTableType.MANAGED,
-          storage = ucStorageFormat(),
-          schema = new StructType()
-        )
-
-        val addFile = AddFile("f1.parquet", Map.empty, 4096L, 0L,
-          dataChange = true, stats = """{"numRecords":50}""")
-        val commitInfo = CommitInfo(
-          version = Some(0L),
-          inCommitTimestamp = None,
-          timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
-          userId = None, userName = None,
-          operation = "WRITE",
-          operationParameters = Map.empty,
-          job = None, notebook = None, clusterId = None,
-          readVersion = None, isolationLevel = None,
-          isBlindAppend = Some(true),
-          operationMetrics = Some(Map("numOutputRows" -> "50")),
-          userMetadata = None, tags = None, engineInfo = None, txnId = None)
-
-        val txn = CommittedTransaction(
-          txnId = "smoke-txn",
-          deltaLog = deltaLog,
-          catalogTable = Some(catalogTable),
-          readSnapshot = snapshot,
-          committedVersion = 0L,
-          committedActions = Seq(commitInfo, addFile),
-          postCommitSnapshot = snapshot,
-          postCommitHooks = Seq.empty,
-          txnExecutionTimeMs = 0L,
-          needsCheckpoint = false,
-          partitionsAddedToOpt = None,
-          isBlindAppend = true
-        )
-
-        UpdateMetricsHook(Some(catalogTable)).run(spark, txn)
-
-        assert(mockServer.getRequestCount() == 1,
-          "Expected exactly 1 HTTP POST")
-        val body = mockServer.getLastRequestBody()
-        val expectedRequest = UpdateMetricsHook.buildRequest(
-          TEST_UC_TABLE_ID, Seq(commitInfo, addFile), 0L)
-        val actualPayload =
-          JsonUtils.fromJson[Map[String, Any]](body)
-        val expectedPayload =
-          JsonUtils.fromJson[Map[String, Any]](
-            JsonUtils.toJson(expectedRequest))
-        assert(actualPayload == expectedPayload,
-          "smoke test payload should match expected JSON")
-      }
-    } finally {
-      mockServer.stop()
+  test("run(): skips when commitMetrics.enabled is false") {
+    withMockMetricsServer(enableFlag = false) {
+        (mockServer, deltaLog, ct) =>
+      UpdateMetricsHook(Some(ct)).run(
+        spark, makeTxn(deltaLog, ct))
+      UpdateMetricsHook.awaitCompletion(5000)
+      assert(mockServer.getRequestCount() == 0,
+        "no HTTP request when feature flag is disabled")
     }
   }
 
-  test("run(): hook does not crash on HTTP 5xx (best-effort)") {
-    val mockServer = new SimpleMockServer(0)
-    try {
-      mockServer.setResponseCode(500)
-      mockServer.start()
+  test("run(): sends metrics asynchronously for UC-managed table") {
+    withMockMetricsServer() { (mockServer, deltaLog, ct) =>
+      val addFile = AddFile("f1.parquet", Map.empty, 4096L, 0L,
+        dataChange = true, stats = """{"numRecords":50}""")
+      val commitInfo = CommitInfo(version = Some(0L),
+        inCommitTimestamp = None,
+        timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
+        userId = None, userName = None, operation = "WRITE",
+        operationParameters = Map.empty, job = None, notebook = None,
+        clusterId = None, readVersion = None, isolationLevel = None,
+        isBlindAppend = Some(true),
+        operationMetrics = Some(Map("numOutputRows" -> "50")),
+        userMetadata = None, tags = None, engineInfo = None,
+        txnId = None)
+      val txn = makeTxn(deltaLog, ct, Seq(commitInfo, addFile))
+      UpdateMetricsHook(Some(ct)).run(spark, txn)
+      assert(UpdateMetricsHook.awaitCompletion(10000),
+        "async send should complete within timeout")
+      assert(mockServer.getRequestCount() == 1,
+        "Expected exactly 1 HTTP POST")
+      val body = mockServer.getLastRequestBody()
+      val expected = UpdateMetricsHook.buildRequest(
+        TEST_UC_TABLE_ID, Seq(commitInfo, addFile), 0L)
+      assert(
+        JsonUtils.fromJson[Map[String, Any]](body) ==
+          JsonUtils.fromJson[Map[String, Any]](
+            JsonUtils.toJson(expected)),
+        "payload should match expected JSON")
+    }
+  }
 
-      withTempDir { dir =>
-        spark.range(10).write.format("delta")
-          .save(dir.getCanonicalPath)
-        val deltaLog = DeltaLog.forTable(
-          spark, dir.getCanonicalPath)
-        val snapshot = deltaLog.snapshot
+  test("run(): async error path logs warning without crashing") {
+    withMockMetricsServer(responseCode = 500) {
+        (mockServer, deltaLog, ct) =>
+      UpdateMetricsHook(Some(ct)).run(
+        spark, makeTxn(deltaLog, ct))
+      assert(UpdateMetricsHook.awaitCompletion(10000),
+        "async send should complete even on error")
+      assert(mockServer.getRequestCount() == 1,
+        "request should have been sent despite 5xx")
+      assert(UpdateMetricsHook.activeRequests.get() == 0,
+        "activeRequests must return to 0 after error")
+    }
+  }
 
-        spark.conf.set(
-          "spark.sql.catalog.spark_catalog",
-          "io.unitycatalog.spark.UCSingleCatalog")
-        spark.conf.set(
-          "spark.sql.catalog.spark_catalog.uri",
-          s"http://localhost:${mockServer.getPort()}")
-        spark.conf.set(
-          "spark.sql.catalog.spark_catalog.token",
-          "error-token")
+  test("run(): returns immediately (async) even with slow server") {
+    withMockMetricsServer(responseDelay = 3000) {
+        (mockServer, deltaLog, ct) =>
+      val startMs = System.currentTimeMillis()
+      UpdateMetricsHook(Some(ct)).run(
+        spark, makeTxn(deltaLog, ct))
+      val elapsedMs = System.currentTimeMillis() - startMs
+      assert(elapsedMs < 1000,
+        s"run() should return immediately but took ${elapsedMs}ms")
+      assert(UpdateMetricsHook.awaitCompletion(10000),
+        "async send should eventually complete")
+      assert(mockServer.getRequestCount() == 1,
+        "request should arrive after async completion")
+    }
+  }
 
-        val catalogTable = CatalogTable(
-          identifier = TableIdentifier(
-            "t", Some("default"), Some("spark_catalog")),
-          tableType = CatalogTableType.MANAGED,
-          storage = ucStorageFormat(),
-          schema = new StructType()
-        )
-
-        val txn = CommittedTransaction(
-          txnId = "error-txn",
-          deltaLog = deltaLog,
-          catalogTable = Some(catalogTable),
-          readSnapshot = snapshot,
-          committedVersion = 0L,
-          committedActions = Seq.empty,
-          postCommitSnapshot = snapshot,
-          postCommitHooks = Seq.empty,
-          txnExecutionTimeMs = 0L,
-          needsCheckpoint = false,
-          partitionsAddedToOpt = None,
-          isBlindAppend = true
-        )
-
-        UpdateMetricsHook(Some(catalogTable)).run(spark, txn)
-
-        assert(mockServer.getRequestCount() == 1,
-          "request should still be sent on 5xx")
-      }
-    } finally {
-      mockServer.stop()
+  test("run(): skips metrics for non-UC-managed table") {
+    withMockMetricsServer() { (mockServer, deltaLog, _) =>
+      val nonUcTable = CatalogTable(
+        identifier = TableIdentifier(
+          "t", Some("d"), Some("spark_catalog")),
+        tableType = CatalogTableType.MANAGED,
+        storage = CatalogStorageFormat.empty,
+        schema = new StructType())
+      UpdateMetricsHook(Some(nonUcTable)).run(
+        spark, makeTxn(deltaLog, nonUcTable))
+      UpdateMetricsHook.awaitCompletion(5000)
+      assert(mockServer.getRequestCount() == 0,
+        "no HTTP request for non-UC-managed table")
     }
   }
 
   test("run(): skips metrics when table ID not in storage properties") {
-    withTempDir { dir =>
-      spark.range(1).write.format("delta").save(dir.getCanonicalPath)
-      val deltaLog = DeltaLog.forTable(spark, dir.getCanonicalPath)
-      val snapshot = deltaLog.snapshot
-
-      val catalogTable = CatalogTable(
+    withMockMetricsServer() { (mockServer, deltaLog, _) =>
+      val noIdTable = CatalogTable(
         identifier = TableIdentifier(
-          "t", Some("default"), Some("spark_catalog")),
+          "t", Some("d"), Some("spark_catalog")),
         tableType = CatalogTableType.MANAGED,
         storage = CatalogStorageFormat(
-          locationUri = None,
-          inputFormat = None,
-          outputFormat = None,
-          serde = None,
+          locationUri = None, inputFormat = None,
+          outputFormat = None, serde = None,
           compressed = false,
           properties = Map(
-            "delta.feature.catalogManaged" -> "supported"
-          )
-        ),
-        schema = new StructType()
-      )
-
-      val txn = CommittedTransaction(
-        txnId = "skip-txn",
-        deltaLog = deltaLog,
-        catalogTable = Some(catalogTable),
-        readSnapshot = snapshot,
-        committedVersion = 0L,
-        committedActions = Seq.empty,
-        postCommitSnapshot = snapshot,
-        postCommitHooks = Seq.empty,
-        txnExecutionTimeMs = 0L,
-        needsCheckpoint = false,
-        partitionsAddedToOpt = None,
-        isBlindAppend = true
-      )
-
-      UpdateMetricsHook(Some(catalogTable)).run(spark, txn)
+            "delta.feature.catalogManaged" -> "supported")),
+        schema = new StructType())
+      UpdateMetricsHook(Some(noIdTable)).run(
+        spark, makeTxn(deltaLog, noIdTable))
+      UpdateMetricsHook.awaitCompletion(5000)
+      assert(mockServer.getRequestCount() == 0,
+        "no HTTP request when table ID is missing")
     }
   }
 }
@@ -614,12 +604,14 @@ class SimpleMockServer(port: Int) {
   private var serverThread: Thread = _
   @volatile private var running = false
   private var responseCode = 200
+  private var responseDelay = 0
   private val requestCount = new AtomicInteger(0)
   @volatile private var lastRequestBody = ""
   @volatile private var lastHeaders = Map[String, String]()
   private var actualPort = port
 
   def setResponseCode(code: Int): Unit = { responseCode = code }
+  def setResponseDelay(delayMs: Int): Unit = { responseDelay = delayMs }
 
   def getPort(): Int = actualPort
 
@@ -677,6 +669,8 @@ class SimpleMockServer(port: Int) {
 
       val body = new Array[Char](contentLength)
       if (contentLength > 0) in.read(body, 0, contentLength)
+
+      if (responseDelay > 0) Thread.sleep(responseDelay)
 
       requestCount.incrementAndGet()
       lastRequestBody = new String(body)


### PR DESCRIPTION
## Summary
- Add `spark.databricks.delta.commitMetrics.enabled` feature flag (default `false`).
- Add `spark.databricks.delta.commitMetrics.threadPoolSize` config (default 20).
- Async dispatch following UpdateCatalog pattern (daemon thread pool, unbounded queue).
- Deduplicated test setup with `withMockMetricsServer` helper.
- Tests for async timing, error path, feature flag gating, and skip logic.

Builds on #6156 (merged).

## Test plan
- [x] `build/sbt "spark/testOnly *metrics.UpdateMetricsHookSuite"` -- 19 tests pass