### PR TITLE
[DRC] Delta Rest Catalog Foundation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1088,6 +1088,12 @@ lazy val storage = (project in file("storage"))
     // Unidoc settings
     unidocSourceFilePatterns += SourceFilePattern("/LogStore.java", "/CloseableIterator.java"),
     TestParallelization.settings
+  ).settings(
+    // Delta REST Catalog java-shims: -DdeltaRestCatalog=true selects drc/, default selects no-drc/
+    Compile / unmanagedSourceDirectories += {
+      val shimDir = if (sys.props.getOrElse("deltaRestCatalog", "false").toBoolean) "drc" else "no-drc"
+      (baseDirectory.value / "src" / "main" / "java-shims" / shimDir)
+    }
   ).configureUnidoc()
 
 lazy val storageS3DynamoDB = (project in file("storage-s3-dynamodb"))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -591,7 +591,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // catches Delta-internal additions (e.g. table-feature flags). This is acceptable for
     // a temporary kill switch - once Delta supports propagating metadata updates to UC,
     // this check will be removed entirely.
-    if (!isCreatingNewTable) {
+    if (!isCreatingNewTable && !isDeltaRestCatalogEnabled) {
       throwIfUCManagedMetadataChanged(snapshot.metadata, context = "updateMetadata")
     }
   }
@@ -638,6 +638,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
             .contains(UCCommitCoordinatorBuilder.COORDINATOR_NAME)
       }
   }
