### PR TITLE
[Kernel] Finalize UC table creation inside Kernel commit path

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CatalogCommitter.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CatalogCommitter.java
@@ -16,6 +16,7 @@
 
 package io.delta.kernel.commit;
 
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.annotation.Experimental;
 import io.delta.kernel.engine.Engine;
 import java.util.Collections;
@@ -74,4 +75,17 @@ public interface CatalogCommitter extends Committer {
    * @throws PublishFailedException if the publish operation fails
    */
   void publish(Engine engine, PublishMetadata publishMetadata) throws PublishFailedException;
+
+  /**
+   * Called by Kernel after a CREATE TABLE commit (version 0) when the post-commit snapshot is
+   * available. Allows catalog implementations to finalize table registration using properties
+   * derived from the committed snapshot.
+   *
+   * <p>The default implementation is a no-op. Catalog-managed committers that need to register the
+   * table with an external catalog after the initial commit should override this method.
+   *
+   * @param engine the {@link Engine} instance
+   * @param postCommitSnapshot the version-0 snapshot after 000.json has been committed
+   */
+  default void onCreateCommitted(Engine engine, Snapshot postCommitSnapshot) {}
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -24,6 +24,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.*;
+import io.delta.kernel.commit.CatalogCommitter;
 import io.delta.kernel.commit.CommitFailedException;
 import io.delta.kernel.commit.CommitMetadata;
 import io.delta.kernel.commit.Committer;
@@ -773,6 +774,16 @@ public class TransactionImpl implements Transaction {
 
     final Optional<SnapshotImpl> postCommitSnapshotOpt =
         buildPostCommitSnapshotOpt(engine, committedDelta, committedIctOpt, postCommitCrcOpt);
+
+    // For catalog-managed CREATE TABLE (version 0), allow the committer to finalize table
+    // registration with the catalog. This must happen after the snapshot is built because
+    // finalization requires properties derived from the committed snapshot (e.g. protocol
+    // features, commit timestamp, clustering columns).
+    if (committer instanceof CatalogCommitter
+        && committedVersion == 0
+        && postCommitSnapshotOpt.isPresent()) {
+      ((CatalogCommitter) committer).onCreateCommitted(engine, postCommitSnapshotOpt.get());
+    }
 
     return new TransactionCommitResult(
         committedVersion,

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
@@ -189,15 +189,39 @@ public class UCCatalogManagedClient {
    * <p>Configures the transaction with a {@link UCCatalogManagedCommitter} and required table
    * properties for catalog-managed table enablement.
    *
-   * <p>This assumes the table is being created in a staging location as per UC semantics. Once this
-   * transaction is built and committed, creating 000.json, you must call {@code
-   * TablesApi::createTable} to inform Unity Catalog of the successful table creation.
+   * <p>When {@code createMetadata} is provided, the committer will finalize the table in UC
+   * automatically after the version-0 commit via {@link
+   * UCCatalogManagedCommitter#onCreateCommitted}. This eliminates the need for the connector to
+   * call a separate finalization API after commit.
    *
    * @param ucTableId The Unity Catalog table ID.
    * @param tablePath The staging path to the Delta table.
    * @param schema The table schema.
    * @param engineInfo Information about the creating engine.
+   * @param createMetadata Catalog-level metadata for UC table registration (name, catalog, schema,
+   *     columns). When present, enables automatic finalization after commit.
    * @return A {@link CreateTableTransactionBuilder} configured for UC managed tables.
+   */
+  public CreateTableTransactionBuilder buildCreateTableTransaction(
+      String ucTableId,
+      String tablePath,
+      StructType schema,
+      String engineInfo,
+      UCCatalogManagedCommitter.CreateMetadata createMetadata) {
+    Objects.requireNonNull(ucTableId, "ucTableId is null");
+    Objects.requireNonNull(tablePath, "tablePath is null");
+    Objects.requireNonNull(schema, "schema is null");
+    Objects.requireNonNull(engineInfo, "engineInfo is null");
+    Objects.requireNonNull(createMetadata, "createMetadata is null");
+
+    return TableManager.buildCreateTableTransaction(tablePath, schema, engineInfo)
+        .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath, createMetadata))
+        .withTableProperties(getRequiredTablePropertiesForCreate(ucTableId));
+  }
+
+  /**
+   * Builds a create table transaction without automatic UC finalization. The connector is
+   * responsible for calling the UC createTable API after commit.
    */
   public CreateTableTransactionBuilder buildCreateTableTransaction(
       String ucTableId, String tablePath, StructType schema, String engineInfo) {
@@ -340,6 +364,14 @@ public class UCCatalogManagedClient {
    */
   protected Committer createUCCommitter(UCClient ucClient, String ucTableId, String tablePath) {
     return new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath);
+  }
+
+  protected Committer createUCCommitter(
+      UCClient ucClient,
+      String ucTableId,
+      String tablePath,
+      UCCatalogManagedCommitter.CreateMetadata createMetadata) {
+    return new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath, createMetadata);
   }
 
   ////////////////////

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -21,9 +21,11 @@ import static io.delta.kernel.internal.util.Preconditions.checkState;
 import static io.delta.kernel.unitycatalog.UCCatalogManagedClient.UC_TABLE_ID_KEY;
 import static java.util.Objects.requireNonNull;
 
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.commit.*;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
@@ -56,21 +58,60 @@ import org.slf4j.LoggerFactory;
 public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
   private static final Logger logger = LoggerFactory.getLogger(UCCatalogManagedCommitter.class);
 
+  /**
+   * Catalog-level metadata needed to finalize table creation in Unity Catalog. Bundled into a
+   * context object per guideline #5 (group related parameters into context objects).
+   */
+  public static class CreateMetadata {
+    private final String tableName;
+    private final String catalogName;
+    private final String schemaName;
+    private final List<UCClient.ColumnDef> columns;
+
+    public CreateMetadata(
+        String tableName, String catalogName, String schemaName, List<UCClient.ColumnDef> columns) {
+      this.tableName = requireNonNull(tableName);
+      this.catalogName = requireNonNull(catalogName);
+      this.schemaName = requireNonNull(schemaName);
+      this.columns = List.copyOf(requireNonNull(columns));
+    }
+  }
+
   protected final UCClient ucClient;
   protected final String ucTableId;
   protected final Path tablePath;
+  private final Optional<CreateMetadata> createMetadata;
 
   /**
-   * Creates a new UCCatalogManagedCommitter for the specified Unity Catalog-managed Delta table.
+   * Creates a committer for an existing Unity Catalog-managed Delta table (version >= 1 writes).
    *
    * @param ucClient the Unity Catalog client to use for commit operations
    * @param ucTableId the unique Unity Catalog table identifier
    * @param tablePath the path to the Delta table in the underlying storage system
    */
   public UCCatalogManagedCommitter(UCClient ucClient, String ucTableId, String tablePath) {
+    this(ucClient, ucTableId, tablePath, Optional.empty());
+  }
+
+  /**
+   * Creates a committer for a new Unity Catalog-managed Delta table (CREATE TABLE). The provided
+   * {@link CreateMetadata} enables {@link #onCreateCommitted} to finalize the table in UC after the
+   * version-0 commit succeeds.
+   */
+  public UCCatalogManagedCommitter(
+      UCClient ucClient, String ucTableId, String tablePath, CreateMetadata createMetadata) {
+    this(ucClient, ucTableId, tablePath, Optional.of(requireNonNull(createMetadata)));
+  }
+
+  private UCCatalogManagedCommitter(
+      UCClient ucClient,
+      String ucTableId,
+      String tablePath,
+      Optional<CreateMetadata> createMetadata) {
     this.ucClient = requireNonNull(ucClient, "ucClient is null");
     this.ucTableId = requireNonNull(ucTableId, "ucTableId is null");
     this.tablePath = new Path(requireNonNull(tablePath, "tablePath is null"));
+    this.createMetadata = requireNonNull(createMetadata);
   }
 
   /////////////////
@@ -170,6 +211,29 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
   }
 
   @Override
+  public void onCreateCommitted(Engine engine, Snapshot postCommitSnapshot) {
+    if (createMetadata.isEmpty()) {
+      return;
+    }
+    CreateMetadata meta = createMetadata.get();
+    SnapshotImpl snapshotImpl = (SnapshotImpl) postCommitSnapshot;
+    Map<String, String> ucProps = UnityCatalogUtils.getPropertiesForCreate(engine, snapshotImpl);
+    try {
+      ucClient.finalizeCreate(
+          meta.tableName,
+          meta.catalogName,
+          meta.schemaName,
+          tablePath.toUri().toString(),
+          meta.columns,
+          ucProps);
+      logger.info("[{}] Finalized table creation in Unity Catalog", ucTableId);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to finalize table creation in Unity Catalog for " + ucTableId, e);
+    }
+  }
+
+  @Override
   public Map<String, String> getRequiredTableProperties() {
     return Collections.singletonMap(UC_TABLE_ID_KEY, ucTableId);
   }
@@ -179,12 +243,10 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
   ///////////////////////////
 
   /**
-   * Handles CATALOG_CREATE by writing the published delta file for version 0.
-   *
-   * <p>Note that this assumes that the table is being created within a staging location, and that
-   * the Connector will post-commit inform UC of this 000.json file.
+   * Handles CATALOG_CREATE by writing the published delta file for version 0. UC finalization
+   * (promoting the staging table) is handled by {@link #onCreateCommitted} after the post-commit
+   * snapshot is built.
    */
-  // TODO: [delta-io/delta#5118] If UC changes CREATE semantics, update logic here.
   private CommitResponse createImpl(
       Engine engine,
       CloseableIterator<Row> finalizedActions,

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -204,6 +204,18 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
     new GetCommitsResponse(filteredCommits.asJava, tableData.getMaxRatifiedVersion)
   }
 
+  override def finalizeCreate(
+      tableName: String,
+      catalogName: String,
+      schemaName: String,
+      storageLocation: String,
+      columns: java.util.List[UCClient.ColumnDef],
+      properties: java.util.Map[String, String]): Unit = {
+    val fqn = s"$catalogName.$schemaName.$tableName"
+    Option(tables.putIfAbsent(fqn, TableData.afterCreate()))
+      .foreach(_ => throw new IllegalArgumentException(s"$fqn already exists"))
+  }
+
   override def close(): Unit = {}
 
   /** Visible for testing. Can be overridden to force an exception in commit method. */

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
@@ -29,10 +29,11 @@ import io.delta.kernel.internal.actions.{Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.{Tuple2 => KernelTuple2}
 import io.delta.kernel.test.{BaseMockJsonHandler, MockFileSystemClientUtils, TestFixtures, VectorTestUtils}
+import io.delta.kernel.types.{IntegerType, StringType, StructType}
 import io.delta.kernel.unitycatalog.adapters.UniformAdapter
-import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+import io.delta.kernel.utils.{CloseableIterable, CloseableIterator, FileStatus}
 import io.delta.storage.commit.Commit
-import io.delta.storage.commit.uccommitcoordinator.InvalidTargetTableException
+import io.delta.storage.commit.uccommitcoordinator.{InvalidTargetTableException, UCClient}
 
 import InMemoryUCClient.TableData
 import org.scalatest.funsuite.AnyFunSuite
@@ -519,9 +520,58 @@ class UCCatalogManagedCommitterSuite
       val fileContent = scala.io.Source.fromFile(file).getLines().mkString("\n")
       assert(fileContent.contains(testValue))
 
-      // Validate that UC was not updated for v0
-      // TODO: [delta-io/delta#5118] If UC changes CREATE semantics, update logic here.
+      // Without CreateMetadata, onCreateCommitted is a no-op so UC is not updated here.
+      // Finalization happens via the hook when CreateMetadata is provided (see separate test).
       assert(!ucClient.getTablesCopy.contains(testUcTableId))
+    }
+  }
+
+  test("onCreateCommitted: finalizes table in UC when CreateMetadata is provided") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      // ===== GIVEN =====
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      val ucCatalogManagedClient = new UCCatalogManagedClient(ucClient)
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val testColumns = java.util.List.of(
+        new UCClient.ColumnDef("id", "INT", "int", """{"type":"integer"}""", false, 0))
+      val createMeta = new UCCatalogManagedCommitter.CreateMetadata(
+        "tbl",
+        "cat",
+        "sch",
+        testColumns)
+
+      // ===== WHEN =====
+      val result = ucCatalogManagedClient
+        .buildCreateTableTransaction(
+          testUcTableId,
+          tablePath,
+          testSchema,
+          "test-engine",
+          createMeta)
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable())
+
+      // ===== THEN =====
+      // onCreateCommitted should have called finalizeCreate, registering the table
+      assert(ucClient.getTablesCopy.contains("cat.sch.tbl"))
+    }
+  }
+
+  test("onCreateCommitted: skips finalization when CreateMetadata is absent") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      // ===== GIVEN =====
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      val ucCatalogManagedClient = new UCCatalogManagedClient(ucClient)
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+
+      // ===== WHEN =====
+      ucCatalogManagedClient
+        .buildCreateTableTransaction(testUcTableId, tablePath, testSchema, "test-engine")
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable())
+
+      // ===== THEN =====
+      assert(ucClient.getTablesCopy.isEmpty)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -92,5 +92,13 @@ class InMemoryUCClient(
       Option(endVersion.orElse(null)).map(_.toLong))
   }
 
