### PR TITLE
[DO-NOT-MERGE] Add UCClient finalizeCreate API for staging table promotion

### DIFF
--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -18,7 +18,7 @@ package io.delta.kernel.unitycatalog
 
 import java.lang.{Long => JLong}
 import java.net.URI
-import java.util.Optional
+import java.util.{List => JList, Map => JMap, Optional}
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
@@ -202,6 +202,20 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
     val tableData = getTableDataElseThrow(tableId)
     val filteredCommits = tableData.getCommitsInRange(startVersion, endVersion)
     new GetCommitsResponse(filteredCommits.asJava, tableData.getMaxRatifiedVersion)
+  }
+
+  override def finalizeCreate(
+      tableName: String,
+      catalogName: String,
+      schemaName: String,
+      storageLocation: String,
+      columns: JList[UCClient.ColumnDef],
+      properties: JMap[String, String]): Unit = {
+    // Keyed by FQN; callers must pass this same FQN as tableId to commit/getCommits.
+    // In production, UC assigns a UUID that serves as tableId — this mock skips that.
+    val fqn = s"$catalogName.$schemaName.$tableName"
+    Option(tables.putIfAbsent(fqn, TableData.afterCreate()))
+      .foreach(_ => throw new IllegalArgumentException(s"Table $fqn already exists"))
   }
 
   override def close(): Unit = {}

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClientSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClientSuite.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import io.delta.storage.commit.{Commit, CommitFailedException}
-import io.delta.storage.commit.uccommitcoordinator.InvalidTargetTableException
+import io.delta.storage.commit.uccommitcoordinator.{InvalidTargetTableException, UCClient}
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -117,6 +117,64 @@ class InMemoryUCClientSuite extends AnyFunSuite with UCCatalogManagedTestUtils {
       startVersionOpt = Optional.of(2L),
       endVersionOpt = Optional.of(4L),
       expectedVersions = 2L to 4L)
