### PR TITLE
[Sharing] Implement SupportsTriggerAvailableNow for DeltaFormatSharingSource

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -43,7 +43,11 @@ import io.delta.sharing.client.model.{Table => DeltaSharingTable}
 import org.apache.spark.delta.sharing.CachedTableManager
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.connector.read.streaming
-import org.apache.spark.sql.connector.read.streaming.{ReadLimit, SupportsAdmissionControl}
+import org.apache.spark.sql.connector.read.streaming.{
+  ReadLimit,
+  SupportsAdmissionControl,
+  SupportsTriggerAvailableNow
+}
 import org.apache.spark.sql.execution.streaming.{Offset, Source}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
@@ -55,7 +59,7 @@ import org.apache.spark.sql.types.StructType
  * When a new stream is started, delta sharing starts by fetching delta log from the server side,
  * constructing a local delta log, and call delta source apis to compute offset or read data.
  *
- * TODO: Support CDC Streaming, SupportsTriggerAvailableNow and SupportsConcurrentExecution.
+ * TODO: Support CDC Streaming and SupportsConcurrentExecution.
  */
 case class DeltaFormatSharingSource(
     spark: SparkSession,
@@ -67,6 +71,7 @@ case class DeltaFormatSharingSource(
     metadataPath: String)
     extends Source
     with SupportsAdmissionControl
+    with SupportsTriggerAvailableNow
     with DeltaLogging {
 
   private val sourceId = Some(UUID.randomUUID().toString().split('-').head)
@@ -194,11 +199,37 @@ case class DeltaFormatSharingSource(
     s", with queryId(${client.getQueryId})"
   }
 
+  // Whether this query is running in Trigger.AvailableNow mode.
+  // TODO: If SupportsConcurrentExecution is added, these need @volatile or synchronization.
+  private var isTriggerAvailableNow: Boolean = false
+
+  // The server version captured at query start for Trigger.AvailableNow. All processing is capped
+  // at this version. Not persisted -- re-captured fresh on every query start.
+  private var frozenServerVersionForAvailableNow: Long = -1
+
   // A variable to store the latest table version on server, returned from the getTableVersion rpc.
   // Used to store the latest table version for getOrUpdateLatestTableVersion when not getting
   // updates from the server.
   // For all other callers, please use getOrUpdateLatestTableVersion instead of this variable.
   private var latestTableVersionOnServer: Long = -1
+
+  override def prepareForTriggerAvailableNow(): Unit = {
+    // Capture the frozen version here rather than lazily in getOrUpdateLatestTableVersion to keep
+    // that method simple (single early-return guard). Lazy capture would require two conditionals
+    // inside getOrUpdateLatestTableVersion (check if already frozen + freeze after RPC).
+    //
+    // Call getOrUpdateLatestTableVersion BEFORE setting isTriggerAvailableNow, so the guard
+    // inside getOrUpdateLatestTableVersion doesn't short-circuit and we get a real RPC.
+    //
+    // DeltaFormatSharingSource is always freshly instantiated per streaming query start, so
+    // lastTimestampForGetVersionFromServer is -1 and the throttle never suppresses this RPC.
+    frozenServerVersionForAvailableNow = getOrUpdateLatestTableVersion
+    // No require(frozenServerVersionForAvailableNow >= 0) needed here:
+    // getOrUpdateLatestTableVersion already throws IllegalStateException for negative versions.
+    isTriggerAvailableNow = true
+    logInfo(s"Prepared for Trigger.AvailableNow with frozenServerVersionForAvailableNow=" +
+      s"$frozenServerVersionForAvailableNow," + getTableInfoForLogging)
+  }
 
   /**
    * Check the latest table version from the delta sharing server through the client.getTableVersion
@@ -208,6 +239,9 @@ case class DeltaFormatSharingSource(
    * @return the latest table version on the server.
    */
   private def getOrUpdateLatestTableVersion: Long = {
+    if (isTriggerAvailableNow) {
+      return frozenServerVersionForAvailableNow
+    }
     val currentTimeMillis = System.currentTimeMillis()
     if ((currentTimeMillis - lastTimestampForGetVersionFromServer) >=
       QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
@@ -509,6 +543,17 @@ case class DeltaFormatSharingSource(
   private def needNewFilesFromServer(
       startingOffset: DeltaSourceOffset,
       latestTableVersion: Long): Boolean = {
+    // In AvailableNow mode, stop fetching once the local log has all data up to the frozen version.
+    // Using >= defensively; in practice the local log version should only equal the frozen version
+    // since fetches are capped at frozenServerVersionForAvailableNow via getEndingVersionForRpc.
+    // The frozenServerVersionForAvailableNow >= 0 check is defense-in-depth: it is logically
+    // guaranteed to be >= 0 here because getOrUpdateLatestTableVersion throws for negative values,
+    // but we keep it explicit to avoid a subtle early-return if the invariant were ever violated.
+    if (isTriggerAvailableNow &&
+        frozenServerVersionForAvailableNow >= 0 &&
+        latestTableVersionInLocalDeltaLogOpt.exists(_ >= frozenServerVersionForAvailableNow)) {
+      return false
+    }
     if (latestTableVersionInLocalDeltaLogOpt.isEmpty) {
       return true
     }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -2565,4 +2565,316 @@ class DeltaFormatSharingSourceSuite
       }
     }
   }
+
+  // Tests for Trigger.AvailableNow with native SupportsTriggerAvailableNow implementation.
+
+  private val disableAvailableNowWorkaround = Map.empty[String, String]
+
+  /**
+   * Helper to set up a Delta Sharing streaming test with AvailableNow trigger.
+   * Creates a delta table and shared table, prepares mock client metadata, and runs the
+   * provided test body with the workaround disabled.
+   */
+  private def withAvailableNowSharingStream(testName: String)(
+      testBody: (String, String, String, java.io.File, java.io.File) => Unit): Unit = {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = s"delta_table_available_now_$testName"
+      withTable(deltaTableName) {
+        createTableForStreaming(deltaTableName)
+        val sharedTableName = s"shared_available_now_$testName"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf((getDeltaSharingClassesSQLConf ++ disableAvailableNowWorkaround).toSeq: _*) {
+          testBody(deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir)
+        }
+      }
+    }
+  }
+
+  /** Run an AvailableNow streaming query to completion, with optional extra read options. */
+  private def runAvailableNowQuery(
+      tablePath: String,
+      outputDir: java.io.File,
+      checkpointDir: java.io.File,
+      extraOptions: Map[String, String] = Map.empty): Unit = {
+    var builder = spark.readStream
+      .format("deltaSharing")
+      .option("responseFormat", "delta")
+    extraOptions.foreach { case (k, v) => builder = builder.option(k, v) }
+    val q = builder
+      .load(tablePath)
+      .writeStream
+      .format("delta")
+      .option("checkpointLocation", checkpointDir.toString)
+      .trigger(Trigger.AvailableNow())
+      .start(outputDir.toString)
+    try {
+      q.processAllAvailable()
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("Trigger.AvailableNow processes all data across multiple micro-batches") {
+    withAvailableNowSharingStream("basic") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        sql(s"INSERT INTO $deltaTableName VALUES ('a'), ('b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('c'), ('d')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('e'), ('f')")
+
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(3L))
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        // Use maxFilesPerTrigger=1 to force multiple micro-batches.
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir,
+          extraOptions = Map("maxFilesPerTrigger" -> "1"))
+
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b", "c", "d", "e", "f").toDF())
+
+        // Exclude .crc sidecar files written by Hadoop; count only the numeric batch files.
+        def countBatchFiles(dir: String): Int =
+          new java.io.File(checkpointDir, dir)
+            .listFiles(f => !f.isDirectory && !f.getName.startsWith(".")).length
+        val numOffsets = countBatchFiles("offsets")
+        val numCommits = countBatchFiles("commits")
+        // With maxFilesPerTrigger=1, one micro-batch per source file; snapshot has 3 files.
+        val expectedBatches = DeltaLog
+          .forTable(spark, TableIdentifier(deltaTableName))
+          .getSnapshotAt(3L).allFiles.count().toInt
+        assert(numOffsets == expectedBatches,
+          s"Expected $expectedBatches offset files (one per source file), got $numOffsets")
+        assert(numCommits == expectedBatches,
+          s"Expected $expectedBatches commit files (one per source file), got $numCommits")
+        assertBlocksAreCleanedUp()
+    }
+  }
+
+  test("Trigger.AvailableNow excludes data arriving after query start") {
+    withAvailableNowSharingStream("snapshot") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        // Insert data at versions 1-3 (to exercise multiple micro-batches with
+        // maxFilesPerTrigger=1), then version 4 which arrives after the query starts.
+        sql(s"INSERT INTO $deltaTableName VALUES ('a'), ('b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('c'), ('d')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('e'), ('f')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('g'), ('h')") // arrives after query start
+
+        // Mock getTableVersion to return version 3 (simulating the frozen version),
+        // even though version 4 exists. This simulates data arriving after query start.
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName, Some(3L))
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(3L))
+
+        // Use maxFilesPerTrigger=1 to exercise multiple micro-batches (one per version file).
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir,
+          extraOptions = Map("maxFilesPerTrigger" -> "1"))
+
+        // Only versions 1-3 data should be processed; version 4 data is excluded.
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b", "c", "d", "e", "f").toDF())
+        assertBlocksAreCleanedUp()
+    }
+  }
+
+  test("Trigger.AvailableNow restart resumes from checkpoint") {
+    withAvailableNowSharingStream("restart") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        sql(s"INSERT INTO $deltaTableName VALUES ('a'), ('b')")
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(1L))
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        // First run: process initial data.
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir)
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b").toDF())
+
+        // Insert more data.
+        sql(s"INSERT INTO $deltaTableName VALUES ('c'), ('d')")
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+        prepareMockedClientAndFileSystemResultForStreaming(
+          deltaTableName, sharedTableName, 2, 2)
+
+        // Second run: should resume from checkpoint and only process new data.
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir)
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b", "c", "d").toDF())
+        assertBlocksAreCleanedUp()
+    }
+  }
+
+  test("Trigger.AvailableNow terminates when no new data after initial run") {
+    withAvailableNowSharingStream("nodata") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        sql(s"INSERT INTO $deltaTableName VALUES ('a'), ('b')")
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(1L))
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir)
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b").toDF())
+
+        // Second run with no new data -- should terminate immediately.
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir)
+
+        // Same data as before -- no new data processed.
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b").toDF())
+        assertBlocksAreCleanedUp()
+    }
+  }
+
+  test("Trigger.AvailableNow processes incremental versions after snapshot") {
+    withAvailableNowSharingStream("incremental") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        sql(s"INSERT INTO $deltaTableName VALUES ('a'), ('b')")
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(1L))
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        // First run: process snapshot.
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir)
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b").toDF())
+
+        // Insert more data across multiple versions.
+        sql(s"INSERT INTO $deltaTableName VALUES ('c')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('d')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('e')")
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+        prepareMockedClientAndFileSystemResultForStreaming(
+          deltaTableName, sharedTableName, 2, 4)
+
+        // Second run: process all incremental versions in multiple micro-batches and terminate.
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir,
+          extraOptions = Map("maxFilesPerTrigger" -> "1"))
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b", "c", "d", "e").toDF())
+        assertBlocksAreCleanedUp()
+    }
+  }
+
+  test("Trigger.ProcessingTime is not affected by AvailableNow changes") {
+    withAvailableNowSharingStream("processing_time") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        sql(s"INSERT INTO $deltaTableName VALUES ('a'), ('b')")
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(1L))
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        // Use default trigger (ProcessingTime) -- should work unchanged.
+        val q = spark.readStream
+          .format("deltaSharing")
+          .option("responseFormat", "delta")
+          .load(tablePath)
+          .writeStream
+          .format("delta")
+          .option("checkpointLocation", checkpointDir.toString)
+          .start(outputDir.toString)
+        try {
+          q.processAllAvailable()
+        } finally {
+          q.stop()
+        }
+
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b").toDF())
+        assertBlocksAreCleanedUp()
+    }
+  }
+
+  test("Trigger.AvailableNow fails when server returns negative version") {
+    withAvailableNowSharingStream("negative_version") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        sql(s"INSERT INTO $deltaTableName VALUES ('a'), ('b')")
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(1L))
+
+        // Mock server returning negative version -- should fail fast.
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName, Some(-1L))
+
+        val e = intercept[StreamingQueryException] {
+          runAvailableNowQuery(tablePath, outputDir, checkpointDir)
+        }
+        assert(e.getMessage.contains("negative table version"))
+    }
+  }
+
+  test("Trigger.AvailableNow restart handles mid-version checkpoint") {
+    withAvailableNowSharingStream("mid_index") {
+      (deltaTableName, sharedTableName, tablePath, outputDir, checkpointDir) =>
+        // Create 3 files in the initial snapshot (one per INSERT = one file per version).
+        sql(s"INSERT INTO $deltaTableName VALUES ('a')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('c')")
+
+        prepareMockedClientAndFileSystemResult(
+          deltaTable = deltaTableName, sharedTable = sharedTableName, versionAsOf = Some(3L))
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName, Some(3L))
+
+        // The reservoir ID is embedded in DeltaSourceOffset and must match what
+        // DeltaFormatSharingSource uses internally (copied from actual table metadata).
+        val reservoirId = DeltaLog.forTable(spark, TableIdentifier(deltaTableName)).tableId
+
+        // Seed the checkpoint to simulate a prior run that committed batch 0 mid-snapshot
+        // (index=0 of 3 files processed, with files at index 1 and 2 still remaining).
+        // This lets us test the restart path without timing-dependent query interruption.
+        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
+        // scalastyle:off deltahadoopconfiguration
+        val hadoopConf = spark.sessionState.newHadoopConf()
+        // scalastyle:on deltahadoopconfiguration
+        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
+        fileManager.mkdirs(
+          new Path(checkpointPath, StreamingCheckpointConstants.DIR_NAME_OFFSETS))
+        fileManager.mkdirs(
+          new Path(checkpointPath, StreamingCheckpointConstants.DIR_NAME_COMMITS))
+        StreamMetadata.write(
+          StreamMetadata(java.util.UUID.randomUUID.toString),
+          new Path(checkpointPath, StreamingCheckpointConstants.DIR_NAME_METADATA),
+          hadoopConf)
+
+        // Offset: batch 0 ended at index=0, isStartingVersion=true (mid initial snapshot).
+        val offsetMetadataJson =
+          """{"batchWatermarkMs":0,"batchTimestampMs":0,"conf":{},"sourceMetadataInfo":{}}"""
+        val midIndexOffsetJson =
+          s"""{"sourceVersion":1,"reservoirId":"$reservoirId",""" +
+          s""""reservoirVersion":3,"index":0,"isStartingVersion":true}"""
+        val offsetContent =
+          s"v1\n$offsetMetadataJson\n$midIndexOffsetJson"
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        val offsetOut = fileManager.createAtomic(
+          new Path(
+            new Path(checkpointPath, StreamingCheckpointConstants.DIR_NAME_OFFSETS), "0"),
+          overwriteIfPossible = true)
+        offsetOut.write(offsetContent)
+        offsetOut.close()
+
+        // No commits/0: simulates a crash after the source committed offsets/0 but
+        // before the sink committed batch 0. On restart the engine re-runs batch 0
+        // (index=0 -> row 'a'), then batch 1 (index=1 -> row 'b'), batch 2 (index=2 ->
+        // row 'c'). All 3 rows appear in the output.
+        runAvailableNowQuery(tablePath, outputDir, checkpointDir,
+          extraOptions = Map("maxFilesPerTrigger" -> "1"))
+
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          Seq("a", "b", "c").toDF())
+        assertBlocksAreCleanedUp()
+    }
+  }
 }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -44,7 +44,7 @@ import io.delta.sharing.spark.test.shims.SharingStreamingTestShims.{
   StreamMetadata
 }
 import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest}
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest, Trigger}
 import org.apache.spark.sql.types.{
   DateType,
   IntegerType,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Sharing)

