### PR TITLE
[kernel-spark] Refactor startVersionNotFoundException

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/StartVersionNotFoundException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/StartVersionNotFoundException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.exceptions;
+
+import io.delta.kernel.annotation.Evolving;
+import java.util.Optional;
+
+/**
+ * Exception thrown when the requested start version is not found in the Delta log. This can happen
+ * when the requested start version has been cleaned up due to log retention policies.
+ *
+ * @since 4.1.0
+ */
+@Evolving
+public class StartVersionNotFoundException extends KernelException {
+
+  private final String tablePath;
+  private final long startVersionRequested;
+  private final Optional<Long> earliestAvailableVersion;
+
+  public StartVersionNotFoundException(
+      String tablePath, long startVersionRequested, Optional<Long> earliestAvailableVersion) {
+    super(buildMessage(tablePath, startVersionRequested, earliestAvailableVersion));
+    this.tablePath = tablePath;
+    this.startVersionRequested = startVersionRequested;
+    this.earliestAvailableVersion = earliestAvailableVersion;
+  }
+
+  /** @return the table path where the start version was not found */
+  public String getTablePath() {
+    return tablePath;
+  }
+
+  /** @return the start version that was requested but not found */
+  public long getStartVersionRequested() {
+    return startVersionRequested;
+  }
+
+  /**
+   * @return the earliest available version in the Delta log, or empty if no versions are available
+   */
+  public Optional<Long> getEarliestAvailableVersion() {
+    return earliestAvailableVersion;
+  }
+
+  private static String buildMessage(
+      String tablePath, long startVersionRequested, Optional<Long> earliestAvailableVersion) {
+    String message =
+        String.format(
+            "%s: Requested table changes beginning with startVersion=%s but no log file found for "
+                + "version %s.",
+            tablePath, startVersionRequested, startVersionRequested);
+    if (earliestAvailableVersion.isPresent()) {
+      message =
+          message
+              + String.format(" Earliest available version is %s", earliestAvailableVersion.get());
+    }
+    return message;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -108,19 +108,10 @@ public final class DeltaErrors {
     return new CommitRangeNotFoundException(tablePath, startVersion, endVersionOpt);
   }
 
-  public static KernelException startVersionNotFound(
+  public static StartVersionNotFoundException startVersionNotFound(
       String tablePath, long startVersionRequested, Optional<Long> earliestAvailableVersion) {
-    String message =
-        String.format(
-            "%s: Requested table changes beginning with startVersion=%s but no log file found for "
-                + "version %s.",
-            tablePath, startVersionRequested, startVersionRequested);
-    if (earliestAvailableVersion.isPresent()) {
-      message =
-          message
-              + String.format(" Earliest available version is %s", earliestAvailableVersion.get());
-    }
-    return new KernelException(message);
+    return new StartVersionNotFoundException(
+        tablePath, startVersionRequested, earliestAvailableVersion);
   }
 
   public static KernelException endVersionNotFound(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6394/files) to review incremental changes.
- [**stack/refactorStartVersionNotFoundExcecption**](https://github.com/delta-io/delta/pull/6394) [[Files changed](https://github.com/delta-io/delta/pull/6394/files)]
  - [stack/failOnDataLoss2](https://github.com/delta-io/delta/pull/6395) [[Files changed](https://github.com/delta-io/delta/pull/6395/files/0c83e18a239a99178ec59db8b2b4634737fef7a6..c01f4d435ff5c73deae282e8b7d1d6913f55a434)]

---------
#### Which Delta project/connector is this regarding?

Kernel

## Description

Introduces a dedicated `StartVersionNotFoundException` exception class that extends `KernelException`, replacing the plain `KernelException` previously thrown by `DeltaErrors.startVersionNotFound()`.

The new exception exposes structured fields:
- `getTablePath()` — the table where the version was not found
- `getStartVersionRequested()` — the version that was requested but missing
- `getEarliestAvailableVersion()` — the earliest version still available (`Optional<Long>`)

This follows the same pattern as `CommitRangeNotFoundException` and allows callers to programmatically handle missing start versions (e.g., for `failOnDataLoss=false` in DSv2 streaming) without fragile message parsing.

Resolves the kernel-side changes for https://github.com/delta-io/delta/issues/6380

## How was this patch tested?

Existing tests continue to pass since `StartVersionNotFoundException extends KernelException`. Callers that previously caught `KernelException` still catch the new subclass. The structured fields are exercised by the DSv2 `failOnDataLoss` tests in the stacked PR #6395.

## Does this PR introduce _any_ user-facing changes?

No