### PR TITLE
[ServerSidePlanning] Add OAuth + credential refresh support

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClient.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClient.scala
@@ -82,95 +82,7 @@ class IcebergRESTCatalogPlanningClient(
   // Partition spec ID for unpartitioned tables
   private val UNPARTITIONED_SPEC_ID = 0
 
-  // IRC config key mappings for each credential type
-  private val S3_KEYS = Seq("s3.access-key-id", "s3.secret-access-key", "s3.session-token")
-  private val AZURE_SAS_TOKEN_KEY_PREFIX = "adls.sas-token."
-  private val GCS_TOKEN_KEY = "gcs.oauth2.token"
-  private val GCS_EXPIRY_KEY = "gcs.oauth2.token-expires-at"
-
-  private case class S3Credentials(
-      accessKeyId: String,
-      secretAccessKey: String,
-      sessionToken: String) extends ScanPlanStorageCredentials {
-    override def configure(conf: Configuration): Unit = {
-      conf.set("fs.s3a.path.style.access", "true")
-      conf.set("fs.s3.impl.disable.cache", "true")
-      conf.set("fs.s3a.impl.disable.cache", "true")
-      conf.set("fs.s3a.access.key", accessKeyId)
-      conf.set("fs.s3a.secret.key", secretAccessKey)
-      conf.set("fs.s3a.session.token", sessionToken)
-    }
-  }
-
-  private case class AzureCredentials(
-      accountName: String,
-      sasToken: String) extends ScanPlanStorageCredentials {
-    override def configure(conf: Configuration): Unit = {
-      val accountSuffix = s"$accountName.dfs.core.windows.net"
-      conf.set("fs.abfs.impl.disable.cache", "true")
-      conf.set("fs.abfss.impl.disable.cache", "true")
-      conf.set(s"fs.azure.account.auth.type.$accountSuffix", "SAS")
-      conf.set(s"fs.azure.sas.fixed.token.$accountSuffix", sasToken)
-    }
-  }
-
-  private case class GcsCredentials(
-      oauth2Token: String,
-      expirationEpochMs: Option[Long] = None) extends ScanPlanStorageCredentials {
-    override def configure(conf: Configuration): Unit = {
-      conf.set("fs.gs.impl.disable.cache", "true")
-      conf.set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
-      conf.set("fs.gs.auth.access.token.provider.impl",
-        classOf[FixedGcsAccessTokenProvider].getName)
-      conf.set("fs.gs.auth.access.token", oauth2Token)
-      expirationEpochMs.foreach { ms =>
-        conf.set("fs.gs.auth.access.token.expiration.ms", ms.toString)
-      }
-    }
-  }
-
-  private def hasAzureKeys(config: Map[String, String]): Boolean =
-    config.keys.exists(_.startsWith(AZURE_SAS_TOKEN_KEY_PREFIX))
-
-  private def buildAzureCredentials(config: Map[String, String]): AzureCredentials = {
-    val sasTokenKey = config.keys
-      .find(_.startsWith(AZURE_SAS_TOKEN_KEY_PREFIX))
-      .getOrElse(throw new IllegalStateException(
-        s"Missing Azure SAS token key starting with: $AZURE_SAS_TOKEN_KEY_PREFIX"))
-
-    val accountName = sasTokenKey
-      .stripPrefix(AZURE_SAS_TOKEN_KEY_PREFIX)
-      .stripSuffix(".dfs.core.windows.net")
-
-    val sasToken = config(sasTokenKey)
-
-    AzureCredentials(accountName = accountName, sasToken = sasToken)
-  }
-
-  private def fromConfig(config: Map[String, String]): ScanPlanStorageCredentials = {
-    def get(key: String): String =
-      config.getOrElse(key, throw new IllegalStateException(s"Missing required credential: $key"))
-
-    def hasAny(keys: Seq[String]): Boolean = keys.exists(config.contains)
-
-    if (hasAny(S3_KEYS)) {
-      S3Credentials(
-        get("s3.access-key-id"),
-        get("s3.secret-access-key"),
-        get("s3.session-token"))
-    } else if (hasAzureKeys(config)) {
-      buildAzureCredentials(config)
-    } else if (config.contains(GCS_TOKEN_KEY)) {
-      val token = get(GCS_TOKEN_KEY)
-      val expirationEpochMs = config.get(GCS_EXPIRY_KEY)
-        .flatMap(s => scala.util.Try(s.toLong).toOption)
-      GcsCredentials(token, expirationEpochMs)
-    } else {
-      throw new IllegalStateException(
-        "Unrecognized credential keys. " +
-          "Expected S3 (s3.*), Azure (adls.*), or GCS (gcs.*) properties.")
-    }
-  }
+  import IcebergRESTCatalogPlanningClient._
 
   /**
    * Lazily fetch the catalog configuration and construct the endpoint URI root.
@@ -461,7 +373,22 @@ class IcebergRESTCatalogPlanningClient(
     }.toSeq
 
     val credentials = extractCredentials(responseBody)
-    ScanPlan(files = files, credentials = credentials)
+
+    // Extract plan-id from response. This UUID serves as
+    // the table ID for UC credential refresh API calls.
+    val planId: Option[String] = try {
+      implicit val formats: Formats = DefaultFormats
+      val json = parse(responseBody)
+      json \ "plan-id" match {
+        case JString(id) => Some(id)
+        case _ => None
+      }
+    } catch { case _: Exception => None }
+
+    ScanPlan(
+      files = files,
+      credentials = credentials,
+      planId = planId)
   }
 
   /**
@@ -572,5 +499,184 @@ class IcebergRESTCatalogPlanningClient(
       specsById.map { case (k, v) => Int.box(k) -> v }.asJava,
       Boolean.box(caseSensitive)
     ).asInstanceOf[PlanTableScanResponse]
+  }
+}
+
+/**
+ * Companion object with credential case classes and helpers.
+ * These must live outside the class to avoid capturing `$outer`
+ * (which makes them non-serializable for Spark task shipping).
+ */
+private[serverSidePlanning] object IcebergRESTCatalogPlanningClient {
+
+  // IRC config key mappings for each credential type
+  private val S3_KEYS = Seq(
+    "s3.access-key-id",
+    "s3.secret-access-key",
+    "s3.session-token")
+  private val S3_EXPIRY_KEY = "s3.session-token-expires-at-ms"
+  private val AZURE_SAS_TOKEN_KEY_PREFIX = "adls.sas-token."
+  private val AZURE_EXPIRY_KEY_PREFIX =
+    "adls.sas-token-expires-at-ms."
+  private val GCS_TOKEN_KEY = "gcs.oauth2.token"
+  private val GCS_EXPIRY_KEY = "gcs.oauth2.token-expires-at"
+
+  // Default expiration: 1 hour (standard STS token lifetime).
+  private val DEFAULT_EXPIRATION_MS = 3600 * 1000L
+
+  // UC provider class names (by string to avoid compile dep).
+  private val AWS_PROVIDER =
+    "io.unitycatalog.spark.auth.storage.AwsVendedTokenProvider"
+  private val AZURE_PROVIDER =
+    "io.unitycatalog.spark.auth.storage.AbfsVendedTokenProvider"
+  private val GCS_PROVIDER =
+    "io.unitycatalog.spark.auth.storage.GcsVendedTokenProvider"
+
+  private def expiryOrDefault(
+      epochMs: Option[Long]): Long =
+    epochMs.getOrElse(
+      System.currentTimeMillis() + DEFAULT_EXPIRATION_MS)
+
+  private[serverSidePlanning] case class S3Credentials(
+      accessKeyId: String,
+      secretAccessKey: String,
+      sessionToken: String,
+      expirationEpochMs: Option[Long] = None
+  ) extends ScanPlanStorageCredentials {
+    override def configure(conf: Configuration): Unit = {
+      conf.set("fs.s3a.path.style.access", "true")
+      conf.set("fs.s3.impl.disable.cache", "true")
+      conf.set("fs.s3a.impl.disable.cache", "true")
+      conf.set("fs.s3a.access.key", accessKeyId)
+      conf.set("fs.s3a.secret.key", secretAccessKey)
+      conf.set("fs.s3a.session.token", sessionToken)
+    }
+
+    override def configureWithRefresh(
+        conf: Configuration): Unit = {
+      conf.set("fs.s3.impl.disable.cache", "true")
+      conf.set("fs.s3a.impl.disable.cache", "true")
+      conf.set("fs.s3a.aws.credentials.provider",
+        AWS_PROVIDER)
+      conf.set("fs.s3a.init.access.key", accessKeyId)
+      conf.set("fs.s3a.init.secret.key", secretAccessKey)
+      conf.set("fs.s3a.init.session.token", sessionToken)
+      conf.setLong("fs.s3a.init.credential.expired.time",
+        expiryOrDefault(expirationEpochMs))
+    }
+  }
+
+  private[serverSidePlanning] case class AzureCredentials(
+      accountName: String,
+      sasToken: String,
+      expirationEpochMs: Option[Long] = None
+  ) extends ScanPlanStorageCredentials {
+    override def configure(conf: Configuration): Unit = {
+      val acct = s"$accountName.dfs.core.windows.net"
+      conf.set("fs.abfs.impl.disable.cache", "true")
+      conf.set("fs.abfss.impl.disable.cache", "true")
+      conf.set(s"fs.azure.account.auth.type.$acct", "SAS")
+      conf.set(s"fs.azure.sas.fixed.token.$acct", sasToken)
+    }
+
+    override def configureWithRefresh(
+        conf: Configuration): Unit = {
+      conf.set("fs.abfs.impl.disable.cache", "true")
+      conf.set("fs.abfss.impl.disable.cache", "true")
+      // Required: tell ABFS to use SAS auth (not SharedKey)
+      conf.set("fs.azure.account.auth.type", "SAS")
+      conf.set("fs.azure.account.hns.enabled", "true")
+      conf.set("fs.azure.sas.token.provider.type",
+        AZURE_PROVIDER)
+      conf.set("fs.azure.init.sas.token", sasToken)
+      conf.setLong(
+        "fs.azure.init.sas.token.expired.time",
+        expiryOrDefault(expirationEpochMs))
+    }
+  }
+
+  private[serverSidePlanning] case class GcsCredentials(
+      oauth2Token: String,
+      expirationEpochMs: Option[Long] = None
+  ) extends ScanPlanStorageCredentials {
+    override def configure(conf: Configuration): Unit = {
+      conf.set("fs.gs.impl.disable.cache", "true")
+      conf.set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
+      conf.set("fs.gs.auth.access.token.provider.impl",
+        classOf[FixedGcsAccessTokenProvider].getName)
+      conf.set("fs.gs.auth.access.token", oauth2Token)
+      expirationEpochMs.foreach { ms =>
+        conf.set("fs.gs.auth.access.token.expiration.ms",
+          ms.toString)
+      }
+    }
+
+    override def configureWithRefresh(
+        conf: Configuration): Unit = {
+      conf.set("fs.gs.impl.disable.cache", "true")
+      conf.set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
+      conf.set("fs.gs.auth.access.token.provider.impl",
+        GCS_PROVIDER)
+      conf.set("fs.gs.init.oauth.token", oauth2Token)
+      conf.setLong("fs.gs.init.oauth.token.expiration.time",
+        expiryOrDefault(expirationEpochMs))
+    }
+  }
+
+  private def hasAzureKeys(
+      config: Map[String, String]): Boolean =
+    config.keys.exists(
+      _.startsWith(AZURE_SAS_TOKEN_KEY_PREFIX))
+
+  private def buildAzureCredentials(
+      config: Map[String, String]): AzureCredentials = {
+    val sasTokenKey = config.keys
+      .find(_.startsWith(AZURE_SAS_TOKEN_KEY_PREFIX))
+      .getOrElse(throw new IllegalStateException(
+        "Missing Azure SAS token key starting with: " +
+        AZURE_SAS_TOKEN_KEY_PREFIX))
+    val accountName = sasTokenKey
+      .stripPrefix(AZURE_SAS_TOKEN_KEY_PREFIX)
+      .stripSuffix(".dfs.core.windows.net")
+    val sasToken = config(sasTokenKey)
+    val expirationMs = config.keys
+      .find(_.startsWith(AZURE_EXPIRY_KEY_PREFIX))
+      .flatMap(k =>
+        scala.util.Try(config(k).toLong).toOption)
+    AzureCredentials(accountName, sasToken, expirationMs)
+  }
+
+  private[serverSidePlanning] def fromConfig(
+      config: Map[String, String]
+  ): ScanPlanStorageCredentials = {
+    def get(key: String): String =
+      config.getOrElse(key,
+        throw new IllegalStateException(
+          s"Missing required credential: $key"))
+    def hasAny(keys: Seq[String]): Boolean =
+      keys.exists(config.contains)
+
+    if (hasAny(S3_KEYS)) {
+      val expiry = config.get(S3_EXPIRY_KEY)
+        .flatMap(s =>
+          scala.util.Try(s.toLong).toOption)
+      S3Credentials(
+        get("s3.access-key-id"),
+        get("s3.secret-access-key"),
+        get("s3.session-token"),
+        expiry)
+    } else if (hasAzureKeys(config)) {
+      buildAzureCredentials(config)
+    } else if (config.contains(GCS_TOKEN_KEY)) {
+      val token = get(GCS_TOKEN_KEY)
+      val expiry = config.get(GCS_EXPIRY_KEY)
+        .flatMap(s =>
+          scala.util.Try(s.toLong).toOption)
+      GcsCredentials(token, expiry)
+    } else {
+      throw new IllegalStateException(
+        "Unrecognized credential keys. Expected " +
+          "S3 (s3.*), Azure (adls.*), or GCS (gcs.*).")
+    }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
@@ -139,7 +139,8 @@ object ServerSidePlannedTable extends DeltaLogging {
       metadata: ServerSidePlanningMetadata): Option[ServerSidePlannedTable] = {
     try {
       val client = ServerSidePlanningClientFactory.buildClient(spark, metadata)
-      Some(new ServerSidePlannedTable(spark, databaseName, tableName, tableSchema, client))
+      Some(new ServerSidePlannedTable(
+        spark, databaseName, tableName, tableSchema, client, metadata))
     } catch {
       case _: IllegalStateException =>
         // Factory not registered - this shouldn't happen in production but could during testing
@@ -178,7 +179,8 @@ class ServerSidePlannedTable(
     databaseName: String,
     tableName: String,
     tableSchema: StructType,
-    planningClient: ServerSidePlanningClient)
+    planningClient: ServerSidePlanningClient,
+    metadata: ServerSidePlanningMetadata)
     extends Table with SupportsRead with AutoCloseable with DeltaLogging {
 
   // Returns fully qualified name (e.g., "catalog.database.table").
@@ -193,7 +195,8 @@ class ServerSidePlannedTable(
   }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-    new ServerSidePlannedScanBuilder(spark, databaseName, tableName, tableSchema, planningClient)
+    new ServerSidePlannedScanBuilder(
+      spark, databaseName, tableName, tableSchema, planningClient, metadata)
   }
 
   override def close(): Unit = {
@@ -212,7 +215,8 @@ class ServerSidePlannedScanBuilder(
     databaseName: String,
     tableName: String,
     tableSchema: StructType,
-    planningClient: ServerSidePlanningClient)
+    planningClient: ServerSidePlanningClient,
+    metadata: ServerSidePlanningMetadata)
   extends ScanBuilder
   with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns
@@ -291,8 +295,9 @@ class ServerSidePlannedScanBuilder(
 
   override def build(): Scan = {
     new ServerSidePlannedScan(
-      spark, databaseName, tableName, tableSchema, planningClient, _pushedFilters, _requiredSchema,
-      _limit)
+      spark, databaseName, tableName, tableSchema,
+      planningClient, metadata, _pushedFilters,
+      _requiredSchema, _limit)
   }
 }
 
@@ -305,6 +310,7 @@ class ServerSidePlannedScan(
     tableName: String,
     tableSchema: StructType,
     planningClient: ServerSidePlanningClient,
+    metadata: ServerSidePlanningMetadata,
     pushedFilters: Array[Filter],
     requiredSchema: StructType,
     limit: Option[Int]) extends Scan with Batch {
@@ -372,7 +378,9 @@ class ServerSidePlannedScan(
 
   override def createReaderFactory(): PartitionReaderFactory = {
     new ServerSidePlannedFilePartitionReaderFactory(
-      spark, tableSchema, requiredSchema, scanPlan.credentials)
+      spark, tableSchema, requiredSchema,
+      scanPlan.credentials, metadata,
+      scanPlan.planId)
   }
 }
 
@@ -388,39 +396,87 @@ case class ServerSidePlannedFileInputPartition(
  * Factory for creating PartitionReaders that read server-side planned files.
  * Builds reader functions on the driver for Parquet files.
  *
+ * Configures Hadoop with UC credential providers (AwsVendedTokenProvider,
+ * AbfsVendedTokenProvider, GcsVendedTokenProvider) that auto-refresh
+ * storage credentials by calling UC's /temporary-table-credentials endpoint.
+ * Initial credentials from the IRC /plan response are used as seeds.
+ *
  * @param tableSchema The full table schema (all columns in the file)
  * @param requiredSchema The required schema (columns to read after projection pushdown)
- * @param credentials Optional storage credentials from server-side planning response
+ * @param credentials Optional storage credentials from IRC /plan response (used as seeds)
+ * @param metadata SSP metadata with UC URI, table ID, and auth config for credential refresh
  */
 class ServerSidePlannedFilePartitionReaderFactory(
     spark: SparkSession,
     tableSchema: StructType,
     requiredSchema: StructType,
-    credentials: Option[ScanPlanStorageCredentials])
+    credentials: Option[ScanPlanStorageCredentials],
+    metadata: ServerSidePlanningMetadata,
+    planId: Option[String])
     extends PartitionReaderFactory {
 
   import org.apache.spark.util.SerializableConfiguration
 
   // scalastyle:off deltahadoopconfiguration
-  // We use sessionState.newHadoopConf() here instead of deltaLog.newDeltaHadoopConf().
-  // This means DataFrame options (like custom S3 credentials) passed by users will NOT be
-  // included in the Hadoop configuration. This is intentional:
-  // - Server-side planning uses server-provided credentials, not user-specified credentials
-  // - ServerSidePlannedTable is NOT a Delta table, so we don't want Delta-specific options
-  //   from deltaLog.newDeltaHadoopConf()
-  // - General Spark options from spark.hadoop.* are included and work for all tables
   private val hadoopConf = {
     val conf = spark.sessionState.newHadoopConf()
 
-    // Inject temporary credentials from IRC server response.
-    // Disable FileSystem cache for S3, Azure, and GCS so each scan uses fresh credentials
-    // (avoids AccessDenied when temp creds expire and a cached FS is reused).
-    // Aligns with CredPropsUtil in the Unity Catalog connector.
-    credentials.foreach(_.configure(conf))
+    // Set up UC credential providers for auto-refreshing storage credentials.
+    // The providers read fs.unitycatalog.* config keys from Hadoop Configuration
+    // and call UC's /temporary-table-credentials to refresh when creds near expiry.
+    // Initial credentials from the IRC /plan response are used as seeds.
+    configureCredentialRefresh(conf)
 
     new SerializableConfiguration(conf)
   }
   // scalastyle:on deltahadoopconfiguration
+
+  /**
+   * Configure Hadoop with UC credential providers for auto-refresh.
+   *
+   * Sets three categories of config keys:
+   * 1. UC connection: URI + auth config so providers can call UC for refresh
+   * 2. Credential metadata: table ID + operation so UC knows what to refresh
+   * 3. Cloud provider + seeds: provider class name + initial IRC credentials
+   *
+   * If metadata lacks table ID or auth config (e.g., non-UC catalogs or tests),
+   * falls back to static credential injection without refresh.
+   */
+  private def configureCredentialRefresh(
+      conf: org.apache.hadoop.conf.Configuration): Unit = {
+    // Use table ID from metadata, or plan-id from /plan response
+    val effectiveTableId =
+      metadata.tableId.orElse(planId)
+
+    val hasCredentialRefreshMetadata =
+      effectiveTableId.isDefined &&
+      metadata.authConfig.nonEmpty &&
+      metadata.ucUri.nonEmpty
+
+    if (hasCredentialRefreshMetadata) {
+      // 1. UC connection for credential refresh API calls
+      conf.set("fs.unitycatalog.uri", metadata.ucUri)
+      metadata.authConfig.foreach { case (key, value) =>
+        conf.set(s"fs.unitycatalog.auth.$key", value)
+      }
+
+      // 2. Credential metadata
+      conf.set("fs.unitycatalog.credentials.uid",
+        java.util.UUID.randomUUID().toString)
+      conf.set("fs.unitycatalog.credentials.type",
+        "table")
+      conf.set("fs.unitycatalog.table.id",
+        effectiveTableId.get)
+      conf.set("fs.unitycatalog.table.operation",
+        "READ")
+
+      // 3. Cloud provider + initial seeds
+      credentials.foreach(_.configureWithRefresh(conf))
+    } else {
+      // Fallback: static credentials without refresh
+      credentials.foreach(_.configure(conf))
+    }
+  }
 
   // Pre-build reader function for Parquet on the driver
   // This function will be serialized and sent to executors

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningClient.scala
@@ -185,7 +185,22 @@ private[serverSidePlanning] object ServerSidePlanningClientFactory {
  * for their respective cloud provider.
  */
 trait ScanPlanStorageCredentials {
+  /**
+   * Apply static credentials to Hadoop config (no refresh).
+   * Used as fallback when credential refresh metadata is unavailable.
+   */
   def configure(conf: org.apache.hadoop.conf.Configuration): Unit
+
+  /**
+   * Apply credentials with UC credential provider for auto-refresh.
+   * Sets the provider class name, initial seed credentials, and expiration time.
+   * The provider class (e.g., AwsVendedTokenProvider) is loaded by Hadoop at runtime
+   * from the unitycatalog-spark JAR on the classpath.
+   *
+   * Assumes UC connection keys (fs.unitycatalog.uri, fs.unitycatalog.auth.*,
+   * fs.unitycatalog.table.id, etc.) are already set in the Configuration.
+   */
+  def configureWithRefresh(conf: org.apache.hadoop.conf.Configuration): Unit
 }
 
 /**
@@ -193,4 +208,5 @@ trait ScanPlanStorageCredentials {
  */
 case class ScanPlan(
     files: Seq[ScanFile],
-    credentials: Option[ScanPlanStorageCredentials] = None)
+    credentials: Option[ScanPlanStorageCredentials] = None,
+    planId: Option[String] = None)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
@@ -42,6 +42,25 @@ private[serverSidePlanning] trait ServerSidePlanningMetadata {
   def catalogName: String
 
   /**
+   * Unity Catalog server URI for credential refresh API calls.
+   * Used by UC credential providers to call /temporary-table-credentials.
+   */
+  def ucUri: String
+
+  /**
+   * Table UUID from Unity Catalog, needed for credential refresh.
+   * The UC /temporary-table-credentials endpoint requires the table ID.
+   */
+  def tableId: Option[String]
+
+  /**
+   * Authentication config for UC credential providers (fs.unitycatalog.auth.* keys).
+   * Maps auth config keys (e.g., "type", "token", "oauth.uri") to values.
+   * Used by GenericCredentialProvider to reconstruct a TokenProvider for refresh calls.
+   */
+  def authConfig: Map[String, String]
+
+  /**
    * Additional table properties that may be needed.
    * For example, table UUID, credential hints, etc.
    */
@@ -57,6 +76,9 @@ private[serverSidePlanning] case class DefaultMetadata(
     tableProps: Map[String, String] = Map.empty) extends ServerSidePlanningMetadata {
   override def planningEndpointUri: String = ""
   override def authToken: Option[String] = None
+  override def ucUri: String = ""
+  override def tableId: Option[String] = None
+  override def authConfig: Map[String, String] = Map.empty
   override def tableProperties: Map[String, String] = tableProps
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/UnityCatalogMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/UnityCatalogMetadata.scala
@@ -21,18 +21,18 @@ import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 
 /**
  * Metadata for Unity Catalog tables.
- * Provides base Iceberg REST endpoint for server-side planning.
+ * Provides base Iceberg REST endpoint, authentication, and credential refresh
+ * metadata for server-side planning.
  */
 case class UnityCatalogMetadata(
     catalogName: String,
-    ucUri: String,
+    override val ucUri: String,
     ucToken: String,
+    override val tableId: Option[String],
+    override val authConfig: Map[String, String],
     tableProps: Map[String, String]) extends ServerSidePlanningMetadata {
 
   override def planningEndpointUri: String = {
-    // Return base Iceberg REST path up to /v1/
-    // The IcebergRESTCatalogPlanningClient will call /v1/config to get the prefix
-    // and construct the full URL according to the Iceberg REST catalog spec
     val base = if (ucUri.endsWith("/")) ucUri.dropRight(1) else ucUri
     s"$base/api/2.1/unity-catalog/iceberg-rest/v1"
   }
@@ -43,6 +43,10 @@ case class UnityCatalogMetadata(
 }
 
 object UnityCatalogMetadata {
+
+  // UC table property key for table UUID
+  private val UC_TABLE_ID_KEY = "io.unitycatalog.tableId"
+
   def fromTable(
       table: Table,
       spark: SparkSession,
@@ -51,18 +55,64 @@ object UnityCatalogMetadata {
     val catalogName = if (ident.namespace().length > 1) {
       ident.namespace().head
     } else {
-      // Use current catalog from session
-      // This allows queries with 2-part names (schema.table) to work with Unity Catalog
       spark.sessionState.catalogManager.currentCatalog.name()
     }
 
-    // Read UC configuration from Spark conf
     val ucUri = spark.conf.get(s"spark.sql.catalog.$catalogName.uri", "")
-    val ucToken = spark.conf.get(s"spark.sql.catalog.$catalogName.token", "")
+    val ucToken = spark.conf.get(
+      s"spark.sql.catalog.$catalogName.token", "")
 
-    // Table properties currently unused, may be needed in future
+    // Extract table UUID from table properties (set by UC's loadTable)
+    val tableId = if (table != null && table.properties() != null) {
+      Option(table.properties().get(UC_TABLE_ID_KEY))
+    } else {
+      None
+    }
+
+    // Extract auth config for UC credential providers.
+    // These are set as fs.unitycatalog.auth.* in Hadoop config so that
+    // GenericCredentialProvider can reconstruct a TokenProvider for refresh.
+    val authCfg = extractAuthConfig(spark, catalogName)
+
     val tableProps = Map.empty[String, String]
 
-    UnityCatalogMetadata(catalogName, ucUri, ucToken, tableProps)
+    UnityCatalogMetadata(
+      catalogName, ucUri, ucToken, tableId, authCfg, tableProps)
+  }
+
+  /**
+   * Extract authentication config for UC credential providers.
+   * Reads spark.sql.catalog.<name>.auth.* configs. Falls back to
+   * legacy .token config converted to static type.
+   *
+   * The returned map keys are stripped of prefix (e.g., "type",
+   * "token", "oauth.uri"). These are set as fs.unitycatalog.auth.*
+   * in Hadoop config for GenericCredentialProvider to read.
+   */
+  private[serverSidePlanning] def extractAuthConfig(
+      spark: SparkSession,
+      catalogName: String): Map[String, String] = {
+    val catalogPrefix = s"spark.sql.catalog.$catalogName."
+    val authPrefix = s"${catalogPrefix}auth."
+
+    val newFormatConfig = spark.conf.getAll
+      .filterKeys(_.startsWith(authPrefix))
+      .map { case (fullKey, value) =>
+        (fullKey.stripPrefix(authPrefix), value)
+      }
+      .toMap
+
+    if (newFormatConfig.nonEmpty) {
+      newFormatConfig
+    } else {
+      // Legacy fallback: spark.sql.catalog.<name>.token -> static
+      val legacyToken = spark.conf.get(
+        s"${catalogPrefix}token", "")
+      if (legacyToken.nonEmpty) {
+        Map("type" -> "static", "token" -> legacyToken)
+      } else {
+        Map.empty
+      }
+    }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -275,6 +275,8 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
       catalogName = "test_catalog",
       ucUri = ucUri,
       ucToken = "test-token",
+      tableId = None,
+      authConfig = Map.empty,
       tableProps = Map.empty
     )
 
@@ -285,6 +287,61 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
       "https://unity-catalog-server.example.com/api/2.1/unity-catalog/" +
       "iceberg-rest/v1"
     assert(metadata.planningEndpointUri == expectedEndpoint)
+  }
+
+  test("extractAuthConfig returns new auth.* format config") {
+    val catalogName = "authTestCat"
+    withSQLConf(
+      s"spark.sql.catalog.$catalogName.auth.type" -> "oauth",
+      s"spark.sql.catalog.$catalogName.auth.oauth.uri" ->
+        "https://oauth.example.com/token",
+      s"spark.sql.catalog.$catalogName.auth.oauth.clientId" ->
+        "client123",
+      s"spark.sql.catalog.$catalogName.auth.oauth.clientSecret" ->
+        "secret456"
+    ) {
+      val config = UnityCatalogMetadata
+        .extractAuthConfig(spark, catalogName)
+      assert(config("type") == "oauth")
+      assert(config("oauth.uri") ==
+        "https://oauth.example.com/token")
+      assert(config("oauth.clientId") == "client123")
+      assert(config("oauth.clientSecret") == "secret456")
+      assert(config.size == 4)
+    }
+  }
+
+  test("extractAuthConfig returns legacy token as static") {
+    val catalogName = "legacyTokenCat"
+    withSQLConf(
+      s"spark.sql.catalog.$catalogName.token" -> "dapi-token"
+    ) {
+      val config = UnityCatalogMetadata
+        .extractAuthConfig(spark, catalogName)
+      assert(config("type") == "static")
+      assert(config("token") == "dapi-token")
+      assert(config.size == 2)
+    }
+  }
+
+  test("extractAuthConfig prefers new format over legacy") {
+    val catalogName = "precedenceCat"
+    withSQLConf(
+      s"spark.sql.catalog.$catalogName.auth.type" -> "static",
+      s"spark.sql.catalog.$catalogName.auth.token" ->
+        "new-token",
+      s"spark.sql.catalog.$catalogName.token" -> "old-token"
+    ) {
+      val config = UnityCatalogMetadata
+        .extractAuthConfig(spark, catalogName)
+      assert(config("token") == "new-token")
+    }
+  }
+
+  test("extractAuthConfig returns empty map when no auth") {
+    val config = UnityCatalogMetadata
+      .extractAuthConfig(spark, "nonExistentCatalog")
+    assert(config.isEmpty)
   }
 
   test("simple EqualTo filter pushed to planning client") {
@@ -500,7 +557,9 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
     }
 
     val table = new ServerSidePlannedTable(
-      spark, "test_db", "test_table", new org.apache.spark.sql.types.StructType(), trackingClient)
+      spark, "test_db", "test_table",
+      new org.apache.spark.sql.types.StructType(),
+      trackingClient, DefaultMetadata("test_catalog"))
     assert(!clientClosed, "Client should not be closed before table.close()")
     table.close()
     assert(clientClosed, "Client should be closed after table.close()")


### PR DESCRIPTION
## Summary

Replace static storage credentials with auto-refreshing UC credential providers. When SSP is enabled and UC metadata is available, storage credentials from the IRC `/plan` response are used as initial seeds and the UC credential providers (`AwsVendedTokenProvider`, `AbfsVendedTokenProvider`, `GcsVendedTokenProvider`) automatically refresh them by calling UC's `/temporary-table-credentials` endpoint before expiry (30s lead time).

### How it works
1. IRC `/plan` response returns initial storage credentials (S3/Azure/GCS)
2. Instead of setting static Hadoop config keys, we set UC provider class names + initial seeds + `fs.unitycatalog.*` connection keys
3. When Hadoop accesses a file, the UC provider uses the initial seeds
4. When seeds near expiry, the provider calls UC `/temporary-table-credentials` for fresh credentials
5. Falls back to static credentials if UC metadata is incomplete (non-UC catalogs, tests)

### Key changes
- `ServerSidePlanningMetadata`: add `ucUri`, `tableId`, `authConfig` for credential refresh
- `UnityCatalogMetadata`: extract table UUID from `io.unitycatalog.tableId` property, extract auth config from Spark session
- `ScanPlanStorageCredentials`: add `configureWithRefresh()` for UC providers
- `ServerSidePlannedFilePartitionReaderFactory`: `configureCredentialRefresh()` wires UC providers into Hadoop config
- Thread metadata through Table → ScanBuilder → Scan → ReaderFactory

### No new user-facing Spark configs
Existing configs provide everything needed:
- `spark.sql.catalog.<name>.uri` — UC endpoint
- `spark.sql.catalog.<name>.token` (or `auth.*`) — authentication
- `spark.databricks.delta.catalog.enableServerSidePlanning=true`

### No new compile-time dependencies
UC provider classes referenced by string name only. Loaded at runtime from `unitycatalog-spark` JAR.

## Test plan
- [ ] Existing SSP tests pass with updated signatures
- [ ] Static credential fallback works when UC metadata is missing
- [ ] E2E test with staging UC (verify auto-refresh via logs)

This pull request was AI-assisted by Isaac.