## Description

Implements the SupportsTriggerAvailableNow interface on DeltaFormatSharingSource, enabling Trigger.AvailableNow to work natively with Delta Sharing streaming sources.

How it works:
  - prepareForTriggerAvailableNow() is called by the Spark streaming engine before the query starts. It fires a getTableVersion RPC and freezes the result in frozenServerVersionForAvailableNow.
  - getOrUpdateLatestTableVersion returns the frozen version immediately when isTriggerAvailableNow is set, so no further RPCs are made and no data arriving after query start is visible.
  - needNewFilesFromServer returns false once the local delta log has caught up to the frozen version, causing the engine to stop scheduling new micro-batches and terminate the query.

  ## How was this patch tested?

  Added 7 unit tests in DeltaFormatSharingSourceSuite:
  - basic: processes all data across multiple micro-batches (maxFilesPerTrigger=1)
  - snapshot: excludes data arriving after query start (frozen version)
  - restart: resumes correctly from a checkpoint on second run
  - nodata: terminates immediately when there is no new data
  - incremental: processes multiple incremental versions after an initial snapshot run
  - processing_time: verifies Trigger.ProcessingTime is unaffected
  - negative_version: fails fast when the server returns a negative version
  - mid_index: restarts correctly from a mid-snapshot checkpoint