### PR TITLE
[SPARK] Add SnapshotDataProvider trait and wire into Snapshot

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -97,7 +97,10 @@ class Snapshot(
     override val version: Long,
     val logSegment: LogSegment,
     override val deltaLog: DeltaLog,
-    val checksumOpt: Option[VersionChecksum]
+    val checksumOpt: Option[VersionChecksum],
+    // When set, Snapshot delegates data access to this provider instead of state reconstruction.
+    private[delta] val dataProviderOpt: Option[
+      org.apache.spark.sql.delta.v2.interop.SnapshotDataProvider] = None
   )
   extends SnapshotDescriptor
   with SnapshotStateManager
@@ -363,13 +366,15 @@ class Snapshot(
   }
 
   /** The current set of actions in this [[Snapshot]] as plain Rows */
-  def stateDF: DataFrame = recordFrameProfile("Delta", "stateDF") {
-    cachedState.getDF
+  def stateDF: DataFrame = dataProviderOpt match {
+    case Some(dp) => dp.stateDS(spark).toDF()
+    case None => recordFrameProfile("Delta", "stateDF") { cachedState.getDF }
   }
 
   /** The current set of actions in this [[Snapshot]] as a typed Dataset. */
-  def stateDS: Dataset[SingleAction] = recordFrameProfile("Delta", "stateDS") {
-    cachedState.getDS
+  def stateDS: Dataset[SingleAction] = dataProviderOpt match {
+    case Some(dp) => dp.stateDS(spark)
+    case None => recordFrameProfile("Delta", "stateDS") { cachedState.getDS }
   }
 
   private[delta] def allFilesViaStateReconstruction: Dataset[AddFile] = {
@@ -378,7 +383,10 @@ class Snapshot(
 
   // Here we need to bypass the ACL checks for SELECT anonymous function permissions.
   /** All of the files present in this [[Snapshot]]. */
-  def allFiles: Dataset[AddFile] = allFilesViaStateReconstruction
+  def allFiles: Dataset[AddFile] = dataProviderOpt match {
+    case Some(dp) => dp.allFiles(spark)
+    case None => allFilesViaStateReconstruction
+  }
 
   /** All unexpired tombstones. */
   def tombstones: Dataset[RemoveFile] = {
@@ -390,9 +398,15 @@ class Snapshot(
 
   def checkpointSizeInBytes(): Long = checkpointProvider.effectiveCheckpointSizeInBytes()
 
-  override def metadata: Metadata = _reconstructedProtocolMetadataAndICT.metadata
+  override def metadata: Metadata = dataProviderOpt match {
+    case Some(dp) => dp.metadata
+    case None => _reconstructedProtocolMetadataAndICT.metadata
+  }
 
-  override def protocol: Protocol = _reconstructedProtocolMetadataAndICT.protocol
+  override def protocol: Protocol = dataProviderOpt match {
+    case Some(dp) => dp.protocol
+    case None => _reconstructedProtocolMetadataAndICT.protocol
+  }
 
   /**
    * Tries to retrieve the protocol, metadata, and in-commit-timestamp (if needed) from the

--- a/spark/src/main/scala/org/apache/spark/sql/delta/v2/interop/SnapshotDataProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/v2/interop/SnapshotDataProvider.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import org.apache.spark.sql.delta.SnapshotState
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol, SingleAction}
+
+import org.apache.spark.sql.{Dataset, SparkSession}
+
+/**
+ * Provides snapshot data from a specific source. Snapshot delegates to this
+ * instead of scattering source-specific logic through its methods.
+ *
+ * Two implementations:
+ *  - None (default): Snapshot uses its legacy path (state reconstruction from LogSegment)
+ *  - KernelSnapshotDataProvider (future): data from Kernel Scan API
+ */
+private[delta] trait SnapshotDataProvider {
+  def metadata: Metadata
+  def protocol: Protocol
+  def allFiles(spark: SparkSession): Dataset[AddFile]
+  def stateDS(spark: SparkSession): Dataset[SingleAction]
+  def computedState(spark: SparkSession, metadata: Metadata, protocol: Protocol): SnapshotState
+  def getInCommitTimestampOpt: Option[Long]
+}


### PR DESCRIPTION
## Description

Add `SnapshotDataProvider` trait to `v2/interop/` that abstracts how `Snapshot` gets its data (metadata, protocol, allFiles, stateDF, stateDS). When a provider is set via the new `dataProviderOpt` parameter, `Snapshot` delegates to it instead of using state reconstruction from the `LogSegment`.

This enables a future `KernelSnapshotDataProvider` that reads table state from Kernel's Scan API instead of log replay.

The `dataProviderOpt` parameter defaults to `None`, preserving all existing behavior.

## How was this patch tested?

All existing `Snapshot` tests pass — `dataProviderOpt` defaults to `None` so all code paths remain unchanged.

## Does this PR introduce _any_ user-facing changes?

No.