### PR TITLE
[kernel-spark] Same-path DV-diff routing for CDC streaming

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2CDCStreamSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2CDCStreamSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.test
 
-import org.apache.spark.sql.delta.{DeltaCDCStreamSuite, DeltaConfigs, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.{DeltaCDCStreamDeletionVectorMixin, DeltaCDCStreamSuite, DeltaConfigs, DeltaLog, DeltaOperations}
 
 /**
  * Test suite that runs DeltaCDCStreamSuite using the V2 connector (V2_ENABLE_MODE=STRICT).
@@ -35,7 +35,10 @@ class DeltaV2CDCStreamSuite extends DeltaCDCStreamSuite with V2ForceTest {
         Map(DeltaConfigs.CHANGE_DATA_FEED.key -> "true")))
   }
 
-  override protected lazy val shouldPassTests = Set(
+  // V2 doesn't support write ops; run DELETE in V1 mode.
+  override protected def executeDeleteSql(sqlText: String): Unit = executeInV1Mode(sqlText)
+
+  override protected def shouldPassTests: Set[String] = Set(
     // ========== Core CDC streaming tests ==========
     "no startingVersion should result fetch the entire snapshot",
     "CDC initial snapshot should end at base index of next version",
@@ -52,12 +55,18 @@ class DeltaV2CDCStreamSuite extends DeltaCDCStreamSuite with V2ForceTest {
     "cdc streams should be able to get offset when there only RemoveFiles",
     "cdc streams should work starting from RemoveFile",
     "cdc streams should work starting from AddCDCFile",
+    "double delete-only on the same file",
 
     // ========== Rate limiting tests ==========
     "rateLimit - maxFilesPerTrigger - overall",
     "rateLimit - maxBytesPerTrigger - overall",
     "rateLimit - maxFilesPerTrigger - starting from initial snapshot",
     "rateLimit - maxBytesPerTrigger - starting from initial snapshot",
+    "rateLimit - maxFilesPerTrigger - should not deadlock",
+    "rateLimit - maxBytesPerTrigger - should not deadlock",
+    "maxFilesPerTrigger - 2 successive AddCDCFile commits",
+    "maxFilesPerTrigger - batch reject stops iteration to prevent data loss",
+    "maxFilesPerTrigger with Trigger.AvailableNow respects read limits",
 
     // ========== Misc tests ==========
     "check starting[Version/Timestamp] > latest version without error",
@@ -71,19 +80,29 @@ class DeltaV2CDCStreamSuite extends DeltaCDCStreamSuite with V2ForceTest {
     "CDC stream rejects reading row tracking metadata fields"
   )
 
-  override protected lazy val shouldFailTests = Set(
+  override protected def shouldFailTests: Set[String] = Set(
     // === Error message format differs in V2 (missing [DELTA_VERSION_NOT_FOUND] prefix) ===
     "starting[Version/Timestamp] > latest version",
-    // === sql("DELETE FROM delta.`...`") not supported under STRICT V2 mode ===
-    "double delete-only on the same file",
-    // === TODO(#6591): Pre-existing vectorized partitioned-CDC bug (PlainIntegerDictionary / NPE).
-    "rateLimit - maxFilesPerTrigger - should not deadlock",
-    "rateLimit - maxBytesPerTrigger - should not deadlock",
-    "maxFilesPerTrigger - 2 successive AddCDCFile commits",
-    "maxFilesPerTrigger - batch reject stops iteration to prevent data loss",
-    "maxFilesPerTrigger with Trigger.AvailableNow respects read limits",
     // === V2 wraps DeltaAnalysisException in RuntimeException, so the test's
     // === ExpectFailure[DeltaAnalysisException] cause-class check fails.
     "startingVersion before CDF was enabled rejects with change-data-not-recorded"
   )
+}
+
+/**
+ * Runs DeltaCDCStreamSuite with DVs enabled using the V2 connector (V2_ENABLE_MODE=STRICT).
+ */
+class DeltaV2CDCStreamDeletionVectorSuite
+    extends DeltaV2CDCStreamSuite with DeltaCDCStreamDeletionVectorMixin {
+
+  override protected def shouldPassTests: Set[String] =
+    super.shouldPassTests ++
+      Set(
+        "CDC DV-diff: only deleted rows appear, not surviving rows",
+        "CDC DV-diff: second delete emits only newly deleted rows, not prior deletions",
+        "CDC DV-diff: partitioned table includes correct partition values",
+        "CDC DV-diff: delete spanning multiple files produces one DV pair per file",
+        "CDC DV-diff: multi-file commit admitted all-or-nothing under maxFilesPerTrigger",
+        "CDC DV-diff: maxBytesPerTrigger rate limits across DV-diff commits"
+      )
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -62,6 +62,8 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       s"(${cdcConfig.key}=true)")
   }
 
