### PR TITLE
[kernel-spark] Migrate schema evolution streaming test suite to V2 connector

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.test
 
 import org.apache.spark.sql.delta.DeltaSourceDeletionVectorsSuite
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 /**
  * Test suite that runs DeltaSourceDeletionVectorsSuite using the V2 connector
@@ -28,18 +27,9 @@ class DeltaV2SourceDeletionVectorsSuite
 
   override protected def useDsv2: Boolean = true
 
-  /**
-   * Override executeDml to temporarily use V1 connector for DML operations.
-   * SparkTable (V2) is read-only and does not support writes, so DML must
-   * go through the V1 path. Only streaming reads use the V2 connector.
-   */
-  override protected def executeDml(sqlText: String): Unit = {
-    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {
-      sql(sqlText)
-    }
-  }
+  override protected def executeDml(sqlText: String): Unit = executeInV1Mode(sqlText)
 
-  private lazy val shouldPassTests = Set(
+  override protected def shouldPassTests: Set[String] = Set(
     "allow to delete files before starting a streaming query",
     "allow to delete files before staring a streaming query without checkpoint",
     "multiple deletion vectors per file with initial snapshot",
@@ -68,16 +58,5 @@ class DeltaV2SourceDeletionVectorsSuite
     "multiple deletion vectors per file - List((ignoreFileDeletion,true))"
   )
 
-  private lazy val shouldFailTests = Set.empty[String]
-
-  override protected def shouldFail(testName: String): Boolean = {
-    val inPassList = shouldPassTests.contains(testName)
-    val inFailList = shouldFailTests.contains(testName)
-
-    assert(inPassList || inFailList, s"Test '$testName' not in shouldPassTests or shouldFailTests")
-    assert(!(inPassList && inFailList),
-      s"Test '$testName' in both shouldPassTests and shouldFailTests")
-
-    inFailList
-  }
+  override protected def shouldFailTests: Set[String] = Set.empty
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.{
+  DeltaLog,
+  DeltaSourceSchemaEvolutionCDCIdColumnMappingSuite,
+  DeltaSourceSchemaEvolutionCDCNameColumnMappingSuite,
+  DeltaSourceSchemaEvolutionIdColumnMappingSuite,
+  DeltaSourceSchemaEvolutionNameColumnMappingSuite,
+  StreamingSchemaEvolutionSuiteBase
+}
+
+/**
+ * Test suite that runs DeltaSourceSchemaEvolutionSuite using the V2 connector
+ * (V2_ENABLE_MODE=STRICT).
+ */
+
+/**
+ * Base trait for V2 schema evolution streaming tests.
+ * Provides common overrides shared by all V2 schema evolution suites.
+ */
+trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
+  self: StreamingSchemaEvolutionSuiteBase =>
+
+  override protected def useDsv2: Boolean = true
+
+  // V2ForceTest handles test selection via shouldFail/shouldPass,
+  // so disable DeltaColumnMappingSelectedTestMixin's runOnlyTests filter.
+  override protected def runAllTests: Boolean = true
+  override protected def runOnlyTests: Seq[String] = Seq()
+
+  // Override testSchemaEvolution to use test() instead of super.test() so that
+  // V2ForceTest.test() can intercept and apply shouldFail logic.
+  // In the V1 base, testSchemaEvolution calls super.test() which resolves to
+  // DeltaColumnMappingSelectedTestMixin.test() in the linearization, bypassing
+  // V2ForceTest.test(). Using test() ensures the full override chain is invoked.
+  override protected def testSchemaEvolution(
+      testName: String,
+      columnMapping: Boolean = true,
+      tags: Seq[org.scalatest.Tag] = Seq.empty)(f: DeltaLog => Unit): Unit = {
+    test(testName, tags: _*) {
+      if (columnMapping) {
+        withStarterTable { log =>
+          f(log)
+        }
+      } else {
+        withColumnMappingConf("none") {
+          withStarterTable { log =>
+            f(log)
+          }
+        }
+      }
+    }
+  }
+
+  // TODO(#5319): Move tests to shouldPassTests as V2 schema tracking log support is implemented.
+  protected def shouldPassTests: Set[String] = Set.empty[String]
+
+  // All tests from StreamingSchemaEvolutionSuiteBase.
+  // Override in CDC suites to add CDC-specific tests.
+  protected def shouldFailTests: Set[String] = Set(
+    // ========== Schema location validation ==========
+    "schema location not under checkpoint",
+    "schema location same as checkpoint",
+    "schema location using a different file system",
+    "schema / checkpoint location unit tests - " +
+      "checkpoint location and schema location are the same",
+    "schema / checkpoint location unit tests - " +
+      "schema location is under checkpoint location",
+    "schema / checkpoint location unit tests - " +
+      "schema location is not under checkpoint location",
+    "schema / checkpoint location unit tests - " +
+      "schema location and checkpoint location are on different file systems",
+    "schema / checkpoint location unit tests - " +
+      "schema location and checkpoint location are the same but with explicit file scheme",
+    "schema / checkpoint location unit tests - special characters in schema location",
+
+    // ========== Schema log core ==========
+    "multiple delta source sharing same schema log is blocked",
+    "schema log is applied",
+    "concurrent schema log modification should be detected",
+    "schema log initialization with additive schema changes",
+    "detect incompatible schema change while streaming",
+    "detect incompatible schema change during first getBatch",
+    "identity columns shouldn't cause schema mismatches",
+    "detect invalid offset during initialization before " +
+      "initializing schema log - rename",
+    "detect invalid offset during initialization before " +
+      "initializing schema log - drop",
+    "no need to block schema log initialization if " +
+      "constructed batch ends on schema change",
+    "resolve the most encompassing schema during getBatch " +
+      "to initialize schema log",
+
+    // ========== Trigger modes ==========
+    "trigger.Once with deferred commit should work",
+    "trigger.AvailableNow should work",
+
+    // ========== Schema evolution scenarios ==========
+    "consecutive schema evolutions without schema merging",
+    "consecutive schema evolutions",
+    "upgrade and downgrade",
+    "multiple sources with schema evolution",
+    "schema evolution with Delta sink",
+    "latestOffset should not progress before schema evolved",
+    "unblock with sql conf",
+    "schema tracking interacting with unsafe escape flag",
+    "streaming with a column mapping upgrade",
+    "partition evolution",
+    "schema log replace current",
+
+    // ========== Backward/forward compatibility ==========
+    "backward-compat: latest version can read back older JSON",
+    "forward-compat: older version can read back newer JSON"
+  )
+
+  override protected def shouldFail(testName: String): Boolean = {
+    val inPassList = shouldPassTests.contains(testName)
+    val inFailList = shouldFailTests.contains(testName)
+
+    assert(inPassList || inFailList,
+      s"Test '$testName' not in shouldPassTests or shouldFailTests")
+    assert(!(inPassList && inFailList),
+      s"Test '$testName' in both shouldPassTests and shouldFailTests")
+
+    inFailList
+  }
+}
+
+// Non-CDC suites
+
+class DeltaV2SourceSchemaEvolutionNameColumnMappingSuite
+  extends DeltaSourceSchemaEvolutionNameColumnMappingSuite
+    with DeltaV2SourceSchemaEvolutionSuiteBase
+
+class DeltaV2SourceSchemaEvolutionIdColumnMappingSuite
+  extends DeltaSourceSchemaEvolutionIdColumnMappingSuite
+    with DeltaV2SourceSchemaEvolutionSuiteBase
+
+// CDC suites
+
+class DeltaV2SourceSchemaEvolutionCDCNameColumnMappingSuite
+  extends DeltaSourceSchemaEvolutionCDCNameColumnMappingSuite
+    with DeltaV2SourceSchemaEvolutionSuiteBase {
+
+  override protected def shouldFailTests: Set[String] = super.shouldFailTests ++ Set(
+    // Additional tests from CDCStreamingSchemaEvolutionSuiteBase
+    "CDC streaming with schema evolution",
+    "protocol and configuration evolution"
+  )
+}
+
+class DeltaV2SourceSchemaEvolutionCDCIdColumnMappingSuite
+  extends DeltaSourceSchemaEvolutionCDCIdColumnMappingSuite
+    with DeltaV2SourceSchemaEvolutionSuiteBase {
+
+  override protected def shouldFailTests: Set[String] = super.shouldFailTests ++ Set(
+    // Additional tests from CDCStreamingSchemaEvolutionSuiteBase
+    "CDC streaming with schema evolution",
+    "protocol and configuration evolution"
+  )
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
@@ -39,6 +39,8 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
 
   override protected def useDsv2: Boolean = true
 
+  override protected def executeDml(sqlText: String): Unit = executeInV1Mode(sqlText)
+
   // V2ForceTest handles test selection via shouldFail/shouldPass,
   // so disable DeltaColumnMappingSelectedTestMixin's runOnlyTests filter.
   override protected def runAllTests: Boolean = true
@@ -69,11 +71,11 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
   }
 
   // TODO(#5319): Move tests to shouldPassTests as V2 schema tracking log support is implemented.
