### PR TITLE
[Kernel] Add withCommitTags API to write custom tags to commitInfo in the Delta log

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
@@ -167,6 +167,18 @@ public interface TransactionBuilder {
   TransactionBuilder withDomainMetadataSupported();
 
   /**
+   * Set custom tags to be written to {@code commitInfo.tags} in the Delta log. Tags are arbitrary
+   * key-value pairs that can be used to track metadata for tools such as table synchronization
+   * utilities.
+   *
+   * <p>If this method is not called, no tags will be written to the Delta log.
+   *
+   * @param tags a non-null map of tag key-value pairs to include in the commit info
+   * @return updated {@link TransactionBuilder} instance
+   */
+  TransactionBuilder withCommitTags(Map<String, String> tags);
+
+  /**
    * Build the transaction. Also validates the given info to ensure that a valid transaction can be
    * created.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/CreateTableTransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/CreateTableTransactionBuilderImpl.java
@@ -48,6 +48,7 @@ public class CreateTableTransactionBuilderImpl implements CreateTableTransaction
   private Optional<DataLayoutSpec> dataLayoutSpec = Optional.empty();
   private Optional<Integer> userProvidedMaxRetries = Optional.empty();
   private Optional<Committer> userProvidedCommitter = Optional.empty();
+  private Map<String, String> commitTags = Collections.emptyMap();
 
   public CreateTableTransactionBuilderImpl(String tablePath, StructType schema, String engineInfo) {
     this.unresolvedPath = requireNonNull(tablePath, "tablePath is null");
@@ -110,6 +111,12 @@ public class CreateTableTransactionBuilderImpl implements CreateTableTransaction
     return this;
   }
 
+  @Override
+  public CreateTableTransactionBuilder withCommitTags(Map<String, String> tags) {
+    this.commitTags = Collections.unmodifiableMap(requireNonNull(tags, "tags is null"));
+    return this;
+  }
+
   @VisibleForTesting
   public CreateTableTransactionBuilder withClock(Clock clock) {
     this.clock = requireNonNull(clock, "clock cannot be null");
@@ -155,7 +162,8 @@ public class CreateTableTransactionBuilderImpl implements CreateTableTransaction
         txnMetadata.physicalNewClusteringColumns,
         userProvidedMaxRetries,
         0, // logCompactionInterval - no compaction for new table
-        clock);
+        clock,
+        commitTags);
   }
 
   @VisibleForTesting

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -47,6 +47,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
   private Optional<Map<String, String>> tableProperties = Optional.empty();
   private Optional<Set<String>> unsetTablePropertiesKeys = Optional.empty();
   private boolean needDomainMetadataSupport = false;
+  private Map<String, String> commitTags = emptyMap();
 
   // The original clustering columns provided by the user when building the transaction.
   // This represents logical column references before schema resolution is applied.
@@ -167,6 +168,12 @@ public class TransactionBuilderImpl implements TransactionBuilder {
   }
 
   @Override
+  public TransactionBuilder withCommitTags(Map<String, String> tags) {
+    this.commitTags = Collections.unmodifiableMap(requireNonNull(tags, "tags is null"));
+    return this;
+  }
+
+  @Override
   public Transaction build(Engine engine) {
     if (operation == Operation.REPLACE_TABLE) {
       throw new UnsupportedOperationException("REPLACE TABLE is not yet supported");
@@ -243,7 +250,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
           Optional.empty(), /* clustering cols=empty */
           userProvidedMaxRetries,
           logCompactionInterval,
-          table.getClock());
+          table.getClock(),
+          commitTags);
     }
 
     // Instead of special casing enabling domain metadata, we should just add them
@@ -307,7 +315,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         outputMetadata.physicalNewClusteringColumns,
         userProvidedMaxRetries,
         logCompactionInterval,