+  protected def executeDeleteSql(sqlText: String): Unit = spark.sql(sqlText)
+
   /** Load a CDC streaming DataFrame, with the CDC read option pre-set. */
   protected def loadCDCStream(
       path: String,
@@ -1081,8 +1083,8 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       spark.range(start = 0L, end = 10L, step = 1L, numPartitions = 1).toDF("id")
         .write.format("delta").save(tablePath)
 
-      spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id IN (1, 3, 6)")
-      spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id IN (2, 4, 7)")
+      executeDeleteSql(s"DELETE FROM delta.`$tablePath` WHERE id IN (1, 3, 6)")
+      executeDeleteSql(s"DELETE FROM delta.`$tablePath` WHERE id IN (2, 4, 7)")
 
       val stream = loadStreamWithOptions(tablePath, Map(
         DeltaOptions.CDC_READ_OPTION -> "true",
@@ -1160,13 +1162,157 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
   }
 }
 
-class DeltaCDCStreamDeletionVectorSuite extends DeltaCDCStreamSuite
-  with DeletionVectorsTestUtils {
+/**
+ * Mixin that enables DVs for all operations and adds DV-specific CDC tests.
+ * Mixed into both [[DeltaCDCStreamDeletionVectorSuite]] (V1) and the V2 equivalent.
+ */
+trait DeltaCDCStreamDeletionVectorMixin extends DeletionVectorsTestUtils {
+  self: DeltaCDCStreamSuiteBase =>
+
+  import testImplicits._
+
   override def beforeAll(): Unit = {
     super.beforeAll()
     enableDeletionVectorsForAllSupportedOperations(spark)
   }
+
+  test("CDC DV-diff: only deleted rows appear, not surviving rows") {
+    // Explicitly guards against wrong DV filter polarity (IF_CONTAINED vs IF_NOT_CONTAINED):
+    // a wrong direction emits the 4 surviving rows instead of the 1 deleted row.
+    withTempDir { inputDir =>
+      spark.range(1, 6).toDF("id")
+        .repartition(1)
+        .write.format("delta").save(inputDir.getAbsolutePath)
+
+      executeDeleteSql(s"DELETE FROM delta.`${inputDir.getAbsolutePath}` WHERE id = 3")
+
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        DeltaOptions.STARTING_VERSION_OPTION -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((3, "delete", 1))
+      )
+    }
+  }
+
+  test("CDC DV-diff: second delete emits only newly deleted rows, not prior deletions") {
+    withTempDir { inputDir =>
+      spark.range(1, 11).toDF("id")
+        .repartition(1)
+        .write.format("delta").save(inputDir.getAbsolutePath)
+
+      val tablePath = inputDir.getAbsolutePath
+      executeDeleteSql(s"DELETE FROM delta.`$tablePath` WHERE id = 3") // v1: Add(DV={3})+Remove
+      executeDeleteSql(s"DELETE FROM delta.`$tablePath` WHERE id = 7") // v2: diff = {7} only
+
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        DeltaOptions.STARTING_VERSION_OPTION -> "2"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((7, "delete", 2))
+      )
+    }
+  }
+
+  test("CDC DV-diff: partitioned table includes correct partition values") {
+    withTempDir { inputDir =>
+      // id=1,2 in part=a; id=3,4 in part=b. Deleting id=2 leaves id=1 in part=a,
+      // so Delta uses a DV (not a partition-prune remove). Partition value must flow through.
+      Seq((1, "a"), (2, "a"), (3, "b"), (4, "b")).toDF("id", "part")
+        .write.format("delta").partitionBy("part").save(inputDir.getAbsolutePath)
+
+      executeDeleteSql(s"DELETE FROM delta.`${inputDir.getAbsolutePath}` WHERE id = 2")
+
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        DeltaOptions.STARTING_VERSION_OPTION -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((2, "a", "delete", 1))
+      )
+    }
+  }
+
+  test("CDC DV-diff: delete spanning multiple files produces one DV pair per file") {
+    withTempDir { inputDir =>
+      // Two separate appends produce two distinct parquet files.
+      spark.range(1, 6).toDF("id").repartition(1)
+        .write.format("delta").save(inputDir.getAbsolutePath)
+      spark.range(6, 11).toDF("id").repartition(1)
+        .write.format("delta").mode("append").save(inputDir.getAbsolutePath)
+
+      // Delete one row from each file -> two same-path DV pairs in a single commit.
+      executeDeleteSql(
+        s"DELETE FROM delta.`${inputDir.getAbsolutePath}` WHERE id = 3 OR id = 8")
+
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        DeltaOptions.STARTING_VERSION_OPTION -> "2"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((3L, "delete", 2L), (8L, "delete", 2L))
+      )
+    }
+  }
+
+  test("CDC DV-diff: multi-file commit admitted all-or-nothing under maxFilesPerTrigger") {
+    withTempDir { inputDir =>
+      spark.range(1, 6).toDF("id").repartition(1)
+        .write.format("delta").save(inputDir.getAbsolutePath)
+      spark.range(6, 11).toDF("id").repartition(1)
+        .write.format("delta").mode("append").save(inputDir.getAbsolutePath)
+
+      executeDeleteSql(
+        s"DELETE FROM delta.`${inputDir.getAbsolutePath}` WHERE id = 3 OR id = 8")
+
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        DeltaOptions.STARTING_VERSION_OPTION -> "2",
+        DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((3L, "delete", 2L), (8L, "delete", 2L))
+      )
+    }
+  }
+
+  test("CDC DV-diff: maxBytesPerTrigger rate limits across DV-diff commits") {
+    withTempDir { inputDir =>
+      spark.range(1, 6).toDF("id").repartition(1)
+        .write.format("delta").save(inputDir.getAbsolutePath)
+
+      val tablePath = inputDir.getAbsolutePath
+      executeDeleteSql(s"DELETE FROM delta.`$tablePath` WHERE id = 2") // v1
+      executeDeleteSql(s"DELETE FROM delta.`$tablePath` WHERE id = 4") // v2
+
+      val df = loadStreamWithOptions(inputDir.toString, Map(
+        DeltaOptions.CDC_READ_OPTION -> "true",
+        DeltaOptions.STARTING_VERSION_OPTION -> "1",
+        "maxBytesPerTrigger" -> "1b"
+      )).drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((2, "delete", 1), (4, "delete", 2))
+      )
+    }
+  }
 }
+
+class DeltaCDCStreamDeletionVectorSuite extends DeltaCDCStreamSuite
+  with DeltaCDCStreamDeletionVectorMixin
 
 class DeltaCDCStreamSuite extends DeltaCDCStreamSuiteBase
 // Batch sizes 1, 2, and 100 exercise different backfill behaviors in the commit coordinator.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/CDCDataFile.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/CDCDataFile.java
@@ -20,7 +20,10 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.actions.AddCDCFile;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.RemoveFile;
+import io.delta.kernel.internal.util.Preconditions;
+import java.util.Optional;
 import javax.annotation.Nullable;
+import org.apache.spark.sql.delta.RowIndexFilterType;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 
 /**
@@ -36,6 +39,8 @@ public class CDCDataFile {
   @Nullable private final String changeType;
   private final long commitTimestamp;
   private final long fileSize;
+  // base64-encoded inline DV of the changed rows (the bitmap diff between the Add and Remove DVs).
+  @Nullable private final String dvBase64Override;
 
   private CDCDataFile(
       @Nullable AddFile addFile,
@@ -45,7 +50,11 @@ public class CDCDataFile {
       @Nullable MapValue cdcPartitionValues,
       @Nullable String changeType,
       long commitTimestamp,
-      long fileSize) {
+      long fileSize,
+      @Nullable String dvBase64Override) {
+    Preconditions.checkArgument(
+        addFile != null || removeFile != null || cdcPath != null,
+        "CDCDataFile must have at least one of addFile, removeFile, or cdcPath");
     this.addFile = addFile;
     this.removeFile = removeFile;
     this.isAddCDCFile = isAddCDCFile;
@@ -54,6 +63,7 @@ public class CDCDataFile {
     this.changeType = changeType;
     this.commitTimestamp = commitTimestamp;
     this.fileSize = fileSize;
+    this.dvBase64Override = dvBase64Override;
   }
 
   /** Create a CDCDataFile inferred from an AddFile action (always "insert"). */
@@ -66,7 +76,8 @@ public class CDCDataFile {
         /* cdcPartitionValues= */ null,
         CDCReader.CDC_TYPE_INSERT(),
         commitTimestamp,
-        addFile.getSize());
+        addFile.getSize(),
+        /* dvBase64Override= */ null);
   }
 
   /** Create a CDCDataFile inferred from a RemoveFile action (always "delete"). */
