### PR TITLE
[kernel-spark] Add DSv2 CDC streaming: routing, reader, and end-to-end tests

### DIFF
--- a/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
+++ b/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.internal
+
+import scala.jdk.OptionConverters._
+
+import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.connector.catalog.Identifier
+
+/**
+ * Plumbs read options into a V2 [[StreamingRelationV2]]'s [[SparkTable]] when those options
+ * change a property the table derives from them.
+ */
+class ApplyV2ReadOptions extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+    case r @ StreamingRelationV2(_, _, sparkTable: SparkTable, extraOptions, _, _, Some(ident), _)
+        if CDCReader.isCDCRead(extraOptions)
+          && !r.output.exists(a => CDCSchemaContext.isCDCColumn(a.name)) =>
+      val newTable = sparkTable.getCatalogTable.toScala match {
+        case Some(catalogTable) => new SparkTable(ident, catalogTable, extraOptions)
+        case None => new SparkTable(ident, sparkTable.getTablePath.toString, extraOptions)
+      }
+      StreamingRelationV2(
+        source = None,
+        sourceName = r.sourceName,
+        table = newTable,
+        extraOptions = extraOptions,
+        output = toAttributes(newTable.schema()),
+        catalog = r.catalog,
+        identifier = Some(ident),
+        v1Relation = None)
+  }
+}

--- a/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -16,7 +16,7 @@
 
 package io.delta.sql
 
