### PR TITLE
[Kernel] enable the Data Skipping for STARTS_WITH

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -28,6 +28,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.CollationIdentifier;
+import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.util.*;
@@ -251,13 +252,13 @@ public class DataSkippingUtils {
           }
         }
         break;
-
       case "=":
       case "<":
       case "<=":
       case ">":
       case ">=":
       case "IS NOT DISTINCT FROM":
+      case "STARTS_WITH":
         Expression left = getLeft(dataFilters);
         Expression right = getRight(dataFilters);
         Optional<CollationIdentifier> collationIdentifier = dataFilters.getCollationIdentifier();
@@ -277,7 +278,11 @@ public class DataSkippingUtils {
             return constructComparatorDataSkippingFilters(
                 dataFilters.getName(), leftCol, rightLit, collationIdentifier, schemaHelper);
           }
-        } else if (right instanceof Column && left instanceof Literal) {
+        } else if (right instanceof Column
+            && left instanceof Literal
+            && REVERSE_COMPARATORS.containsKey(dataFilters.getName().toUpperCase(Locale.ROOT))) {
+          // STARTS_WITH is not commutative, so only reverse operators that have an entry
+          // in REVERSE_COMPARATORS.
           return constructDataSkippingFilter(reverseComparatorFilter(dataFilters), schemaHelper);
         }
         break;
@@ -378,6 +383,26 @@ public class DataSkippingUtils {
                 schemaHelper.getMaxColumn(leftCol, collationIdentifier),
                 rightLit,
                 collationIdentifier));
+        // Match any file whose max is greater than or equal to the prefix.
+        // A file can be skipped if max < prefix, since all values are before the prefix.
+        // STARTS_WITH only applies to string columns and literals, and is only supported
+        // for UTF8_BINARY collation.
+        // TODO: Support non-UTF8_BINARY collations once the default engine supports
+        //  collation-aware expression evaluation.
+      case "STARTS_WITH":
+        if (!(schemaHelper.getColumnDataType(leftCol) instanceof StringType)
+            || !(rightLit.getDataType() instanceof StringType)
+            || (collationIdentifier.isPresent()
+                && !collationIdentifier.get().isSparkUTF8BinaryCollation())) {
+          return Optional.empty();
+        }
+        return Optional.of(
+            constructBinaryDataSkippingPredicate(
+                ">=",
+                schemaHelper.getMaxColumn(leftCol, collationIdentifier),
+                rightLit,
+                collationIdentifier));
+
       case "IS NOT DISTINCT FROM":
         return constructDataSkippingFilter(
             rewriteEqualNullSafe(leftCol, rightLit, collationIdentifier), schemaHelper);
@@ -429,6 +454,28 @@ public class DataSkippingUtils {
         getRight(predicate),
         getLeft(predicate),
         predicate.getCollationIdentifier());
+  }
+
+  /**
+   * Computes the least string that is greater than all strings starting with the given prefix,
+   * under UTF8_BINARY (lexicographic) ordering. Returns {@code Optional.empty()} if no such bound
+   * exists (i.e. the prefix consists entirely of {@code Character.MAX_CODE_POINT}).
+   *
+   * <p>Example: "abc" -> "abd", "ab\uDBFF\uDFFF" -> "ac"
+   */
+  private static Optional<Literal> prefixUtf8BinaryUpperBound(String prefix) {
+    int i = prefix.length();
+    while (i > 0) {
+      int cp = prefix.codePointBefore(i);
+      int cpLen = Character.charCount(cp);
+      if (cp < Character.MAX_CODE_POINT) {
+        return Optional.of(
+            Literal.ofString(
+                prefix.substring(0, i - cpLen) + new String(Character.toChars(cp + 1))));
+      }
+      i -= cpLen;
+    }
+    return Optional.empty();
   }
 
   /** Construct the skipping predicate for a NOT expression child if possible */
@@ -524,6 +571,53 @@ public class DataSkippingUtils {
                     new Predicate(
                         "NOT", rewriteEqualNullSafe(leftColumn, rightLiteral, collationIdentifier)),
                     schemaHelper));
