### PR TITLE
[SPARK] Reject unsupported protocol version numbers on upgrade

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1662,6 +1662,12 @@
     ],
     "sqlState" : "KD004"
   },
+  "DELTA_INVALID_PROTOCOL_VERSION_FOR_UPGRADE" : {
+    "message" : [
+      "Protocol <versionType> version <requestedVersion> is not supported. Supported versions are: <supportedVersions>. Use one of the supported versions when calling upgradeTableProtocol or setting delta.min<versionType>Version."
+    ],
+    "sqlState" : "KD004"
+  },
   "DELTA_INVALID_PROTOCOL_VERSION" : {
     "message" : [
       "Unsupported Delta protocol version: table \"<tableNameOrPath>\" requires reader version <readerRequired> and writer version <writerRequired>, but Delta Lake \"<deltaVersion>\" supports reader versions <supportedReaders> and writer versions <supportedWriters>. Please upgrade to a newer release."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2474,6 +2474,15 @@ trait DeltaErrorsBase
       Array(key, value))
   }
 
+  def invalidProtocolVersionForUpgrade(
+      versionType: String,
+      requestedVersion: Int,
+      supportedVersions: Seq[Int]): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_INVALID_PROTOCOL_VERSION_FOR_UPGRADE",
+      Array(versionType, requestedVersion.toString, supportedVersions.sorted.mkString(", ")))
+  }
+
   def protocolChangedException(
       conflictingCommit: Option[CommitInfo]): io.delta.exceptions.ProtocolChangedException = {
     val additionalInfo = conflictingCommit.map { v =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -770,6 +770,24 @@ trait OptimisticTransactionImpl extends TransactionHelper
         Protocol.getWriterVersionFromTableConf(newMetadataTmp.configuration)
           .getOrElse(protocolBeforeUpdate.minWriterVersion)
 
+      // Validate that user-supplied version numbers are recognized by this release of Delta.
+      // An unrecognized version silently corrupts the table log and makes it unreadable, so
+      // we reject it here before anything is committed. Note: versions coming from the existing
+      // snapshot (the .getOrElse fallback above) are already valid, so we only need to check
+      // when the user explicitly set a value in the configuration.
+      Protocol.getReaderVersionFromTableConf(newMetadataTmp.configuration).foreach { v =>
+        if (!Action.supportedReaderVersionNumbers.contains(v)) {
+          throw DeltaErrors.invalidProtocolVersionForUpgrade(
+            "Reader", v, Action.supportedReaderVersionNumbers.toSeq)
+        }
+      }
+      Protocol.getWriterVersionFromTableConf(newMetadataTmp.configuration).foreach { v =>
+        if (!Action.supportedWriterVersionNumbers.contains(v)) {
+          throw DeltaErrors.invalidProtocolVersionForUpgrade(
+            "Writer", v, Action.supportedWriterVersionNumbers.toSeq)
+        }
+      }
+
       val newProtocolForLatestMetadata =
         Protocol(readerVersionAsTableProp, writerVersionAsTableProp)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -194,6 +194,48 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
+  test("reject unsupported protocol version numbers via ALTER TABLE TBLPROPERTIES") {
+    withTempDir { path =>
+      val log = createTableWithProtocol(Protocol(1, 1), path)
+      val tablePath = path.getCanonicalPath
+
+      // A completely invalid writer version should be rejected
+      val e1 = intercept[DeltaIllegalArgumentException] {
+        sql(s"ALTER TABLE delta.`$tablePath` " +
+          "SET TBLPROPERTIES ('delta.minWriterVersion' = '101')")
+      }
+      assert(e1.getMessage.contains("101"),
+        "Error should mention the invalid version number")
+      assert(log.update().protocol === Protocol(1, 1))
+
+      // A completely invalid reader version should also be rejected
+      val e2 = intercept[DeltaIllegalArgumentException] {
+        sql(s"ALTER TABLE delta.`$tablePath` " +
+          "SET TBLPROPERTIES ('delta.minReaderVersion' = '999')")
+      }
+      assert(e2.getMessage.contains("999"),
+        "Error should mention the invalid version number")
+      assert(log.update().protocol === Protocol(1, 1))
+
+      // Valid upgrade should still work
+      sql(s"ALTER TABLE delta.`$tablePath` " +
+        "SET TBLPROPERTIES ('delta.minWriterVersion' = '2')")
+      assert(log.update().protocol.minWriterVersion === 2)
+    }
+  }
+
+  test("reject unsupported protocol version numbers via upgradeTableProtocol API") {
+    withTempDir { path =>
+      createTableWithProtocol(Protocol(1, 1), path)
+      val table = io.delta.tables.DeltaTable.forPath(spark, path.getCanonicalPath)
+
+      val e = intercept[DeltaIllegalArgumentException] {
+        table.upgradeTableProtocol(1, 101)
+      }
+      assert(e.getMessage.contains("101"))
+    }
+  }
+
   test("upgrade to support table features - no feature") {
     // Setting a table feature versions to a protocol without table features is a noop.
     withTempDir { path =>


### PR DESCRIPTION
## What does this PR do?

When a user calls `ALTER TABLE SET TBLPROPERTIES` or `upgradeTableProtocol` with an unrecognized protocol version number (like `minWriterVersion = 101`), Delta was silently writing that value into the transaction log. The table then became permanently unusable on the next read.

This fixes #1420.

## Root cause

`updateMetadataInternal()` in `OptimisticTransaction` extracts the version from the table configuration and builds a `Protocol` object without checking whether that version number is actually supported. The `DeltaTable.upgradeTableProtocol` Scala/Python API was partially protected via `DeltaConfigs.validateConfigurations`, but the SQL `ALTER TABLE SET TBLPROPERTIES` path bypassed that check entirely.

## Fix

Added validation of the user-supplied reader and writer versions against `Action.supportedReaderVersionNumbers` and `Action.supportedWriterVersionNumbers` in `updateMetadataInternal()`, right before the `Protocol` object is created. This covers both the SQL ALTER TABLE path and any other call path that sets protocol version properties in table configuration.

## Changes

| File | What changed |
|------|-------------|
| `OptimisticTransaction.scala` | Validate reader/writer versions from table config before creating Protocol object |
| `DeltaErrors.scala` | Add `invalidProtocolVersionForUpgrade()` helper |
| `delta-error-classes.json` | Add `DELTA_INVALID_PROTOCOL_VERSION_FOR_UPGRADE` error class |
| `DeltaProtocolVersionSuite.scala` | Two new tests: SQL path and public API path |

## Before / After

```scala
// Before — silently corrupts the table
spark.sql("ALTER TABLE delta.`/path` SET TBLPROPERTIES ('delta.minWriterVersion' = '101')")
// No error. Table is now unreadable.

// After — immediate, clear error
// DeltaIllegalArgumentException: Protocol Writer version 101 is not supported.
// Supported versions are: 1, 2, 3, 4, 5, 6, 7. Use one of the supported versions...
```

Closes #1420