### PR TITLE
Add CreateTableBuilder + V2Mode routing + integration tests

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/CreateTableBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/CreateTableBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.ddl;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.TableManager;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.transaction.CreateTableTransactionBuilder;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
+import io.delta.kernel.unitycatalog.UCTableIdentifier;
+import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import io.delta.storage.commit.uccommitcoordinator.UCClient;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory$;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Prepares and builds Kernel transactions for CREATE TABLE.
+ *
+ * <p>Stateless utility following the pattern of {@link TableManager} — all state flows through
+ * {@link DDLRequestContext}. The two public entry points are {@link #prepare} (Spark→Kernel
+ * conversion) and {@link #buildTransaction} (transaction construction).
+ */
+public final class CreateTableBuilder {
+
+  private CreateTableBuilder() {}
+
+  /** Convert Spark-level inputs into a Kernel-ready {@link DDLRequestContext}. */
+  public static DDLRequestContext prepare(
+      Identifier ident,
+      String catalogName,
+      StructType sparkSchema,
+      Transform[] partitions,
+      Map<String, String> properties,
+      Configuration hadoopConf,
+      Optional<UCTableInfo> ucTableInfo) {
+    requireNonNull(ident);
+    requireNonNull(sparkSchema);
+    requireNonNull(properties);
+    requireNonNull(hadoopConf);
+
+    String tablePath =
+        ucTableInfo
+            .map(UCTableInfo::getTablePath)
+            .orElseGet(() -> DDLUtils.resolveTablePath(properties, ident));
+
+    Optional<String> comment = DDLUtils.extractComment(properties);
+    io.delta.kernel.types.StructType kernelSchema =
+        SchemaUtils.convertSparkSchemaToKernelSchema(sparkSchema);
+    DataLayoutSpec dataLayoutSpec = DDLUtils.toDataLayoutSpec(partitions);
+    DDLUtils.validateClusteringColumns(dataLayoutSpec, kernelSchema);
+
+    CreateTableTransactionBuilder txnBuilder =
+        ucTableInfo.isPresent()
+            ? buildUCTransactionBuilder(
+                ucTableInfo.get(),
+                catalogName,
+                String.join(".", ident.namespace()),
+                ident.name(),
+                kernelSchema)
+            : TableManager.buildCreateTableTransaction(
+                tablePath, kernelSchema, DDLUtils.ENGINE_INFO);
+
+    return new DDLRequestContext(
+        ident,
+        tablePath,
+        kernelSchema,
+        DDLUtils.filterProperties(properties),
+        comment,
+        dataLayoutSpec,
+        DefaultEngine.create(hadoopConf),
+        ucTableInfo,
+        txnBuilder);
+  }
+
+  /**
+   * Applies optional table properties and data layout to the pre-resolved transaction builder, then
+   * builds the final Kernel {@link Transaction}. This is separated from {@link #prepare} so callers
+   * can inspect or modify the {@link DDLRequestContext} between preparation and building.
+   */
+  public static Transaction buildTransaction(DDLRequestContext request) {
+    CreateTableTransactionBuilder builder = request.transactionBuilder();
+    if (!request.properties().isEmpty()) {
+      builder.withTableProperties(request.properties());
+    }
+    if (!request.dataLayoutSpec().hasNoDataLayoutSpec()) {
+      builder.withDataLayoutSpec(request.dataLayoutSpec());
+    }
+    return builder.build(request.engine());
+  }
+
+  /**
+   * Creates a {@link CreateTableTransactionBuilder} backed by Unity Catalog. This wires up the UC
+   * REST client and {@link io.delta.kernel.unitycatalog.UCCatalogManagedCommitter} so that when the
+   * transaction commits, the delta file is written to the staging location and the table is
+   * finalized (promoted) in UC atomically via the committer's {@code createImpl} path.
+   */
+  private static CreateTableTransactionBuilder buildUCTransactionBuilder(
+      UCTableInfo ucTableInfo,
+      String catalogName,
+      String schemaName,
+      String tableName,
+      io.delta.kernel.types.StructType kernelSchema) {
+    UCClient ucClient =
+        UCTokenBasedRestClientFactory$.MODULE$.createUCClient(
+            ucTableInfo.getUcUri(), ucTableInfo.getAuthConfig());
+    return new UCCatalogManagedClient(ucClient)
+        .buildCreateTableTransaction(
+            ucTableInfo.getTableId(),
+            ucTableInfo.getTablePath(),
+            kernelSchema,
+            DDLUtils.ENGINE_INFO,
+            new UCTableIdentifier(catalogName, schemaName, tableName));
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/DDLRequestContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/DDLRequestContext.java
@@ -18,6 +18,7 @@ package io.delta.spark.internal.v2.ddl;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.transaction.CreateTableTransactionBuilder;
 import io.delta.kernel.transaction.DataLayoutSpec;
 import io.delta.kernel.types.StructType;
 import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo;
@@ -47,7 +48,7 @@ public final class DDLRequestContext {
   private final DataLayoutSpec dataLayoutSpec;
   private final Engine engine;
   private final Optional<UCTableInfo> ucTableInfo;
-  private final String engineInfo;
+  private final CreateTableTransactionBuilder transactionBuilder;
 
   /**
    * @param ident Spark catalog identifier (namespace + name); used for logging, not Kernel APIs
@@ -59,7 +60,7 @@ public final class DDLRequestContext {
    * @param dataLayoutSpec partitioning / clustering specification
    * @param engine Kernel engine instance (typically {@code DefaultEngine})
    * @param ucTableInfo Unity Catalog metadata when the table is UC-managed, empty otherwise
-   * @param engineInfo version string for commit provenance (e.g. "Delta-Spark-DSv2/3.4.0")
+   * @param transactionBuilder pre-resolved Kernel transaction builder (UC or path-based)
    */
   DDLRequestContext(
       Identifier ident,
@@ -70,7 +71,7 @@ public final class DDLRequestContext {
       DataLayoutSpec dataLayoutSpec,
       Engine engine,
       Optional<UCTableInfo> ucTableInfo,
-      String engineInfo) {
+      CreateTableTransactionBuilder transactionBuilder) {
     this.ident = requireNonNull(ident);
     this.tablePath = requireNonNull(tablePath);
     this.kernelSchema = requireNonNull(kernelSchema);
@@ -79,7 +80,7 @@ public final class DDLRequestContext {
     this.dataLayoutSpec = requireNonNull(dataLayoutSpec);
     this.engine = requireNonNull(engine);
     this.ucTableInfo = requireNonNull(ucTableInfo);
-    this.engineInfo = requireNonNull(engineInfo);
+    this.transactionBuilder = requireNonNull(transactionBuilder);
   }
 
   public Identifier ident() {
@@ -102,7 +103,8 @@ public final class DDLRequestContext {
   /**
    * Table description from {@code COMMENT 'x'}, if provided. Not yet written to the Delta log
    * because Kernel's {@code CreateTableTransactionBuilder} does not yet expose a {@code
-   * withDescription()} method. Preserved here for when that API becomes available.
+   * withDescription()} method. Preserved here for when that API becomes available. TODO(#6473):
+   * Write comment to Delta log once Kernel exposes withDescription().
    */
   public Optional<String> comment() {
     return comment;
@@ -126,7 +128,7 @@ public final class DDLRequestContext {
     return ucTableInfo;
   }
 
-  public String engineInfo() {
-    return engineInfo;
+  public CreateTableTransactionBuilder transactionBuilder() {
+    return transactionBuilder;
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/DDLUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/DDLUtils.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.ddl;
+
+import io.delta.kernel.Meta;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.StructType;
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.IdentityTransform;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterByTransform;
+
+/**
+ * Shared utilities for DDL operations (CREATE TABLE, REPLACE TABLE, ALTER TABLE). Stateless — all
+ * inputs are passed as parameters.
+ */
+public final class DDLUtils {
+
+  private DDLUtils() {}
+
+  public static final String ENGINE_INFO = "Delta-Spark-DSv2/" + Meta.KERNEL_VERSION;
+
+  private static final Set<String> DSV2_INTERNAL_KEYS =
+      Set.of(
+          TableCatalog.PROP_LOCATION,
+          TableCatalog.PROP_PROVIDER,
+          TableCatalog.PROP_OWNER,
+          TableCatalog.PROP_EXTERNAL,
+          // V1 (AbstractDeltaCatalog) does not strip this key, which is a latent bug — it gets
+          // persisted as a spurious table property in the Delta log. We fix this in V2.
+          TableCatalog.PROP_IS_MANAGED_LOCATION,
+          "path",
+          "option.path");
+
+  private static final Set<String> KERNEL_UNSUPPORTED_PROTOCOL_KEYS =
+      Set.of("delta.minReaderVersion", "delta.minWriterVersion", "delta.ignoreProtocolDefaults");
+
+  /**
+   * Extracts the table description from DSv2 properties. Kernel's transaction builders do not yet
+   * expose a {@code withDescription()} API, so the comment is preserved in {@link
+   * DDLRequestContext#comment()} for when that becomes available. TODO(#6473): Write comment to
+   * Delta log once Kernel exposes withDescription().
+   */
+  public static Optional<String> extractComment(Map<String, String> properties) {
+    String comment = properties.get(TableCatalog.PROP_COMMENT);
+    return Optional.ofNullable(comment).filter(c -> !c.isEmpty());
+  }
+
+  /**
+   * Strips properties that should not be passed to Kernel's transaction builders:
+   *
+   * <ul>
+   *   <li>DSv2 plumbing keys (location, provider, owner, etc.) — catalog metadata, not Delta table
+   *       properties. The V1 path strips these identically in {@code AbstractDeltaCatalog}.
+   *   <li>Protocol version overrides (minReaderVersion, minWriterVersion, ignoreProtocolDefaults) —
+   *       throws {@link UnsupportedOperationException} if present. The V1 path passes these through
+   *       to its own protocol resolution, but Kernel resolves protocol internally and does not
+   *       accept them. We fail loudly rather than silently ignoring the user's intent.
+   *   <li>UC table ID — internal routing marker consumed by {@link UCCommitCoordinatorClient}, not
+   *       a user-visible table property.
+   * </ul>
+   *
+   * User-facing table properties and Delta feature flags (e.g. {@code delta.feature.*}) pass
+   * through.
+   */
+  public static Map<String, String> filterProperties(Map<String, String> properties) {
+    // Fail loudly if the user specified protocol version overrides. Kernel resolves protocol
+    // internally and rejects these via TableConfig.validateAndNormalizeDeltaProperties. Rather
+    // than letting Kernel throw a confusing error, we catch them here with a clear message.
+    // The V1 path passes these through to its own protocol resolution, so this is a deliberate
+    // divergence until Kernel supports protocol overrides natively.
+    for (String key : KERNEL_UNSUPPORTED_PROTOCOL_KEYS) {
+      if (properties.containsKey(key)) {
+        throw new UnsupportedOperationException(
+            "Protocol version overrides are not yet supported in the V2 connector: "
+                + key
+                + ". Remove this property or use the V1 connector.");
+      }
+    }
+    Map<String, String> result = new HashMap<>(properties);
+    DSV2_INTERNAL_KEYS.forEach(result::remove);
+    result.remove(TableCatalog.PROP_COMMENT);
+    result.remove(UCCommitCoordinatorClient.UC_TABLE_ID_KEY);
+    return result;
+  }
+
+  /**
+   * Converts Spark DSv2 {@link Transform} array into a Kernel {@link DataLayoutSpec}. Spark
+   * represents both partitioning (identity transforms) and clustering ({@link ClusterByTransform})
+   * through the same {@code Transform[]} parameter; this method disambiguates and converts to the
+   * corresponding Kernel representation.
+   */
+  public static DataLayoutSpec toDataLayoutSpec(Transform[] partitions) {
+    if (partitions == null || partitions.length == 0) {
+      return DataLayoutSpec.noDataLayout();
+    }
+
+    if (partitions[0] instanceof ClusterByTransform) {
+      return processClustering(partitions);
+    }
+
+    return processPartitioning(partitions);
+  }
+
+  private static DataLayoutSpec processClustering(Transform[] partitions) {
+    if (partitions.length > 1) {
+      throw new IllegalArgumentException(
+          "CLUSTER BY cannot be combined with other transforms; got " + partitions.length);
+    }
+    ClusterByTransform clusterBy = (ClusterByTransform) partitions[0];
+    List<Column> columns = new ArrayList<>(clusterBy.columnNames().size());
+    for (NamedReference ref :
+        scala.jdk.javaapi.CollectionConverters.asJava(clusterBy.columnNames())) {
+      columns.add(new Column(ref.fieldNames()));
+    }
+    return DataLayoutSpec.clustered(columns);
+  }
+
+  private static DataLayoutSpec processPartitioning(Transform[] partitions) {
+    List<Column> columns = new ArrayList<>(partitions.length);
+    for (Transform t : partitions) {
+      if (!(t instanceof IdentityTransform)) {
+        throw new UnsupportedOperationException(
+            "Unsupported transform (expected identity partition or cluster-by): " + t);
+      }
+      NamedReference ref = ((IdentityTransform) t).reference();
+      if (ref.fieldNames().length > 1) {
+        throw new UnsupportedOperationException(
+            "Nested partition columns are not supported: " + String.join(".", ref.fieldNames()));
+      }
+      columns.add(new Column(ref.fieldNames()[0]));
+    }
+    return DataLayoutSpec.partitioned(columns);
+  }
+
+  /**
+   * Resolve table path from DSv2 properties: {@code location} → {@code path} → {@code option.path}.
+   *
+   * @throws IllegalArgumentException if no valid path can be resolved
+   */
+  public static String resolveTablePath(Map<String, String> properties, Identifier ident) {
+    for (String key : new String[] {TableCatalog.PROP_LOCATION, "path", "option.path"}) {
+      String value = properties.get(key);
+      if (value != null && !value.trim().isEmpty()) {
+        return value;
+      }
+    }
+    throw new IllegalArgumentException(
+        "No table path resolved for "
+            + ident
+            + ". Specify a LOCATION or path property for non-UC tables.");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Validation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Validates that every column in a CLUSTER BY spec exists in the schema and that there are no
+   * duplicates (case-insensitive). Delegates to {@link #resolveNestedColumn} for each column path.
+   */
+  public static void validateClusteringColumns(DataLayoutSpec spec, StructType kernelSchema) {
+    if (!spec.hasClustering()) {
+      return;
+    }
+    Set<String> seen = new HashSet<>();
+    for (Column col : spec.getClusteringColumns()) {
+      String[] names = col.getNames();
+      String fullPath = String.join(".", names);
+      resolveNestedColumn(names, kernelSchema, fullPath);
+      if (!seen.add(fullPath.toLowerCase(Locale.ROOT))) {
+        throw new IllegalArgumentException("Duplicate column in CLUSTER BY: " + fullPath);
+      }
+    }
+  }
+
+  /**
+   * Resolves a CLUSTER BY column path through the Kernel schema by walking each segment, verifying
+   * it exists and that intermediate segments are struct types. This catches invalid references at
+   * DDL time rather than letting them slip through to Kernel's write path.
+   *
+   * <p>For example, given:
+   *
+   * <pre>{@code
+   * CREATE TABLE events (
+   *   id INT,
+   *   address STRUCT<city: STRING, zip: INT>
+   * ) CLUSTER BY (address.city)
+   * }</pre>
+   *
+   * Spark passes {@code names = ["address", "city"]}. Resolution walks the schema:
+   *
+   * <ol>
+   *   <li>"address" — found in top-level schema, is a StructType → descend
+   *   <li>"city" — found in address struct, last segment → valid
+   * </ol>
+   *
+   * <p>Failure cases:
+   *
+   * <ul>
+   *   <li>{@code CLUSTER BY (address.state)} — throws ("not found in table schema")
+   *   <li>{@code CLUSTER BY (id.nested)} — throws ("path segment is not a struct")
+   * </ul>
+   */
+  static void resolveNestedColumn(String[] names, StructType schema, String fullPath) {
+    StructType current = schema;
+    for (int i = 0; i < names.length; i++) {
+      if (current.indexOf(names[i]) < 0) {
+        throw new IllegalArgumentException(
+            "CLUSTER BY column not found in table schema: " + fullPath);
+      }
+      if (i < names.length - 1) {
+        DataType fieldType = current.get(names[i]).getDataType();
+        if (!(fieldType instanceof StructType)) {
+          throw new IllegalArgumentException(
+              "CLUSTER BY path segment is not a struct in table schema: " + fullPath);
+        }
+        current = (StructType) fieldType;
+      }
+    }
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/CreateTableBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/CreateTableBuilderTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.ddl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.transaction.DataLayoutSpec;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.MapType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link CreateTableBuilder} helper methods. */
+public class CreateTableBuilderTest {
+
+  // ── filterProperties ──────────────────────────────────────────────
+
+  @Test
+  public void testFilterProperties_removesDsv2InternalKeys() {
+    Map<String, String> props = new HashMap<>();
+    props.put(TableCatalog.PROP_LOCATION, "/some/path");
+    props.put(TableCatalog.PROP_PROVIDER, "delta");
+    props.put(TableCatalog.PROP_COMMENT, "a comment");
+    props.put(TableCatalog.PROP_OWNER, "owner");
+    props.put(TableCatalog.PROP_EXTERNAL, "true");
+    props.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true");
+    props.put("path", "/some/path");
+    props.put("option.path", "/some/path");
+    props.put("delta.feature.catalogManaged", "supported");
+    props.put("io.unitycatalog.tableId", "abc-123");
+    props.put("Foo", "Bar");
+
+    Map<String, String> filtered = DDLUtils.filterProperties(props);
+
+    assertFalse(filtered.containsKey(TableCatalog.PROP_LOCATION));
+    assertFalse(filtered.containsKey(TableCatalog.PROP_PROVIDER));
+    assertFalse(filtered.containsKey(TableCatalog.PROP_COMMENT));
+    assertFalse(filtered.containsKey("path"));
+    assertFalse(filtered.containsKey("option.path"));
+    assertFalse(filtered.containsKey("io.unitycatalog.tableId"));
+    assertEquals("supported", filtered.get("delta.feature.catalogManaged"));
+    assertEquals("Bar", filtered.get("Foo"));
+    assertEquals(2, filtered.size());
+  }
+
+  @Test
+  public void testFilterProperties_throwsOnProtocolVersionOverrides() {
+    for (String key :
+        List.of(
+            "delta.minReaderVersion", "delta.minWriterVersion", "delta.ignoreProtocolDefaults")) {
+      Map<String, String> props = new HashMap<>();
+      props.put(key, "3");
+      UnsupportedOperationException ex =
+          assertThrows(UnsupportedOperationException.class, () -> DDLUtils.filterProperties(props));
+      assertTrue(ex.getMessage().contains(key));
+      assertTrue(ex.getMessage().contains("V2 connector"));
+    }
+  }
+
+  // ── toDataLayoutSpec ──────────────────────────────────────────────
+
+  @Test
+  public void testDataLayoutSpec_emptyAndNull() {
+    assertTrue(DDLUtils.toDataLayoutSpec(new Transform[0]).hasNoDataLayoutSpec());
+    assertTrue(DDLUtils.toDataLayoutSpec(null).hasNoDataLayoutSpec());
+  }
+
+  @Test
+  public void testDataLayoutSpec_identityPartitions() {
+    Transform[] partitions =
+        new Transform[] {Expressions.identity("year"), Expressions.identity("month")};
+
+    DataLayoutSpec spec = DDLUtils.toDataLayoutSpec(partitions);
+
+    assertTrue(spec.hasPartitioning());
+    assertFalse(spec.hasClustering());
+    assertEquals("year", spec.getPartitionColumnsAsStrings().get(0));
+    assertEquals("month", spec.getPartitionColumnsAsStrings().get(1));
+  }
+
+  @Test
+  public void testDataLayoutSpec_clusterBy() {
+    Transform[] partitions = new Transform[] {DDLTestUtils.clusterByTransform("year", "month")};
+
+    DataLayoutSpec spec = DDLUtils.toDataLayoutSpec(partitions);
+
+    assertTrue(spec.hasClustering());
+    assertFalse(spec.hasPartitioning());
+    assertEquals("year", spec.getClusteringColumns().get(0).getNames()[0]);
+    assertEquals("month", spec.getClusteringColumns().get(1).getNames()[0]);
+  }
+
+  @Test
+  public void testDataLayoutSpec_unsupportedTransformThrows() {
+    Transform[] partitions = new Transform[] {Expressions.bucket(10, "col")};
+    assertThrows(UnsupportedOperationException.class, () -> DDLUtils.toDataLayoutSpec(partitions));
+  }
+
+  @Test
+  public void testDataLayoutSpec_mixedClusterByAndPartitionThrows() {
+    Transform[] partitions =
+        new Transform[] {DDLTestUtils.clusterByTransform("year"), Expressions.identity("month")};
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> DDLUtils.toDataLayoutSpec(partitions));
+    assertTrue(ex.getMessage().contains("CLUSTER BY cannot be combined"));
+  }
+
+  // ── resolveTablePath ──────────────────────────────────────────────
+
+  @Test
+  public void testResolveTablePath_precedenceAndFallback() {
+    Identifier ident = Identifier.of(new String[] {"db"}, "tbl");
+
+    assertEquals(
+        "/loc",
+        DDLUtils.resolveTablePath(
+            Map.of(TableCatalog.PROP_LOCATION, "/loc", "path", "/path", "option.path", "/opt"),
+            ident));
+
+    assertThrows(IllegalArgumentException.class, () -> DDLUtils.resolveTablePath(Map.of(), ident));
+  }
+
+  @Test
+  public void testResolveTablePath_skipsNullAndBlankValues() {
+    Identifier ident = Identifier.of(new String[] {"db"}, "tbl");
+    Map<String, String> props = new HashMap<>();
+    props.put(TableCatalog.PROP_LOCATION, null);
+    props.put("path", "   ");
+    props.put("option.path", "/valid");
+
+    assertEquals("/valid", DDLUtils.resolveTablePath(props, ident));
+  }
+
+  // ── extractComment ────────────────────────────────────────────────
+
+  @Test
+  public void testExtractComment() {
+    assertEquals(
+        Optional.of("my table"),
+        DDLUtils.extractComment(Map.of(TableCatalog.PROP_COMMENT, "my table")));
+    assertTrue(DDLUtils.extractComment(Map.of()).isEmpty());
+    assertTrue(DDLUtils.extractComment(Map.of(TableCatalog.PROP_COMMENT, "")).isEmpty());
+  }
+
+  // ── validateClusteringColumns ─────────────────────────────────────
+
+  private static final StructType KERNEL_SCHEMA =
+      new StructType()
+          .add(new StructField("id", IntegerType.INTEGER, false))
+          .add(new StructField("name", StringType.STRING, true))
+          .add(new StructField("year", IntegerType.INTEGER, false))
+          .add(
+              new StructField(
+                  "address",
+                  new StructType()
+                      .add(new StructField("city", StringType.STRING, true))
+                      .add(new StructField("zip", IntegerType.INTEGER, true)),
+                  true))
+          .add(
+              new StructField(
+                  "tags", new MapType(StringType.STRING, StringType.STRING, true), true));
+
+  @Test
+  public void testValidateClusteringColumns_validColumns() {
+    DataLayoutSpec spec = DataLayoutSpec.clustered(List.of(new Column("id"), new Column("year")));
+    DDLUtils.validateClusteringColumns(spec, KERNEL_SCHEMA);
+  }
+
+  @Test
+  public void testValidateClusteringColumns_nonExistentColumnThrows() {
+    DataLayoutSpec spec = DataLayoutSpec.clustered(List.of(new Column("nonexistent")));
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DDLUtils.validateClusteringColumns(spec, KERNEL_SCHEMA));
+    assertTrue(ex.getMessage().contains("nonexistent"));
+  }
+
+  @Test
+  public void testValidateClusteringColumns_duplicateColumnThrows() {
+    DataLayoutSpec spec = DataLayoutSpec.clustered(List.of(new Column("id"), new Column("id")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DDLUtils.validateClusteringColumns(spec, KERNEL_SCHEMA));
+  }
+
+  @Test
+  public void testValidateClusteringColumns_nestedColumns() {
+    DataLayoutSpec spec =
+        DataLayoutSpec.clustered(
+            List.of(new Column(new String[] {"address", "city"}), new Column("id")));
+    DDLUtils.validateClusteringColumns(spec, KERNEL_SCHEMA);
+  }
+
+  @Test
+  public void testValidateClusteringColumns_nestedColumnNotFoundThrows() {
+    DataLayoutSpec spec =
+        DataLayoutSpec.clustered(List.of(new Column(new String[] {"address", "nonexistent"})));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DDLUtils.validateClusteringColumns(spec, KERNEL_SCHEMA));
+  }
+
+  @Test
+  public void testValidateClusteringColumns_nestedThroughNonStructThrows() {
+    DataLayoutSpec spec =
+        DataLayoutSpec.clustered(List.of(new Column(new String[] {"name", "nested"})));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DDLUtils.validateClusteringColumns(spec, KERNEL_SCHEMA));
+  }
+
+  @Test
+  public void testValidateClusteringColumns_nestedThroughMapTypeThrows() {
+    DataLayoutSpec spec =
+        DataLayoutSpec.clustered(List.of(new Column(new String[] {"tags", "key"})));
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DDLUtils.validateClusteringColumns(spec, KERNEL_SCHEMA));
+    assertTrue(ex.getMessage().contains("not a struct"));
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/CreateTableIntegrationTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/CreateTableIntegrationTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.ddl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.TransactionCommitResult;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.utils.CloseableIterable;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration tests for the full prepare → build → commit flow. Exercises path-based tables without
+ * requiring a live Unity Catalog server.
+ */
+public class CreateTableIntegrationTest {
+
+  @Test
+  public void testCreateTable_basic(@TempDir File tempDir) {
+    String tablePath = new File(tempDir, "basic").getAbsolutePath();
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.IntegerType, false)
+            .add("name", DataTypes.StringType, true);
+
+    DDLRequestContext request = prepareRequest(tablePath, schema, new Transform[0]);
+    TransactionCommitResult result = commitCreateTable(request);
+
+    assertEquals(0, result.getVersion());
+    Snapshot snapshot = result.getPostCommitSnapshot().orElseThrow();
+
+    StructField idField = snapshot.getSchema().at(0);
+    assertEquals("id", idField.getName());
+    assertInstanceOf(IntegerType.class, idField.getDataType());
+    assertFalse(idField.isNullable());
+
+    StructField nameField = snapshot.getSchema().at(1);
+    assertEquals("name", nameField.getName());
+    assertInstanceOf(StringType.class, nameField.getDataType());
+    assertTrue(nameField.isNullable());
+
+    assertTrue(snapshot.getPartitionColumnNames().isEmpty());
+    assertTrue(
+        Files.exists(Path.of(tablePath, "_delta_log", "00000000000000000000.json")),
+        "Version 0 commit file should exist");
+  }
+
+  @Test
+  public void testCreateTable_withPartitionsAndProperties(@TempDir File tempDir) {
+    String tablePath = new File(tempDir, "partitioned").getAbsolutePath();
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.IntegerType, false)
+            .add("year", DataTypes.IntegerType, false)
+            .add("name", DataTypes.StringType, true);
+    Map<String, String> properties = new HashMap<>();
+    properties.put("location", tablePath);
+    properties.put("Foo", "Bar");
+    properties.put("provider", "delta");
+    properties.put("comment", "test comment");
+
+    DDLRequestContext request =
+        CreateTableBuilder.prepare(
+            ident("parts"),
+            "test_catalog",
+            schema,
+            new Transform[] {Expressions.identity("year")},
+            properties,
+            new Configuration(),
+            Optional.empty());
+
+    TransactionCommitResult result = commitCreateTable(request);
+    Snapshot snapshot = result.getPostCommitSnapshot().orElseThrow();
+
+    assertEquals(1, snapshot.getPartitionColumnNames().size());
+    assertEquals("year", snapshot.getPartitionColumnNames().get(0));
+    assertEquals("Bar", snapshot.getTableProperties().get("Foo"));
+    assertNull(snapshot.getTableProperties().get("provider"));
+    assertNull(snapshot.getTableProperties().get("comment"));
+    assertEquals(Optional.of("test comment"), request.comment());
+  }
+
+  @Test
+  public void testCreateTable_withClustering(@TempDir File tempDir) {
+    String tablePath = new File(tempDir, "clustered").getAbsolutePath();
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.IntegerType, false)
+            .add("year", DataTypes.IntegerType, false)
+            .add("name", DataTypes.StringType, true);
+    Transform[] clusterBy = new Transform[] {DDLTestUtils.clusterByTransform("year", "id")};
+
+    DDLRequestContext request = prepareRequest(tablePath, schema, clusterBy);
+    assertTrue(request.dataLayoutSpec().hasClustering());
+
+    TransactionCommitResult result = commitCreateTable(request);
+    assertEquals(0, result.getVersion());
+
+    Snapshot snapshot = result.getPostCommitSnapshot().orElseThrow();
+    assertEquals(3, snapshot.getSchema().length());
+    assertTrue(snapshot.getPartitionColumnNames().isEmpty());
+    // Verify clustering columns survived the round-trip through the Delta log
+    Optional<String> clusteringDomain = snapshot.getDomainMetadata("delta.clustering");
+    assertTrue(clusteringDomain.isPresent(), "clustering domain metadata should be persisted");
+    assertTrue(clusteringDomain.get().contains("year"));
+    assertTrue(clusteringDomain.get().contains("id"));
+    assertTrue(Files.exists(Path.of(tablePath, "_delta_log")));
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────
+
+  private static TransactionCommitResult commitCreateTable(DDLRequestContext request) {
+    Transaction txn = CreateTableBuilder.buildTransaction(request);
+    return txn.commit(request.engine(), CloseableIterable.emptyIterable());
+  }
+
+  private static DDLRequestContext prepareRequest(
+      String tablePath, StructType schema, Transform[] partitions) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("location", tablePath);
+    return CreateTableBuilder.prepare(
+        ident("test"),
+        "test_catalog",
+        schema,
+        partitions,
+        properties,
+        new Configuration(),
+        Optional.empty());
+  }
+
+  private static Identifier ident(String name) {
+    return Identifier.of(new String[] {"default"}, name);
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/DDLRequestContextTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/DDLRequestContextTest.java
@@ -17,9 +17,11 @@ package io.delta.spark.internal.v2.ddl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.delta.kernel.TableManager;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Column;
+import io.delta.kernel.transaction.CreateTableTransactionBuilder;
 import io.delta.kernel.transaction.DataLayoutSpec;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.StringType;
@@ -43,6 +45,7 @@ public class DDLRequestContextTest {
   @Test
   public void testConstructionWithAllFields() {
     Identifier ident = Identifier.of(new String[] {"prod_catalog", "analytics"}, "page_views");
+    String tablePath = "/managed/prod_catalog/analytics/page_views";
     StructType schema =
         new StructType()
             .add(new StructField("user_id", IntegerType.INTEGER, false))
@@ -52,26 +55,25 @@ public class DDLRequestContextTest {
         DataLayoutSpec.clustered(List.of(new Column("user_id"), new Column("event_ts")));
     UCTableInfo ucInfo =
         new UCTableInfo(
-            "uc-table-id-123",
-            "/managed/prod_catalog/analytics/page_views",
-            "https://uc.example.com",
-            Map.of("token", "fake-token"));
+            "uc-table-id-123", tablePath, "https://uc.example.com", Map.of("token", "fake-token"));
+    CreateTableTransactionBuilder txnBuilder =
+        TableManager.buildCreateTableTransaction(tablePath, schema, "test");
 
     DDLRequestContext request =
         new DDLRequestContext(
             ident,
-            "/managed/prod_catalog/analytics/page_views",
+            tablePath,
             schema,
             Map.of("delta.appendOnly", "true", "delta.logRetentionDuration", "interval 30 days"),
             Optional.of("Tracks page view events from the analytics pipeline"),
             clustering,
             ENGINE,
             Optional.of(ucInfo),
-            "Delta-Spark-DSv2/4.0.0");
+            txnBuilder);
 
     assertEquals("page_views", request.ident().name());
     assertArrayEquals(new String[] {"prod_catalog", "analytics"}, request.ident().namespace());
-    assertEquals("/managed/prod_catalog/analytics/page_views", request.tablePath());
+    assertEquals(tablePath, request.tablePath());
     assertEquals(3, request.kernelSchema().length());
     assertEquals("true", request.properties().get("delta.appendOnly"));
     assertEquals(
@@ -80,7 +82,7 @@ public class DDLRequestContextTest {
     assertEquals(2, request.dataLayoutSpec().getClusteringColumns().size());
     assertTrue(request.ucTableInfo().isPresent());
     assertEquals("uc-table-id-123", request.ucTableInfo().get().getTableId());
-    assertEquals("Delta-Spark-DSv2/4.0.0", request.engineInfo());
+    assertNotNull(request.transactionBuilder());
   }
 
   @Test
@@ -90,6 +92,8 @@ public class DDLRequestContextTest {
 
     HashMap<String, String> original = new HashMap<>();
     original.put("k", "v");
+    CreateTableTransactionBuilder txnBuilder =
+        TableManager.buildCreateTableTransaction("/p", schema, "test");
     DDLRequestContext request =
         new DDLRequestContext(
             ident,
@@ -100,7 +104,7 @@ public class DDLRequestContextTest {
             DataLayoutSpec.noDataLayout(),
             ENGINE,
             /* ucTableInfo = */ Optional.empty(),
-            "e");
+            txnBuilder);
 
     // Mutating the original map must not leak into the DDLRequestContext
     original.put("injected", "bad");

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/DDLTestUtils.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/ddl/DDLTestUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.ddl;
+
+import java.util.List;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterByTransform;
+
+/** Shared test utilities for DDL tests. */
+final class DDLTestUtils {
+
+  private DDLTestUtils() {}
+
+  static ClusterByTransform clusterByTransform(String... colNames) {
+    List<NamedReference> refs =
+        java.util.Arrays.stream(colNames)
+            .map(Expressions::column)
+            .collect(java.util.stream.Collectors.toList());
+    return new ClusterByTransform(scala.jdk.javaapi.CollectionConverters.asScala(refs).toSeq());
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6449/files) to review incremental changes.
- [stack/kernel-finalize-in-commit](https://github.com/delta-io/delta/pull/6448) [[Files changed](https://github.com/delta-io/delta/pull/6448/files)] [MERGED]
  - [**stack/dsv2-create-with-finalize**](https://github.com/delta-io/delta/pull/6449) [[Files changed](https://github.com/delta-io/delta/pull/6449/files)]
    - [stack/dsv2-wiring-e2e](https://github.com/delta-io/delta/pull/6450) [[Files changed](https://github.com/delta-io/delta/pull/6450/files/8e22865f0603c3e3fe4ce502bec55c0909ecdae1..d33e42c2fd3ab9dbf25ca3dc49554aea1d16c12a)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

The major addition of this PR in the stack is the **CreateTableBuilder**, which is the Spark-To-Kernel conversion layer for DSv2 `CREATE TABLE` to build the **Kernel Transaction.** This is the middle PR in a 3-PR stack:

```
Spark DSv2 inputs            CreateTableBuilder            Kernel types
-------------------          -------------------           ----------------

StructType (schema)   --->   prepare()            --->     DDLRequestContext
Transform[] (layout)                                       ├── kernelSchema
Map<String,String>                                         ├── dataLayoutSpec
Identifier + UCTableInfo                                   ├── filtered properties
Configuration                                              ├── comment (TODO #6473)
                                                           ├── engine
                                                           └── transactionBuilder
                                                                 ├─ UC path: UCCatalogManagedClient
                                                                 └─ local path: TableManager

-------------------- AFTER PREPARE -------------------------------

DDLRequestContext        --->     buildTransaction()     --->     Kernel Transaction
                                      (applies properties
                                       + data layout)
```

**CreateTableBuilder**
The CreateTableBuilder has two utilities:
 1. `prepare()` which converts all the Spark related types to Kernel types and filters properties for Kernel. For example,

Spark | Kernel
-- | --
StructType | io.delta.kernel.types.StructType
Transform[] (partitions/clustering) | DataLayoutSpec via toDataLayoutSpec
Map<String, String> (properties) | Filtered Map<String, String> via filterProperties
COMMENT property | Optional via extractComment
Configuration (Hadoop) | Engine via DefaultEngine.create(hadoopConf)

 2. we also have `buildTransaction()` which takes all these converted items (bundled together into DDLRequestContext) and builds the Kernel Transaction.

**Key design decisions:**
- Property filtering: DSv2 plumbing keys (`location`, `provider`, `owner`) are stripped because they're catalog metadata, not Delta table properties. Protocol version overrides (`minReaderVersion`, `minWriterVersion`, `ignoreProtocolDefaults`) are stripped because Kernel resolves protocol internally and rejects these via `TableConfig.validateAndNormalizeDeltaProperties`. UC table ID is stripped as an internal routing marker.
- UC vs path-based routing: When `UCTableInfo` is present, wires up `UCCatalogManagedClient` + `UCCatalogManagedCommitter` so the commit writes to the staging location and finalizes (promotes) the table in UC. Otherwise uses `TableManager.buildCreateTableTransaction` for path-based tables.
- Comment preservation: `COMMENT 'x'` is extracted but not yet written to the Delta log because Kernel's `CreateTableTransactionBuilder` doesn't expose `withDescription()` yet (tracked in #6473).

**DDLRequestContext change**

Replaced `engineInfo` (String) with `transactionBuilder` (`CreateTableTransactionBuilder`). The transaction builder is now resolved during `prepare()` — UC or path-based — so `buildTransaction()` is catalog-agnostic. This also supports future catalog clients without changing the build step.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