-        table.getClock());
+        table.getClock(),
+        commitTags);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -164,6 +164,7 @@ public class TransactionImpl implements Transaction {
   private Optional<Long> providedRowIdHighWatermark = Optional.empty();
   private Supplier<Map<String, String>> committerProperties = Collections::emptyMap;
   private boolean closed; // To avoid trying to commit the same transaction again.
+  private final Map<String, String> commitTags;
 
   public TransactionImpl(
       boolean isCreateOrReplace,
@@ -179,6 +180,38 @@ public class TransactionImpl implements Transaction {
       Optional<Integer> maxRetriesOpt,
       int logCompactionInterval,
       Clock clock) {
+    this(
+        isCreateOrReplace,
+        dataPath,
+        readSnapshotOpt,
+        engineInfo,
+        operation,
+        newProtocol,
+        newMetadata,
+        committer,
+        setTxnOpt,
+        newClusteringColumnsOpt,
+        maxRetriesOpt,
+        logCompactionInterval,
+        clock,
+        emptyMap() /* commitTags */);
+  }
+
+  public TransactionImpl(
+      boolean isCreateOrReplace,
+      Path dataPath,
+      Optional<SnapshotImpl> readSnapshotOpt,
+      String engineInfo,
+      Operation operation,
+      Optional<Protocol> newProtocol,
+      Optional<Metadata> newMetadata,
+      Committer committer,
+      Optional<SetTransaction> setTxnOpt,
+      Optional<List<Column>> newClusteringColumnsOpt,
+      Optional<Integer> maxRetriesOpt,
+      int logCompactionInterval,
+      Clock clock,
+      Map<String, String> commitTags) {
     checkArgument(isCreateOrReplace || readSnapshotOpt.isPresent());
     // For a new table, a protocol and metadata must be provided
     checkArgument(
@@ -202,6 +235,7 @@ public class TransactionImpl implements Transaction {
     this.logCompactionInterval = logCompactionInterval;
     this.clock = clock;
     this.currentCrcInfo = readSnapshotOpt.flatMap(SnapshotImpl::getCurrentCrcInfo);
+    this.commitTags = Collections.unmodifiableMap(requireNonNull(commitTags, "commitTags is null"));
   }
 
   ////////////////
@@ -623,7 +657,8 @@ public class TransactionImpl implements Transaction {
         getOperationParameters(), /* operationParameters */
         isBlindAppend(), /* isBlindAppend */
         Optional.of(txnId.toString()), /* txnId */
-        emptyMap() /* operationMetrics */);
+        emptyMap(), /* operationMetrics */
+        commitTags /* tags */);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/UpdateTableTransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/UpdateTableTransactionBuilderImpl.java
@@ -50,6 +50,7 @@ public class UpdateTableTransactionBuilderImpl implements UpdateTableTransaction
   private Optional<StructType> updatedSchemaOpt = Optional.empty();
   private Optional<List<Column>> inputLogicalClusteringColumnsOpt = Optional.empty();
   private Optional<Integer> userProvidedMaxRetries = Optional.empty();
+  private Map<String, String> commitTags = Collections.emptyMap();
 
   /** Number of commits between producing a log compaction file. */
   private int logCompactionInterval = 0;
@@ -126,6 +127,12 @@ public class UpdateTableTransactionBuilderImpl implements UpdateTableTransaction
     return this;
   }
 
+  @Override
+  public UpdateTableTransactionBuilder withCommitTags(Map<String, String> tags) {
+    this.commitTags = Collections.unmodifiableMap(requireNonNull(tags, "tags is null"));
+    return this;
+  }
+
   @VisibleForTesting
   public UpdateTableTransactionBuilder withClock(Clock clock) {
     this.clock = requireNonNull(clock, "clock cannot be null");
@@ -166,7 +173,8 @@ public class UpdateTableTransactionBuilderImpl implements UpdateTableTransaction
         txnMetadata.physicalNewClusteringColumns,
         userProvidedMaxRetries,
         logCompactionInterval,
-        clock);
+        clock,
+        commitTags);
   }
 
   private void validateTablePropertiesAddedRemovedNoOverlap() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -79,7 +79,11 @@ public class CommitInfo {
           .add("txnId", StringType.STRING)
           .add(
               "operationMetrics",
-              new MapType(StringType.STRING, StringType.STRING, true /* nullable */));
+              new MapType(StringType.STRING, StringType.STRING, true /* nullable */))
+          .add(
+              "tags",
+              new MapType(StringType.STRING, StringType.STRING, true /* nullable */),
+              true /* nullable */);
 
   private static final StructType READ_SCHEMA =
       new StructType().add("commitInfo", CommitInfo.FULL_SCHEMA);
@@ -96,7 +100,7 @@ public class CommitInfo {
       return null;
     }
 
-    ColumnVector[] children = new ColumnVector[8];
+    ColumnVector[] children = new ColumnVector[9];
     for (int i = 0; i < children.length; i++) {
       children[i] = vector.getChild(i);
     }
