### PR TITLE
[Spark] Add AlwaysTrue/AlwaysFalse filter pushdown to V2 connector

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ExpressionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ExpressionUtils.java
@@ -19,6 +19,7 @@ import static org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseCol
 
 import com.google.common.annotations.VisibleForTesting;
 import io.delta.kernel.expressions.AlwaysFalse;
+import io.delta.kernel.expressions.AlwaysTrue;
 import io.delta.kernel.expressions.And;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.In;
@@ -248,6 +249,13 @@ public final class ExpressionUtils {
           convertSparkFilterToKernelPredicate(f.child(), false /*canPartialPushDown*/, tableSchema);
       return new ConvertedPredicate(
           child.getConvertedPredicate().map(c -> new Predicate("NOT", c)), child.isPartial());
+    }
+
+    if (filter instanceof org.apache.spark.sql.sources.AlwaysTrue) {
+      return new ConvertedPredicate(Optional.of(AlwaysTrue.ALWAYS_TRUE));
+    }
+    if (filter instanceof org.apache.spark.sql.sources.AlwaysFalse) {
+      return new ConvertedPredicate(Optional.of(AlwaysFalse.ALWAYS_FALSE));
     }
 
     return new ConvertedPredicate(Optional.empty());

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/ExpressionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/ExpressionUtilsTest.java
@@ -272,6 +272,28 @@ public class ExpressionUtilsTest {
   }
 
   @Test
+  public void testAlwaysTrueFilter() {
+    Filter filter = new org.apache.spark.sql.sources.AlwaysTrue();
+    ExpressionUtils.ConvertedPredicate result =
+        ExpressionUtils.convertSparkFilterToKernelPredicate(filter);
+
+    assertTrue(result.isPresent(), "AlwaysTrue should be converted");
+    assertFalse(result.isPartial());
+    assertEquals("ALWAYS_TRUE", result.get().getName());
+  }
+
+  @Test
+  public void testAlwaysFalseFilter() {
+    Filter filter = new org.apache.spark.sql.sources.AlwaysFalse();
+    ExpressionUtils.ConvertedPredicate result =
+        ExpressionUtils.convertSparkFilterToKernelPredicate(filter);
+
+    assertTrue(result.isPresent(), "AlwaysFalse should be converted");
+    assertFalse(result.isPartial());
+    assertEquals("ALWAYS_FALSE", result.get().getName());
+  }
+
+  @Test
   public void testUnsupportedFilter() {
     // Create an unsupported filter (StringContains is not implemented in our conversion method)
     Filter unsupportedFilter = new StringContains("col1", "test");


### PR DESCRIPTION
## Summary
- Add support for converting Spark's `AlwaysTrue` and `AlwaysFalse` filters to Kernel `ALWAYS_TRUE` and `ALWAYS_FALSE` predicates in the V2 connector's `ExpressionUtils`.
- `AlwaysFalse` pushdown allows the Kernel to skip all files entirely, while `AlwaysTrue` is a correct no-op passthrough.
- These were the only two Spark filter types with direct Kernel equivalents that were missing from the V2 connector's filter conversion.

## Test plan
- [x] Added `testAlwaysTrueFilter` and `testAlwaysFalseFilter` unit tests in `ExpressionUtilsTest`
- [x] All 74 tests pass in `ExpressionUtilsTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)