### PR TITLE
[ServerSidePlanning] Add OAuth support

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClient.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClient.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.http.client.methods.{HttpGet, HttpPost}
 import org.apache.http.entity.{ContentType, StringEntity}
 import org.apache.http.util.EntityUtils
-import org.apache.http.{HttpHeaders, HttpResponse, HttpStatus}
+import org.apache.http.{HttpHeaders, HttpRequest, HttpRequestInterceptor, HttpResponse, HttpStatus}
 import org.apache.http.client.ServiceUnavailableRetryStrategy
 import org.apache.http.impl.client.{DefaultHttpRequestRetryHandler, HttpClientBuilder}
 import org.apache.http.protocol.HttpContext
@@ -66,12 +66,14 @@ private case class CatalogConfigResponse(
  * @param baseUriRaw Base URI of the Iceberg REST catalog up to /v1, e.g.,
  *                   "http://<catalog-URL>/iceberg/v1". Trailing slashes are handled automatically.
  * @param catalogName Name of the catalog for config endpoint query parameter.
- * @param token Authentication token for the catalog server.
+ * @param tokenSupplier Supplier of auth tokens, called per-request to support OAuth.
+ *                      Returns empty string if no auth is needed.
  */
 class IcebergRESTCatalogPlanningClient(
     baseUriRaw: String,
     catalogName: String,
-    token: String) extends ServerSidePlanningClient with Logging {
+    tokenSupplier: () => String
+) extends ServerSidePlanningClient with Logging {
 
   // Normalize baseUri to handle trailing slashes
   private val baseUri = baseUriRaw.stripSuffix("/")
@@ -213,19 +215,13 @@ class IcebergRESTCatalogPlanningClient(
     }
   }
 
+  // Default headers without auth -- auth is injected per-request via HttpRequestInterceptor
   private val httpHeaders = {
-    val baseHeaders = Map(
+    Map(
       HttpHeaders.ACCEPT -> ContentType.APPLICATION_JSON.getMimeType,
       HttpHeaders.CONTENT_TYPE -> ContentType.APPLICATION_JSON.getMimeType,
       HttpHeaders.USER_AGENT -> buildUserAgent()
-    )
-    // Add Bearer token authentication if token is provided
-    val headersWithAuth = if (token.nonEmpty) {
-      baseHeaders + (HttpHeaders.AUTHORIZATION -> s"Bearer $token")
-    } else {
-      baseHeaders
-    }
-    headersWithAuth.map { case (k, v) => new BasicHeader(k, v) }.toSeq.asJava
+    ).map { case (k, v) => new BasicHeader(k, v) }.toSeq.asJava
   }
 
   /**
@@ -318,14 +314,28 @@ class IcebergRESTCatalogPlanningClient(
   // Maximum number of retries for transient HTTP failures (IOException, 5xx server errors)
   private val HTTP_MAX_RETRIES = 3
 
-  private lazy val httpClient = HttpClientBuilder.create()
-    .setDefaultHeaders(httpHeaders)
-    .setConnectionTimeToLive(30, java.util.concurrent.TimeUnit.SECONDS)
-    // requestSentRetryEnabled=true: safe to retry already-sent requests because
-    // planScan is a read-only operation (idempotent POST to /plan endpoint)
-    .setRetryHandler(new DefaultHttpRequestRetryHandler(HTTP_MAX_RETRIES, true))
-    .setServiceUnavailableRetryStrategy(new ServerErrorRetryStrategy(HTTP_MAX_RETRIES))
-    .build()
+  private lazy val httpClient = {
+    val builder = HttpClientBuilder.create()
+      .setDefaultHeaders(httpHeaders)
+      .setConnectionTimeToLive(30, java.util.concurrent.TimeUnit.SECONDS)
+      // requestSentRetryEnabled=true: safe to retry already-sent requests because
+      // planScan is a read-only operation (idempotent POST to /plan endpoint)
+      .setRetryHandler(new DefaultHttpRequestRetryHandler(HTTP_MAX_RETRIES, true))
+      .setServiceUnavailableRetryStrategy(new ServerErrorRetryStrategy(HTTP_MAX_RETRIES))
+
+    // Per-request interceptor: calls tokenSupplier() to get the current token.
+    // The token provider implementation handles caching as needed.
+    builder.addInterceptorFirst(new HttpRequestInterceptor {
+      override def process(request: HttpRequest, context: HttpContext): Unit = {
+        val token = tokenSupplier()
+        if (token != null && token.nonEmpty) {
+          request.setHeader(HttpHeaders.AUTHORIZATION, s"Bearer $token")
+        }
+      }
+    })
+
+    builder.build()
+  }
 
   override def canConvertFilters(filters: Array[Filter]): Boolean = {
     // Check if all filters can be converted to Iceberg expressions

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientFactory.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientFactory.scala
@@ -28,9 +28,11 @@ class IcebergRESTCatalogPlanningClientFactory extends ServerSidePlanningClientFa
       metadata: ServerSidePlanningMetadata): ServerSidePlanningClient = {
 
     val baseUri = metadata.planningEndpointUri
-    val token = metadata.authToken.getOrElse("")
     val catalogName = metadata.catalogName
+    val supplier: () => String =
+      metadata.tokenSupplier.getOrElse(() => "")
 
-    new IcebergRESTCatalogPlanningClient(baseUri, catalogName, token)
+    new IcebergRESTCatalogPlanningClient(
+      baseUri, catalogName, supplier)
   }
 }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientSuite.scala
@@ -78,7 +78,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
   // Tests that the REST /plan endpoint returns 0 files for an empty table.
   test("basic plan table scan via IcebergRESTCatalogPlanningClient") {
     withTempTable("testTable") { table =>
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         val scanPlan = client.planScan(defaultNamespace.toString, "testTable")
         assert(scanPlan != null, "Scan plan should not be null")
@@ -106,7 +106,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
         .map(row => (new Path(row.getString(0)).getName, row.getLong(1)))
         .toMap
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         val scanPlan = client.planScan(defaultNamespace.toString, "tableWithData")
         assert(scanPlan != null, "Scan plan should not be null")
@@ -145,7 +145,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
 
     withTempTable("testTable") { table =>
       // Client expects baseUri to include the /v1 path (per Iceberg REST spec)
-      val client = new IcebergRESTCatalogPlanningClient(s"$serverUri/v1", "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(s"$serverUri/v1", "test_catalog", () => "")
       try {
         // Make a call that will trigger the lazy initialization of icebergRestCatalogUriRoot
         // which internally calls fetchCatalogPrefix()
@@ -173,7 +173,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
 
     withTempTable("testTable") { table =>
       // Client expects baseUri to include the /v1 path (per Iceberg REST spec)
-      val client = new IcebergRESTCatalogPlanningClient(s"$serverUri/v1", "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(s"$serverUri/v1", "test_catalog", () => "")
       try {
         // Make a call that will trigger the lazy initialization
         val scanPlan = client.planScan(defaultNamespace.toString, "testTable")
@@ -200,7 +200,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
     withTempTable("filterTest") { table =>
       populateTestData(s"rest_catalog.${defaultNamespace}.filterTest")
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         val testCases = Seq(
           (EqualTo("longCol", 2L), "EqualTo numeric (long)"),
@@ -310,7 +310,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
           Set("`address.city`"))
       )
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         testCases.foreach { testCase =>
           // Clear previous captured projection
@@ -343,7 +343,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
       val tableName = s"rest_catalog.${defaultNamespace}.limitTest"
       populateTestData(tableName)
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, null, "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, null, () => "")
       try {
         // Test different limit values
         val testCases = Seq(
@@ -378,7 +378,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
       val tableName = s"rest_catalog.${defaultNamespace}.filterProjectionLimitTest"
       populateTestData(tableName)
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         // Note: Filter types are already tested in "filter sent to IRC server" test.
         // Here we verify filter, projection, AND limit are sent together correctly.
@@ -456,7 +456,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
     withTempTable("caseSensitiveTest") { table =>
       populateTestData(s"rest_catalog.${defaultNamespace}.caseSensitiveTest")
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, null, "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, null, () => "")
       try {
         server.clearCaptured()
 
@@ -481,7 +481,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
     withTempTable("residualTest") { table =>
       populateTestData(s"rest_catalog.${defaultNamespace}.residualTest")
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         // Verify that a trivial (alwaysTrue) residual is accepted
         server.setTestResidual(Expressions.alwaysTrue())
@@ -527,7 +527,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
     withTempTable("retryTest503") { table =>
       populateTestData(s"rest_catalog.${defaultNamespace}.retryTest503")
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         server.clearCaptured()
         // Configure server to fail the first plan request with 503
@@ -552,7 +552,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
     // No populateTestData needed: failure injection intercepts at the servlet level before
     // table data is accessed, so we only need the table to exist for a valid URI.
     withTempTable("retryTestExhausted") { table =>
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         server.clearCaptured()
         // Configure server to fail more requests than the client will retry (max 3 retries = 4
@@ -579,7 +579,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
     // No populateTestData needed: failure injection intercepts at the servlet level before
     // table data is accessed, so we only need the table to exist for a valid URI.
     withTempTable("retryTest404") { table =>
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         server.clearCaptured()
         // Configure server to fail all plan requests with 404
@@ -609,7 +609,7 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
     // warning, and return None — causing icebergRestCatalogUriRoot to fall back to baseUri.
     // The subsequent planScan HTTP POST will also fail (same unreachable host).
     val unreachableUri = "http://localhost:1"
-    val client = new IcebergRESTCatalogPlanningClient(unreachableUri, "test_catalog", "")
+    val client = new IcebergRESTCatalogPlanningClient(unreachableUri, "test_catalog", () => "")
     try {
       val ex = intercept[Exception] {
         client.planScan("test_db", "test_table")
@@ -625,7 +625,8 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
   }
 
   test("User-Agent header format") {
-    val client = new IcebergRESTCatalogPlanningClient("http://localhost:8080", "test_catalog", "")
+    val client = new IcebergRESTCatalogPlanningClient(
+      "http://localhost:8080", "test_catalog", () => "")
     try {
       val userAgent = client.getUserAgent()
 
@@ -661,6 +662,63 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
         s"Scala version should not be 'unknown' in test environment, got: $userAgent")
     } finally {
       client.close()
+    }
+  }
+
+  test("e2e: OAuth token supplier with mock token server") {
+    // Start a mock OAuth token endpoint using JDK HttpServer.
+    // OAuthTokenProvider sends: POST with Basic auth + grant_type=client_credentials
+    val tokenRequestCount = new java.util.concurrent.atomic.AtomicInteger(0)
+    val mockToken = "mock-oauth-access-token"
+    val oauthServer = com.sun.net.httpserver.HttpServer.create(
+      new java.net.InetSocketAddress("localhost", 0), 0)
+    oauthServer.createContext("/token", (exchange: com.sun.net.httpserver.HttpExchange) => {
+      try {
+        tokenRequestCount.incrementAndGet()
+        val responseJson =
+          s"""{"access_token":"$mockToken","token_type":"Bearer","expires_in":3600}"""
+        val bytes = responseJson.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        exchange.getResponseHeaders.add("Content-Type", "application/json")
+        exchange.sendResponseHeaders(200, bytes.length)
+        exchange.getResponseBody.write(bytes)
+      } finally {
+        exchange.close()
+      }
+    })
+    oauthServer.start()
+
+    try {
+      val oauthUri = s"http://localhost:${oauthServer.getAddress.getPort}/token"
+      val authConfig = Map(
+        "type" -> "oauth",
+        "oauth.uri" -> oauthUri,
+        "oauth.clientId" -> "test-client-id",
+        "oauth.clientSecret" -> "test-client-secret")
+      val tokenProvider = io.unitycatalog.client.auth.TokenProvider.create(
+        authConfig.asJava.asInstanceOf[java.util.Map[String, String]])
+      val supplier: () => String = () => tokenProvider.accessToken()
+
+      withTempTable("oauthE2eTest") { table =>
+        val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", supplier)
+        try {
+          // First planScan triggers token fetch from mock server
+          val scanPlan = client.planScan(defaultNamespace.toString, "oauthE2eTest")
+          assert(scanPlan != null)
+
+          // OAuthTokenProvider should have fetched exactly 1 token (cached for reuse)
+          assert(tokenRequestCount.get() == 1,
+            s"Expected 1 token request, got ${tokenRequestCount.get()}")
+
+          // Second planScan reuses cached token (not expired)
+          client.planScan(defaultNamespace.toString, "oauthE2eTest")
+          assert(tokenRequestCount.get() == 1,
+            s"Token should be cached. Expected 1 request, got ${tokenRequestCount.get()}")
+        } finally {
+          client.close()
+        }
+      }
+    } finally {
+      oauthServer.stop(0)
     }
   }
 

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningCredentialsSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningCredentialsSuite.scala
@@ -70,7 +70,7 @@ class ServerSidePlanningCredentialsSuite extends QueryTest with SharedSparkSessi
     withTempTable("credentialsTest") { table =>
       populateTestData(s"rest_catalog.${defaultNamespace}.credentialsTest")
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         // Covers the successful credential extraction and Hadoop configuration injection cases.
         val testCases: Seq[CredentialTestCase] = Seq(
@@ -147,7 +147,7 @@ class ServerSidePlanningCredentialsSuite extends QueryTest with SharedSparkSessi
     withTempTable("incompleteCredsTest") { table =>
       populateTestData(s"rest_catalog.${defaultNamespace}.incompleteCredsTest")
 
-      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", "")
+      val client = new IcebergRESTCatalogPlanningClient(serverUri, "test_catalog", () => "")
       try {
         // Test cases for incomplete credentials that should throw errors
         val errorTestCases = Seq(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
@@ -32,9 +32,11 @@ private[serverSidePlanning] trait ServerSidePlanningMetadata {
   def planningEndpointUri: String
 
   /**
-   * Authentication token for the planning endpoint.
+   * Supplier of authentication tokens for the planning endpoint.
+   * Called per-request to get the current token (supports OAuth).
+   * Returns None if no authentication is configured.
    */
-  def authToken: Option[String]
+  def tokenSupplier: Option[() => String]
 
   /**
    * Catalog name for configuration lookups.
@@ -56,7 +58,7 @@ private[serverSidePlanning] case class DefaultMetadata(
     catalogName: String,
     tableProps: Map[String, String] = Map.empty) extends ServerSidePlanningMetadata {
   override def planningEndpointUri: String = ""
-  override def authToken: Option[String] = None
+  override def tokenSupplier: Option[() => String] = None
   override def tableProperties: Map[String, String] = tableProps
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/UnityCatalogMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/UnityCatalogMetadata.scala
@@ -16,28 +16,27 @@
 
 package org.apache.spark.sql.delta.serverSidePlanning
 
+import scala.jdk.CollectionConverters._
+
+import io.unitycatalog.client.auth.TokenProvider
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 
 /**
  * Metadata for Unity Catalog tables.
- * Provides base Iceberg REST endpoint for server-side planning.
+ * Provides base Iceberg REST endpoint and authentication for server-side planning.
  */
 case class UnityCatalogMetadata(
     catalogName: String,
     ucUri: String,
-    ucToken: String,
+    override val tokenSupplier: Option[() => String],
     tableProps: Map[String, String]) extends ServerSidePlanningMetadata {
 
   override def planningEndpointUri: String = {
-    // Return base Iceberg REST path up to /v1/
-    // The IcebergRESTCatalogPlanningClient will call /v1/config to get the prefix
-    // and construct the full URL according to the Iceberg REST catalog spec
     val base = if (ucUri.endsWith("/")) ucUri.dropRight(1) else ucUri
     s"$base/api/2.1/unity-catalog/iceberg-rest/v1"
   }
-
-  override def authToken: Option[String] = Some(ucToken)
 
   override def tableProperties: Map[String, String] = tableProps
 }
@@ -58,11 +57,55 @@ object UnityCatalogMetadata {
 
     // Read UC configuration from Spark conf
     val ucUri = spark.conf.get(s"spark.sql.catalog.$catalogName.uri", "")
-    val ucToken = spark.conf.get(s"spark.sql.catalog.$catalogName.token", "")
+    val authConfig = extractAuthConfig(spark, catalogName)
 
-    // Table properties currently unused, may be needed in future
+    val supplier: Option[() => String] = if (authConfig.nonEmpty) {
+      val tp = TokenProvider.create(authConfig.asJava)
+      Some(() => tp.accessToken())
+    } else {
+      None
+    }
+
     val tableProps = Map.empty[String, String]
+    UnityCatalogMetadata(catalogName, ucUri, supplier, tableProps)
+  }
 
-    UnityCatalogMetadata(catalogName, ucUri, ucToken, tableProps)
+  /**
+   * Extract authentication config for the planning endpoint.
+   *
+   * Follows the same pattern as UC's AuthConfigUtils:
+   * 1. Scan spark.sql.catalog.<name>.auth.* keys, strip prefix
+   * 2. If legacy .token exists:
+   *    - Error if auth.token also set (configured twice)
+   *    - Otherwise convert to Map("type" -> "static", ...)
+   * 3. Result passed to TokenProvider.create()
+   */
+  private[serverSidePlanning] def extractAuthConfig(
+      spark: SparkSession,
+      catalogName: String): Map[String, String] = {
+    val catalogPrefix = s"spark.sql.catalog.$catalogName."
+    val authPrefix = s"${catalogPrefix}auth."
+
+    // Extract all auth.* configs, stripping the prefix
+    val newFormatConfig = spark.conf.getAll
+      .filterKeys(_.startsWith(authPrefix))
+      .map { case (fullKey, value) => (fullKey.stripPrefix(authPrefix), value) }
+      .toMap
+
+    // Check legacy token
+    val legacyToken = spark.conf.get(s"${catalogPrefix}token", "")
+
+    if (legacyToken.nonEmpty) {
+      // Conflict: both legacy .token and auth.token set
+      require(!newFormatConfig.contains("token"),
+        s"Static token configured twice. Use either " +
+        s"'spark.sql.catalog.$catalogName.token' (legacy) or " +
+        s"'spark.sql.catalog.$catalogName.auth.token' (new), not both.")
+
+      // Legacy token: convert to static format. Matches UC AuthConfigUtils behavior.
+      Map("type" -> "static", "token" -> legacyToken)
+    } else {
+      newFormatConfig
+    }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -265,7 +265,7 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
     // Verify the metadata has expected defaults
     assert(metadata.catalogName == "my_catalog")
     assert(metadata.planningEndpointUri == "")
-    assert(metadata.authToken.isEmpty)
+    assert(metadata.tokenSupplier.isEmpty)
     assert(metadata.tableProperties.isEmpty)
   }
 
@@ -274,7 +274,7 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
     val metadata = UnityCatalogMetadata(
       catalogName = "test_catalog",
       ucUri = ucUri,
-      ucToken = "test-token",
+      tokenSupplier = Some(() => "test-token"),
       tableProps = Map.empty
     )
 
@@ -285,6 +285,76 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
       "https://unity-catalog-server.example.com/api/2.1/unity-catalog/" +
       "iceberg-rest/v1"
     assert(metadata.planningEndpointUri == expectedEndpoint)
+  }
+
+  test("extractAuthConfig: OAuth config") {
+    val cat = "oauthCat"
+    withSQLConf(
+      s"spark.sql.catalog.$cat.auth.type" -> "oauth",
+      s"spark.sql.catalog.$cat.auth.oauth.uri" ->
+        "https://oauth.example.com/token",
+      s"spark.sql.catalog.$cat.auth.oauth.clientId" ->
+        "client123",
+      s"spark.sql.catalog.$cat.auth.oauth.clientSecret" ->
+        "secret456"
+    ) {
+      val config = UnityCatalogMetadata
+        .extractAuthConfig(spark, cat)
+      assert(config("type") == "oauth")
+      assert(config("oauth.uri") ==
+        "https://oauth.example.com/token")
+      assert(config("oauth.clientId") == "client123")
+      assert(config.size == 4)
+    }
+  }
+
+  test("extractAuthConfig: legacy token as static") {
+    val cat = "legacyCat"
+    withSQLConf(
+      s"spark.sql.catalog.$cat.token" -> "dapi-token"
+    ) {
+      val config = UnityCatalogMetadata
+        .extractAuthConfig(spark, cat)
+      assert(config("type") == "static")
+      assert(config("token") == "dapi-token")
+      assert(config.size == 2)
+    }
+  }
+
+  test("extractAuthConfig: error if both token formats") {
+    val cat = "conflictCat"
+    withSQLConf(
+      s"spark.sql.catalog.$cat.auth.token" -> "new",
+      s"spark.sql.catalog.$cat.token" -> "old"
+    ) {
+      val e = intercept[IllegalArgumentException] {
+        UnityCatalogMetadata.extractAuthConfig(spark, cat)
+      }
+      assert(e.getMessage.contains("configured twice"))
+    }
+  }
+
+  test("extractAuthConfig: legacy token wins over auth.*") {
+    val cat = "legacyWinsCat"
+    withSQLConf(
+      s"spark.sql.catalog.$cat.auth.type" -> "oauth",
+      s"spark.sql.catalog.$cat.auth.oauth.uri" ->
+        "https://oauth.example.com",
+      s"spark.sql.catalog.$cat.token" -> "dapi-legacy"
+    ) {
+      val config = UnityCatalogMetadata
+        .extractAuthConfig(spark, cat)
+      // Legacy .token always wins (converted to static)
+      assert(config("type") == "static")
+      assert(config("token") == "dapi-legacy")
+      assert(config.size == 2)
+    }
+  }
+
+  test("extractAuthConfig: empty when no auth") {
+    val config = UnityCatalogMetadata
+      .extractAuthConfig(spark, "nonExistentCat")
+    assert(config.isEmpty)
   }
 
   test("simple EqualTo filter pushed to planning client") {


### PR DESCRIPTION
## Summary
Replace the static bearer token in `IcebergRESTCatalogPlanningClient` with a per-request `tokenSupplier` backed by UC's `TokenProvider`, enabling OAuth client credentials flow.

## Auth config

**Static token (existing, unchanged):**
```
spark.sql.catalog.<name>.token = "dapi..."
```

**OAuth client credentials (new):**
```
spark.sql.catalog.<name>.auth.type = oauth
spark.sql.catalog.<name>.auth.oauth.uri = https://<idp>/token
spark.sql.catalog.<name>.auth.oauth.clientId = <id>
spark.sql.catalog.<name>.auth.oauth.clientSecret = <secret>
```

Follows UC's `AuthConfigUtils` pattern. Error if both `.token` and `.auth.token` are set.

## Key changes
- `ServerSidePlanningMetadata`: `authToken` -> `tokenSupplier` (per-request function)
- `UnityCatalogMetadata`: Extract `auth.*` configs, create `TokenProvider`. Legacy `.token` fallback with conflict check.
- `IcebergRESTCatalogPlanningClient`: `token: String` -> `tokenSupplier: () => String`. `HttpRequestInterceptor` for per-request Bearer token injection.

## Test plan
- [ ] `extractAuthConfig` tests: OAuth, static, legacy, conflict error, legacy wins, empty
- [ ] Existing SSP tests updated for new constructor signatures
- [ ] CI on delta-io/delta

This pull request was AI-assisted by Isaac.