### PR TITLE
Pass streaming DataSource options into DeltaLog snapshot for UC external tables

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
@@ -261,4 +261,96 @@ class DeltaDataFrameHadoopOptionsSuite extends QueryTest
     }
   }
 
+  /**
+   * Clears the DeltaLog cache, runs the operation, then verifies that
+   * the resulting DeltaLog carries the expected fs.* options internally.
+   */
+  private def withOptionsPropagationCheck(path: String, desc: String)(op: => Unit): Unit = {
+    withClue(s"$desc: ") {
+      clearCachedDeltaLogToForceReload()
+      op
+      val deltaLog = DeltaLog.forTable(spark, new Path(path), fakeFileSystemOptions)
+      assert(
+        deltaLog.options("fs.fake.impl") == classOf[FakeFileSystem].getName,
+        "fs.fake.impl was not propagated to DeltaLog.options")
+      assert(
+        deltaLog.newDeltaHadoopConf().get("fs.fake.impl") == classOf[FakeFileSystem].getName,
+        "fs.fake.impl was not propagated to Hadoop configuration")
+    }
+  }
+
+  test("all operations should propagate Hadoop file system options") {
+    withTempPaths(/* numPaths = */ 2) { case Seq(inputDir, checkpointDir) =>
+      val path = fakeFileSystemPath(inputDir)
+
+      // Seed the table
+      spark.range(2).write.format("delta")
+        .options(fakeFileSystemOptions).save(path)
+
+      withOptionsPropagationCheck(path, "batch write (overwrite)") {
+        spark.range(3).write.format("delta")
+          .options(fakeFileSystemOptions).mode("overwrite").save(path)
+      }
+
+      withOptionsPropagationCheck(path, "batch read") {
+        assert(spark.read.format("delta")
+          .options(fakeFileSystemOptions).load(path).count() == 3)
+      }
+
+      withOptionsPropagationCheck(path, "batch append") {
+        spark.range(1).write.format("delta")
+          .options(fakeFileSystemOptions).mode("append").save(path)
+      }
+
+      withOptionsPropagationCheck(path, "streaming read") {
+        val query = spark.readStream.format("delta")
+          .options(fakeFileSystemOptions)
+          .load(path)
+          .writeStream
+          .format("memory")
+          .queryName("options_propagation_test")
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .start()
+        try {
+          query.processAllAvailable()
+          assert(spark.table("options_propagation_test").count() == 4)
+        } finally {
+          query.stop()
+        }
+      }
+    }
+  }
+
+  testQuietly("operations without Hadoop options should fail for fake:// filesystem") {
+    withTempPaths(/* numPaths = */ 2) { case Seq(inputDir, checkpointDir) =>
+      val path = fakeFileSystemPath(inputDir)
+
+      // Write data with options so the Delta table physically exists.
+      spark.range(2).write.format("delta")
+        .options(fakeFileSystemOptions).save(path)
+      clearCachedDeltaLogToForceReload()
+
+      // Batch read without options should fail
+      val batchEx = intercept[Exception] {
+        spark.read.format("delta").load(path).foreach(_ => {})
+      }
+      assert(batchEx.getMessage.contains("""No FileSystem for scheme "fake""""))
+
+      clearCachedDeltaLogToForceReload()
+
+      // Streaming read without options should fail
+      val streamEx = intercept[Exception] {
+        spark.readStream.format("delta")
+          .load(path)
+          .writeStream
+          .format("memory")
+          .queryName("options_failure_test")
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .start()
+          .processAllAvailable()
+      }
+      assert(streamEx.getMessage.contains("""No FileSystem for scheme "fake""""))
+    }
+  }
+
 }


### PR DESCRIPTION
## Description

This PR adds tests to verify that streaming DataSource options (e.g., custom Hadoop filesystem options) are correctly propagated into the DeltaLog snapshot when reading Delta tables.

### Changes
- Add `withOptionsPropagationCheck` helper to validate that `fs.*` options are carried through to `DeltaLog.options` and `newDeltaHadoopConf()`
- Add test: all operations (batch write, read, append, streaming read) should propagate Hadoop filesystem options
- Add test: operations without Hadoop options should fail for a custom `fake://` filesystem

### Testing
New unit tests in `DeltaDataFrameHadoopOptionsSuite`.
