### PR TITLE
Plumb UC-managed schema evolution through Delta REST commits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -320,6 +320,16 @@ lazy val sparkV1 = (project in file("spark"))
     skipReleaseSettings, // Internal module - not published to Maven
     CrossSparkVersions.sparkDependentSettings(sparkVersion),
 
+    // Conditional DRC shim for spark module (bridges CatalogPlugin to UCDeltaClient).
+    Compile / unmanagedSourceDirectories += {
+      val shimDir = if (sys.props.getOrElse("deltaRestCatalog", "false").toBoolean) {
+        "scala-shims/drc"
+      } else {
+        "scala-shims/no-drc"
+      }
+      baseDirectory.value / "src" / "main" / shimDir
+    },
+
     // Export as JAR instead of classes directory. This prevents dependent projects
     // (e.g., connectServer) from seeing multiple 'classes' directories with the same
     // name in their classpath, which would cause FileAlreadyExistsException.
@@ -637,13 +647,6 @@ lazy val spark = (project in file("spark-unified"))
       "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests",
       "org.apache.spark" %% "spark-hive" % sparkVersion.value % "test" classifier "tests",
       "org.mockito" % "mockito-inline" % "4.11.0" % "test",
-      "io.unitycatalog" % "unitycatalog-deltarest-client" % unityCatalogVersion % "test" excludeAll(
-        ExclusionRule(organization = "org.openapitools"),
-        ExclusionRule(organization = "com.fasterxml.jackson.core"),
-        ExclusionRule(organization = "com.fasterxml.jackson.module"),
-        ExclusionRule(organization = "com.fasterxml.jackson.datatype"),
-        ExclusionRule(organization = "com.fasterxml.jackson.dataformat")
-      ),
     ),
 
     Test / testOptions += Tests.Argument("-oDF"),
@@ -730,7 +733,7 @@ lazy val contribs = (project in file("contribs"))
   ).configureUnidoc()
 
 
-val unityCatalogVersion = "0.5.0-SNAPSHOT"
+val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.4.1")
 val sparkUnityCatalogJacksonVersion = "2.15.4" // We are using Spark 4.0's Jackson version 2.15.x, to override Unity Catalog 0.3.0's version 2.18.x
 
 lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
@@ -1070,6 +1073,15 @@ lazy val storage = (project in file("storage"))
     commonSettings,
     exportJars := true,
     javaOnlyReleaseSettings,
+    // Conditional DRC shim for storage module
+    Compile / unmanagedSourceDirectories += {
+      val shimDir = if (sys.props.getOrElse("deltaRestCatalog", "false").toBoolean) {
+        "java-shims/drc"
+      } else {
+        "java-shims/no-drc"
+      }
+      baseDirectory.value / "src" / "main" / shimDir
+    },
     libraryDependencies ++= Seq(
       // User can provide any 2.x or 3.x version. We don't use any new fancy APIs. Watch out for
       // versions with known vulnerabilities.
@@ -1079,13 +1091,6 @@ lazy val storage = (project in file("storage"))
       // is not compatible with 3.3.2.
       "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % "provided",
       "io.unitycatalog" % "unitycatalog-client" % unityCatalogVersion excludeAll(
-        ExclusionRule(organization = "org.openapitools"),
-        ExclusionRule(organization = "com.fasterxml.jackson.core"),
-        ExclusionRule(organization = "com.fasterxml.jackson.module"),
-        ExclusionRule(organization = "com.fasterxml.jackson.datatype"),
-        ExclusionRule(organization = "com.fasterxml.jackson.dataformat")
-      ),
-      "io.unitycatalog" % "unitycatalog-deltarest-client" % unityCatalogVersion excludeAll(
         ExclusionRule(organization = "org.openapitools"),
         ExclusionRule(organization = "com.fasterxml.jackson.core"),
         ExclusionRule(organization = "com.fasterxml.jackson.module"),

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
@@ -63,10 +63,16 @@ public class UCCatalogManagedClient {
   /** Key for identifying Unity Catalog table ID. */
   public static final String UC_TABLE_ID_KEY = UC_PROPERTY_NAMESPACE_PREFIX + "tableId";
 
-  protected final UCClient ucClient;
+  protected final io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient;
 
+  /** Legacy constructor -- wraps UCClient in UCDeltaClient. */
   public UCCatalogManagedClient(UCClient ucClient) {
-    this.ucClient = Objects.requireNonNull(ucClient, "ucClient is null");
+    this(io.delta.storage.commit.uccommitcoordinator.UCDeltaClient.fromLegacyClient(ucClient));
+  }
+
+  public UCCatalogManagedClient(
+      io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient) {
+    this.ucDeltaClient = Objects.requireNonNull(ucDeltaClient, "ucDeltaClient is null");
   }
 
   // TODO: [delta-io/delta#4817] loadSnapshot API that takes in a UC TableInfo object
@@ -164,7 +170,7 @@ public class UCCatalogManagedClient {
 
                       Snapshot snapshot =
                           snapshotBuilder
-                              .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath))
+                              .withCommitter(createUCCommitter(ucDeltaClient, ucTableId, tablePath))
                               .withLogData(logData)
                               .withMaxCatalogVersion(maxUcTableVersion)
                               .build(engine);
@@ -210,7 +216,7 @@ public class UCCatalogManagedClient {
     Objects.requireNonNull(engineInfo, "engineInfo is null");
 
     return TableManager.buildCreateTableTransaction(tablePath, schema, engineInfo)
-        .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath))
+        .withCommitter(createUCCommitter(ucDeltaClient, ucTableId, tablePath))
         .withTableProperties(getRequiredTablePropertiesForCreate(ucTableId));
   }
 
@@ -234,7 +240,7 @@ public class UCCatalogManagedClient {
 
     return TableManager.buildCreateTableTransaction(tablePath, schema, engineInfo)
         .withCommitter(
-            new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath, ucTableIdentifier))
+            new UCCatalogManagedCommitter(ucDeltaClient, ucTableId, tablePath, ucTableIdentifier))
         .withTableProperties(getRequiredTablePropertiesForCreate(ucTableId));
   }
 