-import io.delta.internal.ApplyV2Streaming
+import io.delta.internal.{ApplyV2ReadOptions, ApplyV2Streaming}
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -82,6 +82,13 @@ class DeltaSparkSessionExtension extends AbstractDeltaSparkSessionExtension {
     // handled separately via the nested NoOpRule class below (kept for MiMa).
     extensions.injectResolutionRule { session =>
       new ApplyV2Streaming(session)
+    }
+
+    // Plumb read options into V2 StreamingRelationV2's SparkTable when those options change a
+    // property the table derives from them (today: CDC; future: schema evolution). Runs after
+    // ApplyV2Streaming so it sees both V1-converted and catalog-loaded relations.
+    extensions.injectResolutionRule { _ =>
+      new ApplyV2ReadOptions
     }
   }
 

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
@@ -1,0 +1,243 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.internal
+
+import java.net.URI
+import java.util.{HashMap => JHashMap}
+
+import scala.jdk.CollectionConverters._
+
+import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTableType}
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.delta.DeltaOptions
+import org.apache.spark.sql.delta.Relocated.StreamingRelation
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.sources.{DeltaSQLConf, DeltaSourceUtils}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
+
+  // Mirrors the rule order in DeltaSparkSessionExtension: ApplyV2Streaming runs first to produce
+  // a StreamingRelationV2, then ApplyV2ReadOptions plumbs read options into the table.
+  private def applyRules(plan: LogicalPlan): LogicalPlan = {
+    val afterStreaming = new ApplyV2Streaming(spark).apply(plan)
+    new ApplyV2ReadOptions().apply(afterStreaming)
+  }
+
+  private def assertV2(result: LogicalPlan): Unit = {
+    result match {
+      case StreamingRelationV2(_, _, _: SparkTable, _, _, _, _, v1Relation) =>
+        assert(v1Relation.isEmpty)
+      case other =>
+        fail(s"Expected StreamingRelationV2, got $other")
+    }
+  }
+
+  private def createDeltaTable(path: String): Unit = {
+    spark.range(1).selectExpr("id").write.format("delta").save(path)
+  }
+
+  private def createPartitionedDeltaTable(path: String): Unit = {
+    spark.range(1)
+      .selectExpr("cast(id as int) as id", "'2024-01-01' as date", "'foo' as name")
+      .write.format("delta").partitionBy("date").save(path)
+  }
+
+  private def createCatalogTable(locationUri: URI, ucManaged: Boolean): CatalogTable = {
+    val storageProps = new JHashMap[String, String]()
+    if (ucManaged) {
+      storageProps.put(UCCommitCoordinatorClient.UC_TABLE_ID_KEY, "uc-table-id")
+      storageProps.put("delta.feature.catalogManaged", "supported")
+    }
+    val identifier = TableIdentifier("tbl", Some("default"), Some("spark_catalog"))
+    val storage = CatalogStorageFormat(
+      locationUri = Some(locationUri),
+      inputFormat = None,
+      outputFormat = None,
+      serde = None,
+      compressed = false,
+      properties = storageProps.asScala.toMap)
+    CatalogTable(
+      identifier = identifier,
+      tableType = CatalogTableType.MANAGED,
+      storage = storage,
+      schema = new StructType(),
+      provider = None,
+      partitionColumnNames = Seq.empty,
+      bucketSpec = None,
+      properties = Map.empty)
+  }
+
+  private val cdcColumnNames = Set(
+    CDCReader.CDC_TYPE_COLUMN_NAME,
+    CDCReader.CDC_COMMIT_VERSION,
+    CDCReader.CDC_COMMIT_TIMESTAMP)
+
+  test("Case 1: StreamingRelation with readChangeFeed=true includes CDC columns") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createDeltaTable(path)
+      val catalogTable = createCatalogTable(dir.toURI, ucManaged = false)
+      val dataSource = DataSource(
+        sparkSession = spark,
+        userSpecifiedSchema = None,
+        className = "delta",
+        options = Map("path" -> path, DeltaOptions.CDC_READ_OPTION -> "true"),
+        catalogTable = Some(catalogTable))
+      val plan = StreamingRelation(dataSource)
+
+      withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "STRICT") {
+        val result = applyRules(plan)
+        assertV2(result)
+        val outputNames = result.output.map(_.name).toSet
+        assert(cdcColumnNames.subsetOf(outputNames),
+          s"Output should contain CDC columns. Got: ${outputNames}")
+      }
+    }
+  }
+
+  test("Case 1: StreamingRelation without readChangeFeed excludes CDC columns") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createDeltaTable(path)
+      val catalogTable = createCatalogTable(dir.toURI, ucManaged = false)
+      val dataSource = DataSource(
+        sparkSession = spark,
+        userSpecifiedSchema = None,
+        className = "delta",
+        options = Map("path" -> path),
+        catalogTable = Some(catalogTable))
+      val plan = StreamingRelation(dataSource)
+
+      withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "STRICT") {
+        val result = applyRules(plan)
+        assertV2(result)
+        val outputNames = result.output.map(_.name).toSet
+        assert(cdcColumnNames.intersect(outputNames).isEmpty,
+          s"Output should not contain CDC columns. Got: ${outputNames}")
+      }
+    }
+  }
+
+  test("Case 2: augments StreamingRelationV2 with CDC columns appended after data columns") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createPartitionedDeltaTable(path)
+      val catalogTable = createCatalogTable(dir.toURI, ucManaged = false)
+      val ident = Identifier.of(
+        catalogTable.identifier.database.toArray,
+        catalogTable.identifier.table)
+      // Build the input table without the CDC option so its schema lacks CDC columns. The rule
+      // should rebuild the table with the CDC option from extraOptions and append CDC columns.
+      val table = new SparkTable(ident, catalogTable, new JHashMap[String, String]())
+      val cdcOpts = new JHashMap[String, String]()
+      cdcOpts.put(DeltaOptions.CDC_READ_OPTION, "true")
+      val extraOptions = new CaseInsensitiveStringMap(cdcOpts)
+
+      val plan = StreamingRelationV2(
+        source = None,
+        sourceName = DeltaSourceUtils.NAME,
+        table = table,
+        extraOptions = extraOptions,
+        output = toAttributes(table.schema()),
+        catalog = None,
+        identifier = Some(ident),
+        v1Relation = None)
+
+      withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "STRICT") {
+        val result = applyRules(plan)
+        val outputNames = result.output.map(_.name)
+        val expected = Seq(
+          "id", "date", "name",
+          CDCReader.CDC_TYPE_COLUMN_NAME,
+          CDCReader.CDC_COMMIT_VERSION,
+          CDCReader.CDC_COMMIT_TIMESTAMP)
+        assert(outputNames == expected,
+          s"Expected original column order + CDC, got: $outputNames")
+      }
+    }
+  }
+
+  test("Case 2: StreamingRelationV2 without readChangeFeed is unchanged") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createDeltaTable(path)
+      val catalogTable = createCatalogTable(dir.toURI, ucManaged = false)
+      val ident = Identifier.of(
+        catalogTable.identifier.database.toArray,
+        catalogTable.identifier.table)
+      val table = new SparkTable(ident, catalogTable, new JHashMap[String, String]())
+
+      val plan = StreamingRelationV2(
+        source = None,
+        sourceName = DeltaSourceUtils.NAME,
+        table = table,
+        extraOptions = CaseInsensitiveStringMap.empty,
+        output = toAttributes(table.schema()),
+        catalog = None,
+        identifier = Some(ident),
+        v1Relation = None)
+
+      withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "STRICT") {
+        val result = applyRules(plan)
+        assert(result eq plan, "Plan should be returned unchanged")
+      }
+    }
+  }
+
+  test("ApplyV2ReadOptions is idempotent: applying the rule twice has no effect") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createPartitionedDeltaTable(path)
+      val catalogTable = createCatalogTable(dir.toURI, ucManaged = false)
+      val ident = Identifier.of(
+        catalogTable.identifier.database.toArray,
+        catalogTable.identifier.table)
+      val table = new SparkTable(ident, catalogTable, new JHashMap[String, String]())
+      val cdcOpts = new JHashMap[String, String]()
+      cdcOpts.put(DeltaOptions.CDC_READ_OPTION, "true")
+      val extraOptions = new CaseInsensitiveStringMap(cdcOpts)
+
+      val plan = StreamingRelationV2(
+        source = None,
+        sourceName = DeltaSourceUtils.NAME,
+        table = table,
+        extraOptions = extraOptions,
+        output = toAttributes(table.schema()),
+        catalog = None,
+        identifier = Some(ident),
+        v1Relation = None)
+
+      withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "STRICT") {
+        val rule = new ApplyV2ReadOptions()
+        val once = rule.apply(plan)
+        val twice = rule.apply(once)
+        assert(twice eq once, "Second application should return the same plan instance")
+      }
+    }
+  }
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2CDCStreamSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2CDCStreamSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.{DeltaCDCStreamSuite, DeltaConfigs, DeltaLog, DeltaOperations}
+
+/**
+ * Test suite that runs DeltaCDCStreamSuite using the V2 connector (V2_ENABLE_MODE=STRICT).
+ */
+class DeltaV2CDCStreamSuite extends DeltaCDCStreamSuite with V2ForceTest {
+
+  override protected def useDsv2: Boolean = true
+
+  override protected def enableCDF(path: String): Unit = {
+    val deltaLog = DeltaLog.forTable(spark, path)
+    val metadata = deltaLog.update().metadata
+    deltaLog.startTransaction().commit(
+      metadata.copy(configuration =
+        metadata.configuration + (DeltaConfigs.CHANGE_DATA_FEED.key -> "true")) :: Nil,
+      DeltaOperations.SetTableProperties(
+        Map(DeltaConfigs.CHANGE_DATA_FEED.key -> "true")))
+  }
+
+  override protected lazy val shouldPassTests = Set(
+    // ========== Core CDC streaming tests ==========
+    "no startingVersion should result fetch the entire snapshot",
+    "CDC initial snapshot should end at base index of next version",
+    "startingVersion = latest",
+    "user provided startingVersion",
+    "user provided startingTimestamp",
+    "startingVersion and startingTimestamp are both set",
+    "cdc streams should respect checkpoint",
+    "cdc streams with noop merge",
+    "streams updating latest offset with readChangeFeed=true",
+    "streams updating latest offset with readChangeFeed=false",
+
+    // ========== File action variant tests ==========
+    "cdc streams should be able to get offset when there only RemoveFiles",
+    "cdc streams should work starting from RemoveFile",
+    "cdc streams should work starting from AddCDCFile",
+
+    // ========== Rate limiting tests ==========
+    "rateLimit - maxFilesPerTrigger - overall",
+    "rateLimit - maxBytesPerTrigger - overall",
+    "rateLimit - maxFilesPerTrigger - starting from initial snapshot",
+    "rateLimit - maxBytesPerTrigger - starting from initial snapshot",
+
+    // ========== Misc tests ==========
+    "check starting[Version/Timestamp] > latest version without error",
+    "excludeRegex works with cdc",
+    "excludeRegex on cdcPath should not return Add/RemoveFiles",
+    "schema check for cdc stream",
+    "should not attempt to read a non exist version",
+
+    // ========== Option B refactor + RT-rejection coverage ==========
+    "CDC stream supports column pruning of data columns",
+    "CDC stream rejects reading row tracking metadata fields"
+  )
+
+  override protected lazy val shouldFailTests = Set(
+    // === Error message format differs in V2 (missing [DELTA_VERSION_NOT_FOUND] prefix) ===
+    "starting[Version/Timestamp] > latest version",
+    // === sql("DELETE FROM delta.`...`") not supported under STRICT V2 mode ===
+    "double delete-only on the same file",
+    // === TODO(#6591): Pre-existing vectorized partitioned-CDC bug (PlainIntegerDictionary / NPE).
+    "rateLimit - maxFilesPerTrigger - should not deadlock",
+    "rateLimit - maxBytesPerTrigger - should not deadlock",
+    "maxFilesPerTrigger - 2 successive AddCDCFile commits",
+    "maxFilesPerTrigger - batch reject stops iteration to prevent data loss",
+    "maxFilesPerTrigger with Trigger.AvailableNow respects read limits",
+    // === V2 wraps DeltaAnalysisException in RuntimeException, so the test's
+    // === ExpectFailure[DeltaAnalysisException] cause-class check fails.
+    "startingVersion before CDF was enabled rejects with change-data-not-recorded"
+  )
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.{Date, Locale}
 
 import scala.language.implicitConversions
 
@@ -33,6 +33,7 @@ import io.delta.tables._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest, Trigger}
 import org.apache.spark.sql.types.StructType
