### PR TITLE
[Spark] Fix misleading error message when UniForm Iceberg is enabled without a supported IcebergCompat version

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3543,8 +3543,7 @@ trait DeltaErrorsBase
         UniversalFormat.ICEBERG_FORMAT,
         "Requires IcebergCompat to be explicitly enabled in order for Universal Format (Iceberg) " +
         "to be enabled on an existing table. Supported versions are IcebergCompatV1 and " +
-        "IcebergCompatV2. To enable IcebergCompatV2 (recommended), set the table property " +
-        "'delta.enableIcebergCompatV2' = 'true'."
+        "IcebergCompatV2."
       )
     )
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Backport of #6352 to branch-4.2.

When a user enables `delta.universalFormat.enabledFormats = 'iceberg'` alongside an unrecognized IcebergCompat property (e.g. `delta.enableIcebergCompatV3`), the error message currently says:

> To enable IcebergCompatV2, set the table property 'delta.enableIcebergCompatV2' = 'true'.

This is misleading because:
1. Spark Delta silently ignores the unrecognized V3 property (only V1 and V2 are in `IcebergCompat.knownVersions`)
2. The error then directs the user to V2 with no indication that V3 is not supported

The fix updates the message to explicitly state that the supported versions are IcebergCompatV1 and IcebergCompatV2, making clear to users that higher versions are not yet supported in this Spark Delta release.

## How was this patch tested?

The change is limited to an error message string. Manual reproduction:

```sql
SET spark.databricks.delta.allowArbitraryProperties.enabled=true;

CREATE TABLE demo.icebergCompatV3 (i INT, s STRING) USING DELTA
TBLPROPERTIES (
  'delta.columnMapping.mode'             = 'name',
  'delta.enableIcebergCompatV3'          = 'true',
  'delta.enableDeletionVectors'          = 'false',
  'delta.universalFormat.enabledFormats' = 'iceberg'
);
```

**Before:** `"To enable IcebergCompatV2, set the table property 'delta.enableIcebergCompatV2' = 'true'."`

**After:** `"Supported versions are IcebergCompatV1 and IcebergCompatV2."`

## Does this PR introduce _any_ user-facing changes?

Yes. The error message for `DELTA_UNIVERSAL_FORMAT_VIOLATION` (when UniForm Iceberg is enabled without a recognized IcebergCompat version) now explicitly lists the supported IcebergCompat versions (V1 and V2), instead of directing the user to enable V2. This helps users who set an unsupported version (e.g. V3) understand why the error occurred.