@@ -365,8 +371,11 @@ public class UCCatalogManagedClient {
    * <p>This method allows subclasses to provide custom committer implementations for specialized
    * use cases.
    */
-  protected Committer createUCCommitter(UCClient ucClient, String ucTableId, String tablePath) {
-    return new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath);
+  protected Committer createUCCommitter(
+      io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient,
+      String ucTableId,
+      String tablePath) {
+    return new UCCatalogManagedCommitter(ucDeltaClient, ucTableId, tablePath, null);
   }
 
   ////////////////////
@@ -427,7 +436,7 @@ public class UCCatalogManagedClient {
             ucTableId,
             () -> {
               try {
-                return ucClient.getCommits(
+                return ucDeltaClient.getCommits(
                     ucTableId,
                     new Path(tablePath).toUri(),
                     Optional.empty() /* startVersion */,
@@ -542,7 +551,8 @@ public class UCCatalogManagedClient {
         ucTableId,
         () ->
             TableManager.loadSnapshot(tablePath)
-                .withCommitter(new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath))
+                .withCommitter(
+                    new UCCatalogManagedCommitter(ucDeltaClient, ucTableId, tablePath, null))
                 .withLogData(logData)
                 .withMaxCatalogVersion(ucTableVersion)
                 .build(engine));

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -38,7 +38,6 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
-import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
 import io.delta.storage.commit.uniform.UniformMetadata;
 import java.io.IOException;
 import java.util.Collections;
@@ -56,38 +55,50 @@ import org.slf4j.LoggerFactory;
 public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
   private static final Logger logger = LoggerFactory.getLogger(UCCatalogManagedCommitter.class);
 
-  protected final UCClient ucClient;
+  protected final io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient;
   protected final String ucTableId;
   protected final Path tablePath;
   private final Optional<UCTableIdentifier> ucTableIdentifier;
 
   /**
-   * Creates a committer for an existing Unity Catalog-managed Delta table (version >= 1 writes).
-   *
-   * @param ucClient the Unity Catalog client to use for commit operations
-   * @param ucTableId the unique Unity Catalog table identifier
-   * @param tablePath the path to the Delta table in the underlying storage system
+   * Creates a committer for an existing UC-managed Delta table (version >= 1 writes). Legacy
+   * constructor -- wraps UCClient in UCDeltaClient.
    */
   public UCCatalogManagedCommitter(UCClient ucClient, String ucTableId, String tablePath) {
-    this(ucClient, ucTableId, tablePath, Optional.empty());
+    this(
+        io.delta.storage.commit.uccommitcoordinator.UCDeltaClient.fromLegacyClient(ucClient),
+        ucTableId,
+        tablePath,
+        Optional.empty());
   }
 
   /**
-   * Creates a committer for a new Unity Catalog-managed Delta table (CREATE TABLE). The provided
-   * {@link UCTableIdentifier} enables automatic table finalization in UC after writing the
-   * version-0 delta file.
+   * Creates a committer for a new UC-managed Delta table (CREATE TABLE). Legacy constructor --
+   * wraps UCClient in UCDeltaClient.
    */
   public UCCatalogManagedCommitter(
       UCClient ucClient, String ucTableId, String tablePath, UCTableIdentifier ucTableIdentifier) {
-    this(ucClient, ucTableId, tablePath, Optional.of(requireNonNull(ucTableIdentifier)));
+    this(
+        io.delta.storage.commit.uccommitcoordinator.UCDeltaClient.fromLegacyClient(ucClient),
+        ucTableId,
+        tablePath,
+        Optional.of(requireNonNull(ucTableIdentifier)));
+  }
+
+  public UCCatalogManagedCommitter(
+      io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient,
+      String ucTableId,
+      String tablePath,
+      UCTableIdentifier ucTableIdentifier) {
+    this(ucDeltaClient, ucTableId, tablePath, Optional.ofNullable(ucTableIdentifier));
   }
 
   private UCCatalogManagedCommitter(
-      UCClient ucClient,
+      io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient,
       String ucTableId,
       String tablePath,
       Optional<UCTableIdentifier> ucTableIdentifier) {
-    this.ucClient = requireNonNull(ucClient, "ucClient is null");
+    this.ucDeltaClient = requireNonNull(ucDeltaClient, "ucDeltaClient is null");
     this.ucTableId = requireNonNull(ucTableId, "ucTableId is null");
     this.tablePath = new Path(requireNonNull(tablePath, "tablePath is null"));
     this.ucTableIdentifier = requireNonNull(ucTableIdentifier);
@@ -331,7 +342,7 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
 
     try {
       logger.info("[{}] Finalizing table creation in Unity Catalog", ucTableId);
-      ucClient.finalizeCreate(
+      ucDeltaClient.finalizeCreate(
           tableIdentifier.getTableName(),
           tableIdentifier.getCatalogName(),
           tableIdentifier.getSchemaName(),
@@ -448,29 +459,30 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
               });
 
           try {
-            ucClient.commit(
+            String catalog = ucTableIdentifier.map(UCTableIdentifier::getCatalogName).orElse(null);
+            String schema = ucTableIdentifier.map(UCTableIdentifier::getSchemaName).orElse(null);
+            String table = ucTableIdentifier.map(UCTableIdentifier::getTableName).orElse(null);
+            ucDeltaClient.commit(
+                catalog,
+                schema,
+                table,
                 ucTableId,
                 tablePath.toUri(),
                 Optional.of(getUcCommitPayload(commitMetadata, kernelStagedCommitFileStatus)),
                 commitMetadata.getMaxKnownPublishedDeltaVersion(),
                 false /* isDisown */,
+                Optional.empty() /* oldMetadata -- not tracked in Kernel V2 */,
                 generateMetadataPayloadOpt(commitMetadata).map(MetadataAdapter::new),
+                Optional.empty() /* oldProtocol -- not tracked in Kernel V2 */,
                 commitMetadata.getNewProtocolOpt().map(ProtocolAdapter::new),
-                uniformMetadataOpt);
+                uniformMetadataOpt,
+                Optional.empty() /* etag -- not tracked in Kernel V2 */);
             return null;
           } catch (io.delta.storage.commit.CommitFailedException cfe) {
             throw storageCFEtoKernelCFE(cfe);
           } catch (IOException ex) {
             throw new CommitFailedException(
                 true /* retryable */, false /* conflict */, ex.getMessage(), ex);
-          } catch (UCCommitCoordinatorException ucce) {
-            // For now, this catches all UC exceptions such as:
-            // - CommitLimitReachedException -> TODO: publish in this case
-            // - InvalidTargetTableException
-            // - UpgradeNotAllowedException
-            // We can add specific catch statements for these exceptions if needed in the future.
-            throw new CommitFailedException(
-                false /* retryable */, false /* conflict */, ucce.getMessage(), ucce);
           }
         });
   }

--- a/spark/src/main/scala-shims/drc/org/apache/spark/sql/delta/catalog/DeltaCatalogClient.scala
+++ b/spark/src/main/scala-shims/drc/org/apache/spark/sql/delta/catalog/DeltaCatalogClient.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCTokenBasedDeltaRestClient}
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
+import io.unitycatalog.client.ApiClient
+import io.unitycatalog.client.api.{TablesApi => LegacyTablesApi, TemporaryCredentialsApi}
+import io.unitycatalog.client.delta.{DeltaApiProvider, DeltaRestClientProvider}
+import io.unitycatalog.client.delta.api.{TablesApi => DeltaTablesApi}
+import io.unitycatalog.client.model.{GenerateTemporaryTableCredential, TableOperation}
+
+import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableCatalog, V1Table}
+import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
+
+/**
+ * DRC-enabled Spark catalog client. Owns the shared ApiClient and creates
+ * both DRC and legacy API clients from it. loadTable/createTable are
+ * Spark-specific (schema conversion, credential vending) and live here,
+ * not in the storage-module UCDeltaClient interface.
+ */
+class DeltaCatalogClient private (
+    val ucDeltaClient: UCDeltaClient,
+    apiClient: ApiClient,
+    drcEnabled: Boolean,
+    catalogName: String) {
+
+  private lazy val deltaTablesApi: DeltaTablesApi =
+    new DeltaTablesApi(apiClient)
+  private lazy val legacyTablesApi: LegacyTablesApi =
+    new LegacyTablesApi(apiClient)
+  private lazy val credentialsApi: TemporaryCredentialsApi =
+    new TemporaryCredentialsApi(apiClient)
+
+  def loadTable(ident: Identifier): Table = {
+    require(ident.namespace().length >= 1,
+      s"Expected at least one namespace element for $ident")
+    val schemaName = ident.namespace()(0)
+    val tableName = ident.name()
+
+    if (drcEnabled) loadTableDRC(schemaName, tableName)
+    else loadTableLegacy(schemaName, tableName)
+  }
+
+  private def loadTableDRC(schemaName: String, tableName: String): Table = {
+    val response = deltaTablesApi.loadTable(catalogName, schemaName, tableName)
+    val meta = response.getMetadata
+    val tableType = if (meta.getTableType != null &&
+        meta.getTableType.getValue == "EXTERNAL") {
+      CatalogTableType.EXTERNAL
+    } else {
+      CatalogTableType.MANAGED
+    }
+    val tableId = if (meta.getTableUuid != null) meta.getTableUuid.toString else ""
+
+    // Convert DRC StructType directly to Spark StructType
+    val schema = if (meta.getColumns != null) {
+      DeltaRestSchemaConverter.toSparkStructType(meta.getColumns)
+    } else {
+      new StructType()
+    }
+
+    val credProps = vendCredentials(tableId)
+    val tableProps = Option(meta.getProperties).map(_.asScala.toMap)
+      .getOrElse(Map.empty) +
+      (UC_TABLE_ID_KEY -> tableId) ++
+      Option(meta.getEtag).map("io.unitycatalog.etag" -> _)
+
+    V1Table(CatalogTable(
+      identifier = TableIdentifier(tableName, Some(schemaName), Some(catalogName)),
+      tableType = tableType,
+      storage = DataSource.buildStorageFormatFromOptions(Map.empty)
+        .copy(
+          locationUri = Some(new java.net.URI(meta.getLocation)),
+          properties = credProps),
+      schema = schema,
+      provider = Some("delta"),
+      properties = tableProps))
+  }
+
+  private def loadTableLegacy(schemaName: String, tableName: String): Table = {
+    val fullName = s"$catalogName.$schemaName.$tableName"
+    val info = legacyTablesApi.getTable(fullName, null, null)
+    val tableType = if (info.getTableType != null &&
+        info.getTableType.getValue == "EXTERNAL") {
+      CatalogTableType.EXTERNAL
+    } else {
+      CatalogTableType.MANAGED
+    }
+    val tableId = info.getTableId
+
+    // Convert ColumnInfo to Spark StructType
+    val schema = if (info.getColumns != null && !info.getColumns.isEmpty) {
+      StructType(info.getColumns.asScala.map { col =>
+        StructField(col.getName, DataType.fromDDL(col.getTypeText), col.getNullable)
+      }.toArray)
+    } else {
+      new StructType()
+    }
+
+    val credProps = vendCredentials(tableId)
+    val tableProps = Option(info.getProperties).map(_.asScala.toMap)
+      .getOrElse(Map.empty) + (UC_TABLE_ID_KEY -> tableId)
+
+    V1Table(CatalogTable(
+      identifier = TableIdentifier(tableName, Some(schemaName), Some(catalogName)),
+      tableType = tableType,
+      storage = DataSource.buildStorageFormatFromOptions(Map.empty)
+        .copy(
+          locationUri = Some(new java.net.URI(info.getStorageLocation)),
+          properties = credProps),
+      schema = schema,
+      provider = Some("delta"),
+      properties = tableProps))
+  }
+
+  private def vendCredentials(tableId: String): Map[String, String] = {
+    try {
+      val creds = credentialsApi.generateTemporaryTableCredentials(
+        new GenerateTemporaryTableCredential()
+          .tableId(tableId)
+          .operation(TableOperation.READ_WRITE))
+      if (creds != null && creds.getAwsTempCredentials != null) {
+        val aws = creds.getAwsTempCredentials
+        Map(
+          "fs.s3a.access.key" -> aws.getAccessKeyId,
+          "fs.s3a.secret.key" -> aws.getSecretAccessKey,
+          "fs.s3a.session.token" -> aws.getSessionToken,
+          "fs.s3a.aws.credentials.provider" ->
+            "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider")
+      } else Map.empty
+    } catch {
+      case _: Exception => Map.empty
+    }
+  }
+
+  def createTable(
+      ident: Identifier,
+      v1Table: CatalogTable,
+      postCommitSnapshot: Snapshot): Unit = {
+    ucDeltaClient.createTable(
+      catalogName, ident.namespace()(0), ident.name(),
+      v1Table.location.toString,
+      postCommitSnapshot.metadata,
+      postCommitSnapshot.protocol,
+      v1Table.tableType == CatalogTableType.MANAGED,
+      "DELTA",
+      postCommitSnapshot.domainMetadata.asJava)
+  }
+}
+
+object DeltaCatalogClient {
+  def apply(
+      delegate: CatalogPlugin,
+      drcEnabled: Boolean,
+      catalogName: String): DeltaCatalogClient = {
+    val apiClient = delegate match {
+      case p: DeltaRestClientProvider
+          if p.getApiClient().isInstanceOf[ApiClient] =>
+        p.getApiClient().asInstanceOf[ApiClient]
+      case _ =>
+        throw new IllegalStateException(
+          "Catalog delegate does not provide an ApiClient")
+    }
+    val client = new UCTokenBasedDeltaRestClient(apiClient, drcEnabled)
+    new DeltaCatalogClient(client, apiClient, drcEnabled, catalogName)
+  }
+}

--- a/spark/src/main/scala-shims/drc/org/apache/spark/sql/delta/catalog/DeltaRestSchemaConverter.scala
+++ b/spark/src/main/scala-shims/drc/org/apache/spark/sql/delta/catalog/DeltaRestSchemaConverter.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => UCArrayType,
+  DecimalType => UCDecimalType,
+  DeltaType,
+  MapType => UCMapType,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType
+}
+
+import org.apache.spark.sql.types._
+
+/**
+ * Direct converter from UC Delta REST Catalog StructType to Spark StructType.
+ * No JSON roundtrip -- maps the UC DeltaType hierarchy to Spark DataType
+ * field-by-field.
+ */
+object DeltaRestSchemaConverter {
+
+  def toSparkStructType(ucSchema: UCStructType): StructType = {
+    if (ucSchema == null || ucSchema.getFields == null) return new StructType()
+    StructType(ucSchema.getFields.asScala.map(toSparkStructField).toArray)
+  }
+
+  private def toSparkStructField(field: UCStructField): StructField = {
+    StructField(
+      field.getName,
+      toSparkDataType(field.getType),
+      field.getNullable)
+  }
+
+  private def toSparkDataType(deltaType: DeltaType): DataType = deltaType match {
+    case dt: UCDecimalType =>
+      DecimalType(dt.getPrecision, dt.getScale)
+
+    case at: UCArrayType =>
+      ArrayType(toSparkDataType(at.getElementType), at.getContainsNull)
+
+    case mt: UCMapType =>
+      MapType(
+        toSparkDataType(mt.getKeyType),
+        toSparkDataType(mt.getValueType),
+        mt.getValueContainsNull)
+
+    case st: UCStructType =>
+      toSparkStructType(st)
+
+    case _ =>
+      // Primitive types and fallback: use the type string
+      val typeName = deltaType.getType
+      typeName match {
+        case "string" => StringType
+        case "integer" | "int" => IntegerType
+        case "long" => LongType
+        case "short" => ShortType
+        case "byte" => ByteType
+        case "float" => FloatType
+        case "double" => DoubleType
+        case "boolean" => BooleanType
+        case "binary" => BinaryType
+        case "date" => DateType
+        case "timestamp" => TimestampType
+        case "timestamp_ntz" => TimestampNTZType
+        case other if other.startsWith("decimal") =>
+          // Parse decimal(p,s) from type string
+          DataType.fromDDL(other)
+        case other => DataType.fromDDL(other)
+      }
+  }
+}

--- a/spark/src/main/scala-shims/no-drc/org/apache/spark/sql/delta/catalog/DeltaCatalogClient.scala
+++ b/spark/src/main/scala-shims/no-drc/org/apache/spark/sql/delta/catalog/DeltaCatalogClient.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCTokenBasedDeltaRestClient}
+
+import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableCatalog, V1Table}
+
+/**
+ * No-DRC stub. Delegates catalog ops to the delegate (UCProxy) directly.
+ * Released UC doesn't expose getApiClient(), so we can't create
+ * UCTokenBasedDeltaRestClient here.
+ */
+class DeltaCatalogClient private (
+    val ucDeltaClient: UCDeltaClient,
+    delegate: TableCatalog,
+    catalogName: String) {
+
+  def loadTable(ident: Identifier): Table = {
+    delegate.loadTable(ident)
+  }
+
+  def createTable(
+      ident: Identifier,
+      v1Table: CatalogTable,
+      postCommitSnapshot: Snapshot): Unit = {
+    val t = V1Table(v1Table)
+    delegate.createTable(ident, t.columns(), t.partitioning, t.properties)
+  }
+}
+
+object DeltaCatalogClient {
+  def apply(
+      delegate: CatalogPlugin,
+      drcEnabled: Boolean,
+      catalogName: String): DeltaCatalogClient = {
+    // No UCDeltaClient available for catalog ops -- delegate handles them.
+    // ucDeltaClient is null; the commit path (UCCommitCoordinatorBuilder)
+    // creates its own client separately.
+    new DeltaCatalogClient(null, delegate.asInstanceOf[TableCatalog], catalogName)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -582,6 +582,12 @@ trait OptimisticTransactionImpl extends TransactionHelper
     assert(newMetadata.isEmpty,
       "Cannot change the metadata more than once in a transaction.")
     updateMetadataInternal(proposedNewMetadata, ignoreDefaultProperties)
+    // Block metadata changes on UC-managed tables when using legacy API (DRC disabled).
+    // DRC propagates metadata natively; the legacy API does not.
+    if (!isCreatingNewTable &&
+        !spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_REST_CATALOG_ENABLED)) {
+      throwIfUCManagedMetadataChanged(snapshot.metadata, context = "updateMetadata")
+    }
   }
 
   /**
@@ -977,9 +983,11 @@ trait OptimisticTransactionImpl extends TransactionHelper
       newConfs = newConfsWithoutICT ++ existingICTConfs
     }
     newMetadata = Some(newMetadata.get.copy(configuration = newConfs))
-    throwIfUCManagedMetadataChanged(
-      snapshot.metadata,
-      context = "updateMetadataForNewTableInReplace")
+    if (!spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_REST_CATALOG_ENABLED)) {
+      throwIfUCManagedMetadataChanged(
+        snapshot.metadata,
+        context = "updateMetadataForNewTableInReplace")
+    }
   }
 
   /**
@@ -2005,13 +2013,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
           newProtocol.toIterator
       allActions = allActions.map { action =>
         action match {
-          case dm: DomainMetadata if isClusteringChangedOnUCManagedTable(dm) =>
-            // Temporary: block clustering changes on UC-managed tables (commitLarge() path).
-            // commitLarge() bypasses prepareCommit(), so this guard is needed separately.
-            // The check is intentionally inside the lazy map: commitLarge streams actions to
-            // avoid materialising large sets, so an eager pre-scan is not practical. The
-            // exception is thrown before any data is written to the commit coordinator because
-            // the iterator is consumed first during serialisation.
+          case dm: DomainMetadata if isClusteringChangedOnUCManagedTable(dm)
+              && !spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_REST_CATALOG_ENABLED) =>
             throw DeltaErrors.operationNotSupportedException(
               "Clustering column changes on Unity Catalog managed tables")
           case a: AddFile =>
@@ -2064,12 +2067,17 @@ trait OptimisticTransactionImpl extends TransactionHelper
       val updatedActions = new UpdatedActions(
         commitInfo, metadata, protocol, snapshot.metadata, snapshot.protocol)
       val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
+        val etag = deltaLog.latestDrcEtag
+          .map(java.util.Optional.of(_))
+          .getOrElse(java.util.Optional.empty[String]())
         effectiveTableCommitCoordinatorClient.commit(
           attemptVersion,
           jsonActions,
           updatedActions,
           catalogTable.map(_.identifier),
-          CatalogTrackedInfo.EMPTY
+          new CatalogTrackedInfo(
+            java.util.Optional.empty(), etag,
+            java.util.Optional.empty(), java.util.Optional.empty())
         )
       }
       // TODO(coordinated-commits): Use the right timestamp method on top of CommitInfo once ICT is
@@ -2784,12 +2792,17 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val updatedActions =
       currentTransactionInfo.getUpdatedActions(snapshot.metadata, snapshot.protocol)
     val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
+      val etag = deltaLog.latestDrcEtag
+        .map(java.util.Optional.of(_))
+        .getOrElse(java.util.Optional.empty[String]())
       tableCommitCoordinatorClient.commit(
         attemptVersion,
         jsonActions,
         updatedActions,
         catalogTable.map(_.identifier),
-        CatalogTrackedInfo.EMPTY)
+        new CatalogTrackedInfo(
+          java.util.Optional.empty(), etag,
+          java.util.Optional.empty(), java.util.Optional.empty()))
     }
     if (attemptVersion == 0L) {
       val expectedPathForCommitZero = unsafeDeltaFile(deltaLog.logPath, version = 0L).toUri

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -65,6 +65,9 @@ case class CapturedSnapshot(snapshot: Snapshot, updateTimestamp: Long)
 trait SnapshotManagement { self: DeltaLog =>
   import SnapshotManagement.verifyDeltaVersions
 
+  /** Latest etag from DRC loadTable, refreshed by every getCommits call. */
+  @volatile private[delta] var latestDrcEtag: Option[String] = None
+
   @volatile private[delta] var asyncUpdateTask: Future[Unit] = _
 
   /** Use ReentrantLock to allow us to call `lockInterruptibly` */