-  protected def shouldPassTests: Set[String] = Set.empty[String]
+  override protected def shouldPassTests: Set[String] = Set.empty[String]
 
   // All tests from StreamingSchemaEvolutionSuiteBase.
   // Override in CDC suites to add CDC-specific tests.
-  protected def shouldFailTests: Set[String] = Set(
+  override protected def shouldFailTests: Set[String] = Set(
     // ========== Schema location validation ==========
     "schema location not under checkpoint",
     "schema location same as checkpoint",
@@ -128,18 +130,6 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
     "backward-compat: latest version can read back older JSON",
     "forward-compat: older version can read back newer JSON"
   )
-
-  override protected def shouldFail(testName: String): Boolean = {
-    val inPassList = shouldPassTests.contains(testName)
-    val inFailList = shouldFailTests.contains(testName)
-
-    assert(inPassList || inFailList,
-      s"Test '$testName' not in shouldPassTests or shouldFailTests")
-    assert(!(inPassList && inFailList),
-      s"Test '$testName' in both shouldPassTests and shouldFailTests")
-
-    inFailList
-  }
 }
 
 // Non-CDC suites

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) The Delta Lake Project Authors.
+ * Copyright (2025) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -46,7 +46,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     )
   }
 
-  private lazy val shouldPassTests = Set(
+  override protected def shouldPassTests: Set[String] = Set(
     // ========== Core streaming tests ==========
     "basic",
     "initial snapshot ends at base index of next version",
@@ -135,7 +135,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
       "non-data operations"
   )
 
-  private lazy val shouldFailTests = Set(
+  override protected def shouldFailTests: Set[String] = Set(
     // === Null Type Column Handling ===
     "streaming delta source should not drop null columns",
     "streaming delta source should drop null columns without feature flag",
@@ -172,15 +172,4 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     // Calls deltaSource.createSource() directly
     "createSource should create source with empty or matching table schema provided"
   )
-
-  override protected def shouldFail(testName: String): Boolean = {
-    val inPassList = shouldPassTests.contains(testName)
-    val inFailList = shouldFailTests.contains(testName)
-
-    assert(inPassList || inFailList, s"Test '$testName' not in shouldPassTests or shouldFailTests")
-    assert(!(inPassList && inFailList),
-      s"Test '$testName' in both shouldPassTests and shouldFailTests")
-
-    inFailList
-  }
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) The Delta Lake Project Authors.
+ * Copyright (2025) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
@@ -33,9 +33,8 @@ import scala.collection.mutable
  * Usage:
  * {{{
  * class MyKernelTest extends MyOriginalSuite with V2ForceTest {
- *   override protected def shouldSkipTest(testName: String): Boolean = {
- *     testName.contains("unsupported feature")
- *   }
+ *   override protected def shouldPassTests: Set[String] = Set("supported test")
+ *   override protected def shouldFailTests: Set[String] = Set("unsupported test")
  * }
  * }}}
  */
@@ -62,15 +61,27 @@ trait V2ForceTest extends DeltaSQLCommandTest {
     }
   }
 
+  /** Tests expected to pass under the V2 connector. Subclasses populate this set. */
+  protected def shouldPassTests: Set[String] = Set.empty
+
+  /** Tests expected to fail under the V2 connector. Subclasses populate this set. */
+  protected def shouldFailTests: Set[String] = Set.empty
+
   /**
-   * Determine if a test is expected to fail based on the test name.
-   * Subclasses should override this method to define which tests are expected to fail.
-   * By default, no tests are expected to fail.
-   *
-   * @param testName The name of the test
-   * @return true if the test is expected to fail, false otherwise
+   * Determine if a test is expected to fail. Every test must appear in exactly one of
+   * [[shouldPassTests]] or [[shouldFailTests]] so the V2 contract is explicit.
    */
