### PR TITLE
mistake...

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -49,7 +49,7 @@ import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.stats._
 import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
-import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils, TransactionHelper}
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils, PartitionUtils, TransactionHelper}
 import org.apache.spark.sql.util.ScalaExtensions._
 import io.delta.storage.commit._
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
@@ -1233,23 +1233,73 @@ trait OptimisticTransactionImpl extends TransactionHelper
   }
 
   /**
-   * Returns files within the given partitions.
-   *
-   * `partitions` is a set of the `partitionValues` stored in [[AddFile]]s. This means they refer to
-   * the physical column names, and values are stored as strings.
-   * */
-  def filterFiles(partitions: Set[Map[String, String]]): Seq[AddFile] = {
+   * Returns files within the partitions of the given [[AddFile]]s.
+   */
+  def filterFiles(newFiles: Seq[AddFile]): Seq[AddFile] = {
     import org.apache.spark.sql.functions.col
     val df = snapshot.allFiles.toDF()
-    val isFileInTouchedPartitions =
-      DeltaUDF.booleanFromMap(partitions.contains)(col("partitionValues"))
-    val filteredFiles = df
-      .filter(isFileInTouchedPartitions)
-      .withColumn("stats", DataSkippingReader.nullStringLiteral)
-      .as[AddFile]
-      .collect()
+    val parseToTypedLiterals =
+      spark.conf.get(DeltaSQLConf.DELTA_DYNAMIC_PARTITION_OVERWRITE_PARSE_PARTITION_VALUES)
+    val timeZone = spark.sessionState.conf.sessionLocalTimeZone
+
+    val (filteredFiles, filterPredicate) = try {
+      // Always fail on error. We log and throw it again or fall back depending on the config.
+      val newFilesNormalizedPartitionValues = newFiles.map(f =>
+        Action.normalizePartitionValues(
+          f.partitionValues,
+          metadata.physicalPartitionSchema,
+          timeZone,
+          parseToTypedLiterals,
+          failOnParsingError = true)
+      ).toSet
+
+      val existingFilesPartitionSchema = snapshot.metadata.physicalPartitionSchema
+      val pred = DeltaUDF.booleanFromMap { filePartValues =>
+        newFilesNormalizedPartitionValues.contains(Action.normalizePartitionValues(
+          filePartValues,
+          existingFilesPartitionSchema,
+          timeZone,
+          parseToTypedLiterals,
+          failOnParsingError = true))
+      }(col("partitionValues"))
+      val files = df.filter(pred)
+          .withColumn("stats", DataSkippingReader.nullStringLiteral)
+          .as[AddFile]
+          .collect()
+      (files, pred)
+    } catch {
+      case NonFatal(e) =>
+        val opTypeSuffix = PartitionUtils.classifyPartitionValueParsingError(e)
+        recordDeltaEvent(
+          deltaLog,
+          opType = "delta.dynamicPartitionOverwrite.partitionValueParsingError" + opTypeSuffix,
+          data = getErrorData(e) ++ Map(
+            "readSnapshotMetadata" -> snapshot.metadata,
+            "txnMetadata" -> metadata,
+            "commitInfo" -> commitInfo,
+            "readSnapshotVersion" -> snapshot.version,
+            "timeZone" -> timeZone
+          )
+        )
+        if (spark.conf.get(DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR)) {
+          e match {
+            // UDF exceptions get wrapped in SparkException. Unwrap to throw the root cause.
+            case se: SparkException => throw Option(se.getCause).getOrElse(se)
+            case _ => throw e
+          }
+        }
+        // Partition value parsing failed, fall back to raw string comparison.
+        val rawPartitions = newFiles.map(_.partitionValues).toSet
+        val pred = DeltaUDF.booleanFromMap(rawPartitions.contains)(col("partitionValues"))
+        val files = df.filter(pred)
+            .withColumn("stats", DataSkippingReader.nullStringLiteral)
+            .as[AddFile]
+            .collect()
+        (files, pred)
+    }
+
     trackReadPredicates(
-      Seq(isFileInTouchedPartitions.expr), partitionOnly = true, shouldRewriteFilter = false)
+      Seq(filterPredicate.expr), partitionOnly = true, shouldRewriteFilter = false)
     filteredFiles
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -99,6 +99,45 @@ object Action extends DeltaLogging {
     }
   }
 
