### PR TITLE
[kernel-spark] Support failOnDataLoss read option DSv2

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -82,6 +82,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     // === Commit/Checkpoint file missing detection ===
     "incremental: first commit file missing, fails",
     "incremental: commit file gap between versions, fails",
+    "incremental: first commit file missing, failOnDataLoss=false succeeds",
     "initial snapshot: commit file missing but checkpoint intact, succeeds",
     "initial snapshot: both checkpoint and commit file missing, fails",
     "initial snapshot: log retention deletes old checkpoint and commit files mid-stream," +
@@ -146,7 +147,8 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "type widening: restarting with stale DataFrame should recover",
 
     // === Data Loss Detection ===
-    "incremental: first commit file missing, failOnDataLoss=false succeeds",
+    // V2 only tolerates missing start versions with failOnDataLoss=false; mid-log gaps still
+    // throw InvalidTableException because non-contiguous versions are not a log-retention scenario.
     "incremental: commit file gap between versions, failOnDataLoss=false succeeds",
     // Kernel cannot reconstruct snapshot without checkpoint file (_last_checkpoint still
     // points to deleted checkpoint). V1 falls back to delta files; Kernel does not.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -117,6 +117,15 @@ public class SparkMicroBatchStream
                   DeltaAction.CDC,
                   DeltaAction.COMMITINFO)));
 
+  /**
+   * Max attempts to resolve the start version when failOnDataLoss=false. Attempt 1 is the initial
+   * try with the user's startVersion (surfaces the StartVersionNotFoundException that triggers the
+   * failOnDataLoss check). Attempt 2 retries with the earliest available version to recover when
+   * failOnDataLoss=false. Attempt 3 guards against a concurrent log-retention prune in the tiny
+   * window between attempt 2's exception and its retry.
+   */
+  private static final int FAIL_ON_DATA_LOSS_FALSE_MAX_ATTEMPTS = 3;
+
   private final Engine engine;
   private final DeltaSnapshotManager snapshotManager;
   private final DeltaOptions options;
@@ -931,13 +940,34 @@ public class SparkMicroBatchStream
       }
     }
 