@@ -51,6 +52,24 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(cdcConfig.defaultTablePropertyKey, "true")
+
+  /**
+   * Enable CDF on a table at the given path. Override in V2 subclasses where
+   * `ALTER TABLE delta.\`...\`` doesn't work under STRICT V2 mode.
+   */
+  protected def enableCDF(path: String): Unit = {
+    sql(s"ALTER TABLE delta.`$path` SET TBLPROPERTIES " +
+      s"(${cdcConfig.key}=true)")
+  }
+
+  /** Load a CDC streaming DataFrame, with the CDC read option pre-set. */
+  protected def loadCDCStream(
+      path: String,
+      additionalOptions: Map[String, String] = Map.empty): DataFrame = {
+    loadStreamWithOptions(
+      path,
+      Map(DeltaOptions.CDC_READ_OPTION -> "true") ++ additionalOptions)
+  }
 
   /**
    * Create two tests for maxFilesPerTrigger and maxBytesPerTrigger
@@ -83,14 +102,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
           .save(inputDir.getAbsolutePath)
       }
       // enable cdc - version 3
-      sql(s"ALTER TABLE delta.`${inputDir.getAbsolutePath}` SET TBLPROPERTIES " +
-        s"(${cdcConfig.key}=true)")
+      enableCDF(inputDir.getAbsolutePath)
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       val version = 3
       val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
@@ -114,11 +130,9 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
         val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
 
-        val df = spark.readStream
-          .option(DeltaOptions.CDC_READ_OPTION, "true")
-          .format("delta")
-          .load(inputDir.getCanonicalPath)
-          .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+        val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+          DeltaOptions.CDC_READ_OPTION -> "true"
+        )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
         testStream(df)(
           ProcessAllAvailable(),
@@ -141,12 +155,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
     withTempDir { inputDir =>
       Seq(1, 2).toDF("value").write.format("delta").save(inputDir.getAbsolutePath)
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "latest")
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "latest"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df) (
         ProcessAllAvailable(),
@@ -169,12 +181,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       // version 2
       val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "1")
-        .format("delta")
-        .load(inputDir.toString)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df) (
         ProcessAllAvailable(),
@@ -184,6 +194,31 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
         },
         ProcessAllAvailable(),
         CheckAnswer((4, "insert", 1), (5, "insert", 1), (3, "delete", 2))
+      )
+    }
+  }
+
+  // CDF check must use the metadata at the start version, not at source-init time.
+  testQuietly("startingVersion before CDF was enabled rejects with change-data-not-recorded") {
+    withTempDir { inputDir =>
+      withSQLConf(cdcConfig.defaultTablePropertyKey -> "false") {
+        // v0: CDF=false at create. v1: append (no metadata action, CDF still false).
+        Seq(1, 2).toDF("id").write.format("delta").save(inputDir.getAbsolutePath)
+        Seq(3, 4).toDF("id").write.format("delta").mode("append").save(inputDir.getAbsolutePath)
+      }
+      // v2: enable CDF. v3: append.
+      enableCDF(inputDir.getAbsolutePath)
+      Seq(5, 6).toDF("id").write.format("delta").mode("append").save(inputDir.getAbsolutePath)
+
+      val df = loadCDCStream(inputDir.toString, Map("startingVersion" -> "1"))
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ExpectFailure[org.apache.spark.sql.delta.DeltaAnalysisException] { t =>
+          assert(t.getMessage.contains("DELTA_MISSING_CHANGE_DATA") ||
+            t.getMessage.toLowerCase(Locale.ROOT).contains("change data was not"),
+            s"Expected change-data-not-recorded error, got: ${t.getMessage}")
+        }
       )
     }
   }
@@ -202,12 +237,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
       val startTs = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         .format(new Date(2000))
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingTimestamp", startTs)
-        .format("delta")
-        .load(inputDir.toString)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingTimestamp" -> startTs
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df) (
         ProcessAllAvailable(),
@@ -228,22 +261,19 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       val deltaLog = DeltaLog.forTable(spark, inputDir.getAbsolutePath)
       modifyCommitTimestamp(deltaLog, 0, 1000)
 
-      val df1 = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", 1)
-        .format("delta")
-        .load(inputDir.toString)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df1 = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       val startTs = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
         .format(new Date(3000))
       val commitTs = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
       .format(new Date(1000))
-      val df2 = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingTimestamp", startTs)
-        .format("delta")
-        .load(inputDir.toString)
+      val df2 = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingTimestamp" -> startTs
+      ))
 
       val e1 = VersionNotFoundException(1, 0, 0).getMessage
       val e2 = DeltaErrors.timestampGreaterThanLatestCommit(
@@ -282,21 +312,17 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
             // build dataframe with starting timestamp option.
             val startTs = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
               .format(new Date(2000))
-            spark.readStream
-              .option(DeltaOptions.CDC_READ_OPTION, "true")
-              .option("startingTimestamp", startTs)
-              .format("delta")
-              .load(inputDir.toString)
-              .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+            loadStreamWithOptions(inputDir.toString, Map(
+              DeltaOptions.CDC_READ_OPTION -> "true",
+              "startingTimestamp" -> startTs
+            )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
           } else {
             assert(target == "version")
             // build dataframe with starting version option.
-            spark.readStream
-              .option(DeltaOptions.CDC_READ_OPTION, "true")
-              .option("startingVersion", 1)
-              .format("delta")
-              .load(inputDir.toString)
-              .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+            loadStreamWithOptions(inputDir.toString, Map(
+              DeltaOptions.CDC_READ_OPTION -> "true",
+              "startingVersion" -> "1"
+            )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
           }
 
           testStream(df)(
@@ -319,13 +345,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
     withTempDir { tableDir =>
       val tablePath = tableDir.getCanonicalPath
       spark.range(10).write.format("delta").save(tableDir.getAbsolutePath)
-      val q = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", 0L)
-        .option("startingTimestamp", "2020-07-15")
-        .load(tablePath)
-        .writeStream
+      val q = loadStreamWithOptions(tablePath, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0",
+        "startingTimestamp" -> "2020-07-15"
+      )).writeStream
         .format("console")
         .start()
       assert(intercept[StreamingQueryException] {
@@ -352,12 +376,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       def streamChanges(
           startingVersion: Long,
           checkpointLocation: String): Unit = {
-        val q = spark.readStream
-          .format("delta")
-          .option(DeltaOptions.CDC_READ_OPTION, "true")
-          .option("startingVersion", startingVersion)
-          .load(inputDir.getCanonicalPath)
-          .select("id")
+        val q = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+          DeltaOptions.CDC_READ_OPTION -> "true",
+          "startingVersion" -> startingVersion.toString
+        )).select("id")
           .writeStream
           .format("delta")
           .option("checkpointLocation", checkpointLocation)
@@ -431,12 +453,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
         // Read the target dir with cdc read option and ensure that
         // data frame is empty.
-        val q = spark.readStream
-          .format("delta")
-          .option(DeltaOptions.CDC_READ_OPTION, "true")
-          .option("startingVersion", "1")
-          .load(targetDir.getCanonicalPath)
-          .writeStream
+        val q = loadStreamWithOptions(targetDir.getCanonicalPath, Map(
+          DeltaOptions.CDC_READ_OPTION -> "true",
+          "startingVersion" -> "1"
+        )).writeStream
           .format("memory")
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
           .queryName("testQuery")
@@ -465,10 +485,9 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
           def runStreamingQuery(): StreamingQuery = {
             // process the input table in a CDC manner
-            val df = spark.readStream
-              .option(DeltaOptions.CDC_READ_OPTION, readChangeFeed)
-              .format("delta")
-              .load(inputDir.getAbsolutePath)
+            val df = loadStreamWithOptions(inputDir.getAbsolutePath, Map(
+              DeltaOptions.CDC_READ_OPTION -> readChangeFeed.toString
+            ))
             val query = df
               .select("id")
               .writeStream
@@ -520,12 +539,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
       val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", 0)
-        .format("delta")
-        .load(inputDir.toString)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df) (
         ProcessAllAvailable(),
@@ -552,12 +569,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
       deltaTable.delete("part = 0")
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", 1)
-        .format("delta")
-        .load(inputDir.toString)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df) (
         ProcessAllAvailable(),
@@ -579,12 +594,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
       deltaTable.delete("col2 = 0")
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", 1)
-        .format("delta")
-        .load(inputDir.toString)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df) (
         ProcessAllAvailable(),
@@ -641,13 +654,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
         4, // 4 rows(pre_image and post_image) from the 2 AddCDCFile
         4 // 4 rows(pre_image and post_image) from the 2 AddCDCFile
       )
-      val q = spark.readStream
-        .format("delta")
-        .option(key, value)
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "0")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val q = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        key -> value,
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(q) (
         ProcessAllAvailable(),
@@ -694,12 +705,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
       assert(deltaLog.snapshot.numOfFiles === 5)
 
-      val q = spark.readStream
-        .format("delta")
-        .option(key, value)
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val q = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        key -> value,
+        DeltaOptions.CDC_READ_OPTION -> "true"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       // 5 batches for the 5 commits split across commits and index number.
       val rowsPerBatch = Seq(1, 1, 1, 1, 1)
@@ -737,13 +746,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       // version 2 - 2 AddCDCFiles
       deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("1")))
 
-      val df = spark.readStream
-        .format("delta")
-        .option(key, value)
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "1")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        key -> value,
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df)(
         ProcessAllAvailable(),
@@ -781,13 +788,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       // version 2 - 2 AddCDCFiles
       deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("1")))
 
-      val df = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "3")
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "0")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "3",
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       // test whether the AddCDCFile commits do not get split up.
       val rowsPerBatch = Seq(
@@ -815,6 +820,56 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
     }
   }
 
+  test("maxFilesPerTrigger - batch reject stops iteration to prevent data loss") {
+    withTempDir { inputDir =>
+      // v0: 2 AddFiles (one per partition)
+      spark.range(2)
+        .withColumn("part", 'id % 2)
+        .withColumn("col3", lit(0))
+        .repartition(1)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      // v1: UPDATE -> 2 AddCDCFiles (explicit CDC, batch-admitted)
+      deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("1")))
+
+      // v2: INSERT -> 1 AddFile
+      spark.range(10, 11)
+        .withColumn("part", lit(0L))
+        .withColumn("col3", lit(2))
+        .write.format("delta").mode("append")
+        .save(inputDir.getAbsolutePath)
+
+      // maxFilesPerTrigger=3, startingVersion=0:
+      // Trigger 1: v0 initial snapshot (2 files, budget=1 left).
+      //            v1 explicit CDC batch (2 files, 2 > 1 -> rejected, budget goes negative).
+      //            v2 must NOT be admitted -- rejected batch stops iteration.
+      // Trigger 2: v1 batch admitted (fresh budget, deadlock protection). v2 (1 file) admitted.
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "3",
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckProgress(Seq(2, 5)),
+        CheckAnswer(
+          (0, 0, 0, "insert", 0),
+          (1, 1, 0, "insert", 0),
+          (0, 0, 0, "update_preimage", 1),
+          (0, 0, 1, "update_postimage", 1),
+          (1, 1, 0, "update_preimage", 1),
+          (1, 1, 1, "update_postimage", 1),
+          (10, 0, 2, "insert", 2)
+        )
+      )
+    }
+  }
+
   test("maxFilesPerTrigger with Trigger.AvailableNow respects read limits") {
     withTempDir { inputDir =>
       // version 0 - 2 AddFiles
@@ -834,13 +889,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       // version 2 - 2 AddCDCFiles
       deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("1")))
 
-      val df = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "3")
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "0")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "3",
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       // test whether the AddCDCFile commits do not get split up.
       val rowsPerBatch = Seq(
@@ -881,13 +934,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
         .partitionBy("part")
         .save(inputDir.getAbsolutePath)
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "0")
-        .option(DeltaOptions.EXCLUDE_REGEX_OPTION, "part=0")
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0",
+        DeltaOptions.EXCLUDE_REGEX_OPTION -> "part=0"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df)(
         ProcessAllAvailable(),
@@ -917,13 +968,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
         .asInstanceOf[AddCDCFile]
         .path
 
-      val df = spark.readStream
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", "0")
-        .option(DeltaOptions.EXCLUDE_REGEX_OPTION, excludePath)
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0",
+        DeltaOptions.EXCLUDE_REGEX_OPTION -> excludePath
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df)(
         ProcessAllAvailable(),
@@ -939,12 +988,10 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
         Seq(i).toDF.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
       }
 
-      val df = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.CDC_READ_OPTION, "true")
-        .option("startingVersion", 0)
-        .load(inputDir.getCanonicalPath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val df = loadStreamWithOptions(inputDir.getCanonicalPath, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        "startingVersion" -> "0"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(df)(
         AssertOnQuery { q => q.processAllAvailable(); true },
@@ -979,14 +1026,12 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       spark.range(1, 2).write.format("delta").save(inputDir2.getCanonicalPath)
 
       def startQuery(): StreamingQuery = {
-        val df1 = spark.readStream
-          .format("delta")
-          .option("readChangeFeed", "true")
-          .load(inputDir1.getCanonicalPath)
-        val df2 = spark.readStream
-          .format("delta")
-          .option("readChangeFeed", "true")
-          .load(inputDir2.getCanonicalPath)
+        val df1 = loadStreamWithOptions(inputDir1.getCanonicalPath, Map(
+          "readChangeFeed" -> "true"
+        ))
+        val df2 = loadStreamWithOptions(inputDir2.getCanonicalPath, Map(
+          "readChangeFeed" -> "true"
+        ))
         df1.union(df2).writeStream
           .format("noop")
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
@@ -1039,13 +1084,11 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id IN (1, 3, 6)")
       spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id IN (2, 4, 7)")
 
-      val stream = spark.readStream
-        .format("delta")
-        .option(DeltaOptions.CDC_READ_OPTION, true)
-        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, 1)
-        .option(DeltaOptions.STARTING_VERSION_OPTION, 1)
-        .load(tablePath)
-        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      val stream = loadStreamWithOptions(tablePath, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1",
+        DeltaOptions.STARTING_VERSION_OPTION -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
 
       testStream(stream)(
         ProcessAllAvailable(),
@@ -1057,6 +1100,61 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
           (4L, "delete", 2L),
           (7L, "delete", 2L)
         )
+      )
+    }
+  }
+
+  test("CDC stream supports column pruning of data columns") {
+    withTempDir { inputDir =>
+      val path = inputDir.getCanonicalPath
+      // version 0: three data columns. CDF is on by default via cdcConfig.defaultTablePropertyKey.
+      Seq((1, "a", 100), (2, "b", 200)).toDF("id", "name", "value")
+        .write.format("delta").save(path)
+      // version 1: append more data so we get multiple commits worth of CDF events.
+      Seq((3, "c", 300)).toDF("id", "name", "value")
+        .write.format("delta").mode("append").save(path)
+
+      // Project only id + _change_type, dropping the other two data columns. The Option B
+      // refactor of CDCSchemaContext is what makes the pruned readDataSchema flow cleanly to
+      // the reader; before it, this would have thrown IllegalStateException.
+      val df = loadCDCStream(path, Map(DeltaOptions.STARTING_VERSION_OPTION -> "0"))
+        .select("id", "_change_type")
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((1, "insert"), (2, "insert"), (3, "insert"))
+      )
+    }
+  }
+
+  test("CDC stream rejects reading row tracking metadata fields") {
+    // Per Delta protocol ("Reader Requirements for Row Tracking"), readers cannot expose row
+    // IDs or row commit versions while reading change data files from `cdc` actions. v1
+    // enforces this by stripping row tracking fields from `_metadata.metadataSchemaFields`
+    // when isCDCRead=true, so the analyzer can't resolve `_metadata.row_id`.
+    withTempDir { inputDir =>
+      val path = inputDir.getCanonicalPath
+      // Enable both CDF and Row Tracking via writer options (works under STRICT V2 mode where
+      // ALTER TABLE may be unavailable).
+      Seq((1L, "Alice"), (2L, "Bob")).toDF("id", "name")
+        .write.format("delta")
+        .option("delta.enableChangeDataFeed", "true")
+        .option("delta.enableRowTracking", "true")
+        .save(path)
+      Seq((3L, "Charlie")).toDF("id", "name")
+        .write.format("delta").mode("append").save(path)
+
+      // v1 rejects at analysis time (selectExpr); v2 may surface the error later (during stream
+      // execution). Wrap both in the intercept so we catch wherever it fires.
+      val ex = intercept[Exception] {
+        val df = loadCDCStream(path, Map(DeltaOptions.STARTING_VERSION_OPTION -> "0"))
+          .selectExpr("id", "_metadata.row_id", "_change_type")
+        testStream(df)(ProcessAllAvailable())
+      }
+      assert(
+        ex.getMessage.toLowerCase(Locale.ROOT).contains("row_id") ||
+          ex.getMessage.toLowerCase(Locale.ROOT).contains("cannot be resolved"),
+        s"Expected error mentioning row_id under CDC, got: ${ex.getMessage}"
       )
     }
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/CDCDataFile.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/CDCDataFile.java
@@ -15,6 +15,7 @@
  */
 package io.delta.spark.internal.v2.read;
 
