### PR TITLE
[UniForm] Support verifying read result on Iceberg metadata location in IcebergConverterSuite

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/NonSparkReadIceberg.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/NonSparkReadIceberg.scala
@@ -1,0 +1,102 @@
+package org.apache.spark.sql.delta
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.delta.uniform.UniFormE2ETest
+import org.apache.iceberg.data.{GenericRecord, IcebergGenerics, Record}
+import org.apache.iceberg.hadoop.HadoopTables
+import org.apache.iceberg.types.Type
+import org.apache.iceberg.types.Type.TypeID
+import org.apache.iceberg.types.Types.{StructType => IcebergStructType}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.StructType
+
+trait NonSparkReadIceberg extends UniFormE2ETest {
+  implicit class IcebergRecordConvert(record: Record) {
+    def convertRecordToRow(struct: IcebergStructType): Row = {
+      val values = struct.fields().asScala.map { field =>
+        convertValue(record.getField(field.name), field.`type`)
+      }.toSeq
+      Row.fromSeq(values)
+    }
+
+    def convertValue(value: Any, tpe: Type): Any = {
+      if (value == null) return null
+      tpe.typeId() match {
+        case TypeID.INTEGER | TypeID.LONG | TypeID.FLOAT | TypeID.DOUBLE | TypeID.BOOLEAN |
+             TypeID.STRING | TypeID.BINARY | TypeID.DATE | TypeID.TIME |
+             TypeID.UUID | TypeID.DECIMAL =>
+          value
+        case TypeID.TIMESTAMP =>
+          java.sql.Timestamp.from(value.asInstanceOf[java.time.OffsetDateTime].toInstant())
+        case TypeID.STRUCT =>
+          val struct = tpe.asStructType()
+          val rec = value.asInstanceOf[Record]
+          rec.convertRecordToRow(struct)
+
+        case TypeID.LIST =>
+          val listType = tpe.asListType()
+          val elemType = listType.elementType()
+          value.asInstanceOf[java.util.List[_]].asScala.map(elem => convertValue(elem, elemType))
+
+        case TypeID.MAP =>
+          val mapType = tpe.asMapType()
+          val keyType = mapType.keyType()
+          val valueType = mapType.valueType()
+          value
+            .asInstanceOf[java.util.Map[_, _]]
+            .asScala
+            .map {
+              case (k, v) => convertValue(k, keyType) -> convertValue(v, valueType)
+            }
+            .toMap
+
+        case other =>
+          throw new UnsupportedOperationException(s"Unsupported Iceberg type: $other")
+      }
+    }
+  }
+
+  protected def readIcebergByPath(
+      icebergMetadataPath: String, orderBy: String, schema: StructType): DataFrame = {
+    val hadoopTables = new HadoopTables(spark.sessionState.newHadoopConf())
+    val hadoopTable = hadoopTables.load(icebergMetadataPath)
+
+    val result = IcebergGenerics
+      .read(hadoopTable)
+      .build()
+      .asScala
+      .toList
+
+    val sorted = result.head.getField(orderBy) match {
+      case _: Integer => result.sortBy(_.getField(orderBy).asInstanceOf[Integer])
+      case _: java.lang.Long => result.sortBy(_.getField(orderBy).asInstanceOf[java.lang.Long])
+      case _: BigDecimal => result.sortBy(_.getField(orderBy).asInstanceOf[BigDecimal])
+      case _: String => result.sortBy(_.getField(orderBy).asInstanceOf[String])
+      case input => throw new UnsupportedOperationException(input.getClass.getSimpleName)
+    }
+
+    spark.createDataFrame(
+      sorted.map(_.convertRecordToRow(hadoopTable.schema().asStruct())).asJava,
+      schema
+    )
+  }
+
+  protected def verifyReadByPath(
+      icebergMetadataPath: String,
+      schema: StructType,
+      fields: String,
+      orderBy: String,
+      expect: Seq[Row]): Unit = {
+    val fieldCols = fields.split("\\s*,\\s*").map(col)
+    checkAnswer(
+      readIcebergByPath(icebergMetadataPath, orderBy, schema).select(fieldCols: _*),
+      expect
+    )
+  }
+}

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -19,9 +19,11 @@ package org.apache.spark.sql.delta.uniform
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, DeltaOperations, DeltaTableReadPredicate, Snapshot}
+import org.apache.spark.sql.delta.NonSparkReadIceberg
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, DomainMetadata, Metadata}
 import org.apache.spark.sql.delta.icebergShaded.{IcebergConverter, UNIFORM_CC_MODE, UNIFORM_POST_COMMIT_MODE}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -51,7 +53,8 @@ class IcebergConverterForTest extends IcebergConverter {
   }
 }
 
-class UniFormConverterSuite extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+class UniFormConverterSuite extends
+  QueryTest with SharedSparkSession with DeltaSQLCommandTest with NonSparkReadIceberg {
   def constructDummyAddFile(path: String = "s3://path1/1.parquet"): AddFile = {
     AddFile(
       path = path,
@@ -87,7 +90,7 @@ class UniFormConverterSuite extends QueryTest with SharedSparkSession with Delta
     )
   }
 
-  test("convertSnapshot writes Iceberg metadata and file count matches Delta snapshot") {
+  test("Verify convertSnapshot writes Iceberg metadata") {
     val tableName = "test_iceberg_converter"
     withTable(tableName) {
       spark.sql(
@@ -115,10 +118,13 @@ class UniFormConverterSuite extends QueryTest with SharedSparkSession with Delta
         numFilesInIceberg == snapshot.numOfFiles,
         s"Iceberg total-data-files ($numFilesInIceberg) must equal " +
           s"Delta numOfFiles (${snapshot.numOfFiles})")
+      verifyReadByPath(metadataPath,
+        snapshot.schema, fields = "id", orderBy = "id", Seq(Row(1), Row(2), Row(3))
+      )
     }
   }
 
-  test("convertSnapshot file count matches Delta snapshot after multiple inserts") {
+  test("Verify convertSnapshot after multiple inserts") {
     val tableName = "test_iceberg_converter_multi"
     withTable(tableName) {
       spark.sql(
@@ -148,6 +154,9 @@ class UniFormConverterSuite extends QueryTest with SharedSparkSession with Delta
         numFilesInIceberg == snapshot.numOfFiles,
         s"Iceberg total-data-files ($numFilesInIceberg) must equal " +
           s"Delta numOfFiles (${snapshot.numOfFiles})")
+      verifyReadByPath(metadataPath,
+        snapshot.schema, fields = "id", orderBy = "id", Seq(Row(1), Row(2), Row(3))
+      )
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Support verifying read result on Iceberg metadata location inside Iceberg test

## How was this patch tested?
Test-only change
```
build/sbt -DsparkVersion=4.0 "iceberg/testOnly org.apache.spark.sql.delta.uniform.UniFormConverterSuite"
```
