### PR TITLE
[UC Commit Metrics] Use full-table histogram from snapshot

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DeletedRecordCountsHistogram
 import org.apache.spark.sql.delta.stats.DeletedRecordCountsHistogramUtils
-import org.apache.spark.sql.delta.stats.FileSizeHistogram
+import org.apache.spark.sql.delta.stats.{FileSizeHistogram, FileSizeHistogramUtils}
 
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions.{coalesce, col, collect_set, count, last, lit, sum, when}
@@ -188,7 +188,15 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
       "domainMetadata" -> collect_set(col("domainMetadata")),
       "metadata" -> last(col("metaData"), ignoreNulls = true),
       "protocol" -> last(col("protocol"), ignoreNulls = true),
-      "fileSizeHistogram" -> lit(null).cast(FileSizeHistogram.schema)
+      "fileSizeHistogram" -> {
+        if (spark.sessionState.conf.getConf(
+            DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED)) {
+          FileSizeHistogramUtils.histogramAggregate(
+            coalesce(col("add.size"), lit(-1L)).expr)
+        } else {
+          lit(null).cast(FileSizeHistogram.schema)
+        }
+      }
     ) ++ persistentDVsAggs ++ histogramDVsAgg
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.stats.FileSizeHistogram
+import org.apache.spark.sql.delta.stats.{FileSizeHistogram, FileSizeHistogramUtils}
 import org.apache.spark.sql.delta.util.{CatalogTableUtils, JsonUtils}
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
 
@@ -119,13 +119,14 @@ case class UpdateMetricsHook(catalogTable: Option[CatalogTable])
     val actions = txn.committedActions
     val version = txn.committedVersion
     val logPath = txn.deltaLog.logPath
