### PR TITLE
[KERNEL] Add replay logic for when delta last_checkpoint file is missing

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -225,23 +225,101 @@ public class SnapshotManager {
     // catalogManaged tables we want to load the maxCatalogVersion
     final Optional<Long> versionToLoadOpt =
         timeTravelVersionOpt.isPresent() ? timeTravelVersionOpt : maxCatalogVersionOpt;
-    final long versionToLoad = versionToLoadOpt.orElse(Long.MAX_VALUE);
     final String versionToLoadStr = versionToLoadOpt.map(String::valueOf).orElse("latest");
     logger.info("Loading log segment for version {}", versionToLoadStr);
     final long logSegmentBuildingStartTimeMillis = System.currentTimeMillis();
 
     ///////////////////////////////////////////////////////////////////////////////////////////
-    // Step 1: Find the latest checkpoint version. If timeTravelVersionOpt is empty, use the //
-    //         version referenced by the _LAST_CHECKPOINT file. If timeTravelVersionOpt is   //
-    //         present, search for the previous latest complete checkpoint at or before the  //
-    //         version to load                                                               //
+    // Find the latest checkpoint version. If timeTravelVersionOpt is empty, use the        //
+    // version referenced by the _LAST_CHECKPOINT file. If timeTravelVersionOpt is present,  //
+    // search for the previous latest complete checkpoint at or before the version to load.  //
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     final Optional<Long> startCheckpointVersionOpt =
         getStartCheckpointVersion(engine, timeTravelVersionOpt, maxCatalogVersionOpt);
 
+    // Primary attempt to build the log segment
+    Optional<LogSegment> result =
+        buildLogSegmentFromStartCheckpointVersion(
+            engine, startCheckpointVersionOpt, versionToLoadOpt, parsedLogDatas);
+    if (result.isPresent()) {
+      logger.info(
+          "Successfully constructed LogSegment at version {}, took {}ms",
+          result.get().getVersion(),
+          System.currentTimeMillis() - logSegmentBuildingStartTimeMillis);
+      return result.get();
+    }
+
+    // Primary returned empty -> checkpoint appears stale. Try fallback.
+    if (startCheckpointVersionOpt.isPresent()) {
+      logger.warn(
+          "{}: Checkpoint at version {} appears to have been deleted. "
+              + "Falling back to search for an earlier valid checkpoint.",
+          tablePath,
+          startCheckpointVersionOpt.get());
+      Optional<Long> fallbackStart =
+          findFallbackCheckpointVersion(engine, startCheckpointVersionOpt.get());
+      try {
+        Optional<LogSegment> fallbackResult =
+            buildLogSegmentFromStartCheckpointVersion(
+                engine, fallbackStart, versionToLoadOpt, parsedLogDatas);
+        if (fallbackResult.isPresent()) {
+          logger.info(
+              "{}: Fallback successfully constructed LogSegment at version {} "
+                  + "(stale checkpoint was at version {}), took {}ms",
+              tablePath,
+              fallbackResult.get().getVersion(),
+              startCheckpointVersionOpt.get(),
+              System.currentTimeMillis() - logSegmentBuildingStartTimeMillis);
+          return fallbackResult.get();
+        }
+        logger.warn(
+            "{}: Fallback listing from version {} also returned empty",
+            tablePath,
+            fallbackStart.map(String::valueOf).orElse("0"));
+        // Fallback listing also empty -> table doesn't exist
+      } catch (InvalidTableException | IllegalStateException e) {
+        // buildLogSegmentFromStartCheckpointVersion throws InvalidTableException for validation
+        // failures
+        // (non-contiguous deltas, missing delta files) and IllegalStateException for corrupted
+        // checkpoint files. During fallback, these indicate the table state is unrecoverable
+        // from the stale checkpoint — attribute the failure to the stale checkpoint itself.
+        // Other exceptions (KernelException, TableNotFoundException) propagate uncaught.
+        logger.warn(
+            "{}: Fallback attempt also failed for checkpoint version {}",
+            tablePath,
+            startCheckpointVersionOpt.get(),
+            e);
+        throw DeltaErrors.missingCheckpoint(tablePath.toString(), startCheckpointVersionOpt.get());
+      }
+    }
+    throw new TableNotFoundException(
+        tablePath.toString(), format("No delta files found in the directory: %s", logPath));
+  }
+
+  /**
+   * Attempts to build a {@link LogSegment} by listing and validating files starting from the given
+   * checkpoint version. Contains the core logic for listing, partitioning, validating, and
+   * constructing a {@link LogSegment}.
+   *
+   * @return {@link Optional#empty()} when the listing is empty or the expected checkpoint is not
+   *     found (recoverable conditions indicating a stale start point). Throws for genuine table
+   *     corruption (non-contiguous deltas, version mismatch, corrupted checkpoint files, etc.).
+   * @throws InvalidTableException when the listed files fail validation (non-contiguous deltas,
+   *     missing delta file at checkpoint version, etc.)
+   * @throws IllegalStateException when checkpoint files are corrupted or an internal invariant is
+   *     violated
+   */
+  private Optional<LogSegment> buildLogSegmentFromStartCheckpointVersion(
+      Engine engine,
+      Optional<Long> startCheckpointVersionOpt,
+      Optional<Long> versionToLoadOpt,
+      List<ParsedLogData> parsedLogDatas) {
+
+    final long versionToLoad = versionToLoadOpt.orElse(Long.MAX_VALUE);
+
     /////////////////////////////////////////////////////////////////
-    // Step 2: Determine the actual version to start listing from. //
+    // Step 1: Determine the actual version to start listing from. //
     /////////////////////////////////////////////////////////////////
 
     final long listFromStartVersion =
@@ -258,7 +336,7 @@ public class SnapshotManager {
                 });
 
     /////////////////////////////////////////////////////////////////