+import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.actions.AddCDCFile;
 import io.delta.kernel.internal.actions.AddFile;
@@ -30,6 +31,8 @@ public class CDCDataFile {
   @Nullable private final AddFile addFile;
   @Nullable private final RemoveFile removeFile;
   private final boolean isAddCDCFile;
+  @Nullable private final String cdcPath;
+  @Nullable private final MapValue cdcPartitionValues;
   @Nullable private final String changeType;
   private final long commitTimestamp;
   private final long fileSize;
@@ -38,12 +41,16 @@ public class CDCDataFile {
       @Nullable AddFile addFile,
       @Nullable RemoveFile removeFile,
       boolean isAddCDCFile,
+      @Nullable String cdcPath,
+      @Nullable MapValue cdcPartitionValues,
       @Nullable String changeType,
       long commitTimestamp,
       long fileSize) {
     this.addFile = addFile;
     this.removeFile = removeFile;
     this.isAddCDCFile = isAddCDCFile;
+    this.cdcPath = cdcPath;
+    this.cdcPartitionValues = cdcPartitionValues;
     this.changeType = changeType;
     this.commitTimestamp = commitTimestamp;
     this.fileSize = fileSize;
@@ -55,6 +62,8 @@ public class CDCDataFile {
         addFile,
         /* removeFile= */ null,
         /* isAddCDCFile= */ false,
+        /* cdcPath= */ null,
+        /* cdcPartitionValues= */ null,
         CDCReader.CDC_TYPE_INSERT(),
         commitTimestamp,
         addFile.getSize());
@@ -66,6 +75,8 @@ public class CDCDataFile {
         /* addFile= */ null,
         removeFile,
         /* isAddCDCFile= */ false,
+        /* cdcPath= */ null,
+        /* cdcPartitionValues= */ null,
         CDCReader.CDC_TYPE_DELETE_STRING(),
         commitTimestamp,
         removeFile.getSize().orElse(0L));
@@ -73,11 +84,15 @@ public class CDCDataFile {
 
   /** Create a CDCDataFile for an explicit AddCDCFile action. */
   public static CDCDataFile fromAddCDCFile(Row cdcRow, long commitTimestamp) {
+    String path = cdcRow.getString(AddCDCFile.FULL_SCHEMA.indexOf("path"));
+    MapValue partitionValues = cdcRow.getMap(AddCDCFile.FULL_SCHEMA.indexOf("partitionValues"));
     long size = cdcRow.getLong(AddCDCFile.FULL_SCHEMA.indexOf("size"));
     return new CDCDataFile(
         /* addFile= */ null,
         /* removeFile= */ null,
         /* isAddCDCFile= */ true,
+        /* cdcPath= */ path,
+        /* cdcPartitionValues= */ partitionValues,
         /* changeType= */ null,
         commitTimestamp,
         size);
@@ -91,6 +106,28 @@ public class CDCDataFile {
   @Nullable
   public RemoveFile getRemoveFile() {
     return removeFile;
+  }
+
+  /** Returns the file path for any CDC file variant. */
+  public String getPath() {
+    if (addFile != null) {
+      return addFile.getPath();
+    } else if (removeFile != null) {
+      return removeFile.getPath();
+    } else {
+      return cdcPath;
+    }
+  }
+
+  /**
+   * Returns the partition values for any CDC file variant. May be null for RemoveFile when
+   * extendedFileMetadata is not present.
+   */
+  @Nullable
+  public MapValue getPartitionValues() {
+    if (addFile != null) return addFile.getPartitionValues();
+    if (removeFile != null) return removeFile.getPartitionValues().orElse(null);
+    return cdcPartitionValues;
   }
 
   @Nullable

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -169,6 +169,9 @@ public class SparkMicroBatchStream
    */
   private volatile boolean hasCheckedReadIncompatibleSchemaChangesOnStreamStart = false;
 
+  /** One-shot flag for {@link #validateCDFEnabledOnTable}. */
+  private volatile boolean cdfEnabledOnStreamStartValidated = false;
+
   /**
    * When AvailableNow is used, this offset will be the upper bound where this run of the query will
    * process up. We may run multiple micro batches, but the query will stop itself when it reaches
@@ -471,25 +474,23 @@ public class SparkMicroBatchStream
 
     List<PartitionedFile> partitionedFiles = new ArrayList<>();
     long totalBytesToRead = 0;
-    try (CloseableIterator<IndexedFile> fileChanges =
-        getFileChanges(fromVersion, fromIndex, isInitialSnapshot, Optional.of(endOffset))) {
-      while (fileChanges.hasNext()) {
-        IndexedFile indexedFile = fileChanges.next();
-        if (indexedFile.getAddFile() == null) {
-          continue;
-        }
-        AddFile addFile = indexedFile.getAddFile();
-        // TODO(#5319): Apply excludeRegex to RemoveFile/AddCDCFile when CDC is supported
-        if (excludeRegex.isPresent()
-            && excludeRegex.get().findFirstIn(addFile.getPath()).isDefined()) {
-          continue;
-        }
-        PartitionedFile partitionedFile =
-            PartitionUtils.buildPartitionedFile(
-                addFile, partitionSchema, tablePath, ZoneId.of(sqlConf.sessionLocalTimeZone()));
+    boolean isCDC = options.readChangeFeed();
+    ZoneId zoneId = ZoneId.of(sqlConf.sessionLocalTimeZone());
 
-        totalBytesToRead += addFile.getSize();
-        partitionedFiles.add(partitionedFile);
+    try (CloseableIterator<IndexedFile> fileChanges =
+        isCDC
+            ? getFileChangesWithRateLimitForCDC(
+                fromVersion,
+                fromIndex,
+                isInitialSnapshot,
+                /* limits= */ Optional.empty(),
+                Optional.of(endOffset))
+            : getFileChanges(fromVersion, fromIndex, isInitialSnapshot, Optional.of(endOffset))) {
+      while (fileChanges.hasNext()) {
+        PartitionedFile pf = buildPartitionedFile(fileChanges.next(), isCDC, zoneId);
+        if (pf == null) continue;
+        totalBytesToRead += pf.fileSize();
+        partitionedFiles.add(pf);
       }
     } catch (IOException e) {
       throw new RuntimeException(
@@ -527,6 +528,26 @@ public class SparkMicroBatchStream
         /* isCDCRead */ options.readChangeFeed());
   }
 
+  /**
+   * Returns a {@link PartitionedFile} for the given {@link IndexedFile}, or {@code null} if the
+   * file should be skipped (no AddFile/CDC payload, or path matches the excludeRegex).
+   */
+  private PartitionedFile buildPartitionedFile(
+      IndexedFile indexedFile, boolean isCDC, ZoneId zoneId) {
+    if (indexedFile.getAddFile() != null) {
+      AddFile addFile = indexedFile.getAddFile();
+      if (isExcludedPath(addFile.getPath())) return null;
+      return PartitionUtils.buildPartitionedFile(addFile, partitionSchema, tablePath, zoneId);
+    }
+    if (isCDC && indexedFile.getCDCDataFile() != null) {
+      CDCDataFile cdcFile = indexedFile.getCDCDataFile();
+      if (isExcludedPath(cdcFile.getPath())) return null;
+      return PartitionUtils.buildCDCPartitionedFile(
+          cdcFile, indexedFile.getVersion(), partitionSchema, tablePath, zoneId);
+    }
+    return null;
+  }
+
   ///////////////
   // lifecycle //
   ///////////////
@@ -555,6 +576,10 @@ public class SparkMicroBatchStream
     return Optional.empty();
   }
 
+  private boolean isExcludedPath(String path) {
+    return excludeRegex.isPresent() && excludeRegex.get().findFirstIn(path).isDefined();
+  }
+
   ///////////////////////
   // getStartingVersion //
   ///////////////////////
@@ -574,8 +599,8 @@ public class SparkMicroBatchStream
     // Note: returning a version beyond latest snapshot version won't be a problem as callers
     // of this function won't use the version to retrieve snapshot(refer to
     // [[getStartingOffset]]).
-    // TODO(#5319): fetch spark config if CDF is supported.
-    boolean allowOutOfRange = false;
+    boolean allowOutOfRange =
+        (Boolean) sqlConf.getConf(DeltaSQLConf.DELTA_CDF_ALLOW_OUT_OF_RANGE_TIMESTAMP());
 
     if (options.startingVersion().isDefined()) {
       DeltaStartingVersion startingVersion = options.startingVersion().get();
@@ -593,7 +618,7 @@ public class SparkMicroBatchStream
           // check is skipped, so this is technically not safe, but we keep it this way for
           // historical reasons.
           snapshotManager.checkVersionExists(
-              version, /* mustBeRecreatable= */ false, /* allowOutOfRange= */ false);
+              version, /* mustBeRecreatable= */ false, allowOutOfRange);
         }
         cachedStartingVersion = Optional.of(version);
         return cachedStartingVersion;
@@ -782,7 +807,7 @@ public class SparkMicroBatchStream
       boolean isInitialSnapshot,
       Optional<DeltaSource.AdmissionLimits> limits,
       Optional<DeltaSourceOffset> endOffset) {
-    validateCDFEnabledOnTable();
+    validateCDFEnabledOnTable(fromVersion);
     CloseableIterator<IndexedFile> result;
     if (isInitialSnapshot) {
       InitialSnapshotCache snapshot = getSnapshotFiles(fromVersion);
@@ -877,14 +902,30 @@ public class SparkMicroBatchStream
     return result;
   }
 
-  private void validateCDFEnabledOnTable() {
-    if (!isCDFEnabled(snapshotAtSourceInit.getMetadata())) {
-      long version = snapshotAtSourceInit.getVersion();
-      // DeltaErrors.changeDataNotRecordedException returns a DeltaAnalysisException (checked),
-      // so we wrap it to propagate through the streaming pipeline.
-      Throwable error = DeltaErrors.changeDataNotRecordedException(version, version, version);
-      throw new RuntimeException(error.getMessage(), error);
+  @VisibleForTesting
+  void validateCDFEnabledOnTable(long startVersion) {
+    // Make sure CDF is enabled at startVersion during stream start.
+    if (cdfEnabledOnStreamStartValidated) {
+      return;
     }
+    SnapshotImpl startSnapshot;
+    if (startVersion == snapshotAtSourceInit.getVersion()) {
+      startSnapshot = snapshotAtSourceInit;
+    } else {
+      try {
+        startSnapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(startVersion);
+      } catch (io.delta.kernel.exceptions.KernelException e) {
+        // startVersion may not yet exist (e.g. startingVersion=latest resolves to latest+1).
+        // TODO(#6745): narrow this catch once kernel exposes a specific exception subclass
+        // for "version not yet materialized".
+        return;
+      }
+    }
+    if (!isCDFEnabled(startSnapshot.getMetadata())) {
+      throw new RuntimeException(
+          DeltaErrors.changeDataNotRecordedException(startVersion, startVersion, startVersion));
+    }
+    cdfEnabledOnStreamStartValidated = true;
   }
 
   private CloseableIterator<IndexedFile> filterDeltaLogs(
@@ -1848,10 +1889,14 @@ public class SparkMicroBatchStream
   }
 
   private static boolean isCDFEnabled(Metadata metadata) {
-    return metadata
-        .getConfiguration()
-        .getOrDefault("delta.enableChangeDataFeed", "false")
-        .equalsIgnoreCase("true");
+    // Fall back to the deprecated delta.enableChangeDataCapture key when
+    // delta.enableChangeDataFeed is not set.
+    Map<String, String> config = metadata.getConfiguration();
+    String value = config.get("delta.enableChangeDataFeed");
+    if (value == null) {
+      value = config.get("delta.enableChangeDataCapture");
+    }
+    return value != null && value.equalsIgnoreCase("true");
   }
 
   /** Checks if the endOffset is at BASE_INDEX for the given version (early exit condition). */

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -73,20 +73,14 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
               DeltaOptions.IGNORE_DELETES_OPTION(),
               DeltaOptions.SKIP_CHANGE_COMMITS_OPTION(),
               DeltaOptions.EXCLUDE_REGEX_OPTION(),
-              DeltaOptions.FAIL_ON_DATA_LOSS_OPTION()));
+              DeltaOptions.FAIL_ON_DATA_LOSS_OPTION(),
+              DeltaOptions.CDC_READ_OPTION(),
+              DeltaOptions.CDC_READ_OPTION_LEGACY()));
 