+  /**
+   * Normalizes partition values to typed Literals. This method is serializable and does not
+   * require SparkSession, so it can be used inside UDFs for parallel processing.
+   *
+   * @param rawPartitionValues Map of partition column names to their string values.
+   * @param partitionSchema Schema defining the data types for each partition column.
+   * @param timeZoneId The Spark session time zone ID. This should ALWAYS be the session timezone
+   *                   to ensure consistent parsing between read and write paths.
+   * @param parseToTypedLiterals Whether to parse partition values to their actual types.
+   *                             When false, verbatim value from the log action is returned in a
+   *                             String Literal.
+   * @param failOnParsingError If true, throw the exception if parsing fails.
+   *                           If false, return the raw partition values as string Literals.
+   * @return Map of partition column names to their literal values.
+   */
+  def normalizePartitionValues(
+      rawPartitionValues: Map[String, String],
+      partitionSchema: StructType,
+      timeZoneId: String,
+      parseToTypedLiterals: Boolean,
+      failOnParsingError: Boolean): Map[String, Literal] = {
+    def parseToStringLiterals = rawPartitionValues.map { case (k, v) => (k, Literal(v)) }
+    if (parseToTypedLiterals) {
+      try {
+        PartitionUtils.parsePartitionValues(
+          rawPartitionValues, partitionSchema, timeZoneId, validatePartitionColumns = true)
+      } catch {
+        case NonFatal(e) =>
+          if (failOnParsingError) {
+            throw e
+          } else {
+            parseToStringLiterals
+          }
+      }
+    } else {
+      parseToStringLiterals
+    }
+  }
+
   /** All reader protocol version numbers supported by the system. */
   private[delta] lazy val supportedReaderVersionNumbers: Set[Int] = {
     val allVersions =
@@ -673,6 +712,68 @@ sealed trait FileAction extends Action {
   def getTag(tagName: String): Option[String] = Option(tags).flatMap(_.get(tagName))
 
 
+  /**
+   * Return partition values as literals, optionally parsed to their actual data types.
+   * When `parseToTypedLiterals` is true, partition values are parsed to their actual
+   * types for comparison purposes. When false, they are returned as string literals,
+   * using verbatim value written in the action.
+   *
+   * @param deltaLog The DeltaLog for logging events. May be null if unavailable.
+   * @param errorOpType Prefix for logging event opTypes.
+   * @param errorData Extra fields to include in logging events.
+   * @return Map of partition column names to literals.
+   */
+  private[delta] def normalizedPartitionValues(
+      spark: SparkSession,
+      partitionSchema: StructType,
+      parseToTypedLiterals: Boolean,
+      deltaLog: DeltaLog,
+      errorOpType: String,
+      errorData: Map[String, Any]): Map[String, Literal] = {
+    val timeZone = spark.sessionState.conf.sessionLocalTimeZone
+
+    try {
+      val partitionValueLiterals = Action.normalizePartitionValues(
+        partitionValues,
+        partitionSchema,
+        timeZone,
+        parseToTypedLiterals,
+        failOnParsingError = true)
+
+      if (parseToTypedLiterals) {
+        val stringNormalizedPartitionValues = partitionValueLiterals.map {
+          case (k, v) => (k, PartitionUtils.literalToNormalizedString(
+            v,
+            Some(timeZone),
+            useUtcNormalizedTimestamp = true))
+        }
+        if (stringNormalizedPartitionValues != partitionValues) {
+          Action.recordDeltaEvent(
+            deltaLog,
+            opType = errorOpType + ".unnormalizedValuesExist",
+            data = errorData
+          )
+        }
+      }
+      partitionValueLiterals
+    } catch {
+      case NonFatal(e) =>
+        val opTypeSuffix = PartitionUtils.classifyPartitionValueParsingError(e)
+        Action.recordDeltaEvent(
+          deltaLog,
+          opType = errorOpType + ".partitionValueParsingError" + opTypeSuffix,
+          data = errorData ++ Map(
+            "exceptionMessage" -> e.getMessage,
+            "timeZone" -> timeZone
+          )
+        )
+        if (spark.conf.get(DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR)) {
+          throw e
+        }
+        partitionValues.map { case (k, v) => (k, Literal(v)) }
+    }
+  }
+
   /** Returns the [[SparkPath]] for this file action. */
   def sparkPath: SparkPath = SparkPath.fromUrlString(path)
 
@@ -889,63 +990,19 @@ case class AddFile(
       spark: SparkSession,
       partitionSchema: StructType,
       deltaTxn: Option[OptimisticTransaction] = None): Map[String, Literal] = {
-
-    def partitionValuesAsStringLiterals: Map[String, Literal] = {
-      // Convert all partition values to string literals
-      partitionValues.map { case (k, v) => (k, Literal(v)) }
-    }
-
-    val normalizePartitionValuesOnRead =
-      spark.conf.get(DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ)
-    if (normalizePartitionValuesOnRead) {
-      val timeZone = spark.sessionState.conf.sessionLocalTimeZone
-
-      try {
-        val typedPartitionValueLiterals = PartitionUtils.parsePartitionValues(
-          partitionValues,
-          partitionSchema,
-          java.util.TimeZone.getDefault.getID,
-          validatePartitionColumns = true)
-
-        val stringNormalizedPartitionValues = typedPartitionValueLiterals.map {
-          case (k, v) => (k, PartitionUtils.literalToNormalizedString(
-            v,
-            Some(timeZone),
-            useUtcNormalizedTimestamp = true))
-        }
-
-        if (stringNormalizedPartitionValues != partitionValues) {
-          Action.recordDeltaEvent(
-            deltaTxn.map(_.deltaLog).orNull,
-            opType = "delta.normalizedPartitionValues.unnormalizedValuesExist",
-            data = Map(
-              "readSnapshotMetadata" -> deltaTxn.map(_.snapshot.metadata).orNull,
-              "txnMetadata" -> deltaTxn.map(_.metadata).orNull,
-              "commitInfo" -> deltaTxn.map(_.getCommitInfo).orNull
-            )
-          )
-        }
-        typedPartitionValueLiterals
-      } catch {
-        case NonFatal(e) =>
-          val opTypeSuffix = PartitionUtils.classifyPartitionValueParsingError(e)
-          Action.recordDeltaEvent(
-            deltaTxn.map(_.deltaLog).orNull,
-            opType = "delta.normalizedPartitionValues.partitionValueParsingError" + opTypeSuffix,
-            data = Map(
-              "exceptionMessage" -> e.getMessage,
-              "readSnapshotMetadata" -> deltaTxn.map(_.snapshot.metadata).orNull,
-              "txnMetadata" -> deltaTxn.map(_.metadata).orNull,
-              "commitInfo" -> deltaTxn.map(_.getCommitInfo).orNull,
-              "readSnapshotVersion" -> deltaTxn.map(_.snapshot.version).getOrElse(-1L),
-              "timeZone" -> timeZone
-            )
-          )
-          partitionValuesAsStringLiterals
-      }
-    } else {
-        partitionValuesAsStringLiterals
-    }
+    normalizedPartitionValues(
+      spark,
+      partitionSchema,
+      parseToTypedLiterals =
+        spark.conf.get(DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ),
+      deltaLog = deltaTxn.map(_.deltaLog).orNull,
+      errorOpType = "delta.normalizedPartitionValues",
+      errorData = Map(
+        "readSnapshotMetadata" -> deltaTxn.map(_.snapshot.metadata).orNull,
+        "txnMetadata" -> deltaTxn.map(_.metadata).orNull,
+        "commitInfo" -> deltaTxn.map(_.getCommitInfo).orNull,
+        "readSnapshotVersion" -> deltaTxn.map(_.snapshot.version).getOrElse(-1L))
+    )
   }
 
   // Don't use lazy val because we want to save memory.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -354,22 +354,22 @@ case class WriteIntoDelta(
         val deletedFiles = if (useDynamicPartitionOverwriteMode) {
           // with dynamic partition overwrite for any partition that is being written to all
           // existing data in that partition will be deleted.
-          // the selection what to delete is determined by `updatePartitions`.
+          // the selection what to delete is determined by `filesToFilter`.
 
           // Dynamic Partition Overwrite (DPO) uses null-tolerant equality, meaning NULL partitions
           // in the table will be overwritten if there are matching NULL values in the query.
           // This option simulates null-intolerant equality by not including partitions with
           // NULL values in the set of partitions to be overwritten.
-          val updatePartitions =
+          val filesToFilter =
             if (options.useNullIntolerantEqualityWithDPO.contains(true)) {
               addFiles.collect { case addFile
                 if addFile.partitionValues.forall { case (_, value) => value != null }
-                  => addFile.partitionValues
-              }.toSet
+                  => addFile
+              }
             } else {
-              addFiles.map(_.partitionValues).toSet
+              addFiles
             }
-          txn.filterFiles(updatePartitions).map(_.remove)
+          txn.filterFiles(filesToFilter).map(_.remove)
         } else {
           txn.filterFiles().map(_.remove)
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3156,6 +3156,27 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR =
+    buildConf("failOnPartitionValueParsingError")
+      .internal()
+      .doc(
+        "When true, we will fail (rethrow) if there is an error when parsing partition values " +
+        "to their actual types. When false, we will fall back to using partition value strings."
+      )
+      .booleanConf
+      .createWithDefault(DeltaUtils.isTesting)
+
+  val DELTA_DYNAMIC_PARTITION_OVERWRITE_PARSE_PARTITION_VALUES =
+    buildConf("dynamicPartitionOverwrite.parsePartitionValues")
+      .internal()
+      .doc(
+        "When true, we will parse partition values to their actual types for comparison during " +
+        "dynamic partition overwrite file filtering, instead of using raw strings. " +
+        "This helps prevent issues with inconsistently formatted partition values."
+      )
+      .booleanConf
+      .createWithDefault(true)
+
   //////////////////
   // CORRECTNESS
   //////////////////

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{EqualTo, Literal}
 import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.sql.types.{IntegerType, StructType, TimestampType}
 import org.apache.spark.util.ManualClock
 
 
@@ -733,8 +733,7 @@ class OptimisticTransactionSuite
 
             // txn1: read files in partitions of our new data (part=0)
             val txn = log.startTransaction()
-            val addFiles =
-                txn.filterFiles(newData.map(_.partitionValues).toSet)
+            val addFiles = txn.filterFiles(newData)
 
             // txn2
             log.startTransaction().commit(concurrentActions(partCol), ManualUpdate)
@@ -799,6 +798,153 @@ class OptimisticTransactionSuite
     concurrentActions = partCol => Seq(
       RemoveFile("b", None, partitionValues = Map(partCol -> "1")))
   )
+
+  for (enableNormalization <- BOOLEAN_DOMAIN) {
+    test("filterFiles for timestamp partitions with different string formats, " +
+      s"enableNormalization = $enableNormalization") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_DYNAMIC_PARTITION_OVERWRITE_PARSE_PARTITION_VALUES.key ->
+          enableNormalization.toString
+      ) {
+        DeltaTestUtils.withTimeZone("UTC") {
+          withTempDir { tempDir =>
+            val tablePath = tempDir.getCanonicalPath
+            val log = DeltaLog.forTable(spark, tablePath)
+
+            log.startTransaction().commit(Seq(
+              Metadata(
+                schemaString = new StructType()
+                  .add("ts", TimestampType)
+                  .add("value", IntegerType).json,
+                partitionColumns = Seq("ts"))
+            ), ManualUpdate)
+
+            // Add files with non-UTC formatted timestamp partition values
+            val nonUtcTimestamp = "2000-01-01 12:00:00"
+            log.startTransaction().commit(
+              Seq(
+                AddFile("a", Map("ts" -> nonUtcTimestamp), 1, 1, dataChange = true),
+                AddFile("b", Map("ts" -> "2000-02-02 12:00:00"), 1, 1, dataChange = true)),
+              ManualUpdate)
+
+            // Query using UTC formatted timestamp (different string, same logical value)
+            val utcTimestamp = "2000-01-01T12:00:00.000000Z"
+            val txn = log.startTransaction()
+            val utcAddFile = AddFile("tmp", Map("ts" -> utcTimestamp), 0, 0, dataChange = false)
+            val matchedFiles = txn.filterFiles(Seq(utcAddFile))
+
+            if (enableNormalization) {
+              assert(matchedFiles.map(_.path).toSet == Set("a"))
+            } else {
+              assert(matchedFiles.isEmpty)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (failOnError <- BOOLEAN_DOMAIN) {
+    test("filterFiles falls back to string comparison when partition parsing fails, " +
+      s"failOnError = $failOnError") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_DYNAMIC_PARTITION_OVERWRITE_PARSE_PARTITION_VALUES.key -> "true",
+        DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> failOnError.toString
+      ) {
+        withTempDir { tempDir =>
+          val tablePath = tempDir.getCanonicalPath
+          val log = DeltaLog.forTable(spark, tablePath)
+
+          log.startTransaction().commit(Seq(
+            Metadata(
+              schemaString = new StructType()
+                .add("part", IntegerType)
+                .add("value", IntegerType).json,
+              partitionColumns = Seq("part"))
+          ), ManualUpdate)
+
+          // Add existing file with an unparseable partition value.
+          val badValue = "not_a_number"
+          log.startTransaction().commit(
+            Seq(AddFile("a", Map("part" -> badValue), 1, 1, dataChange = true)),
+            ManualUpdate)
+
+          // New file also has the same unparseable value
+          val txn = log.startTransaction()
+          val newFile = AddFile("tmp", Map("part" -> badValue), 0, 0, dataChange = false)
+
+          if (failOnError) {
+            checkError(
+              intercept[DeltaRuntimeException] {
+                txn.filterFiles(Seq(newFile))
+              },
+              condition = "DELTA_PARTITION_COLUMN_CAST_FAILED",
+              sqlState = "22525",
+              parameters = Map(
+                "value" -> badValue,
+                "dataType" -> "IntegerType",
+                "columnName" -> "part")
+            )
+          } else {
+            // Falls back to raw string comparison — strings match, so file "a" is returned
+            val matched = txn.filterFiles(Seq(newFile))
+            assert(matched.map(_.path).toSet == Set("a"))
+          }
+        }
+      }
+    }
+  }
+
+  for (failOnError <- BOOLEAN_DOMAIN) {
+    test("filterFiles when existing files have unparseable partition values, " +
+      s"failOnError = $failOnError") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_DYNAMIC_PARTITION_OVERWRITE_PARSE_PARTITION_VALUES.key -> "true",
+        DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> failOnError.toString
+      ) {
+        withTempDir { tempDir =>
+          val tablePath = tempDir.getCanonicalPath
+          val log = DeltaLog.forTable(spark, tablePath)
+
+          log.startTransaction().commit(Seq(
+            Metadata(
+              schemaString = new StructType()
+                .add("part", IntegerType)
+                .add("value", IntegerType).json,
+              partitionColumns = Seq("part"))
+          ), ManualUpdate)
+
+          // Existing file has an unparseable partition value.
+          val badValue = "not_a_number"
+          log.startTransaction().commit(
+            Seq(AddFile("a", Map("part" -> badValue), 1, 1, dataChange = true)),
+            ManualUpdate)
+
+          // New file has a valid partition value. Only the UDF fails
+          val txn = log.startTransaction()
+          val newFile = AddFile("tmp", Map("part" -> "1"), 0, 0, dataChange = false)
+
+          if (failOnError) {
+            checkError(
+              intercept[DeltaRuntimeException] {
+                txn.filterFiles(Seq(newFile))
+              },
+              condition = "DELTA_PARTITION_COLUMN_CAST_FAILED",
+              sqlState = "22525",
+              parameters = Map(
+                "value" -> badValue,
+                "dataType" -> "IntegerType",
+                "columnName" -> "part")
+            )
+          } else {
+            // Falls back to raw string comparison — "1" != "not_a_number", so no match
+            val matched = txn.filterFiles(Seq(newFile))
+            assert(matched.isEmpty)
+          }
+        }
+      }
+    }
+  }
 
   test("can set partition columns in first commit") {
     withTempDir { tableDir =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/AddFileSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/AddFileSuite.scala
@@ -354,6 +354,7 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
 
   test("normalizedPartitionValues for DateType should return the original date string") {
     withSQLConf(
+      DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
       DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true"
     ) {
       withTempDir { tempDir =>
@@ -379,6 +380,7 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
 
   test("normalizedPartitionValues should handle __HIVE_DEFAULT_PARTITION__") {
     withSQLConf(
+      DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
       DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true"
     ) {
       withTempDir { tempDir =>
@@ -402,6 +404,7 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
 
   test("normalizedPartitionValues preserves escaped characters in AddFile partition values") {
     withSQLConf(
+      DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
       DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true"
     ) {
       withTempDir { tempDir =>
@@ -429,6 +432,7 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
     withJvmTimeZone("Europe/Berlin") {
       withSQLConf(
         DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true",
+        DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
         "spark.sql.session.timeZone" -> "Europe/Berlin" // UTC + 1 in winter time
       ) {
         withTempDir { tempDir =>
@@ -457,6 +461,7 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
     "and a non UTC session time zone gets converted to UTC.") {
     withSQLConf(
       DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true",
+      DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
       "spark.sql.session.timeZone" -> "America/Los_Angeles" // UTC - 8 in winter time
     ) {
       withTempDir { tempDir =>
@@ -493,6 +498,7 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
     withJvmTimeZone("UTC") {
       withSQLConf(
         DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true",
+        DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
         "spark.sql.session.timeZone" -> "UTC"
       ) {
         withTempDir { tempDir =>
@@ -545,7 +551,8 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
     withJvmTimeZone("Europe/Berlin") {
       withSQLConf(
         DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true",
-        "spark.sql.session.timeZone" -> "Europe/Berlin" // UTC + 1 in winter time
+        DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
+        "spark.sql.session.timeZone" -> "America/Los_Angeles" // UTC - 8 in winter time
       ) {
         withTempDir { tempDir =>
           spark.createDataFrame(
@@ -557,20 +564,23 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
           ).write.format("delta").partitionBy("tsCol").save(tempDir.getCanonicalPath)
           val deltaTxn = DeltaLog.forTable(spark, tempDir.getCanonicalPath).startTransaction()
 
-          // ISO 8601 format with 'T' separator but no time zone should use the JVM time zone.
+          // ISO 8601 format with 'T' separator but no time zone should use the session time zone
+          // since the timestamp formatter fails to parse this format.
           val file = createAddFileWithPartitionValue(Map("tsCol" -> "2000-01-01T12:00:00"))
-          // The normalized timestamp should be 11:00 UTC (12:00 Berlin = 11:00 UTC)
+          // The normalized timestamp should be 20:00 UTC (12:00 LA + 8h = 20:00 UTC)
           val normalized = file.normalizedPartitionValues(spark, deltaTxn)
-          assert(normalized("tsCol") == timestampLiteral("2000-01-01 12:00:00", "Europe/Berlin"))
+          assert(normalized("tsCol") ==
+            timestampLiteral("2000-01-01 12:00:00", "America/Los_Angeles"))
         }
       }
     }
   }
 
-  test("normalizedPartitionValues should also use the JVM timezone on read") {
+  test("normalizedPartitionValues should use the session timezone on read") {
     withJvmTimeZone("America/Los_Angeles") {
       withSQLConf(
         DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key -> "true",
+        DeltaSQLConf.DELTA_FAIL_ON_PARTITION_VALUE_PARSING_ERROR.key -> "true",
         "spark.sql.session.timeZone" -> "UTC"
       ) {
         withTempDir { tempDir =>
@@ -583,15 +593,15 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
           ).write.format("delta").partitionBy("tsCol").save(tempDir.getCanonicalPath)
           val deltaTxn = DeltaLog.forTable(spark, tempDir.getCanonicalPath).startTransaction()
 
-          // ON WRITE we use the JVM timezone, parsing this as an America/Los_Angeles timestamp.
           val file = createAddFileWithPartitionValue(Map("tsCol" -> "2000-01-01 12:00:00"))
           val normalized = file.normalizedPartitionValues(spark, deltaTxn)
 
-          // ON READ we also need to use the JVM timezone again, reading it again as an
-          // America/Los_Angeles timestamp.
-          assert(
-            normalized("tsCol") == timestampLiteral("2000-01-01 12:00:00", "America/Los_Angeles"))
-          assert(normalized("tsCol") != timestampLiteral("2000-01-01 12:00:00", "UTC"))
+          // ON READ we use the session timezone (UTC), not the JVM timezone
+          // (America/Los_Angeles), to be consistent with the WRITE path in
+          // DelayedCommitProtocol which also uses the session timezone.
+          assert(normalized("tsCol") == timestampLiteral("2000-01-01 12:00:00", "UTC"))
+          assert(normalized("tsCol") !=
+            timestampLiteral("2000-01-01 12:00:00", "America/Los_Angeles"))
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -881,7 +881,7 @@ trait DataSkippingDeltaTestsBase extends QueryTest
     Seq(1, 2, 3).toDF().write.format("delta").save(tempDir.toString)
     val log = DeltaLog.forTable(spark, new Path(tempDir.toString))
     val txn = log.startTransaction()
-    val noStats = txn.filterFiles(Nil).map(_.copy(stats = null))
+    val noStats = txn.filterFiles().map(_.copy(stats = null))
     txn.commit(noStats, DeltaOperations.ComputeStats(Nil))
 
     val df = spark.read.format("delta").load(tempDir.toString)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
* We use the session timezone consistently instead of the JVM timezone. Fallback paths are dead codes so we switch them also to the session timezone.
* We fix a bug regarding checking on different formatted timestamp patterns which may cause data loss for DPO code.

## How was this patch tested?
New unit tests and existing

## Does this PR introduce _any_ user-facing changes?
No, switching the JVM timezone to session timezone was currently dead code.
