### PR TITLE
[Spark] Add table property to write partition columns, default to true

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -1031,6 +1031,18 @@ trait DeltaConfigsBase extends DeltaLogging {
     v => Option(v).map(_.toBoolean),
     _ => true,
     "needs to be a boolean.")
+
+
+  /**
+   * If false, does not write partition columns in parquet data files. Defaults to
+   * writing partition columns in parquet data files if unset.
+   */
+  val WRITE_PARTITION_COLUMNS_TO_PARQUET = buildConfig[Option[Boolean]](
+    "writePartitionColumnsToParquet",
+    null,
+    v => Option(v).map(_.toBoolean),
+    _ => true,
+    "needs to be a boolean.")
 }
 
 object DeltaConfigs extends DeltaConfigsBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -476,7 +476,8 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
 
       // Iceberg spec requires partition columns in data files
       val writePartitionColumns = IcebergCompat.isAnyEnabled(metadata) ||
-        protocol.isFeatureSupported(MaterializePartitionColumnsTableFeature)
+        protocol.isFeatureSupported(MaterializePartitionColumnsTableFeature) ||
+        DeltaConfigs.WRITE_PARTITION_COLUMNS_TO_PARQUET.fromMetaData(metadata).getOrElse(true)
       // Retain only a minimal selection of Spark writer options to avoid any potential
       // compatibility issues
       val filteredOptions = (writeOptions match {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MaterializePartitionColumnsFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MaterializePartitionColumnsFeatureSuite.scala
@@ -102,7 +102,8 @@ class MaterializePartitionColumnsFeatureSuite
            |PARTITIONED BY (partCol)
            |""".stripMargin)
       sql(s"ALTER TABLE $tbl SET TBLPROPERTIES ('${DeltaConfigs
-        .ENABLE_MATERIALIZE_PARTITION_COLUMNS_FEATURE.key}' = 'true')")
+        .ENABLE_MATERIALIZE_PARTITION_COLUMNS_FEATURE.key}' = 'true'," +
+        s"'${DeltaConfigs.WRITE_PARTITION_COLUMNS_TO_PARQUET.key}' = 'false')")
 
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/files/TransactionalWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/files/TransactionalWriteSuite.scala
@@ -16,9 +16,16 @@
 
 package org.apache.spark.sql.delta.files
 
-import org.apache.spark.sql.delta.DeltaLog
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaLog}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.DeltaFileOperations
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.util.HadoopInputFile
 
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.functions.column
@@ -66,6 +73,40 @@ class TransactionalWriteSuite extends QueryTest with SharedSparkSession with Del
         snapshot.allFiles.collect().foreach { f =>
           assert(!f.path.startsWith("data/"))
         }
+      }
+    }
+  }
+
+  test("partitioned table defaults to writing partition columns to parquet files") {
+    withTempDir { dir =>
+      spark.range(100).toDF("id")
+        .withColumn("partCol", column("id") % 5)
+        .write.format("delta")
+        .partitionBy("partCol")
+        .save(dir.getCanonicalPath)
+
+      val deltaLog = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = deltaLog.update()
+      val files = snapshot.allFiles.collect()
+      assert(files.nonEmpty)
+
+      val logicalToPhysicalNameMap =
+        DeltaColumnMapping.getLogicalNameToPhysicalNameMap(snapshot.schema)
+      val physicalPartCol = logicalToPhysicalNameMap(Seq("partCol")).head
+
+      files.foreach { file =>
+        val filePath = DeltaFileOperations.absolutePath(deltaLog.dataPath.toString, file.path)
+        val fileReader = ParquetFileReader.open(
+          HadoopInputFile.fromPath(new Path(filePath.toString), new Configuration()))
+        val parquetSchema = try {
+          fileReader.getFooter.getFileMetaData.getSchema
+        } finally {
+          fileReader.close()
+        }
+        val fieldNames = parquetSchema.getFields.asScala.map(_.getName).toSet
+        assert(fieldNames.contains(physicalPartCol),
+          s"Partition column 'partCol' (physical: '$physicalPartCol') should be present " +
+            s"in parquet file ${file.path}, but found fields: $fieldNames")
       }
     }
   }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This change adds a new table property
delta.writePartitionColumnsToParquet that controls whether partition columns are materialized to data parquet files. If set to true, or unset (default), we write partition columns to all data parquet files. If false, we revert to the old behaviour.

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

No
