### PR TITLE
[UniForm] Write atomic-supported property to Iceberg compact tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -850,6 +850,18 @@ trait DeltaConfigsBase extends DeltaLogging {
     validationFunction = _ => true,
     helpMessage = "needs to be a boolean."
   )
+  /**
+   * Guard property automatically set when a new IcebergCompat table is created
+   * Atomic UniForm Iceberg conversion requires this property to be present
+   */
+  val ICEBERG_ATOMIC_CONVERSION_SUPPORTED = buildConfig[Boolean](
+    "universalFormat.iceberg.atomicConversion.supported",
+    "false",
+    _.toBoolean,
+    _ => true,
+    "needs to be a boolean.",
+    userConfigurable = true
+  )
 
   val CAST_ICEBERG_TIME_TYPE = buildConfig[Boolean](
     key = "castIcebergTimeType",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -383,6 +383,13 @@ class RequireColumnMapping(allowedModes: Seq[DeltaColumnMappingMode])
 
 object RequireColumnMapping extends RequireColumnMapping(Seq(NameMapping, IdMapping))
 
+object OptionalAtomicEligible extends OptionalDeltaTableProperty(
+  deltaConfig = DeltaConfigs.ICEBERG_ATOMIC_CONVERSION_SUPPORTED,
+  autoEnableOnExistingTables = false,
+  autoSetValue = "true",
+  shouldExistingValuesBeingPreserved = true
+)
+
 
 case class IcebergCompatContext(
     spark: SparkSession,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -423,8 +423,7 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
 
       def getUpdatedConfiguration(conf: Map[String, String]): Map[String, String] =
         UniversalFormat.enforceDependenciesInConfiguration(spark,
-            catalogTable = catalogTable, conf, snapshot
-        )
+            catalogTable = catalogTable, conf, snapshot)
 
       var updatedConfiguration = getUpdatedConfiguration(configurationUnderTest)
       assert(configurationUnderTest == configurationUnderTest)
@@ -474,6 +473,37 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
     }
   }
 
+  test("enforceDependenciesInConfiguration preserves existing atomic guard property") {
+    withTempTableAndDir { case (id, _) =>
+      executeSql(s"CREATE TABLE $id (id INT) USING DELTA")
+      val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(id))
+
+      def getConfig: Map[String, String] = {
+        val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(id))
+        UniversalFormat.enforceDependenciesInConfiguration(
+          spark, catalogTable,
+          Map(DeltaConfigs.ICEBERG_COMPAT_V2_ENABLED.key -> "true"),
+          snapshot
+        )
+      }
+
+      // Case 1: snapshot has no guard -> auto-set to "true"
+      assert(getConfig.get(
+        DeltaConfigs.ICEBERG_ATOMIC_CONVERSION_SUPPORTED.key).contains("true"))
+
+      // Case 2: snapshot has guard = false -> preserve false
+      executeSql(s"ALTER TABLE $id SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ICEBERG_ATOMIC_CONVERSION_SUPPORTED.key}' = 'false')")
+      assert(getConfig.get(
+        DeltaConfigs.ICEBERG_ATOMIC_CONVERSION_SUPPORTED.key).contains("false"))
+
+      // Case 3: snapshot has guard = true -> preserve true
+      executeSql(s"ALTER TABLE $id SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ICEBERG_ATOMIC_CONVERSION_SUPPORTED.key}' = 'true')")
+      assert(getConfig.get(
+        DeltaConfigs.ICEBERG_ATOMIC_CONVERSION_SUPPORTED.key).contains("true"))
+    }
+  }
 
   test("UniForm config validation") {
     Seq("ICEBERG", "iceberg,iceberg", "iceber", "paimon").foreach { invalidConf =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
@@ -105,7 +105,6 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
     }
   }
 
-
   compatVersions.foreach { compatVersion =>
     test(s"Table with partition - compatV$compatVersion") {
       withTable(testTableName) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Write atomic-supported property to Iceberg compact tables. This is part of project to support write to UC managed UniForm tables

## How was this patch tested?
Add UTs
```
build/sbt -DsparkVersion=4.0 "iceberg/testOnly org.apache.spark.sql.delta.uniform.UniversalFormatSuite"
```