### PR TITLE
[CI Improvements] Fix flaky DeltaRetentionWithCatalogOwnedBatch1Suite test

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -130,10 +130,9 @@ class DeltaRetentionSuite extends QueryTest
         deltaFile.setLastModified(clock.getTimeMillis() + i * 10000)
         val crcFile = new File(FileNames.checksumFile(log.logPath, version).toUri)
         crcFile.setLastModified(clock.getTimeMillis() + i * 10000)
-        val chk = new File(FileNames.checkpointFileSingular(log.logPath, version).toUri)
-        if (chk.exists()) {
-          chk.setLastModified(clock.getTimeMillis() + i * 10000)
-        }
+        getCheckpointFiles(logPath)
+          .filter(f => FileNames.checkpointVersion(new Path(f.getCanonicalPath)) == version)
+          .foreach(_.setLastModified(clock.getTimeMillis() + i * 10000))
       }
 
       // delete some files in the middle


### PR DESCRIPTION
## Description

Fixes a flaky test in `DeltaRetentionWithCatalogOwnedBatch1Suite` that fails intermittently with:

```
20 did not equal 0 Delta files before the last checkpoint version should have been deleted
(DeltaRetentionSuite.scala:152)
```

### Root Cause

The test `"log files being already deleted shouldn't fail log deletion job"` fails **only when executed between 00:00-01:00 UTC**. The mechanism:

1. `getStartTimeForRetentionTest()` returns today at 01:00 UTC — which is a **future** timestamp if the test runs before 01:00 UTC.
2. Delta files get `setLastModified` to this future time (01:00:xx UTC).
3. V2 checkpoint files (introduced by CatalogOwned in #5841) use UUID-based names (`*.checkpoint.<uuid>.json`) that don't match `checkpointFileSingular` format (`*.checkpoint.parquet`), so the test never sets their timestamps — they keep their real wallclock time (~00:04 UTC).
4. `BufferingLogDeletionIterator` checks `needsTimeAdjustment()` **before** `isCheckpointFile()`. When a V2 checkpoint (modTime=00:04) follows a delta file (modTime=01:01), the checkpoint's earlier real timestamp triggers time adjustment, causing it to be treated as a regular file instead of a checkpoint boundary. The buffer is never flushed, and zero files get deleted.

### Fix

Replace the `checkpointFileSingular` lookup (lines 133-136) with the `getCheckpointFiles` + `checkpointVersion` pattern already used and working correctly elsewhere in the same file (lines 724-734). This finds all checkpoint file formats including V2.

### Verified

Reproduced the failure by forcing `getStartTimeForRetentionTest` to return a future timestamp:
- **Without fix**: `FAILED` — `20 did not equal 0` (identical to CI failures)
- **With fix**: `PASSED`

Confirmed all CI failures occurred in the 00:00-01:00 UTC window: 00:04:33, 00:13:10, 00:21:48, 00:04:47 UTC.

## How was this patch tested?

Existing test `DeltaRetentionWithCatalogOwnedBatch1Suite."log files being already deleted shouldn't fail log deletion job"` — this PR fixes it.

## Does this PR introduce _any_ user-facing changes?

No. Test-only change.

This pull request was AI-assisted by Isaac.