+    val snapshotHistogram = txn.postCommitSnapshot.fileSizeHistogram
 
     implicit val ec: ExecutionContext =
       UpdateMetricsHook.getOrCreateExecutionContext(spark)
     UpdateMetricsHook.activeRequests.incrementAndGet()
     Future {
       val request = UpdateMetricsHook.buildRequest(
-        tableId, actions, version)
+        tableId, actions, version, snapshotHistogram)
       UpdateMetricsHook.sendMetrics(
         spark, request, catalogName)
       logDebug(
@@ -185,7 +186,9 @@ object UpdateMetricsHook {
   private[metrics] def buildRequest(
       tableId: String,
       committedActions: Seq[Action],
-      committedVersion: Long): ReportDeltaMetricsRequest = {
+      committedVersion: Long,
+      snapshotHistogram: Option[FileSizeHistogram] = None
+      ): ReportDeltaMetricsRequest = {
     val commitInfo =
       committedActions.collectFirst { case ci: CommitInfo => ci }
     val opMetrics =
@@ -205,8 +208,16 @@ object UpdateMetricsHook {
       numRowsRemoved =
         extractRowsRemoved(opMetrics, removeFiles),
       numRowsUpdated = extractRowsUpdated(opMetrics),
-      fileSizeHistogram =
-        buildFileSizeHistogram(addFiles, committedVersion)
+      fileSizeHistogram = snapshotHistogram match {
+        case Some(h) =>
+          FileSizeHistogramPayload(
+            sortedBinBoundaries = h.sortedBinBoundaries,
+            fileCounts = h.fileCounts.toSeq,
+            totalBytes = h.totalBytes.toSeq,
+            commitVersion = committedVersion)
+        case None =>
+          buildFileSizeHistogram(addFiles, committedVersion)
+      }
     )
 
     ReportDeltaMetricsRequest(
@@ -261,7 +272,7 @@ object UpdateMetricsHook {
   private def buildFileSizeHistogram(
       addFiles: Seq[AddFile],
       committedVersion: Long): FileSizeHistogramPayload = {
-    val histogram = FileSizeHistogram.emptyHistogram
+    val histogram = FileSizeHistogramUtils.emptyHistogram
     addFiles.foreach(f => histogram.insert(f.size))
     FileSizeHistogramPayload(
       sortedBinBoundaries = histogram.sortedBinBoundaries,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/FileSizeHistogram.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/FileSizeHistogram.scala
@@ -72,36 +72,6 @@ case class FileSizeHistogram(
 
 private[delta] object FileSizeHistogram {
 
-  private val KB = 1024L
-  private val MB = 1024L * KB
-  private val GB = 1024L * MB
-
-  // Exponentially spaced bins with finer resolution around the 128MB region.
-  val DEFAULT_BINS: IndexedSeq[Long] = IndexedSeq(
-    0L,
-    8*KB, 16*KB, 32*KB, 64*KB, 128*KB, 256*KB,
-    512*KB, 1*MB, 2*MB, 4*MB,
-    8*MB, 12*MB, 16*MB, 20*MB, 24*MB, 28*MB,
-    32*MB, 36*MB, 40*MB,
-    48*MB, 56*MB, 64*MB, 72*MB, 80*MB,
-    88*MB, 96*MB, 104*MB, 112*MB, 120*MB,
-    124*MB, 128*MB, 132*MB, 136*MB, 140*MB, 144*MB,
-    160*MB, 176*MB, 192*MB, 208*MB, 224*MB, 240*MB,
-    256*MB, 272*MB, 288*MB, 304*MB, 320*MB, 336*MB,
-    352*MB, 368*MB, 384*MB, 400*MB, 416*MB, 432*MB,
-    448*MB, 464*MB, 480*MB, 496*MB, 512*MB, 528*MB,
-    544*MB, 560*MB, 576*MB,
-    640*MB, 704*MB, 768*MB, 832*MB, 896*MB, 960*MB,
-    1024*MB, 1088*MB, 1152*MB, 1216*MB, 1280*MB,
-    1344*MB, 1408*MB,
-    1536*MB, 1664*MB, 1792*MB, 1920*MB, 2048*MB,
-    2304*MB, 2560*MB, 2816*MB, 3072*MB,
-    3328*MB, 3584*MB, 3840*MB, 4*GB,
-    8*GB, 16*GB, 32*GB, 64*GB, 128*GB, 256*GB
-  )
-
-  def emptyHistogram: FileSizeHistogram = FileSizeHistogram(DEFAULT_BINS)
-
   /**
    * Returns the index of the bin to which given fileSize belongs OR -1 if given fileSize doesn't
    * belongs to any bin

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/FileSizeHistogramUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/FileSizeHistogramUtils.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.stats
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.classic.ClassicConversions._
+import org.apache.spark.sql.functions.udf
+
+/**
+ * Histogram bin boundaries and helpers for [[FileSizeHistogram]].
+ */
+object FileSizeHistogramUtils {
+
+  private val KB: Long = 1024
+  private val MB: Long = 1024 * 1024
+  private val GB: Long = 1024 * 1024 * 1024
+
+  val DEFAULT_BINS: IndexedSeq[Long] = IndexedSeq(
+    0,
+    // Power of 2 till 4 MB
+    8 * KB, 16 * KB, 32 * KB, 64 * KB, 128 * KB, 256 * KB, 512 * KB, 1 * MB, 2 * MB, 4 * MB,
+    // 4 MB jumps till 40 MB
+    8 * MB, 12 * MB, 16 * MB, 20 * MB, 24 * MB, 28 * MB, 32 * MB, 36 * MB, 40 * MB,
+    // 8 MB jumps till 120 MB
+    48 * MB, 56 * MB, 64 * MB, 72 * MB, 80 * MB, 88 * MB, 96 * MB, 104 * MB, 112 * MB, 120 * MB,
+    // 4 MB jumps till 144 MB (since we want more detail around the 128 MB mark)
+    124 * MB, 128 * MB, 132 * MB, 136 * MB, 140 * MB, 144 * MB,
+    // 16 MB jumps till 576 MB (reasonable detail until past the 512 MB mark)
+    160 * MB, 176 * MB, 192 * MB, 208 * MB, 224 * MB, 240 * MB, 256 * MB, 272 * MB, 288 * MB,
+    304 * MB, 320 * MB, 336 * MB, 352 * MB, 368 * MB, 384 * MB, 400 * MB, 416 * MB, 432 * MB,
+    448 * MB, 464 * MB, 480 * MB, 496 * MB, 512 * MB, 528 * MB, 544 * MB, 560 * MB, 576 * MB,
+    // 64 MB jumps till 1408 MB (detail around the 1024MB mark, allowing for overshoot)
+    640 * MB, 704 * MB, 768 * MB, 832 * MB, 896 * MB, 960 * MB, 1024 * MB, 1088 * MB, 1152 * MB,
+    1216 * MB, 1280 * MB, 1344 * MB, 1408 * MB,
+    // 128 MB jumps till 2 GB
+    1536 * MB, 1664 * MB, 1792 * MB, 1920 * MB, 2048 * MB,
+    // 256 MB jumps till 4 GB
+    2304 * MB, 2560 * MB, 2816 * MB, 3072 * MB, 3328 * MB, 3584 * MB, 3840 * MB, 4 * GB,
+    // power of 2 till 256 GB
+    8 * GB, 16 * GB, 32 * GB, 64 * GB, 128 * GB, 256 * GB
+  )
+
+  /**
+   * Returns an empty histogram with [[DEFAULT_BINS]]
+   */
+  def emptyHistogram: FileSizeHistogram = FileSizeHistogram.apply(DEFAULT_BINS)
+
+  /**
+   * Returns a compacted version of this FileSizeHistogram where empty bins are merged together.
+   */
+  def compress(h: FileSizeHistogram): FileSizeHistogram = {
+    FileStatsHistogram.compress(h, FileSizeHistogram.apply)
+  }
+
+
+  /**
+   * An imperative aggregate implementation of FileSizeHistogram.
+   * Extends the base FileStatsHistogramAggBase class with file size specific bins.
+   */
+  case class FileSizeHistogramAgg(
+    child: Expression,
+    sortedBinBoundaries: IndexedSeq[Long] = DEFAULT_BINS,
+    mutableAggBufferOffset: Int = 0,
+    inputAggBufferOffset: Int = 0
+  ) extends FileStatsHistogram.FileStatsHistogramAggBase {
+
+    override protected def withNewChildInternal(newChild: Expression): FileSizeHistogramAgg =
+      copy(child = newChild)
+
+    override def withNewMutableAggBufferOffset(offset: Int): FileSizeHistogramAgg =
+      copy(mutableAggBufferOffset = offset)
+
+    override def withNewInputAggBufferOffset(offset: Int): FileSizeHistogramAgg =
+      copy(inputAggBufferOffset = offset)
+  }
+
+  /**
+   * A UDF to convert flattenedHistogram (returned by [[FileSizeHistogramAgg]]) to
+   * [[FileSizeHistogram]]
+   */
+  private lazy val flattenedHistogramToHistogramUDF = udf((flattenedHistogram: Array[Long]) => {
+    val splits = flattenedHistogram.grouped(flattenedHistogram.length / 3).toSeq
+    new FileSizeHistogram(splits(0), splits(1), splits(2))
+  })
+
+  def histogramAggregate(child: Expression): Column = {
+    val aggregate = Column(FileSizeHistogramAgg(child).toAggregateExpression())
+    FileSizeHistogramUtils.flattenedHistogramToHistogramUDF(aggregate)
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6503/files/7cef73e0d954e450f833965cba7348e5114c26b9..fd89464e3dd4bb72323a0cac559f1b3c0a418faa) to review incremental changes.

**Stack:**
- [[Delta] Export FileSizeHistogramUtils to OSS](https://github.com/delta-io/delta/pull/6502) [[Files changed](https://github.com/delta-io/delta/pull/6502/files)]
  - **[[UC Commit Metrics] Use full-table histogram from snapshot](https://github.com/delta-io/delta/pull/6503)** [[Files changed](https://github.com/delta-io/delta/pull/6503/files/7cef73e0d954e450f833965cba7348e5114c26b9..fd89464e3dd4bb72323a0cac559f1b3c0a418faa)] ⬅️ _This PR_

---

## Summary
- Enable `FileSizeHistogram` aggregation in `SnapshotState` when `commitMetrics.enabled` is true, using the newly exported `FileSizeHistogramUtils.histogramAggregate`.
- Remove stopgap `DEFAULT_BINS` / `emptyHistogram` from `FileSizeHistogram` companion object (now provided by `FileSizeHistogramUtils` via PR #6502).
- `UpdateMetricsHook` reads `postCommitSnapshot.fileSizeHistogram` for the full-table histogram, falling back to per-commit histogram from AddFiles when the snapshot histogram is unavailable.

Builds on #6502 (exports FileSizeHistogramUtils to OSS).

## Test plan
- [ ] `build/sbt "spark/testOnly *metrics.UpdateMetricsHookSuite"`
- [ ] `build/sbt "spark/testOnly *SnapshotSuite"`