### PR TITLE
[Spark] Introduce `InMemorySparkTable`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -54,14 +54,6 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
     }
   }
 
-  override def afterEach(): Unit = {
-    try {
-      InMemoryDeltaCatalog.reset()
-    } finally {
-      super.afterEach()
-    }
-  }
-
   /**
    * Asserts that no physical parquet data files exist under the table's location.
    * This validates that DML operations went through the in-memory V2 path and

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -42,9 +42,15 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
     .set("spark.sql.catalog.spark_catalog", classOf[InMemoryDeltaCatalog].getName)
 
   override protected def withTable(tableNames: String*)(f: => Unit): Unit = {
-    super.withTable(tableNames: _*) {
-      f
-      tableNames.foreach(assertNoParquetFiles)
+    try {
+      super.withTable(tableNames: _*) {
+        f
+        tableNames.foreach(assertNoParquetFiles)
+      }
+    } finally {
+      for (tableName <- tableNames) {
+        assert(!InMemoryDeltaCatalog.contains(tableName))
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+import java.net.URI
+import java.nio.file.{Files, Path}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.delta.catalog.{InMemoryDeltaCatalog, InMemorySparkTable}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+/**
+ * Tests that DML operations can be executed through the DSv2 code path using
+ * [[InMemorySparkTable]] as the backing table implementation.
+ *
+ * Uses [[InMemoryDeltaCatalog]] as the session catalog so that:
+ * 1. CREATE TABLE still creates real Delta tables (for schema resolution)
+ * 2. Subsequent table loads return [[InMemorySparkTable]] (supports V2 DML)
+ * 3. DML operations flow through Spark's V2 execution path
+ */
+class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set("spark.sql.catalog.spark_catalog", classOf[InMemoryDeltaCatalog].getName)
+
+  override def afterEach(): Unit = {
+    try {
+      InMemoryDeltaCatalog.reset()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  /**
+   * Asserts that no physical parquet data files exist under the table's location.
+   * This validates that DML operations went through the in-memory V2 path and
+   * did not fall back to the V1 connector (which would write actual parquet files).
+   */
+  private def assertNoParquetFiles(tableName: String): Unit = {
+    val catalogTable = spark.sessionState.catalog.getTableMetadata(
+      TableIdentifier(tableName))
+    val dataPath = new File(new URI(catalogTable.location.toString))
+    if (dataPath.exists()) {
+      val parquetFiles = Files.walk(dataPath.toPath)
+        .filter(Files.isRegularFile(_))
+        .filter(_.toString.endsWith(".parquet"))
+        .toArray.map(_.asInstanceOf[Path].toString).toSeq
+      assert(parquetFiles.isEmpty,
+        s"Physical parquet files found under '$dataPath' while V2 in-memory mode is enabled. " +
+        s"DML may have fallen back to V1. Files: $parquetFiles")
+    }
+  }
+
+  test("catalog returns InMemorySparkTable when InMemoryDeltaCatalog is configured") {
+    val tableName = "v2_dml_test_catalog"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (id LONG, value STRING) USING delta")
+
+      val catalog = spark.sessionState.catalogManager.v2SessionCatalog
+        .asInstanceOf[InMemoryDeltaCatalog]
+      val table = catalog.loadTable(Identifier.of(Array("default"), tableName))
+
+      assert(table.isInstanceOf[InMemorySparkTable],
+        s"Expected InMemorySparkTable, got ${table.getClass.getName}")
+    }
+  }
+
+  test("INSERT via DSv2 InMemoryTable") {
+    val tableName = "v2_dml_test_insert"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (id LONG, value STRING) USING delta")
+
+      sql(s"INSERT INTO $tableName VALUES (1, 'a'), (2, 'b')")
+      checkAnswer(
+        sql(s"SELECT id, value FROM $tableName ORDER BY id"),
+        Seq(Row(1L, "a"), Row(2L, "b")))
+      assertNoParquetFiles(tableName)
+    }
+  }
+
+  test("INSERT OVERWRITE via DSv2 InMemoryTable") {
+    val tableName = "v2_dml_test_overwrite"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (id LONG, value STRING) USING delta")
+
+      sql(s"INSERT INTO $tableName VALUES (1, 'a'), (2, 'b')")
+      sql(s"INSERT OVERWRITE $tableName VALUES (3, 'c')")
+      checkAnswer(
+        sql(s"SELECT id, value FROM $tableName ORDER BY id"),
+        Seq(Row(3L, "c")))
+      assertNoParquetFiles(tableName)
+    }
+  }
+
+  test("DELETE via DSv2 InMemoryTable") {
+    val tableName = "v2_dml_test_delete"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (pk INT NOT NULL, value STRING) USING delta")
+      sql(s"INSERT INTO $tableName VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+      sql(s"DELETE FROM $tableName WHERE pk = 2")
+      checkAnswer(
+        sql(s"SELECT pk, value FROM $tableName ORDER BY pk"),
+        Seq(Row(1, "a"), Row(3, "c")))
+      assertNoParquetFiles(tableName)
+    }
+  }
+
+  test("UPDATE via DSv2 InMemoryTable") {
+    val tableName = "v2_dml_test_update"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (pk INT NOT NULL, value STRING) USING delta")
+      sql(s"INSERT INTO $tableName VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+      sql(s"UPDATE $tableName SET value = 'updated' WHERE pk >= 2")
+      checkAnswer(
+        sql(s"SELECT pk, value FROM $tableName ORDER BY pk"),
+        Seq(Row(1, "a"), Row(2, "updated"), Row(3, "updated")))
+      assertNoParquetFiles(tableName)
+    }
+  }
+
+  test("MERGE via DSv2 InMemoryTable") {
+    val targetTable = "v2_dml_test_merge_target"
+    withTable(targetTable) {
+      sql(s"CREATE TABLE $targetTable (pk INT NOT NULL, value STRING) USING delta")
+      sql(s"INSERT INTO $targetTable VALUES (1, 'a'), (2, 'b')")
+
+      withTempView("source") {
+        sql("CREATE TEMP VIEW source AS SELECT * FROM VALUES (1, 'updated'), (3, 'c') AS t(pk, value)")
+
+        sql(
+          s"""MERGE INTO $targetTable t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN UPDATE SET t.value = s.value
+             |WHEN NOT MATCHED THEN INSERT (pk, value) VALUES (s.pk, s.value)
+             |""".stripMargin)
+
+        checkAnswer(
+          sql(s"SELECT pk, value FROM $targetTable ORDER BY pk"),
+          Seq(Row(1, "updated"), Row(2, "b"), Row(3, "c")))
+        assertNoParquetFiles(targetTable)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -150,7 +150,8 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
       sql(s"INSERT INTO $targetTable VALUES (1, 'a'), (2, 'b')")
 
       withTempView("source") {
-        sql("CREATE TEMP VIEW source AS SELECT * FROM VALUES (1, 'updated'), (3, 'c') AS t(pk, value)")
+        sql("CREATE TEMP VIEW source AS SELECT * FROM VALUES (1, 'updated'), (3, 'c') " +
+            "AS t(pk, value)")
 
         sql(
           s"""MERGE INTO $targetTable t

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -23,7 +23,7 @@ import java.nio.file.{Files, Path}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.connector.catalog.{TableCatalog, Identifier}
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.delta.catalog.{InMemoryDeltaCatalog, InMemorySparkTable}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -23,7 +23,7 @@ import java.nio.file.{Files, Path}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.catalog.{TableCatalog, Identifier}
 import org.apache.spark.sql.delta.catalog.{InMemoryDeltaCatalog, InMemorySparkTable}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
@@ -40,6 +40,13 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.spark_catalog", classOf[InMemoryDeltaCatalog].getName)
+
+  override protected def withTable(tableNames: String*)(f: => Unit): Unit = {
+    super.withTable(tableNames: _*) {
+      f
+      tableNames.foreach(assertNoParquetFiles)
+    }
+  }
 
   override def afterEach(): Unit = {
     try {
@@ -59,13 +66,18 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
       TableIdentifier(tableName))
     val dataPath = new File(new URI(catalogTable.location.toString))
     if (dataPath.exists()) {
-      val parquetFiles = Files.walk(dataPath.toPath)
-        .filter(Files.isRegularFile(_))
-        .filter(_.toString.endsWith(".parquet"))
-        .toArray.map(_.asInstanceOf[Path].toString).toSeq
-      assert(parquetFiles.isEmpty,
-        s"Physical parquet files found under '$dataPath' while V2 in-memory mode is enabled. " +
-        s"DML may have fallen back to V1. Files: $parquetFiles")
+      val stream = Files.walk(dataPath.toPath)
+      try {
+        val parquetFiles = stream
+          .filter(Files.isRegularFile(_))
+          .filter(_.toString.endsWith(".parquet"))
+          .toArray.map(_.asInstanceOf[Path].toString).toSeq
+        assert(parquetFiles.isEmpty,
+          s"Physical parquet files found under '$dataPath' while V2 in-memory mode is enabled. " +
+          s"DML may have fallen back to V1. Files: $parquetFiles")
+      } finally {
+        stream.close()
+      }
     }
   }
 
@@ -74,8 +86,7 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
     withTable(tableName) {
       sql(s"CREATE TABLE $tableName (id LONG, value STRING) USING delta")
 
-      val catalog = spark.sessionState.catalogManager.v2SessionCatalog
-        .asInstanceOf[InMemoryDeltaCatalog]
+      val catalog = spark.sessionState.catalogManager.v2SessionCatalog.asInstanceOf[TableCatalog]
       val table = catalog.loadTable(Identifier.of(Array("default"), tableName))
 
       assert(table.isInstanceOf[InMemorySparkTable],
@@ -92,7 +103,6 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
       checkAnswer(
         sql(s"SELECT id, value FROM $tableName ORDER BY id"),
         Seq(Row(1L, "a"), Row(2L, "b")))
-      assertNoParquetFiles(tableName)
     }
   }
 
@@ -106,7 +116,6 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
       checkAnswer(
         sql(s"SELECT id, value FROM $tableName ORDER BY id"),
         Seq(Row(3L, "c")))
-      assertNoParquetFiles(tableName)
     }
   }
 
@@ -120,7 +129,6 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
       checkAnswer(
         sql(s"SELECT pk, value FROM $tableName ORDER BY pk"),
         Seq(Row(1, "a"), Row(3, "c")))
-      assertNoParquetFiles(tableName)
     }
   }
 
@@ -134,7 +142,6 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
       checkAnswer(
         sql(s"SELECT pk, value FROM $tableName ORDER BY pk"),
         Seq(Row(1, "a"), Row(2, "updated"), Row(3, "updated")))
-      assertNoParquetFiles(tableName)
     }
   }
 
@@ -158,7 +165,6 @@ class V2DmlInMemoryTableSuite extends QueryTest with DeltaSQLCommandTest {
         checkAnswer(
           sql(s"SELECT pk, value FROM $targetTable ORDER BY pk"),
           Seq(Row(1, "updated"), Row(2, "b"), Row(3, "c")))
-        assertNoParquetFiles(targetTable)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -31,9 +31,11 @@ import org.apache.spark.sql.connector.expressions.Transform
  * to return [[InMemorySparkTable]].
  */
 class InMemoryDeltaCatalog extends DeltaCatalog {
-  override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table = {
+  override def dropTable(ident: Identifier): Boolean =
+    InMemoryDeltaCatalog.dropTable(ident)
+
+  override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table =
     InMemoryDeltaCatalog.getOrCreateTable(ident, catalogTable, spark)
-  }
 }
 
 object InMemoryDeltaCatalog {
@@ -66,6 +68,18 @@ object InMemoryDeltaCatalog {
         props)
     })
   }
+
+  /**
+   * Remove a table defined by [[ident]] from the table list.
+   * Returns true if there was a table and it was removed, false otherwise.
+   */
+  def dropTable(ident: Identifier): Boolean =
+    tables.remove(ident.name()) != null
+
+  /**
+   * Check whether table [[name]] exists here.
+   */
+  def contains(name: String): Boolean = tables.containsKey(name)
 
   /**
    * Reset the catalog, removing all created tables from the storage.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.connector.expressions.Transform
+
+/**
+ * Test-only catalog that extends [[DeltaCatalog]] and overrides [[loadCatalogTable]]
+ * to return [[InMemorySparkTable]] instead of SparkTable or DeltaTableV2.
+ *
+ * This allows testing DSv2 DML operations (INSERT, DELETE, UPDATE, MERGE) through
+ * Delta's catalog without requiring a fully functional SparkTable write implementation.
+ *
+ * Table creation still goes through the normal Delta path (creating real Delta tables
+ * on disk for schema resolution), but subsequent table loads return cached in-memory
+ * tables that support all V2 operations.
+ */
+class InMemoryDeltaCatalog extends DeltaCatalog {
+  override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table = {
+    InMemoryDeltaCatalog.getOrCreateTable(ident, catalogTable, spark)
+  }
+}
+
+object InMemoryDeltaCatalog {
+  private val tableCache = new ConcurrentHashMap[String, InMemorySparkTable]()
+
+  def getOrCreateTable(
+      ident: Identifier,
+      catalogTable: CatalogTable,
+      spark: SparkSession): InMemorySparkTable = {
+    val tablePath = catalogTable.location.toString
+    tableCache.computeIfAbsent(tablePath, _ => {
+      val deltaTable = DeltaTableV2(
+        spark, new Path(catalogTable.location), catalogTable = Some(catalogTable))
+      val tableName = s"${ident.namespace().mkString(".")}.${ident.name()}"
+      val props = new java.util.HashMap[String, String](catalogTable.properties.asJava)
+      props.put("supports-deltas", "true")
+      new InMemorySparkTable(
+        tableName,
+        deltaTable.schema(),
+        Array.empty[Transform],
+        props)
+    })
+  }
+
+  def reset(): Unit = tableCache.clear()
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -28,14 +28,7 @@ import org.apache.spark.sql.connector.expressions.Transform
 
 /**
  * Test-only catalog that extends [[DeltaCatalog]] and overrides [[loadCatalogTable]]
- * to return [[InMemorySparkTable]] instead of SparkTable or DeltaTableV2.
- *
- * This allows testing DSv2 DML operations (INSERT, DELETE, UPDATE, MERGE) through
- * Delta's catalog without requiring a fully functional SparkTable write implementation.
- *
- * Table creation still goes through the normal Delta path (creating real Delta tables
- * on disk for schema resolution), but subsequent table loads return cached in-memory
- * tables that support all V2 operations.
+ * to return [[InMemorySparkTable]].
  */
 class InMemoryDeltaCatalog extends DeltaCatalog {
   override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table = {
@@ -45,6 +38,10 @@ class InMemoryDeltaCatalog extends DeltaCatalog {
 
 object InMemoryDeltaCatalog {
 
+  /**
+   * The actual tables.
+   * Maps a table name -> [[InMemorySparkTable]].
+   */
   private val tables = new ConcurrentHashMap[String, InMemorySparkTable]()
 
   /**
@@ -70,5 +67,8 @@ object InMemoryDeltaCatalog {
     })
   }
 
+  /**
+   * Reset the catalog, removing all created tables from the storage.
+   */
   def reset(): Unit = tables.clear()
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -44,19 +44,24 @@ class InMemoryDeltaCatalog extends DeltaCatalog {
 }
 
 object InMemoryDeltaCatalog {
-  private val tableCache = new ConcurrentHashMap[String, InMemorySparkTable]()
 
+  private val tables = new ConcurrentHashMap[String, InMemorySparkTable]()
+
+  /**
+   * Get or create a table defined by [[ident]].
+   * [[catalogTable]] and [[spark]] are used to discover the table schema.
+   *
+   * NB: Ignores `ident.namespace()`, instead using `ident.name()` as the key.
+   */
   def getOrCreateTable(
       ident: Identifier,
       catalogTable: CatalogTable,
       spark: SparkSession): InMemorySparkTable = {
-    val tablePath = catalogTable.location.toString
-    tableCache.computeIfAbsent(tablePath, _ => {
+    val tableName = ident.name()
+    tables.computeIfAbsent(tableName, _ => {
       val deltaTable = DeltaTableV2(
         spark, new Path(catalogTable.location), catalogTable = Some(catalogTable))
-      val tableName = s"${ident.namespace().mkString(".")}.${ident.name()}"
       val props = new java.util.HashMap[String, String](catalogTable.properties.asJava)
-      props.put("supports-deltas", "true")
       new InMemorySparkTable(
         tableName,
         deltaTable.schema(),
@@ -65,5 +70,5 @@ object InMemoryDeltaCatalog {
     })
   }
 
-  def reset(): Unit = tableCache.clear()
+  def reset(): Unit = tables.clear()
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.delta.catalog
 import java.util
 
 import org.apache.spark.sql.connector.catalog.InMemoryRowLevelOperationTable
-import org.apache.spark.sql.connector.catalog.constraints.Constraint
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -34,10 +33,9 @@ class InMemorySparkTable(
     name: String,
     schema: StructType,
     partitioning: Array[Transform],
-    properties: util.Map[String, String],
-    constraints: Array[Constraint] = Array.empty)
+    properties: util.Map[String, String])
   extends InMemoryRowLevelOperationTable(
-    name, schema, partitioning, properties, constraints) {
+    name, schema, partitioning, properties) {
 
   // Force DELETE to go through the SupportsRowLevelOperations path instead of
   // the SupportsDeleteV2.deleteWhere path inherited from InMemoryTable, which

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import java.util
+
+import org.apache.spark.sql.connector.catalog.InMemoryRowLevelOperationTable
+import org.apache.spark.sql.connector.catalog.constraints.Constraint
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+
+/**
+ * In-memory DSv2 table used as a test stand-in for SparkTable (the Kernel-based Delta V2
+ * connector).
+ *
+ * Created by [[InMemoryDeltaCatalog]] when used as the session catalog in tests.
+ */
+class InMemorySparkTable(
+    name: String,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String],
+    constraints: Array[Constraint] = Array.empty)
+  extends InMemoryRowLevelOperationTable(
+    name, schema, partitioning, properties, constraints) {
+
+  // Force DELETE to go through the SupportsRowLevelOperations path instead of
+  // the SupportsDeleteV2.deleteWhere path inherited from InMemoryTable, which
+  // only supports filtering by partition columns.
+  override def canDeleteWhere(filters: Array[Filter]): Boolean = false
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark.

## Description

Adding `InMemorySparkTable` -- a `SparkTable` that can be used in tests for spark's DataSourceV2 DML without involving the Delta connector.

## How was this patch tested?

Includes tests:

- one verifies that the catalog plugin actually returns an instance of `InMemorySparkTable`.
- five more test the major DML commands (INSERT, INSERT OVERWRITE, DELETE, UPDATE, MERGE) using sql.
- each of these five also have a sanity-check that asserts absence of parquet files in the data-directory of the used table.

## Does this PR introduce _any_ user-facing changes?

No.
