### PR TITLE
Improve comment clarity in UniForm example

### DIFF
--- a/examples/scala/src/main/scala/example/UniForm.scala
+++ b/examples/scala/src/main/scala/example/UniForm.scala
@@ -92,7 +92,7 @@ object UniForm {
          |)""".stripMargin)
     deltaSpark.sql(s"INSERT INTO $testTableName VALUES (${getRowToInsertStr(1)})")
 
-    // Wait for the conversion to be done
+    // Wait for the async UniForm Iceberg metadata conversion to complete.
     Thread.sleep(10000)
 
     val icebergSpark = SparkSession.builder()


### PR DESCRIPTION
## Description
Clarify the comment on the `Thread.sleep` call in the UniForm example to explain it waits for the async Iceberg metadata conversion to complete.

## How was this patch tested?
Comment-only change, no functional impact.