### PR TITLE
[PROTOCOL] Add delta.parquet.format.version property

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -109,6 +109,7 @@
   - [Writer Version Requirements](#writer-version-requirements)
 - [Requirements for Readers](#requirements-for-readers)
   - [Reader Version Requirements](#reader-version-requirements)
+- [Table Properties](#table-properties)
 - [Appendix](#appendix)
   - [Valid Feature Names in Table Features](#valid-feature-names-in-table-features)
   - [Deletion Vector Format](#deletion-vector-format)
@@ -2441,6 +2442,7 @@ Delta Lake tables support a set of properties stored in the `configuration` fiel
 Property | Description | Details
 -|-|-
 `delta.parquet.compression.codec` | Compression codec writers SHOULD use for new Parquet data and checkpoint files. Changing this property does not affect existing files; a table may contain files written with different codecs, which is a normal and expected state. | Widely supported values (matched case-insensitively): `uncompressed`/`none` (no compression), `snappy`, `gzip`, `lz4` (deprecated, Hadoop framing), `lz4_raw` ([LZ4 block format](https://parquet.apache.org/docs/file-format/data-pages/compression/#lz4_raw)), `zstd`.<br><br>When absent, writers SHOULD default to `zstd`. If a writer does not support or recognize the specified codec, it SHOULD abort with an appropriate error or fall back to a default codec.<br><br>Readers SHOULD support all codecs listed above regardless of the current property value. Parquet files written with other [parquet-supported codecs](https://parquet.apache.org/docs/file-format/data-pages/compression/) may also exist; readers MAY support reading these files.
+`delta.parquet.format.version` | Parquet data page format writers SHOULD use for new data files. This property is a directive to writers only; readers do not need to consult it, as Parquet pages are self-describing via the `PageType` field in each page header. Changing this property does not affect existing files; a table MAY contain files written with different data page versions, which is a normal and expected state. | Valid values: `1.0.0` (DataPageV1) and `2.x.x` (DataPageV2, where `x.x` is any minor.patch version). Recommended values are `1.0.0` and `2.12.0`.<br><br>When absent, writers SHOULD default to `1.0.0`. Writers SHOULD validate this property and abort if the value does not match `1.0.0` or `2.MINOR.PATCH`.<br><br>Readers SHOULD support both DataPageV1 and DataPageV2 pages regardless of this property's value. Tables intended for access by engines beyond the Delta Lake connectors SHOULD use `1.0.0`, as DataPageV2 support varies across the broader Parquet ecosystem.
 
 # Appendix
 


### PR DESCRIPTION
## Summary
1/ Adds delta.parquet.format.version to the Table Properties section of the protocol spec
2/ Documents valid values (`1.0.0` for DataPageV1, `2.x.x` for DataPageV2), writer validation behavior, reader expectations, and cross-engine interop guidance

## Details
1/ Writers: use this property to select the Parquet data page format. Valid values are `1.0.0` (DataPageV1) and any `2.x.x` (DataPageV2). Recommended values are `1.0.0` and `2.12.0`. Writers SHOULD default to `1.0.0` when absent.
2/ Readers: do not need to consult this property. Parquet pages are self-describing via the `PageType` field in each page header. Readers SHOULD support both DataPageV1 and DataPageV2.
3/ Interop: tables accessed by engines beyond the Delta Lake connectors SHOULD use `1.0.0`, as DataPageV2 support varies across the broader Parquet ecosystem.

## Test plan
- [x] Protocol-only change — no code changes, no tests needed
- [x] Verify markdown table renders correctly