### PR TITLE
fix: deduplicated sentence in protocol md

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1866,7 +1866,7 @@ metadata | binary | The binary-encoded Variant metadata, as described in [Varian
 The parquet struct must include the two struct fields `value` and `metadata`.
 Supported writers must write the two binary fields, and supported readers must read the two binary fields.
 
-[Variant shredding](https://github.com/apache/parquet-format/blob/master/VariantShredding.md) will be introduced in a separate `variantShredding` table feature. will be introduced later, as a separate `variantShredding` table feature.
+[Variant shredding](https://github.com/apache/parquet-format/blob/master/VariantShredding.md) will be introduced in a separate `variantShredding` table feature.
 
 ## Writer Requirements for Variant Data Type
 


### PR DESCRIPTION
## Description

Removed redundant text about variant shredding introduction.

## How was this patch tested?

No tests needed.

## Does this PR introduce _any_ user-facing changes?

No, just simple markdown edit.
