### PR TITLE
[DSv2] Extract shared buildFileName from DelayedCommitProtocol

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/DelayedCommitProtocol.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/DelayedCommitProtocol.scala
@@ -109,22 +109,17 @@ class DelayedCommitProtocol(
     addedFiles = new ArrayBuffer[(Map[String, String], String)]
   }
 
-  /** Prefix added in testing mode to all filenames to test special chars that need URL-encoding. */
-  val FILE_NAME_PREFIX = SQLConf.get.getConf(DeltaSQLConf.TEST_FILE_NAME_PREFIX)
-
+  // The file name looks like part-r-00000-2dd664f9-d2c4-4ffe-878f-c6c70c1fb0cb_00003.gz.parquet
+  // Note that %05d does not truncate the split number, so if we have more than 100000 tasks,
+  // the file name is fine and won't overflow.
+  // CDC files (CDC_PARTITION_COL = true) are named with "cdc-..." instead of "part-...".
   protected def getFileName(
       taskContext: TaskAttemptContext,
       ext: String,
       partitionValues: Map[String, String]): String = {
-    // The file name looks like part-r-00000-2dd664f9-d2c4-4ffe-878f-c6c70c1fb0cb_00003.gz.parquet
-    // Note that %05d does not truncate the split number, so if we have more than 100000 tasks,
-    // the file name is fine and won't overflow.
     val split = taskContext.getTaskAttemptID.getTaskID.getId
-    val uuid = UUID.randomUUID.toString
-    // CDC files (CDC_PARTITION_COL = true) are named with "cdc-..." instead of "part-...".
-    val typePrefix =
-      if (partitionValues.get(CDC_PARTITION_COL).contains("true")) "cdc-" else "part-"
-    f"${FILE_NAME_PREFIX}${typePrefix}${split}%05d-${uuid}${ext}"
+    val isCdc = partitionValues.get(CDC_PARTITION_COL).contains("true")
+    DelayedCommitProtocol.buildFileName(split, ext, isCdc)
   }
 
   protected def parsePartitions(
@@ -280,5 +275,25 @@ class DelayedCommitProtocol(
 
   override def abortTask(taskContext: TaskAttemptContext): Unit = {
     // TODO: we can also try delete the addedFiles as a best-effort cleanup.
+  }
+}
+
+object DelayedCommitProtocol {
+  /**
+   * Builds a Delta data file name following the standard naming convention:
+   * {testPrefix}{typePrefix}{splitId%05d}-{uuid}{ext}
+   *
+   * Shared between V1 (DelayedCommitProtocol.getFileName) and DSv2 (DataWriter).
+   *
+   * @param splitId the task split/partition ID
+   * @param ext file extension including dot (e.g. ".snappy.parquet")
+   * @param isCdc true for CDC files (uses "cdc-" prefix instead of "part-")
+   * @return the file name string
+   */
+  def buildFileName(splitId: Int, ext: String, isCdc: Boolean): String = {
+    val fileNamePrefix = SQLConf.get.getConf(DeltaSQLConf.TEST_FILE_NAME_PREFIX)
+    val uuid = UUID.randomUUID.toString
+    val typePrefix = if (isCdc) "cdc-" else "part-"
+    f"${fileNamePrefix}${typePrefix}${splitId}%05d-${uuid}${ext}"
   }
 }


### PR DESCRIPTION
Extract the file name construction logic from DelayedCommitProtocol.getFileName into a shared companion object method DelayedCommitProtocol.buildFileName.

This enables reuse of the standard Delta file naming convention (part-NNNNN-uuid.ext / cdc-NNNNN-uuid.ext) by both the V1 write path (DelayedCommitProtocol) and the DSv2 write path (DataWriter), ensuring consistent file naming across both code paths.

Changes:
- Move file name building logic to DelayedCommitProtocol.buildFileName companion method
- Simplify getFileName to delegate to the new shared method
- Preserve all existing behavior (test prefix, CDC prefix, split formatting)