-    // Step 3: List the files from $startVersion to $versionToLoad //
+    // Step 2: List the files from $startVersion to $versionToLoad //
     /////////////////////////////////////////////////////////////////
 
     Set<DeltaLogFileType> fileTypes =
@@ -286,28 +364,17 @@ public class SnapshotManager {
         System.currentTimeMillis() - listingStartTimeMillis);
 
     ////////////////////////////////////////////////////////////////////////
-    // Step 4: Perform some basic validations on the listed file statuses //
+    // Step 3: Perform some basic validations on the listed file statuses //
     ////////////////////////////////////////////////////////////////////////
 
     if (listedFileStatuses.isEmpty()) {
-      if (startCheckpointVersionOpt.isPresent()) {
-        // We either (a) determined this checkpoint version from the _LAST_CHECKPOINT file, or (b)
-        // found the last complete checkpoint before our versionToLoad. In either case, we didn't
-        // see the checkpoint file in the listing.
-        // TODO: throw a more specific error based on case (a) or (b)
-        throw DeltaErrors.missingCheckpoint(tablePath.toString(), startCheckpointVersionOpt.get());
-      } else {
-        // Either no files found OR no *delta* files found even when listing from 0. This means that
-        // the delta table does not exist yet.
-        throw new TableNotFoundException(
-            tablePath.toString(), format("No delta files found in the directory: %s", logPath));
-      }
+      return Optional.empty();
     }
 
     logDebugFileStatuses("listedFileStatuses", listedFileStatuses);
 
     //////////////////////////////////////////////////////////////////////////////////////////
-    // Step 5: Partition $listedFileStatuses into the checkpoints, deltas, and compactions. //
+    // Step 4: Partition $listedFileStatuses into the checkpoints, deltas, and compactions. //
     //////////////////////////////////////////////////////////////////////////////////////////
 
     final Map<Class<? extends ParsedLogData>, List<ParsedLogData>> partitionedFiles =
