### PR TITLE
[DSv2] Move DeltaParquetFileFormatV2 and ProtocolMetadataAdapterV2 to shared format package

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV2Suite.scala
@@ -17,7 +17,7 @@ package org.apache.spark.sql.delta
 
 import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
 import io.delta.kernel.internal.util.VectorUtils
-import io.delta.spark.internal.v2.format.ProtocolMetadataAdapterV2
+import io.delta.spark.internal.v2.parquet.ProtocolMetadataAdapterV2
 import io.delta.spark.internal.v2.utils.SchemaUtils
 import io.delta.kernel.types.{ArrayType, StringType => KernelStringType}
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/parquet/DeltaParquetFileFormatV2.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/parquet/DeltaParquetFileFormatV2.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.spark.internal.v2.format;
+package io.delta.spark.internal.v2.parquet;
 
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/parquet/ProtocolMetadataAdapterV2.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/parquet/ProtocolMetadataAdapterV2.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.spark.internal.v2.format;
+package io.delta.spark.internal.v2.parquet;
 
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -23,7 +23,7 @@ import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
-import io.delta.spark.internal.v2.format.DeltaParquetFileFormatV2;
+import io.delta.spark.internal.v2.parquet.DeltaParquetFileFormatV2;
 import io.delta.spark.internal.v2.read.SparkReaderFactory;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContext;


### PR DESCRIPTION
## Summary
- move `DeltaParquetFileFormatV2` from `io.delta.spark.internal.v2.read` to `io.delta.spark.internal.v2.format`
- move `ProtocolMetadataAdapterV2` to the same shared `format` package
- update import sites in `PartitionUtils` and `ProtocolMetadataAdapterV2Suite`

## Notes
- mechanical package extraction only
- no behavior changes
- this makes ownership clearer for reuse across both DSv2 read and write paths

## Validation
- `build/sbt \"sparkV2/compile\"`
- `build/sbt \"sparkV2/test:compile\"`
- `build/sbt \"sparkV2/javafmtCheck\"`
- `build/sbt \"spark/testOnly org.apache.spark.sql.delta.ProtocolMetadataAdapterV2Suite\"`
- grep check confirms no stale imports of `io.delta.spark.internal.v2.read.{DeltaParquetFileFormatV2,ProtocolMetadataAdapterV2}` in Java/Scala sources