### PR TITLE
[KERNEL] Fixes for geometry and geography type in 3.3.1

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeographyType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeographyType.java
@@ -16,6 +16,9 @@
 package io.delta.kernel.types;
 
 import io.delta.kernel.annotation.Evolving;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -35,7 +38,8 @@ public final class GeographyType extends DataType {
   public static final String DEFAULT_ALGORITHM = "spherical";
 
   public static final Set<String> VALID_ALGORITHMS =
-      Set.of("spherical", "vincenty", "thomas", "andoyer", "karney");
+      Collections.unmodifiableSet(
+          new HashSet<>(Arrays.asList("spherical", "vincenty", "thomas", "andoyer", "karney")));
 
   private final String srid;
   private final String algorithm;
@@ -103,11 +107,6 @@ public final class GeographyType extends DataType {
    */
   public String getAlgorithm() {
     return algorithm;
-  }
-
-  @Override
-  public boolean isNested() {
-    return false;
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeometryType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeometryType.java
@@ -70,11 +70,6 @@ public final class GeometryType extends DataType {
     return srid;
   }
 
-  @Override
-  public boolean isNested() {
-    return false;
-  }
-
   /**
    * Serialize this GeometryType to its string representation with minimal info.
    *


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Following up on https://github.com/delta-io/delta/pull/6425, this PR makes the necessary updates to `GeometryType` and `GeographyType` in order to allow building the `kernelApi` JAR from `kernel-20250227`.

## How was this patch tested?

Existing tests suffice, also built Kernel API JAR manually to confirm that there are no failures.

## Does this PR introduce _any_ user-facing changes?

Yes, the two new types (geometry and geography) are now properly enabled in Kernel API.
