### PR TITLE
[kernel-spark] Create v2 adapters for metadata and protocol

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1253,8 +1253,7 @@ case class Metadata(
 
   /** Returns the partitionSchema as a [[StructType]] */
   @JsonIgnore
-  lazy val partitionSchema: StructType =
-    new StructType(partitionColumns.map(c => schema(c)).toArray)
+  override lazy val partitionSchema: StructType = super.partitionSchema
 
   /** Partition value keys in the AddFile map. */
   @JsonIgnore

--- a/spark/src/main/scala/org/apache/spark/sql/delta/v2/interop/AbstractMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/v2/interop/AbstractMetadata.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.v2.interop
 
+import org.apache.spark.sql.delta.DeltaColumnMappingMode
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -42,5 +43,12 @@ trait AbstractMetadata {
 
   /** The table properties/configuration defined on the table. */
   def configuration: Map[String, String]
+
+  /** Column mapping mode for this table. */
+  def columnMappingMode: DeltaColumnMappingMode
+
+  /** Returns the partitionSchema as a [[StructType]] */
+  def partitionSchema: StructType =
+    new StructType(partitionColumns.map(c => schema(c)).toArray)
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/v2/interop/AbstractProtocol.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/v2/interop/AbstractProtocol.scala
@@ -40,5 +40,16 @@ trait AbstractProtocol {
    * Returns None if table features are not enabled for writers.
    */
   def writerFeatures: Option[Set[String]]
+
+  /**
+   * Field-wise equality across the abstract surface of [[AbstractProtocol]]. Use this instead of
+   * comparing fields ad-hoc at call sites so that adding a new field to this trait forces an
+   * update here rather than silently leaving stale comparisons elsewhere.
+   */
+  def equalsByFields(other: AbstractProtocol): Boolean =
+    minReaderVersion == other.minReaderVersion &&
+      minWriterVersion == other.minWriterVersion &&
+      readerFeatures == other.readerFeatures &&
+      writerFeatures == other.writerFeatures
 }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/adapters/KernelMetadataAdapter.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/adapters/KernelMetadataAdapter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.adapters;
+
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import java.util.List;
+import java.util.Objects;
+import org.apache.spark.sql.delta.DeltaColumnMappingMode;
+import org.apache.spark.sql.delta.DeltaColumnMappingMode$;
+import org.apache.spark.sql.delta.NoMapping$;
+import org.apache.spark.sql.delta.v2.interop.AbstractMetadata;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.immutable.Map;
+import scala.collection.immutable.Seq;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Adapter from {@link io.delta.kernel.internal.actions.Metadata} to {@link
+ * org.apache.spark.sql.delta.v2.interop.AbstractMetadata}.
+ */
+public class KernelMetadataAdapter implements AbstractMetadata {
+
+  private final Metadata kernelMetadata;
+  private volatile StructType cachedSchema;
+  private volatile Seq<String> cachedPartitionColumns;
+  private volatile Map<String, String> cachedConfiguration;
+  private volatile StructType cachedPartitionSchema;
+  private volatile DeltaColumnMappingMode cachedColumnMappingMode;
+
+  public KernelMetadataAdapter(Metadata kernelMetadata) {
+    this.kernelMetadata = Objects.requireNonNull(kernelMetadata, "kernelMetadata is null");
+  }
+
+  @Override
+  public String id() {
+    return kernelMetadata.getId();
+  }
+
+  @Override
+  public String name() {
+    return kernelMetadata.getName().orElse(null);
+  }
+
+  @Override
+  public String description() {
+    return kernelMetadata.getDescription().orElse(null);
+  }
+
+  @Override
+  public StructType schema() {
+    if (cachedSchema == null) {
+      cachedSchema = SchemaUtils.convertKernelSchemaToSparkSchema(kernelMetadata.getSchema());
+    }
+    return cachedSchema;
+  }
+
+  @Override
+  public Seq<String> partitionColumns() {
+    if (cachedPartitionColumns == null) {
+      List<String> rawCols = VectorUtils.toJavaList(kernelMetadata.getPartitionColumns());
+      cachedPartitionColumns = CollectionConverters.asScala(rawCols).toSeq();
+    }
+    return cachedPartitionColumns;
+  }
+
+  @Override
+  public Map<String, String> configuration() {
+    if (cachedConfiguration == null) {
+      cachedConfiguration = ScalaUtils.toScalaMap(kernelMetadata.getConfiguration());
+    }
+    return cachedConfiguration;
+  }
+
+  @Override
+  public DeltaColumnMappingMode columnMappingMode() {
+    if (cachedColumnMappingMode == null) {
+      String mode = kernelMetadata.getConfiguration().get(ColumnMapping.COLUMN_MAPPING_MODE_KEY);
+      cachedColumnMappingMode =
+          mode == null ? NoMapping$.MODULE$ : DeltaColumnMappingMode$.MODULE$.apply(mode);
+    }
+    return cachedColumnMappingMode;
+  }
+
+  @Override
+  public StructType partitionSchema() {
+    if (cachedPartitionSchema == null) {
+      cachedPartitionSchema = AbstractMetadata.super.partitionSchema();
+    }
+    return cachedPartitionSchema;
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/adapters/KernelProtocolAdapter.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/adapters/KernelProtocolAdapter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.adapters;
+
+import io.delta.kernel.internal.actions.Protocol;
+import java.util.Objects;
+import org.apache.spark.sql.delta.v2.interop.AbstractProtocol;
+import scala.Option;
+import scala.collection.immutable.Set;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Adapter from {@link io.delta.kernel.internal.actions.Protocol} to {@link
+ * org.apache.spark.sql.delta.v2.interop.AbstractProtocol}.
+ */
+public class KernelProtocolAdapter implements AbstractProtocol {
+
+  private final Protocol kernelProtocol;
+  private volatile Option<Set<String>> cachedReaderFeatures;
+  private volatile Option<Set<String>> cachedWriterFeatures;
+
+  public KernelProtocolAdapter(Protocol kernelProtocol) {
+    this.kernelProtocol = Objects.requireNonNull(kernelProtocol, "kernelProtocol is null");
+  }
+
+  @Override
+  public int minReaderVersion() {
+    return kernelProtocol.getMinReaderVersion();
+  }
+
+  @Override
+  public int minWriterVersion() {
+    return kernelProtocol.getMinWriterVersion();
+  }
+
+  @Override
+  public Option<Set<String>> readerFeatures() {
+    if (cachedReaderFeatures == null) {
+      cachedReaderFeatures =
+          kernelProtocol.supportsReaderFeatures()
+              ? Option.apply(
+                  CollectionConverters.asScala(kernelProtocol.getReaderFeatures()).toSet())
+              : Option.empty();
+    }
+    return cachedReaderFeatures;
+  }
+
+  @Override
+  public Option<Set<String>> writerFeatures() {
+    if (cachedWriterFeatures == null) {
+      cachedWriterFeatures =
+          kernelProtocol.supportsWriterFeatures()
+              ? Option.apply(
+                  CollectionConverters.asScala(kernelProtocol.getWriterFeatures()).toSet())
+              : Option.empty();
+    }
+    return cachedWriterFeatures;
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/adapters/ActionAdaptersTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/adapters/ActionAdaptersTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.adapters;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.data.ArrayValue;
+import io.delta.kernel.internal.actions.Format;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import java.util.*;
+import org.apache.spark.sql.delta.IdMapping$;
+import org.apache.spark.sql.delta.NameMapping$;
+import org.apache.spark.sql.delta.NoMapping$;
+import org.junit.jupiter.api.Test;
+import scala.jdk.javaapi.CollectionConverters;
+
+/** Unit tests for {@link KernelMetadataAdapter} and {@link KernelProtocolAdapter}. */
+public class ActionAdaptersTest {
+
+  // ===== KernelProtocolAdapter =====
+
+  @Test
+  public void testProtocolAdapterWithTableFeatures() {
+    // Reader features: supported but empty (version >= 3 means features are supported, even with
+    // an empty set). Writer features: supported and populated.
+    Set<String> readerFeatures = Collections.emptySet();
+    Set<String> writerFeatures = new HashSet<>(Arrays.asList("v2Checkpoint", "rowTracking"));
+    Protocol kernelProtocol = new Protocol(3, 7, readerFeatures, writerFeatures);
+
+    KernelProtocolAdapter adapter = new KernelProtocolAdapter(kernelProtocol);
+
+    assertEquals(3, adapter.minReaderVersion());
+    assertEquals(7, adapter.minWriterVersion());
+    assertTrue(adapter.readerFeatures().isDefined());
+    assertTrue(CollectionConverters.asJava(adapter.readerFeatures().get()).isEmpty());
+    assertTrue(adapter.writerFeatures().isDefined());
+    assertEquals(
+        new HashSet<>(Arrays.asList("v2Checkpoint", "rowTracking")),
+        CollectionConverters.asJava(adapter.writerFeatures().get()));
+  }
+
+  @Test
+  public void testProtocolAdapterLegacyProtocol() {
+    Protocol kernelProtocol = new Protocol(1, 2);
+
+    KernelProtocolAdapter adapter = new KernelProtocolAdapter(kernelProtocol);
+
+    assertEquals(1, adapter.minReaderVersion());
+    assertEquals(2, adapter.minWriterVersion());
+    assertTrue(adapter.readerFeatures().isEmpty());
+    assertTrue(adapter.writerFeatures().isEmpty());
+  }
+
+  @Test
+  public void testProtocolAdapterNullThrows() {
+    assertThrows(NullPointerException.class, () -> new KernelProtocolAdapter(null));
+  }
+
+  @Test
+  public void testProtocolAdapterEqualsByFields() {
+    Set<String> rf = new HashSet<>(Arrays.asList("v2Checkpoint"));
+    Set<String> wf = new HashSet<>(Arrays.asList("rowTracking"));
+    KernelProtocolAdapter base = new KernelProtocolAdapter(new Protocol(3, 7, rf, wf));
+
+    // Identical fields (built from a fresh Protocol instance) compare equal both directions.
+    KernelProtocolAdapter same =
+        new KernelProtocolAdapter(
+            new Protocol(
+                3,
+                7,
+                new HashSet<>(Arrays.asList("v2Checkpoint")),
+                new HashSet<>(Arrays.asList("rowTracking"))));
+    assertTrue(base.equalsByFields(same));
+    assertTrue(same.equalsByFields(base));
+
+    // Each field difference flips the result to false.
+    assertFalse(
+        base.equalsByFields(new KernelProtocolAdapter(new Protocol(2, 7, rf, wf))),
+        "minReaderVersion mismatch should not be equal");
+    assertFalse(
+        base.equalsByFields(new KernelProtocolAdapter(new Protocol(3, 6, rf, wf))),
+        "minWriterVersion mismatch should not be equal");
+    assertFalse(
+        base.equalsByFields(
+            new KernelProtocolAdapter(
+                new Protocol(3, 7, new HashSet<>(Arrays.asList("columnMapping")), wf))),
+        "readerFeatures mismatch should not be equal");
+    assertFalse(
+        base.equalsByFields(
+            new KernelProtocolAdapter(
+                new Protocol(3, 7, rf, new HashSet<>(Arrays.asList("columnMapping"))))),
+        "writerFeatures mismatch should not be equal");
+
+    // Some(empty) vs None — features defined only at table-features versions; the helper must
+    // distinguish (3,7,Some(empty),Some(empty)) from legacy (1,2,None,None).
+    KernelProtocolAdapter emptyFeatures =
+        new KernelProtocolAdapter(
+            new Protocol(3, 7, Collections.emptySet(), Collections.emptySet()));
+    KernelProtocolAdapter legacy = new KernelProtocolAdapter(new Protocol(1, 2));
+    assertFalse(emptyFeatures.equalsByFields(legacy));
+    assertTrue(legacy.equalsByFields(new KernelProtocolAdapter(new Protocol(1, 2))));
+  }
+
+  // ===== KernelMetadataAdapter =====
+
+  @Test
+  public void testMetadataAdapter() {
+    ArrayValue partCols =
+        VectorUtils.buildArrayValue(Arrays.asList("part1", "part2"), StringType.STRING);
+    Map<String, String> formatOptions = Collections.singletonMap("foo", "bar");
+    Format format = new Format("parquet", formatOptions);
+    Map<String, String> configuration = new HashMap<>();
+    configuration.put("zip", "zap");
+    configuration.put("delta.columnMapping.mode", "name");
+
+    Metadata kernelMetadata =
+        new Metadata(
+            "id",
+            Optional.of("name"),
+            Optional.of("description"),
+            format,
+            "{\"type\":\"struct\",\"fields\":"
+                + "[{\"name\":\"part1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},"
+                + "{\"name\":\"part2\",\"type\":\"string\",\"nullable\":false,\"metadata\":{}},"
+                + "{\"name\":\"col1\",\"type\":\"string\",\"nullable\":false,\"metadata\":{}}]}",
+            new StructType()
+                .add("part1", IntegerType.INTEGER)
+                .add("part2", StringType.STRING, false /* nullable */)
+                .add("col1", StringType.STRING, false /* nullable */),
+            partCols,
+            Optional.of(42L),
+            VectorUtils.stringStringMapValue(configuration));
+
+    KernelMetadataAdapter adapter = new KernelMetadataAdapter(kernelMetadata);
+
+    assertEquals("id", adapter.id());
+    assertEquals("name", adapter.name());
+    assertEquals("description", adapter.description());
+    assertEquals(3, adapter.schema().fields().length);
+    assertEquals("integer", adapter.schema().apply("part1").dataType().typeName());
+    assertTrue(adapter.schema().apply("part1").nullable());
+    assertEquals("string", adapter.schema().apply("part2").dataType().typeName());
+    assertFalse(adapter.schema().apply("part2").nullable());
+    assertEquals("string", adapter.schema().apply("col1").dataType().typeName());
+    assertFalse(adapter.schema().apply("col1").nullable());
+    assertEquals(
+        Arrays.asList("part1", "part2"), CollectionConverters.asJava(adapter.partitionColumns()));
+    org.apache.spark.sql.types.StructType partSchema = adapter.partitionSchema();
+    assertEquals(2, partSchema.fields().length);
+    assertEquals("part1", partSchema.fields()[0].name());
+    assertEquals("integer", partSchema.fields()[0].dataType().typeName());
+    assertTrue(partSchema.fields()[0].nullable());
+    assertEquals("part2", partSchema.fields()[1].name());
+    assertEquals("string", partSchema.fields()[1].dataType().typeName());
+    assertFalse(partSchema.fields()[1].nullable());
+    assertEquals(configuration, CollectionConverters.asJava(adapter.configuration()));
+    assertEquals(NameMapping$.MODULE$, adapter.columnMappingMode());
+  }
+
+  @Test
+  public void testMetadataAdapterWithNullOptionalFields() {
+    ArrayValue emptyPartCols =
+        VectorUtils.buildArrayValue(Collections.emptyList(), StringType.STRING);
+    Format format = new Format("parquet", Collections.emptyMap());
+
+    Metadata kernelMetadata =
+        new Metadata(
+            "id2",
+            Optional.empty(),
+            Optional.empty(),
+            format,
+            "{\"type\":\"struct\",\"fields\":[]}",
+            new StructType(),
+            emptyPartCols,
+            Optional.empty(),
+            VectorUtils.stringStringMapValue(Collections.emptyMap()));
+
+    KernelMetadataAdapter adapter = new KernelMetadataAdapter(kernelMetadata);
+
+    assertEquals("id2", adapter.id());
+    assertNull(adapter.name());
+    assertNull(adapter.description());
+    assertEquals(0, adapter.schema().fields().length);
+    assertTrue(CollectionConverters.asJava(adapter.partitionColumns()).isEmpty());
+    assertEquals(0, adapter.partitionSchema().fields().length);
+    assertTrue(CollectionConverters.asJava(adapter.configuration()).isEmpty());
+    assertEquals(NoMapping$.MODULE$, adapter.columnMappingMode());
+  }
+
+  @Test
+  public void testMetadataAdapterNullThrows() {
+    assertThrows(NullPointerException.class, () -> new KernelMetadataAdapter(null));
+  }
+
+  @Test
+  public void testMetadataAdapterIdColumnMappingMode() {
+    KernelMetadataAdapter adapter =
+        new KernelMetadataAdapter(
+            buildMinimalKernelMetadata(Collections.singletonMap("delta.columnMapping.mode", "id")));
+
+    assertEquals(IdMapping$.MODULE$, adapter.columnMappingMode());
+  }
+
+  @Test
+  public void testMetadataAdapterUnknownColumnMappingModeThrows() {
+    KernelMetadataAdapter adapter =
+        new KernelMetadataAdapter(
+            buildMinimalKernelMetadata(
+                Collections.singletonMap("delta.columnMapping.mode", "bogus")));
+
+    assertThrows(UnsupportedOperationException.class, adapter::columnMappingMode);
+  }
+
+  @Test
+  public void testMetadataAdapterPartitionColumnCaseMismatch() {
+    // Kernel stores partition column names verbatim; a connector may persist a different
+    // capitalization than the schema field. The adapter must not silently normalize the case,
+    // and the default Spark `StructType.apply` lookup is case-sensitive — exercise both.
+    ArrayValue partCols =
+        VectorUtils.buildArrayValue(Collections.singletonList("Part1"), StringType.STRING);
+    Format format = new Format("parquet", Collections.emptyMap());
+
+    Metadata kernelMetadata =
+        new Metadata(
+            "id",
+            Optional.empty(),
+            Optional.empty(),
+            format,
+            "{\"type\":\"struct\",\"fields\":"
+                + "[{\"name\":\"part1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}",
+            new StructType().add("part1", IntegerType.INTEGER),
+            partCols,
+            Optional.empty(),
+            VectorUtils.stringStringMapValue(Collections.emptyMap()));
+
+    KernelMetadataAdapter adapter = new KernelMetadataAdapter(kernelMetadata);
+
+    assertEquals(
+        Collections.singletonList("Part1"),
+        CollectionConverters.asJava(adapter.partitionColumns()));
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, adapter::partitionSchema);
+    assertTrue(
+        ex.getMessage().contains("[FIELD_NOT_FOUND]")
+            && ex.getMessage().contains("`Part1`")
+            && ex.getMessage().contains("`part1`"),
+        "Unexpected exception message: " + ex.getMessage());
+  }
+
+  private static Metadata buildMinimalKernelMetadata(Map<String, String> configuration) {
+    ArrayValue emptyPartCols =
+        VectorUtils.buildArrayValue(Collections.emptyList(), StringType.STRING);
+    return new Metadata(
+        "id",
+        Optional.empty(),
+        Optional.empty(),
+        new Format("parquet", Collections.emptyMap()),
+        "{\"type\":\"struct\",\"fields\":[]}",
+        new StructType(),
+        emptyPartCols,
+        Optional.empty(),
+        VectorUtils.stringStringMapValue(configuration));
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6546/files) to review incremental changes.
- [**stack/SparkMetadataAdapter**](https://github.com/delta-io/delta/pull/6546) [[Files changed](https://github.com/delta-io/delta/pull/6546/files)]
  - [stack/RefactorMetadataTrackingLog](https://github.com/delta-io/delta/pull/6550) [[Files changed](https://github.com/delta-io/delta/pull/6550/files/9271a6262f7a2615b977de0319c7238044b7d0a9..8378d33acda70a34a109b35173a968a4b3401ec1)]
    - [stack/RefactorDeltaSourceMetadataEvolutionSupport](https://github.com/delta-io/delta/pull/6562) [[Files changed](https://github.com/delta-io/delta/pull/6562/files/8378d33acda70a34a109b35173a968a4b3401ec1..90365431b12640de181446ec9c2033fb1b143b03)]
      - [stack/MetadataEvolutionHandler2](https://github.com/delta-io/delta/pull/6563) [[Files changed](https://github.com/delta-io/delta/pull/6563/files/28bb7021adb12b055e1b281fdfee0ab48a8732ac..578870181fa81a9146b2fa907244e350ffcabb52)]
        - [stack/NonAdditiveSchemaEvolution2](https://github.com/delta-io/delta/pull/6570) [[Files changed](https://github.com/delta-io/delta/pull/6570/files/578870181fa81a9146b2fa907244e350ffcabb52..c025b7c3c386e8d46d6142d0727dce95582bb0ef)]
          - [stack/NonAdditiveSchemaEvolution3](https://github.com/delta-io/delta/pull/6697) [[Files changed](https://github.com/delta-io/delta/pull/6697/files/c025b7c3c386e8d46d6142d0727dce95582bb0ef..db16b9fa80a80c105430c93589126ba8b828458f)]
            - [stack/consecutiveSchemaChangesMerger](https://github.com/delta-io/delta/pull/6698) [[Files changed](https://github.com/delta-io/delta/pull/6698/files/0148020ffe11e7b079e99fa8c5189a19c354f2be..9a360aa819f20d78b5361b2e997d24433fb793d5)]

---------
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

PR 1/7 in the non-additive schema evolution for V2 streaming connector stack.

The shared V1 Scala utilities (`DeltaColumnMapping`, `DeltaSourceMetadataEvolutionSupport`) operate on `AbstractMetadata`/`AbstractProtocol`, but V2 holds Kernel types. This PR creates two adapter classes that bridge the gap:

- `KernelMetadataAdapter`: Kernel `Metadata` → `AbstractMetadata` (schema conversion via `SchemaUtils`, partition columns and configuration converted to Scala collections)
- `KernelProtocolAdapter`: Kernel `Protocol` → `AbstractProtocol` (maps reader/writer features to `Option[Set[String]]`)

Also adds `columnMappingMode` and `partitionSchema` to the `AbstractMetadata` trait — V1's `Metadata` already had these fields, the trait just didn't expose them.

## How was this patch tested?

Unit tests in `ActionAdaptersTest.java`: table-features protocol, legacy protocol, full metadata round-trip, null optional fields, and null constructor rejection.

## Does this PR introduce _any_ user-facing changes?

No.