### PR TITLE
[Kernel] Validate readSchema is a subset of the table schema in ScanBuilder

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
@@ -24,6 +24,7 @@ import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.LogReplay;
+import io.delta.kernel.internal.util.SchemaUtils;
 import io.delta.kernel.metrics.SnapshotReport;
 import io.delta.kernel.types.StructType;
 import java.util.Optional;
@@ -72,8 +73,7 @@ public class ScanBuilderImpl implements ScanBuilder {
 
   @Override
   public ScanBuilder withReadSchema(StructType readSchema) {
-    // TODO: Validate that readSchema is a subset of the table schema or that extra fields are
-    //  metadata columns.
+    SchemaUtils.validateReadSchemaIsSubset(readSchema, snapshotSchema);
     this.readSchema = readSchema;
     return this;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -328,6 +328,78 @@ public class SchemaUtils {
   }
 
   /**
+   * Validates that {@code readSchema} is a valid subset of {@code tableSchema}. Each data field in
+   * readSchema must exist in tableSchema (case-insensitive name match) and have a compatible type.
+   * Nested structs are checked recursively. Metadata columns (where {@link
+   * StructField#isMetadataColumn()} is true) are exempt from this check.
+   *
+   * @param readSchema the schema requested by the connector
+   * @param tableSchema the actual table schema from snapshot
+   * @throws IllegalArgumentException if readSchema contains fields not in tableSchema or with
+   *     incompatible types
+   */
+  public static void validateReadSchemaIsSubset(StructType readSchema, StructType tableSchema) {
+    validateReadSchemaIsSubsetRecursive(readSchema, tableSchema, "");
+  }
+
+  /**
+   * Recursively validates that {@code readSchema} is a subset of {@code tableSchema}, tracking the
+   * parent path for nested error messages.
+   */
+  private static void validateReadSchemaIsSubsetRecursive(
+      StructType readSchema, StructType tableSchema, String parentPath) {
+    for (StructField readField : readSchema.fields()) {
+      if (readField.isMetadataColumn()) {
+        continue;
+      }
+      String fieldPath =
+          parentPath.isEmpty() ? readField.getName() : parentPath + "." + readField.getName();
+      int idx = findColIndex(tableSchema, readField.getName());
+      if (idx < 0) {
+        String msg =
+            parentPath.isEmpty()
+                ? format(
+                    "Field '%s' is not found in the table schema. Table schema: %s",
+                    readField.getName(), tableSchema.fieldNames())
+                : format(
+                    "Field '%s' is not found in '%s'. Schema at '%s': %s",
+                    readField.getName(), parentPath, parentPath, tableSchema.fieldNames());
+        throw new IllegalArgumentException(msg);
+      }
+      StructField tableField = tableSchema.at(idx);
+      validateDataTypeIsSubset(readField.getDataType(), tableField.getDataType(), fieldPath);
+    }
+  }
+
+  /**
+   * Validates that the read data type is compatible with the table data type. For struct types,
+   * this checks recursively that the read struct is a subset of the table struct. For array and map
+   * types, this recurses into element/key/value types.
+   */
+  private static void validateDataTypeIsSubset(
+      DataType readType, DataType tableType, String fieldPath) {
+    if (readType instanceof StructType && tableType instanceof StructType) {
+      validateReadSchemaIsSubsetRecursive((StructType) readType, (StructType) tableType, fieldPath);
+    } else if (readType instanceof ArrayType && tableType instanceof ArrayType) {
+      validateDataTypeIsSubset(
+          ((ArrayType) readType).getElementType(),
+          ((ArrayType) tableType).getElementType(),
+          fieldPath + ".element");
+    } else if (readType instanceof MapType && tableType instanceof MapType) {
+      MapType readMap = (MapType) readType;
+      MapType tableMap = (MapType) tableType;
+      validateDataTypeIsSubset(readMap.getKeyType(), tableMap.getKeyType(), fieldPath + ".key");
+      validateDataTypeIsSubset(
+          readMap.getValueType(), tableMap.getValueType(), fieldPath + ".value");
+    } else if (!readType.equivalent(tableType)) {
+      throw new IllegalArgumentException(
+          format(
+              "Field '%s' has type %s which is incompatible with the table type %s",
+              fieldPath, readType, tableType));
+    }
+  }
+
+  /**
    * Collects all leaf columns from the given schema (including flattened columns only for
    * StructTypes), up to maxColumns. NOTE: If maxColumns = -1, we collect ALL leaf columns in the
    * schema.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -31,7 +31,7 @@ import io.delta.kernel.internal.types.DataTypeJsonSerDe
 import io.delta.kernel.internal.util.ColumnMapping.{COLUMN_MAPPING_ID_KEY, COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_PHYSICAL_NAME_KEY}
 import io.delta.kernel.internal.util.SchemaUtils.{computeSchemaChangesById, validateUpdatedSchemaAndGetUpdatedSchema}
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
-import io.delta.kernel.types.{ArrayType, ByteType, DataType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, StringType, StructField, StructType, TypeChange, VariantType}
+import io.delta.kernel.types.{ArrayType, ByteType, DataType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, MetadataColumnSpec, StringType, StructField, StructType, TypeChange, VariantType}
 import io.delta.kernel.types.IntegerType.INTEGER
 import io.delta.kernel.types.LongType.LONG
 import io.delta.kernel.types.TimestampType.TIMESTAMP
@@ -2097,5 +2097,268 @@ class SchemaUtilsSuite extends AnyFunSuite {
       dummyProtocol,
       emptySet(),
       false)
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // validateReadSchemaIsSubset tests
+  ///////////////////////////////////////////////////////////////////////////
+
+  private val baseTableSchema = new StructType()
+    .add("id", INTEGER)
+    .add("name", StringType.STRING)
+    .add("age", INTEGER)
+
+  private def assertReadSchemaRejected(
+      readSchema: StructType,
+      tableSchema: StructType,
+      expectedMsg: String): Unit = {
+    val e = intercept[IllegalArgumentException] {
+      SchemaUtils.validateReadSchemaIsSubset(readSchema, tableSchema)
+    }
+    assert(
+      e.getMessage.contains(expectedMsg),
+      s"Error message '${e.getMessage}' didn't contain: $expectedMsg")
+  }
+
+  test("validateReadSchemaIsSubset - valid subset") {
+    val readSchema = new StructType().add("id", INTEGER)
+    SchemaUtils.validateReadSchemaIsSubset(readSchema, baseTableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - full schema identity") {
+    SchemaUtils.validateReadSchemaIsSubset(baseTableSchema, baseTableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - empty read schema") {
+    SchemaUtils.validateReadSchemaIsSubset(new StructType(), baseTableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - non-existent column") {
+    val readSchema = new StructType().add("fake", INTEGER)
+    assertReadSchemaRejected(readSchema, baseTableSchema, "fake")
+  }
+
+  test("validateReadSchemaIsSubset - type mismatch") {
+    val readSchema = new StructType().add("id", StringType.STRING)
+    assertReadSchemaRejected(readSchema, baseTableSchema, "id")
+  }
+
+  test("validateReadSchemaIsSubset - case insensitive match") {
+    val readSchema = new StructType()
+      .add("ID", INTEGER)
+      .add("NAME", StringType.STRING)
+    SchemaUtils.validateReadSchemaIsSubset(readSchema, baseTableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - metadata column is exempt") {
+    val readSchema = new StructType()
+      .add("id", INTEGER)
+      .addMetadataColumn("_row_index", MetadataColumnSpec.ROW_INDEX)
+    SchemaUtils.validateReadSchemaIsSubset(readSchema, baseTableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - nested struct pruning allowed") {
+    val tableSchema = new StructType()
+      .add(
+        "addr",
+        new StructType()
+          .add("city", StringType.STRING)
+          .add("zip", StringType.STRING)
+          .add("state", StringType.STRING))
+    val readSchema = new StructType()
+      .add(
+        "addr",
+        new StructType()
+          .add("city", StringType.STRING))
+    SchemaUtils.validateReadSchemaIsSubset(readSchema, tableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - nested struct field not found") {
+    val tableSchema = new StructType()
+      .add(
+        "addr",
+        new StructType()
+          .add("city", StringType.STRING)
+          .add("zip", StringType.STRING))
+    val readSchema = new StructType()
+      .add(
+        "addr",
+        new StructType()
+          .add("country", StringType.STRING))
+    assertReadSchemaRejected(readSchema, tableSchema, "country")
+    assertReadSchemaRejected(readSchema, tableSchema, "'addr'")
+  }
+
+  test("validateReadSchemaIsSubset - array element type mismatch") {
+    val tableSchema = new StructType()
+      .add("tags", new ArrayType(StringType.STRING, true))
+    val readSchema = new StructType()
+      .add("tags", new ArrayType(INTEGER, true))
+    assertReadSchemaRejected(readSchema, tableSchema, "tags.element")
+  }
+
+  test("validateReadSchemaIsSubset - array of struct pruning allowed") {
+    val tableSchema = new StructType()
+      .add(
+        "items",
+        new ArrayType(
+          new StructType()
+            .add("k", StringType.STRING)
+            .add("v", INTEGER),
+          true))
+    val readSchema = new StructType()
+      .add(
+        "items",
+        new ArrayType(
+          new StructType()
+            .add("k", StringType.STRING),
+          true))
+    SchemaUtils.validateReadSchemaIsSubset(readSchema, tableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - map value type mismatch") {
+    val tableSchema = new StructType()
+      .add("m", new MapType(StringType.STRING, StringType.STRING, true))
+    val readSchema = new StructType()
+      .add("m", new MapType(StringType.STRING, INTEGER, true))
+    assertReadSchemaRejected(readSchema, tableSchema, "m.value")
+  }
+
+  test("validateReadSchemaIsSubset - map key type mismatch") {
+    val tableSchema = new StructType()
+      .add("m", new MapType(StringType.STRING, INTEGER, true))
+    val readSchema = new StructType()
+      .add("m", new MapType(INTEGER, INTEGER, true))
+    assertReadSchemaRejected(readSchema, tableSchema, "m.key")
+  }
+
+  test("validateReadSchemaIsSubset - map with struct value pruning allowed") {
+    val tableSchema = new StructType()
+      .add(
+        "m",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("a", INTEGER)
+            .add("b", StringType.STRING),
+          true))
+    val readSchema = new StructType()
+      .add(
+        "m",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("a", INTEGER),
+          true))
+    SchemaUtils.validateReadSchemaIsSubset(readSchema, tableSchema)
+  }
+
+  test("validateReadSchemaIsSubset - struct type where table has primitive") {
+    val tableSchema = new StructType().add("id", INTEGER)
+    val readSchema = new StructType()
+      .add("id", new StructType().add("x", INTEGER))
+    assertReadSchemaRejected(readSchema, tableSchema, "id")
+  }
+
+  test("validateReadSchemaIsSubset - deeply nested struct field not found") {
+    val tableSchema = new StructType()
+      .add(
+        "user",
+        new StructType()
+          .add(
+            "address",
+            new StructType()
+              .add("city", StringType.STRING)
+              .add("zip", StringType.STRING)))
+    val readSchema = new StructType()
+      .add(
+        "user",
+        new StructType()
+          .add(
+            "address",
+            new StructType()
+              .add("country", StringType.STRING)))
+    assertReadSchemaRejected(readSchema, tableSchema, "country")
+    assertReadSchemaRejected(readSchema, tableSchema, "'user.address'")
+  }
+
+  test("validateReadSchemaIsSubset - deeply nested type mismatch") {
+    val tableSchema = new StructType()
+      .add(
+        "user",
+        new StructType()
+          .add(
+            "address",
+            new StructType()
+              .add("city", StringType.STRING)))
+    val readSchema = new StructType()
+      .add(
+        "user",
+        new StructType()
+          .add(
+            "address",
+            new StructType()
+              .add("city", INTEGER)))
+    assertReadSchemaRejected(readSchema, tableSchema, "user.address.city")
+  }
+
+  test("validateReadSchemaIsSubset - map with struct value field not found includes path") {
+    val tableSchema = new StructType()
+      .add(
+        "m",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("x", INTEGER)
+            .add("y", INTEGER),
+          true))
+    val readSchema = new StructType()
+      .add(
+        "m",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("z", INTEGER),
+          true))
+    assertReadSchemaRejected(readSchema, tableSchema, "'m.value'")
+  }
+
+  test("validateReadSchemaIsSubset - map value struct type mismatch includes full path") {
+    val tableSchema = new StructType()
+      .add(
+        "m",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("x", StringType.STRING),
+          true))
+    val readSchema = new StructType()
+      .add(
+        "m",
+        new MapType(
+          StringType.STRING,
+          new StructType()
+            .add("x", INTEGER),
+          true))
+    assertReadSchemaRejected(readSchema, tableSchema, "m.value.x")
+  }
+
+  test("validateReadSchemaIsSubset - array of struct nested field not found includes path") {
+    val tableSchema = new StructType()
+      .add(
+        "items",
+        new ArrayType(
+          new StructType()
+            .add("k", StringType.STRING)
+            .add("v", INTEGER),
+          true))
+    val readSchema = new StructType()
+      .add(
+        "items",
+        new ArrayType(
+          new StructType()
+            .add("missing", StringType.STRING),
+          true))
+    assertReadSchemaRejected(readSchema, tableSchema, "'items.element'")
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Resolves #2149

**1. Wire up validation in `ScanBuilderImpl`**

Replaces the TODO comment in `ScanBuilderImpl.withReadSchema()` with an actual call to `SchemaUtils.validateReadSchemaIsSubset()`, so that invalid read schemas are rejected early.

**2. Improve error messages with nested path context (additional enhancement)**

While implementing `validateReadSchemaIsSubset`, I realized that a naive recursive approach would lose parent path information when descending into nested structs, arrays, and maps. For example, without path tracking, if a field `country` were not found inside a nested struct `addr`, the error message would say:

> Field 'country' is not found in the table schema. Table schema: struct(...)

This makes it hard to locate the problematic field in complex schemas. I added parent path tracking so the message now includes the full context:

> Field 'country' is not found in 'addr'. Schema at 'addr': [city, zip]

Other examples:

| Case | Error message |
|------|--------------|
| Deeply nested type mismatch | `Field 'user.address.city' has type integer which is incompatible with the table type string` |
| Array element | `Field 'tags.element' has type integer ...` |
| Map value struct | `Field 'm.value.x' has type integer ...` |

## How was this patch tested?

Added and updated unit tests in `SchemaUtilsSuite`:

- Updated 3 existing tests to verify path context in error messages (array element, map key, map value)
- Added 5 new tests:
  - Deeply nested struct field not found (verifies `'user.address'` in message)
  - Deeply nested type mismatch (verifies `user.address.city` in message)
  - Map with struct value field not found (verifies `'m.value'` in message)
  - Map value struct type mismatch (verifies `m.value.x` in message)
  - Array of struct nested field not found (verifies `'items.element'` in message)

All 79 tests in `SchemaUtilsSuite` pass:

```
build/sbt 'kernelApi/testOnly *SchemaUtilsSuite'
```

## Does this PR introduce _any_ user-facing changes?

Yes. `ScanBuilder.withReadSchema()` now validates that the read schema is a subset of the table schema, throwing `IllegalArgumentException` with a descriptive error message if not. Previously this was a TODO and no validation was performed.
