### PR TITLE
Upgrade Unity Catalog to 0.4.1-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -723,7 +723,7 @@ lazy val contribs = (project in file("contribs"))
   ).configureUnidoc()
 
 
-val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.4.0")
+val unityCatalogVersion = "0.4.1-SNAPSHOT"
 val sparkUnityCatalogJacksonVersion = "2.15.4" // We use Spark 4.0's Jackson version 2.15.x to override Unity Catalog's transitive Jackson 2.18.x
 
 lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))

--- a/build/sbt-config/repositories
+++ b/build/sbt-config/repositories
@@ -14,3 +14,4 @@
   typesafe-releases: https://repo.typesafe.com/typesafe/releases/
   apache-snapshot: https://repository.apache.org/content/groups/snapshots/
   jitpack: https://jitpack.io
+  sonatype-central-snapshots: https://central.sonatype.com/repository/maven-snapshots/

--- a/kernel/examples/kernel-examples/pom.xml
+++ b/kernel/examples/kernel-examples/pom.xml
@@ -36,6 +36,13 @@ limitations under the License.-->
             <id>staging-repo</id>
             <url>${staging.repo.url}</url>
         </repository>
+        <repository>
+            <id>sonatype-central-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Upgrade `unityCatalogVersion` from `0.4.0` to `0.4.1-SNAPSHOT` in `build.sbt`
- Add `sonatype-central-snapshots` repository (`https://central.sonatype.com/repository/maven-snapshots/`) to SBT resolver config and kernel examples Maven POM to resolve SNAPSHOT artifacts

## Test plan
- [ ] Verify SBT resolves UC 0.4.1-SNAPSHOT dependencies successfully (`build/sbt compile`)
- [ ] Verify kernel examples Maven build resolves correctly
- [ ] Run UC-related tests to confirm compatibility