### PR TITLE
[Python] Pass EXTRA_MAVEN_REPO env var through Docker path

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -225,6 +225,10 @@ def run_tests_in_docker(image_tag, test_group):
     if disable_unidoc is not None:
         envs = envs + "-e DISABLE_UNIDOC=%s " % disable_unidoc
 
+    extra_maven_repo = os.getenv("EXTRA_MAVEN_REPO")
+    if extra_maven_repo is not None:
+        envs = envs + "-e EXTRA_MAVEN_REPO=%s " % extra_maven_repo
+
     cwd = os.getcwd()
     test_script = os.path.basename(__file__)
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (test infrastructure)

## Description

Pass the `EXTRA_MAVEN_REPO` environment variable into the Docker container when running tests via the Docker path in `run-tests.py`, so that Python tests inside Docker can resolve artifacts from a customized Maven repository (e.g., a staging repo for release verification).

Currently, when running Python tests inside Docker (`USE_DOCKER=1 ./run-tests.py --group spark-python`), the `EXTRA_MAVEN_REPO` env var is not forwarded into the container. This means the PyPi packaging test (`using_with_pip.py`) inside Docker cannot pick up the custom Maven repo.

### Where is `EXTRA_MAVEN_REPO` consumed?

`EXTRA_MAVEN_REPO` is read by several downstream scripts to configure `spark.jars.repositories`:

| File | How it's used |
|------|--------------|
| `examples/python/using_with_pip.py` | `builder.config("spark.jars.repositories", os.getenv('EXTRA_MAVEN_REPO'))` |
| `examples/python/image_storage.py` | Same as above |
| `examples/scala/build.sbt` | `sys.env.get("EXTRA_MAVEN_REPO")` added as a resolver |
| `run-integration-tests.py` | Sets `env["EXTRA_MAVEN_REPO"]` for integration test subprocesses |

### Call stack: Python tests in Docker

```
[Host] USE_DOCKER=1 ./run-tests.py --group spark-python
│
├─ pull_or_build_docker_image()                     # run-tests.py:288
│
└─ run_tests_in_docker(image_tag, "spark-python")   # run-tests.py:289
     Forwards env vars into Docker container:
       JENKINS_URL, SBT_1_5_5_MIRROR_JAR_URL, SCALA_VERSION,
       TEST_PARALLELISM_COUNT, DISABLE_UNIDOC,
       EXTRA_MAVEN_REPO  ← this PR
     │
     └─ docker run ... ./run-tests.py --group spark-python
          │
          [Inside Docker — USE_DOCKER is NOT forwarded, prevents recursion]
          │
          └─ run_python_tests(root_dir)                # run-tests.py:291→101
               │
               └─ python3 python/run-tests.py          # run-tests.py:105
                    │
                    ├─ prepare()                        # python/run-tests.py:65
                    │    └─ sbt clean publishM2
                    │         (builds Delta jars → ~/.m2/repository)
                    │
                    ├─ run_python_style_checks()        # lint
                    ├─ run_mypy_tests()                 # type checking
                    │
                    ├─ run_pypi_packaging_tests()       # python/run-tests.py:165
                    │    ├─ pip install delta-spark wheel
                    │    └─ python3 examples/python/using_with_pip.py
                    │         └─ reads EXTRA_MAVEN_REPO ← consumed here
                    │            builder.config("spark.jars.repositories", ...)
                    │            SparkSession starts with custom Maven repo
                    │
                    └─ test(root_dir, "delta", ...)     # python/run-tests.py:26
                         └─ spark-submit \
                              --repositories file://~/.m2/repo,<public repos> \
                              --packages io.delta:delta-spark_2.13:X.Y.Z \
                              <test_file.py>
```

## How was this patch tested?

Manually verified the env var is correctly forwarded into the `docker run` command.

## Does this PR introduce _any_ user-facing changes?

No.