### PR TITLE
Track fully pushed partition filters in SparkScan

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -107,7 +107,7 @@ public class SparkScan
   private final StructType partitionSchema;
   private final Predicate[] pushedToKernelFilters;
   private final Filter[] dataFilters;
-  // Filters that are fully pushed and don't need post-scan evaluation
+  // Partition filters fully handled by the kernel scan
   private final Filter[] pushedPartitionFilters;
   private final io.delta.kernel.Scan kernelScan;
   private final Optional<Statistics> catalogStats;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScanBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScanBuilder.java
@@ -57,9 +57,7 @@ public class SparkScanBuilder
   private Predicate[] pushedKernelPredicates;
   private Filter[] pushedSparkFilters;
   private Filter[] dataFilters;
-  // pushedPartitionFilters: Filters that are fully pushed and do not need post-scan evaluation.
-  // These are filters that are kernel-supported, fully converted (not partial), and not data
-  // filters. They are used for filter deduplication in physical planning.
+  // Partition filters fully handled by the kernel scan (not partial, not data filters).
   private Filter[] pushedPartitionFilters;
 
   /**
@@ -155,8 +153,7 @@ public class SparkScanBuilder
         postScanFilters.add(filter);
       }
 
-      // Collect fully pushed partition filters that don't need post-scan evaluation.
-      // These are filters that are kernel-supported, fully converted, and not data filters.
+      // Partition filters fully handled by the kernel scan.
       if (classification.isKernelSupported
           && !classification.isPartialConversion
           && !classification.isDataFilter) {


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

SparkScanBuilder now identifies filters that are fully pushed to the kernel (kernel-supported, fully converted, not data filters) and passes them to SparkScan as pushedPartitionFilters. These are partition filters that do not need post-scan evaluation, enabling further deduplication of them if needed. 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

No