### PR TITLE
[Spark] Add test: no rate limit batches multiple versions together

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -2019,7 +2019,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  test("multiple versions with deletes are batched together with ignoreChanges") {
+  test("no rate limit: multiple versions per batch") {
     withTempDir { inputDir =>
       val path = inputDir.getCanonicalPath
 


### PR DESCRIPTION
  #### Which Delta project/connector is this regarding?                                                                                                                                                          
                                                                                                                                                                                                                 
  - [x] Spark                                                                                                                                                                                                    
  - [ ] Standalone                                                        
  - [ ] Flink
  - [ ] Kernel
  - [ ] Other (fill in here)
                                                                                                                                                                                                                 
  ## Description
                                                                                                                                                                                                                 
  Adds a unit test verifying that Delta streaming correctly batches multiple versions into a single micro-batch when the total file count is under the default `maxFilesPerTrigger` (1000).

  The test writes 8 versions with a mix of appends, overwrites, and deletes, reads with `ignoreChanges=true`, and asserts all versions are consumed in one batch. This ensures the admission control counts files
   (not versions) and that versions with `RemoveFile` actions don't force one-version-per-batch behavior.
                                                                                                                                                                                                                 
  ## How was this patch tested?                                           

  New test added: `DeltaSourceSuite` — "no rate limit: multiple versions per batch". Verified passing locally via:                                                                                               
  build/sbt "spark/testOnly org.apache.spark.sql.delta.DeltaSourceSuite -- -z "no rate limit: multiple versions per batch""
                                                                                                                                                                                                                 
  ## Does this PR introduce _any_ user-facing changes?                    
                                                                                                                                                                                                                 
  No.     