### PR TITLE
Add delta.parquet.format.version table property implementation

### DIFF
--- a/spark/src/main/java/org/apache/spark/sql/delta/util/ParquetFormatVersion.java
+++ b/spark/src/main/java/org/apache/spark/sql/delta/util/ParquetFormatVersion.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util;
+
+import org.apache.parquet.SemanticVersion;
+import org.apache.parquet.SemanticVersion.SemanticVersionParseException;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
+
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Supported Parquet format versions for Delta tables. Each value maps to a version listed in
+ * https://parquet.apache.org/blog/parquet-format/.
+ */
+public enum ParquetFormatVersion {
+  // Must be in ascending SemanticVersion sorted order as resolve() assumes values() is sorted.
+  V1_0_0(new SemanticVersion(1, 0, 0)),
+  V2_12_0(new SemanticVersion(2, 12, 0));
+
+  private final SemanticVersion semver;
+
+  ParquetFormatVersion(SemanticVersion semver) {
+    this.semver = semver;
+  }
+
+  public String getVersion() {
+    return this.semver.toString();
+  }
+
+  public WriterVersion getWriterVersion() {
+    if (this == V1_0_0) return WriterVersion.PARQUET_1_0;
+    if (this == V2_12_0) return WriterVersion.PARQUET_2_0;
+    throw new IllegalArgumentException("Unsupported Parquet format version: " + this);
+  }
+
+  public int compare(ParquetFormatVersion other) {
+    return this.semver.compareTo(other.semver);
+  }
+
+  /**
+   * Resolves a version string to the highest known ParquetFormatVersion whose version is <= the
+   * input. Exact matches on known versions use a fast path. Arbitrary 3-part semver strings are
+   * accepted and resolved to the closest known version. Throws if the input is not a valid 3-part
+   * semver or if no known version is <= the input.
+   */
+  public static ParquetFormatVersion resolve(String s) {
+    SemanticVersion target;
+    try {
+      target = SemanticVersion.parse(s);
+    } catch (SemanticVersionParseException e) {
+      throw new IllegalArgumentException("Invalid Parquet version string: " + s, e);
+    }
+
+    // Find the highest supported version that is <= the target.
+    ParquetFormatVersion[] versions = values();
+    for (int i = versions.length - 1; i >= 0; i--) {
+      if (versions[i].semver.compareTo(target) <= 0) return versions[i];
+    }
+    throw new IllegalArgumentException("No matching Parquet format version <= " + s);
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.{DataSkippingReaderConf, StatisticsCollection}
 import org.apache.spark.sql.delta.util.{DeltaSqlParserUtils, JsonUtils}
+import org.apache.spark.sql.delta.util.ParquetFormatVersion
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.{DateTimeConstants, IntervalUtils}
@@ -609,6 +610,23 @@ trait DeltaConfigsBase extends DeltaLogging {
     fromString = _.toBoolean,
     validationFunction = _ => true,
     helpMessage = "needs to be a boolean.")
+
+  /*
+   * This is the table property that determines which Parquet format version should be used when
+   * writing new Parquet files on the table.
+   */
+  val PARQUET_FORMAT_VERSION: DeltaConfig[Option[String]] =
+    buildConfig[Option[String]](
+      "parquet.format.version",
+      ParquetFormatVersion.V1_0_0.getVersion(),
+      fromString = v => Option(v),
+      validationFunction = v => {
+        v.foreach(s => ParquetFormatVersion.resolve(s))
+        true
+      },
+      s"needs to be a valid Parquet format version " +
+      s"(${ParquetFormatVersion.values().map(_.getVersion).mkString(", ")})"
+    )
 
   val ENABLE_VARIANT_SHREDDING = buildConfig[Boolean](
     key = "enableVariantShredding",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -356,6 +356,7 @@ object DeltaOptions extends DeltaLogging {
   val TIMESTAMP_AS_OF = "timestampAsOf"
 
   val COMPRESSION = "compression"
+  val PARQUET_VERSION = "parquet.writer.version"
   val MAX_RECORDS_PER_FILE = "maxRecordsPerFile"
   val TXN_APP_ID = "txnAppId"
   val TXN_VERSION = "txnVersion"
@@ -384,6 +385,7 @@ object DeltaOptions extends DeltaLogging {
    * An option to control if delta will write partition columns to data files
    */
   val WRITE_PARTITION_COLUMNS = "writePartitionColumns"
+  val PARQUET_OUTPUT_TIMESTAMP_TYPE = SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key
 
   val validOptionKeys : Set[String] = Set(
     IS_DATAFRAME_WRITER_V1_SAVE_AS_TABLE_OVERWRITE,
@@ -414,6 +416,8 @@ object DeltaOptions extends DeltaLogging {
     CDC_END_VERSION,
     COMPRESSION,
     MAX_RECORDS_PER_FILE,
+    PARQUET_VERSION,
+    PARQUET_OUTPUT_TIMESTAMP_TYPE,
     TXN_APP_ID,
     TXN_VERSION,
     SCHEMA_TRACKING_LOCATION,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.delta.stats.{
   StatisticsCollection,
   StatsCollectionUtils
 }
+import org.apache.spark.sql.delta.util.TableParquetVersionOption
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.Path
 
@@ -478,16 +479,23 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
         protocol.isFeatureSupported(MaterializePartitionColumnsTableFeature)
       // Retain only a minimal selection of Spark writer options to avoid any potential
       // compatibility issues
-      val options = (writeOptions match {
+      val filteredOptions = (writeOptions match {
         case None => Map.empty[String, String]
         case Some(writeOptions) =>
           writeOptions.options.filterKeys { key =>
             key.equalsIgnoreCase(DeltaOptions.MAX_RECORDS_PER_FILE) ||
-              key.equalsIgnoreCase(DeltaOptions.COMPRESSION)
+              key.equalsIgnoreCase(DeltaOptions.COMPRESSION) ||
+              key.equalsIgnoreCase(DeltaOptions.PARQUET_VERSION) ||
+              key.equalsIgnoreCase(DeltaOptions.PARQUET_OUTPUT_TIMESTAMP_TYPE)
           }.toMap
-      }) + (DeltaOptions.WRITE_PARTITION_COLUMNS -> writePartitionColumns.toString) ++
+      }) + (DeltaOptions.WRITE_PARTITION_COLUMNS -> writePartitionColumns.toString)
+      val options = filteredOptions ++
         VariantShreddingShims.getVariantInferShreddingSchemaOptions(
-          DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata))
+          DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)) ++
+        TableParquetVersionOption.getWriterOptions(
+          spark = spark,
+          writerOptions = filteredOptions,
+          tableProperties = metadata.configuration)
 
       try {
         DeltaFileFormatWriter.write(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3371,6 +3371,16 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .doc("Maximum number of files allowed in initial snapshot for V2 streaming.")
       .intConf
       .createWithDefault(100000)
+
+  val TABLE_PARQUET_V2_DEFAULT_TIMESTAMP_ENCODING =
+    buildConf("table.parquetV2.timestampOutputType")
+      .internal()
+      .doc("Sets the Parquet timestamp type to use when writing to Delta tables with Parquet " +
+        "format version 2.12.0 or higher. The default is TIMESTAMP_MICROS, which stores number " +
+        "microseconds from the Unix epoch as an int64 value in Parquet.")
+      .stringConf
+      .checkValues(SQLConf.ParquetOutputTimestampType.values.map(_.toString))
+      .createWithDefault(SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TableParquetVersionOption.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TableParquetVersionOption.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.parquet.column.ParquetProperties.{WriterVersion => ParquetWriterVersion}
+import org.apache.parquet.hadoop.ParquetOutputFormat
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
+
+object TableParquetVersionOption {
+  private val tablePropKey = DeltaConfigs.PARQUET_FORMAT_VERSION.key
+  private val writerOptionKey = ParquetOutputFormat.WRITER_VERSION
+
+  /**
+   * Determines the writer options to add to indicate the Parquet format version of the files
+   * being written. The precedence order is:
+   * 1. The ParquetOutputFormat.WRITER_VERSION DataFrame writer option or table property
+   *    (e.g. if specified via CREATE TABLE ... OPTIONS).
+   * 2. The DeltaConfigs.PARQUET_FORMAT_VERSION table property.
+   * 3. The ParquetOutputFormat.WRITER_VERSION Spark configuration.
+   * 4. Parquet v1 (the final default).
+   */
+  def getWriterOptions(
+    spark: SparkSession,
+    writerOptions: Map[String, String],
+    tableProperties: Map[String, String]
+  ): Map[String, String] = {
+    if (writerOptions.contains(writerOptionKey)
+    ) {
+      Map.empty[String, String]
+    } else if (tableProperties.contains(writerOptionKey)) {
+      Map(writerOptionKey -> tableProperties(writerOptionKey))
+    } else if (tableProperties.contains(tablePropKey)
+    ) {
+      val version = ParquetFormatVersion.resolve(tableProperties(tablePropKey))
+      getWriterOptions(spark, version)
+    } else {
+      Map(
+        writerOptionKey -> spark.sessionState.conf.getConfString(
+          writerOptionKey, writerVersionShortName(ParquetWriterVersion.PARQUET_1_0)
+        )
+      )
+    }
+  }
+
+  private def getWriterOptions(
+    spark: SparkSession,
+    version: ParquetFormatVersion
+  ): Map[String, String] = {
+    Map(
+      writerOptionKey -> writerVersionShortName(ParquetWriterVersion.PARQUET_1_0)
+    ) ++ (
+      if (version.compare(ParquetFormatVersion.V2_12_0) >= 0) {
+        Map(
+          writerOptionKey -> writerVersionShortName(ParquetWriterVersion.PARQUET_2_0),
+          SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> spark.sessionState.conf.getConf(
+            DeltaSQLConf.TABLE_PARQUET_V2_DEFAULT_TIMESTAMP_ENCODING
+          )
+        )
+      } else {
+        Map.empty
+      }
+    )
+  }
+
+  def writerVersionShortName(v: ParquetWriterVersion): String = v match {
+    case ParquetWriterVersion.PARQUET_1_0 => "v1"
+    case ParquetWriterVersion.PARQUET_2_0 => "v2"
+    case other => throw new IllegalArgumentException(
+      s"Unrecognized ParquetWriterVersion: $other")
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFormatVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFormatVersionSuite.scala
@@ -1,0 +1,253 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.ParquetFormatVersion
+import org.apache.spark.sql.delta.util.TableParquetVersionOption.writerVersionShortName
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.column.Encoding
+import org.apache.parquet.column.ParquetProperties.{WriterVersion => ParquetWriterVersion}
+import org.apache.parquet.hadoop.{ParquetFileReader, ParquetOutputFormat}
+import org.apache.parquet.hadoop.util.HadoopInputFile
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrameWriter, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
+import org.apache.spark.sql.functions.current_timestamp
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.delta.test.shims.GridTestShim
+
+class DeltaParquetFormatVersionSuite
+    extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest
+    with GridTestShim {
+  import testImplicits._
+
+  val v1Format: ParquetFormatVersion = ParquetFormatVersion.V1_0_0
+  val v2Format: ParquetFormatVersion = ParquetFormatVersion.V2_12_0
+  val v1Writer: ParquetWriterVersion = ParquetWriterVersion.PARQUET_1_0
+  val v2Writer: ParquetWriterVersion = ParquetWriterVersion.PARQUET_2_0
+  val tablePropertyKey: String = DeltaConfigs.PARQUET_FORMAT_VERSION.key
+  val writerOptionKey: String = ParquetOutputFormat.WRITER_VERSION
+
+  private def validateFileParquetVersion(table: String,
+    formatVersion: ParquetFormatVersion): Unit = {
+    val catalogTable = spark.sessionState.catalog
+      .getTableMetadata(TableIdentifier(table))
+    val files = DeltaLog
+      .forTable(spark, catalogTable)
+      .update()
+      .allFiles
+      .collect()
+    assert(files.nonEmpty)
+
+    files.foreach { addFile =>
+      val path = ExternalCatalogUtils.unescapePathName(
+        s"${catalogTable.location}/${addFile.path}"
+      )
+      val file = HadoopInputFile.fromPath(new Path(path), new Configuration())
+      val reader = ParquetFileReader.open(file)
+      try {
+        val encodings = reader.getFooter
+          .getBlocks
+          .asScala
+          .flatMap(
+            _.getColumns.asScala.flatMap(_.getEncodings.asScala.toSet)
+          ).toSet
+        formatVersion match {
+          case ParquetFormatVersion.V1_0_0 =>
+            assert(!encodings.contains(Encoding.DELTA_BINARY_PACKED))
+          case ParquetFormatVersion.V2_12_0 =>
+            assert(encodings.contains(Encoding.DELTA_BINARY_PACKED))
+          case _ =>
+            fail(s"Unexpected format version: $formatVersion")
+        }
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
+  private def writeDF: DataFrameWriter[Row] = {
+    (1 to 100)
+      .map(i => (i, i.toString))
+      .toDF("c0", "c1")
+      .withColumn("c2", current_timestamp())
+      .repartition(10)
+      .write
+      .format("delta")
+  }
+
+  private def getProperties(tableName: String): Map[String, String] =
+    sql(s"describe detail $tableName")
+      .collect()
+      .head
+      .getAs[Map[String, String]]("properties")
+
+  def validateProperties(
+    table: String,
+    includedProps: Map[String, String],
+    excludedProps: String*
+  ): Unit = {
+    val props = getProperties(table)
+    includedProps.foreach { case (k, v) => assert(props.get(k).contains(v)) }
+    excludedProps.foreach { k => assert(!props.contains(k)) }
+  }
+
+  /**
+   * Guard for tests that need SPARK-56414 (per-write options overriding session conf in Parquet
+   * writes). Databricks Spark always has the fix; OSS Spark needs >= 4.2.
+   */
+  private def assumeSpark56414Available(): Unit = {
+    assume(spark.version >= "4.2",
+      "Requires SPARK-56414 (per-write options override session conf in Parquet writes)")
+  }
+
+  gridTest("DataFrame options are respected")(Seq(
+    (v1Writer, v1Format),
+    (v2Writer, v2Format)
+  )) { case (writerVersion, formatVersion) =>
+    if (formatVersion == v2Format) assumeSpark56414Available()
+    withTable("t1") {
+      writeDF.option(writerOptionKey, writerVersionShortName(writerVersion)).saveAsTable("t1")
+      validateProperties("t1", Map.empty, tablePropertyKey, writerOptionKey)
+      validateFileParquetVersion("t1", formatVersion)
+    }
+  }
+
+  gridTest("CREATE TABLE options are respected")(Seq(
+    (v1Writer, v1Format),
+    (v2Writer, v2Format)
+  )) { case (writerVersion, formatVersion) =>
+    withTable("t1") {
+      sql(s"""CREATE TABLE t1 (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+      |OPTIONS ('${writerOptionKey}' = '${writerVersionShortName(writerVersion)}')
+      """.stripMargin)
+      writeDF.mode("append").saveAsTable("t1")
+      validateProperties("t1", Map(writerOptionKey -> writerVersionShortName(writerVersion)),
+        tablePropertyKey)
+      validateFileParquetVersion("t1", formatVersion)
+    }
+  }
+
+  gridTest("CREATE TABLE TBLPROPERTIES are respected")(Seq(v1Format, v2Format)) { formatVersion =>
+    if (formatVersion == v2Format) assumeSpark56414Available()
+    withTable("t1") {
+      sql(s"""CREATE TABLE t1 (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+      |TBLPROPERTIES ('${tablePropertyKey}' = '${formatVersion.getVersion()}')
+      """.stripMargin)
+      writeDF.mode("append").saveAsTable("t1")
+      validateProperties("t1", Map(tablePropertyKey -> formatVersion.getVersion()),
+        writerOptionKey)
+      validateFileParquetVersion("t1", formatVersion)
+    }
+  }
+
+  gridTest("Spark conf is respected")(Seq(
+    (v1Writer, v1Format),
+    (v2Writer, v2Format)
+  )) { case (writerVersion, formatVersion) =>
+    withTable("t1") {
+      withSQLConf(
+        writerOptionKey -> writerVersionShortName(writerVersion)
+      ) {
+        writeDF.saveAsTable("t1")
+        validateProperties("t1", Map.empty, tablePropertyKey, writerOptionKey)
+        validateFileParquetVersion("t1", formatVersion)
+      }
+    }
+  }
+
+  gridTest("Table property can be an arbitrary version string")(Seq(
+    ("1.1.1", v1Format),
+    ("99.99.99", v2Format)
+  )) { case (formatVersionStr, formatVersion) =>
+    if (formatVersion == v2Format) assumeSpark56414Available()
+    withTable("t1") {
+      sql(s"""CREATE TABLE t1 (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+      |TBLPROPERTIES ('${tablePropertyKey}' = '${formatVersionStr}')
+      """.stripMargin)
+      writeDF.mode("append").saveAsTable("t1")
+      validateProperties("t1", Map(tablePropertyKey -> formatVersionStr),
+        writerOptionKey)
+      validateFileParquetVersion("t1", formatVersion)
+    }
+  }
+
+  test("DataFrame option wins") {
+    withTable("t1") {
+      sql(s"""CREATE TABLE t1 (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+      |TBLPROPERTIES ('${tablePropertyKey}' = '${v2Format.getVersion()}')
+      """.stripMargin)
+      validateProperties("t1", Map(tablePropertyKey -> v2Format.getVersion()))
+      writeDF.option(writerOptionKey, writerVersionShortName(v1Writer))
+        .mode("append").saveAsTable("t1")
+      validateFileParquetVersion("t1", v1Format)
+    }
+  }
+
+  test("CREATE TABLE option wins") {
+    withTable("t1") {
+      withSQLConf(
+        writerOptionKey -> writerVersionShortName(v2Writer)
+      ) {
+        sql(s"""CREATE TABLE t1 (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+        |OPTIONS ('${writerOptionKey}' = '${writerVersionShortName(v1Writer)}')
+        """.stripMargin)
+        validateProperties("t1", Map(writerOptionKey -> writerVersionShortName(v1Writer)))
+        writeDF.mode("append").saveAsTable("t1")
+        validateFileParquetVersion("t1", v1Format)
+      }
+    }
+  }
+
+  test("CREATE TABLE property wins") {
+    assumeSpark56414Available()
+    withTable("t1") {
+      withSQLConf(
+        writerOptionKey -> writerVersionShortName(v2Writer)
+      ) {
+        sql(s"""CREATE TABLE t1 (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+        |TBLPROPERTIES ('${tablePropertyKey}' = '${v1Format.getVersion()}')
+        """.stripMargin)
+        validateProperties("t1", Map(tablePropertyKey -> v1Format.getVersion()))
+        writeDF.mode("append").saveAsTable("t1")
+        validateFileParquetVersion("t1", v1Format)
+      }
+    }
+  }
+
+  test("ALTER TABLE can change the Parquet version") {
+    withTable("t1") {
+      sql(s"""CREATE TABLE t1 (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+      |TBLPROPERTIES ('${tablePropertyKey}' = '${v2Format.getVersion()}')
+      """.stripMargin)
+      validateProperties("t1", Map(tablePropertyKey -> v2Format.getVersion()))
+      sql(s"ALTER TABLE t1 SET TBLPROPERTIES ('${tablePropertyKey}' = '${v1Format.getVersion()}')")
+      validateProperties("t1", Map(tablePropertyKey -> v1Format.getVersion()))
+      writeDF.mode("append").saveAsTable("t1")
+      validateFileParquetVersion("t1", v1Format)
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR adds an implementation of the `delta.parquet.format.version` table property. This property has valid values `"1.0.0"` and `"2.12.0"` (for now, the idea is that more will be added as newer Parquet format features are introduced). It is used only when writing to a Delta table: the writer takes the version set on the table and uses it to decide which Parquet features it can use. The PR also introduces a precedence order to decide between Spark configs, table options, and table properties for this feature. 

## How was this patch tested?
New test suite to verify the behavior and precedence.

## Does this PR introduce _any_ user-facing changes?
Yes, a new table property. It is not set by default on tables and is only opt-in.