@@ -115,7 +119,10 @@ public class CommitInfo {
         Optional.ofNullable(children[6].isNullAt(rowId) ? null : children[6].getString(rowId)),
         children[7].isNullAt(rowId)
             ? Collections.emptyMap()
-            : VectorUtils.toJavaMap(children[7].getMap(rowId)));
+            : VectorUtils.toJavaMap(children[7].getMap(rowId)),
+        children[8].isNullAt(rowId)
+            ? Collections.emptyMap()
+            : VectorUtils.toJavaMap(children[8].getMap(rowId)));
   }
 
   /**
@@ -222,6 +229,7 @@ public class CommitInfo {
   private final Optional<String> txnId;
   private Optional<Long> inCommitTimestamp;
   private final Map<String, String> operationMetrics;
+  private final Map<String, String> tags;
 
   public CommitInfo(
       Optional<Long> inCommitTimestamp,
@@ -232,6 +240,28 @@ public class CommitInfo {
       Optional<Boolean> isBlindAppend,
       Optional<String> txnId,
       Map<String, String> operationMetrics) {
+    this(
+        inCommitTimestamp,
+        timestamp,
+        engineInfo,
+        operation,
+        operationParameters,
+        isBlindAppend,
+        txnId,
+        operationMetrics,
+        Collections.emptyMap() /* tags */);
+  }
+
+  public CommitInfo(
+      Optional<Long> inCommitTimestamp,
+      long timestamp,
+      Optional<String> engineInfo,
+      Optional<String> operation,
+      Map<String, String> operationParameters,
+      Optional<Boolean> isBlindAppend,
+      Optional<String> txnId,
+      Map<String, String> operationMetrics,
+      Map<String, String> tags) {
     this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
     this.timestamp = timestamp;
     this.engineInfo = requireNonNull(engineInfo);
@@ -240,6 +270,7 @@ public class CommitInfo {
     this.isBlindAppend = requireNonNull(isBlindAppend);
     this.txnId = requireNonNull(txnId);
     this.operationMetrics = Collections.unmodifiableMap(requireNonNull(operationMetrics));
+    this.tags = Collections.unmodifiableMap(requireNonNull(tags));
   }
 
   public long getTimestamp() {
@@ -274,6 +305,10 @@ public class CommitInfo {
     return operationMetrics;
   }
 
+  public Map<String, String> getTags() {
+    return tags;
+  }
+
   public void setInCommitTimestamp(Optional<Long> inCommitTimestamp) {
     this.inCommitTimestamp = inCommitTimestamp;
   }
@@ -295,6 +330,8 @@ public class CommitInfo {
     commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId.orElse(null));
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));
+    commitInfo.put(
+        COL_NAME_TO_ORDINAL.get("tags"), tags.isEmpty() ? null : stringStringMapValue(tags));
 
     return new GenericRow(CommitInfo.FULL_SCHEMA, commitInfo);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/transaction/CreateTableTransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/transaction/CreateTableTransactionBuilder.java
@@ -83,6 +83,18 @@ public interface CreateTableTransactionBuilder {
   CreateTableTransactionBuilder withCommitter(Committer committer);
 
   /**
+   * Set custom tags to be written to {@code commitInfo.tags} in the Delta log. Tags are arbitrary
+   * key-value pairs that can be used to track metadata for tools such as table synchronization
+   * utilities.
+   *
+   * <p>If this method is not called, no tags will be written to the Delta log.
+   *
+   * @param tags a non-null map of tag key-value pairs to include in the commit info
+   * @return updated {@link CreateTableTransactionBuilder} instance
+   */
+  CreateTableTransactionBuilder withCommitTags(Map<String, String> tags);
+
+  /**
    * Build the transaction for creating the Delta table.
    *
    * <p>This validates all the configuration and creates a {@link Transaction} that can be used to

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/transaction/UpdateTableTransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/transaction/UpdateTableTransactionBuilder.java
@@ -144,6 +144,18 @@ public interface UpdateTableTransactionBuilder {
   UpdateTableTransactionBuilder withLogCompactionInterval(int logCompactionInterval);
 
   /**
+   * Set custom tags to be written to {@code commitInfo.tags} in the Delta log. Tags are arbitrary
+   * key-value pairs that can be used to track metadata for tools such as table synchronization
+   * utilities.
+   *
+   * <p>If this method is not called, no tags will be written to the Delta log.
+   *
+   * @param tags a non-null map of tag key-value pairs to include in the commit info
+   * @return updated {@link UpdateTableTransactionBuilder} instance
+   */
+  UpdateTableTransactionBuilder withCommitTags(Map<String, String> tags);
+
+  /**
    * Build the transaction for updating the Delta table.
    *
    * <p>This validates all the configuration and creates a {@link Transaction} that can be used to

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -209,7 +209,8 @@ class MockReadICTFileJsonHandler(
             mapTypeVector(Seq(Map("operationParameter" -> ""))), /* operationParameters */
             booleanVector(Seq(false)), /* isBlindAppend */
             stringVector(Seq("txnId")), /* txnId */
-            mapTypeVector(Seq(Map("operationMetrics" -> ""))) /* operationMetrics */
+            mapTypeVector(Seq(Map("operationMetrics" -> ""))), /* operationMetrics */
+            mapTypeVector(Seq(Map.empty[String, String])) /* tags */
           )
           ordinal match {
             case 0 => new ColumnVector {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CommitMetadataE2ESuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CommitMetadataE2ESuite.scala
@@ -137,6 +137,25 @@ class CommitMetadataE2ESuite extends AnyFunSuite
     }
   }
 