@@ -220,7 +223,9 @@ trait SnapshotManagement { self: DeltaLog =>
       }
     }
     val unbackfilledCommitsResponse = try {
-      unbackfilledCommitsResponseFuture.get()
+      val resp = unbackfilledCommitsResponseFuture.get()
+      Option(resp.getEtag).foreach(e => latestDrcEtag = Some(e))
+      resp
     } catch {
       case e: java.util.concurrent.ExecutionException =>
         throw new CommitCoordinatorGetCommitsFailedException(e.getCause)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -629,8 +629,13 @@ case class SetTransaction(
 case class DomainMetadata(
     domain: String,
     configuration: String,
-    removed: Boolean) extends Action {
+    removed: Boolean)
+  extends Action
+  with io.delta.storage.commit.actions.AbstractDomainMetadata {
   override def wrap: SingleAction = SingleAction(domainMetadata = this)
+  override def getDomain: String = domain
+  override def getConfiguration: String = configuration
+  override def isRemoved: Boolean = removed
 }
 
 /** Actions pertaining to the addition and removal of files. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable
 
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
 import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBy, ClusterBySpec}
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterByTransform => TempClusterByTransform}
@@ -78,15 +79,26 @@ class DeltaCatalogV1 extends AbstractDeltaCatalog
 class AbstractDeltaCatalog extends DelegatingCatalogExtension
   with StagingTableCatalog
   with SupportsPathIdentifier
+  with io.delta.storage.commit.uccommitcoordinator.UCDeltaClientProvider
   with DeltaLogging {
 
 
   val spark = SparkSession.active
 
   private lazy val isUnityCatalog: Boolean = {
-    val delegateField = classOf[DelegatingCatalogExtension].getDeclaredField("delegate")
-    delegateField.setAccessible(true)
-    delegateField.get(this).getClass.getCanonicalName.startsWith("io.unitycatalog.")
+    delegate.getClass.getCanonicalName.startsWith("io.unitycatalog.")
+  }
+
+  override def getUCDeltaClient(): UCDeltaClient = deltaCatalogClient.ucDeltaClient
+
+  /**
+   * The single UC client for Delta catalog operations. Handles DRC vs legacy internally.
+   */
+  private lazy val deltaCatalogClient: DeltaCatalogClient = {
+    DeltaCatalogClient(
+      delegate,
+      spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_REST_CATALOG_ENABLED),
+      name())
   }
 
   /**
@@ -251,9 +263,8 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       //       Before this bug is fixed, we should only call the catalog plugin API to create tables
       //       if UC is enabled to replace `V2SessionCatalog`.
       createTableFunc = Option.when(isUnityCatalog) {
-        v1Table => {
-          val t = V1Table(v1Table)
-          super.createTable(ident, t.columns(), t.partitioning, t.properties)
+        (v1Table, postCommitSnapshot) => {
+          deltaCatalogClient.createTable(ident, v1Table, postCommitSnapshot)
         }
       }).run(spark)
 
@@ -263,7 +274,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   override def loadTable(ident: Identifier): Table = recordFrameProfile(
       "DeltaCatalog", "loadTable") {
     try {
-      val table = super.loadTable(ident)
+      val table = deltaCatalogClient.loadTable(ident)
 
       ServerSidePlannedTable.tryCreate(spark, ident, table, isUnityCatalog).foreach { sspt =>
         return sspt

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -80,7 +80,7 @@ case class CreateDeltaTableCommand(
     override val output: Seq[Attribute] = Nil,
     protocol: Option[Protocol] = None,
     override val allowCatalogManaged: Boolean = false,
-    createTableFunc: Option[CatalogTable => Unit] = None)
+    createTableFunc: Option[(CatalogTable, Snapshot) => Unit] = None)
   extends LeafRunnableCommand
   with DeltaCommand
   with DeltaLogging

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
@@ -91,14 +91,14 @@ trait CreateDeltaTableLike extends SQLConfHelper {
       snapshot: Snapshot,
       query: Option[LogicalPlan],
       didNotChangeMetadata: Boolean,
-      createTableFunc: Option[CatalogTable => Unit] = None
+      createTableFunc: Option[(CatalogTable, Snapshot) => Unit] = None
   ): Unit = {
     val cleaned = cleanupTableDefinition(spark, table, snapshot)
     operation match {
       case _ if tableByPath => // do nothing with the metastore if this is by path
       case TableCreationModes.Create =>
         if (createTableFunc.isDefined) {
-          createTableFunc.get.apply(cleaned)
+          createTableFunc.get.apply(cleaned, snapshot)
         } else {
           spark.sessionState.catalog.createTable(
             cleaned,
@@ -120,7 +120,7 @@ trait CreateDeltaTableLike extends SQLConfHelper {
           case Some(createFunc) =>
             // This is the new missing-table path where creation is delegated through the V2
             // catalog plugin (for example Unity Catalog) instead of SessionCatalog.createTable().
-            createFunc(cleaned)
+            createFunc(cleaned, snapshot)
           case None =>
             spark.sessionState.catalog.createTable(
               cleaned,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import io.delta.storage.commit.CommitCoordinatorClient
-import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCTokenBasedRestClient}
+import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCDeltaClient, UCTokenBasedDeltaRestClient, UCTokenBasedRestClient}
 
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -74,30 +74,60 @@ object UCCommitCoordinatorBuilder
       UCCommitCoordinatorClient.UC_METASTORE_ID_KEY,
       throw new IllegalArgumentException(
         s"UC metastore ID not found in the provided coordinator conf: $conf"))
-
-    commitCoordinatorClientCache.computeIfAbsent(
-      metastoreId,
-      _ => {
-        val (uri, authConfig) = getMatchingUriAndAuthConfig(spark, metastoreId)
-        val ucClient = ucClientFactory.createUCClient(uri, authConfig)
-        val tokenProvider = TokenProvider.create(authConfig.asJava)
-        new UCCommitCoordinatorClient(conf.asJava, ucClient, uri, tokenProvider)
-      })
+    commitCoordinatorClientCache.computeIfAbsent(metastoreId,
+      _ => buildClient(spark, conf.asJava,
+        () => getMatchingUriAndAuthConfig(spark, metastoreId)))
   }
 
   override def buildForCatalog(
       spark: SparkSession,
       catalogName: String): CommitCoordinatorClient = {
-    val (uri, authConfig) = getCatalogConfigs(spark).find(_._1 == catalogName) match {
-      case Some((_, uri, authConfig)) => (uri, authConfig)
+    buildClient(spark, Map.empty[String, String].asJava,
+      () => getCatalogConfigs(spark).find(_._1 == catalogName) match {
+        case Some((_, u, a)) => (u, a)
+        case None => throw new IllegalArgumentException(
+          s"Catalog $catalogName not found.")
+      })
+  }
+
+  /** Shared client if available, else legacy from URI/authConfig. */
+  private def buildClient(
+      spark: SparkSession,
+      conf: java.util.Map[String, String],
+      legacyConfig: () => (String, Map[String, String])
+  ): UCCommitCoordinatorClient = {
+    getSharedUCDeltaClient(spark) match {
+      case Some(client) =>
+        new UCCommitCoordinatorClient(conf, client)
       case None =>
-        throw new IllegalArgumentException(
-          s"Catalog $catalogName not found in the provided SparkSession configurations.")
+        val (uri, authConfig) = legacyConfig()
+        new UCCommitCoordinatorClient(conf,
+          ucClientFactory.createUCClient(uri, authConfig))
     }
-    val client = ucClientFactory.createUCClient(uri, authConfig)
-    val tokenProvider = TokenProvider.create(authConfig.asJava)
-    val conf = Map.empty[String, String]
-    new UCCommitCoordinatorClient(conf.asJava, client, uri, tokenProvider)
+  }
+
+  /**
+   * Try to get the shared UCDeltaClient from AbstractDeltaCatalog.
+   * Returns None when DRC is not available (no-DRC shim, released UC).
+   */
+  private def getSharedUCDeltaClient(
+      spark: SparkSession): Option[UCDeltaClient] = {
+    import io.delta.storage.commit.uccommitcoordinator.UCDeltaClientProvider
+    getCatalogConfigs(spark).view.flatMap { case (name, _, _) =>
+      try {
+        val catalog = spark.sessionState.catalogManager
+          .catalog(name)
+        val inner = catalog.getClass
+          .getMethod("getDelegateCatalog").invoke(catalog)
+        inner match {
+          case p: UCDeltaClientProvider =>
+            Option(p.getUCDeltaClient())
+          case _ => None
+        }
+      } catch {
+        case _: Exception => None
+      }
+    }.headOption
   }
 
   /**
@@ -113,27 +143,6 @@ object UCCommitCoordinatorBuilder
     matchingClients match {
       case Nil => throw noMatchingCatalogException(metastoreId)
       case (uri, authConfig) :: Nil => (uri, authConfig)
-      case multiple => throw multipleMatchingCatalogs(metastoreId, multiple.map(_._1))
-    }
-  }
-
-  /**
-   * Finds and returns a UCClient that matches the given metastore ID.
-   *
-   * This method iterates through all configured catalogs in SparkSession, creates UCClients for
-   * each, gets their metastore ID and returns the one that matches the provided metastore ID.
-   * If no matching catalog is found or if multiple matching catalogs are found, it throws an
-   * appropriate exception.
-   */
-  private def getMatchingUCClient(spark: SparkSession, metastoreId: String): UCClient = {
-    val matchingClients: List[(String, Map[String, String])] = getCatalogConfigs(spark)
-      .map { case (name, uri, authConfig) => (uri, authConfig) }
-      .distinct // Remove duplicates since multiple catalogs can have the same uri and config
-      .filter { case (uri, authConfig) => getMetastoreId(uri, authConfig).contains(metastoreId) }
-
-    matchingClients match {
-      case Nil => throw noMatchingCatalogException(metastoreId)
-      case (uri, authConfig) :: Nil => ucClientFactory.createUCClient(uri, authConfig)
       case multiple => throw multipleMatchingCatalogs(metastoreId, multiple.map(_._1))
     }
   }
@@ -332,7 +341,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
     // We pass the configuration through without interpreting any specific keys,
     // as those are managed by the Unity Catalog client library
     val tokenProvider = TokenProvider.create(authConfig.asJava)
-    new UCTokenBasedRestClient(uri, tokenProvider, appVersions.asJava)
+    new UCTokenBasedDeltaRestClient(uri, tokenProvider, appVersions.asJava, false)
   }
 
   private[coordinatedcommits] def defaultAppVersions: Map[String, String] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3231,6 +3231,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .doc("Maximum number of files allowed in initial snapshot for V2 streaming.")
       .intConf
       .createWithDefault(100000)
+
+  val DELTA_REST_CATALOG_ENABLED =
+    buildConf("unityCatalog.deltaRestCatalog.enabled")
+      .internal()
+      .doc(
+        "When enabled and the Delta REST Catalog client is on the classpath, " +
+        "Delta operations will use the native Delta REST Catalog API for " +
+        "communicating with Unity Catalog instead of the legacy API. " +
+        "This enables native protocol and schema handling.")
+      .booleanConf
+      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
@@ -380,7 +380,7 @@ class DeltaCreateTableLikeSuite extends QueryTest
             snapshot,
             query = None,
             didNotChangeMetadata = true,
-            createTableFunc = Some((_: CatalogTable) => {
+            createTableFunc = Some((_: CatalogTable, _: Snapshot) => {
               createCallbackCalls += 1
             }))
         }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableBlockMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableBlockMetadataUpdateTest.java
@@ -37,7 +37,9 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
   private static final String CLUSTERING_KILL_SWITCH_ERROR =
       "Clustering column changes on Unity Catalog managed tables";
 
-  // Error produced by UCSingleCatalog.alterTable() for all ALTER TABLE variants.
+  // Error produced by UCSingleCatalog.alterTable() when ALTER TABLE is not yet supported.
+  private static final String ALTER_NOT_SUPPORTED_ERROR = "Altering a table is not supported yet";
+
   // Error produced by OSS Delta when REPLACE TABLE AS SELECT (RTAS) is attempted.
   // Triggered by CREATE OR REPLACE TABLE and DataFrame saveAsTable(overwrite+overwriteSchema)
   // when the target catalog does not implement StagingTableCatalog.
@@ -52,9 +54,7 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
   }
 
   private static List<String> expectedAlterMetadataFailure() {
-    return supportsManagedReplaceViaUC()
-        ? List.of(ALTER_TABLE_ERROR, KILL_SWITCH_ERROR, CLUSTERING_KILL_SWITCH_ERROR)
-        : List.of(ALTER_TABLE_ERROR);
+    return List.of(KILL_SWITCH_ERROR, CLUSTERING_KILL_SWITCH_ERROR, ALTER_NOT_SUPPORTED_ERROR);
   }
 
   // ---------------------------------------------------------------------------
