### PR TITLE
Add DDLContext POJO and prerequisite infra for DSv2 CREATE TABLE

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/DDLRequestContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/DDLRequestContext.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.ddl;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.types.StructType;
+import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.sql.connector.catalog.Identifier;
+
+/**
+ * Immutable POJO capturing all inputs for a DDL operation (CREATE TABLE, CTAS, RTAS).
+ *
+ * <p>Spark-level types (schema, partitions) are pre-converted to Kernel types by {@link
+ * CreateTableBuilder#prepare} so downstream code deals only with Kernel abstractions. The Spark
+ * {@link Identifier} is retained for logging and catalog-level identification only — it is never
+ * passed to Kernel APIs.
+ *
+ * <p>All collection fields are defensively copied; accessors return unmodifiable views.
+ */
+public final class DDLRequestContext {
+
+  private final Identifier ident;
+  private final String tablePath;
+  private final StructType kernelSchema;
+  private final Map<String, String> properties;
+  private final Optional<String> comment;
+  private final DataLayoutSpec dataLayoutSpec;
+  private final Engine engine;
+  private final Optional<UCTableInfo> ucTableInfo;
+  private final String engineInfo;
+
+  /**
+   * @param ident Spark catalog identifier (namespace + name); used for logging, not Kernel APIs
+   * @param tablePath resolved filesystem path for the Delta table
+   * @param kernelSchema Kernel-typed schema converted from Spark StructType
+   * @param properties user and Delta table properties with DSv2-internal keys already stripped
+   * @param comment table description from {@code CREATE TABLE ... COMMENT 'x'}, if provided; not
+   *     yet written to the Delta log (see {@link #comment()})
+   * @param dataLayoutSpec partitioning / clustering specification
+   * @param engine Kernel engine instance (typically {@code DefaultEngine})
+   * @param ucTableInfo Unity Catalog metadata when the table is UC-managed, empty otherwise
+   * @param engineInfo version string for commit provenance (e.g. "Delta-Spark-DSv2/3.4.0")
+   */
+  DDLRequestContext(
+      Identifier ident,
+      String tablePath,
+      StructType kernelSchema,
+      Map<String, String> properties,
+      Optional<String> comment,
+      DataLayoutSpec dataLayoutSpec,
+      Engine engine,
+      Optional<UCTableInfo> ucTableInfo,
+      String engineInfo) {
+    this.ident = requireNonNull(ident);
+    this.tablePath = requireNonNull(tablePath);
+    this.kernelSchema = requireNonNull(kernelSchema);
+    this.properties = Collections.unmodifiableMap(new HashMap<>(requireNonNull(properties)));
+    this.comment = requireNonNull(comment);
+    this.dataLayoutSpec = requireNonNull(dataLayoutSpec);
+    this.engine = requireNonNull(engine);
+    this.ucTableInfo = requireNonNull(ucTableInfo);
+    this.engineInfo = requireNonNull(engineInfo);
+  }
+
+  public Identifier ident() {
+    return ident;
+  }
+
+  public String tablePath() {
+    return tablePath;
+  }
+
+  public StructType kernelSchema() {
+    return kernelSchema;
+  }
+
+  /** Returns an unmodifiable view of the table properties. */
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  /**
+   * Table description from {@code COMMENT 'x'}, if provided. Not yet written to the Delta log
+   * because Kernel's {@code CreateTableTransactionBuilder} does not yet expose a {@code
+   * withDescription()} method. Preserved here for when that API becomes available.
+   */
+  public Optional<String> comment() {
+    return comment;
+  }
+
+  public DataLayoutSpec dataLayoutSpec() {
+    return dataLayoutSpec;
+  }
+
+  /**
+   * Kernel engine instance created via {@code DefaultEngine.create(hadoopConf)}. A new engine is
+   * created per DDL operation. {@code DefaultEngine} does not hold closeable resources so explicit
+   * shutdown is not required. See <a href="https://github.com/delta-io/delta/issues/5675">#5675</a>
+   * for centralizing engine creation.
+   */
+  public Engine engine() {
+    return engine;
+  }
+
+  public Optional<UCTableInfo> ucTableInfo() {
+    return ucTableInfo;
+  }
+
+  public String engineInfo() {
+    return engineInfo;
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/DDLRequestContextTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/DDLRequestContextTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.ddl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.TimestampType;
+import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the {@link DDLRequestContext} POJO. */
+public class DDLRequestContextTest {
+
+  private static final Engine ENGINE = DefaultEngine.create(new Configuration());
+
+  @Test
+  public void testConstructionWithAllFields() {
+    Identifier ident = Identifier.of(new String[] {"prod_catalog", "analytics"}, "page_views");
+    StructType schema =
+        new StructType()
+            .add(new StructField("user_id", IntegerType.INTEGER, false))
+            .add(new StructField("url", StringType.STRING, false))
+            .add(new StructField("event_ts", TimestampType.TIMESTAMP, false));
+    DataLayoutSpec clustering =
+        DataLayoutSpec.clustered(List.of(new Column("user_id"), new Column("event_ts")));
+    UCTableInfo ucInfo =
+        new UCTableInfo(
+            "uc-table-id-123",
+            "/managed/prod_catalog/analytics/page_views",
+            "https://uc.example.com",
+            Map.of("token", "fake-token"));
+
+    DDLRequestContext request =
+        new DDLRequestContext(
+            ident,
+            "/managed/prod_catalog/analytics/page_views",
+            schema,
+            Map.of("delta.appendOnly", "true", "delta.logRetentionDuration", "interval 30 days"),
+            Optional.of("Tracks page view events from the analytics pipeline"),
+            clustering,
+            ENGINE,
+            Optional.of(ucInfo),
+            "Delta-Spark-DSv2/4.0.0");
+
+    assertEquals("page_views", request.ident().name());
+    assertArrayEquals(new String[] {"prod_catalog", "analytics"}, request.ident().namespace());
+    assertEquals("/managed/prod_catalog/analytics/page_views", request.tablePath());
+    assertEquals(3, request.kernelSchema().length());
+    assertEquals("true", request.properties().get("delta.appendOnly"));
+    assertEquals(
+        Optional.of("Tracks page view events from the analytics pipeline"), request.comment());
+    assertTrue(request.dataLayoutSpec().hasClustering());
+    assertEquals(2, request.dataLayoutSpec().getClusteringColumns().size());
+    assertTrue(request.ucTableInfo().isPresent());
+    assertEquals("uc-table-id-123", request.ucTableInfo().get().getTableId());
+    assertEquals("Delta-Spark-DSv2/4.0.0", request.engineInfo());
+  }
+
+  @Test
+  public void testPropertiesAreImmutableAndDefensivelyCopied() {
+    Identifier ident = Identifier.of(new String[] {"db"}, "tbl");
+    StructType schema = new StructType().add(new StructField("id", IntegerType.INTEGER, false));
+
+    HashMap<String, String> original = new HashMap<>();
+    original.put("k", "v");
+    DDLRequestContext request =
+        new DDLRequestContext(
+            ident,
+            "/p",
+            schema,
+            original,
+            /* comment = */ Optional.empty(),
+            DataLayoutSpec.noDataLayout(),
+            ENGINE,
+            /* ucTableInfo = */ Optional.empty(),
+            "e");
+
+    // Mutating the original map must not leak into the DDLRequestContext
+    original.put("injected", "bad");
+    assertNull(request.properties().get("injected"));
+
+    // The returned map must be unmodifiable
+    assertThrows(UnsupportedOperationException.class, () -> request.properties().put("x", "y"));
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6377/files) to review incremental changes.
- [**stack/ddl-1-foundations**](https://github.com/delta-io/delta/pull/6377) [[Files changed](https://github.com/delta-io/delta/pull/6377/files)]
  - [stack/ddl-2-builder](https://github.com/delta-io/delta/pull/6378) [[Files changed](https://github.com/delta-io/delta/pull/6378/files/b8c478ac19da5afb5aea0d8ce25dfa744b689e4f..4eff0a28ac60cfcd85a5d1e683f2d27cc957ebfe)]
    - [stack/ddl-2b-builder](https://github.com/delta-io/delta/pull/6442) [[Files changed](https://github.com/delta-io/delta/pull/6442/files/4eff0a28ac60cfcd85a5d1e683f2d27cc957ebfe..62e3d0397001937ae6c8b579b3b87bfa51420fa3)]
      - [stack/ddl-3-wiring](https://github.com/delta-io/delta/pull/6379) [[Files changed](https://github.com/delta-io/delta/pull/6379/files/62e3d0397001937ae6c8b579b3b87bfa51420fa3..4e6986960d1da9dac957666590e5ccca22508c2d)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

## Description
In this stack of PRs we are implementing the foundation for DDL operations (metadata-only CREATE, CTAS, RTAS).

For context, CREATE TABLE in this DSv2 world is 3 main steps:
 1. pre-register the table to the catalog (UCProxy.createTable or HMS.createTable)
 2. build a transaction for table creation (Delta commit 0)
 3. commit (actually commit the transaction above)

**We also want to make implementing future DDL operations easier in the future**. That's why in this PR we create a unified DDL request POJO. This POJO/request will be fed into the transaction builder. 

**Significance**: CreateTableBuilder.prepare() does all the Spark → Kernel conversion - DDLContext is a normalized request for downstream Kernel operations.
> By the time DDLContext is constructed, everything is Kernel-native. buildTransaction() just passes it straight through to TableManager or UCCatalogManagedClient with no further conversion.
```
                                  SQL: CREATE TABLE t (id INT, name STRING)
                                                       │
                                                       ▼
                                 ┌──────────────────────────────────────────┐
                                 │  UCSingleCatalog.createTable(            │
                                 │    ident, schema, partitions, props)     │
                                 │                                          │
                                 │  Spark's UC catalog plugin. Delegates    │
                                 │  to DeltaCatalog for Delta tables.       │
                                 └─────────────────────┬────────────────────┘
                                                       │
                                                       ▼
  ┌──────────────────────────────────────────────────────────────────────────────────────────┐
  │  DeltaCatalog.createTable(ident, schema, partitions, properties)                         │
  │                                                                                          │
  │  1. DeltaV2Mode routing check                                                            │
  │     STRICT → always Kernel path                                                          │
  │     AUTO   → Kernel only if UC + catalogManaged feature flag                             │
  │     NONE   → V1 path (super.createTable)                                                 │
  │                                                                                          │
  │  2. If UC: preRegisterIfNeeded(ident, schema, parts, props)                              │
  │     └→ Optional<CatalogTable>                                                            │
  │     then injectStorageCredentials(ct, hadoopConf)                                        │
  │     then UCUtils.extractTableInfo(ct, spark) → Optional<UCTableInfo>                     │
  │                                                                                          │
  │  3. CreateTableBuilder.prepare(ident, schema, parts, props, hadoopConf, ucTableInfo)     │
  │     └→ DDLContext                                                                        │
  │                                                                                          │
  │  4. CreateTableBuilder.buildTransaction(ddlContext) → Transaction                        │
  │                                                                                          │
  │  5. txn.commit(engine, emptyIterable()) — metadata-only                                  │
  │                                                                                          │
  │  6. return new SparkTable(ident, tablePath) — V2 connector                               │
  └──────┬─────────────────────┬──────────────────────────┬──────────────────────┬───────────┘
         │                     │                          │                      │
         ▼                     ▼                          ▼                      ▼

       STEP 2                STEP 3                     STEP 4                 STEP 5
       Pre-register          Prepare                    Build Txn              Commit

       UC-only.              Converts Spark             Routes to Kernel       txn.commit(
       Calls delegate        types to Kernel:            API based on            engine,
       .createTable()                                    ucTableInfo:            emptyIterable()
       via UCProxy.          sparkSchema →                                       )
                              kernelSchema              ┌── UC present? ───┐
       UC assigns:            (SchemaUtils)             │                  │   Kernel handles
       • tableId                                        │  YES             │   conflict
       • managed             Transform[] →              │  UCCatalog       │   resolution,
         location             DataLayoutSpec            │  ManagedClient   │   protocol,
       • ucUri                (identity or              │  .buildCreate    │    and log write.
       • authConfig           cluster-by)               │  TableTxn(       │
                                                        │    tableId,      │   For UC: commit
       Returns               properties →               │    path,         │   goes through
       Optional               filtered props            │    schema,       │   UC committer.
       <CatalogTable>         (strip DSv2 keys:         │    engineInfo)   │
                               location, provider,      │  + UC committer  │   For path-based:
       Non-UC: returns         comment, owner,          │  + UC properties │   writes directly
       Optional.empty()        external, path,          │                  │   to filesystem.
                               option.path)             │  NO              │
       On failure:                                      │  TableManager    │   Returns
       drops pre-            hadoopConf →               │  .buildCreate    │    TransactionCommit
       registered             Engine                    │  TableTxn(       │   Result with:
       catalog entry          (DefaultEngine)           │    path,         │   • version (0)
                                                        │    schema,       │   • postCommit
                             path resolved:             │    engineInfo)   │     Snapshot
                              UC → ucTableInfo          └───────┬──────────┘
                                  .tablePath
                              non-UC → props            Then applies:
                                  ["location"]          • .withTableProperties(filtered)
                                  (throws if            • .withDataLayoutSpec(layout)
                                  none found)           • .build(engine) → Transaction

                             Returns:
                             DDLContext POJO
                             (ident, tablePath,
                              kernelSchema,
                              filteredProps,
                              comment,
                              dataLayoutSpec,
                              engine,
                              ucTableInfo,
                              engineInfo)
```

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