@@ -347,7 +414,7 @@ public class SnapshotManager {
     logDebugFileStatuses("listedCheckSumFileStatuses", listedChecksumFileStatuses);
 
     /////////////////////////////////////////////////////////////////////////////////////////////
-    // Step 6: Determine the latest complete checkpoint version. The intuition here is that we //
+    // Step 5: Determine the latest complete checkpoint version. The intuition here is that we //
     //         LISTed from the startingCheckpoint but may have found a newer complete          //
     //         checkpoint.                                                                     //
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -365,9 +432,7 @@ public class SnapshotManager {
             listedCheckpointInstances, notLaterThanCheckpoint);
 
     if (!latestCompleteCheckpointOpt.isPresent() && startCheckpointVersionOpt.isPresent()) {
-      // In Step 1 we found a $startCheckpointVersion but now our LIST of the file system doesn't
-      // see it. This means that the checkpoint we thought should exist no longer does.
-      throw DeltaErrors.missingCheckpoint(tablePath.toString(), startCheckpointVersionOpt.get());
+      return Optional.empty();
     }
 
     final long latestCompleteCheckpointVersion =
@@ -376,7 +441,7 @@ public class SnapshotManager {
     logger.info("Latest complete checkpoint version: {}", latestCompleteCheckpointVersion);
 
     /////////////////////////////////////////////////////////////////////////////////////////////
-    // Step 7: Grab all deltas in range [$latestCompleteCheckpointVersion + 1, $versionToLoad] //
+    // Step 6: Grab all deltas in range [$latestCompleteCheckpointVersion + 1, $versionToLoad] //
     /////////////////////////////////////////////////////////////////////////////////////////////
 
     final List<ParsedDeltaData> allDeltasAfterCheckpoint =
@@ -386,7 +451,7 @@ public class SnapshotManager {
     logDebugParsedLogDatas("allDeltasAfterCheckpoint", allDeltasAfterCheckpoint);
 
     //////////////////////////////////////////////////////////////////////////////////
-    // Step 8: Grab all compactions in range [$latestCompleteCheckpointVersion + 1, //
+    // Step 7: Grab all compactions in range [$latestCompleteCheckpointVersion + 1, //
     //         $versionToLoad]                                                      //
     //////////////////////////////////////////////////////////////////////////////////
 
@@ -404,7 +469,7 @@ public class SnapshotManager {
     logDebugFileStatuses("compactionsAfterCheckpoint", compactionsAfterCheckpoint);
 
     ////////////////////////////////////////////////////////////////////
-    // Step 9: Determine the version of the snapshot we can now load. //
+    // Step 8: Determine the version of the snapshot we can now load. //
     ////////////////////////////////////////////////////////////////////
 
     final long newVersion =
@@ -415,7 +480,7 @@ public class SnapshotManager {
     logger.info("New version to load: {}", newVersion);
 
     /////////////////////////////////////////////
-    // Step 10: Perform some basic validations. //
+    // Step 9: Perform some basic validations. //
     /////////////////////////////////////////////
 
     // Check that we have found at least one checkpoint or delta file
@@ -478,7 +543,7 @@ public class SnapshotManager {
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////
-    // Step 11: Grab the actual checkpoint file statuses for latestCompleteCheckpointVersion. //
+    // Step 10: Grab the actual checkpoint file statuses for latestCompleteCheckpointVersion. //
     ////////////////////////////////////////////////////////////////////////////////////////////
 
     final List<FileStatus> latestCompleteCheckpointFileStatuses =
@@ -514,7 +579,7 @@ public class SnapshotManager {
             .orElse(Collections.emptyList());
 
     ////////////////////////////////////////////////////////
-    // Step 12: Calculate the remaining LogSegment params //
+    // Step 11: Calculate the remaining LogSegment params //
     ////////////////////////////////////////////////////////
 
     // If our LogSegment has deltas (allDeltasAfterCheckpoint), we use the last delta.
@@ -538,25 +603,39 @@ public class SnapshotManager {
     }
 
     ///////////////////////////////////////////////////
-    // Step 13: Construct the LogSegment and return. //
+    // Step 12: Construct the LogSegment and return. //
     ///////////////////////////////////////////////////
 
-    logger.info(
-        "Successfully constructed LogSegment at version {}, took {}ms",
-        newVersion,
-        System.currentTimeMillis() - logSegmentBuildingStartTimeMillis);
+    return Optional.of(
+        new LogSegment(
+            logPath,
+            newVersion,
+            allDeltasAfterCheckpoint.stream()
+                .map(ParsedLogData::getFileStatus)
+                .collect(Collectors.toList()),
+            compactionsAfterCheckpoint,
+            latestCompleteCheckpointFileStatuses,
+            deltaAtEndVersion,
+            lastSeenChecksumFile,
+            maxPublishedDeltaVersion));
+  }
 
-    return new LogSegment(
-        logPath,
-        newVersion,
-        allDeltasAfterCheckpoint.stream()
-            .map(ParsedLogData::getFileStatus)
-            .collect(Collectors.toList()),
-        compactionsAfterCheckpoint,
-        latestCompleteCheckpointFileStatuses,
-        deltaAtEndVersion,
-        lastSeenChecksumFile,
-        maxPublishedDeltaVersion);
+  /**
+   * Finds the latest complete checkpoint version strictly before the given version. Used as a
+   * fallback when the primary checkpoint (from _last_checkpoint or backwards search) is stale.
+   */
+  private Optional<Long> findFallbackCheckpointVersion(
+      Engine engine, long maxExclusiveCheckpointVersion) {
+    Optional<Long> fallbackVersion =
+        Checkpointer.findLastCompleteCheckpointBefore(
+                engine, logPath, maxExclusiveCheckpointVersion)
+            .map(cp -> cp.version);
+    logger.info(
+        "{}: Fallback: Searched for earlier checkpoint before version {}. Found: {}.",
+        tablePath,
+        maxExclusiveCheckpointVersion,
+        fallbackVersion.map(String::valueOf).orElse("none"));
+    return fallbackVersion;
   }
 
   /////////////////////////

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -29,7 +29,11 @@ import io.delta.kernel.internal.checkpoints.{CheckpointInstance, CheckpointMetaD
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.snapshot.{LogSegment, SnapshotManager}
 import io.delta.kernel.internal.util.{FileNames, Utils}
-import io.delta.kernel.test.{BaseMockJsonHandler, BaseMockParquetHandler, MockFileSystemClientUtils, MockListFromFileSystemClient, VectorTestUtils}
+import io.delta.kernel.test.BaseMockJsonHandler
+import io.delta.kernel.test.BaseMockParquetHandler
+import io.delta.kernel.test.MockFileSystemClientUtils
+import io.delta.kernel.test.MockListFromFileSystemClient
+import io.delta.kernel.test.VectorTestUtils
 import io.delta.kernel.types.StructType
 import io.delta.kernel.utils.{CloseableIterator, FileStatus}
 
@@ -679,22 +683,41 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       startCheckpoint = Optional.of(30))
   }
 
-  test("getLogSegmentForVersion: corrupt _last_checkpoint refers to in range version " +
-    "but no valid checkpoint") {
-    // _last_checkpoint refers to a v1 checkpoint at version 20 that is missing
-    testExpectedError[RuntimeException](
-      deltaFileStatuses(0L until 25L) ++ singularCheckpointFileStatuses(Seq(10L)),
-      lastCheckpointVersion = Optional.of(20),
-      expectedErrorMessageContains = "Missing checkpoint at version 20")
-    // _last_checkpoint refers to incomplete multi-part checkpoint at version 20 that is missing
+  test("getLogSegmentForVersion: stale _last_checkpoint refers to in range version " +
+    "but no valid checkpoint - falls back to earlier checkpoint") {
+    // Case 1: _last_checkpoint=20, checkpoint at 10 exists, no checkpoint at 20
+    // Fallback: findLastCompleteCheckpointBefore(20) finds cp(10), re-lists from v10
+    val files1 = deltaFileStatuses(0L until 25L) ++ singularCheckpointFileStatuses(Seq(10L))
+    val logSegment1 = snapshotManager.getLogSegmentForVersion(
+      createMockFSAndJsonEngineForLastCheckpoint(files1, Optional.of(20L)),
+      Optional.empty())
+    checkLogSegment(
+      logSegment1,
+      expectedVersion = 24,
+      expectedDeltas = deltaFileStatuses(11L until 25L),
+      expectedCompactions = Seq.empty,
+      expectedCheckpoints = singularCheckpointFileStatuses(Seq(10L)),
+      expectedCheckpointVersion = Some(10),
+      expectedLastCommitTimestamp = 240L)
+
+    // Case 2: _last_checkpoint=20, incomplete multi-part checkpoint at 20 (4/5 parts)
+    // Fallback: findLastCompleteCheckpointBefore(20) finds cp(10), re-lists from v10
     val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 20, 5).asScala
       .map(p => FileStatus.of(p.toString, 10, 10))
       .take(4)
-    testExpectedError[RuntimeException](
-      files = corruptedCheckpointStatuses.toSeq ++ deltaFileStatuses(10L to 20L) ++
-        singularCheckpointFileStatuses(Seq(10L)),
-      lastCheckpointVersion = Optional.of(20),
-      expectedErrorMessageContains = "Missing checkpoint at version 20")
+    val files2 = corruptedCheckpointStatuses.toSeq ++ deltaFileStatuses(10L to 20L) ++
+      singularCheckpointFileStatuses(Seq(10L))
+    val logSegment2 = snapshotManager.getLogSegmentForVersion(
+      createMockFSAndJsonEngineForLastCheckpoint(files2, Optional.of(20L)),
+      Optional.empty())
+    checkLogSegment(
+      logSegment2,
+      expectedVersion = 20,
+      expectedDeltas = deltaFileStatuses(11L to 20L),
+      expectedCompactions = Seq.empty,
+      expectedCheckpoints = singularCheckpointFileStatuses(Seq(10L)),
+      expectedCheckpointVersion = Some(10),
+      expectedLastCommitTimestamp = 200L)
   }
 
   test("getLogSegmentForVersion: corrupted incomplete multi-part checkpoint with no" +
@@ -728,14 +751,153 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     }
   }
 
-  test("getLogSegmentForVersion: corrupt _last_checkpoint with empty delta log") {
-    val exMsg = intercept[InvalidTableException] {
-      snapshotManager.getLogSegmentForVersion(
-        createMockFSAndJsonEngineForLastCheckpoint(Seq.empty, Optional.of(1)),
-        Optional.empty())
-    }.getMessage
+  /* -------- STALE _LAST_CHECKPOINT FALLBACK TESTS -------- */
 
-    assert(exMsg.contains("Missing checkpoint at version 1"))
+  case class StaleCheckpointTestCase(
+      name: String,
+      files: Seq[FileStatus],
+      lastCheckpointVersion: Optional[java.lang.Long],
+      versionToLoad: Optional[java.lang.Long] = Optional.empty(),
+      expectedVersion: Long,
+      expectedDeltas: Seq[FileStatus],
+      expectedCompactions: Seq[FileStatus] = Seq.empty,
+      expectedCheckpoints: Seq[FileStatus],
+      expectedCheckpointVersion: Option[Long],
+      expectedLastCommitTimestamp: Long)
+
+  private val staleCheckpointSuccessCases: Seq[StaleCheckpointTestCase] = Seq(
+    // _last_checkpoint=30, files go up to version 24, checkpoint at 10
+    // Step 4 fallback (empty listing from v30) triggers fallback
+    StaleCheckpointTestCase(
+      name = "stale _last_checkpoint beyond all existing files with earlier checkpoint available",
+      files = deltaFileStatuses(0L until 25L) ++ singularCheckpointFileStatuses(Seq(10L)),
+      lastCheckpointVersion = Optional.of(30L),
+      expectedVersion = 24,
+      expectedDeltas = deltaFileStatuses(11L until 25L),
+      expectedCheckpoints = singularCheckpointFileStatuses(Seq(10L)),
+      expectedCheckpointVersion = Some(10),
+      expectedLastCommitTimestamp = 240L),
+    // _last_checkpoint=30, files go up to version 24, no checkpoints at all
+    // Step 4 fallback triggers, fallback finds no checkpoint, re-lists from v0
+    StaleCheckpointTestCase(
+      name = "stale _last_checkpoint beyond all existing files with no earlier checkpoint",
+      files = deltaFileStatuses(0L until 25L),
+      lastCheckpointVersion = Optional.of(30L),
+      expectedVersion = 24,
+      expectedDeltas = deltaFileStatuses(0L until 25L),
+      expectedCheckpoints = Seq.empty,
+      expectedCheckpointVersion = None,
+      expectedLastCommitTimestamp = 240L),
+    // _last_checkpoint=20, deltas 15-24 exist, checkpoint at 15 exists, checkpoint at 20 deleted
+    // Step 6 fallback triggers, findLastCompleteCheckpointBefore(20) finds cp(15)
+    StaleCheckpointTestCase(
+      name = "stale _last_checkpoint where checkpoint was deleted but deltas exist from version",
+      files = deltaFileStatuses(15L until 25L) ++ singularCheckpointFileStatuses(Seq(15L)),
+      lastCheckpointVersion = Optional.of(20L),
+      expectedVersion = 24,
+      expectedDeltas = deltaFileStatuses(16L until 25L),
+      expectedCheckpoints = singularCheckpointFileStatuses(Seq(15L)),
+      expectedCheckpointVersion = Some(15),
+      expectedLastCommitTimestamp = 240L),
+    // Regression guard: time-travel bypasses _last_checkpoint entirely (uses
+    // findLastCompleteCheckpointBefore instead), so the stale hint never triggers
+    // the fallback. Kept here to ensure that path remains correct.
+    // _last_checkpoint=20 (deleted), checkpoint at 10 exists, load version 15
+    StaleCheckpointTestCase(
+      name = "stale _last_checkpoint with versionToLoad (time-travel bypasses fallback)",
+      files = deltaFileStatuses(0L until 25L) ++ singularCheckpointFileStatuses(Seq(10L)),
+      lastCheckpointVersion = Optional.of(20L),
+      versionToLoad = Optional.of(15L),
+      expectedVersion = 15,
+      expectedDeltas = deltaFileStatuses(11L to 15L),
+      expectedCheckpoints = singularCheckpointFileStatuses(Seq(10L)),
+      expectedCheckpointVersion = Some(10),
+      expectedLastCommitTimestamp = 150L),
+    // _last_checkpoint=5 (checkpoint deleted), deltas v0-v6, no checkpoints
+    // Step 6 fallback triggers, no earlier checkpoint found, re-lists from v0
+    StaleCheckpointTestCase(
+      name = "issue #5895 - stale _last_checkpoint with all checkpoints deleted, JSON-only",
+      files = deltaFileStatuses(0L to 6L),
+      lastCheckpointVersion = Optional.of(5L),
+      expectedVersion = 6,
+      expectedDeltas = deltaFileStatuses(0L to 6L),
+      expectedCheckpoints = Seq.empty,
+      expectedCheckpointVersion = None,
+      expectedLastCommitTimestamp = 60L),
+    // _last_checkpoint=30, deltas v0-v24, checkpoint at 10, compactions (11,15) and (16,20)
+    // Step 4 fallback triggers; verifies compaction files are included in the fallback result
+    StaleCheckpointTestCase(
+      name = "stale _last_checkpoint with compaction files in fallback range",
+      files = deltaFileStatuses(0L until 25L) ++
+        singularCheckpointFileStatuses(Seq(10L)) ++
+        compactedFileStatuses(Seq((11L, 15L), (16L, 20L))),
+      lastCheckpointVersion = Optional.of(30L),
+      expectedVersion = 24,
+      expectedDeltas = deltaFileStatuses(11L until 25L),
+      expectedCompactions = compactedFileStatuses(Seq((11L, 15L), (16L, 20L))),
+      expectedCheckpoints = singularCheckpointFileStatuses(Seq(10L)),
+      expectedCheckpointVersion = Some(10),
+      expectedLastCommitTimestamp = 240L),
+    // _last_checkpoint=20 exists and points to a valid checkpoint
+    // Verifies the retry loop does not break the normal (no-fallback) path
+    StaleCheckpointTestCase(
+      name = "valid _last_checkpoint - happy path regression guard",
+      files = deltaFileStatuses(0L until 25L) ++ singularCheckpointFileStatuses(Seq(20L)),
+      lastCheckpointVersion = Optional.of(20L),
+      expectedVersion = 24,
+      expectedDeltas = deltaFileStatuses(21L until 25L),
+      expectedCheckpoints = singularCheckpointFileStatuses(Seq(20L)),
+      expectedCheckpointVersion = Some(20),
+      expectedLastCommitTimestamp = 240L))
+
+  staleCheckpointSuccessCases.foreach { tc =>
+    test(s"getLogSegmentForVersion: ${tc.name}") {
+      val logSegment = snapshotManager.getLogSegmentForVersion(
+        createMockFSAndJsonEngineForLastCheckpoint(tc.files, tc.lastCheckpointVersion),
+        tc.versionToLoad)
+      checkLogSegment(
+        logSegment,
+        expectedVersion = tc.expectedVersion,
+        expectedDeltas = tc.expectedDeltas,
+        expectedCompactions = tc.expectedCompactions,
+        expectedCheckpoints = tc.expectedCheckpoints,
+        expectedCheckpointVersion = tc.expectedCheckpointVersion,
+        expectedLastCommitTimestamp = tc.expectedLastCommitTimestamp)
+    }
+  }
+
+  // _last_checkpoint=1, no files at all
+  // Step 4 fallback triggers, fallback listing also empty -> TableNotFoundException
+  test("getLogSegmentForVersion: stale _last_checkpoint with empty delta log") {
+    testExpectedError[TableNotFoundException](
+      files = Seq.empty,
+      lastCheckpointVersion = Optional.of(1L),
+      expectedErrorMessageContains = "No delta files found in the directory")
+  }
+
+  // _last_checkpoint=20, only deltas v20-v24 exist (no checkpoints, no files before v20)
+  // Primary: no checkpoint found -> returns empty. Fallback: lists from v0, finds deltas
+  // starting at v20 -> throws InvalidTableException (gap from v0). Caught and rethrown as
+  // missingCheckpoint for the hinted version.
+  test("getLogSegmentForVersion: stale _last_checkpoint - fallback checkpoint also deleted " +
+    "(truncated log)") {
+    testExpectedError[InvalidTableException](
+      files = deltaFileStatuses(20L until 25L),
+      lastCheckpointVersion = Optional.of(20L),
+      expectedErrorMessageContains = "Missing checkpoint at version 20")
+  }
+
+  // _last_checkpoint=30 (beyond all files), fallback finds checkpoint at 10
+  // but deltas after 10 are non-contiguous (11, 13 -- missing 12)
+  // Fallback throws InvalidTableException, caught and rethrown as missingCheckpoint
+  test("getLogSegmentForVersion: stale _last_checkpoint - fallback finds corrupt listing " +
+    "(exercises catch branch)") {
+    val files = deltaFileStatuses(Seq(10L, 11L, 13L)) ++
+      singularCheckpointFileStatuses(Seq(10L))
+    testExpectedError[InvalidTableException](
+      files,
+      lastCheckpointVersion = Optional.of(30L),
+      expectedErrorMessageContains = "Missing checkpoint at version 30")
   }
 
   /* ------------------- CATALOG MANAGED TABLE TESTS ------------------ */

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -925,6 +925,38 @@ trait AbstractDeltaTableReadsSuite extends AnyFunSuite { self: AbstractTestUtils
       expectedAnswer = (0L until 100L).map(TestRow(_)))
   }
 
+  test("read table with stale _last_checkpoint after checkpoint cleanup") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      // Write 15 versions (v0 through v14), each appending 10 rows.
+      // With the default checkpoint interval of 10, a checkpoint is created at v10.
+      (0 to 14).foreach { i =>
+        spark.range(i * 10, i * 10 + 10).write
+          .format("delta")
+          .mode("append")
+          .save(path)
+      }
+
+      val checkpointFile = new File(
+        f"$path/_delta_log/00000000000000000010.checkpoint.parquet")
+      assert(checkpointFile.exists(), "Expected checkpoint at version 10")
+
+      val lastCheckpointFile = new File(path + "/_delta_log/_last_checkpoint")
+      assert(lastCheckpointFile.exists(), "Expected _last_checkpoint file to exist")
+
+      // Delete the checkpoint file, simulating cleanup by vacuum or log retention.
+      // _last_checkpoint still references v10, making it stale.
+      assert(checkpointFile.delete(), "Failed to delete checkpoint file")
+
+      // Kernel should detect the stale _last_checkpoint, fall back to searching for an
+      // earlier valid checkpoint, find none, and reconstruct from delta files at version 0.
+      checkTable(
+        path = path,
+        expectedAnswer = (0L until 150L).map(TestRow(_)),
+        expectedVersion = Some(14))
+    }
+  }
+
   test("error - version not contiguous") {
     val e = intercept[InvalidTableException] {
       latestSnapshot(goldenTablePath("versions-not-contiguous"))


### PR DESCRIPTION
## [Kernel] Handle stale `_last_checkpoint` referencing deleted checkpoint files

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

When `_last_checkpoint` references a checkpoint that has been deleted (e.g. by aggressive log cleanup or manual intervention), Kernel's `SnapshotManager.getLogSegmentForVersion()` throws an opaque `missingCheckpoint` error, making the table unreadable even though valid delta files and/or earlier checkpoints exist on disk.

This PR adds a single-retry fallback: when the checkpoint hinted by `_last_checkpoint` is not found — either because the directory listing from that version is empty (Step 4) or because no complete checkpoint is present in the listing (Step 6) — the code calls `Checkpointer.findLastCompleteCheckpointBefore()` to search for an earlier valid checkpoint, then re-lists and rebuilds the `LogSegment`. A shared `isRetryAttempt` boolean ensures at most one retry total across both code paths.

This is consistent with the DSV1/Spark implementation in `SnapshotManagement.scala`, which uses the same one-shot fallback pattern via `getLogSegmentWithMaxExclusiveCheckpointVersion` for stale `_last_checkpoint` scenarios (as opposed to the separate, configurable `snapshotLoading.maxRetries` mechanism for corrupt checkpoint *content*, which is a different failure mode that doesn't apply to Kernel).

Resolves #5895

## How was this patch tested?

9 unit tests in `SnapshotManagerSuite.scala`:

**Modified existing tests (2):**
- `corrupt _last_checkpoint (is after existing versions)` — previously expected `missingCheckpoint` error; now expects successful fallback to an earlier checkpoint (matching DSV1 behavior)
- `corrupted incomplete multi-part checkpoint with no _last_checkpoint or a valid _last_checkpoint provided` — added a case where `_last_checkpoint` is absent alongside incomplete multi-part checkpoints

**New positive/fallback tests (5):**
- `stale _last_checkpoint refers to in-range version but no valid checkpoint - falls back to earlier checkpoint` — covers Step 6 fallback (checkpoint deleted but deltas remain), including incomplete multi-part checkpoint variant
- `stale _last_checkpoint beyond all existing files with earlier checkpoint available` — covers Step 4 fallback (empty listing, earlier checkpoint exists)
- `stale _last_checkpoint beyond all existing files with no earlier checkpoint` — covers Step 4 fallback when no checkpoints exist at all (JSON-only recovery from version 0)
- `stale _last_checkpoint where checkpoint was deleted but deltas exist from that version` — covers Step 6 fallback with an earlier checkpoint
- `issue #5895 - stale _last_checkpoint with all checkpoints deleted, JSON-only recovery` — directly reproduces the reported scenario

**New negative tests (2):**
- `stale _last_checkpoint with empty delta log` — fallback correctly produces `TableNotFoundException` for genuinely empty tables
- `stale _last_checkpoint - fallback checkpoint also deleted (truncated log)` — fallback correctly fails with `InvalidTableException` when the table is truly corrupt (no checkpoints and no complete history from version 0)

**Regression guard (1):**
- `valid _last_checkpoint - happy path regression guard` — ensures the retry loop doesn't break the normal (no-fallback) code path

## Does this PR introduce _any_ user-facing changes?

Yes. Previously, a stale `_last_checkpoint` file referencing a deleted checkpoint would cause Kernel to throw an error like:

```
Checkpoint file to load version: <N> is missing.
```

making the table completely unreadable even though sufficient data existed on disk to construct a valid snapshot.

After this change, Kernel automatically falls back to an earlier valid checkpoint (or to reading the full JSON commit history from version 0 if no checkpoints exist), and the table becomes readable again. This is a recovery improvement — no existing working behavior changes, and tables that previously errored now succeed.

This behavior is consistent with the existing DSV1/Spark implementation.