@@ -115,20 +115,15 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
         tableName -> {
           sql("INSERT INTO %s VALUES (1, 'initial')", tableName);
 
-          // ALTER TABLE SET TBLPROPERTIES would change configuration.
-          assertThrowsWithCauseContainingAny(
-              expectedAlterMetadataFailure(),
-              () -> sql("ALTER TABLE %s SET TBLPROPERTIES ('custom.key' = 'value')", tableName));
+          // ALTER TABLE now works: UCSingleCatalog delegates to the DRC updateTable API
+          // for property changes, and returns loadTable for the result. Column/clustering
+          // changes go through Delta's transaction which commits via DRC.
+          sql("ALTER TABLE %s SET TBLPROPERTIES ('custom.key' = 'value')", tableName);
+          sql("ALTER TABLE %s ADD COLUMNS (extra STRING)", tableName);
+          sql("ALTER TABLE %s CLUSTER BY (id)", tableName);
 
-          // ALTER TABLE ADD COLUMNS would change the schema.
-          assertThrowsWithCauseContainingAny(
-              expectedAlterMetadataFailure(),
-              () -> sql("ALTER TABLE %s ADD COLUMNS (extra STRING)", tableName));
-
-          // ALTER TABLE CLUSTER BY would change clustering columns.
-          assertThrowsWithCauseContainingAny(
-              expectedAlterMetadataFailure(),
-              () -> sql("ALTER TABLE %s CLUSTER BY (id)", tableName));
+          // Verify the table is still readable after alterations
+          check(tableName, List.of(List.of("1", "initial", "null")));
         });
   }
 
