### PR TITLE
[CI Improvements] restrict cache writes to master to prevent PR cache eviction

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Cache Scala, SBT
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      - name: Restore SBT cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.sbt
@@ -37,3 +37,13 @@ jobs:
 
       - name: Run cross-Spark build test
         run: python project/tests/test_cross_spark_publish.py
+
+      - name: Save SBT cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: delta-sbt-cache-cross-spark

--- a/.github/workflows/flink_test.yaml
+++ b/.github/workflows/flink_test.yaml
@@ -34,14 +34,13 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
-      - name: Cache SBT and dependencies
+      - name: Restore SBT cache
         id: cache-sbt
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache
+            ~/.ivy2
             ~/.cache/coursier
           key: sbt-flink
       - name: Check cache status
@@ -54,3 +53,12 @@ jobs:
       - name: Run unit tests
         run: |
           build/sbt flinkGroup/test
+      - name: Save SBT cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: sbt-flink

--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -51,14 +51,13 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
-      - name: Cache SBT and dependencies
+      - name: Restore SBT cache
         id: cache-sbt
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache
+            ~/.ivy2
             ~/.cache/coursier
           key: sbt-kernel-${{ runner.os }}-scala${{ env.SCALA_VERSION }}
       - name: Check cache status
@@ -71,6 +70,15 @@ jobs:
       - name: Run unit tests
         run: |
           python run-tests.py --group kernel --coverage --shard ${{ matrix.shard }}
+      - name: Save SBT cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: sbt-kernel-${{ runner.os }}-scala${{ env.SCALA_VERSION }}
 
   integration-test:
     name: "DK: Integration"

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -63,17 +63,13 @@ jobs:
         with:
           distribution: "zulu"
           java-version: ${{ steps.spark-details.outputs.jvm_version }}
-      - name: Cache Scala, SBT
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      - name: Restore SBT cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          # Change the key if dependencies are changed. For each key, GitHub Actions will cache the
-          # the above directories when we use the key for the first time. After that, each run will
-          # just use the cache. The cache is immutable so we need to use a new key when trying to
-          # cache new stuff.
           key: delta-sbt-cache-spark${{ matrix.spark_version }}-scala${{ matrix.scala }}
       - name: Install Job dependencies
         run: |
@@ -101,3 +97,12 @@ jobs:
           SPARK_VERSION: ${{ steps.spark-details.outputs.spark_full_version }}
         run: |
           cd examples/scala && build/sbt "++ $SCALA_VERSION runMain example.UnityCatalogQuickstart"
+      - name: Save SBT cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: delta-sbt-cache-spark${{ matrix.spark_version }}-scala${{ matrix.scala }}

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -64,17 +64,13 @@ jobs:
         with:
           distribution: "zulu"
           java-version: ${{ steps.spark-details.outputs.jvm_version }}
-      - name: Cache Scala, SBT
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      - name: Restore SBT cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          # Change the key if dependencies are changed. For each key, GitHub Actions will cache the
-          # the above directories when we use the key for the first time. After that, each run will
-          # just use the cache. The cache is immutable so we need to use a new key when trying to
-          # cache new stuff.
           key: delta-sbt-cache-spark${{ matrix.spark_version }}-scala${{ matrix.scala }}
       - name: Scala structured logging style check
         run: |
@@ -91,3 +87,12 @@ jobs:
           name: test-reports-spark${{ matrix.spark_version }}-shard${{ matrix.shard }}
           path: "**/target/test-reports/*.xml"
           retention-days: 7
+      - name: Save SBT cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: delta-sbt-cache-spark${{ matrix.spark_version }}-scala${{ matrix.scala }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

CI builds on PRs may be compiling dependencies from scratch even though `build.sbt`
rarely changes and `actions/cache` should be providing warm caches.

**Root cause:** GitHub Actions caches are scoped by git ref. A PR's cache can only be read
by that same PR, never by sibling PRs. Every PR writes cache entries (across 5 active
workflows with 20+ matrix jobs) that no other PR can use. This fills the 10GB cache budget,
LRU-evicts master's shared entries, and forces every PR to recompile from scratch.

**Fix:** Split `actions/cache` into `actions/cache/restore` (runs on all events) and
`actions/cache/save` (only on `push` to `master`). PRs still read from master's cache
(exact key hit when dependencies match), but no longer write their own entries. Master's
cache stays alive, and every PR benefits from it.

The save condition checks both `event_name == 'push'` and `ref == refs/heads/master`
to prevent accidental cache writes from non-master push events.

All cache actions are SHA-pinned to `actions/cache@0057852b...` (v4.3.0), consistent
with the repo's supply-chain hardening convention.

Also normalizes cache paths in `kernel_test.yaml` and `flink_test.yaml` to match
other workflows (`~/.ivy2` instead of `~/.ivy2/cache`, drops redundant `~/.coursier/cache`).

### Workflows modified (5 active):
- `build.yaml` — 1 cache key
- `spark_test.yaml` — N cache keys (per Spark version)
- `spark_examples_test.yaml` — N cache keys (per Spark version)
- `kernel_test.yaml` — 1 cache key
- `flink_test.yaml` — 1 cache key

Disabled workflows (`disabled_iceberg_test.yaml`, `disabled_spark_python_test.yaml`,
`disabled_publish_docs.yaml`) are not modified.

## How was this change tested?

All CI checks passed on a previous iteration of this PR (before rebase). The
`cache/restore` step works identically to the old `cache` step for reads.

### When will the benefit be visible?

**This PR itself does not show dramatic speed improvements.** The optimization is about
**preventing future degradation**, not speeding up individual runs.

1. **Today**, this PR reads from master's existing cache via `actions/cache/restore` —
   same as before. The change is that it **does not write** cache entries (by design).
2. **The real benefit comes after merging.** Currently, every PR writes cache entries that
   evict master's caches via LRU. After this merges:
   - Master pushes write caches (and keep them warm)
   - PRs only read, never write
   - Master's caches survive LRU eviction indefinitely
   - **All future PRs** get consistent cache hits instead of random misses
3. **Where savings will show:** The SBT dependency resolution + compilation phase is where
   cache hits save time. On a cold cache miss, SBT dependency resolution alone can add
   **5-15 minutes per job**. With 20+ matrix jobs per PR, this prevents significant wasted
   aggregate CI time when cache misses occur.

### Post-merge verification plan:
1. Observe master's CI run writes caches (`"Saved cache"` in post-action logs)
2. Open a new PR and verify it hits master's cache and does NOT write its own
3. Compare compile times on new PRs against pre-merge baseline

Inspired by [delta-io/delta-kernel-rs#2130](https://github.com/delta-io/delta-kernel-rs/pull/2130).