+      case "STARTS_WITH":
+        {
+          // NOT(col STARTS_WITH 'prefix') can skip a file if ALL values start with the
+          // prefix. This holds when min >= prefix AND max < upperBound(prefix).
+          // The keep-file predicate is: min < prefix OR max >= upperBound(prefix).
+          // Only supported for UTF8_BINARY collation.
+          // TODO: Support non-UTF8_BINARY collations once the default engine supports
+          //  collation-aware expression evaluation.
+          Optional<CollationIdentifier> swCollation = childPredicate.getCollationIdentifier();
+          if (swCollation.isPresent() && !swCollation.get().isSparkUTF8BinaryCollation()) {
+            return Optional.empty();
+          }
+
+          Expression swLeft = getLeft(childPredicate);
+          Expression swRight = getRight(childPredicate);
+          if (!(swLeft instanceof Column && swRight instanceof Literal)) {
+            return Optional.empty();
+          }
+          Column leftCol = (Column) swLeft;
+          Literal rightLit = (Literal) swRight;
+          if (!schemaHelper.isSkippingEligibleMinMaxColumn(leftCol)
+              || !(schemaHelper.getColumnDataType(leftCol) instanceof StringType)
+              || !(rightLit.getDataType() instanceof StringType)) {
+            return Optional.empty();
+          }
+
+          String prefix = (String) rightLit.getValue();
+          Optional<Literal> upperBound = prefixUtf8BinaryUpperBound(prefix);
+          if (!upperBound.isPresent()) {
+            // Prefix is all MAX_VALUE chars — can only use one-sided filter.
+            return Optional.of(
+                constructBinaryDataSkippingPredicate(
+                    "<", schemaHelper.getMinColumn(leftCol, swCollation), rightLit, swCollation));
+          }
+
+          // Keep file if: min < prefix OR max >= upperBound
+          return Optional.of(
+              new DataSkippingPredicate(
+                  "OR",
+                  constructBinaryDataSkippingPredicate(
+                      "<", schemaHelper.getMinColumn(leftCol, swCollation), rightLit, swCollation),
+                  constructBinaryDataSkippingPredicate(
+                      ">=",
+                      schemaHelper.getMaxColumn(leftCol, swCollation),
+                      upperBound.get(),
+                      swCollation)));
+        }
       case "NOT":
         // Remove redundant pairs of NOT
         return constructDataSkippingFilter(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -259,6 +259,14 @@ public class StatsSchemaHelper {
   }
 
   /**
+   * Returns the data type of the given logical column in the data schema, or {@code null} if the
+   * column is not found.
+   */
+  public DataType getColumnDataType(Column column) {
+    return logicalToDataType.get(column);
+  }
+
+  /**
    * Returns true if the given column is skipping-eligible using null count statistics. This means
    * the column exists and is a leaf column as we only collect stats for leaf columns.
    */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/DataSkippingUtilsSuite.scala
@@ -397,7 +397,99 @@ class DataSkippingUtilsSuite extends AnyFunSuite with TestUtils {
           dataSkippingPredicate(
             "<=",
             Seq(nestedCol(s"$MIN.b"), literal(7)),
-            Set(nestedCol(s"$MIN.b")))))))
+            Set(nestedCol(s"$MIN.b")))))),
+      // STARTS_WITH: col STARTS_WITH 'abc' => max.col >= 'abc'
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        createPredicate(
+          "STARTS_WITH",
+          col("a"),
+          literal("abc"),
+          Optional.empty[CollationIdentifier]),
+        Some(dataSkippingPredicate(
+          ">=",
+          Seq(nestedCol(s"$MAX.a"), literal("abc")),
+          Set(nestedCol(s"$MAX.a"))))),
+      // STARTS_WITH: non-string column => None (only string columns supported)
+      (
+        new StructType()
+          .add("a", IntegerType.INTEGER),
+        createPredicate(
+          "STARTS_WITH",
+          col("a"),
+          literal("abc"),
+          Optional.empty[CollationIdentifier]),
+        None),
+      // STARTS_WITH: both sides are columns => None (not eligible)
+      (
+        new StructType()
+          .add("a", StringType.STRING)
+          .add("b", StringType.STRING),
+        createPredicate(
+          "STARTS_WITH",
+          col("a"),
+          col("b"),
+          Optional.empty[CollationIdentifier]),
+        None),
+      // STARTS_WITH: literal STARTS_WITH column => None (not commutative)
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        createPredicate(
+          "STARTS_WITH",
+          literal("abc"),
+          col("a"),
+          Optional.empty[CollationIdentifier]),
+        None),
+      // NOT STARTS_WITH: NOT(a STARTS_WITH 'abc') => min.a < 'abc' OR max.a >= 'abd'
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        new Predicate(
+          "NOT",
+          createPredicate(
+            "STARTS_WITH",
+            col("a"),
+            literal("abc"),
+            Optional.empty[CollationIdentifier])),
+        Some(dataSkippingPredicate(
+          "OR",
+          dataSkippingPredicate(
+            "<",
+            Seq(nestedCol(s"$MIN.a"), literal("abc")),
+            Set(nestedCol(s"$MIN.a"))),
+          dataSkippingPredicate(
+            ">=",
+            Seq(nestedCol(s"$MAX.a"), literal("abd")),
+            Set(nestedCol(s"$MAX.a")))))),
+      // NOT STARTS_WITH with MAX_CODE_POINT prefix => one-sided: min.a < '\uDBFF\uDFFF'
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        new Predicate(
+          "NOT",
+          createPredicate(
+            "STARTS_WITH",
+            col("a"),
+            literal("\uDBFF\uDFFF"),
+            Optional.empty[CollationIdentifier])),
+        Some(dataSkippingPredicate(
+          "<",
+          Seq(nestedCol(s"$MIN.a"), literal("\uDBFF\uDFFF")),
+          Set(nestedCol(s"$MIN.a"))))),
+      // NOT STARTS_WITH with non-string column => None
+      (
+        new StructType()
+          .add("a", IntegerType.INTEGER),
+        new Predicate(
+          "NOT",
+          createPredicate(
+            "STARTS_WITH",
+            col("a"),
+            literal("abc"),
+            Optional.empty[CollationIdentifier])),
+        None))
 
     testCases.foreach { case (schema, predicate, expectedDataSkippingPredicateOpt) =>
       val dataSkippingPredicateOpt =
@@ -546,7 +638,39 @@ class DataSkippingUtilsSuite extends AnyFunSuite with TestUtils {
             Seq(minA, literal(1)),
             utf8Lcase,
             Set(minA)))