-    CommitRange commitRange;
-    try {
-      commitRange = snapshotManager.getTableChanges(engine, startVersion, endVersionOpt);
-    } catch (io.delta.kernel.exceptions.CommitRangeNotFoundException e) {
-      // If the requested version range doesn't exist (e.g., we're asking for version 6 when
-      // the table only has versions 0-5).
-      return Utils.toCloseableIterator(Collections.emptyIterator());
+    // Start commit may be missing (e.g. due to log retention). When failOnDataLoss=false, skip
+    // to the earliest available version. Mid-log gaps still throw regardless of failOnDataLoss —
+    // stricter than DSv1.
+    CommitRange commitRange = null;
+    long earliestVersionToFetch = startVersion;
+    for (int attempt = 1; attempt <= FAIL_ON_DATA_LOSS_FALSE_MAX_ATTEMPTS; attempt++) {
+      try {
+        commitRange =
+            snapshotManager.getTableChanges(engine, earliestVersionToFetch, endVersionOpt);
+        break;
+      } catch (io.delta.kernel.exceptions.StartVersionNotFoundException e) {
+        if (options.failOnDataLoss()
+            || !e.getEarliestAvailableVersion().isPresent()
+            || attempt >= FAIL_ON_DATA_LOSS_FALSE_MAX_ATTEMPTS) {
+          throw e;
+        }
+        earliestVersionToFetch = e.getEarliestAvailableVersion().get();
+        logger.warn(
+            "Start version commit {} no longer exists for table {} (attempt {}/{}). "
+                + "Skipping to earliest available version {} because failOnDataLoss is false.",
+            startVersion,
+            tablePath,
+            attempt,
+            FAIL_ON_DATA_LOSS_FALSE_MAX_ATTEMPTS,
+            earliestVersionToFetch);
+      } catch (io.delta.kernel.exceptions.CommitRangeNotFoundException e) {
+        return Utils.toCloseableIterator(Collections.emptyIterator());
+      }
     }
 
     // Use getCommitActionsFromRangeUnsafe instead of CommitRange.getCommitActions() because:

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -76,19 +76,19 @@ public class SparkScan
               DeltaOptions.IGNORE_CHANGES_OPTION(),
               DeltaOptions.IGNORE_DELETES_OPTION(),
               DeltaOptions.SKIP_CHANGE_COMMITS_OPTION(),
-              DeltaOptions.EXCLUDE_REGEX_OPTION()));
+              DeltaOptions.EXCLUDE_REGEX_OPTION(),
+              DeltaOptions.FAIL_ON_DATA_LOSS_OPTION()));
 
   /**
    * Block list of DeltaOptions that are not supported for streaming in V2 connector. Only
    * startingVersion, startingTimestamp, maxFilesPerTrigger, maxBytesPerTrigger, ignoreFileDeletion,
-   * ignoreChanges, ignoreDeletes, skipChangeCommits, and excludeRegex are supported. User-defined
-   * custom options (not in DeltaOptions) are allowed to pass through.
+   * ignoreChanges, ignoreDeletes, skipChangeCommits, excludeRegex, and failOnDataLoss are
+   * supported. User-defined custom options (not in DeltaOptions) are allowed to pass through.
    */
   private static final Set<String> UNSUPPORTED_STREAMING_OPTIONS =
       Collections.unmodifiableSet(
           new HashSet<>(
               Arrays.asList(
-                  DeltaOptions.FAIL_ON_DATA_LOSS_OPTION().toLowerCase(),
                   DeltaOptions.CDC_READ_OPTION().toLowerCase(),
                   DeltaOptions.CDC_READ_OPTION_LEGACY().toLowerCase(),
                   DeltaOptions.CDC_END_VERSION().toLowerCase(),

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -3411,6 +3411,198 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   // ================================================================================================
+  // Tests for failOnDataLoss option
+  // ================================================================================================
+
+  /**
+   * Helper to simulate log retention by creating a checkpoint and deleting delta log files up to
+   * the given version.
+   */
+  private void simulateLogRetention(String tablePath, long deleteUpToVersion) {
+    DeltaLog.forTable(spark, new Path(tablePath)).checkpoint();
+    Path logPath = new Path(tablePath, "_delta_log");
+    for (long v = 0; v <= deleteUpToVersion; v++) {
+      File logFile = new File(new Path(logPath, String.format("%020d.json", v)).toUri().getPath());
+      if (logFile.exists()) {
+        logFile.delete();
+      }
+    }
+  }
+
+  /** Parity test: failOnDataLoss=false with missing start version skips to earliest available. */
+  @Test
+  public void testFailOnDataLoss_false_getFileChangesParity(@TempDir File tempDir)
+      throws Exception {
+    String testTablePath = tempDir.getAbsolutePath();
+    String testTableName = "test_fdl_false_parity_" + System.nanoTime();
+    createEmptyTestTable(testTablePath, testTableName);
+    insertVersions(
+        testTableName,
+        /* numVersions= */ 5,
+        /* rowsPerVersion= */ 2,
+        /* includeEmptyVersion= */ false);
+
+    simulateLogRetention(testTablePath, /* deleteUpToVersion= */ 2);
+
+    long fromVersion = 0L;
+    long fromIndex = DeltaSourceOffset.BASE_INDEX();
+    DeltaOptions options = createDeltaOptions("failOnDataLoss", "false");
+
+    // DSv1
+    DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
+    DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath, options);
+    ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> dsv1Changes =
+        deltaSource.getFileChanges(
+            fromVersion,
+            fromIndex,
+            /* isInitialSnapshot= */ false,
+            Option.empty(),
+            /* verifyMetadataAction= */ true);
+    List<org.apache.spark.sql.delta.sources.IndexedFile> dsv1Files = new ArrayList<>();
+    while (dsv1Changes.hasNext()) {
+      dsv1Files.add(dsv1Changes.next());
+    }
+    dsv1Changes.close();
+
+    // DSv2
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(testTablePath, hadoopConf);
+    SparkMicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
+    try (CloseableIterator<IndexedFile> dsv2Changes =
+        stream.getFileChanges(
+            fromVersion, fromIndex, /* isInitialSnapshot= */ false, Optional.empty())) {
+      List<IndexedFile> dsv2Files = new ArrayList<>();
+      while (dsv2Changes.hasNext()) {
+        dsv2Files.add(dsv2Changes.next());
+      }
+      compareFileChanges(dsv1Files, dsv2Files);
+    }
+  }
+
+  /** Parity test: failOnDataLoss=true (default) with missing start version throws in both. */
+  @Test
+  public void testFailOnDataLoss_true_getFileChangesThrowsParity(@TempDir File tempDir) {
+    String testTablePath = tempDir.getAbsolutePath();
+    String testTableName = "test_fdl_true_parity_" + System.nanoTime();
+    createEmptyTestTable(testTablePath, testTableName);
+    insertVersions(
+        testTableName,
+        /* numVersions= */ 5,
+        /* rowsPerVersion= */ 2,
+        /* includeEmptyVersion= */ false);
+
+    simulateLogRetention(testTablePath, /* deleteUpToVersion= */ 2);
+
+    long fromVersion = 0L;
+    long fromIndex = DeltaSourceOffset.BASE_INDEX();
+
+    // DSv1: failOnDataLoss=true throws DeltaIllegalStateException with
+    // DELTA_MISSING_FILES_UNEXPECTED_VERSION error class.
+    // expectedVersion=0 (startVersion), seenVersion=3 (earliest available after deleting 0-2)
+    DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
+    DeltaOptions defaultOptions = emptyDeltaOptions();
+    DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath, defaultOptions);
+    DeltaIllegalStateException dsv1Exception =
+        assertThrows(
+            DeltaIllegalStateException.class,
+            () -> {
+              ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> iter =
+                  deltaSource.getFileChanges(
+                      fromVersion,
+                      fromIndex,
+                      /* isInitialSnapshot= */ false,
+                      Option.empty(),
+                      /* verifyMetadataAction= */ true);
+              while (iter.hasNext()) {
+                iter.next();
+              }
+              iter.close();
+            });
+    assertEquals("DELTA_MISSING_FILES_UNEXPECTED_VERSION", dsv1Exception.getErrorClass());
+    // Parameters: startVersion=0, earliestVersion=3, option=failOnDataLoss
+    assertThat(dsv1Exception.getMessageParameters())
+        .containsEntry("startVersion", "0")
+        .containsEntry("earliestVersion", "3")
+        .containsEntry("option", DeltaOptions.FAIL_ON_DATA_LOSS_OPTION());
+
+    // DSv2: failOnDataLoss=true throws StartVersionNotFoundException with structured fields
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(testTablePath, hadoopConf);
+    SparkMicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, defaultOptions);
+    io.delta.kernel.exceptions.StartVersionNotFoundException dsv2Exception =
+        assertThrows(
+            io.delta.kernel.exceptions.StartVersionNotFoundException.class,
+            () -> {
+              try (CloseableIterator<IndexedFile> iter =
+                  stream.getFileChanges(
+                      fromVersion, fromIndex, /* isInitialSnapshot= */ false, Optional.empty())) {
+                while (iter.hasNext()) {
+                  iter.next();
+                }
+              }
+            });
+    assertEquals(0, dsv2Exception.getStartVersionRequested());
+    assertTrue(dsv2Exception.getEarliestAvailableVersion().isPresent());
+    assertEquals(3L, dsv2Exception.getEarliestAvailableVersion().get().longValue());
+  }
+
+  /**
+   * failOnDataLoss=false in v2 only handles missing start commits. Mid-log gaps (e.g., a deleted
+   * file in the middle) still throw regardless of failOnDataLoss.
+   */
+  @Test
+  public void testFailOnDataLoss_false_midLogGapStillThrows(@TempDir File tempDir)
+      throws Exception {
+    String testTablePath = tempDir.getAbsolutePath();
+    String testTableName = "test_fdl_mid_gap_" + System.nanoTime();
+    createEmptyTestTable(testTablePath, testTableName);
+    insertVersions(
+        testTableName,
+        /* numVersions= */ 5,
+        /* rowsPerVersion= */ 2,
+        /* includeEmptyVersion= */ false);
+
+    // Create checkpoint, then delete only version 3 (mid-log gap, not start)
+    DeltaLog.forTable(spark, new Path(testTablePath)).checkpoint();
+    Path logPath = new Path(testTablePath, "_delta_log");
+    File midFile = new File(new Path(logPath, String.format("%020d.json", 3)).toUri().getPath());
+    if (midFile.exists()) {
+      midFile.delete();
+    }
+
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(testTablePath, hadoopConf);
+    DeltaOptions options = createDeltaOptions("failOnDataLoss", "false");
+    SparkMicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
+
+    // Reading from version 1 (which exists) should throw InvalidTableException because
+    // version 3 is missing in the middle — non-contiguous versions are not a log-retention
+    // scenario and are never ignored.
+    io.delta.kernel.exceptions.InvalidTableException midGapException =
+        assertThrows(
+            io.delta.kernel.exceptions.InvalidTableException.class,
+            () -> {
+              try (CloseableIterator<IndexedFile> changes =
+                  stream.getFileChanges(
+                      /* fromVersion= */ 1L,
+                      /* fromIndex= */ DeltaSourceOffset.BASE_INDEX(),
+                      /* isInitialSnapshot= */ false,
+                      /* endOffset= */ Optional.empty())) {
+                while (changes.hasNext()) {
+                  changes.next();
+                }
+              }
+            });
+    assertThat(midGapException.getMessage()).contains("versions are not contiguous");
+  }
+
+  // ================================================================================================
 
   // Helper methods
   // ================================================================================================

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -608,7 +608,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     assertEquals(
         "The following streaming options are not supported: [readchangefeed]. "
             + "Supported options are: [startingVersion, startingTimestamp, maxFilesPerTrigger, "
-            + "maxBytesPerTrigger, ignoreFileDeletion, ignoreChanges, ignoreDeletes, skipChangeCommits, excludeRegex].",
+            + "maxBytesPerTrigger, ignoreFileDeletion, ignoreChanges, ignoreDeletes, skipChangeCommits, "
+            + "excludeRegex, failOnDataLoss].",
         exception.getMessage());
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6395/files/0c83e18a239a99178ec59db8b2b4634737fef7a6..c01f4d435ff5c73deae282e8b7d1d6913f55a434) to review incremental changes.
- [stack/refactorStartVersionNotFoundExcecption](https://github.com/delta-io/delta/pull/6394) [[Files changed](https://github.com/delta-io/delta/pull/6394/files)]
  - [**stack/failOnDataLoss2**](https://github.com/delta-io/delta/pull/6395) [[Files changed](https://github.com/delta-io/delta/pull/6395/files/0c83e18a239a99178ec59db8b2b4634737fef7a6..c01f4d435ff5c73deae282e8b7d1d6913f55a434)]

---------
#### Which Delta project/connector is this regarding?

Kernel / Spark (DSv2)

## Description

Implements the `failOnDataLoss` streaming read option for the DSv2 Kernel-based connector (`SparkMicroBatchStream`). Previously this option was blocked as unsupported.

### Behavior

- **`failOnDataLoss=true` (default):** Throws `StartVersionNotFoundException` when the start version is missing — same semantics as DSv1.
- **`failOnDataLoss=false`:** Catches `StartVersionNotFoundException` in `filterDeltaLogs()` and retries from the earliest available version reported in the exception. Retries up to 3 times to handle concurrent log retention pruning the earliest version between the exception and the retry. Mid-log gaps (`InvalidTableException` for non-contiguous versions) still throw regardless of the setting — stricter than DSv1 which silently skips all gaps.

### Changes

- **`SparkMicroBatchStream.java`**: Added retry loop in `filterDeltaLogs()` that catches `StartVersionNotFoundException` and skips to the earliest available version when `failOnDataLoss=false`.
- **`SparkScan.java`**: Moved `failOnDataLoss` from the unsupported options block list to the supported options list.
- **`SparkMicroBatchStreamTest.java`**: Added parity tests (DSv1 vs DSv2 for both `true` and `false`), and a mid-log gap test verifying `InvalidTableException` still throws with `failOnDataLoss=false`.
- **`SparkScanTest.java`** / **`DeltaV2SourceSuite.scala`**: Updated option validation tests.

Resolves https://github.com/delta-io/delta/issues/6380

## How was this patch tested?

New unit tests in `SparkMicroBatchStreamTest`:
- **`testFailOnDataLoss_false_getFileChangesParity`** — Compares DSv1 and DSv2 output with `failOnDataLoss=false` after simulated log retention. Both return the same files from surviving versions.
- **`testFailOnDataLoss_true_getFileChangesThrowsParity`** — Verifies both DSv1 (`DELTA_MISSING_FILES_UNEXPECTED_VERSION`) and DSv2 (`StartVersionNotFoundException`) throw with correct error parameters when the start version is missing.
- **`testFailOnDataLoss_false_midLogGapStillThrows`** — Verifies mid-log gaps throw `InvalidTableException` regardless of `failOnDataLoss`.

E2E test enabled in `DeltaV2SourceSuite`:
- `incremental: first commit file missing, failOnDataLoss=false succeeds`

## Does this PR introduce _any_ user-facing changes?

Yes. DSv2 streaming queries now support the `failOnDataLoss` option:
- **Previously:** Setting `.option("failOnDataLoss", "false")` on a DSv2 stream threw `UnsupportedOperationException`.
- **Now:** The option is supported. With `failOnDataLoss=false`, streams skip to the earliest available version when the start version is missing (e.g., due to log retention), instead of failing. Mid-log gaps still throw — this is stricter than DSv1. Default (`true`) behavior matches DSv1.