### PR TITLE
[Spark] Add regression test for streaming data loss with coordinated commits

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -135,6 +135,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "fail on data loss - gaps of files",
     "fail on data loss - starting from missing files with option off",
     "fail on data loss - gaps of files with option off",
+    "streaming processes 100 sequential single-value commits and contains all values 0 to 99",
 
     // === Misc ===
     // TODO(#5900): fix exception mismatch

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -2948,6 +2948,47 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       }
     }
   }
+
+  test("streaming processes 100 sequential single-value commits and contains all values 0 to 99") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      // TODO(#6339): enable batch size 2 after fix PR merged
+      assume(!catalogOwnedCoordinatorBackfillBatchSize.contains(2),
+        "Test cannot pass with batch size 2 due to issue #6339")
+      // Write the first value to initialize the Delta table
+      Seq(0).toDF("x").write.format("delta").save(inputDir.toString)
+
+      val df = loadStreamWithOptions(inputDir.toString, Map.empty[String, String])
+
+      val q = df.writeStream
+        .format("delta")
+        .option("checkpointLocation", checkpointDir.toString)
+        .start(outputDir.toString)
+
+      try {
+        // Process the initial commit (value 0)
+        q.processAllAvailable()
+
+        // Append values 1 through 99, one commit each
+        (1 until 100).foreach { i =>
+          Seq(i).toDF("x")
+            .write
+            .format("delta")
+            .mode("append")
+            .save(inputDir.toString)
+        }
+
+        q.processAllAvailable()
+
+        // Verify the output contains exactly all values from 0 to 99
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.toString),
+          (0 until 100).map(Row(_))
+        )
+      } finally {
+        q.stop()
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR adds a regression test that exposes a **data loss bug** in Delta streaming when used with Coordinated Commits and non-trivial backfill batch sizes.

Related issue: #6339

### Observed Behavior

The test writes 100 sequential single-row commits to a Delta table while a streaming query is running, then verifies all 100 values appear in the sink.

- **batchSize = 1**: Test passes consistently. All 100 values present.
- **batchSize = 2**: Test fails. ~4 out of 100 commits are lost on average. **Only odd-versioned commits are lost** (these are the versions that are not immediately backfilled).
- **batchSize = 3**: Test fails. The loss pattern follows the backfill cycle:
  - `v % 3 == 0`: no loss (these versions trigger backfill)
  - `v % 3 == 1`: v may be lost, and if v is lost, v+1 is always lost together (they get backfilled as a pair)
  - `v % 3 == 2`: v may be lost independently

The pattern strongly correlates with which commits are sitting unbackfilled in the coordinator at any given time, suggesting the bug is related to the interaction between backfill and commit listing.

### Hypothesized Root Cause

We suspect the issue is a race condition in `CoordinatedCommitsUtils.commitFilesIterator`, which is used by `DeltaSource.getFileChanges` during both `latestOffset` and `getBatch`. This method lists commits in two lazy, sequential steps:

1. List backfilled commits from the filesystem (`listedDeltas`)
2. Query the coordinator for unbackfilled commits (`tailFromSnapshot`)

These two steps are **not atomic**. A possible scenario (example with batchSize = 3):

1. **During `latestOffset`**: filesystem has `[0.json]`, coordinator has `[1, 2]`. `latestOffset` correctly computes endOffset covering through version 2.
2. **During `getBatch`**: the filesystem listing iterator runs and sees `[0.json]`.
3. **Between the two iterators**: a concurrent write creates version 3, triggering `backfillToVersion(3)`. This writes versions 1, 2, 3 to the filesystem and **removes them from the coordinator** via `registerBackfill`.
4. **The coordinator query runs**: returns empty — versions 1 and 2 have been removed.
5. **Result**: `getBatch` misses versions 1 and 2. The next batch starts from version 3, so they are never re-read.

## How was this patch tested?

Added a new test `"streaming processes 100 sequential single-value commits and contains all values 0 to 99"` that:
- Creates a Delta table and starts a streaming query
- Appends 100 single-row commits while the stream is running
- Verifies all 100 values appear in the sink

The test passes for batchSize = 1 but fails for batchSize = 2 and 3 due to the data loss.

## Does this PR introduce _any_ user-facing changes?

No. This PR only adds a test to demonstrate the existing bug. A fix will follow in a subsequent PR.