-        }))
+        }),
+      // STARTS_WITH with non-UTF8_BINARY collation => None (only UTF8_BINARY supported)
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        createPredicate(
+          "STARTS_WITH",
+          col("a"),
+          literal("abc"),
+          Optional.of(utf8Lcase)),
+        None),
+      // STARTS_WITH with collation without version => None
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        createPredicate(
+          "STARTS_WITH",
+          col("a"),
+          literal("abc"),
+          Optional.of(CollationIdentifier.fromString("SPARK.UTF8_LCASE"))),
+        None),
+      // NOT STARTS_WITH with non-UTF8_BINARY collation => None
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        new Predicate(
+          "NOT",
+          createPredicate(
+            "STARTS_WITH",
+            col("a"),
+            literal("abc"),
+            Optional.of(utf8Lcase))),
+        None))
 
     testCases.foreach { case (schema, predicate, expectedDataSkippingPredicateOpt) =>
       val dataSkippingPredicateOpt =

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -2084,7 +2084,88 @@ class ScanSuite extends AnyFunSuite with TestUtils
               new Predicate(
                 ">",
                 ofString("y"),
-                col("c2"))) -> 0)
+                col("c2"))) -> 0,
+            // Data skipping: STARTS_WITH on non-partition column c1
+            // Files have c1 values: "a", "c", "e" (one per file)
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("f")) -> 0,
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("c")) -> 2,
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("a")) -> totalFiles,
+            // STARTS_WITH with literal carrying c2's collation
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("f", c2Collation)) -> 0,
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("c", c2Collation)) -> 2,
+            // STARTS_WITH with explicit SPARK.UTF8_BINARY collation
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("f"),
+              CollationIdentifier.SPARK_UTF8_BINARY) -> 0,
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("c"),
+              CollationIdentifier.SPARK_UTF8_BINARY) -> 2,
+            new Predicate(
+              "STARTS_WITH",
+              col("c1"),
+              ofString("c", c2Collation),
+              CollationIdentifier.SPARK_UTF8_BINARY) -> 2,
+            // NOT STARTS_WITH
+            new Predicate(
+              "NOT",
+              new Predicate(
+                "STARTS_WITH",
+                col("c1"),
+                ofString("c"))) -> 2,
+            new Predicate(
+              "NOT",
+              new Predicate(
+                "STARTS_WITH",
+                col("c1"),
+                ofString("z"))) -> totalFiles,
+            // NOT STARTS_WITH with literal carrying c2's collation
+            new Predicate(
+              "NOT",
+              new Predicate(
+                "STARTS_WITH",
+                col("c1"),
+                ofString("c", c2Collation))) -> 2,
+            // NOT STARTS_WITH with explicit SPARK.UTF8_BINARY collation
+            new Predicate(
+              "NOT",
+              new Predicate(
+                "STARTS_WITH",
+                col("c1"),
+                ofString("c"),
+                CollationIdentifier.SPARK_UTF8_BINARY)) -> 2,
+            new Predicate(
+              "NOT",
+              new Predicate(
+                "STARTS_WITH",
+                col("c1"),
+                ofString("z"),
+                CollationIdentifier.SPARK_UTF8_BINARY)) -> totalFiles,
+            new Predicate(
+              "NOT",
+              new Predicate(
+                "STARTS_WITH",
+                col("c1"),
+                ofString("c", c2Collation),
+                CollationIdentifier.SPARK_UTF8_BINARY)) -> 2)
           checkSkipping(tempDir.getCanonicalPath, filterToFileNumber)
         }
       }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Enable data skipping for `STARTS_WITH` predicates using min/max statistics, reducing the number of files scanned for queries with string prefix filters:
- For `col STARTS_WITH 'prefix'`: skip files where `max < 'prefix'` (i.e., keep files where `max >= 'prefix'`)
- For `NOT (col STARTS_WITH 'prefix')`: skip files where all values start with the prefix, using an upper-bound computation (`min < 'prefix' OR max >= upperBound('prefix')`)
- Restricted to `UTF8_BINARY` collation only; non-`UTF8_BINARY` collations return no skipping filter (with TODO for future support once the default engine supports collation-aware evaluation)

Resolves #2539.

## How was this patch tested?

- `DataSkippingUtilsSuite` unit tests on `kernel-api`
- `ScanSuite` integration tests on `kernel-defaults`

## Does this PR introduce _any_ user-facing changes?

No