+  }
+
+  private def makeColumns(specs: (String, String, String)*): java.util.List[UCClient.ColumnDef] = {
+    val cols = new java.util.ArrayList[UCClient.ColumnDef]()
+    specs.zipWithIndex.foreach { case ((name, typeName, typeText), idx) =>
+      cols.add(new UCClient.ColumnDef(name, typeName, typeText, s""""$typeText"""", true, idx))
+    }
+    cols
+  }
+
+  private val testColumns = makeColumns(("id", "INT", "int"), ("name", "STRING", "string"))
+
+  private val testProperties: java.util.Map[String, String] = {
+    val m = new java.util.HashMap[String, String]()
+    m.put("delta.lastUpdateVersion", "0")
+    m
+  }
+
+  test("finalizeCreate then commit and getCommits works end-to-end") {
+    val client = new InMemoryUCClient("ucMetastoreId")
+    val fqn = "cat.sch.tbl"
+
+    client.finalizeCreate(
+      "tbl",
+      "cat",
+      "sch",
+      "s3://bucket/tbl",
+      testColumns,
+      testProperties)
+
+    client.commitWithDefaults(fqn, fakeURI, Optional.of(createCommit(1L)))
+    client.commitWithDefaults(fqn, fakeURI, Optional.of(createCommit(2L)))
+
+    val response = client.getCommits(fqn, fakeURI, Optional.empty(), Optional.empty())
+    assert(response.getCommits.size() == 2)
+    assert(response.getLatestTableVersion == 2L)
+  }
+
+  test("finalizeCreate throws on duplicate table name") {
+    val client = new InMemoryUCClient("ucMetastoreId")
+    client.finalizeCreate(
+      "tbl",
+      "cat",
+      "sch",
+      "s3://bucket/tbl",
+      testColumns,
+      testProperties)
+
+    val ex = intercept[IllegalArgumentException] {
+      client.finalizeCreate(
+        "tbl",
+        "cat",
+        "sch",
+        "s3://bucket/tbl2",
+        testColumns,
+        testProperties)
+    }
+    assert(ex.getMessage.contains("cat.sch.tbl already exists"))
   }
 
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -92,5 +92,17 @@ class InMemoryUCClient(
       Option(endVersion.orElse(null)).map(_.toLong))
   }
 
+  /**
+   * No-op: this test double delegates commit coordination to [[InMemoryUCCommitCoordinator]]
+   * and does not model UC's catalog-level table registration.
+   */
+  override def finalizeCreate(
+      tableName: String,
+      catalogName: String,
+      schemaName: String,
+      storageLocation: String,
+      columns: java.util.List[UCClient.ColumnDef],
+      properties: java.util.Map[String, String]): Unit = {}
+
   override def close(): Unit = {}
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -25,6 +25,9 @@ import io.delta.storage.commit.uniform.UniformMetadata;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -120,6 +123,77 @@ public interface UCClient extends AutoCloseable {
       URI tableUri,
       Optional<Long> startVersion,
       Optional<Long> endVersion) throws IOException, UCCommitCoordinatorException;
+
+  /**
+   * Lightweight data transfer object that carries column metadata across the module boundary
+   * between the Spark connector and {@code delta-storage}. Needed because {@code delta-storage}
+   * cannot depend on Spark's {@code StructField} or UC SDK's {@code ColumnInfo}, so this
+   * plain-Java type bridges the gap.
+   */
+  final class ColumnDef {
+    private final String name;
+    private final String typeName;
+    private final String typeText;
+    private final String typeJson;
+    private final boolean nullable;
+    private final int position;
+
+    /**
+     * @param name     column name
+     * @param typeName UC type name (e.g. {@code "INT"}, {@code "ARRAY"}, {@code "DECIMAL"}).
+     *                 Must match a {@code ColumnTypeName} enum value in the UC SDK.
+     * @param typeText human-readable type string from Spark's {@code DataType.catalogString()}
+     *                 (e.g. {@code "int"}, {@code "array<string>"})
+     * @param typeJson JSON representation from Spark's {@code DataType.json()}
+     *                 (e.g. {@code "\"integer\""} or
+     *                 {@code {"type":"array","elementType":"string","containsNull":true}})
+     * @param nullable whether the column allows null values
+     * @param position zero-based ordinal position in the schema
+     */
+    public ColumnDef(
+        String name,
+        String typeName,
+        String typeText,
+        String typeJson,
+        boolean nullable,
+        int position) {
+      this.name = Objects.requireNonNull(name, "name is null");
+      this.typeName = Objects.requireNonNull(typeName, "typeName is null");
+      this.typeText = Objects.requireNonNull(typeText, "typeText is null");
+      this.typeJson = Objects.requireNonNull(typeJson, "typeJson is null");
+      this.nullable = nullable;
+      this.position = position;
+    }
+
+    public String getName() { return name; }
+    public String getTypeName() { return typeName; }
+    public String getTypeText() { return typeText; }
+    public String getTypeJson() { return typeJson; }
+    public boolean isNullable() { return nullable; }
+    public int getPosition() { return position; }
+  }
+
+  /**
+   * Promotes a staging table into a real managed table in Unity Catalog by calling the UC
+   * {@code createTable} REST endpoint. This is the correct API for version 0 (CREATE);
+   * for version 1+ (WRITE), use {@link #commit} instead. See delta#5118 for rationale.
+   *
+   * @param tableName table name (relative to parent schema)
+   * @param catalogName parent catalog name in Unity Catalog
+   * @param schemaName parent schema name in Unity Catalog
+   * @param storageLocation the storage root URL for the table (same as staging table)
+   * @param columns column definitions for the table schema
+   * @param properties properties to persist in UC (protocol features, metadata config, etc.)
+   * @throws IOException if there is a network or server error during finalization
+   * @throws IllegalArgumentException if a column's type name cannot be mapped to a known UC type
+   */
+  void finalizeCreate(
+      String tableName,
+      String catalogName,
+      String schemaName,
+      String storageLocation,
+      List<ColumnDef> columns,
+      Map<String, String> properties) throws IOException;
 
   /**
    * Closes any resources used by this client.

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -29,7 +29,12 @@ import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.DeltaCommitsApi;
 import io.unitycatalog.client.api.MetastoresApi;
+import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.DeltaCommit;
 import io.unitycatalog.client.model.DeltaCommitInfo;
 import io.unitycatalog.client.model.DeltaCommitMetadataProperties;
@@ -39,12 +44,14 @@ import io.unitycatalog.client.model.DeltaMetadata;
 import io.unitycatalog.client.model.DeltaUniform;
 import io.unitycatalog.client.model.DeltaUniformIceberg;
 import io.unitycatalog.client.model.GetMetastoreSummaryResponse;
+import io.unitycatalog.client.model.TableType;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A REST client implementation of {@link UCClient} for interacting with Unity Catalog's commit
@@ -80,6 +87,7 @@ public class UCTokenBasedRestClient implements UCClient {
 
   private DeltaCommitsApi deltaCommitsApi;
   private MetastoresApi metastoresApi;
+  private TablesApi tablesApi;
 
   // HTTP status codes for error handling
   private static final int HTTP_BAD_REQUEST = 400;
@@ -118,13 +126,14 @@ public class UCTokenBasedRestClient implements UCClient {
     ApiClient apiClient = builder.build();
     this.deltaCommitsApi = new DeltaCommitsApi(apiClient);
     this.metastoresApi = new MetastoresApi(apiClient);
+    this.tablesApi = new TablesApi(apiClient);
   }
 
   /**
    * Ensures the client has not been closed. Must be called before any API operation.
    */
   private void ensureOpen() {
-    if (deltaCommitsApi == null || metastoresApi == null) {
+    if (deltaCommitsApi == null || metastoresApi == null || tablesApi == null) {
       throw new IllegalStateException("UCTokenBasedRestClient has been closed.");
     }
   }
@@ -220,12 +229,75 @@ public class UCTokenBasedRestClient implements UCClient {
     }
   }
 
+  /**
+   * Promotes a staging table to a managed table by building a UC SDK {@link CreateTable} request
+   * from the provided {@link UCClient.ColumnDef} list and properties, then calling
+   * {@link TablesApi#createTable}. Each column's {@link UCClient.ColumnDef#getTypeName()} is
+   * resolved to a {@link ColumnTypeName}; unrecognized types fail fast with
+   * {@link IllegalArgumentException}.
+   */
+  @Override
+  public void finalizeCreate(
+      String tableName,
+      String catalogName,
+      String schemaName,
+      String storageLocation,
+      List<UCClient.ColumnDef> columns,
+      Map<String, String> properties) throws IOException {
+    ensureOpen();
+    Objects.requireNonNull(tableName, "tableName must not be null.");
+    Objects.requireNonNull(catalogName, "catalogName must not be null.");
+    Objects.requireNonNull(schemaName, "schemaName must not be null.");
+    Objects.requireNonNull(storageLocation, "storageLocation must not be null.");
+    Objects.requireNonNull(columns, "columns must not be null.");
+    Objects.requireNonNull(properties, "properties must not be null.");
+
+    List<ColumnInfo> ucColumns = columns.stream()
+        .map(c -> {
+          ColumnTypeName resolved = ColumnTypeName.fromValue(c.getTypeName());
+          if (resolved == ColumnTypeName.UNKNOWN_DEFAULT_OPEN_API) {
+            throw new IllegalArgumentException(
+                "Unsupported column type '" + c.getTypeName()
+                + "' for column '" + c.getName() + "'");
+          }
+          return new ColumnInfo()
+              .name(c.getName())
+              .typeText(c.getTypeText())
+              .typeName(resolved)
+              .typeJson(c.getTypeJson())
+              .nullable(c.isNullable())
+              .position(c.getPosition());
+        })
+        .collect(Collectors.toList());
+
+    CreateTable request = new CreateTable()
+        .name(tableName)
+        .catalogName(catalogName)
+        .schemaName(schemaName)
+        .tableType(TableType.MANAGED)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .columns(ucColumns)
+        .storageLocation(storageLocation)
+        .properties(properties);
+
+    try {
+      tablesApi.createTable(request);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format(
+              "Failed to finalize table creation for %s.%s.%s (HTTP %s): %s",
+              catalogName, schemaName, tableName, e.getCode(), e.getResponseBody()),
+          e);
+    }
+  }
+
   @Override
   public void close() throws IOException {
     // Nulling out the API instances makes them eligible for GC. Once garbage collected,
     // the underlying connection pool is freed and destroyed.
     this.deltaCommitsApi = null;
     this.metastoresApi = null;
+    this.tablesApi = null;
   }
 
   /**

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -45,6 +45,7 @@ class UCTokenBasedRestClientSuite
   private var serverUri: String = _
   private var metastoreHandler: HttpExchange => Unit = _
   private var commitsHandler: HttpExchange => Unit = _
+  private var tablesHandler: HttpExchange => Unit = _
   private val objectMapper = new ObjectMapper()
 
   override def beforeAll(): Unit = {
@@ -63,6 +64,11 @@ class UCTokenBasedRestClientSuite
       }
       exchange.close()
     })
+    server.createContext("/api/2.1/unity-catalog/tables", exchange => {
+      if (tablesHandler != null) tablesHandler(exchange)
+      else sendJson(exchange, HttpStatus.SC_OK, """{"table_id":"new-table-id"}""")
+      exchange.close()
+    })
     server.start()
     serverUri = s"http://localhost:${server.getAddress.getPort}"
   }
@@ -72,6 +78,7 @@ class UCTokenBasedRestClientSuite
   override def beforeEach(): Unit = {
     metastoreHandler = null
     commitsHandler = null
+    tablesHandler = null
   }
 
   private def readRequestBody(exchange: HttpExchange): String = {
@@ -305,5 +312,112 @@ class UCTokenBasedRestClientSuite
 
     val json = objectMapper.readTree(capturedBody)
     assert(!json.has("uniform") || json.get("uniform").isNull)
+  }
+
+  // finalizeCreate tests
+  test("finalizeCreate sends correct CreateTable request with complex types") {
+    // Capture the HTTP request body sent to UC's createTable endpoint
+    var capturedBody: String = null
+    tablesHandler = exchange => {
+      capturedBody = readRequestBody(exchange)
+      sendJson(exchange, HttpStatus.SC_OK, """{"table_id":"new-table-id"}""")
+    }
+
+    // Prepare columns with primitive, complex, and parameterized types
+    val columns = new java.util.ArrayList[UCClient.ColumnDef]()
+    columns.add(new UCClient.ColumnDef("id", "INT", "int", "\"integer\"", false, 0))
+    columns.add(new UCClient.ColumnDef("tags", "ARRAY", "array<string>",
+      """{"type":"array","elementType":"string","containsNull":true}""", true, 1))
+    columns.add(new UCClient.ColumnDef("price", "DECIMAL", "decimal(10,2)",
+      """{"type":"decimal","precision":10,"scale":2}""", true, 2))
+
+    val props = new java.util.HashMap[String, String]()
+    props.put("delta.minReaderVersion", "1")
+
+    // Send the finalizeCreate request
+    withClient { client =>
+      client.finalizeCreate("my_table", "my_catalog", "my_schema",
+        "s3://bucket/path", columns, props)
+    }
+
+    // Verify the serialized CreateTable JSON matches UC's expected schema
+    val json = objectMapper.readTree(capturedBody)
+    assert(json.get("name").asText() === "my_table")
+    assert(json.get("catalog_name").asText() === "my_catalog")
+    assert(json.get("schema_name").asText() === "my_schema")
+    assert(json.get("table_type").asText() === "MANAGED")
+    assert(json.get("data_source_format").asText() === "DELTA")
+    assert(json.get("storage_location").asText() === "s3://bucket/path")
+
+    val cols = json.get("columns")
+    assert(cols.size() === 3)
+    assert(cols.get(0).get("name").asText() === "id")
+    assert(cols.get(0).get("type_name").asText() === "INT")
+    assert(cols.get(1).get("name").asText() === "tags")
+    assert(cols.get(1).get("type_name").asText() === "ARRAY")
+    assert(cols.get(2).get("name").asText() === "price")
+    assert(cols.get(2).get("type_name").asText() === "DECIMAL")
+  }
+
+  test("finalizeCreate throws IllegalArgumentException for unsupported column type") {
+    // Prepare a column with a type name that doesn't map to any ColumnTypeName enum value
+    val columns = new java.util.ArrayList[UCClient.ColumnDef]()
+    columns.add(new UCClient.ColumnDef("col", "FAKETYPE", "faketype", "\"faketype\"", true, 0))
+
+    // Expect IllegalArgumentException before any HTTP call is made
+    withClient { client =>
+      val ex = intercept[IllegalArgumentException] {
+        client.finalizeCreate("tbl", "cat", "sch", "s3://bucket/tbl",
+          columns, Collections.emptyMap())
+      }
+      assert(ex.getMessage.contains("Unsupported column type"))
+      assert(ex.getMessage.contains("FAKETYPE"))
+    }
+  }
+
+  test("finalizeCreate throws IOException on server error") {
+    // Simulate UC returning HTTP 500
+    tablesHandler = exchange =>
+      sendJson(exchange, HttpStatus.SC_INTERNAL_SERVER_ERROR, """{"error":"boom"}""")
+
+    val columns = new java.util.ArrayList[UCClient.ColumnDef]()
+    columns.add(new UCClient.ColumnDef("id", "INT", "int", "\"integer\"", false, 0))
+
+    // Expect IOException wrapping the server error with the FQN in the message
+    withClient { client =>
+      val ex = intercept[java.io.IOException] {
+        client.finalizeCreate("tbl", "cat", "sch", "s3://bucket/tbl",
+          columns, Collections.emptyMap())
+      }
+      assert(ex.getMessage.contains("Failed to finalize table creation"))
+      assert(ex.getMessage.contains("cat.sch.tbl"))
+    }
+  }
+
+  test("finalizeCreate validates required parameters") {
+    val columns = new java.util.ArrayList[UCClient.ColumnDef]()
+    columns.add(new UCClient.ColumnDef("id", "INT", "int", "\"integer\"", false, 0))
+
+    // Each of the 6 required parameters must reject null
+    withClient { client =>
+      intercept[NullPointerException] {
+        client.finalizeCreate(null, "cat", "sch", "s3://b", columns, Collections.emptyMap())
+      }
+      intercept[NullPointerException] {
+        client.finalizeCreate("tbl", null, "sch", "s3://b", columns, Collections.emptyMap())
+      }
+      intercept[NullPointerException] {
+        client.finalizeCreate("tbl", "cat", null, "s3://b", columns, Collections.emptyMap())
+      }
+      intercept[NullPointerException] {
+        client.finalizeCreate("tbl", "cat", "sch", null, columns, Collections.emptyMap())
+      }
+      intercept[NullPointerException] {
+        client.finalizeCreate("tbl", "cat", "sch", "s3://b", null, Collections.emptyMap())
+      }
+      intercept[NullPointerException] {
+        client.finalizeCreate("tbl", "cat", "sch", "s3://b", columns, null)
+      }
+    }
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6378/files) to review incremental changes.
- [stack/ddl-1-foundations](https://github.com/delta-io/delta/pull/6377) [[Files changed](https://github.com/delta-io/delta/pull/6377/files)] [MERGED]
  - [**stack/ddl-2-builder**](https://github.com/delta-io/delta/pull/6378) [[Files changed](https://github.com/delta-io/delta/pull/6378/files)]
    - [stack/ddl-2b-builder](https://github.com/delta-io/delta/pull/6442) [[Files changed](https://github.com/delta-io/delta/pull/6442/files/a756ee7ada2ff356fbe616f3e1d15a024866d950..64aea78fc5da49c4d0266febfcf2f4f537e853d5)]
      - [stack/ddl-3-wiring](https://github.com/delta-io/delta/pull/6379) [[Files changed](https://github.com/delta-io/delta/pull/6379/files/64aea78fc5da49c4d0266febfcf2f4f537e853d5..02310da7ada6cfc6f280bc8342ed2b4fd539212a)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->
## Description

**The problem:** Today, the only way to register a commit with Unity Catalog is `UCClient.commit(tableId, ...)`. But `commit()` requires the table to *already exist* in UC — it takes a `tableId` that UC previously assigned. This works fine for version 1+ writes, but for CREATE TABLE (version 0) the table is still a staging allocation, so v0 bypasses UC entirely via direct filesystem writes. It works, but UC has no involvement in table creation at all — there's no API on `UCClient` to say "this staging table is ready, here are its columns and properties, make it real."

**Why it matters:** Because v0 bypasses UC, the table's schema and metadata never flow through UC at creation time. UC only discovers the table exists when the first real commit arrives, leaving a gap and forcing downstream code to handle the `maxRatifiedVersion=-1` edge case everywhere ([delta#5118](https://github.com/delta-io/delta/issues/5118)).
```
Without finalizeCreate:

 CREATE TABLE         First WRITE (v1)
      │                     │
      ▼                     ▼
 Kernel writes        commit(tableId, ...)
 000.json directly         │
      │                     ▼
      ▼               UC sees table for
 UC knows nothing     the FIRST time here
      │                     │
      ▼                     ▼
 maxRatifiedVersion = -1   gap!
```
**The solution:** Add `finalizeCreate()` to `UCClient` as the dedicated version-0 API. After Kernel writes `000.json`, `finalizeCreate(tableName, catalogName, schemaName, storageLocation, columns, properties)` is called to hit UC's `createTable` REST endpoint and promote staging → real table. From that point on, normal `commit()` calls work for version 1+.
```
CREATE TABLE (version 0)                    WRITE (version 1+)
========================                    ===================

 Spark Connector                             Spark Connector
      │                                           │
      ▼                                           ▼
 UC allocates staging table                  commit(tableId, ...)
      │                                           │
      ▼                                           ▼
 Kernel writes 000.json                      UC ratifies version
      │
      ▼
 ┌─────────────────────────────┐
 │  finalizeCreate()  ◄── THIS PR
 │                             │
 │  Calls UC createTable REST  │
 │  endpoint which promotes    │
 │  staging → real table       │
 └─────────────────────────────┘
      │
      ▼
 Table now exists for commit()
```

**Module boundary:** `finalizeCreate()` needs to pass column schema from the Spark connector down to the UC REST client. But these live in different modules — the connector has Spark's `StructField`, the REST client needs UC SDK's `ColumnInfo`, and the `UCClient` interface sits between them in `delta-storage`, which can't depend on either. To bridge that gap, this PR introduces `ColumnDef`, a plain-Java DTO that carries column metadata (name, type, nullability) across the module boundary without pulling in any external dependencies.

```
Spark Connector          UCClient interface           UCTokenBasedRestClient
───────────────          ──────────────────           ──────────────────────

 has StructField   ──►   has ColumnDef          ──►   has ColumnInfo
 (Spark types)           (plain Java, no deps)        (UC SDK types)
```


<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