-  /**
-   * Block list of DeltaOptions that are not supported for streaming in V2 connector. Only
-   * startingVersion, startingTimestamp, maxFilesPerTrigger, maxBytesPerTrigger, ignoreFileDeletion,
-   * ignoreChanges, ignoreDeletes, skipChangeCommits, excludeRegex, and failOnDataLoss are
-   * supported. User-defined custom options (not in DeltaOptions) are allowed to pass through.
-   */
   private static final Set<String> UNSUPPORTED_STREAMING_OPTIONS =
       Collections.unmodifiableSet(
           new HashSet<>(
               Arrays.asList(
-                  DeltaOptions.CDC_READ_OPTION().toLowerCase(),
-                  DeltaOptions.CDC_READ_OPTION_LEGACY().toLowerCase(),
                   DeltaOptions.CDC_END_VERSION().toLowerCase(),
                   DeltaOptions.CDC_END_TIMESTAMP().toLowerCase(),
                   DeltaOptions.SCHEMA_TRACKING_LOCATION().toLowerCase(),

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/cdc/CDCSchemaContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/cdc/CDCSchemaContext.java
@@ -73,6 +73,13 @@ public class CDCSchemaContext implements Serializable {
    * @param partitionSchema the partition schema
    */
   public CDCSchemaContext(StructType readDataSchema, StructType partitionSchema) {
+    // check that pruneColumns has pruned any existing CDC columns
+    for (StructField field : readDataSchema.fields()) {
+      if (isCDCColumn(field.name())) {
+        throw new IllegalArgumentException(
+            "readDataSchema already contains the CDC column: " + field.name());
+      }
+    }
     this.readDataSchemaWithCDC = appendCDCColumns(readDataSchema);
     int dataColCount = readDataSchema.fields().length;
     int partColCount = partitionSchema.fields().length;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -38,15 +38,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.paths.SparkPath;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
 import org.apache.spark.sql.delta.DeltaColumnMapping;
+import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.DeltaParquetFileFormat;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.delta.RowIndexFilterType;
@@ -173,8 +176,7 @@ public class PartitionUtils {
                 : PartitioningUtils.castPartValueToDesiredType(field.dataType(), strVal, zoneId);
       }
     }
-    return InternalRow.fromSeq(
-        CollectionConverters.asScala(Arrays.asList(values).iterator()).toSeq());
+    return new GenericInternalRow(values);
   }
 
   /**
@@ -188,34 +190,107 @@ public class PartitionUtils {
    */
   public static PartitionedFile buildPartitionedFile(
       AddFile addFile, StructType partitionSchema, String tablePath, ZoneId zoneId) {
-    InternalRow partitionRow =
-        getPartitionRow(addFile.getPartitionValues(), partitionSchema, zoneId);
+    scala.collection.immutable.Map<String, Object> metadata =
+        mergeIntoScalaMap(
+            buildDvMetadata(addFile.getDeletionVector()),
+            buildRowTrackingMetadata(addFile.getBaseRowId(), addFile.getDefaultRowCommitVersion()));
+    return makePartitionedFile(
+        new Path(tablePath, addFile.getPath()).toString(),
+        addFile.getSize(),
+        addFile.getModificationTime(),
+        getPartitionRow(addFile.getPartitionValues(), partitionSchema, zoneId),
+        metadata);
+  }
 
-    // Preferred node locations are not used.
-    String[] preferredLocations = new String[0];
-
-    // Build metadata map with DV info if present
-    scala.collection.immutable.Map<String, Object> deletionVectorMetadata =
-        buildDvMetadata(addFile.getDeletionVector());
-    scala.collection.immutable.Map<String, Object> rowTrackingMetadata =
-        buildRowTrackingMetadata(addFile.getBaseRowId(), addFile.getDefaultRowCommitVersion());
-    scala.collection.immutable.Map<String, Object> otherConstantMetadataColumnValues =
-        deletionVectorMetadata;
-    for (Map.Entry<String, Object> entry :
-        CollectionConverters.asJava(rowTrackingMetadata).entrySet()) {
-      otherConstantMetadataColumnValues =
-          otherConstantMetadataColumnValues.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
+  /**
+   * Build a PartitionedFile from a CDCDataFile with CDC constants in
+   * otherConstantMetadataColumnValues for the {@link CDCReadFunction} to null-coalesce.
+   *
+   * <p>Row tracking metadata is intentionally NOT included: per Delta protocol "Reader Requirements
+   * for Row Tracking", readers must not expose row IDs / row commit versions while reading change
+   * data files from {@code cdc} actions.
+   */
+  public static PartitionedFile buildCDCPartitionedFile(
+      io.delta.spark.internal.v2.read.CDCDataFile cdcFile,
+      long commitVersion,
+      StructType partitionSchema,
+      String tablePath,
+      ZoneId zoneId) {
+    Map<String, Object> cdcConstants = new HashMap<>();
+    cdcConstants.put(CDCSchemaContext.CDC_COMMIT_VERSION, commitVersion);
+    cdcConstants.put(
+        CDCSchemaContext.CDC_COMMIT_TIMESTAMP,
+        TimeUnit.MILLISECONDS.toMicros(cdcFile.getCommitTimestamp()));
+    if (!cdcFile.isAddCDCFile()) {
+      cdcConstants.put(CDCSchemaContext.CDC_TYPE_COLUMN, cdcFile.getChangeType());
     }
+    scala.collection.immutable.Map<String, Object> metadata =
+        buildDvMetadata(getCDCFileDvDescriptor(cdcFile));
+    for (Map.Entry<String, Object> entry : cdcConstants.entrySet()) {
+      metadata = metadata.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
+    }
+    MapValue partitionValues = cdcFile.getPartitionValues();
+    if (partitionValues == null) {
+      // Only RemoveFile reaches here, when extendedFileMetadata is absent. Match V1's
+      // TahoeRemoveFileIndex behaviour rather than silently consuming missing metadata.
+      throw (RuntimeException) DeltaErrors.removeFileCDCMissingExtendedMetadata(cdcFile.getPath());
+    }
+    InternalRow partitionRow =
+        partitionSchema.fields().length > 0
+            ? getPartitionRow(partitionValues, partitionSchema, zoneId)
+            : emptyPartitionRow(0);
+    long modificationTime =
+        cdcFile.getAddFile() != null
+            ? cdcFile.getAddFile().getModificationTime()
+            : cdcFile.getCommitTimestamp();
+    return makePartitionedFile(
+        new Path(tablePath, cdcFile.getPath()).toString(),
+        cdcFile.getFileSize(),
+        modificationTime,
+        partitionRow,
+        metadata);
+  }
 
+  private static PartitionedFile makePartitionedFile(
+      String path,
+      long size,
+      long modificationTime,
+      InternalRow partitionRow,
+      scala.collection.immutable.Map<String, Object> metadata) {
     return new PartitionedFile(
         partitionRow,
-        SparkPath.fromUrlString(new Path(tablePath, addFile.getPath()).toString()),
+        SparkPath.fromUrlString(path),
         /* start= */ 0L,
-        /* length= */ addFile.getSize(),
-        preferredLocations,
-        addFile.getModificationTime(),
-        /* fileSize= */ addFile.getSize(),
-        otherConstantMetadataColumnValues);
+        /* length= */ size,
+        /* preferredLocations= */ new String[0],
+        modificationTime,
+        /* fileSize= */ size,
+        metadata);
+  }
+
+  private static InternalRow emptyPartitionRow(int numFields) {
+    return new GenericInternalRow(new Object[numFields]);
+  }
+
+  private static scala.collection.immutable.Map<String, Object> mergeIntoScalaMap(
+      scala.collection.immutable.Map<String, Object> base,
+      scala.collection.immutable.Map<String, Object> additions) {
+    scala.collection.immutable.Map<String, Object> result = base;
+    for (Map.Entry<String, Object> entry : CollectionConverters.asJava(additions).entrySet()) {
+      result = result.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
+    }
+    return result;
+  }
+
+  private static Optional<DeletionVectorDescriptor> getCDCFileDvDescriptor(
+      io.delta.spark.internal.v2.read.CDCDataFile cdcFile) {
+    if (cdcFile.getAddFile() != null) {
+      return cdcFile.getAddFile().getDeletionVector();
+    }
+    if (cdcFile.getRemoveFile() != null) {
+      return cdcFile.getRemoveFile().getDeletionVector();
+    }
+    return Optional.empty();
   }
 
   /**

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
@@ -94,6 +94,68 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         "Expected DELTA_MISSING_CHANGE_DATA error class");
   }
 
+  @Test
+  public void testValidateCDFEnabled_passesWhenEnabledAtStartVersionEqualToInit(
+      @TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdf_init_version_" + System.nanoTime();
+    createEmptyTestTable(tablePath, tableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')", tableName);
+    sql("INSERT INTO %s VALUES (1, 'User1')", tableName);
+
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    SparkMicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
+
+    long initVersion = snapshotManager.loadLatestSnapshot().getVersion();
+    assertDoesNotThrow(() -> stream.validateCDFEnabledOnTable(initVersion));
+  }
+
+  @Test
+  public void testValidateCDFEnabled_throwsWhenCDFOffAtStartVersionButOnAtInit(
+      @TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdf_off_at_start_" + System.nanoTime();
+    // v0: CREATE (CDF off). v1: INSERT (CDF still off). v2: ALTER enable CDF. v3: INSERT.
+    createEmptyTestTable(tablePath, tableName);
+    sql("INSERT INTO %s VALUES (1, 'User1')", tableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')", tableName);
+    sql("INSERT INTO %s VALUES (2, 'User2')", tableName);
+
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    SparkMicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
+
+    // Init snapshot has CDF=on (v3), but startVersion=0 had CDF=off. The check must use the
+    // metadata at startVersion, not at source-init time.
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> stream.validateCDFEnabledOnTable(0L));
+    Throwable cause = exception.getCause() != null ? exception.getCause() : exception;
+    assertInstanceOf(AnalysisException.class, cause);
+    assertEquals("DELTA_MISSING_CHANGE_DATA", ((AnalysisException) cause).getErrorClass());
+  }
+
+  @Test
+  public void testValidateCDFEnabled_swallowsForUnmaterializedStartVersion(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdf_future_version_" + System.nanoTime();
+    createEmptyTestTable(tablePath, tableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')", tableName);
+    sql("INSERT INTO %s VALUES (1, 'User1')", tableName);
+
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    SparkMicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
+    long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+
+    // startingVersion=latest resolves to latest+1, which is not materialized. The KernelException
+    // is swallowed and the validator returns without throwing.
+    assertDoesNotThrow(() -> stream.validateCDFEnabledOnTable(latestVersion + 1));
+  }
+
   private static final SparkMicroBatchStreamTest.ScenarioSetup CDC_TWO_INSERT_SETUP =
       (tableName, tempDir) -> {
         sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -712,6 +712,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     javaOptions.put("startingVersion", "0");
     javaOptions.put("MaxFilesPerTrigger", "100");
     javaOptions.put("MAXBYTESPERTRIGGER", "1g");
+    javaOptions.put("readChangeFeed", "true");
     javaOptions.put("myCustomOption", "value");
     scala.collection.immutable.Map<String, String> supportedOptions =
         ScalaUtils.toScalaMap(javaOptions);
@@ -721,6 +722,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     assertEquals(true, deltaOptions.maxFilesPerTrigger().isDefined());
     assertEquals(100, deltaOptions.maxFilesPerTrigger().get());
     assertEquals(true, deltaOptions.maxBytesPerTrigger().isDefined());
+    assertEquals(true, deltaOptions.readChangeFeed());
 
     // Should not throw - supported and custom options are allowed
     SparkScan.validateStreamingOptions(deltaOptions);
@@ -731,7 +733,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     // Test with blocked DeltaOptions, supported options, and custom user options
     Map<String, String> javaOptions = new HashMap<>();
     javaOptions.put("startingVersion", "0");
-    javaOptions.put("readChangeFeed", "true");
+    javaOptions.put("schemaTrackingLocation", "/tmp/schema-tracking");
     javaOptions.put("myCustomOption", "value");
     scala.collection.immutable.Map<String, String> mixedOptions =
         ScalaUtils.toScalaMap(javaOptions);
@@ -745,10 +747,10 @@ public class SparkScanTest extends DeltaV2TestBase {
     // Verify exact error message - only the blocked option should appear
     // Note: DeltaOptions uses CaseInsensitiveMap which lowercases keys during iteration
     assertEquals(
-        "The following streaming options are not supported: [readchangefeed]. "
+        "The following streaming options are not supported: [schematrackinglocation]. "
             + "Supported options are: [startingVersion, startingTimestamp, maxFilesPerTrigger, "
-            + "maxBytesPerTrigger, ignoreFileDeletion, ignoreChanges, ignoreDeletes, skipChangeCommits, "
-            + "excludeRegex, failOnDataLoss].",
+            + "maxBytesPerTrigger, ignoreFileDeletion, ignoreChanges, ignoreDeletes, "
+            + "skipChangeCommits, excludeRegex, failOnDataLoss, readChangeFeed, readChangeData].",
         exception.getMessage());
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/cdc/CDCSchemaContextTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/cdc/CDCSchemaContextTest.java
@@ -126,6 +126,34 @@ public class CDCSchemaContextTest {
   }
 
   @Test
+  void testConstructorRejectsCDCColumnsInReadDataSchema() {
+    StructType withChangeType =
+        new StructType()
+            .add("id", DataTypes.IntegerType)
+            .add(CDCSchemaContext.CDC_TYPE_COLUMN, DataTypes.StringType);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CDCSchemaContext(withChangeType, new StructType()));
+
+    StructType withCommitVersion =
+        new StructType().add(CDCSchemaContext.CDC_COMMIT_VERSION, DataTypes.LongType);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CDCSchemaContext(withCommitVersion, new StructType()));
+
+    StructType withCommitTimestamp =
+        new StructType().add(CDCSchemaContext.CDC_COMMIT_TIMESTAMP, DataTypes.TimestampType);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CDCSchemaContext(withCommitTimestamp, new StructType()));
+
+    // Case-insensitive: matches isCDCColumn semantics.
+    StructType mixedCase = new StructType().add("_Change_Type", DataTypes.StringType);
+    assertThrows(
+        IllegalArgumentException.class, () -> new CDCSchemaContext(mixedCase, new StructType()));
+  }
+
+  @Test
   void testAppendCDCColumns() {
     StructType augmented = CDCSchemaContext.appendCDCColumns(DATA_SCHEMA);
     assertEquals(5, augmented.fields().length);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6363/files) to review incremental changes.
- [stack/cdf2](https://github.com/delta-io/delta/pull/6076) [[Files changed](https://github.com/delta-io/delta/pull/6076/files)] [MERGED]
  - [stack/cdf3](https://github.com/delta-io/delta/pull/6336) [[Files changed](https://github.com/delta-io/delta/pull/6336/files)] [MERGED]
    - [stack/cdf4](https://github.com/delta-io/delta/pull/6359) [[Files changed](https://github.com/delta-io/delta/pull/6359/files)] [MERGED]
      - [**stack/cdf6**](https://github.com/delta-io/delta/pull/6363) [[Files changed](https://github.com/delta-io/delta/pull/6363/files)]
        - [stack/cdc-schema-refactor](https://github.com/delta-io/delta/pull/6744) [[Files changed](https://github.com/delta-io/delta/pull/6744/files/e0f507d5aee8af1419eb957ce34804b55f0f1e18..705fdfece98d200a526def679049f44be67aa103)]
        - [stack/cdf7](https://github.com/delta-io/delta/pull/6370) [[Files changed](https://github.com/delta-io/delta/pull/6370/files/7e3488eee3c90a79f95f33b4d1ebf8a54351d4e8..73e7f60e482f4ed1aa86b9a80ae631ffb3c46cfc)]

---------
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Wires CDC into the V2 streaming connector end-to-end and adds the corresponding integration test suite.

- **Routing**: `SparkMicroBatchStream` switches between AddFile and CDC commit-action sets based on the `readChangeFeed` option, so CDC reads pick up `AddCDCFile` / `RemoveFile` actions and feed them through the existing CDC read path.
- **CDC file reading**: `PartitionUtils.buildCDCPartitionedFile` builds `PartitionedFile`s from `AddCDCFile` / `RemoveFile` (path + partition values + per-file CDC constants), reused by both batch and streaming.

## How was this patch tested?

- New `DeltaV2CDCStreamSuite` (V2 override of `DeltaCDCStreamSuiteBase`) exercises the full V2 CDC streaming pipeline end-to-end

## Does this PR introduce _any_ user-facing changes?

No.