+
+  /** True when the Delta REST Catalog API is enabled for this session. */
+  private lazy val isDeltaRestCatalogEnabled: Boolean =
+    spark.conf.get(DeltaSQLConf.DELTA_REST_CATALOG_ENABLED)
 
   /**
    * Returns true if committing [[dm]] would change the clustering columns on a UC-managed
@@ -989,9 +993,11 @@ trait OptimisticTransactionImpl extends TransactionHelper
       newConfs = newConfsWithoutICT ++ existingICTConfs
     }
     newMetadata = Some(newMetadata.get.copy(configuration = newConfs))
-    throwIfUCManagedMetadataChanged(
-      snapshot.metadata,
-      context = "updateMetadataForNewTableInReplace")
+    if (!isDeltaRestCatalogEnabled) {
+      throwIfUCManagedMetadataChanged(
+        snapshot.metadata,
+        context = "updateMetadataForNewTableInReplace")
+    }
   }
 
   /**
@@ -2067,8 +2073,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
           newProtocol.toIterator
       allActions = allActions.map { action =>
         action match {
-          case dm: DomainMetadata if isClusteringChangedOnUCManagedTable(dm) =>
+          case dm: DomainMetadata
+            if !isDeltaRestCatalogEnabled && isClusteringChangedOnUCManagedTable(dm) =>
             // Temporary: block clustering changes on UC-managed tables (commitLarge() path).
+            // Lifted when DRC is enabled — metadata propagates atomically with the commit.
             // commitLarge() bypasses prepareCommit(), so this guard is needed separately.
             // The check is intentionally inside the lazy map: commitLarge streams actions to
             // avoid materialising large sets, so an eager pre-scan is not practical. The

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -262,7 +262,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       //       Before this bug is fixed, we should only call the catalog plugin API to create tables
       //       if UC is enabled to replace `V2SessionCatalog`.
       createTableFunc = Option.when(isUnityCatalog) {
-        v1Table => {
+        (v1Table, _snapshot) => {
           val t = V1Table(v1Table)
           super.createTable(ident, t.columns(), t.partitioning, t.properties)
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -80,7 +80,7 @@ case class CreateDeltaTableCommand(
     override val output: Seq[Attribute] = Nil,
     protocol: Option[Protocol] = None,
     override val allowCatalogManaged: Boolean = false,
-    createTableFunc: Option[CatalogTable => Unit] = None)
+    createTableFunc: Option[(CatalogTable, Snapshot) => Unit] = None)
   extends LeafRunnableCommand
   with DeltaCommand
   with DeltaLogging

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
@@ -91,14 +91,14 @@ trait CreateDeltaTableLike extends SQLConfHelper {
       snapshot: Snapshot,
       query: Option[LogicalPlan],
       didNotChangeMetadata: Boolean,
-      createTableFunc: Option[CatalogTable => Unit] = None
+      createTableFunc: Option[(CatalogTable, Snapshot) => Unit] = None
   ): Unit = {
     val cleaned = cleanupTableDefinition(spark, table, snapshot)
     operation match {
       case _ if tableByPath => // do nothing with the metastore if this is by path
       case TableCreationModes.Create =>
         if (createTableFunc.isDefined) {
-          createTableFunc.get.apply(cleaned)
+          createTableFunc.get.apply(cleaned, snapshot)
         } else {
           spark.sessionState.catalog.createTable(
             cleaned,
@@ -120,7 +120,7 @@ trait CreateDeltaTableLike extends SQLConfHelper {
           case Some(createFunc) =>
             // This is the new missing-table path where creation is delegated through the V2
             // catalog plugin (for example Unity Catalog) instead of SessionCatalog.createTable().
-            createFunc(cleaned)
+            createFunc(cleaned, snapshot)
           case None =>
             spark.sessionState.catalog.createTable(
               cleaned,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -23,10 +23,11 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import io.delta.storage.commit.CommitCoordinatorClient
-import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCTokenBasedRestClient}
+import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCDeltaClient, UCTokenBasedRestClient}
 
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import io.unitycatalog.client.auth.TokenProvider
 import org.apache.spark.internal.MDC
@@ -90,7 +91,13 @@ object UCCommitCoordinatorBuilder
           s"Catalog $catalogName not found in the provided SparkSession configurations.")
     }
     val conf = Map.empty[String, String]
-    new UCCommitCoordinatorClient(conf.asJava, client)
+    if (spark.conf.get(DeltaSQLConf.DELTA_REST_CATALOG_ENABLED)) {
+      val catalogPlugin = spark.sessionState.catalogManager.catalog(catalogName)
+      val ucDeltaClient = UCDeltaClient.createFromCatalogDelegate(catalogPlugin, client)
+      new UCCommitCoordinatorClient(conf.asJava, client, ucDeltaClient)
+    } else {
+      new UCCommitCoordinatorClient(conf.asJava, client)
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -842,6 +842,15 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .checkValue(_ > 0, "threadPoolSize must be positive")
       .createWithDefault(20)
 
+  val DELTA_REST_CATALOG_ENABLED =
+    buildConf("unityCatalog.deltaRestCatalog.enabled")
+      .doc("When enabled, Delta Spark uses the Delta REST Catalog API " +
+        "for catalog operations (loadTable, createTable) and commit " +
+        "coordination instead of the legacy UC API. Requires a UC server " +
+        "that supports the /delta/v1/ endpoints.")
+      .booleanConf
+      .createWithDefault(false)
+
   val COORDINATED_COMMITS_GET_COMMITS_THREAD_POOL_SIZE =
     buildStaticConf("coordinatedCommits.getCommits.threadPoolSize")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
@@ -380,7 +380,7 @@ class DeltaCreateTableLikeSuite extends QueryTest
             snapshot,
             query = None,
             didNotChangeMetadata = true,
-            createTableFunc = Some((_: CatalogTable) => {
+            createTableFunc = Some((_: CatalogTable, _: Snapshot) => {
               createCallbackCalls += 1
             }))
         }

--- a/storage/src/main/java-shims/no-drc/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java-shims/no-drc/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.GetCommitsResponse;
+import io.delta.storage.commit.UpdatedActions;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * No-DRC stub of UCDeltaClient. Compiled when -DdeltaRestCatalog is not set (the default).
+ * Delegates commit/getCommits to the legacy UCClient. Catalog operations (loadTable, createTable)
+ * return null/false, signaling the caller to use the legacy path.
+ */
+public class UCDeltaClient {
+
+    private final UCClient legacyClient;
+
+    public UCDeltaClient(UCClient legacyClient) {
+        this.legacyClient = legacyClient;
+    }
+
+    /**
+     * Factory method. In the no-DRC stub, the delegate is ignored — only the legacy
+     * client is used.
+     *
+     * @param delegate the catalog delegate (UCSingleCatalog or UCProxy); unused in no-DRC
+     * @param legacyClient the legacy UCClient for commit/getCommits
+     * @return a new UCDeltaClient backed by the legacy client
+     */
+    public static UCDeltaClient createFromCatalogDelegate(
+            Object delegate, UCClient legacyClient) {
+        return new UCDeltaClient(legacyClient);
+    }
+
+    /** Result of a loadTable call. */
+    public static class LoadResult {
+        private final String location;
+        private final String tableId;
+        private final String tableType;
+        private final String etag;
+
+        public LoadResult(String location, String tableId, String tableType, String etag) {
+            this.location = location;
+            this.tableId = tableId;
+            this.tableType = tableType;
+            this.etag = etag;
+        }
+
+        public String getLocation() { return location; }
+        public String getTableId() { return tableId; }
+        public String getTableType() { return tableType; }
+        public String getEtag() { return etag; }
+    }
+
+    /**
+     * No-DRC stub: returns null. Caller must fall through to the legacy path
+     * (super.loadTable() via UCProxy).
+     */
+    public LoadResult loadTable(String catalog, String schema, String table) {
+        return null;
+    }
+
+    /**
+     * No-DRC stub: returns false. Caller must fall through to the legacy path
+     * (super.createTable() via UCProxy).
+     */
+    public boolean createTable(
+            String name,
+            String location,
+            String tableType,
+            String dataSourceFormat,
+            String schemaJson,
+            List<String> partitionColumns,
+            Map<String, String> properties,
+            int minReaderVersion,
+            int minWriterVersion,
+            Set<String> readerFeatures,
+            Set<String> writerFeatures,
+            Map<String, String> domainMetadata) {
+        return false;
+    }
+
+    /**
+     * No-DRC stub: delegates to legacy UCClient.commit().
+     */
+    public void commit(
+            String tableId,
+            URI tableUri,
+            Optional<Commit> commit,
+            Optional<Long> lastKnownBackfilledVersion,
+            boolean disown,
+            UpdatedActions updatedActions)
+            throws IOException, CommitFailedException, UCCommitCoordinatorException {
+        legacyClient.commit(
+            tableId,
+            tableUri,
+            commit,
+            lastKnownBackfilledVersion,
+            disown,
+            updatedActions.getNewMetadata() == updatedActions.getOldMetadata() ?
+                Optional.empty() : Optional.of(updatedActions.getNewMetadata()),
+            updatedActions.getNewProtocol() == updatedActions.getOldProtocol() ?
+                Optional.empty() : Optional.of(updatedActions.getNewProtocol()),
+            Optional.empty() // uniform — not supported in legacy path
+        );
+    }
+
+    /**
+     * No-DRC stub: delegates to legacy UCClient.getCommits().
+     */
+    public GetCommitsResponse getCommits(
+            String tableId,
+            URI tableUri,
+            Optional<Long> startVersion,
+            Optional<Long> endVersion)
+            throws IOException, UCCommitCoordinatorException {
+        return legacyClient.getCommits(tableId, tableUri, startVersion, endVersion);
+    }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -53,6 +53,14 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
   public UCCommitCoordinatorClient(Map<String, String> conf, UCClient ucClient) {
     this.conf = conf;
     this.ucClient = ucClient;
+    this.ucDeltaClient = null;
+  }
+
+  public UCCommitCoordinatorClient(
+      Map<String, String> conf, UCClient ucClient, UCDeltaClient ucDeltaClient) {
+    this.conf = conf;
+    this.ucClient = ucClient;
+    this.ucDeltaClient = ucDeltaClient;
   }
 
   /**
@@ -148,6 +156,9 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
 
   /** Configuration map containing settings for the coordinator client. */
   public final Map<String, String> conf;
+
+  /** Optional DRC client. When present, commit/getCommits route through it. */
+  private final UCDeltaClient ucDeltaClient;
 
   /**
    * Runs a task asynchronously using the backfillThreadPool.
@@ -449,22 +460,33 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
     int transientErrorRetryCount = 0;
     while (transientErrorRetryCount <= MAX_RETRIES_ON_TRANSIENT_ERROR) {
       try {
-        commitToUC(
-          tableDesc,
-          logPath,
-          Optional.of(commitFile),
-          Optional.of(commitVersion),
-          Optional.of(commitTimestamp),
-          Optional.of(lastKnownBackfilledVersion.get()),
-          catalogTrackedInfo,
-          disown,
-          updatedActions.getNewMetadata() == updatedActions.getOldMetadata() || !SHOULD_PASS_METADATA_TO_UC ?
-            Optional.empty() :
-            Optional.of(updatedActions.getNewMetadata()),
-          updatedActions.getNewProtocol() == updatedActions.getOldProtocol() ?
-            Optional.empty() :
-            Optional.of(updatedActions.getNewProtocol())
-        );
+        if (ucDeltaClient != null) {
+          ucDeltaClient.commit(
+            tableId,
+            CoordinatedCommitsUtils.getTablePath(logPath).toUri(),
+            Optional.of(new Commit(commitVersion, commitFile, commitTimestamp)),
+            Optional.of(lastKnownBackfilledVersion.get()),
+            disown,
+            updatedActions
+          );
+        } else {
+          commitToUC(
+            tableDesc,
+            logPath,
+            Optional.of(commitFile),
+            Optional.of(commitVersion),
+            Optional.of(commitTimestamp),
+            Optional.of(lastKnownBackfilledVersion.get()),
+            catalogTrackedInfo,
+            disown,
+            updatedActions.getNewMetadata() == updatedActions.getOldMetadata() || !SHOULD_PASS_METADATA_TO_UC ?
+              Optional.empty() :
+              Optional.of(updatedActions.getNewMetadata()),
+            updatedActions.getNewProtocol() == updatedActions.getOldProtocol() ?
+              Optional.empty() :
+              Optional.of(updatedActions.getNewProtocol())
+          );
+        }
         break;
       } catch (CommitFailedException cfe) {
         if (transientErrorRetryCount > 0 && cfe.getConflict() && cfe.getRetryable() &&
@@ -830,6 +852,13 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional<Long> startVersion,
       Optional<Long> endVersion) {
     try {
+      if (ucDeltaClient != null) {
+        return ucDeltaClient.getCommits(
+          extractUCTableId(tableDesc),
+          CoordinatedCommitsUtils.getTablePath(tableDesc.getLogPath()).toUri(),
+          startVersion,
+          endVersion);
+      }
       return ucClient.getCommits(
         extractUCTableId(tableDesc),
         CoordinatedCommitsUtils.getTablePath(tableDesc.getLogPath()).toUri(),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR adds the runtime config gate (`spark.databricks.delta.unityCatalog.deltaRestCatalog.enabled`, default `false`) for the upcoming Delta REST Catalog (DRC) API.

We introduce `java-shims/` conditional compilation in the storage module based on the flag `-DdeltaRestCatalog=true`. When set to `true`, we select the DRC implementation, otherwise default to the non-DRC stub which uses the legacy UC API.

Since this is just the foundational PR, we only create the non-DRC stub `UCDeltaClient` that delegates to the legacy `UCClient` - we don't introduce any behavioural changes when the feature is off.

Additionally, we previously introduced a few kill switches for metadata updates (i.e., if the operation you were performing had metadata changes, it would throw an error). Now, we gate those three UC-managed metadata kill switches so they are **lifted** when DRC is enabled since DRC carries metadata atomically with commits, removing the structural reason for the blocks.

Lastly, we introduce changes `createTableFunc` from `CatalogTable => Unit` to `(CatalogTable, Snapshot) => Unit` so the DRC path can extract native Delta types `(protocol, schema, domain metadata)` from the post-commit snapshot.

### Future work
  * DRC UCDeltaClient implementation (uses generated `delta.api.TablesApi`)
  * AbstractDeltaCatalog wiring (loadTable, createTable via DRC)
  * UCCommitCoordinatorClient wiring (commit/getCommits via DRC with metadata diff)
  * End-to-end integration testing

## How was this patch tested?
Locally and CI.

## Does this PR introduce _any_ user-facing changes?
No.