+  override def finalizeCreate(
+      tableName: String,
+      catalogName: String,
+      schemaName: String,
+      storageLocation: String,
+      columns: java.util.List[UCClient.ColumnDef],
+      properties: java.util.Map[String, String]): Unit = {}
+
   override def close(): Unit = {}
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -25,6 +25,8 @@ import io.delta.storage.commit.uniform.UniformMetadata;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -120,6 +122,54 @@ public interface UCClient extends AutoCloseable {
       URI tableUri,
       Optional<Long> startVersion,
       Optional<Long> endVersion) throws IOException, UCCommitCoordinatorException;
+
+  /** Column definition for registering table schema with Unity Catalog. */
+  class ColumnDef {
+    private final String name;
+    private final String typeName;
+    private final String typeText;
+    private final String typeJson;
+    private final boolean nullable;
+    private final int position;
+
+    public ColumnDef(
+        String name, String typeName, String typeText, String typeJson,
+        boolean nullable, int position) {
+      this.name = name;
+      this.typeName = typeName;
+      this.typeText = typeText;
+      this.typeJson = typeJson;
+      this.nullable = nullable;
+      this.position = position;
+    }
+
+    public String getName() { return name; }
+    public String getTypeName() { return typeName; }
+    public String getTypeText() { return typeText; }
+    public String getTypeJson() { return typeJson; }
+    public boolean isNullable() { return nullable; }
+    public int getPosition() { return position; }
+  }
+
+  /**
+   * Promotes a staging table to a real managed table in Unity Catalog. This is the correct API
+   * for version 0 (CREATE); for version 1+ (WRITE), use {@link #commit} instead.
+   *
+   * @param tableName table name (relative to parent schema)
+   * @param catalogName parent catalog name in Unity Catalog
+   * @param schemaName parent schema name in Unity Catalog
+   * @param storageLocation the storage root URL for the table
+   * @param columns column definitions for the table schema
+   * @param properties properties to persist in UC (protocol features, metadata config, etc.)
+   * @throws IOException if there is a network or server error during finalization
+   */
+  void finalizeCreate(
+      String tableName,
+      String catalogName,
+      String schemaName,
+      String storageLocation,
+      List<ColumnDef> columns,
+      Map<String, String> properties) throws IOException;
 
   /**
    * Closes any resources used by this client.

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -29,6 +29,7 @@ import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.DeltaCommitsApi;
 import io.unitycatalog.client.api.MetastoresApi;
+import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.model.DeltaCommit;
 import io.unitycatalog.client.model.DeltaCommitInfo;
@@ -38,7 +39,12 @@ import io.unitycatalog.client.model.DeltaGetCommitsResponse;
 import io.unitycatalog.client.model.DeltaMetadata;
 import io.unitycatalog.client.model.DeltaUniform;
 import io.unitycatalog.client.model.DeltaUniformIceberg;
+import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.ColumnTypeName;
+import io.unitycatalog.client.model.CreateTable;
+import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.GetMetastoreSummaryResponse;
+import io.unitycatalog.client.model.TableType;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
@@ -80,6 +86,7 @@ public class UCTokenBasedRestClient implements UCClient {
 
   private DeltaCommitsApi deltaCommitsApi;
   private MetastoresApi metastoresApi;
+  private TablesApi tablesApi;
 
   // HTTP status codes for error handling
   private static final int HTTP_BAD_REQUEST = 400;
@@ -118,13 +125,14 @@ public class UCTokenBasedRestClient implements UCClient {
     ApiClient apiClient = builder.build();
     this.deltaCommitsApi = new DeltaCommitsApi(apiClient);
     this.metastoresApi = new MetastoresApi(apiClient);
+    this.tablesApi = new TablesApi(apiClient);
   }
 
   /**
    * Ensures the client has not been closed. Must be called before any API operation.
    */
   private void ensureOpen() {
-    if (deltaCommitsApi == null || metastoresApi == null) {
+    if (deltaCommitsApi == null || metastoresApi == null || tablesApi == null) {
       throw new IllegalStateException("UCTokenBasedRestClient has been closed.");
     }
   }
@@ -226,6 +234,7 @@ public class UCTokenBasedRestClient implements UCClient {
     // the underlying connection pool is freed and destroyed.
     this.deltaCommitsApi = null;
     this.metastoresApi = null;
+    this.tablesApi = null;
   }
 
   /**
@@ -338,6 +347,62 @@ public class UCTokenBasedRestClient implements UCClient {
   // ===========================
   // Exception Handling Methods
   // ===========================
+
+  @Override
+  public void finalizeCreate(
+      String tableName,
+      String catalogName,
+      String schemaName,
+      String storageLocation,
+      List<UCClient.ColumnDef> columns,
+      Map<String, String> properties) throws IOException {
+    ensureOpen();
+    Objects.requireNonNull(tableName, "tableName must not be null.");
+    Objects.requireNonNull(catalogName, "catalogName must not be null.");
+    Objects.requireNonNull(schemaName, "schemaName must not be null.");
+    Objects.requireNonNull(storageLocation, "storageLocation must not be null.");
+    Objects.requireNonNull(columns, "columns must not be null.");
+    Objects.requireNonNull(properties, "properties must not be null.");
+
+    List<ColumnInfo> ucColumns = columns.stream()
+        .map(c -> {
+          ColumnTypeName typeName;
+          try {
+            typeName = ColumnTypeName.fromValue(c.getTypeName());
+          } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException(
+                "Unknown column type '" + c.getTypeName() + "' for column '" + c.getName() + "'");
+          }
+          return new ColumnInfo()
+              .name(c.getName())
+              .typeName(typeName)
+              .typeText(c.getTypeText())
+              .typeJson(c.getTypeJson())
+              .nullable(c.isNullable())
+              .position(c.getPosition());
+        })
+        .collect(java.util.stream.Collectors.toList());
+
+    CreateTable request = new CreateTable()
+        .name(tableName)
+        .catalogName(catalogName)
+        .schemaName(schemaName)
+        .tableType(TableType.MANAGED)
+        .dataSourceFormat(DataSourceFormat.DELTA)
+        .columns(ucColumns)
+        .storageLocation(storageLocation)
+        .properties(properties);
+
+    try {
+      tablesApi.createTable(request);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format(
+              "Failed to finalize table creation for %s.%s.%s (HTTP %s): %s",
+              catalogName, schemaName, tableName, e.getCode(), e.getResponseBody()),
+          e);
+    }
+  }
 
   /**
    * Handles {@link ApiException} from commit operations by converting to appropriate Delta


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Move UC table finalization (staging table promotion) from the connector into the Kernel commit path via a CatalogCommitter.onCreateCommitted hook. TransactionImpl calls the hook after the version-0 post-commit snapshot is built, allowing UCCatalogManagedCommitter to compute Class B properties and call UCClient.finalizeCreate without connector involvement.

**Before** - connector is responsible for finalizing create (short term solution, where connectors are responsible):
```java
// Build transaction (no finalization metadata)
Transaction txn = ucCatalogManagedClient
    .buildCreateTableTransaction(ucTableId, tablePath, schema, engineInfo)
    .build(engine);

// Commit writes 000.json
TransactionCommitResult result = txn.commit(engine, actions);

// Connector is responsible for calling UC to promote the staging table
// This is error-prone: if it crashes here, the table is orphaned
ucClient.finalizeCreate(tableName, catalogName, schemaName,
    storageLocation, columns, computeClassBProperties(result));
```

**After** - finalization happens inside the commit path (long term solution, where kernel is responsible):
```java
// Pass CreateMetadata so the committer knows how to finalize
CreateMetadata createMeta = new UCCatalogManagedCommitter.CreateMetadata(
    tableName, catalogName, schemaName, columns);

Transaction txn = ucCatalogManagedClient
    .buildCreateTableTransaction(ucTableId, tablePath, schema, engineInfo, createMeta)
    .build(engine);

// Commit writes 000.json, builds post-commit snapshot, then automatically
// calls onCreateCommitted → finalizeCreate. No manual step needed.
TransactionCommitResult result = txn.commit(engine, actions);
```

Additionally, kernel side, the hook is minimal:
```java
// TransactionImpl.java — after building the post-commit snapshot
if (committer instanceof CatalogCommitter
    && committedVersion == 0
    && postCommitSnapshotOpt.isPresent()) {
  ((CatalogCommitter) committer).onCreateCommitted(engine, postCommitSnapshotOpt.get());
}
```

Here is the "stack trace" of a `TransactionImpl.commit()`
```
TransactionImpl.commit(engine, actions)
  │
  ├─ 1. committer.commit(...)              → writes 000.json
  ├─ 2. buildPostCommitSnapshot(...)       → parses 000.json into a Snapshot
  ├─ 3. committer.onCreateCommitted(snapshot)  ← NEW HOOK
  │       └─ Computes Class B properties from snapshot (protocol features,
  │          commit timestamp, clustering columns)
  │       └─ Calls ucClient.finalizeCreate(...) to promote staging table
  └─ 4. return TransactionCommitResult
```
## Review order
This is the review order: interface -> integration -> implementation
```
┌─────────────────────────────────────────────────────────────────────┐
│ STEP 1: The contract (what)                                        │
│                                                                     │
│  CatalogCommitter.java  ← new default method onCreateCommitted()   │
│  UCClient.java          ← new ColumnDef type + finalizeCreate() API │
│                                                                     │
│  "What hooks exist and what can they call?"                         │
├─────────────────────────────────────────────────────────────────────┤
│ STEP 2: The integration point (when)                                │
│                                                                     │
│  TransactionImpl.java   ← 4 lines: call hook after snapshot built  │
│                                                                     │
│  "When does the hook fire? (version==0, snapshot present,           │
│   committer is CatalogCommitter)"                                  │
├─────────────────────────────────────────────────────────────────────┤
│ STEP 3: The UC implementation (how)                                 │
│                                                                     │
│  UCCatalogManagedCommitter.java                                     │
│    ├─ CreateMetadata         (context object: name/catalog/schema/  │
│    │                          columns)                              │
│    ├─ new constructor        (accepts CreateMetadata)               │
│    └─ onCreateCommitted()    (computes Class B props from snapshot, │
│                               calls ucClient.finalizeCreate)        │
│                                                                     │
│  UCCatalogManagedClient.java                                        │
│    └─ new buildCreateTableTransaction overload                      │
│       (passes CreateMetadata to committer constructor)              │
│                                                                     │
│  "How does the UC committer use the hook?"                          │
├─────────────────────────────────────────────────────────────────────┤
│ STEP 4: The REST implementation (production path)                   │
│                                                                     │
│  UCTokenBasedRestClient.java  ← finalizeCreate via TablesApi SDK   │
│                                                                     │
│  "How does finalizeCreate talk to the UC server?"                   │
├─────────────────────────────────────────────────────────────────────┤
│ STEP 5: Tests                                                       │
│                                                                     │
│  UCCatalogManagedCommitterSuite.scala  ← 2 new tests               │
│  InMemoryUCClient.scala (kernel+spark) ← test doubles              │
│                                                                     │
│  "Does the hook fire correctly? Does it skip when it should?"       │
└─────────────────────────────────────────────────────────────────────┘
```

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

- 2 new unit tests in `UCCatalogManagedCommitterSuite`:
  - `onCreateCommitted: finalizes table in UC when CreateMetadata is provided` -- verifies the full flow through `TransactionImpl.commit()` triggers UC finalization
  - `onCreateCommitted: skips finalization when CreateMetadata is absent` -- verifies backward compatibility
- All 22 existing `UCCatalogManagedCommitterSuite` tests pass
- All 3 existing `UnityCatalogUtilsSuite` tests pass
- `storage`, `kernelApi`, `kernelUnityCatalog`, and `spark` modules compile clean
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