@@ -79,7 +90,8 @@ public class CDCDataFile {
         /* cdcPartitionValues= */ null,
         CDCReader.CDC_TYPE_DELETE_STRING(),
         commitTimestamp,
-        removeFile.getSize().orElse(0L));
+        removeFile.getSize().orElse(0L),
+        /* dvBase64Override= */ null);
   }
 
   /** Create a CDCDataFile for an explicit AddCDCFile action. */
@@ -95,7 +107,26 @@ public class CDCDataFile {
         /* cdcPartitionValues= */ partitionValues,
         /* changeType= */ null,
         commitTimestamp,
-        size);
+        size,
+        /* dvBase64Override= */ null);
+  }
+
+  /**
+   * Create a CDCDataFile for a DV-diff same-path pair: an Add+Remove on the same parquet file where
+   * the DV bitmap diff identifies the changed rows.
+   */
+  public static CDCDataFile fromDVDiff(
+      AddFile addFile, String changeType, long commitTimestamp, String dvBase64) {
+    return new CDCDataFile(
+        addFile,
+        /* removeFile= */ null,
+        /* isAddCDCFile= */ false,
+        /* cdcPath= */ null,
+        /* cdcPartitionValues= */ null,
+        changeType,
+        commitTimestamp,
+        addFile.getSize(),
+        dvBase64);
   }
 
   @Nullable
@@ -130,6 +161,36 @@ public class CDCDataFile {
     return cdcPartitionValues;
   }
 
