### PR TITLE
[Kernel] Support def value in v3

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV3MetadataValidatorAndUpdater.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV3MetadataValidatorAndUpdater.java
@@ -116,6 +116,7 @@ public class IcebergWriterCompatV3MetadataValidatorAndUpdater
                   VARIANT_SHREDDING_RW_FEATURE,
                   VARIANT_SHREDDING_PREVIEW_RW_FEATURE,
                   VARIANT_RW_PREVIEW_FEATURE,
+                  ALLOW_COLUMN_DEFAULTS_W_FEATURE,
                   // Also allow writerV1 features for backward compatibility.
                   //
                   // Note: We already enforce that these features cannot be enabled

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV3MetadataValidatorAndUpdaterSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/icebergcompat/IcebergWriterCompatV3MetadataValidatorAndUpdaterSuite.scala
@@ -431,23 +431,12 @@ class IcebergWriterCompatV3MetadataValidatorAndUpdaterSuite
       "variantShredding-preview",
       "icebergCompatV2",
       "icebergWriterCompatV1",
+      "allowColumnDefaults",
       "catalogManaged")
     val protocol = new Protocol(3, 7, readerFeatures.asJava, writerFeatures.asJava)
     val metadata = getCompatEnabledMetadata(cmTestSchema())
     validateAndUpdateIcebergWriterCompatV3Metadata(true, metadata, protocol, Optional.empty())
     validateAndUpdateIcebergWriterCompatV3Metadata(false, metadata, protocol, Optional.empty())
-  }
-
-  Seq("defaultColumns").foreach { unsupportedIncompatibleFeature =>
-    test(s"cannot enable with incompatible UNSUPPORTED feature $unsupportedIncompatibleFeature") {
-      // We add this test here so that it will fail when we add Kernel support for these features
-      // When this happens -> add the feature to the test above
-      checkUnsupportedOrIncompatibleFeature(
-        unsupportedIncompatibleFeature,
-        "Unsupported Delta table feature: table requires feature " +
-          s""""$unsupportedIncompatibleFeature" which is unsupported by this version of """ +
-          "Delta Kernel")
-    }
   }
 
   /* --- INVARIANTS_INACTIVE_CHECK tests --- */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Make Iceberg V3 support Default Value table feature
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Updating existing UT to support it.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