-  protected def shouldFail(testName: String): Boolean = false
+  protected def shouldFail(testName: String): Boolean = {
+    val inPassList = shouldPassTests.contains(testName)
+    val inFailList = shouldFailTests.contains(testName)
+
+    assert(inPassList || inFailList,
+      s"Test '$testName' not in shouldPassTests or shouldFailTests")
+    assert(!(inPassList && inFailList),
+      s"Test '$testName' in both shouldPassTests and shouldFailTests")
+
+    inFailList
+  }
 
   /**
    * Override `sparkConf` to set V2_ENABLE_MODE to "STRICT".
@@ -79,6 +90,16 @@ trait V2ForceTest extends DeltaSQLCommandTest {
   abstract override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set(DeltaSQLConf.V2_ENABLE_MODE.key, "STRICT")
+  }
+
+  /**
+   * Run a SQL statement through the V1 connector by temporarily setting
+   * V2_ENABLE_MODE to NONE. Useful for DDL/DML that SparkTable (V2) doesn't support.
+   */
+  protected def executeInV1Mode(sqlText: String): Unit = {
+    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {
+      sql(sqlText)
+    }
   }
 
   override def afterAll(): Unit = {

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/columnmapping/RemoveColumnMappingStreamingReadV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/columnmapping/RemoveColumnMappingStreamingReadV2Suite.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test.columnmapping
+
+import org.apache.spark.sql.delta.columnmapping.RemoveColumnMappingStreamingReadSuite
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.V2ForceTest
+
+/**
+ * Test suite that runs [[RemoveColumnMappingStreamingReadSuite]] using the V2 connector
+ * (V2_ENABLE_MODE=STRICT).
+ *
+ * SparkTable (V2) is read-only and does not support DDL, so DDL/DML operations are routed
+ * through the V1 connector via `executeSql`. Only streaming reads use the V2 connector.
+ */
+class RemoveColumnMappingStreamingReadV2Suite
+  extends RemoveColumnMappingStreamingReadSuite
+    with V2ForceTest {
+
+  override protected def executeSql(sqlText: String): Unit = {
+    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {
+      sql(sqlText)
+    }
+  }
+
+  // Tests that run without schema tracking. These exercise non-additive column-mapping schema
+  // change detection, which is supported on the V2 connector.
+  protected def shouldPassTests: Set[String] = Set(
+    "Upgrade, StartStreamRead, Downgrade, FailNonAdditiveChange",
+    "Upgrade, Downgrade, StartStreamRead, Success",
+    "StartStreamRead, Upgrade, Rename, Downgrade, FailNonAdditiveChange",
+    "StartStreamRead, Upgrade, Drop, Downgrade, FailNonAdditiveChange",
+    "StartStreamRead, Upgrade, Rename, Downgrade, Upgrade, FailNonAdditiveChange",
+    "StartStreamRead, Upgrade, Drop, Downgrade, Upgrade, FailNonAdditiveChange",
+    "Upgrade, StartStreamRead, Rename, Downgrade, FailNonAdditiveChange",
+    "Upgrade, StartStreamRead, Drop, Downgrade, FailNonAdditiveChange",
+    "Upgrade, StartStreamRead, Rename, Downgrade, Upgrade, FailNonAdditiveChange",
+    "Upgrade, StartStreamRead, Drop, Downgrade, Upgrade, FailNonAdditiveChange",
+    "Upgrade, Rename, StartStreamRead, Downgrade, FailNonAdditiveChange",
+    "Upgrade, Rename, StartStreamRead, Downgrade, Upgrade, FailNonAdditiveChange",
+    "Upgrade, Drop, StartStreamRead, Downgrade, FailNonAdditiveChange",
+    "Upgrade, Drop, StartStreamRead, Downgrade, Upgrade, FailNonAdditiveChange",
+    "Upgrade, Rename, Downgrade, StartStreamRead, Success",
+    "Upgrade, Drop, Downgrade, StartStreamRead, Success"
+  )
+
+  // Tests that run with schema tracking enabled. The schema tracking log is not yet supported
+  // on the V2 connector.
+  protected def shouldFailTests: Set[String] = Set(
+    // TODO(#5319): the three tests are not supported in v2 yet due to the gap of columnMapping
+    //  check util.
+    "StartStreamRead, Upgrade, Downgrade, SuccessAndFailSchemaTracking",
+    "Upgrade, Rename, Downgrade, StartStreamRead, Upgrade, SuccessAndFailSchemaTracking",
+    "Upgrade, Drop, Downgrade, StartStreamRead, Upgrade, SuccessAndFailSchemaTracking",
+    // TODO(#5319): Move these to shouldPassTests as V2 schema tracking log support is implemented.
+    "StartStreamRead, Upgrade, Downgrade, SuccessAndFailSchemaTracking with schema tracking",
+    "Upgrade, StartStreamRead, Downgrade, FailNonAdditiveChange with schema tracking",
+    "Upgrade, Downgrade, StartStreamRead, Success with schema tracking",
+    "StartStreamRead, Upgrade, Rename, Downgrade, FailNonAdditiveChange with schema tracking",
+    "StartStreamRead, Upgrade, Drop, Downgrade, FailNonAdditiveChange with schema tracking",
+    "StartStreamRead, Upgrade, Rename, Downgrade, Upgrade, FailNonAdditiveChange" +
+      " with schema tracking",
+    "StartStreamRead, Upgrade, Drop, Downgrade, Upgrade, FailNonAdditiveChange" +
+      " with schema tracking",
+    "Upgrade, StartStreamRead, Rename, Downgrade, FailNonAdditiveChange with schema tracking",
+    "Upgrade, StartStreamRead, Drop, Downgrade, FailNonAdditiveChange with schema tracking",
+    "Upgrade, StartStreamRead, Rename, Downgrade, Upgrade, FailNonAdditiveChange" +
+      " with schema tracking",
+    "Upgrade, StartStreamRead, Drop, Downgrade, Upgrade, FailNonAdditiveChange" +
+      " with schema tracking",
+    "Upgrade, Rename, StartStreamRead, Downgrade, FailNonAdditiveChange with schema tracking",
+    "Upgrade, Rename, StartStreamRead, Downgrade, Upgrade, FailNonAdditiveChange" +
+      " with schema tracking",
+    "Upgrade, Drop, StartStreamRead, Downgrade, FailNonAdditiveChange with schema tracking",
+    "Upgrade, Drop, StartStreamRead, Downgrade, Upgrade, FailNonAdditiveChange" +
+      " with schema tracking",
+    "Upgrade, Rename, Downgrade, StartStreamRead, Success with schema tracking",
+    "Upgrade, Drop, Downgrade, StartStreamRead, Success with schema tracking",
+    "Upgrade, Rename, Downgrade, StartStreamRead, Upgrade, SuccessAndFailSchemaTracking" +
+      " with schema tracking",
+    "Upgrade, Drop, Downgrade, StartStreamRead, Upgrade, SuccessAndFailSchemaTracking" +
+      " with schema tracking"
+  )
+
+  override protected def shouldFail(testName: String): Boolean = {
+    val inPassList = shouldPassTests.contains(testName)
+    val inFailList = shouldFailTests.contains(testName)
+
+    assert(inPassList || inFailList,
+      s"Test '$testName' not in shouldPassTests or shouldFailTests")
+    assert(!(inPassList && inFailList),
+      s"Test '$testName' in both shouldPassTests and shouldFailTests")
+
+    inFailList
+  }
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/columnmapping/RemoveColumnMappingStreamingReadV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/columnmapping/RemoveColumnMappingStreamingReadV2Suite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.test.columnmapping
 
 import org.apache.spark.sql.delta.columnmapping.RemoveColumnMappingStreamingReadSuite
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.V2ForceTest
 
 /**
@@ -25,21 +24,17 @@ import org.apache.spark.sql.delta.test.V2ForceTest
  * (V2_ENABLE_MODE=STRICT).
  *
  * SparkTable (V2) is read-only and does not support DDL, so DDL/DML operations are routed
- * through the V1 connector via `executeSql`. Only streaming reads use the V2 connector.
+ * through the V1 connector via `executeDml`. Only streaming reads use the V2 connector.
  */
 class RemoveColumnMappingStreamingReadV2Suite
   extends RemoveColumnMappingStreamingReadSuite
     with V2ForceTest {
 
-  override protected def executeSql(sqlText: String): Unit = {
-    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {
-      sql(sqlText)
-    }
-  }
+  override protected def executeDml(sqlText: String): Unit = executeInV1Mode(sqlText)
 
   // Tests that run without schema tracking. These exercise non-additive column-mapping schema
   // change detection, which is supported on the V2 connector.
-  protected def shouldPassTests: Set[String] = Set(
+  override protected def shouldPassTests: Set[String] = Set(
     "Upgrade, StartStreamRead, Downgrade, FailNonAdditiveChange",
     "Upgrade, Downgrade, StartStreamRead, Success",
     "StartStreamRead, Upgrade, Rename, Downgrade, FailNonAdditiveChange",
@@ -60,7 +55,7 @@ class RemoveColumnMappingStreamingReadV2Suite
 
   // Tests that run with schema tracking enabled. The schema tracking log is not yet supported
   // on the V2 connector.
-  protected def shouldFailTests: Set[String] = Set(
+  override protected def shouldFailTests: Set[String] = Set(
     // TODO(#5319): the three tests are not supported in v2 yet due to the gap of columnMapping
     //  check util.
     "StartStreamRead, Upgrade, Downgrade, SuccessAndFailSchemaTracking",
@@ -95,16 +90,4 @@ class RemoveColumnMappingStreamingReadV2Suite
     "Upgrade, Drop, Downgrade, StartStreamRead, Upgrade, SuccessAndFailSchemaTracking" +
       " with schema tracking"
   )
-
-  override protected def shouldFail(testName: String): Boolean = {
-    val inPassList = shouldPassTests.contains(testName)
-    val inFailList = shouldFailTests.contains(testName)
-
-    assert(inPassList || inFailList,
-      s"Test '$testName' not in shouldPassTests or shouldFailTests")
-    assert(!(inPassList && inFailList),
-      s"Test '$testName' in both shouldPassTests and shouldFailTests")
-
-    inFailList
-  }
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/typewidening/TypeWideningStreamingV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/typewidening/TypeWideningStreamingV2SourceSuite.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.delta.test.typewidening
 
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.V2ForceTest
 import org.apache.spark.sql.delta.typewidening.{
   TypeWideningStreamingSourceSchemaTrackingSuite,
@@ -33,23 +32,14 @@ trait TypeWideningStreamingV2SourceSuiteBase extends V2ForceTest {
 
   override protected def useDsv2: Boolean = true
 
-  /**
-   * Override executeSql to temporarily use V1 connector for DDL operations.
-   * SparkTable (V2) is read-only and does not support DDL, so DDL must
-   * go through the V1 path. Only streaming reads use the V2 connector.
-   */
-  override protected def executeSql(sqlText: String): Unit = {
-    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {
-      sql(sqlText)
-    }
-  }
+  override protected def executeDml(sqlText: String): Unit = executeInV1Mode(sqlText)
 
   // TODO(#5319): Move tests to shouldPassTests as V2 schema tracking log support is implemented.
-  protected def shouldPassTests: Set[String] = Set.empty[String]
+  override protected def shouldPassTests: Set[String] = Set.empty[String]
 
   // Tests from TypeWideningStreamingSourceTests, shared by both suites.
   // Override in subclasses to add suite-specific tests.
-  protected def shouldFailTests: Set[String] = Set(
+  override protected def shouldFailTests: Set[String] = Set(
     "type change - filter",
     "type change - projection",
     "type change - projection partition column",
@@ -69,18 +59,6 @@ trait TypeWideningStreamingV2SourceSuiteBase extends V2ForceTest {
     "arbitrary type changes are not supported",
     "type change in delta source writing to a delta sink"
   )
-
-  override protected def shouldFail(testName: String): Boolean = {
-    val inPassList = shouldPassTests.contains(testName)
-    val inFailList = shouldFailTests.contains(testName)
-
-    assert(inPassList || inFailList,
-      s"Test '$testName' not in shouldPassTests or shouldFailTests")
-    assert(!(inPassList && inFailList),
-      s"Test '$testName' in both shouldPassTests and shouldFailTests")
-
-    inFailList
-  }
 }
 
 class TypeWideningStreamingV2SourceSuite

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/typewidening/TypeWideningStreamingV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/typewidening/TypeWideningStreamingV2SourceSuite.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test.typewidening
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.V2ForceTest
+import org.apache.spark.sql.delta.typewidening.{
+  TypeWideningStreamingSourceSchemaTrackingSuite,
+  TypeWideningStreamingSourceSuite,
+  TypeWideningStreamingSourceTestMixin
+}
+
+/**
+ * Base trait for V2 type widening streaming source tests.
+ * Provides common shouldFail logic shared by both suites.
+ */
+trait TypeWideningStreamingV2SourceSuiteBase extends V2ForceTest {
+  self: TypeWideningStreamingSourceTestMixin =>
+
+  override protected def useDsv2: Boolean = true
+
+  /**
+   * Override executeSql to temporarily use V1 connector for DDL operations.
+   * SparkTable (V2) is read-only and does not support DDL, so DDL must
+   * go through the V1 path. Only streaming reads use the V2 connector.
+   */
+  override protected def executeSql(sqlText: String): Unit = {
+    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {
+      sql(sqlText)
+    }
+  }
+
+  // TODO(#5319): Move tests to shouldPassTests as V2 schema tracking log support is implemented.
+  protected def shouldPassTests: Set[String] = Set.empty[String]
+
+  // Tests from TypeWideningStreamingSourceTests, shared by both suites.
+  // Override in subclasses to add suite-specific tests.
+  protected def shouldFailTests: Set[String] = Set(
+    "type change - filter",
+    "type change - projection",
+    "type change - projection partition column",
+    "type change - widen unused scala udf field",
+    "type change - widen scala udf argument",
+    "type change - widen aggregation grouping key",
+    "type change - widen aggregation expression",
+    "type change - widen aggregation expression partition column",
+    "type change - widen aggregation expression after projection",
+    "type change - widen limit",
+    "type change - widen distinct",
+    "type change - widen drop duplicates",
+    "type change - widen drop duplicates with watermark",
+    "type change - widen flatMap groups with state",
+    "widening type change then restore back",
+    "narrowing type changes are not supported",
+    "arbitrary type changes are not supported",
+    "type change in delta source writing to a delta sink"
+  )
+
+  override protected def shouldFail(testName: String): Boolean = {
+    val inPassList = shouldPassTests.contains(testName)
+    val inFailList = shouldFailTests.contains(testName)
+
+    assert(inPassList || inFailList,
+      s"Test '$testName' not in shouldPassTests or shouldFailTests")
+    assert(!(inPassList && inFailList),
+      s"Test '$testName' in both shouldPassTests and shouldFailTests")
+
+    inFailList
+  }
+}
+
+class TypeWideningStreamingV2SourceSuite
+  extends TypeWideningStreamingSourceSuite
+    with TypeWideningStreamingV2SourceSuiteBase {
+
+  // All tests pass without schema tracking enabled, except where noted in shouldFailTests.
+  override protected def shouldPassTests: Set[String] =
+    super.shouldFailTests -- shouldFailTests
+
+  override protected def shouldFailTests: Set[String] = Set(
+    // Delta log event is not supported in V2, so event-logging tests are not meaningful.
+    "schema changed event is logged for type widening",
+    "schema changed event is not logged when there are no schema changes",
+    // TODO(#5319): Partition column schema has a bug in V2 causing these to fail.
+    "type change - projection partition column",
+    "type change - widen aggregation expression partition column",
+    // TODO(#5319): V2 lacks the implementation of
+    //  validateAndInitMetadataLogForPlannedBatchesDuringStreamStart, so the
+    //  2nd testStream restart does not throw on the incompatible type change.
+    "widening type change then restore back",
+    "narrowing type changes are not supported",
+    "arbitrary type changes are not supported"
+  )
+}
+
+class TypeWideningStreamingV2SourceSchemaTrackingSuite
+  extends TypeWideningStreamingSourceSchemaTrackingSuite
+    with TypeWideningStreamingV2SourceSuiteBase {
+
+  override protected def shouldFailTests: Set[String] = super.shouldFailTests ++ Set(
+    // Additional tests from TypeWideningStreamingSourceSchemaTrackingTests
+    "type change first without schemaTrackingLocation and unblock using schemaTrackingLocation",
+    "unblocking stream with sql conf after type change - unblock all",
+    "unblocking stream with sql conf after type change - unblock stream",
+    "unblocking stream with sql conf after type change - unblock version",
+    "unblocking stream with reader option after type change - unblock stream",
+    "unblocking stream with reader option after type change - unblock version",
+    "overwrite schema with type change and dropped column",
+    "disable schema tracking log using internal conf"
+  )
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -196,20 +196,20 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       startingVersion: Option[Long] = None,
       maxFilesPerTrigger: Option[Int] = None,
       ignoreDeletes: Option[Boolean] = None)(implicit log: DeltaLog): DataFrame = {
-    var dsr = spark.readStream.format("delta")
+    var options = Map.empty[String, String]
     if (isCdcTest) {
-      dsr = dsr.option(DeltaOptions.CDC_READ_OPTION, "true")
+      options += DeltaOptions.CDC_READ_OPTION -> "true"
     }
-    schemaLocation.foreach { loc => dsr = dsr.option(DeltaOptions.SCHEMA_TRACKING_LOCATION, loc) }
+    schemaLocation.foreach { loc =>
+      options += DeltaOptions.SCHEMA_TRACKING_LOCATION -> loc
+    }
     sourceTrackingId.foreach { name =>
-      dsr = dsr.option(DeltaOptions.STREAMING_SOURCE_TRACKING_ID, name)
+      options += DeltaOptions.STREAMING_SOURCE_TRACKING_ID -> name
     }
-    startingVersion.foreach { v => dsr = dsr.option("startingVersion", v) }
-    maxFilesPerTrigger.foreach { f => dsr = dsr.option("maxFilesPerTrigger", f) }
-    ignoreDeletes.foreach{ i => dsr.option("ignoreDeletes", i) }
-    val df = {
-        dsr.load(log.dataPath.toString)
-    }
+    startingVersion.foreach { v => options += "startingVersion" -> v.toString }
+    maxFilesPerTrigger.foreach { f => options += "maxFilesPerTrigger" -> f.toString }
+    ignoreDeletes.foreach { i => options += "ignoreDeletes" -> i.toString }
+    val df = loadStreamWithOptions(log.dataPath.toString, options)
     if (isCdcTest) {
       dropCDCFields(df)
     } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -233,16 +233,22 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
   protected def getDefaultSchemaLocation(implicit log: DeltaLog): Path =
     new Path(getDefaultCheckpoint, "_schema_location")
 
+  /**
+   * Executes a DDL/DML SQL statement. Overridable so that V2 suites can route it through the V1
+   * connector, since SparkTable (V2) is read-only and does not support writes/DDL.
+   */
+  protected def executeDml(sqlText: String): Unit = sql(sqlText)
+
   protected def addColumn(column: String, dt: String = "STRING")(implicit log: DeltaLog): Unit = {
-    sql(s"ALTER TABLE delta.`${log.dataPath}` ADD COLUMN ($column $dt)")
+    executeDml(s"ALTER TABLE delta.`${log.dataPath}` ADD COLUMN ($column $dt)")
   }
 
   protected def renameColumn(oldColumn: String, newColumn: String)(implicit log: DeltaLog): Unit = {
-    sql(s"ALTER TABLE delta.`${log.dataPath}` RENAME COLUMN $oldColumn TO $newColumn")
+    executeDml(s"ALTER TABLE delta.`${log.dataPath}` RENAME COLUMN $oldColumn TO $newColumn")
   }
 
   protected def dropColumn(column: String)(implicit log: DeltaLog): Unit = {
-    sql(s"ALTER TABLE delta.`${log.dataPath}` DROP COLUMN $column")
+    executeDml(s"ALTER TABLE delta.`${log.dataPath}` DROP COLUMN $column")
   }
 
   protected def overwriteSchema(
@@ -257,7 +263,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
   }
 
   protected def upgradeToNameMode(implicit log: DeltaLog): Unit = {
-    sql(
+    executeDml(
       s"""ALTER TABLE delta.`${log.dataPath}` SET TBLPROPERTIES (
          |'delta.columnMapping.mode' = "name",
          |'delta.minReaderVersion' = '2',
@@ -838,7 +844,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
 
   test("identity columns shouldn't cause schema mismatches") {
     withTable("source") {
-      sql(
+      executeDml(
         s"""
           |CREATE TABLE source (key INT, id LONG GENERATED ALWAYS AS IDENTITY)
           |USING DELTA
@@ -2292,11 +2298,11 @@ trait CDCStreamingSchemaEvolutionSuiteBase extends StreamingSchemaEvolutionSuite
             .toDF("id").withColumn("age", lit("string"))
             .createOrReplaceTempView("data")
 
-          spark.sql(s"CREATE TABLE merge_source USING delta AS SELECT * FROM data")
+          executeDml(s"CREATE TABLE merge_source USING delta AS SELECT * FROM data")
 
           // Use merge to trigger schema evolution as well (add column age)
           withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
-            spark.sql(
+            executeDml(
               s"""
                  |MERGE INTO delta.`${log.dataPath}` t
                  |USING merge_source s
@@ -2351,7 +2357,7 @@ trait CDCStreamingSchemaEvolutionSuiteBase extends StreamingSchemaEvolutionSuite
   testSchemaEvolution(
     "protocol and configuration evolution", columnMapping = false) { implicit log =>
     // Updates table properties / protocol
-    spark.sql(
+    executeDml(
       s"""
          |ALTER TABLE delta.`${log.dataPath}`
          |SET TBLPROPERTIES (
@@ -2363,7 +2369,7 @@ trait CDCStreamingSchemaEvolutionSuiteBase extends StreamingSchemaEvolutionSuite
 
     addData(5 until 10)
     // Update just delta table property
-    spark.sql(
+    executeDml(
       s"""
          |ALTER TABLE delta.`${log.dataPath}`
          |SET TBLPROPERTIES (
@@ -2375,7 +2381,7 @@ trait CDCStreamingSchemaEvolutionSuiteBase extends StreamingSchemaEvolutionSuite
 
     addData(10 until 13)
     // Update non-delta property won't need stream stop
-    spark.sql(
+    executeDml(
       s"""
          |ALTER TABLE delta.`${log.dataPath}`
          |SET TBLPROPERTIES (

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingStreamingReadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingStreamingReadSuite.scala
@@ -219,7 +219,7 @@ class RemoveColumnMappingStreamingReadSuite
   }
 
   private def createTable(columnMappingMode: String = "none"): Unit = {
-    executeSql(s"""CREATE TABLE $testTableName
+    executeDml(s"""CREATE TABLE $testTableName
            |USING delta
            |TBLPROPERTIES ('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = '$columnMappingMode',
            |  '${DeltaConfigs.CHANGE_DATA_FEED.key}' = 'true'
@@ -231,7 +231,7 @@ class RemoveColumnMappingStreamingReadSuite
 
   private def insertMoreRows(v: Int = -1): Unit = {
     val values = List.fill(currentNumCols)(v.toString).mkString(", ")
-    executeSql(s"INSERT INTO $testTableName SELECT $values FROM $testTableName LIMIT $totalRows")
+    executeDml(s"INSERT INTO $testTableName SELECT $values FROM $testTableName LIMIT $totalRows")
   }
 
   private def currentNumCols = deltaLog.update().schema.length

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingStreamingReadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingStreamingReadSuite.scala
@@ -219,7 +219,7 @@ class RemoveColumnMappingStreamingReadSuite
   }
 
   private def createTable(columnMappingMode: String = "none"): Unit = {
-    sql(s"""CREATE TABLE $testTableName
+    executeSql(s"""CREATE TABLE $testTableName
            |USING delta
            |TBLPROPERTIES ('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = '$columnMappingMode',
            |  '${DeltaConfigs.CHANGE_DATA_FEED.key}' = 'true'
@@ -231,7 +231,7 @@ class RemoveColumnMappingStreamingReadSuite
 
   private def insertMoreRows(v: Int = -1): Unit = {
     val values = List.fill(currentNumCols)(v.toString).mkString(", ")
-    sql(s"INSERT INTO $testTableName SELECT $values FROM $testTableName LIMIT $totalRows")
+    executeSql(s"INSERT INTO $testTableName SELECT $values FROM $testTableName LIMIT $totalRows")
   }
 
   private def currentNumCols = deltaLog.update().schema.length

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuiteUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuiteUtils.scala
@@ -59,6 +59,10 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
   protected val testTableName: String = "test_table_" + this.getClass.getSimpleName
   protected def deltaLog = DeltaLog.forTable(spark, TableIdentifier(testTableName))
 
+  // Hook for subclasses to route DDL/DML through a specific connector mode (e.g. V1 for V2 suites
+  // that require DDL to go through the V1 connector). Defaults to `sql`.
+  protected def executeSql(sqlText: String): Unit = sql(sqlText)
+
   import testImplicits._
 
   protected def testRemovingColumnMapping(unsetTableProperty: Boolean = false): Any = {
@@ -133,14 +137,14 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
     } else {
       s"SET TBLPROPERTIES ('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'none')"
     }
-    sql(
+    executeSql(
       s"""
          |ALTER TABLE $testTableName $unsetStr
          |""".stripMargin)
   }
 
   protected def enableColumnMapping(): Unit = {
-    sql(
+    executeSql(
       s"""ALTER TABLE $testTableName
         SET TBLPROPERTIES (
         '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name',
@@ -149,11 +153,11 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
   }
 
   protected def renameColumn(): Unit = {
-    sql(s"ALTER TABLE $testTableName RENAME COLUMN $thirdColumn TO $renamedThirdColumn")
+    executeSql(s"ALTER TABLE $testTableName RENAME COLUMN $thirdColumn TO $renamedThirdColumn")
   }
 
   protected def dropColumn(): Unit = {
-    sql(s"ALTER TABLE $testTableName DROP COLUMN $thirdColumn")
+    executeSql(s"ALTER TABLE $testTableName DROP COLUMN $thirdColumn")
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuiteUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuiteUtils.scala
@@ -43,7 +43,7 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
   }
 
   override protected def afterEach(): Unit = {
-    sql(s"DROP TABLE IF EXISTS $testTableName")
+    executeDml(s"DROP TABLE IF EXISTS $testTableName")
     super.afterEach()
   }
 
@@ -61,7 +61,7 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
 
   // Hook for subclasses to route DDL/DML through a specific connector mode (e.g. V1 for V2 suites
   // that require DDL to go through the V1 connector). Defaults to `sql`.
-  protected def executeSql(sqlText: String): Unit = sql(sqlText)
+  protected def executeDml(sqlText: String): Unit = sql(sqlText)
 
   import testImplicits._
 
@@ -70,7 +70,7 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
     val originalData = spark.table(tableName = testTableName).select(logicalColumnName).collect()
     // Add a schema comment and verify it is preserved after the rewrite.
     val comment = "test comment"
-    sql(s"ALTER TABLE $testTableName ALTER COLUMN $logicalColumnName COMMENT '$comment'")
+    executeDml(s"ALTER TABLE $testTableName ALTER COLUMN $logicalColumnName COMMENT '$comment'")
 
     val table = DeltaTableV2(spark, TableIdentifier(tableName = testTableName))
     val originalSnapshot = table.update()
@@ -137,14 +137,14 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
     } else {
       s"SET TBLPROPERTIES ('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'none')"
     }
-    executeSql(
+    executeDml(
       s"""
          |ALTER TABLE $testTableName $unsetStr
          |""".stripMargin)
   }
 
   protected def enableColumnMapping(): Unit = {
-    executeSql(
+    executeDml(
       s"""ALTER TABLE $testTableName
         SET TBLPROPERTIES (
         '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name',
@@ -153,11 +153,11 @@ trait RemoveColumnMappingSuiteUtils extends QueryTest with DeltaColumnMappingSui
   }
 
   protected def renameColumn(): Unit = {
-    executeSql(s"ALTER TABLE $testTableName RENAME COLUMN $thirdColumn TO $renamedThirdColumn")
+    executeDml(s"ALTER TABLE $testTableName RENAME COLUMN $thirdColumn TO $renamedThirdColumn")
   }
 
   protected def dropColumn(): Unit = {
-    executeSql(s"ALTER TABLE $testTableName DROP COLUMN $thirdColumn")
+    executeDml(s"ALTER TABLE $testTableName DROP COLUMN $thirdColumn")
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -115,10 +115,10 @@ trait TypeWideningStreamingSourceTestMixin
   }
 
   /**
-   * Executes a SQL statement. Overridable so that V2 suites can route SQL through the V1
+   * Executes a DDL/DML SQL statement. Overridable so that V2 suites can route it through the V1
    * connector, since SparkTable (V2) is read-only and does not support writes/DDL.
    */
-  protected def executeSql(sqlText: String): Unit = sql(sqlText)
+  protected def executeDml(sqlText: String): Unit = sql(sqlText)
 
   /** Test action checking that the stream fails due to a metadata change - typ. a schema change. */
   object ExpectMetadataEvolutionException {
@@ -187,22 +187,22 @@ trait TypeWideningStreamingSourceTests
     test(s"type change - $name") {
       withTempDir { dir =>
         val partitionByStr = partitionBy.map(p => s"PARTITIONED BY ($p)").getOrElse("")
-        executeSql(
+        executeDml(
           s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA $partitionByStr")
         val checkpointDir = new File(dir, "sink_checkpoint")
 
         testStream(query(readStream(dir, checkpointDir)), outputMode)(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
           ProcessAllAvailable(),
-          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeDml(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
         val streamActions = expectedResult match {
           case ExpectedResult.Success(rows: Seq[Row @unchecked]) =>
             Seq(
-              Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789, 2)") },
+              Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (123456789, 2)") },
               ProcessAllAvailable(),
               CheckLastBatch(rows: _*)
             )
@@ -344,14 +344,14 @@ trait TypeWideningStreamingSourceTests
 
   test("widening type change then restore back") {
     withTempDir { dir =>
-      executeSql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+      executeDml(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       testStream(readStream(dir, checkpointDir))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1)") },
         ProcessAllAvailable(),
-        Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
+        Execute { _ => executeDml(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
         // Widening a column type requires restarting the stream so that the new, wider schema is
         // used to process the batch.
         ExpectMetadataEvolutionException()
@@ -368,11 +368,11 @@ trait TypeWideningStreamingSourceTests
       withUnblockedTypeChanges {
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
           ProcessAllAvailable(),
           CheckLastBatch(123456789),
           // Restore will narrow the type back, the schema change fails the query.
-          Execute { _ => executeSql(s"RESTORE delta.`$dir` VERSION AS OF 1") },
+          Execute { _ => executeDml(s"RESTORE delta.`$dir` VERSION AS OF 1") },
           if (schemaTrackingEnabled) {
             // With schema tracking, the first try evolves the tracked schema. The unsupported
             // type change is surfaced on the next retry.
@@ -399,12 +399,12 @@ trait TypeWideningStreamingSourceTests
   } {
     test(s"$name type changes are not supported") {
       withTempDir { dir =>
-        executeSql(s"CREATE TABLE delta.`$dir` (a int) USING DELTA")
+        executeDml(s"CREATE TABLE delta.`$dir` (a int) USING DELTA")
         val checkpointDir = new File(dir, "sink_checkpoint")
 
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1)") },
           ProcessAllAvailable(),
           Execute { _ =>
             // Overwrite the table schema to apply an arbitrary type change.
@@ -430,7 +430,7 @@ trait TypeWideningStreamingSourceTests
         // Try to restart the stream even though the error is not retryable and it will fail again.
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (2)") },
           ExpectIncompatibleSchemaChangeException()
         )
       }
@@ -443,8 +443,8 @@ trait TypeWideningStreamingSourceTests
       withTempDir { sinkDir =>
         // The test mixin implicitly enables type widening on all tables, disable type widening on
         // the sink initially for this test.
-        executeSql(s"CREATE TABLE delta.`$sourceDir` (a byte) USING DELTA")
-        executeSql(
+        executeDml(s"CREATE TABLE delta.`$sourceDir` (a byte) USING DELTA")
+        executeDml(
           s"""
              |CREATE TABLE delta.`$sinkDir` (a byte) USING DELTA
              |TBLPROPERTIES('delta.enableTypeWidening' = 'false')
@@ -469,16 +469,16 @@ trait TypeWideningStreamingSourceTests
         }
 
         // Start with no type change.
-        executeSql(s"INSERT INTO delta.`$sourceDir` VALUES (1)")
+        executeDml(s"INSERT INTO delta.`$sourceDir` VALUES (1)")
         runStream(mergeSchema = false)
         checkAnswer(readDeltaTable(sinkDir.toString), Seq(Row(1)))
 
         // Change type of column 'a' and introduce a new column 'b'. Schema evolution is enabled
         // so the new column 'b' is added to the sink, but type widening is disabled on the sink so
         // the type of column 'a' remains INT: values are downcasted from INT to BYTE on write.
-        executeSql(s"ALTER TABLE delta.`$sourceDir`ALTER COLUMN a TYPE int")
-        executeSql(s"ALTER TABLE delta.`$sourceDir`ADD COLUMN b int")
-        executeSql(s"INSERT INTO delta.`$sourceDir` VALUES (2, 2)")
+        executeDml(s"ALTER TABLE delta.`$sourceDir`ALTER COLUMN a TYPE int")
+        executeDml(s"ALTER TABLE delta.`$sourceDir`ADD COLUMN b int")
+        executeDml(s"INSERT INTO delta.`$sourceDir` VALUES (2, 2)")
 
         if (schemaTrackingEnabled) {
           val evolutionException = intercept[DeltaRuntimeException] {
@@ -494,9 +494,9 @@ trait TypeWideningStreamingSourceTests
         // Enable type widening on the sink and insert a value in 'a' that won't fit, first with
         // schema evolution disabled: the type of column 'a' in the sink isn't automatically changed
         // to INT and values are downcast: the value overflows and fails.
-        executeSql(
+        executeDml(
           s"ALTER TABLE delta.`$sinkDir` SET TBLPROPERTIES('delta.enableTypeWidening' = 'true')")
-        executeSql(s"INSERT INTO delta.`$sourceDir` VALUES (${Int.MaxValue}, ${Int.MaxValue})")
+        executeDml(s"INSERT INTO delta.`$sourceDir` VALUES (${Int.MaxValue}, ${Int.MaxValue})")
 
         def getSparkArithmeticException(ex: Throwable): SparkArithmeticException = ex match {
           case e: SparkArithmeticException => e
@@ -533,21 +533,21 @@ trait TypeWideningStreamingSourceWithoutSchemaTrackingTests
 
   test("schema changed event is logged for type widening") {
     withTempDir { dir =>
-      executeSql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
+      executeDml(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       val logs = Log4jUsageLogger.track {
         testStream(readStream(dir, checkpointDir))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1)") },
           ProcessAllAvailable(),
-          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeDml(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
         testStream(readStream(dir, checkpointDir))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
           ProcessAllAvailable(),
           CheckLastBatch(Row(123456789))
         )
@@ -574,16 +574,16 @@ trait TypeWideningStreamingSourceWithoutSchemaTrackingTests
 
   test("schema changed event is not logged when there are no schema changes") {
     withTempDir { dir =>
-      executeSql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
+      executeDml(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       val logs = Log4jUsageLogger.track {
         testStream(readStream(dir, checkpointDir))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1)") },
           // This doesn't do anything since the type is already `byte`.
-          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE byte") },
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (100)") },
+          Execute { _ => executeDml(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE byte") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (100)") },
           ProcessAllAvailable(),
           CheckAnswer(1, 100)
         )
@@ -610,20 +610,20 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
   test(
     "type change first without schemaTrackingLocation and unblock using schemaTrackingLocation") {
     withTempDir { dir =>
-      executeSql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
+      executeDml(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       testStream(readStreamWithoutSchemaTracking(dir))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1)") },
         ProcessAllAvailable(),
         CheckAnswer(1)
       )
 
       testStream(readStreamWithoutSchemaTracking(dir))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
-        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+        Execute { _ => executeDml(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+        Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
         ExpectFailure[DeltaStreamingNonAdditiveSchemaIncompatibleException]()
       )
 
@@ -660,7 +660,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
   )) {
     test(s"unblocking stream with sql conf after type change - $name") {
       withTempDir { dir =>
-        executeSql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
+        executeDml(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
         // Getting the checkpoint dir through the delta log to ensure the format is consistent with
         // the path used internally to compute the hash of the checkpoint location to unblock the
         // stream.
@@ -674,8 +674,8 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
         testStream(readWithAgg(), outputMode = OutputMode.Complete())(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
-          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => executeDml(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
@@ -689,7 +689,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
         withSQLConf(s"spark.databricks.delta.streaming.${getSqlConf(checkpointHash)}" -> value) {
           testStream(readWithAgg(), outputMode = OutputMode.Complete())(
             StartStream(checkpointLocation = checkpointDir.toString),
-            Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
+            Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
             ProcessAllAvailable(),
             CheckLastBatch(Row(1, 2))
           )
@@ -704,7 +704,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
   )) {
     test(s"unblocking stream with reader option after type change - $name") {
       withTempDir { dir =>
-        executeSql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
+        executeDml(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
         val checkpointDir = new File(dir, "sink_checkpoint")
 
         def readWithAgg(options: Map[String, String] = Map.empty): DataFrame =
@@ -714,8 +714,8 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
         testStream(readWithAgg(), outputMode = OutputMode.Complete())(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
-          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => executeDml(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
@@ -728,7 +728,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
             readWithAgg(Map("allowSourceColumnTypeChange" -> optionValue)),
             outputMode = OutputMode.Complete())(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
           ProcessAllAvailable(),
           CheckLastBatch(Row(1, 2))
         )
@@ -738,12 +738,12 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
   test(s"overwrite schema with type change and dropped column") {
     withTempDir { dir =>
-      executeSql(s"CREATE TABLE delta.`$dir` (a byte, b int) USING DELTA")
+      executeDml(s"CREATE TABLE delta.`$dir` (a byte, b int) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+        Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
         ProcessAllAvailable(),
         Execute { _ =>
           // Overwrite the table schema.
@@ -795,7 +795,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
           "spark.databricks.delta.streaming.allowSourceColumnTypeChange" -> "always") {
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+          Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (2)") },
           ProcessAllAvailable()
         )
       }
@@ -804,7 +804,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
   test("disable schema tracking log using internal conf") {
      withTempDir { dir =>
-       executeSql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+       executeDml(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
        val checkpointDir = new File(dir, "sink_checkpoint")
 
        // When we disable schema tracking for widening type changes, the stream should succeed
@@ -814,9 +814,9 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
          DeltaSQLConf.DELTA_TYPE_WIDENING_ENABLE_STREAMING_SCHEMA_TRACKING.key -> "false") {
          testStream(readStreamWithoutSchemaTracking(dir))(
            StartStream(checkpointLocation = checkpointDir.toString),
-           Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+           Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (1)") },
            ProcessAllAvailable(),
-           Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
+           Execute { _ => executeDml(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
            ExpectFailure[DeltaIllegalStateException] { ex =>
              assert(ex.asInstanceOf[SparkThrowable].getErrorClass ===
                "DELTA_SCHEMA_CHANGED_WITH_VERSION")
@@ -825,7 +825,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
          testStream(readStreamWithoutSchemaTracking(dir))(
            StartStream(checkpointLocation = checkpointDir.toString),
-           Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+           Execute { _ => executeDml(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
            ProcessAllAvailable(),
            CheckLastBatch(123456789)
          )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -82,6 +82,9 @@ trait TypeWideningStreamingSourceTestMixin
     super.afterAll()
   }
 
+  /** Whether the suite uses the DSv2 connector. Override to true in V2 test suites. */
+  protected def useDsv2: Boolean = false
+
   /** Short-hand to read a data stream from the Delta table at the given location. */
   protected def readStream(
       path: File,
@@ -90,10 +93,32 @@ trait TypeWideningStreamingSourceTestMixin
     val allOptions = options ++ Option.when(schemaTrackingEnabled)(
       DeltaOptions.SCHEMA_TRACKING_LOCATION -> checkpointDir.toString
     )
-    spark.readStream.format("delta")
-      .options(allOptions)
-      .load(path.getCanonicalPath)
+    loadStreamWithOptions(path, allOptions)
   }
+
+  /** Read a data stream without schema tracking options. */
+  protected def readStreamWithoutSchemaTracking(
+      path: File,
+      options: Map[String, String] = Map.empty): DataFrame = {
+    loadStreamWithOptions(path, options)
+  }
+
+  /** Loads a stream from the given path, routing through V2 connector when useDsv2 is true. */
+  private def loadStreamWithOptions(path: File, options: Map[String, String]): DataFrame = {
+    val reader = spark.readStream.options(options)
+    if (useDsv2) {
+      // This will route through DeltaCatalog which checks V2_ENABLE_MODE
+      reader.table(s"delta.`${path.getCanonicalPath}`")
+    } else {
+      reader.format("delta").load(path.getCanonicalPath)
+    }
+  }
+
+  /**
+   * Executes a SQL statement. Overridable so that V2 suites can route SQL through the V1
+   * connector, since SparkTable (V2) is read-only and does not support writes/DDL.
+   */
+  protected def executeSql(sqlText: String): Unit = sql(sqlText)
 
   /** Test action checking that the stream fails due to a metadata change - typ. a schema change. */
   object ExpectMetadataEvolutionException {
@@ -162,21 +187,22 @@ trait TypeWideningStreamingSourceTests
     test(s"type change - $name") {
       withTempDir { dir =>
         val partitionByStr = partitionBy.map(p => s"PARTITIONED BY ($p)").getOrElse("")
-        sql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA $partitionByStr")
+        executeSql(
+          s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA $partitionByStr")
         val checkpointDir = new File(dir, "sink_checkpoint")
 
         testStream(query(readStream(dir, checkpointDir)), outputMode)(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
           ProcessAllAvailable(),
-          Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
         val streamActions = expectedResult match {
           case ExpectedResult.Success(rows: Seq[Row @unchecked]) =>
             Seq(
-              Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789, 2)") },
+              Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789, 2)") },
               ProcessAllAvailable(),
               CheckLastBatch(rows: _*)
             )
@@ -318,14 +344,14 @@ trait TypeWideningStreamingSourceTests
 
   test("widening type change then restore back") {
     withTempDir { dir =>
-      sql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+      executeSql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       testStream(readStream(dir, checkpointDir))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
         ProcessAllAvailable(),
-        Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
+        Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
         // Widening a column type requires restarting the stream so that the new, wider schema is
         // used to process the batch.
         ExpectMetadataEvolutionException()
@@ -342,11 +368,11 @@ trait TypeWideningStreamingSourceTests
       withUnblockedTypeChanges {
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
           ProcessAllAvailable(),
           CheckLastBatch(123456789),
           // Restore will narrow the type back, the schema change fails the query.
-          Execute { _ => sql(s"RESTORE delta.`$dir` VERSION AS OF 1") },
+          Execute { _ => executeSql(s"RESTORE delta.`$dir` VERSION AS OF 1") },
           if (schemaTrackingEnabled) {
             // With schema tracking, the first try evolves the tracked schema. The unsupported
             // type change is surfaced on the next retry.
@@ -373,12 +399,12 @@ trait TypeWideningStreamingSourceTests
   } {
     test(s"$name type changes are not supported") {
       withTempDir { dir =>
-        sql(s"CREATE TABLE delta.`$dir` (a int) USING DELTA")
+        executeSql(s"CREATE TABLE delta.`$dir` (a int) USING DELTA")
         val checkpointDir = new File(dir, "sink_checkpoint")
 
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
           ProcessAllAvailable(),
           Execute { _ =>
             // Overwrite the table schema to apply an arbitrary type change.
@@ -404,7 +430,7 @@ trait TypeWideningStreamingSourceTests
         // Try to restart the stream even though the error is not retryable and it will fail again.
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (2)") },
           ExpectIncompatibleSchemaChangeException()
         )
       }
@@ -417,8 +443,8 @@ trait TypeWideningStreamingSourceTests
       withTempDir { sinkDir =>
         // The test mixin implicitly enables type widening on all tables, disable type widening on
         // the sink initially for this test.
-        sql(s"CREATE TABLE delta.`$sourceDir` (a byte) USING DELTA")
-        sql(
+        executeSql(s"CREATE TABLE delta.`$sourceDir` (a byte) USING DELTA")
+        executeSql(
           s"""
              |CREATE TABLE delta.`$sinkDir` (a byte) USING DELTA
              |TBLPROPERTIES('delta.enableTypeWidening' = 'false')
@@ -443,16 +469,16 @@ trait TypeWideningStreamingSourceTests
         }
 
         // Start with no type change.
-        sql(s"INSERT INTO delta.`$sourceDir` VALUES (1)")
+        executeSql(s"INSERT INTO delta.`$sourceDir` VALUES (1)")
         runStream(mergeSchema = false)
         checkAnswer(readDeltaTable(sinkDir.toString), Seq(Row(1)))
 
         // Change type of column 'a' and introduce a new column 'b'. Schema evolution is enabled
         // so the new column 'b' is added to the sink, but type widening is disabled on the sink so
         // the type of column 'a' remains INT: values are downcasted from INT to BYTE on write.
-        sql(s"ALTER TABLE delta.`$sourceDir`ALTER COLUMN a TYPE int")
-        sql(s"ALTER TABLE delta.`$sourceDir`ADD COLUMN b int")
-        sql(s"INSERT INTO delta.`$sourceDir` VALUES (2, 2)")
+        executeSql(s"ALTER TABLE delta.`$sourceDir`ALTER COLUMN a TYPE int")
+        executeSql(s"ALTER TABLE delta.`$sourceDir`ADD COLUMN b int")
+        executeSql(s"INSERT INTO delta.`$sourceDir` VALUES (2, 2)")
 
         if (schemaTrackingEnabled) {
           val evolutionException = intercept[DeltaRuntimeException] {
@@ -468,8 +494,9 @@ trait TypeWideningStreamingSourceTests
         // Enable type widening on the sink and insert a value in 'a' that won't fit, first with
         // schema evolution disabled: the type of column 'a' in the sink isn't automatically changed
         // to INT and values are downcast: the value overflows and fails.
-        sql(s"ALTER TABLE delta.`$sinkDir` SET TBLPROPERTIES('delta.enableTypeWidening' = 'true')")
-        sql(s"INSERT INTO delta.`$sourceDir` VALUES (${Int.MaxValue}, ${Int.MaxValue})")
+        executeSql(
+          s"ALTER TABLE delta.`$sinkDir` SET TBLPROPERTIES('delta.enableTypeWidening' = 'true')")
+        executeSql(s"INSERT INTO delta.`$sourceDir` VALUES (${Int.MaxValue}, ${Int.MaxValue})")
 
         def getSparkArithmeticException(ex: Throwable): SparkArithmeticException = ex match {
           case e: SparkArithmeticException => e
@@ -506,21 +533,21 @@ trait TypeWideningStreamingSourceWithoutSchemaTrackingTests
 
   test("schema changed event is logged for type widening") {
     withTempDir { dir =>
-      sql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
+      executeSql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       val logs = Log4jUsageLogger.track {
         testStream(readStream(dir, checkpointDir))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
           ProcessAllAvailable(),
-          Execute { _ => sql(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
         testStream(readStream(dir, checkpointDir))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
           ProcessAllAvailable(),
           CheckLastBatch(Row(123456789))
         )
@@ -547,16 +574,16 @@ trait TypeWideningStreamingSourceWithoutSchemaTrackingTests
 
   test("schema changed event is not logged when there are no schema changes") {
     withTempDir { dir =>
-      sql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
+      executeSql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       val logs = Log4jUsageLogger.track {
         testStream(readStream(dir, checkpointDir))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
           // This doesn't do anything since the type is already `byte`.
-          Execute { _ => sql(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE byte") },
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (100)") },
+          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir` ALTER COLUMN widened TYPE byte") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (100)") },
           ProcessAllAvailable(),
           CheckAnswer(1, 100)
         )
@@ -583,23 +610,20 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
   test(
     "type change first without schemaTrackingLocation and unblock using schemaTrackingLocation") {
     withTempDir { dir =>
-      sql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
+      executeSql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
-      def readWithoutSchemaTrackingLog(): DataFrame =
-        spark.readStream.format("delta").load(dir.getCanonicalPath)
-
-      testStream(readWithoutSchemaTrackingLog())(
+      testStream(readStreamWithoutSchemaTracking(dir))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
         ProcessAllAvailable(),
         CheckAnswer(1)
       )
 
-      testStream(readWithoutSchemaTrackingLog())(
+      testStream(readStreamWithoutSchemaTracking(dir))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
-        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+        Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
         ExpectFailure[DeltaStreamingNonAdditiveSchemaIncompatibleException]()
       )
 
@@ -636,7 +660,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
   )) {
     test(s"unblocking stream with sql conf after type change - $name") {
       withTempDir { dir =>
-        sql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
+        executeSql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
         // Getting the checkpoint dir through the delta log to ensure the format is consistent with
         // the path used internally to compute the hash of the checkpoint location to unblock the
         // stream.
@@ -650,8 +674,8 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
         testStream(readWithAgg(), outputMode = OutputMode.Complete())(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
-          Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
@@ -665,7 +689,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
         withSQLConf(s"spark.databricks.delta.streaming.${getSqlConf(checkpointHash)}" -> value) {
           testStream(readWithAgg(), outputMode = OutputMode.Complete())(
             StartStream(checkpointLocation = checkpointDir.toString),
-            Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
+            Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
             ProcessAllAvailable(),
             CheckLastBatch(Row(1, 2))
           )
@@ -680,7 +704,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
   )) {
     test(s"unblocking stream with reader option after type change - $name") {
       withTempDir { dir =>
-        sql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
+        executeSql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
         val checkpointDir = new File(dir, "sink_checkpoint")
 
         def readWithAgg(options: Map[String, String] = Map.empty): DataFrame =
@@ -690,8 +714,8 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
         testStream(readWithAgg(), outputMode = OutputMode.Complete())(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
-          Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
           ExpectMetadataEvolutionException()
         )
 
@@ -704,7 +728,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
             readWithAgg(Map("allowSourceColumnTypeChange" -> optionValue)),
             outputMode = OutputMode.Complete())(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
           ProcessAllAvailable(),
           CheckLastBatch(Row(1, 2))
         )
@@ -714,12 +738,12 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
   test(s"overwrite schema with type change and dropped column") {
     withTempDir { dir =>
-      sql(s"CREATE TABLE delta.`$dir` (a byte, b int) USING DELTA")
+      executeSql(s"CREATE TABLE delta.`$dir` (a byte, b int) USING DELTA")
       val checkpointDir = new File(dir, "sink_checkpoint")
 
       testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
         StartStream(checkpointLocation = checkpointDir.toString),
-        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+        Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
         ProcessAllAvailable(),
         Execute { _ =>
           // Overwrite the table schema.
@@ -771,7 +795,7 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
           "spark.databricks.delta.streaming.allowSourceColumnTypeChange" -> "always") {
         testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
           StartStream(checkpointLocation = checkpointDir.toString),
-          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+          Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (2)") },
           ProcessAllAvailable()
         )
       }
@@ -780,31 +804,28 @@ trait TypeWideningStreamingSourceSchemaTrackingTests
 
   test("disable schema tracking log using internal conf") {
      withTempDir { dir =>
-       sql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+       executeSql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
        val checkpointDir = new File(dir, "sink_checkpoint")
-
-       def readStream(): DataFrame =
-         spark.readStream.format("delta").load(dir.getCanonicalPath)
 
        // When we disable schema tracking for widening type changes, the stream should succeed
        // without requiring the user to provide a schema tracking location or unblock the type
        // change.
        withSQLConf(
          DeltaSQLConf.DELTA_TYPE_WIDENING_ENABLE_STREAMING_SCHEMA_TRACKING.key -> "false") {
-         testStream(readStream())(
+         testStream(readStreamWithoutSchemaTracking(dir))(
            StartStream(checkpointLocation = checkpointDir.toString),
-           Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+           Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (1)") },
            ProcessAllAvailable(),
-           Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
+           Execute { _ => executeSql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
            ExpectFailure[DeltaIllegalStateException] { ex =>
              assert(ex.asInstanceOf[SparkThrowable].getErrorClass ===
                "DELTA_SCHEMA_CHANGED_WITH_VERSION")
            }
          )
 
-         testStream(readStream())(
+         testStream(readStreamWithoutSchemaTracking(dir))(
            StartStream(checkpointLocation = checkpointDir.toString),
-           Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+           Execute { _ => executeSql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
            ProcessAllAvailable(),
            CheckLastBatch(123456789)
          )


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Migrates streaming schema-tracking-related test suites to the V2 (Kernel-based) connector, ahead of the V2 schema tracking log implementation.

New V2 suites under `spark-unified/.../test`:
- `DeltaV2SourceSchemaEvolutionSuite` (name/id column mapping, CDC variants)
- `TypeWideningStreamingV2SourceSuite` (+ schema-tracking variant)
- `RemoveColumnMappingStreamingReadV2Suite`

Each mixes in `V2ForceTest` (forces `V2_ENABLE_MODE=STRICT`) and routes DDL/DML through an `executeDml` seam on its V1 base — `SparkTable` (V2) is read-only. Tests are partitioned into `shouldPassTests` / `shouldFailTests`; schema-tracking-log tests are tracked as expected-to-fail until V2 support lands.

Shared infrastructure consolidated into `V2ForceTest`:
- Lifted the strict `shouldFail` body (pass/fail exclusive-membership assert), previously duplicated across five V2 suites.
- Added `executeInV1Mode(sqlText)` helper that wraps a SQL call in `withSQLConf(V2_ENABLE_MODE = NONE)`. Each V2 suite's `executeDml` override collapses to one line.

V1 bases touched only to make the seam dual-path: added `executeDml` on `StreamingSchemaEvolutionSuiteBase`, and renamed the pre-existing `executeSql` seam to `executeDml` on typewidening / column-mapping bases for consistency. Default implementation is still `sql(...)`, so non-V2 behavior is unchanged.

## How was this patch tested?
Test-only change.

## Does this PR introduce _any_ user-facing changes?

No.