+  /**
+   * Returns the DV bytes to use for filtering when reading this CDC file. For DV-diff entries, this
+   * is the override bitmap (the diff between the Add and Remove DVs). For regular CDC inferred from
+   * an AddFile/RemoveFile, this is the underlying file's DV if any. Empty if the file has no DV at
+   * all.
+   */
+  public Optional<String> getEffectiveDv() {
+    if (dvBase64Override != null) {
+      return Optional.of(dvBase64Override);
+    }
+    if (addFile != null && addFile.getDeletionVector().isPresent()) {
+      return Optional.of(addFile.getDeletionVector().get().serializeToBase64());
+    }
+    if (removeFile != null && removeFile.getDeletionVector().isPresent()) {
+      return Optional.of(removeFile.getDeletionVector().get().serializeToBase64());
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the filter polarity to apply with {@link #getEffectiveDv()}. DV-diff files use
+   * IF_NOT_CONTAINED (keep rows marked in the bitmap); all other files use IF_CONTAINED (skip rows
+   * marked in the bitmap).
+   */
+  public RowIndexFilterType getDvFilterType() {
+    return dvBase64Override != null
+        ? RowIndexFilterType.IF_NOT_CONTAINED
+        : RowIndexFilterType.IF_CONTAINED;
+  }
+
   @Nullable
   public String getChangeType() {
     return changeType;
@@ -148,8 +209,10 @@ public class CDCDataFile {
     return isAddCDCFile;
   }
 
-  /** Returns true if the underlying file action has a deletion vector. */
   public boolean hasDeletionVector() {
+    if (dvBase64Override != null) {
+      return true;
+    }
     if (addFile != null) {
       return addFile.getDeletionVector().isPresent();
     }
@@ -167,12 +230,15 @@ public class CDCDataFile {
     } else if (removeFile != null) {
       sb.append("removeFile=").append(removeFile);
     } else {
-      sb.append("explicit=true");
+      sb.append("explicit=true, path=").append(cdcPath);
     }
     if (changeType != null) {
       sb.append(", changeType='").append(changeType).append("'");
     }
     sb.append(", commitTimestamp=").append(commitTimestamp);
+    if (dvBase64Override != null) {
+      sb.append(", dvDiff=true");
+    }
     sb.append("}");
     return sb.toString();
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -79,6 +79,7 @@ import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset$;
 import org.apache.spark.sql.delta.sources.DeltaStreamUtils;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
+import org.apache.spark.sql.delta.v2.CDCDeletionVectorHelper;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
@@ -1850,7 +1851,7 @@ public class SparkMicroBatchStream
       Optional<DeltaSourceOffset> endOffsetOpt)
       throws IOException {
     // Phase 1: scan actions to validate metadata and collect CDC/Add/Remove files.
-    List<CDCDataFile> cdcFiles = new ArrayList<>();
+    List<CDCDataFile> explicitCdcFiles = new ArrayList<>();
     // Single ordered list for inferred CDC files, preserving delta-log action ordering.
     // DSv1 assigns IndexedFile.index via zipWithIndex on the original action sequence.
     List<CDCDataFile> inferredCdcFiles = new ArrayList<>();
@@ -1892,7 +1893,7 @@ public class SparkMicroBatchStream
           // Explicit CDC files
           Optional<CDCDataFile> cdcOpt = StreamingHelper.getCDCFile(batch, rowId, timestamp);
           if (cdcOpt.isPresent()) {
-            cdcFiles.add(cdcOpt.get());
+            explicitCdcFiles.add(cdcOpt.get());
             continue;
           }
 
@@ -1925,13 +1926,67 @@ public class SparkMicroBatchStream
 
     // Explicit CDC files and inferred files are mutually exclusive: if a commit contains any
     // AddCDCFile actions, only those are emitted and AddFile/RemoveFile are ignored.
-    if (!cdcFiles.isEmpty()) {
-      for (CDCDataFile cdcFile : cdcFiles) {
+    if (!explicitCdcFiles.isEmpty()) {
+      for (CDCDataFile cdcFile : explicitCdcFiles) {
         result.add(IndexedFile.cdc(version, fileIndex++, cdcFile));
       }
     } else {
-      for (CDCDataFile cdcFile : inferredCdcFiles) {
-        result.add(IndexedFile.cdc(version, fileIndex++, cdcFile));
+      // Bucket AddFile and RemoveFile by path to detect same-path pairs.
+      // DV-based deletes reuse the same parquet file (marking rows in the DV instead of rewriting),
+      // so both the Remove and Add reference the same path.
+      Map<String, AddFile> addByPath = new HashMap<>();
+      Map<String, RemoveFile> removeByPath = new HashMap<>();
+      for (CDCDataFile cdc : inferredCdcFiles) {
+        if (cdc.getAddFile() != null) {
+          AddFile prev = addByPath.put(cdc.getAddFile().getPath(), cdc.getAddFile());
+          Preconditions.checkArgument(
+              prev == null,
+              "Unexpected duplicate AddFile at path %s in a single commit",
+              cdc.getAddFile().getPath());
+        } else if (cdc.getRemoveFile() != null) {
+          RemoveFile prev = removeByPath.put(cdc.getRemoveFile().getPath(), cdc.getRemoveFile());
+          Preconditions.checkArgument(
+              prev == null,
+              "Unexpected duplicate RemoveFile at path %s in a single commit",
+              cdc.getRemoveFile().getPath());
+        }
+      }
+
+      Set<String> samePathKeys = new HashSet<>(addByPath.keySet());
+      samePathKeys.retainAll(removeByPath.keySet());
+
+      // Walk inferredCdcFiles in delta-log order. Non-pair files are emitted as-is. Same-path
+      // pairs are emitted at the FIRST occurrence of the path (the counterpart, encountered
+      // later in the loop, is skipped).
+      Set<String> emittedPairs = new HashSet<>();
+      for (CDCDataFile cdc : inferredCdcFiles) {
+        String path = cdc.getPath();
+        if (!samePathKeys.contains(path)) {
+          // File with unique paths: emit as-is.
+          result.add(IndexedFile.cdc(version, fileIndex++, cdc));
+        } else if (emittedPairs.add(path)) {
+          // First occurrence of a same-path pair: emit the consolidated pair entries.
+          AddFile add = addByPath.get(path);
+          RemoveFile remove = removeByPath.get(path);
+          if (add.getDeletionVector().isPresent() || remove.getDeletionVector().isPresent()) {
+            // DV-based delete/restore: compute the bitmap diff and emit one CDC file per diff
+            // entry. Path.toString() avoids percent-encoding that breaks DV file resolution.
+            String dataPath = snapshotAtSourceInit.getDataPath().toString();
+            for (CDCDataFile f :
+                CDCDeletionVectorHelper.generateDVDiffCDCFiles(
+                    add, remove, timestamp, dataPath, hadoopConf)) {
+              result.add(IndexedFile.cdc(version, fileIndex++, f));
+            }
+          } else {
+            // Same-path Add+Remove without DV: emit plain insert + delete.
+            result.add(
+                IndexedFile.cdc(version, fileIndex++, CDCDataFile.fromAddFile(add, timestamp)));
+            result.add(
+                IndexedFile.cdc(
+                    version, fileIndex++, CDCDataFile.fromRemoveFile(remove, timestamp)));
+          }
+        }
+        // Else: second occurrence of an already-emitted same-path pair; skip.
       }
     }
 
@@ -1958,7 +2013,8 @@ public class SparkMicroBatchStream
    * and appends an END sentinel only when all data files are admitted. Returns empty list on
    * batch-reject so the offset doesn't advance.
    */
-  private List<IndexedFile> applyPerCommitCDCAdmission(
+  @VisibleForTesting
+  List<IndexedFile> applyPerCommitCDCAdmission(
       List<IndexedFile> commitFiles,
       DeltaSource.AdmissionLimits admissionLimits,
       long commitVersion) {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -224,8 +224,11 @@ public class PartitionUtils {
     if (!cdcFile.isAddCDCFile()) {
       cdcConstants.put(CDCSchemaContext.CDC_TYPE_COLUMN, cdcFile.getChangeType());
     }
+    Optional<String> effectiveDv = cdcFile.getEffectiveDv();
     scala.collection.immutable.Map<String, Object> metadata =
-        buildDvMetadata(getCDCFileDvDescriptor(cdcFile));
+        effectiveDv.isPresent()
+            ? buildDvMetadata(effectiveDv.get(), cdcFile.getDvFilterType())
+            : scala.collection.immutable.Map$.MODULE$.empty();
     for (Map.Entry<String, Object> entry : cdcConstants.entrySet()) {
       metadata = metadata.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
     }
@@ -280,17 +283,6 @@ public class PartitionUtils {
       result = result.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
     }
     return result;
-  }
-
-  private static Optional<DeletionVectorDescriptor> getCDCFileDvDescriptor(
-      io.delta.spark.internal.v2.read.CDCDataFile cdcFile) {
-    if (cdcFile.getAddFile() != null) {
-      return cdcFile.getAddFile().getDeletionVector();
-    }
-    if (cdcFile.getRemoveFile() != null) {
-      return cdcFile.getRemoveFile().getDeletionVector();
-    }
-    return Optional.empty();
   }
 
   /**
@@ -474,6 +466,14 @@ public class PartitionUtils {
       metadata.put(
           DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE(), RowIndexFilterType.IF_CONTAINED);
     }
+    return scala.collection.immutable.Map$.MODULE$.from(CollectionConverters.asScala(metadata));
+  }
+
+  private static scala.collection.immutable.Map<String, Object> buildDvMetadata(
+      String dvBase64, RowIndexFilterType filterType) {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED(), dvBase64);
+    metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE(), filterType);
     return scala.collection.immutable.Map$.MODULE$.from(CollectionConverters.asScala(metadata));
   }
 

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/CDCDeletionVectorHelper.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/CDCDeletionVectorHelper.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta.v2
+
+import java.util.{ArrayList => JArrayList, List => JList}
+import javax.annotation.Nullable
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.delta.actions.{DeletionVectorDescriptor => SparkDvDescriptor}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+
+import io.delta.kernel.internal.actions.{AddFile, RemoveFile}
+import io.delta.spark.internal.v2.read.CDCDataFile
+
+/**
+ * Helper for DV-diff operations needed by DSv2 CDC streaming. Lives in the
+ * `org.apache.spark.sql.delta.v2` package (Scala) because it needs access to `private[delta]`
+ * APIs (DeletionVectorStore, RoaringBitmapArray, DeletionVectorUtils) that are not exposed to
+ * Java.
+ */
+object CDCDeletionVectorHelper {
+
+  /**
+   * Computes the CDC diff between an AddFile's DV and a RemoveFile's DV for a same-path pair.
+   *
+   * @param addDvBase64    base64 of the AddFile's DV descriptor, or null if no DV.
+   * @param removeDvBase64 base64 of the RemoveFile's DV descriptor, or null if no DV.
+   * @param hadoopConf     Hadoop conf used to construct a DV store for any on-disk DV reads.
+   * @param tablePath      table data path; used when resolving on-disk DV files and as a
+   *                       diagnostic in the require() message.
+   * @return array of `(changeType, dvBase64)` pairs describing the bitmap diff. At least one of
+   *         `addDvBase64` or `removeDvBase64` must be non-null.
+   */
+  def computeDVDiff(
+      @Nullable addDvBase64: String,
+      @Nullable removeDvBase64: String,
+      hadoopConf: Configuration,
+      tablePath: String): Array[(String, String)] = {
+    computeDVDiffInternal(Option(addDvBase64), Option(removeDvBase64), hadoopConf, tablePath)
+  }
+
+  /**
+   * Produces the CDCDataFiles for a same-path Add+Remove pair by computing the DV bitmap diff.
+   * Returns one or two CDCDataFiles depending on which diff entries are non-empty.
+   */
+  def generateDVDiffCDCFiles(
+      add: AddFile,
+      remove: RemoveFile,
+      commitTimestamp: Long,
+      dataPath: String,
+      hadoopConf: Configuration): JList[CDCDataFile] = {
+    val addDvBase64: String =
+      if (add.getDeletionVector.isPresent) add.getDeletionVector.get.serializeToBase64 else null
+    val removeDvBase64: String =
+      if (remove.getDeletionVector.isPresent) remove.getDeletionVector.get.serializeToBase64
+      else null
+
+    val diffs = computeDVDiff(addDvBase64, removeDvBase64, hadoopConf, dataPath)
+    val out = new JArrayList[CDCDataFile](diffs.length)
+    diffs.foreach { case (changeType, dvBase64) =>
+      out.add(CDCDataFile.fromDVDiff(add, changeType, commitTimestamp, dvBase64))
+    }
+    out
+  }
+
+  private def computeDVDiffInternal(
+      addDvOpt: Option[String],
+      removeDvOpt: Option[String],
+      hadoopConf: Configuration,
+      tablePath: String): Array[(String, String)] = {
+    require(addDvOpt.isDefined || removeDvOpt.isDefined,
+      s"Same-path Add+Remove pair must have at least one DV, tablePath: $tablePath")
+    val addDv = addDvOpt.map(SparkDvDescriptor.deserializeFromBase64)
+    val removeDv = removeDvOpt.map(SparkDvDescriptor.deserializeFromBase64)
+
+    val dvStore = DeletionVectorStore.createInstance(hadoopConf)
+    val dataPath = new Path(tablePath)
+    val results = scala.collection.mutable.ArrayBuffer[(String, String)]()
+
+    (removeDv, addDv) match {
+      case (None, Some(aDv)) =>
+        // Remove without DV, Add with DV -> rows in addDv are deleted.
+        // Skip disk read if the DV is already inline.
+        val dvBase64 = if (aDv.isInline) addDvOpt.get
+                       else readAndSerializeInline(dvStore, aDv, dataPath)
+        results += ((CDCReader.CDC_TYPE_DELETE_STRING, dvBase64))
+
+      case (Some(rDv), None) =>
+        // Remove with DV, Add without DV -> rows in removeDv are re-added.
+        // Skip disk read if the DV is already inline.
+        val dvBase64 = if (rDv.isInline) removeDvOpt.get
+                       else readAndSerializeInline(dvStore, rDv, dataPath)
+        results += ((CDCReader.CDC_TYPE_INSERT, dvBase64))
+
+      case (Some(rDv), Some(aDv)) =>
+        // Both have DVs -> compute bitmap diff
+        val removeBitmap = dvStore.read(rDv, dataPath)
+        val addBitmap = dvStore.read(aDv, dataPath)
+
+        // Rows in addDv but not removeDv are newly deleted
+        val deletedRows = addBitmap.copy()
+        deletedRows.diff(removeBitmap)
+        if (!deletedRows.isEmpty) {
+          results += ((CDCReader.CDC_TYPE_DELETE_STRING, serializeInline(deletedRows, dataPath)))
+        }
+
+        // Rows in removeDv but not addDv are re-added (table restore case)
+        val readdedRows = removeBitmap.copy()
+        readdedRows.diff(addBitmap)
+        if (!readdedRows.isEmpty) {
+          results += ((CDCReader.CDC_TYPE_INSERT, serializeInline(readdedRows, dataPath)))
+        }
+
+      case (None, None) => // unreachable - guarded by require() above
+    }
+
+    results.toArray
+  }
+
+  private def readAndSerializeInline(
+      dvStore: DeletionVectorStore,
+      sparkDv: SparkDvDescriptor,
+      dataPath: Path): String = {
+    val bitmap = dvStore.read(sparkDv, dataPath)
+    serializeInline(bitmap, dataPath)
+  }
+
+  private def serializeInline(bitmap: RoaringBitmapArray, dataPath: Path): String = {
+    val bytes = DeletionVectorUtils.serialize(
+      bitmap, RoaringBitmapArrayFormat.Portable, Some(dataPath))
+    SparkDvDescriptor.inlineInLog(bytes, bitmap.cardinality).serializeToBase64
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/CDCDataFileTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/CDCDataFileTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.spark.sql.delta.RowIndexFilterType;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 import org.junit.jupiter.api.Test;
 
@@ -173,5 +174,38 @@ public class CDCDataFileTest {
     assertEquals(55555L, cdcFile.getCommitTimestamp());
     assertEquals(8192, cdcFile.getFileSize());
     assertTrue(cdcFile.isAddCDCFile());
+  }
+
+  @Test
+  public void testFromDVDiff_delete() {
+    AddFile addFile = createTestAddFile("data.parquet", 1024, 100L, Optional.of(TEST_DV));
+    CDCDataFile cdcFile =
+        CDCDataFile.fromDVDiff(
+            addFile,
+            CDCReader.CDC_TYPE_DELETE_STRING(),
+            /* commitTimestamp= */ 77777L,
+            "inline-dv==");
+
+    assertSame(addFile, cdcFile.getAddFile());
+    assertEquals(CDCReader.CDC_TYPE_DELETE_STRING(), cdcFile.getChangeType());
+    assertEquals(77777L, cdcFile.getCommitTimestamp());
+    assertEquals(1024, cdcFile.getFileSize());
+    assertFalse(cdcFile.isAddCDCFile());
+    assertEquals(Optional.of("inline-dv=="), cdcFile.getEffectiveDv());
+    assertEquals(RowIndexFilterType.IF_NOT_CONTAINED, cdcFile.getDvFilterType());
+    assertEquals("data.parquet", cdcFile.getPath());
+    assertTrue(cdcFile.hasDeletionVector());
+  }
+
+  @Test
+  public void testFromDVDiff_insert() {
+    AddFile addFile = createTestAddFile("data.parquet", 2048, 200L, Optional.of(TEST_DV));
+    CDCDataFile cdcFile =
+        CDCDataFile.fromDVDiff(
+            addFile, CDCReader.CDC_TYPE_INSERT(), /* commitTimestamp= */ 88888L, "restore-dv==");
+
+    assertEquals(CDCReader.CDC_TYPE_INSERT(), cdcFile.getChangeType());
+    assertEquals(Optional.of("restore-dv=="), cdcFile.getEffectiveDv());
+    assertEquals(RowIndexFilterType.IF_NOT_CONTAINED, cdcFile.getDvFilterType());
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
@@ -15,6 +15,7 @@
  */
 package io.delta.spark.internal.v2.read;
 
+import static io.delta.kernel.internal.util.VectorUtils.stringStringMapValue;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.delta.kernel.CommitActions;
@@ -23,6 +24,7 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
+import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
@@ -39,6 +41,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.delta.Snapshot;
+import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 import org.apache.spark.sql.delta.sources.DeltaSource;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset$;
@@ -236,7 +239,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
       throws Exception {
     String tablePath = tempDir.getAbsolutePath();
     String tableName =
-        "test_cdc_compare_" + Math.abs(testDescription.hashCode()) + "_" + System.nanoTime();
+        "test_cdc_compare_" + (testDescription.hashCode() & 0x7fffffff) + "_" + System.nanoTime();
     createEmptyTestTable(tablePath, tableName);
     sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')", tableName);
     setup.setup(tableName, tempDir);
@@ -1063,11 +1066,166 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     java.nio.file.Files.writeString(commitFile, commitInfo + "\n" + remove + "\n" + add + "\n");
   }
 
+  @Test
+  public void testProcessCommit_samePath_noDV_emitsPlainInsertDelete(@TempDir File tempDir)
+      throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_samepath_nodv_" + (System.nanoTime() & 0x7fffffff);
+    createCDFEnabledTable(tablePath, tableName);
+    sql("INSERT INTO %s VALUES (1, 'A'), (2, 'B')", tableName);
+
+    // Write a synthetic commit where Add and Remove reference the same path but neither has a DV.
+    // This exercises the non-DV same-path branch that emits plain insert + delete.
+    long commitVersion = 3;
+    writeSyntheticSamePathNoDVCommit(tablePath, commitVersion);
+
+    DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
+    deltaLog.update(false, Option.empty(), Option.empty());
+
+    SparkMicroBatchStream stream = createStream(tablePath);
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+
+    List<IndexedFile> files;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit,
+            /* startVersion= */ commitVersion,
+            /* limits= */ Optional.empty(),
+            Optional.empty(),
+            /* lastProcessedVersion= */ commitVersion,
+            /* lastProcessedIndex= */ DeltaSourceOffset.BASE_INDEX())) {
+      files = collectAll(iter);
+    }
+
+    List<IndexedFile> dataFiles = new ArrayList<>();
+    for (IndexedFile f : files) {
+      if (f.getCDCDataFile() != null) dataFiles.add(f);
+    }
+    assertEquals(2, dataFiles.size(), "Expected exactly 2 CDC data files (insert + delete)");
+    for (IndexedFile f : dataFiles) {
+      assertFalse(
+          f.getCDCDataFile().getEffectiveDv().isPresent(),
+          "Plain same-path pair must not produce a DV-diff CDCDataFile");
+    }
+    long inserts =
+        dataFiles.stream()
+            .filter(f -> CDCReader.CDC_TYPE_INSERT().equals(f.getCDCDataFile().getChangeType()))
+            .count();
+    long deletes =
+        dataFiles.stream()
+            .filter(
+                f -> CDCReader.CDC_TYPE_DELETE_STRING().equals(f.getCDCDataFile().getChangeType()))
+            .count();
+    assertEquals(1, inserts, "Expected 1 insert");
+    assertEquals(1, deletes, "Expected 1 delete");
+  }
+
   /**
-   * Compare CDC file changes between DSv1 and DSv2. Delegates to {@link
-   * SparkMicroBatchStreamTest#compareFileChanges} for version/index/path comparison, then verifies
-   * CDC metadata on DSv2 data files.
+   * Writes a synthetic UPDATE commit where AddFile and RemoveFile reference the same path and
+   * neither has a DV. This exercises the non-DV same-path CDC branch.
    */
+  private void writeSyntheticSamePathNoDVCommit(String tablePath, long version) throws Exception {
+    String logDir = tablePath + "/_delta_log";
+    String filename = String.format("%020d.json", version);
+    java.nio.file.Path commitFile = java.nio.file.Paths.get(logDir, filename);
+
+    long ts = System.currentTimeMillis();
+    String commitInfo =
+        "{\"commitInfo\":{"
+            + "\"timestamp\":"
+            + ts
+            + ","
+            + "\"operation\":\"UPDATE\","
+            + "\"operationParameters\":{},"
+            + "\"isBlindAppend\":false,"
+            + "\"operationMetrics\":{"
+            + "\"numTargetRowsUpdated\":\"1\","
+            + "\"numTargetFilesAdded\":\"1\","
+            + "\"numTargetFilesRemoved\":\"1\""
+            + "}}}";
+    // Same path on both Remove and Add, no deletionVector on either side.
+    String remove =
+        "{\"remove\":{"
+            + "\"path\":\"same-file.parquet\","
+            + "\"deletionTimestamp\":"
+            + ts
+            + ","
+            + "\"dataChange\":true,"
+            + "\"partitionValues\":{},"
+            + "\"size\":100"
+            + "}}";
+    String add =
+        "{\"add\":{"
+            + "\"path\":\"same-file.parquet\","
+            + "\"partitionValues\":{},"
+            + "\"size\":100,"
+            + "\"modificationTime\":"
+            + ts
+            + ","
+            + "\"dataChange\":true"
+            + "}}";
+
+    java.nio.file.Files.writeString(commitFile, commitInfo + "\n" + remove + "\n" + add + "\n");
+  }
+
+  @Test
+  public void testApplyPerCommitCDCAdmission_dvDiffNoDvOnAdd_batchAdmitted(@TempDir File tempDir)
+      throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_admission_gap_" + (System.nanoTime() & 0x7fffffff);
+    createEmptyTestTable(tablePath, tableName);
+    sql("INSERT INTO %s VALUES (1, 'A')", tableName);
+
+    SparkMicroBatchStream stream = createStream(tablePath);
+
+    // Simulate a "Some+None" DV-diff result: the CDCDataFile is from fromDVDiff but the backing
+    // AddFile has NO deletion vector (restore case). hasDeletionVector() returns false.
+    AddFile addFileNoDv =
+        new AddFile(
+            AddFile.createAddFileRow(
+                new io.delta.kernel.types.StructType(),
+                "restore-file.parquet",
+                stringStringMapValue(java.util.Collections.emptyMap()),
+                1024L,
+                100L,
+                /* dataChange= */ true,
+                /* deletionVector= */ java.util.Optional.empty(),
+                java.util.Optional.empty(),
+                java.util.Optional.empty(),
+                java.util.Optional.empty(),
+                java.util.Optional.empty()));
+
+    CDCDataFile dvDiffFile =
+        CDCDataFile.fromDVDiff(
+            addFileNoDv,
+            CDCReader.CDC_TYPE_INSERT(),
+            /* commitTimestamp= */ 1000L,
+            /* dvBase64= */ "some-inline-dv==");
+    CDCDataFile plainInsert = CDCDataFile.fromAddFile(addFileNoDv, /* commitTimestamp= */ 1000L);
+
+    long version = 2;
+    List<IndexedFile> commitFiles = new ArrayList<>();
+    commitFiles.add(IndexedFile.sentinel(version, DeltaSourceOffset.BASE_INDEX()));
+    commitFiles.add(IndexedFile.cdc(version, 0, dvDiffFile));
+    commitFiles.add(IndexedFile.cdc(version, 1, plainInsert));
+
+    // With maxFilesPerTrigger=1: if batch admission is NOT triggered, the two files are split
+    // across batches. The bug: dvDiffFile.hasDeletionVector() == false because addFileNoDv has
+    // no DV, so requiresBatchAdmission is false and DSv2 allows splitting.
+    Optional<DeltaSource.AdmissionLimits> limits =
+        createAdmissionLimits(Optional.of(1), Optional.empty());
+    List<IndexedFile> result =
+        stream.applyPerCommitCDCAdmission(commitFiles, limits.get(), version);
+
+    // Both files must be admitted together: any DV-diff file (getEffectiveDv().isPresent())
+    // signals that the commit cannot be split, even when the backing AddFile has no DV.
+    long admittedData = result.stream().filter(IndexedFile::hasFileAction).count();
+    assertEquals(
+        2,
+        admittedData,
+        "DV-diff CDCDataFile must trigger batch admission even when AddFile has no DV");
+  }
+
   private void assertCDCFileChangesMatch(
       List<org.apache.spark.sql.delta.sources.IndexedFile> dsv1Files, List<IndexedFile> dsv2Files) {
     SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
@@ -25,14 +25,22 @@ import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.read.CDCDataFile;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.delta.DeltaParquetFileFormat;
+import org.apache.spark.sql.delta.RowIndexFilterType;
+import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
@@ -41,10 +49,35 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import scala.collection.immutable.Map$;
+import scala.jdk.javaapi.CollectionConverters;
 
 public class PartitionUtilsTest extends DeltaV2TestBase {
 
   private static final long MB = 1024 * 1024;
+
+  private static final DeletionVectorDescriptor TEST_DV =
+      new DeletionVectorDescriptor("u", "ab^-rstxgiarsd", Optional.of(4), 40, 3L);
+
+  private static AddFile createAddFileForCDC(
+      String path, long size, long modificationTime, Optional<DeletionVectorDescriptor> dv) {
+    return new AddFile(
+        AddFile.createAddFileRow(
+            new io.delta.kernel.types.StructType(),
+            path,
+            VectorUtils.stringStringMapValue(Collections.emptyMap()),
+            size,
+            modificationTime,
+            /* dataChange= */ true,
+            dv,
+            /* tags= */ Optional.empty(),
+            /* baseRowId= */ Optional.empty(),
+            /* defaultRowCommitVersion= */ Optional.empty(),
+            /* stats= */ Optional.empty()));
+  }
+
+  private static java.util.Map<String, Object> getFileMetadata(PartitionedFile pf) {
+    return CollectionConverters.asJava(pf.otherConstantMetadataColumnValues());
+  }
 
   @Test
   public void testGetPartitionRow_FieldOrdering() {
@@ -460,5 +493,72 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
   private String getTempTablePath(String tableName) {
     return java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"), "delta-test-" + tableName)
         .toString();
+  }
+
+  @Test
+  public void testBuildCDCPartitionedFile_dvDiff_setsOverrideDvAndIfNotContained() {
+    AddFile addFile = createAddFileForCDC("data.parquet", 1024, 100L, Optional.of(TEST_DV));
+    CDCDataFile cdcFile =
+        CDCDataFile.fromDVDiff(
+            addFile,
+            CDCReader.CDC_TYPE_DELETE_STRING(),
+            /* commitTimestamp= */ 1000L,
+            "override==");
+
+    PartitionedFile pf =
+        PartitionUtils.buildCDCPartitionedFile(
+            cdcFile,
+            /* commitVersion= */ 1L,
+            new StructType(),
+            "file:/tmp/table",
+            ZoneId.of("UTC"));
+
+    java.util.Map<String, Object> metadata = getFileMetadata(pf);
+    assertEquals(
+        "override==", metadata.get(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED()));
+    assertEquals(
+        RowIndexFilterType.IF_NOT_CONTAINED,
+        metadata.get(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE()));
+  }
+
+  @Test
+  public void testBuildCDCPartitionedFile_regularAddFileWithDv_setsIfContained() {
+    AddFile addFile = createAddFileForCDC("data.parquet", 2048, 200L, Optional.of(TEST_DV));
+    CDCDataFile cdcFile = CDCDataFile.fromAddFile(addFile, /* commitTimestamp= */ 2000L);
+
+    PartitionedFile pf =
+        PartitionUtils.buildCDCPartitionedFile(
+            cdcFile,
+            /* commitVersion= */ 2L,
+            new StructType(),
+            "file:/tmp/table",
+            ZoneId.of("UTC"));
+
+    java.util.Map<String, Object> metadata = getFileMetadata(pf);
+    assertEquals(
+        TEST_DV.serializeToBase64(),
+        metadata.get(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED()));
+    assertEquals(
+        RowIndexFilterType.IF_CONTAINED,
+        metadata.get(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE()));
+  }
+
+  @Test
+  public void testBuildCDCPartitionedFile_noDv_noFilterMetadata() {
+    AddFile addFile = createAddFileForCDC("data.parquet", 512, 300L, Optional.empty());
+    CDCDataFile cdcFile = CDCDataFile.fromAddFile(addFile, /* commitTimestamp= */ 3000L);
+
+    PartitionedFile pf =
+        PartitionUtils.buildCDCPartitionedFile(
+            cdcFile,
+            /* commitVersion= */ 3L,
+            new StructType(),
+            "file:/tmp/table",
+            ZoneId.of("UTC"));
+
+    java.util.Map<String, Object> metadata = getFileMetadata(pf);
+    assertFalse(
+        metadata.containsKey(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED()),
+        "No filter metadata expected when AddFile has no DV");
   }
 }

--- a/spark/v2/src/test/scala/org/apache/spark/sql/delta/v2/CDCDeletionVectorHelperSuite.scala
+++ b/spark/v2/src/test/scala/org/apache/spark/sql/delta/v2/CDCDeletionVectorHelperSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta.v2
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.delta.actions.{DeletionVectorDescriptor => SparkDvDescriptor}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+
+/** Unit tests for [[CDCDeletionVectorHelper.computeDVDiff]]. All tests use inline DVs. */
+class CDCDeletionVectorHelperSuite extends SparkFunSuite {
+
+  private val conf = new Configuration()
+  private val dummyPath = "/tmp/dummy-dv-table"
+
+  private def makeInlineDv(rowIds: Long*): String = {
+    val bitmap = new RoaringBitmapArray()
+    rowIds.foreach(bitmap.add)
+    val bytes = DeletionVectorUtils.serialize(bitmap, RoaringBitmapArrayFormat.Portable, None)
+    SparkDvDescriptor.inlineInLog(bytes, bitmap.cardinality).serializeToBase64
+  }
+
+  private def readBitmap(dvBase64: String): RoaringBitmapArray = {
+    val dv = SparkDvDescriptor.deserializeFromBase64(dvBase64)
+    DeletionVectorStore.createInstance(conf).read(dv, new Path(dummyPath))
+  }
+
+  test("noneAndSome: Add has DV, Remove has none — returns single delete via inline shortcut") {
+    val addDvBase64 = makeInlineDv(0L, 1L)
+    val result = CDCDeletionVectorHelper.computeDVDiff(addDvBase64, null, conf, dummyPath)
+
+    assert(result.length === 1)
+    assert(result(0)._1 === CDCReader.CDC_TYPE_DELETE_STRING)
+    // Inline shortcut: the same base64 value is returned without re-serialization.
+    assert(result(0)._2 === addDvBase64)
+  }
+
+  test("someAndNone: Remove has DV, Add has none — returns single insert via inline shortcut") {
+    val removeDvBase64 = makeInlineDv(2L, 3L)
+    val result = CDCDeletionVectorHelper.computeDVDiff(null, removeDvBase64, conf, dummyPath)
+
+    assert(result.length === 1)
+    assert(result(0)._1 === CDCReader.CDC_TYPE_INSERT)
+    assert(result(0)._2 === removeDvBase64)
+  }
+
+  test("bothSome: Add DV is superset of Remove DV — only newly deleted rows become delete") {
+    // Remove marked row 0; Add marks rows 0 and 1. Row 1 is the new deletion.
+    val removeDvBase64 = makeInlineDv(0L)
+    val addDvBase64 = makeInlineDv(0L, 1L)
+    val result = CDCDeletionVectorHelper.computeDVDiff(addDvBase64, removeDvBase64, conf, dummyPath)
+
+    assert(result.length === 1)
+    assert(result(0)._1 === CDCReader.CDC_TYPE_DELETE_STRING)
+    val bitmap = readBitmap(result(0)._2)
+    assert(bitmap.cardinality === 1L)
+    assert(bitmap.contains(1L), "only the newly deleted row 1 should appear")
+  }
+
+  test("bothSome: Remove DV is superset of Add DV — only restored rows become insert") {
+    // Remove marked rows 0 and 1; Add marks only row 0. Row 1 is restored.
+    val removeDvBase64 = makeInlineDv(0L, 1L)
+    val addDvBase64 = makeInlineDv(0L)
+    val result = CDCDeletionVectorHelper.computeDVDiff(addDvBase64, removeDvBase64, conf, dummyPath)
+
+    assert(result.length === 1)
+    assert(result(0)._1 === CDCReader.CDC_TYPE_INSERT)
+    val bitmap = readBitmap(result(0)._2)
+    assert(bitmap.cardinality === 1L)
+    assert(bitmap.contains(1L), "only the restored row 1 should appear")
+  }
+
+  test("bothSome: disjoint DVs — produces both delete and insert") {
+    // Remove had row 0 deleted (now restored); Add has row 1 newly deleted.
+    val removeDvBase64 = makeInlineDv(0L)
+    val addDvBase64 = makeInlineDv(1L)
+    val result = CDCDeletionVectorHelper.computeDVDiff(addDvBase64, removeDvBase64, conf, dummyPath)
+
+    assert(result.length === 2)
+    val types = result.map(_._1).toSet
+    assert(types === Set(CDCReader.CDC_TYPE_DELETE_STRING, CDCReader.CDC_TYPE_INSERT))
+  }
+
+  test("bothNull: throws IllegalArgumentException") {
+    intercept[IllegalArgumentException] {
+      CDCDeletionVectorHelper.computeDVDiff(null, null, conf, dummyPath)
+    }
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6370/files) to review incremental changes.
- [stack/cdf2](https://github.com/delta-io/delta/pull/6076) [[Files changed](https://github.com/delta-io/delta/pull/6076/files)] [MERGED]
  - [stack/cdf3](https://github.com/delta-io/delta/pull/6336) [[Files changed](https://github.com/delta-io/delta/pull/6336/files)] [MERGED]
    - [stack/cdf4](https://github.com/delta-io/delta/pull/6359) [[Files changed](https://github.com/delta-io/delta/pull/6359/files)] [MERGED]
      - [stack/cdf6](https://github.com/delta-io/delta/pull/6363) [[Files changed](https://github.com/delta-io/delta/pull/6363/files)] [MERGED]
        - [stack/cdc-schema-refactor](https://github.com/delta-io/delta/pull/6744) [[Files changed](https://github.com/delta-io/delta/pull/6744/files)]
        - [**stack/cdf7**](https://github.com/delta-io/delta/pull/6370) [[Files changed](https://github.com/delta-io/delta/pull/6370/files)]

---------
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Adds deletion-vector support to the DSv2 CDC streaming connector, bringing it
to parity with DSv1's `CDCReader.generateFileActionsWithInlineDv`.

DV-based DELETE/UPDATE/MERGE produces same-path Add + Remove pairs where the DV
bitmap (not the data file) records the change. The stream now detects these
pairs, computes the bitmap diff in `CDCDeletionVectorHelper.computeDVDiff`,
and emits CDC entries that read only the diff rows (`IF_NOT_CONTAINED`
filter on the inline override bitmap). DV-diff commits are admitted
all-or-nothing under `maxFilesPerTrigger` / `maxBytesPerTrigger`, matching
DSv1.

## How was this patch tested?

- E2E: `DeltaCDCStreamDeletionVectorMixin` runs 6 DV-specific CDC tests
  (filter polarity, incremental deletes, partitioned tables, multi-file
  commits, atomic admission, byte-rate limiting) on both V1
  (`DeltaCDCStreamDeletionVectorSuite`) and V2
  (`DeltaV2CDCStreamDeletionVectorSuite`).
- Unit: `CDCDeletionVectorHelperSuite`, `PartitionUtilsTest`,
  `CDCDataFileTest`, and `SparkMicroBatchStreamCDCTest` cover the new branches.

## Does this PR introduce _any_ user-facing changes?

No.
