### PR TITLE
[Kernel-Spark] Handle stale UC latestTableVersion in streaming offset discovery

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -783,6 +783,20 @@ public class SparkMicroBatchStream
       // If the requested version range doesn't exist (e.g., we're asking for version 6 when
       // the table only has versions 0-5).
       return Utils.toCloseableIterator(Collections.emptyIterator());
+    } catch (IllegalArgumentException e) {
+      // Handle TOCTOU race: loadLatestSnapshot() and getTableChanges() each make independent
+      // HTTP calls to the UC getCommits endpoint. Under CI resource pressure, the UC server can
+      // return a stale latestTableVersion on the second call, causing
+      // validateVersionBoundariesExist to throw. This is safe to retry on the next micro-batch.
+      if (e.getMessage() != null && e.getMessage().contains("latest version ratified by UC")) {
+        logger.warn(
+            "UC server returned stale version during offset discovery (startVersion={}). "
+                + "Treating as no new data; next micro-batch will retry. Error: {}",
+            startVersion,
+            e.getMessage());
+        return Utils.toCloseableIterator(Collections.emptyIterator());
+      }
+      throw e;
     }
 
     // Use getCommitActionsFromRangeUnsafe instead of CommitRange.getCommitActions() because:


### PR DESCRIPTION
## Summary

Fixes a TOCTOU race condition in `SparkMicroBatchStream.filterDeltaLogs()` where two sequential UC `getCommits` calls can return inconsistent `latestTableVersion` values, causing `IllegalArgumentException` during streaming offset discovery.

### Error

```
IllegalArgumentException: Cannot load commit range with start version N
  as the latest version ratified by UC is N-1
```

This was discovered via intermittent CI failures across multiple independent PRs:

- PR #6342: `UCDeltaStreamingTest` — `start version 3, ratified is 2` ([failed](https://github.com/delta-io/delta/actions/runs/23395362605) / [passed re-trigger](https://github.com/delta-io/delta/actions/runs/23395362186), same SHA)
- PR #6263: `UCDeltaTableDataFrameStreamingTest` — `start version 2, ratified is 1` (failed attempt 1, passed attempt 2)

### The Bug

`filterDeltaLogs()` makes two independent HTTP calls to UC `getCommits` during offset discovery:

```java
// Call 1: guard check — returns latestTableVersion = N
long currentLatestVersion = snapshotManager.loadLatestSnapshot().getVersion();
if (startVersion > currentLatestVersion) return empty;

// Call 2: fetch data — returns stale latestTableVersion = N-1
commitRange = snapshotManager.getTableChanges(engine, startVersion, endVersionOpt);
// → validateVersionBoundariesExist throws IllegalArgumentException
```

Both calls go through `UCManagedTableSnapshotManager` → `UCCatalogManagedClient` → `getRatifiedCommitsFromUC()` with **no caching at any layer** (verified by tracing through all client-side code).

### Why the UC Server Returns Stale Data

Two server-side mechanisms contribute:

**1. H2 stale MVCC snapshot via Hibernate connection pool**

The UC server uses Hibernate's built-in `DriverManagerConnectionProviderImpl` (pool size 20) with `autocommit=false`. This pool does **not** reset connection state on return — connections re-enter the pool with open implicit transactions. When `getAllCommitDAOsDesc()` (which serves `getCommits`) borrows a pooled connection and calls `setTransactionIsolation(REPEATABLE_READ)`, H2's isolation level change takes effect for the *next* transaction, not the current implicit one. If the connection's implicit transaction predates a concurrent `postCommit`, the REPEATABLE_READ snapshot is anchored to a stale point in time.

Evidence:
- `TransactionManager.java:72-76` sets isolation BEFORE `beginTransaction()` but does NOT call `connection.commit()` first to flush the implicit transaction
- Hibernate logs confirm `autocommit mode: false` and built-in pool (not HikariCP)
- `postCommit` uses default isolation; `getCommits` uses explicit REPEATABLE_READ

**2. HTTP/2 multiplexing + Vert.x proxy**

The UC Java client defaults to HTTP/2 (`HttpClient.newBuilder()` without `.version()`). A Vert.x URL transcoder proxy (`URLTranscoderVerticle`) sits between the client and the Armeria server, adding a second connection-pool layer. Armeria dispatches HTTP/2 streams independently to event loop threads — no ordering guarantee. `DeltaCommitsService` lacks the `@Blocking` annotation, so blocking DB operations run on event loop threads. Under CI load (4 JVMs, 2 vCPUs), this widens the race window.

### Fix

Catch `IllegalArgumentException` from `validateVersionBoundariesExist` in `filterDeltaLogs()`, alongside the existing `CommitRangeNotFoundException` catch. When the error matches the UC stale-version pattern, log a warning and return an empty iterator. The next micro-batch retries and sees the correct version.

This is safe because:
- The streaming query's offset is already committed for the previous batch — no data loss
- The pattern matches the existing `CommitRangeNotFoundException` handling (same return path)
- A `logger.warn()` makes the transient staleness observable


## Test plan

- [x] `sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaStreamingTest` — all 4 tests pass
- [x] No changes to test code — production code only
- [x] Follows the same defensive pattern as the existing `CommitRangeNotFoundException` handler

This pull request was AI-assisted by Isaac.