### PR TITLE
[Spark] Fix flaky testPlanInputPartitionsGroupsFilesByPartition

### DIFF
--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -1067,7 +1067,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testPlanInputPartitionsGroupsFilesByPartition(@TempDir File tempDir) {
+  public void testPlanInputPartitionsGroupsFilesByPartition(@TempDir File tempDir)
+      throws Exception {
     // Create a table with multiple files per partition to actually exercise the grouping logic
     // in planPartitionedInputPartitions (the default test table has 1 file per partition,
     // which would pass even without grouping).
@@ -1091,44 +1092,52 @@ public class SparkScanTest extends DeltaV2TestBase {
             tempDir.getAbsolutePath(),
             options);
 
-    SparkScanBuilder builder = (SparkScanBuilder) multiFileTable.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
-    Batch batch = scan.toBatch();
+    // Force maxPartitionBytes=1 so each file gets its own FilePartition, making the
+    // totalPartitions > 2 assertion deterministic regardless of default parallelism.
+    withSQLConf(
+        "spark.sql.files.maxPartitionBytes",
+        "1",
+        () -> {
+          SparkScanBuilder builder = (SparkScanBuilder) multiFileTable.newScanBuilder(options);
+          SparkScan scan = (SparkScan) builder.build();
+          Batch batch = scan.toBatch();
 
-    InputPartition[] partitions = batch.planInputPartitions();
+          InputPartition[] partitions = batch.planInputPartitions();
 
-    // Verify all partitions are DeltaInputPartition with partition keys
-    Map<InternalRow, List<DeltaInputPartition>> partitionsByKey = new HashMap<>();
-    for (InputPartition p : partitions) {
-      assertTrue(p instanceof DeltaInputPartition);
-      DeltaInputPartition dp = (DeltaInputPartition) p;
-      partitionsByKey.computeIfAbsent(dp.partitionKey(), k -> new ArrayList<>()).add(dp);
-    }
+          // Verify all partitions are DeltaInputPartition with partition keys
+          Map<InternalRow, List<DeltaInputPartition>> partitionsByKey = new HashMap<>();
+          for (InputPartition p : partitions) {
+            assertTrue(p instanceof DeltaInputPartition);
+            DeltaInputPartition dp = (DeltaInputPartition) p;
+            partitionsByKey.computeIfAbsent(dp.partitionKey(), k -> new ArrayList<>()).add(dp);
+          }
 
-    // Should have exactly 2 unique partition keys (part=1 and part=2)
-    assertEquals(2, partitionsByKey.size(), "Should have 2 unique partition keys");
+          // Should have exactly 2 unique partition keys (part=1 and part=2)
+          assertEquals(2, partitionsByKey.size(), "Should have 2 unique partition keys");
 
-    // Verify that the grouping actually produced multiple DeltaInputPartitions for a single
-    // partition key (since multiple files exist per partition and each gets its own
-    // FilePartition at default maxSplitBytes)
-    int totalPartitions = partitions.length;
-    assertTrue(
-        totalPartitions > 2,
-        "With 5 files across 2 partitions, should have more than 2 input partitions, "
-            + "got "
-            + totalPartitions);
+          // Verify that the grouping actually produced multiple DeltaInputPartitions for a
+          // single partition key (since multiple files exist per partition and each gets its
+          // own FilePartition when maxPartitionBytes=1)
+          int totalPartitions = partitions.length;
+          assertTrue(
+              totalPartitions > 2,
+              "With 5 files across 2 partitions, should have more than 2 input partitions, "
+                  + "got "
+                  + totalPartitions);
 
-    // Verify all DeltaInputPartitions with the same key share the same partition key instance
-    for (Map.Entry<InternalRow, List<DeltaInputPartition>> entry : partitionsByKey.entrySet()) {
-      List<DeltaInputPartition> group = entry.getValue();
-      InternalRow expectedKey = group.get(0).partitionKey();
-      for (DeltaInputPartition dp : group) {
-        assertEquals(
-            expectedKey,
-            dp.partitionKey(),
-            "All partitions in the same group should have equal partition keys");
-      }
-    }
+          // Verify all DeltaInputPartitions with the same key share the same partition key
+          for (Map.Entry<InternalRow, List<DeltaInputPartition>> entry :
+              partitionsByKey.entrySet()) {
+            List<DeltaInputPartition> group = entry.getValue();
+            InternalRow expectedKey = group.get(0).partitionKey();
+            for (DeltaInputPartition dp : group) {
+              assertEquals(
+                  expectedKey,
+                  dp.partitionKey(),
+                  "All partitions in the same group should have equal partition keys");
+            }
+          }
+        });
   }
 
   @Test


### PR DESCRIPTION


#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

  `testPlanInputPartitionsGroupsFilesByPartition` is flaky because it asserts totalPartitions > 2, expecting 5 tiny test files to each get their own FilePartition. However, Spark's split size is min(maxPartitionBytes, bytesPerCore) where bytesPerCore = (totalBytes + openCostInBytes * numFiles) / defaultParallelism. On machines with fewer cores (lower defaultParallelism), bytesPerCore stays large enough that all files in each partition key merge into one split, yielding exactly 2 DeltaInputPartitions and failing the assertion.

  Fix: wrap the scan/assertion block in withSQLConf("spark.sql.files.maxPartitionBytes", "1", ...) so each file is forced into its own FilePartition regardless of the machine's core count.

## How was this patch tested?

local uni test run

## Does this PR introduce _any_ user-facing changes?

No