+  test("commit tags are written to the Delta log JSON and can be read back") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val expectedTags = Map("k1" -> "v1", "k2" -> "v2").asJava
+
+      TableManager
+        .buildCreateTableTransaction(tablePath, testSchema, "engineInfo")
+        .withCommitTags(expectedTags)
+        .build(engine)
+        .commit(engine, emptyIterable())
+
+      // Read back the commitInfo from the written Delta log
+      val logPath = new io.delta.kernel.internal.fs.Path(tablePath + "/_delta_log")
+      val commitInfoOpt = io.delta.kernel.internal.actions.CommitInfo
+        .unsafeTryReadCommitInfoFromPublishedDeltaFile(engine, logPath, 0L)
+      assert(commitInfoOpt.isPresent)
+      assert(commitInfoOpt.get.getTags === expectedTags)
+    }
+  }
+
   test("maxKnownPublishedDeltaVersion is correctly passed for UPDATE operation") {
     withTempDirAndEngine { (tablePath, engine) =>
       val capturingCommitter = new CapturingCommitter()

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
@@ -544,7 +544,8 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
       true,
       "cb009f42-5da1-4e7e-b4fa-09de3332f52a",
       Map("numFiles" -> "1", "serializedAsNumber" -> "2", "serializedAsBoolean" -> "true"),
-      null) // tags
+      null
+    ) // tags
 
     checkAnswer(Seq(actResult), Seq(expResult))
   }
@@ -581,7 +582,8 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
       null, // isBlindAppend is missing from JSON, should be null
       "cb009f42-5da1-4e7e-b4fa-09de3332f52a",
       Map("numFiles" -> "1"),
-      null) // tags
+      null
+    ) // tags
 
     checkAnswer(Seq(actResult), Seq(expResult))
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
@@ -543,7 +543,8 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
       Map("mode" -> "Append", "statsOnLoad" -> "false", "partitionBy" -> "[]"),
       true,
       "cb009f42-5da1-4e7e-b4fa-09de3332f52a",
-      Map("numFiles" -> "1", "serializedAsNumber" -> "2", "serializedAsBoolean" -> "true"))
+      Map("numFiles" -> "1", "serializedAsNumber" -> "2", "serializedAsBoolean" -> "true"),
+      null) // tags
 
     checkAnswer(Seq(actResult), Seq(expResult))
   }
@@ -579,7 +580,8 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
       Map("mode" -> "Append", "partitionBy" -> "[]"),
       null, // isBlindAppend is missing from JSON, should be null
       "cb009f42-5da1-4e7e-b4fa-09de3332f52a",
-      Map("numFiles" -> "1"))
+      Map("numFiles" -> "1"),
+      null) // tags
 
     checkAnswer(Seq(actResult), Seq(expResult))
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Adds `withCommitTags(Map<String, String> tags)` to Delta Kernel's transaction builder APIs so callers can write custom key-value pairs to `commitInfo.tags` in the Delta log.

This field is part of the Delta protocol and is already written by Delta Spark, but was never exposed in Kernel. Tools like table sync utilities use it to annotate commits with metadata.

The `tags` field is added to `CommitInfo` schema and wired through all three builder interfaces (`TransactionBuilder`, `CreateTableTransactionBuilder`, `UpdateTableTransactionBuilder`) down to the actual commit. When not set, the field is omitted from the log.

Resolves #6167

## How was this patch tested?

Added a test in `CommitMetadataE2ESuite` that creates a table with commit tags set, then reads back the `commitInfo` from the written Delta log JSON using `CommitInfo.unsafeTryReadCommitInfoFromPublishedDeltaFile` and asserts the tags are present.

## Does this PR introduce _any_ user-facing changes?

Yes - adds `withCommitTags(Map<String, String>)` to the transaction builder APIs. Existing code is unaffected.