### PR TITLE
[Spark] Fix decimal IN predicate crash when BigDecimal precision < scale

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ExpressionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ExpressionUtils.java
@@ -395,9 +395,11 @@ public final class ExpressionUtils {
       return Optional.of(Literal.ofDouble(d));
     }
     if (value instanceof BigDecimal) {
-      // Preserve precision and scale from the original BigDecimal
       BigDecimal bd = (BigDecimal) value;
-      return Optional.of(Literal.ofDecimal(bd, bd.precision(), bd.scale()));
+      // BigDecimal precision can be less than scale (e.g. BigDecimal("0.00") has
+      // precision=1, scale=2). Kernel requires precision >= scale, so normalize.
+      int precision = Math.max(bd.precision(), bd.scale() + 1);
+      return Optional.of(Literal.ofDecimal(bd, precision, bd.scale()));
     }
     if (value instanceof UTF8String) {
       UTF8String s = (UTF8String) value;

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/ExpressionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/ExpressionUtilsTest.java
@@ -452,6 +452,22 @@ public class ExpressionUtilsTest {
   }
 
   @Test
+  public void testConvertValueToKernelLiteral_DecimalWithScaleExceedingPrecision() {
+    // BigDecimal("0.00") has precision=1, scale=2 which violates precision >= scale.
+    // The conversion should normalize precision to max(precision, scale + 1).
+    BigDecimal bd = new BigDecimal("0.00");
+    assertEquals(1, bd.precision(), "Precondition: precision of 0.00 should be 1");
+    assertEquals(2, bd.scale(), "Precondition: scale of 0.00 should be 2");
+
+    Optional<Literal> result = ExpressionUtils.convertValueToKernelLiteral(bd);
+    assertTrue(result.isPresent(), "BigDecimal 0.00 should be convertible");
+
+    Literal literal = result.get();
+    // Normalized precision should be max(1, 2+1) = 3
+    assertEquals(new DecimalType(3, 2), literal.getDataType());
+  }
+
+  @Test
   public void testConvertValueToKernelLiteral_NullValue() {
     Optional<Literal> result = ExpressionUtils.convertValueToKernelLiteral(null);
     assertFalse(result.isPresent(), "null values should return empty Optional");


### PR DESCRIPTION
## Summary
- Fix `ExpressionUtils.convertValueToKernelLiteral` crash when a `BigDecimal` has precision less than scale
- Normalize precision to `Math.max(bd.precision(), bd.scale() + 1)` before calling `Literal.ofDecimal`
- Add unit test for the edge case

## Problem

A query with a decimal `IN` predicate containing `0.00` crashes when using the V2 connector:

```sql
SELECT * FROM delta_table WHERE dec10_2 IN (0.00, 100.00)
```

This throws an `IllegalArgumentException: Invalid precision and scale combo` from Kernel's `Literal.ofDecimal`.

**Root cause:** Java's `BigDecimal("0.00")` reports `precision()=1` and `scale()=2`. This violates the invariant that `precision >= scale` required by Kernel's `Literal.ofDecimal`. The V2 code in `ExpressionUtils.convertValueToKernelLiteral` was passing these values through without normalization.

## Fix

Before constructing the Kernel literal, normalize precision:

```java
int precision = Math.max(bd.precision(), bd.scale() + 1);
```

For `BigDecimal("0.00")`, this yields `precision=3, scale=2` (i.e., `DECIMAL(3,2)`), which correctly represents the value.

## Test plan
- [x] New unit test `testConvertValueToKernelLiteral_DecimalWithScaleExceedingPrecision` passes
- [x] All 73 `ExpressionUtilsTest` tests pass