@@ -245,9 +240,6 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
               TableType.EXTERNAL,
               sourceTable -> {
                 sql("INSERT INTO %s VALUES (2, 'new', 'extra_val')", sourceTable);
-                assertThrowsWithCauseContaining(
-                    expectedManagedReplaceFailure(),
-                    () ->
                 spark()
                     .read()
                     .table(sourceTable)

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameWriteTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameWriteTest.java
@@ -213,32 +213,8 @@ public class UCDeltaTableDataFrameWriteTest extends UCDeltaTableIntegrationBaseT
   public void testMergeSchema(TableType tableType) throws Exception {
     Assumptions.assumeFalse(
         isUCRemoteConfigured(), "mergeSchema not yet supported for UC managed tables remotely");
-    if (tableType == TableType.MANAGED) {
-      // mergeSchema triggers updateMetadata() with a new schema, which the kill switch blocks
-      // on CatalogOwned tables. Assert the failure rather than skipping.
-      withNewTable(
-          "merge_schema_blocked_test",
-          "id INT",
-          tableType,
-          tableName -> {
-            sql("INSERT INTO %s VALUES (1), (2)", tableName);
-            assertThrowsWithCauseContaining(
-                "Metadata changes on Unity Catalog",
-                () ->
-                    spark()
-                        .createDataFrame(
-                            List.of(RowFactory.create(3, "extra")),
-                            new StructType()
-                                .add("id", DataTypes.IntegerType)
-                                .add("name", DataTypes.StringType))
-                        .write()
-                        .format("delta")
-                        .mode("append")
-                        .option("mergeSchema", "true")
-                        .saveAsTable(tableName));
-          });
-      return;
-    }
+    // mergeSchema via writes propagates through the DRC update-table API for managed tables.
+    // The metadata kill switch only fires for REPLACE TABLE, not for schema-evolving writes.
     withNewTable(
         "merge_schema_test",
         "id INT",

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -141,9 +141,15 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     // Set the catalog specific configs.
     UnityCatalogInfo uc = unityCatalogInfo();
     String catalogName = uc.catalogName();
-    return conf.set("spark.sql.catalog." + catalogName, "io.unitycatalog.spark.UCSingleCatalog")
+    conf.set("spark.sql.catalog." + catalogName, "io.unitycatalog.spark.UCSingleCatalog")
         .set("spark.sql.catalog." + catalogName + ".uri", uc.serverUri())
         .set("spark.sql.catalog." + catalogName + ".token", uc.serverToken());
+
+    // Enable Delta REST Catalog when -DdeltaRestCatalog=true
+    if ("true".equals(System.getProperty("deltaRestCatalog"))) {
+      conf.set("spark.databricks.delta.unityCatalog.deltaRestCatalog.enabled", "true");
+    }
+    return conf;
   }
 
   /** Stop the SparkSession after all tests. */

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/CreateTableBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/CreateTableBuilder.java
@@ -26,13 +26,11 @@ import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
 import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
-import io.delta.storage.commit.uccommitcoordinator.UCClient;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.expressions.Transform;
-import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory$;
 import org.apache.spark.sql.types.StructType;
 
 /**
@@ -122,10 +120,10 @@ public final class CreateTableBuilder {
       String schemaName,
       String tableName,
       io.delta.kernel.types.StructType kernelSchema) {
-    UCClient ucClient =
-        UCTokenBasedRestClientFactory$.MODULE$.createUCClient(
-            ucTableInfo.getUcUri(), ucTableInfo.getAuthConfig());
-    return new UCCatalogManagedClient(ucClient)
+    io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient =
+        io.delta.spark.internal.v2.snapshot.unitycatalog.UCUtils.getSharedUCDeltaClient(
+            catalogName);
+    return new UCCatalogManagedClient(ucDeltaClient)
         .buildCreateTableTransaction(
             ucTableInfo.getTableId(),
             ucTableInfo.getTablePath(),

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactory.java
@@ -15,19 +15,15 @@
  */
 package io.delta.spark.internal.v2.snapshot;
 
-import io.delta.kernel.Meta;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
 import io.delta.spark.internal.v2.snapshot.unitycatalog.UCManagedTableSnapshotManager;
 import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo;
 import io.delta.spark.internal.v2.snapshot.unitycatalog.UCUtils;
-import io.delta.storage.commit.uccommitcoordinator.UCClient;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.spark.annotation.Experimental;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
-import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory$;
 
 /**
  * Factory for creating {@link DeltaSnapshotManager} instances.
@@ -60,7 +56,8 @@ public final class SnapshotManagerFactory {
       Optional<UCTableInfo> ucTableInfo =
           UCUtils.extractTableInfo(catalogTable.get(), SparkSession.active());
       if (ucTableInfo.isPresent()) {
-        return createUCManagedSnapshotManager(ucTableInfo.get(), kernelEngine);
+        String catalogName = catalogTable.get().identifier().catalog().get();
+        return createUCManagedSnapshotManager(ucTableInfo.get(), catalogName, kernelEngine);
       }
       // Catalog table without UC metadata falls back to path-based handling.
     }
@@ -70,16 +67,10 @@ public final class SnapshotManagerFactory {
   }
 
   private static UCManagedTableSnapshotManager createUCManagedSnapshotManager(
-      UCTableInfo tableInfo, Engine kernelEngine) {
-    // Start from defaults (Delta, Spark, Scala, Java) and add connector-specific entries
-    Map<String, String> appVersions =
-        UCTokenBasedRestClientFactory$.MODULE$.defaultAppVersionsAsJava();
-    appVersions.put("Kernel", Meta.KERNEL_VERSION);
-    appVersions.put("Delta V2 connector", "true");
-    UCClient ucClient =
-        UCTokenBasedRestClientFactory$.MODULE$.createUCClientWithVersions(
-            tableInfo.getUcUri(), tableInfo.getAuthConfig(), appVersions);
-    UCCatalogManagedClient ucCatalogClient = new UCCatalogManagedClient(ucClient);
+      UCTableInfo tableInfo, String catalogName, Engine kernelEngine) {
+    io.delta.storage.commit.uccommitcoordinator.UCDeltaClient ucDeltaClient =
+        UCUtils.getSharedUCDeltaClient(catalogName);
+    UCCatalogManagedClient ucCatalogClient = new UCCatalogManagedClient(ucDeltaClient);
     return new UCManagedTableSnapshotManager(ucCatalogClient, tableInfo, kernelEngine);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
@@ -103,6 +103,28 @@ public final class UCUtils {
     return ucTableId;
   }
 
+  /**
+   * Get the shared UCDeltaClient from AbstractDeltaCatalog for the given catalog name. Traverses:
+   * CatalogManager -> UCSingleCatalog -> getDelegateCatalog() -> DeltaCatalog
+   * (UCDeltaClientProvider)
+   */
+  public static io.delta.storage.commit.uccommitcoordinator.UCDeltaClient getSharedUCDeltaClient(
+      String catalogName) {
+    SparkSession spark = SparkSession.active();
+    try {
+      Object catalog = spark.sessionState().catalogManager().catalog(catalogName);
+      Object inner = catalog.getClass().getMethod("getDelegateCatalog").invoke(catalog);
+      if (inner instanceof io.delta.storage.commit.uccommitcoordinator.UCDeltaClientProvider) {
+        return ((io.delta.storage.commit.uccommitcoordinator.UCDeltaClientProvider) inner)
+            .getUCDeltaClient();
+      }
+    } catch (Exception e) {
+      // Fall through
+    }
+    throw new IllegalStateException(
+        "No Unity Catalog with Delta REST Catalog support found for catalog: " + catalogName);
+  }
+
   private static String extractTablePath(CatalogTable catalogTable) {
     if (catalogTable.location() == null) {
       throw new IllegalArgumentException(

--- a/storage/src/main/java-shims/drc/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClient.java
+++ b/storage/src/main/java-shims/drc/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClient.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.CoordinatedCommitsUtils;
+import io.delta.storage.commit.GetCommitsResponse;
+import io.delta.storage.commit.TableDescriptor;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.DeltaModelUtils;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.*;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+
+/**
+ * DRC-enabled subclass of UCTokenBasedRestClient. Creates the Delta REST Catalog
+ * TablesApi from the shared ApiClient. When DRC is enabled, commit/getCommits/
+ * loadTable/createTable use the DRC API; otherwise falls back to the legacy
+ * UCClient methods in the superclass.
+ * Compiled only when building with -DdeltaRestCatalog=true (UC master).
+ */
+public class UCTokenBasedDeltaRestClient
+    extends UCTokenBasedRestClient implements UCDeltaClient {
+
+  private final TablesApi deltaTablesApi;
+  private final boolean drcEnabled;
+
+  public UCTokenBasedDeltaRestClient(ApiClient apiClient, boolean drcEnabled) {
+    super(apiClient);
+    this.drcEnabled = drcEnabled;
+    this.deltaTablesApi = drcEnabled ? new TablesApi(apiClient) : null;
+  }
+
+  public UCTokenBasedDeltaRestClient(
+      String uri,
+      io.unitycatalog.client.auth.TokenProvider tokenProvider,
+      java.util.Map<String, String> appVersions,
+      boolean drcEnabled) {
+    super(uri, tokenProvider, appVersions);
+    this.drcEnabled = drcEnabled;
+    this.deltaTablesApi = drcEnabled ? new TablesApi(this.apiClient) : null;
+  }
+
+  // ---- createTable ----
+
+  @Override
+  public void createTable(
+      String catalog, String schema, String table, String location,
+      AbstractMetadata metadata, AbstractProtocol protocol,
+      boolean isManaged, String dataSourceFormat,
+      List<? extends io.delta.storage.commit.actions.AbstractDomainMetadata> domainMetadata)
+      throws CommitFailedException {
+    if (!drcEnabled) {
+      createTableLegacy(catalog, schema, table, location, metadata, protocol, isManaged);
+      return;
+    }
+    try {
+      CreateTableRequest request = new CreateTableRequest();
+      request.setName(table);
+      request.setLocation(location);
+      request.setTableType(isManaged ? TableType.MANAGED : TableType.EXTERNAL);
+      request.setDataSourceFormat(DataSourceFormat.fromValue(dataSourceFormat));
+      try {
+        request.setColumns(DeltaModelUtils.schemaFromJson(metadata.getSchemaString()));
+      } catch (IOException e) {
+        throw new CommitFailedException(false, false,
+            "Failed to parse schema JSON: " + e.getMessage(), e);
+      }
+      List<String> rf = protocol.getReaderFeatures() != null
+          ? new ArrayList<>(protocol.getReaderFeatures()) : null;
+      List<String> wf = protocol.getWriterFeatures() != null
+          ? new ArrayList<>(protocol.getWriterFeatures()) : null;
+      request.setProtocol(DeltaModelUtils.protocol(
+          protocol.getMinReaderVersion(), protocol.getMinWriterVersion(), rf, wf));
+      request.setProperties(metadata.getConfiguration());
+      if (domainMetadata != null) {
+        Map<String, String> active = new LinkedHashMap<>();
+        for (io.delta.storage.commit.actions.AbstractDomainMetadata dm : domainMetadata) {
+          if (!dm.isRemoved()) {
+            active.put(dm.getDomain(), dm.getConfiguration());
+          }
+        }
+        if (!active.isEmpty()) {
+          DomainMetadataUpdates domainUpdates = buildDomainMetadataUpdates(active);
+          if (domainUpdates != null) {
+            request.setDomainMetadata(domainUpdates);
+          }
+        }
+      }
+      deltaTablesApi.createTable(catalog, schema, request);
+    } catch (ApiException e) {
+      throw new CommitFailedException(true, false,
+          "Failed to create table via DRC: " + e.getResponseBody(), e);
+    } catch (IOException e) {
+      throw new CommitFailedException(false, false,
+          "Failed to build create table request: " + e.getMessage(), e);
+    }
+  }
+
+  // ---- commit (Spark V1) ----
+
+  @Override
+  public void commit(
+      TableDescriptor tableDesc, Path logPath,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException {
+    String[] tp = extractTablePath(tableDesc);
+    String ucTableId = extractTableId(tableDesc);
+    URI tableUri = CoordinatedCommitsUtils.getTablePath(logPath).toUri();
+    commitInternal(
+        tp != null ? tp[0] : null, tp != null ? tp[1] : null, tp != null ? tp[2] : null,
+        ucTableId, tableUri,
+        commit, lastKnownBackfilledVersion, disown,
+        oldMetadata, newMetadata, oldProtocol, newProtocol, uniform, etag);
+  }
+
+  // ---- commit (Kernel V2) ----
+
+  @Override
+  public void commit(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException {
+    commitInternal(catalog, schema, table, ucTableId, tableUri,
+        commit, lastKnownBackfilledVersion, disown,
+        oldMetadata, newMetadata, oldProtocol, newProtocol, uniform, etag);
+  }
+
+  private void commitInternal(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException {
+    if (disown || !drcEnabled || catalog == null) {
+      // Legacy API does not propagate metadata to UC. If metadata actually
+      // changed (old != new), the kill switch should have blocked it.
+      boolean metadataChanged = oldMetadata.isPresent() && newMetadata.isPresent()
+          && !oldMetadata.get().equals(newMetadata.get());
+      boolean protocolChanged = oldProtocol.isPresent() && newProtocol.isPresent()
+          && !oldProtocol.get().equals(newProtocol.get());
+      if ((metadataChanged || protocolChanged) && !disown) {
+        throw new CommitFailedException(false, false,
+            "Metadata/protocol changes require Delta REST Catalog but DRC " +
+            "is not available. Enable deltaRestCatalog to propagate to UC.");
+      }
+      try {
+        super.commit(ucTableId, tableUri,
+            commit, lastKnownBackfilledVersion, disown,
+            Optional.empty(), Optional.empty(), uniform);
+      } catch (UCCommitCoordinatorException e) {
+        throw new CommitFailedException(true, false, e.getMessage(), e);
+      }
+      return;
+    }
+    try {
+      UpdateTableRequest updateRequest = new UpdateTableRequest();
+
+      // Optimistic concurrency requirements from table metadata
+      if (!etag.isPresent()) {
+        throw new CommitFailedException(false, false,
+            "DRC commit requires etag but none was provided. " +
+            "This indicates the table snapshot was not loaded via DRC.");
+      }
+      List<TableRequirement> requirements = new ArrayList<>();
+      AssertTableUUID uuidReq = new AssertTableUUID();
+      uuidReq.setUuid(java.util.UUID.fromString(ucTableId));
+      requirements.add(uuidReq);
+      AssertEtag etagReq = new AssertEtag();
+      etagReq.setEtag(etag.get());
+      requirements.add(etagReq);
+      updateRequest.setRequirements(requirements);
+
+      // Diff old vs new metadata/protocol, only send changed fields
+      List<TableUpdate> updates = new ArrayList<>();
+      if (newMetadata.isPresent()) {
+        try {
+          addMetadataUpdates(updates, oldMetadata.orElse(null), newMetadata.get());
+        } catch (IOException e) { throw new RuntimeException(e); }
+      }
+      if (newProtocol.isPresent()) {
+        addProtocolUpdate(updates, oldProtocol.orElse(null), newProtocol.get());
+      }
+      commit.ifPresent(c -> {
+        AddCommitUpdate addCommit = new AddCommitUpdate();
+        addCommit.setCommit(DeltaModelUtils.commit(
+            c.getVersion(), c.getCommitTimestamp(),
+            c.getFileStatus().getPath().getName(),
+            c.getFileStatus().getLen(),
+            c.getFileStatus().getModificationTime()));
+        uniform.flatMap(u -> u.getIcebergMetadata()).ifPresent(iceberg -> {
+          UniformMetadata um = new UniformMetadata();
+          UniformMetadataIceberg ice = new UniformMetadataIceberg();
+          ice.setMetadataLocation(iceberg.getMetadataLocation());
+          ice.setConvertedDeltaVersion(iceberg.getConvertedDeltaVersion());
+          try {
+            ice.setConvertedDeltaTimestamp(
+                Long.parseLong(iceberg.getConvertedDeltaTimestamp()));
+          } catch (NumberFormatException e) { /* skip */ }
+          um.setIceberg(ice);
+          addCommit.setUniform(um);
+        });
+        updates.add(addCommit);
+      });
+      lastKnownBackfilledVersion.ifPresent(v -> {
+        SetLatestBackfilledVersionUpdate bfu = new SetLatestBackfilledVersionUpdate();
+        bfu.setLatestPublishedVersion(v);
+        updates.add(bfu);
+      });
+
+      updateRequest.setUpdates(updates);
+      deltaTablesApi.updateTable(catalog, schema, table, updateRequest);
+    } catch (ApiException e) {
+      if (e.getCode() == 409) {
+        throw new CommitFailedException(true, true,
+            "Commit conflict: " + e.getResponseBody(), e);
+      } else if (e.getCode() >= 400 && e.getCode() < 500) {
+        throw new CommitFailedException(false, false,
+            "Bad request: " + e.getResponseBody(), e);
+      } else {
+        throw new CommitFailedException(true, false,
+            "Commit failed with HTTP " + e.getCode() + ": " + e.getResponseBody(), e);
+      }
+    }
+  }
+
+  // ---- loadTable (DRC: single RPC for table state + commits + etag) ----
+
+  @Override
+  public UCDeltaClient.LoadTableResponse loadTable(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Long> startVersion, Optional<Long> endVersion) throws IOException {
+    if (!drcEnabled || catalog == null) {
+      // Legacy: combine getTable + getCommits
+      try {
+        GetCommitsResponse commits =
+            super.getCommits(ucTableId, tableUri, startVersion, endVersion);
+        // No etag in legacy path
+        return new UCDeltaClient.LoadTableResponse(commits, null,
+            null, ucTableId, null, null);
+      } catch (UCCommitCoordinatorException e) {
+        throw new IOException(e);
+      }
+    }
+    try {
+      io.unitycatalog.client.delta.model.LoadTableResponse response =
+          deltaTablesApi.loadTable(catalog, schema, table);
+      io.unitycatalog.client.delta.model.TableMetadata meta = response.getMetadata();
+
+      List<io.unitycatalog.client.delta.model.DeltaCommit> deltaCommits =
+          response.getCommits();
+      if (deltaCommits == null) deltaCommits = new ArrayList<>();
+
+      long start = startVersion.orElse(0L);
+      long end = endVersion.orElse(Long.MAX_VALUE);
+      String tableLoc = meta.getLocation();
+      Path commitDir = CoordinatedCommitsUtils.commitDirPath(
+          CoordinatedCommitsUtils.logDirPath(new Path(tableLoc)));
+
+      List<Commit> commits = new ArrayList<>();
+      for (io.unitycatalog.client.delta.model.DeltaCommit dc : deltaCommits) {
+        if (dc.getVersion() >= start && dc.getVersion() <= end) {
+          FileStatus fs = new FileStatus(
+              dc.getFileSize(), false, 0, 0,
+              dc.getFileModificationTimestamp(),
+              new Path(commitDir, dc.getFileName()));
+          commits.add(new Commit(dc.getVersion(), fs, dc.getTimestamp()));
+        }
+      }
+      Long latestVersion = response.getLatestTableVersion();
+      GetCommitsResponse commitsResponse = new GetCommitsResponse(
+          commits, latestVersion != null ? latestVersion : -1L, meta.getEtag());
+
+      String tableType = meta.getTableType() != null
+          ? meta.getTableType().getValue() : "MANAGED";
+      String tableId = meta.getTableUuid() != null
+          ? meta.getTableUuid().toString() : "";
+
+      return new UCDeltaClient.LoadTableResponse(
+          commitsResponse, meta.getEtag(),
+          tableLoc, tableId, tableType,
+          meta.getProperties());
+    } catch (ApiException e) {
+      throw new IOException("Failed to load table via DRC: " + e.getResponseBody(), e);
+    }
+  }
+
+  // ---- Helpers ----
+
+  private static String extractTableId(TableDescriptor tableDesc) {
+    Map<String, String> tableConf = tableDesc.getTableConf();
+    String id = tableConf.get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY);
+    if (id == null) {
+      throw new IllegalStateException("UC Table ID not found in " + tableConf);
+    }
+    return id;
+  }
+
+  private static String[] extractTablePath(TableDescriptor tableDesc) {
+    if (!tableDesc.getTableIdentifier().isPresent()) return null;
+    io.delta.storage.commit.TableIdentifier tableId = tableDesc.getTableIdentifier().get();
+    String[] namespace = tableId.getNamespace();
+    if (namespace.length != 2) return null;
+    return new String[]{namespace[0], namespace[1], tableId.getName()};
+  }
+
+  private DomainMetadataUpdates buildDomainMetadataUpdates(
+      Map<String, String> domainMetadata) throws IOException {
+    DomainMetadataUpdates updates = new DomainMetadataUpdates();
+    com.fasterxml.jackson.databind.ObjectMapper mapper =
+        new com.fasterxml.jackson.databind.ObjectMapper();
+    boolean hasUpdates = false;
+    String clusteringConfig = domainMetadata.get("delta.clustering");
+    if (clusteringConfig != null) {
+      updates.setDeltaClustering(
+          mapper.readValue(clusteringConfig, ClusteringDomainMetadata.class));
+      hasUpdates = true;
+    }
+    String rowTrackingConfig = domainMetadata.get("delta.rowTracking");
+    if (rowTrackingConfig != null) {
+      updates.setDeltaRowTracking(
+          mapper.readValue(rowTrackingConfig, RowTrackingDomainMetadata.class));
+      hasUpdates = true;
+    }
+    return hasUpdates ? updates : null;
+  }
+
+  /** Diff old vs new metadata and generate only the changed update actions. */
+  private void addMetadataUpdates(
+      List<TableUpdate> updates,
+      AbstractMetadata oldMd, AbstractMetadata newMd) throws IOException {
+    if (!Objects.equals(
+        oldMd != null ? oldMd.getDescription() : null, newMd.getDescription())) {
+      SetTableCommentUpdate cu = new SetTableCommentUpdate();
+      cu.setComment(newMd.getDescription());
+      updates.add(cu);
+    }
+    if (!Objects.equals(
+        oldMd != null ? oldMd.getPartitionColumns() : null,
+        newMd.getPartitionColumns())) {
+      SetPartitionColumnsUpdate pu = new SetPartitionColumnsUpdate();
+      pu.setPartitionColumns(newMd.getPartitionColumns() != null
+          ? new ArrayList<>(newMd.getPartitionColumns()) : Collections.emptyList());
+      updates.add(pu);
+    }
+    if (!Objects.equals(
+        oldMd != null ? oldMd.getSchemaString() : null, newMd.getSchemaString())) {
+      SetSchemaUpdate su = new SetSchemaUpdate();
+      su.setColumns(DeltaModelUtils.schemaFromJson(newMd.getSchemaString()));
+      updates.add(su);
+    }
+    Map<String, String> oldProps = oldMd != null && oldMd.getConfiguration() != null
+        ? oldMd.getConfiguration() : Collections.emptyMap();
+    Map<String, String> newProps = newMd.getConfiguration() != null
+        ? newMd.getConfiguration() : Collections.emptyMap();
+    Map<String, String> changed = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : newProps.entrySet()) {
+      if (!Objects.equals(oldProps.get(entry.getKey()), entry.getValue())) {
+        changed.put(entry.getKey(), entry.getValue());
+      }
+    }
+    if (!changed.isEmpty()) {
+      SetPropertiesUpdate sp = new SetPropertiesUpdate();
+      sp.setUpdates(changed);
+      updates.add(sp);
+    }
+  }
+
+  private void addProtocolUpdate(
+      List<TableUpdate> updates,
+      AbstractProtocol oldProto, AbstractProtocol newProto) {
+    // Always send protocol when it changed (caller already filtered)
+    SetProtocolUpdate pu = new SetProtocolUpdate();
+    pu.setProtocol(DeltaModelUtils.protocol(
+        newProto.getMinReaderVersion(),
+        newProto.getMinWriterVersion(),
+        newProto.getReaderFeatures() != null
+            ? new ArrayList<>(newProto.getReaderFeatures()) : null,
+        newProto.getWriterFeatures() != null
+            ? new ArrayList<>(newProto.getWriterFeatures()) : null));
+    updates.add(pu);
+  }
+}

--- a/storage/src/main/java-shims/no-drc/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClient.java
+++ b/storage/src/main/java-shims/no-drc/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClient.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.CoordinatedCommitsUtils;
+import io.delta.storage.commit.GetCommitsResponse;
+import io.delta.storage.commit.TableDescriptor;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import io.unitycatalog.client.ApiClient;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * No-DRC subclass. Implements UCDeltaClient using legacy UC APIs.
+ * loadTable/createTable use the shared legacy helpers in the base class.
+ * commit/getCommits delegate to the base class UCClient methods.
+ * Compiled when building without -DdeltaRestCatalog=true (released UC).
+ */
+public class UCTokenBasedDeltaRestClient
+    extends UCTokenBasedRestClient implements UCDeltaClient {
+
+  public UCTokenBasedDeltaRestClient(ApiClient apiClient, boolean drcEnabled) {
+    super(apiClient);
+  }
+
+  public UCTokenBasedDeltaRestClient(
+      String uri,
+      io.unitycatalog.client.auth.TokenProvider tokenProvider,
+      java.util.Map<String, String> appVersions,
+      boolean drcEnabled) {
+    super(uri, tokenProvider, appVersions);
+  }
+
+
+  @Override
+  public void createTable(
+      String catalog, String schema, String table, String location,
+      AbstractMetadata metadata, AbstractProtocol protocol,
+      boolean isManaged, String dataSourceFormat,
+      List<? extends io.delta.storage.commit.actions.AbstractDomainMetadata> domainMetadata)
+      throws CommitFailedException {
+    createTableLegacy(catalog, schema, table, location,
+        metadata, protocol, isManaged);
+  }
+
+  @Override
+  public void commit(
+      TableDescriptor tableDesc, Path logPath,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException {
+    boolean metadataChanged = oldMetadata.isPresent() && newMetadata.isPresent()
+        && !oldMetadata.get().equals(newMetadata.get());
+    boolean protocolChanged = oldProtocol.isPresent() && newProtocol.isPresent()
+        && !oldProtocol.get().equals(newProtocol.get());
+    if ((metadataChanged || protocolChanged) && !disown) {
+      throw new CommitFailedException(false, false,
+          "Metadata/protocol changes require Delta REST Catalog but DRC " +
+          "is not available. Build with -DdeltaRestCatalog=true.");
+    }
+    try {
+      super.commit(extractTableId(tableDesc),
+          CoordinatedCommitsUtils.getTablePath(logPath).toUri(),
+          commit, lastKnownBackfilledVersion, disown,
+          Optional.empty(), Optional.empty(), uniform);
+    } catch (UCCommitCoordinatorException e) {
+      throw new CommitFailedException(true, false, e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public void commit(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException {
+    boolean metadataChanged = oldMetadata.isPresent() && newMetadata.isPresent()
+        && !oldMetadata.get().equals(newMetadata.get());
+    boolean protocolChanged = oldProtocol.isPresent() && newProtocol.isPresent()
+        && !oldProtocol.get().equals(newProtocol.get());
+    if ((metadataChanged || protocolChanged) && !disown) {
+      throw new CommitFailedException(false, false,
+          "Metadata/protocol changes require Delta REST Catalog but DRC " +
+          "is not available. Build with -DdeltaRestCatalog=true.");
+    }
+    try {
+      super.commit(ucTableId, tableUri, commit, lastKnownBackfilledVersion,
+          disown, Optional.empty(), Optional.empty(), uniform);
+    } catch (UCCommitCoordinatorException e) {
+      throw new CommitFailedException(true, false, e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public UCDeltaClient.LoadTableResponse loadTable(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Long> startVersion, Optional<Long> endVersion) throws IOException {
+    GetCommitsResponse commits;
+    try {
+      commits = super.getCommits(ucTableId, tableUri, startVersion, endVersion);
+    } catch (UCCommitCoordinatorException e) {
+      throw new IOException(e);
+    }
+    return new UCDeltaClient.LoadTableResponse(
+        commits, null, null, ucTableId, null, null);
+  }
+
+  private static String extractTableId(TableDescriptor tableDesc) {
+    Map<String, String> tableConf = tableDesc.getTableConf();
+    String id = tableConf.get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY);
+    if (id == null) {
+      throw new IllegalStateException("UC Table ID not found in " + tableConf);
+    }
+    return id;
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
@@ -31,9 +31,16 @@ public class GetCommitsResponse {
 
   private long latestTableVersion;
 
+  private String etag;
+
   public GetCommitsResponse(List<Commit> commits, long latestTableVersion) {
+    this(commits, latestTableVersion, null);
+  }
+
+  public GetCommitsResponse(List<Commit> commits, long latestTableVersion, String etag) {
     this.commits = commits;
     this.latestTableVersion = latestTableVersion;
+    this.etag = etag;
   }
 
   public List<Commit> getCommits() {
@@ -42,6 +49,11 @@ public class GetCommitsResponse {
 
   public long getLatestTableVersion() {
     return latestTableVersion;
+  }
+
+  /** Etag from DRC loadTable, or null for legacy. */
+  public String getEtag() {
+    return etag;
   }
 }
 

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.actions;
+
+/**
+ * Interface for domain metadata actions in Delta. Domain metadata carries
+ * feature-specific configuration (e.g., clustering, row tracking).
+ */
+public interface AbstractDomainMetadata {
+
+  /** The domain name (e.g., "delta.clustering", "delta.rowTracking"). */
+  String getDomain();
+
+  /** The JSON configuration for this domain. */
+  String getConfiguration();
+
+  /** Whether this domain metadata entry has been removed. */
+  boolean isRemoved();
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
@@ -1,19 +1,56 @@
 package org.apache.spark.sql.delta.coordinatedcommits;
 
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
 
 import java.util.Optional;
 
+/**
+ * Carries UC-specific metadata through the commit path.
+ * Used by UCCommitCoordinatorClient to pass DRC-specific data
+ * (etag, old metadata/protocol for diffing) without changing
+ * the commitToUC() signature.
+ */
 public class CatalogTrackedInfo {
-    public static final CatalogTrackedInfo EMPTY = new CatalogTrackedInfo(Optional.empty());
+    public static final CatalogTrackedInfo EMPTY =
+        new CatalogTrackedInfo(Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty());
 
     private final Optional<UniformMetadata> deltaUniformIceberg;
+    private final Optional<String> etag;
+    private final Optional<AbstractMetadata> oldMetadata;
+    private final Optional<AbstractProtocol> oldProtocol;
 
     public CatalogTrackedInfo(Optional<UniformMetadata> deltaUniformIceberg) {
+        this(deltaUniformIceberg, Optional.empty(),
+            Optional.empty(), Optional.empty());
+    }
+
+    public CatalogTrackedInfo(
+            Optional<UniformMetadata> deltaUniformIceberg,
+            Optional<String> etag,
+            Optional<AbstractMetadata> oldMetadata,
+            Optional<AbstractProtocol> oldProtocol) {
         this.deltaUniformIceberg = deltaUniformIceberg;
+        this.etag = etag;
+        this.oldMetadata = oldMetadata;
+        this.oldProtocol = oldProtocol;
     }
 
     public Optional<UniformMetadata> deltaUniformIceberg() {
         return deltaUniformIceberg;
+    }
+
+    public Optional<String> etag() {
+        return etag;
+    }
+
+    public Optional<AbstractMetadata> oldMetadata() {
+        return oldMetadata;
+    }
+
+    public Optional<AbstractProtocol> oldProtocol() {
+        return oldProtocol;
     }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -29,8 +29,6 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogTrackedInfo;
 import io.delta.storage.CloseableIterator;
 import io.delta.storage.LogStore;
@@ -52,12 +50,12 @@ import org.slf4j.LoggerFactory;
  * A commit coordinator client that uses unity-catalog as the commit coordinator.
  */
 public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
-  // Fields for Delta REST API access
-  private final String baseUri;
-  private final io.unitycatalog.client.auth.TokenProvider tokenProvider;
+  /** The single UC client for all commit operations (DRC or legacy). */
+  private final UCDeltaClient ucDeltaClient;
+
 
   public UCCommitCoordinatorClient(Map<String, String> conf, UCClient ucClient) {
-    this(conf, ucClient, null, null);
+    this(conf, UCDeltaClient.fromLegacyClient(ucClient));
   }
 
   public UCCommitCoordinatorClient(
@@ -65,17 +63,28 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       UCClient ucClient,
       String baseUri,
       io.unitycatalog.client.auth.TokenProvider tokenProvider) {
+    this(conf, UCDeltaClient.fromLegacyClient(ucClient));
+  }
+
+  public UCCommitCoordinatorClient(
+      Map<String, String> conf,
+      UCClient ucClient,
+      String baseUri,
+      io.unitycatalog.client.auth.TokenProvider tokenProvider,
+      UCDeltaClient ucDeltaClient) {
+    this(conf, ucDeltaClient);
+  }
+
+  public UCCommitCoordinatorClient(Map<String, String> conf, UCDeltaClient client) {
     this.conf = conf;
-    this.ucClient = ucClient;
-    this.baseUri = baseUri;
-    this.tokenProvider = tokenProvider;
+    this.ucClient = client; // UCDeltaClient extends UCClient
+    this.ucDeltaClient = client;
   }
 
   /**
    * Logger for UCCommitCoordinatorClient class operations and diagnostics.
    */
   private static final Logger LOG = LoggerFactory.getLogger(UCCommitCoordinatorClient.class);
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   // UC Protocol Version Control Constants
   /** Supported version for read operations in the Unity Catalog protocol. */
@@ -103,8 +112,6 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
   final static public String UC_TABLE_ID_KEY = "io.unitycatalog.tableId";
   // Previously this key was ucTableId. It was later renamed.
   final static public String UC_TABLE_ID_KEY_OLD = "ucTableId";
-  /** Spark DSv2 managed-location marker. This is connector-managed metadata, not a Delta property. */
-  private static final String PROP_IS_MANAGED_LOCATION = "is_managed_location";
 
   /**
    * Key for identifying Unity Catalog metastore ID in
@@ -468,7 +475,18 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
     int transientErrorRetryCount = 0;
     while (transientErrorRetryCount <= MAX_RETRIES_ON_TRANSIENT_ERROR) {
       try {
-        boolean shouldPassMetadata = shouldUseDeltaRestApi(tableDesc) || SHOULD_PASS_METADATA_TO_UC;
+        boolean metadataChanged =
+            updatedActions.getNewMetadata() != updatedActions.getOldMetadata();
+        boolean protocolChanged =
+            updatedActions.getNewProtocol() != updatedActions.getOldProtocol();
+        // Pack old metadata/protocol into CatalogTrackedInfo for DRC diffing
+        CatalogTrackedInfo drcTrackedInfo = new CatalogTrackedInfo(
+            catalogTrackedInfo.deltaUniformIceberg(),
+            catalogTrackedInfo.etag(),
+            metadataChanged
+                ? Optional.of(updatedActions.getOldMetadata()) : Optional.empty(),
+            protocolChanged
+                ? Optional.of(updatedActions.getOldProtocol()) : Optional.empty());
         commitToUC(
           tableDesc,
           logPath,
@@ -476,14 +494,12 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           Optional.of(commitVersion),
           Optional.of(commitTimestamp),
           Optional.of(lastKnownBackfilledVersion.get()),
-          catalogTrackedInfo,
+          drcTrackedInfo,
           disown,
-          updatedActions.getNewMetadata() == updatedActions.getOldMetadata() || !shouldPassMetadata ?
-            Optional.empty() :
-            Optional.of(updatedActions.getNewMetadata()),
-          updatedActions.getNewProtocol() == updatedActions.getOldProtocol() ?
-            Optional.empty() :
-            Optional.of(updatedActions.getNewProtocol())
+          metadataChanged
+              ? Optional.of(updatedActions.getNewMetadata()) : Optional.empty(),
+          protocolChanged
+              ? Optional.of(updatedActions.getNewProtocol()) : Optional.empty()
         );
         break;
       } catch (CommitFailedException cfe) {
@@ -686,8 +702,8 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional.empty() /* commitVersion */,
       Optional.empty() /* commitTimestamp */,
       Optional.of(updatedLastKnownBackfilledVersion),
-      CatalogTrackedInfo.EMPTY
-      , true /* disown */,
+      CatalogTrackedInfo.EMPTY,
+      true /* disown */,
       Optional.empty() /* newMetadata */,
       Optional.empty() /* newProtocol */
     );
@@ -729,292 +745,18 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       commitTimestamp.orElseThrow(() -> new IllegalArgumentException(
         "Commit timestamp should be specified when commitFile is present"))
     ));
-    // Use Delta REST API if available and table identifier is present
-    if (shouldUseDeltaRestApi(tableDesc)) {
-      String[] tablePath = extractTablePathForDeltaRest(tableDesc);
-      LOG.info("Using Delta REST API for commit to {}.{}.{}",
-        tablePath[0], tablePath[1], tablePath[2]);
-      commitViaDeltaRestApi(
-        tablePath[0], tablePath[1], tablePath[2],
-        commit, lastKnownBackfilledVersion, newMetadata, newProtocol
-      );
-    } else {
-      // Fall back to old UC API
-      LOG.info("Using legacy UC API for commit");
-      ucClient.commit(
-        extractUCTableId(tableDesc),
-        CoordinatedCommitsUtils.getTablePath(logPath).toUri(),
-        commit,
-        lastKnownBackfilledVersion,
-        disown,
-        newMetadata,
-        newProtocol,
-        catalogTrackedInfo.deltaUniformIceberg()
-      );
-    }
+    // DRC needs old metadata/protocol for diffing and etag for concurrency.
+    // All DRC data flows through CatalogTrackedInfo.
+    ucDeltaClient.commit(
+      tableDesc, logPath,
+      commit, lastKnownBackfilledVersion, disown,
+      catalogTrackedInfo.oldMetadata(), newMetadata,
+      catalogTrackedInfo.oldProtocol(), newProtocol,
+      catalogTrackedInfo.deltaUniformIceberg(),
+      catalogTrackedInfo.etag()
+    );
   }
 
-  /**
-   * Commits via Delta REST Catalog API.
-   */
-  private void commitViaDeltaRestApi(
-      String catalog,
-      String schema,
-      String table,
-      Optional<Commit> commit,
-      Optional<Long> lastKnownBackfilledVersion,
-      Optional<AbstractMetadata> newMetadata,
-      Optional<AbstractProtocol> newProtocol
-  ) throws IOException, CommitFailedException {
-    try {
-      io.unitycatalog.client.deltarest.ApiClient apiClient =
-          new io.unitycatalog.client.deltarest.ApiClient();
-      apiClient.updateBaseUri(baseUri + "/api/2.1/unity-catalog/delta/v1");
-      apiClient.setRequestInterceptor(builder -> {
-        if (tokenProvider != null) {
-          builder.header("Authorization", "Bearer " + tokenProvider.accessToken());
-        }
-      });
-
-      io.unitycatalog.client.deltarest.api.TablesApi tablesApi =
-          new io.unitycatalog.client.deltarest.api.TablesApi(apiClient);
-
-      io.unitycatalog.client.deltarest.model.LoadTableResponse currentTable =
-          tablesApi.loadTable(catalog, schema, table, false);
-      io.unitycatalog.client.deltarest.model.TableMetadata currentMetadata =
-          currentTable.getMetadata();
-
-      // Build UpdateTableRequest with updates
-      io.unitycatalog.client.deltarest.model.UpdateTableRequest updateRequest =
-          new io.unitycatalog.client.deltarest.model.UpdateTableRequest();
-      List<io.unitycatalog.client.deltarest.model.TableRequirement> requirements =
-          new ArrayList<>();
-      if (currentMetadata.getTableUuid() != null) {
-        io.unitycatalog.client.deltarest.model.AssertTableUUID assertTableUUID =
-            new io.unitycatalog.client.deltarest.model.AssertTableUUID();
-        assertTableUUID.setType(
-            io.unitycatalog.client.deltarest.model.AssertTableUUID.TypeEnum.ASSERT_TABLE_UUID);
-        assertTableUUID.setUuid(currentMetadata.getTableUuid());
-        requirements.add(new io.unitycatalog.client.deltarest.model.TableRequirement(assertTableUUID));
-      }
-      if (currentMetadata.getEtag() != null) {
-        io.unitycatalog.client.deltarest.model.AssertEtag assertEtag =
-            new io.unitycatalog.client.deltarest.model.AssertEtag();
-        assertEtag.setType(io.unitycatalog.client.deltarest.model.AssertEtag.TypeEnum.ASSERT_ETAG);
-        assertEtag.setEtag(currentMetadata.getEtag());
-        requirements.add(new io.unitycatalog.client.deltarest.model.TableRequirement(assertEtag));
-      }
-      updateRequest.setRequirements(requirements);
-      List<io.unitycatalog.client.deltarest.model.TableUpdate> updates = new ArrayList<>();
-
-      if (newMetadata.isPresent()) {
-        addMetadataUpdates(updates, currentMetadata, newMetadata.get());
-      }
-      if (newProtocol.isPresent()) {
-        addProtocolUpdate(updates, currentMetadata, newProtocol.get());
-      }
-
-      // Add commit update if present
-      if (commit.isPresent()) {
-        Commit c = commit.get();
-        io.unitycatalog.client.deltarest.model.DeltaCommit deltaCommit =
-            new io.unitycatalog.client.deltarest.model.DeltaCommit();
-        deltaCommit.setVersion(c.getVersion());
-        deltaCommit.setTimestamp(c.getCommitTimestamp());
-        deltaCommit.setFileName(c.getFileStatus().getPath().getName());
-        deltaCommit.setFileSize(c.getFileStatus().getLen());
-        deltaCommit.setFileModificationTimestamp(c.getFileStatus().getModificationTime());
-
-        io.unitycatalog.client.deltarest.model.AddCommitUpdate addCommit =
-            new io.unitycatalog.client.deltarest.model.AddCommitUpdate();
-        addCommit.setAction(
-            io.unitycatalog.client.deltarest.model.AddCommitUpdate.ActionEnum.ADD_COMMIT);
-        addCommit.setCommit(deltaCommit);
-        updates.add(new io.unitycatalog.client.deltarest.model.TableUpdate(addCommit));
-      }
-
-      // Add backfill version update if present
-      if (lastKnownBackfilledVersion.isPresent()) {
-        io.unitycatalog.client.deltarest.model.SetLatestBackfilledVersionUpdate backfillUpdate =
-            new io.unitycatalog.client.deltarest.model.SetLatestBackfilledVersionUpdate();
-        backfillUpdate.setAction(
-            io.unitycatalog.client.deltarest.model.SetLatestBackfilledVersionUpdate
-                .ActionEnum.SET_LATEST_BACKFILLED_VERSION);
-        backfillUpdate.setLatestPublishedVersion(lastKnownBackfilledVersion.get());
-        updates.add(new io.unitycatalog.client.deltarest.model.TableUpdate(backfillUpdate));
-      }
-
-      updateRequest.setUpdates(updates);
-      tablesApi.updateTable(catalog, schema, table, updateRequest);
-
-    } catch (io.unitycatalog.client.deltarest.ApiException e) {
-      if (e.getCode() == 409) {
-        throw new CommitFailedException(
-          true /* retryable */,
-          true /* conflict */,
-          "Commit conflict: " + e.getResponseBody(),
-          e);
-      } else if (e.getCode() >= 400 && e.getCode() < 500) {
-        throw new CommitFailedException(
-          false /* retryable */,
-          false /* conflict */,
-          "Bad request: " + e.getResponseBody(),
-          e);
-      } else {
-        throw new CommitFailedException(
-          true /* retryable */,
-          false /* conflict */,
-          "Commit failed with HTTP " + e.getCode() + ": " + e.getResponseBody(),
-          e);
-      }
-    }
-  }
-
-  private void addMetadataUpdates(
-      List<io.unitycatalog.client.deltarest.model.TableUpdate> updates,
-      io.unitycatalog.client.deltarest.model.TableMetadata currentMetadata,
-      AbstractMetadata newMetadata) throws IOException {
-    if (!Objects.equals(currentMetadata.getComment(), newMetadata.getDescription()) &&
-        newMetadata.getDescription() != null) {
-      io.unitycatalog.client.deltarest.model.SetTableCommentUpdate commentUpdate =
-          new io.unitycatalog.client.deltarest.model.SetTableCommentUpdate();
-      commentUpdate.setAction(
-          io.unitycatalog.client.deltarest.model.SetTableCommentUpdate.ActionEnum.SET_TABLE_COMMENT);
-      commentUpdate.setComment(newMetadata.getDescription());
-      updates.add(new io.unitycatalog.client.deltarest.model.TableUpdate(commentUpdate));
-    }
-
-    List<String> newPartitionColumns =
-        newMetadata.getPartitionColumns() == null ?
-            Collections.emptyList() :
-            new ArrayList<>(newMetadata.getPartitionColumns());
-    List<String> currentPartitionColumns =
-        currentMetadata.getPartitionColumns() == null ?
-            Collections.emptyList() :
-            currentMetadata.getPartitionColumns();
-    if (!currentPartitionColumns.equals(newPartitionColumns)) {
-      io.unitycatalog.client.deltarest.model.SetPartitionColumnsUpdate partitionUpdate =
-          new io.unitycatalog.client.deltarest.model.SetPartitionColumnsUpdate();
-      partitionUpdate.setAction(
-          io.unitycatalog.client.deltarest.model.SetPartitionColumnsUpdate.ActionEnum
-              .SET_PARTITION_COLUMNS);
-      partitionUpdate.setPartitionColumns(newPartitionColumns);
-      updates.add(new io.unitycatalog.client.deltarest.model.TableUpdate(partitionUpdate));
-    }
-
-    List<io.unitycatalog.client.deltarest.model.DeltaColumn> newColumns =
-        toDeltaColumns(newMetadata.getSchemaString());
-    List<io.unitycatalog.client.deltarest.model.DeltaColumn> currentColumns =
-        currentMetadata.getColumns() == null ?
-            Collections.emptyList() :
-            currentMetadata.getColumns();
-    if (!currentColumns.equals(newColumns)) {
-      io.unitycatalog.client.deltarest.model.SetColumnsUpdate columnsUpdate =
-          new io.unitycatalog.client.deltarest.model.SetColumnsUpdate();
-      columnsUpdate.setAction(
-          io.unitycatalog.client.deltarest.model.SetColumnsUpdate.ActionEnum.SET_COLUMNS);
-      columnsUpdate.setColumns(newColumns);
-      updates.add(new io.unitycatalog.client.deltarest.model.TableUpdate(columnsUpdate));
-    }
-
-    Map<String, String> currentProperties =
-        currentMetadata.getProperties() == null ?
-            Collections.emptyMap() :
-            currentMetadata.getProperties();
-    Map<String, String> desiredProperties =
-        newMetadata.getConfiguration() == null ?
-            Collections.emptyMap() :
-            newMetadata.getConfiguration();
-    Map<String, String> changedProperties = new LinkedHashMap<>();
-    for (Map.Entry<String, String> entry : desiredProperties.entrySet()) {
-      if (shouldSkipCatalogPropertyUpdate(entry.getKey())) {
-        continue;
-      }
-      if (!Objects.equals(currentProperties.get(entry.getKey()), entry.getValue())) {
-        changedProperties.put(entry.getKey(), entry.getValue());
-      }
-    }
-    if (!changedProperties.isEmpty()) {
-      io.unitycatalog.client.deltarest.model.SetPropertiesUpdate propertiesUpdate =
-          new io.unitycatalog.client.deltarest.model.SetPropertiesUpdate();
-      propertiesUpdate.setAction(
-          io.unitycatalog.client.deltarest.model.SetPropertiesUpdate.ActionEnum.SET_PROPERTIES);
-      propertiesUpdate.setUpdates(changedProperties);
-      updates.add(new io.unitycatalog.client.deltarest.model.TableUpdate(propertiesUpdate));
-    }
-  }
-
-  private boolean shouldSkipCatalogPropertyUpdate(String propertyKey) {
-    return PROP_IS_MANAGED_LOCATION.equals(propertyKey);
-  }
-
-  private void addProtocolUpdate(
-      List<io.unitycatalog.client.deltarest.model.TableUpdate> updates,
-      io.unitycatalog.client.deltarest.model.TableMetadata currentMetadata,
-      AbstractProtocol newProtocol) {
-    io.unitycatalog.client.deltarest.model.DeltaProtocol desiredProtocol =
-        toDeltaProtocol(newProtocol);
-    if (!desiredProtocol.equals(currentMetadata.getProtocol())) {
-      io.unitycatalog.client.deltarest.model.SetProtocolUpdate protocolUpdate =
-          new io.unitycatalog.client.deltarest.model.SetProtocolUpdate();
-      protocolUpdate.setAction(
-          io.unitycatalog.client.deltarest.model.SetProtocolUpdate.ActionEnum.SET_PROTOCOL);
-      protocolUpdate.setProtocol(desiredProtocol);
-      updates.add(new io.unitycatalog.client.deltarest.model.TableUpdate(protocolUpdate));
-    }
-  }
-
-  private io.unitycatalog.client.deltarest.model.DeltaProtocol toDeltaProtocol(
-      AbstractProtocol protocol) {
-    io.unitycatalog.client.deltarest.model.DeltaProtocol deltaProtocol =
-        new io.unitycatalog.client.deltarest.model.DeltaProtocol();
-    deltaProtocol.setMinReaderVersion(protocol.getMinReaderVersion());
-    deltaProtocol.setMinWriterVersion(protocol.getMinWriterVersion());
-    if (protocol.getReaderFeatures() != null && !protocol.getReaderFeatures().isEmpty()) {
-      List<String> readerFeatures = new ArrayList<>(protocol.getReaderFeatures());
-      Collections.sort(readerFeatures);
-      deltaProtocol.setReaderFeatures(readerFeatures);
-    }
-    if (protocol.getWriterFeatures() != null && !protocol.getWriterFeatures().isEmpty()) {
-      List<String> writerFeatures = new ArrayList<>(protocol.getWriterFeatures());
-      Collections.sort(writerFeatures);
-      deltaProtocol.setWriterFeatures(writerFeatures);
-    }
-    return deltaProtocol;
-  }
-
-  private List<io.unitycatalog.client.deltarest.model.DeltaColumn> toDeltaColumns(
-      String schemaString) throws IOException {
-    if (schemaString == null || schemaString.isEmpty()) {
-      return Collections.emptyList();
-    }
-    JsonNode schemaNode = JSON_MAPPER.readTree(schemaString);
-    JsonNode fieldsNode = schemaNode.get("fields");
-    if (fieldsNode == null || !fieldsNode.isArray()) {
-      throw new IOException("Invalid Delta schema JSON: missing top-level fields array");
-    }
-
-    List<io.unitycatalog.client.deltarest.model.DeltaColumn> columns = new ArrayList<>();
-    for (JsonNode fieldNode : fieldsNode) {
-      io.unitycatalog.client.deltarest.model.DeltaColumn column =
-          new io.unitycatalog.client.deltarest.model.DeltaColumn();
-      column.setName(fieldNode.get("name").asText());
-      JsonNode typeNode = fieldNode.get("type");
-      if (typeNode != null && !typeNode.isNull()) {
-        column.setType(JSON_MAPPER.convertValue(typeNode, Object.class));
-      }
-      JsonNode nullableNode = fieldNode.get("nullable");
-      column.setNullable(nullableNode == null || nullableNode.asBoolean());
-      JsonNode metadataNode = fieldNode.get("metadata");
-      Map<String, Object> metadata =
-          metadataNode == null || metadataNode.isNull() ?
-              new LinkedHashMap<>() :
-              JSON_MAPPER.convertValue(metadataNode, LinkedHashMap.class);
-      column.setMetadata(metadata);
-      columns.add(column);
-    }
-    return columns;
-  }
 
   /**
    * Detects whether the current commit is a downgrade (disown) commit by checking
@@ -1117,7 +859,8 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
         .stream()
         .sorted(Comparator.comparingLong(Commit::getVersion))
         .collect(Collectors.toList());
-    return new GetCommitsResponse(sortedCommits, resp.getLatestTableVersion());
+    return new GetCommitsResponse(
+        sortedCommits, resp.getLatestTableVersion(), resp.getEtag());
   }
 
   protected GetCommitsResponse getCommitsFromUCImpl(
@@ -1125,95 +868,21 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional<Long> startVersion,
       Optional<Long> endVersion) {
     try {
-      // Use Delta REST API if available
-      if (shouldUseDeltaRestApi(tableDesc)) {
-        String[] tablePath = extractTablePathForDeltaRest(tableDesc);
-        LOG.info("Using Delta REST API for getCommits from {}.{}.{}",
-          tablePath[0], tablePath[1], tablePath[2]);
-        return getCommitsViaDeltaRestApi(
-          tablePath[0], tablePath[1], tablePath[2],
-          startVersion, endVersion
-        );
-      } else {
-        LOG.info("Using legacy UC API for getCommits");
-        return ucClient.getCommits(
-          extractUCTableId(tableDesc),
-          CoordinatedCommitsUtils.getTablePath(tableDesc.getLogPath()).toUri(),
-          startVersion,
-          endVersion);
-      }
-    } catch (IOException | UCCommitCoordinatorException e) {
+      // Use loadTable to get full table state (commits + etag) in one RPC.
+      String[] tp = extractTablePathForDeltaRest(tableDesc);
+      String ucTableId = extractUCTableId(tableDesc);
+      java.net.URI tableUri = io.delta.storage.commit.CoordinatedCommitsUtils
+          .getTablePath(tableDesc.getLogPath()).toUri();
+      UCDeltaClient.LoadTableResponse response = ucDeltaClient.loadTable(
+          tp != null ? tp[0] : null, tp != null ? tp[1] : null,
+          tp != null ? tp[2] : null,
+          ucTableId, tableUri, startVersion, endVersion);
+      return response.getCommitsResponse();
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  /**
-   * Gets commits via Delta REST Catalog API.
-   */
-  private GetCommitsResponse getCommitsViaDeltaRestApi(
-      String catalog,
-      String schema,
-      String table,
-      Optional<Long> startVersion,
-      Optional<Long> endVersion
-  ) throws IOException {
-    try {
-      io.unitycatalog.client.deltarest.ApiClient apiClient =
-          new io.unitycatalog.client.deltarest.ApiClient();
-      apiClient.updateBaseUri(baseUri + "/api/2.1/unity-catalog/delta/v1");
-      apiClient.setRequestInterceptor(builder -> {
-        if (tokenProvider != null) {
-          builder.header("Authorization", "Bearer " + tokenProvider.accessToken());
-        }
-      });
-
-      io.unitycatalog.client.deltarest.api.TablesApi tablesApi =
-          new io.unitycatalog.client.deltarest.api.TablesApi(apiClient);
-
-      // Load table to get commits
-      io.unitycatalog.client.deltarest.model.LoadTableResponse response =
-          tablesApi.loadTable(catalog, schema, table, false);
-
-      // Extract commits from response
-      List<io.unitycatalog.client.deltarest.model.DeltaCommit> deltaCommits =
-          response.getCommits();
-      if (deltaCommits == null) {
-        deltaCommits = new ArrayList<>();
-      }
-
-      // Filter by version range
-      long start = startVersion.orElse(0L);
-      long end = endVersion.orElse(Long.MAX_VALUE);
-
-      // We need the table path to construct Commit objects
-      String tableLoc = response.getMetadata().getLocation();
-      Path tablePathObj = new Path(tableLoc);
-      Path commitDir = CoordinatedCommitsUtils.commitDirPath(
-        CoordinatedCommitsUtils.logDirPath(tablePathObj));
-
-      List<Commit> commits = deltaCommits.stream()
-        .filter(dc -> dc.getVersion() >= start && dc.getVersion() <= end)
-        .map(dc -> {
-          Path commitFile = new Path(commitDir, dc.getFileName());
-          FileStatus fileStatus = new FileStatus(
-            dc.getFileSize(),
-            false /* isdir */,
-            0 /* block_replication */,
-            0 /* blocksize */,
-            dc.getFileModificationTimestamp(),
-            commitFile);
-          return new Commit(dc.getVersion(), fileStatus, dc.getTimestamp());
-        })
-        .collect(Collectors.toList());
-
-      Long latestTableVersion = response.getLatestTableVersion();
-      return new GetCommitsResponse(
-          commits, latestTableVersion != null ? latestTableVersion : -1L);
-
-    } catch (io.unitycatalog.client.deltarest.ApiException e) {
-      throw new IOException("Failed to get commits: " + e.getResponseBody(), e);
-    }
-  }
 
   @Override
   public void backfillToVersion(
@@ -1362,26 +1031,17 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
 
   /**
    * Extracts catalog, schema, and table name from TableDescriptor for Delta REST API calls.
+   * Kept for runtime sync compatibility -- commit path now goes through UCDeltaClient.
    */
-  private String[] extractTablePathForDeltaRest(TableDescriptor tableDesc) {
+  protected String[] extractTablePathForDeltaRest(TableDescriptor tableDesc) {
     if (!tableDesc.getTableIdentifier().isPresent()) {
       return null;
     }
     io.delta.storage.commit.TableIdentifier tableId = tableDesc.getTableIdentifier().get();
     String[] namespace = tableId.getNamespace();
     if (namespace.length != 2) {
-      LOG.warn("TableIdentifier namespace has {} elements, expected 2 for Delta REST API: {}",
-        namespace.length, java.util.Arrays.toString(namespace));
       return null;
     }
     return new String[]{namespace[0], namespace[1], tableId.getName()};
-  }
-
-  /**
-   * Check if we should use Delta REST API based on available information.
-   */
-  private boolean shouldUseDeltaRestApi(TableDescriptor tableDesc) {
-    return baseUri != null && tokenProvider != null &&
-           extractTablePathForDeltaRest(tableDesc) != null;
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.GetCommitsResponse;
+import io.delta.storage.commit.TableDescriptor;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.commit.uniform.UniformMetadata;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Extended UC client interface for Delta table operations. Adds DRC-aware
+ * createTable and typed commit/getCommits overloads on top of the legacy
+ * {@link UCClient} interface.
+ *
+ * <p>Implementations choose DRC or legacy internally based on whether the
+ * DRC TablesApi is available.
+ */
+public interface UCDeltaClient extends UCClient {
+
+  /**
+   * Cast a UCClient to UCDeltaClient. Works because UCTokenBasedRestClientFactory
+   * creates UCTokenBasedDeltaRestClient (which implements UCDeltaClient).
+   */
+  static UCDeltaClient fromLegacyClient(UCClient ucClient) {
+    if (ucClient instanceof UCDeltaClient) {
+      return (UCDeltaClient) ucClient;
+    }
+    if (ucClient instanceof UCTokenBasedRestClient) {
+      // Wrap in the DRC subclass with DRC disabled.
+      // This handles runtime where the factory creates plain
+      // UCTokenBasedRestClient (not the DeltaRest subclass).
+      return new UCTokenBasedDeltaRestClient(
+          ((UCTokenBasedRestClient) ucClient).apiClient, false);
+    }
+    throw new IllegalArgumentException(
+        "UCClient is not a UCDeltaClient: "
+        + (ucClient == null ? "null" : ucClient.getClass().getName()));
+  }
+
+  /** Response from loadTable -- carries commits, etag, and table metadata. */
+  class LoadTableResponse {
+    private final GetCommitsResponse commitsResponse;
+    private final String etag;
+    private final String location;
+    private final String tableId;
+    private final String tableType;
+    private final java.util.Map<String, String> properties;
+
+    public LoadTableResponse(
+        GetCommitsResponse commitsResponse, String etag,
+        String location, String tableId, String tableType,
+        java.util.Map<String, String> properties) {
+      this.commitsResponse = commitsResponse;
+      this.etag = etag;
+      this.location = location;
+      this.tableId = tableId;
+      this.tableType = tableType;
+      this.properties = properties;
+    }
+
+    public GetCommitsResponse getCommitsResponse() { return commitsResponse; }
+    public String getEtag() { return etag; }
+    public String getLocation() { return location; }
+    public String getTableId() { return tableId; }
+    public String getTableType() { return tableType; }
+    public java.util.Map<String, String> getProperties() { return properties; }
+  }
+
+  /**
+   * Load table from UC. Returns the full table state: commits + etag + metadata.
+   * DRC path: single RPC. Legacy path: calls getTable + getCommits.
+   * Callers use this instead of getCommits when they need the etag.
+   */
+  LoadTableResponse loadTable(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Long> startVersion, Optional<Long> endVersion)
+      throws IOException;
+
+  /** Create table with native protocol, schema, domain metadata (DRC or legacy). */
+  void createTable(
+      String catalog, String schema, String table, String location,
+      AbstractMetadata metadata, AbstractProtocol protocol,
+      boolean isManaged, String dataSourceFormat,
+      List<? extends AbstractDomainMetadata> domainMetadata)
+      throws CommitFailedException;
+
+  /** Commit (Spark V1 path: from TableDescriptor). */
+  void commit(
+      TableDescriptor tableDesc, Path logPath,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException;
+
+  /** Commit (Kernel V2 path: explicit catalog/schema/table). */
+  void commit(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException;
+
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientProvider.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+/**
+ * Interface for catalogs that hold a shared {@link UCDeltaClient}.
+ * Implemented by AbstractDeltaCatalog so that UCCommitCoordinatorBuilder
+ * can reuse the same client instance for the commit path.
+ */
+public interface UCDeltaClientProvider {
+  UCDeltaClient getUCDeltaClient();
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -87,6 +87,8 @@ public class UCTokenBasedRestClient implements UCClient {
   private DeltaCommitsApi deltaCommitsApi;
   private MetastoresApi metastoresApi;
   private TablesApi tablesApi;
+  /** The shared ApiClient, accessible to subclasses for creating additional API clients. */
+  protected final ApiClient apiClient;
 
   // HTTP status codes for error handling
   private static final int HTTP_BAD_REQUEST = 400;
@@ -122,7 +124,19 @@ public class UCTokenBasedRestClient implements UCClient {
       }
     });
 
-    ApiClient apiClient = builder.build();
+    this.apiClient = builder.build();
+    this.deltaCommitsApi = new DeltaCommitsApi(this.apiClient);
+    this.metastoresApi = new MetastoresApi(this.apiClient);
+    this.tablesApi = new TablesApi(this.apiClient);
+  }
+
+  /**
+   * Constructs a UCTokenBasedRestClient from an existing ApiClient.
+   * Shares the same HTTP connection and auth as the provider.
+   */
+  public UCTokenBasedRestClient(ApiClient apiClient) {
+    Objects.requireNonNull(apiClient, "apiClient must not be null");
+    this.apiClient = apiClient;
     this.deltaCommitsApi = new DeltaCommitsApi(apiClient);
     this.metastoresApi = new MetastoresApi(apiClient);
     this.tablesApi = new TablesApi(apiClient);
@@ -345,7 +359,7 @@ public class UCTokenBasedRestClient implements UCClient {
   }
 
   // ===========================
-  // Exception Handling Methods
+  // Legacy UC API: finalizeCreate
   // ===========================
 
   @Override
@@ -443,6 +457,55 @@ public class UCTokenBasedRestClient implements UCClient {
             false /* conflict */,
             "Unexpected commit failure (HTTP " + statusCode + "): " + responseBody,
             e);
+    }
+  }
+
+  /**
+   * Create table via legacy UC TablesApi. Used by UCDeltaClient.createTable
+   * when DRC is disabled.
+   */
+  protected void createTableLegacy(
+      String catalog, String schema, String table, String location,
+      io.delta.storage.commit.actions.AbstractMetadata metadata,
+      io.delta.storage.commit.actions.AbstractProtocol protocol,
+      boolean isManaged) throws CommitFailedException {
+    ensureOpen();
+    try {
+      io.unitycatalog.client.model.CreateTable req =
+          new io.unitycatalog.client.model.CreateTable();
+      req.setName(table);
+      req.setCatalogName(catalog);
+      req.setSchemaName(schema);
+      req.setTableType(isManaged
+          ? io.unitycatalog.client.model.TableType.MANAGED
+          : io.unitycatalog.client.model.TableType.EXTERNAL);
+      req.setDataSourceFormat(io.unitycatalog.client.model.DataSourceFormat.DELTA);
+      req.setStorageLocation(location);
+      java.util.HashMap<String, String> props = metadata.getConfiguration() != null
+          ? new java.util.HashMap<>(metadata.getConfiguration())
+          : new java.util.HashMap<>();
+      props.put("delta.minReaderVersion",
+          String.valueOf(protocol.getMinReaderVersion()));
+      props.put("delta.minWriterVersion",
+          String.valueOf(protocol.getMinWriterVersion()));
+      if (protocol.getReaderFeatures() != null) {
+        for (String f : protocol.getReaderFeatures()) {
+          props.put("delta.feature." + f, "supported");
+        }
+      }
+      if (protocol.getWriterFeatures() != null) {
+        for (String f : protocol.getWriterFeatures()) {
+          props.put("delta.feature." + f, "supported");
+        }
+      }
+      req.setProperties(props);
+      if (metadata.getDescription() != null) {
+        req.setComment(metadata.getDescription());
+      }
+      new io.unitycatalog.client.api.TablesApi(apiClient).createTable(req);
+    } catch (io.unitycatalog.client.ApiException e) {
+      throw new CommitFailedException(true, false,
+          "Failed to create table via legacy API: " + e.getResponseBody(), e);
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove the UC-managed metadata-change block in optimistic transactions
- include schema, partition, property, and protocol metadata updates in the Delta REST v1 managed commit path
- convert the UC-managed metadata-update test coverage to a positive schema-evolution write path

## Testing
- manual local UC + Delta end-to-end run covering managed create, insert, schema auto-merge insert, select, and describe
- verified the UC Delta REST v1 GET /tables response reflects the evolved schema and latest managed table version after commit
