### PR TITLE
Revert "[kernel-spark] E2E tests on all data loss scenarios during initial snapshot (#6298)"

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -79,15 +79,6 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "read options [ignoreDeletes, ignoreChanges, skipChangeCommits]: " +
       "equivalent to skipChangeCommits",
 
-    // === Commit/Checkpoint file missing detection ===
-    "incremental: first commit file missing, fails",
-    "incremental: commit file gap between versions, fails",
-    "initial snapshot: commit file missing but checkpoint intact, succeeds",
-    "initial snapshot: both checkpoint and commit file missing, fails",
-    "initial snapshot: log retention deletes old checkpoint and commit files mid-stream," +
-      " restart fails",
-    "streaming processes 100 sequential single-value commits and contains all values 0 to 99",
-
     // ========== startingVersion option tests ==========
     "startingVersion",
     "startingVersion latest",
@@ -146,11 +137,11 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "type widening: restarting with stale DataFrame should recover",
 
     // === Data Loss Detection ===
-    "incremental: first commit file missing, failOnDataLoss=false succeeds",
-    "incremental: commit file gap between versions, failOnDataLoss=false succeeds",
-    // Kernel cannot reconstruct snapshot without checkpoint file (_last_checkpoint still
-    // points to deleted checkpoint). V1 falls back to delta files; Kernel does not.
-    "initial snapshot: checkpoint missing but all commit files intact, succeeds",
+    "fail on data loss - starting from missing files",
+    "fail on data loss - gaps of files",
+    "fail on data loss - starting from missing files with option off",
+    "fail on data loss - gaps of files with option off",
+    "streaming processes 100 sequential single-value commits and contains all values 0 to 99",
 
     // === Misc ===
     // TODO(#5900): fix exception mismatch

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -34,7 +34,6 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.{MemoryStream, OffsetSeqLog}
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
-import io.delta.kernel.exceptions.{InvalidTableException, KernelException}
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
@@ -2057,7 +2056,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       expectedAfterOverwriteAppend = Right(Seq(1, 2, 3, 4, 5, 9, 10)))
   }
 
-  test("incremental: first commit file missing, fails") {
+  test("fail on data loss - starting from missing files") {
     withTempDirs { (srcData, targetData, chkLocation) =>
       def addData(): Unit = {
         spark.range(10).write.format("delta").mode("append").save(srcData.getCanonicalPath)
@@ -2088,18 +2087,11 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           .start(targetData.getCanonicalPath)
         q.processAllAvailable()
       }
-      if (useDsv2) {
-        // Kernel throws KernelException when the start version is not found
-        assert(e.getCause.isInstanceOf[KernelException])
-        assert(e.getCause.getMessage.contains("no log file found for version"))
-      } else {
-        assert(e.getCause.isInstanceOf[DeltaIllegalStateException])
-        assert(e.getCause.getMessage === DeltaErrors.failOnDataLossException(1L, 2L).getMessage)
-      }
+      assert(e.getCause.getMessage === DeltaErrors.failOnDataLossException(1L, 2L).getMessage)
     }
   }
 
-  test("incremental: commit file gap between versions, fails") {
+  test("fail on data loss - gaps of files") {
     withTempDirs { (srcData, targetData, chkLocation) =>
       def addData(): Unit = {
         spark.range(10).write.format("delta").mode("append").save(srcData.getCanonicalPath)
@@ -2130,18 +2122,11 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           .start(targetData.getCanonicalPath)
         q.processAllAvailable()
       }
-      if (useDsv2) {
-        // Kernel throws InvalidTableException when delta files are not contiguous
-        assert(e.getCause.isInstanceOf[InvalidTableException])
-        assert(e.getCause.getMessage.contains("versions are not contiguous"))
-      } else {
-        assert(e.getCause.isInstanceOf[DeltaIllegalStateException])
-        assert(e.getCause.getMessage === DeltaErrors.failOnDataLossException(2L, 3L).getMessage)
-      }
+      assert(e.getCause.getMessage === DeltaErrors.failOnDataLossException(2L, 3L).getMessage)
     }
   }
 
-  test("incremental: first commit file missing, failOnDataLoss=false succeeds") {
+  test("fail on data loss - starting from missing files with option off") {
     withTempDirs { (srcData, targetData, chkLocation) =>
       def addData(): Unit = {
         spark.range(10).write.format("delta").mode("append").save(srcData.getCanonicalPath)
@@ -2178,7 +2163,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  test("incremental: commit file gap between versions, failOnDataLoss=false succeeds") {
+  test("fail on data loss - gaps of files with option off") {
     withTempDirs { (srcData, targetData, chkLocation) =>
       def addData(): Unit = {
         spark.range(10).write.format("delta").mode("append").save(srcData.getCanonicalPath)
@@ -2212,218 +2197,6 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       q2.stop()
 
       assert(spark.read.format("delta").load(targetData.getCanonicalPath).count() === 30)
-    }
-  }
-
-  test("initial snapshot: commit file missing but checkpoint intact, succeeds") {
-    withTempDirs { (srcData, targetData, chkLocation) =>
-      def addData(): Unit = {
-        spark.range(10).write.format("delta").mode("append").save(srcData.getCanonicalPath)
-      }
-
-      addData()
-      addData()
-      addData()
-      addData()
-
-      val srcLog = DeltaLog.forTable(spark, srcData)
-      // Create a checkpoint so that we can create a snapshot without json files before version 3
-      srcLog.checkpoint()
-      // Delete an early delta file - this simulates data loss in the log
-      assert(new File(FileNames.unsafeDeltaFile(srcLog.logPath, 1).toUri).delete())
-
-      DeltaLog.clearCache()
-
-      // Start a brand new stream (no prior checkpoint) - this will read the initial snapshot
-      // The initial snapshot reads from the checkpoint, not individual delta files,
-      // so failOnDataLoss should NOT be triggered even with the default option (true)
-      val df = loadStreamWithOptions(srcData.getCanonicalPath, Map.empty)
-
-      val q = df.writeStream.format("delta")
-        .option("checkpointLocation", chkLocation.getCanonicalPath)
-        .start(targetData.getCanonicalPath)
-      q.processAllAvailable()
-      q.stop()
-
-      assert(spark.read.format("delta").load(targetData.getCanonicalPath).count() === 40)
-    }
-  }
-
-  test("initial snapshot: both checkpoint and commit file missing, fails") {
-    withTempDir { srcData =>
-      def addData(): Unit = {
-        spark.range(10).write.format("delta").mode("append").save(srcData.getCanonicalPath)
-      }
-
-      addData()
-      addData()
-      addData()
-      addData()
-
-      val srcLog = DeltaLog.forTable(spark, srcData)
-      srcLog.checkpoint()
-
-      // Delete the checkpoint file and a delta file to simulate snapshot data loss
-      val checkpoints = new File(srcLog.logPath.toUri).listFiles()
-        .filter(f => FileNames.isCheckpointFile(new Path(f.getAbsolutePath)))
-      assert(checkpoints.nonEmpty)
-      checkpoints.foreach(_.delete())
-      assert(new File(FileNames.unsafeDeltaFile(srcLog.logPath, 1).toUri).delete())
-
-      DeltaLog.clearCache()
-
-      // Start a brand new stream - the snapshot cannot be reconstructed because both
-      // checkpoint and delta files are missing. This should fail, but NOT with
-      // failOnDataLossException since that check only applies to incremental changes.
-      // The error is thrown during DeltaLog initialization (before the stream starts),
-      // so it is not wrapped in StreamingQueryException.
-      if (useDsv2) {
-        // Kernel throws InvalidTableException when checkpoint is missing
-        val e = intercept[InvalidTableException] {
-          loadStreamWithOptions(srcData.getCanonicalPath, Map.empty)
-        }
-        assert(e.getMessage.contains("Missing checkpoint"))
-      } else {
-        val e = intercept[DeltaIllegalStateException] {
-          loadStreamWithOptions(srcData.getCanonicalPath, Map.empty)
-        }
-        assert(e.getErrorClass == "DELTA_MISSING_PART_FILES")
-      }
-    }
-  }
-
-  test("initial snapshot: checkpoint missing but all commit files intact, succeeds") {
-    withTempDirs { (srcData, targetData, chkLocation) =>
-      def addData(): Unit = {
-        spark.range(10).write.format("delta").mode("append").save(srcData.getCanonicalPath)
-      }
-
-      addData()
-      addData()
-      addData()
-      addData()
-
-      val srcLog = DeltaLog.forTable(spark, srcData)
-      srcLog.checkpoint()
-
-      // Delete only the checkpoint file, keep all delta files
-      val checkpoints = new File(srcLog.logPath.toUri).listFiles()
-        .filter(f => FileNames.isCheckpointFile(new Path(f.getAbsolutePath)))
-      assert(checkpoints.nonEmpty)
-      checkpoints.foreach(_.delete())
-
-      DeltaLog.clearCache()
-
-      // Start a brand new stream - the snapshot is reconstructed from delta files alone
-      // This should succeed because all delta files are intact
-      val df = loadStreamWithOptions(srcData.getCanonicalPath, Map.empty)
-
-      val q = df.writeStream.format("delta")
-        .option("checkpointLocation", chkLocation.getCanonicalPath)
-        .start(targetData.getCanonicalPath)
-      q.processAllAvailable()
-      q.stop()
-
-      assert(spark.read.format("delta").load(targetData.getCanonicalPath).count() === 40)
-    }
-  }
-
-  test("initial snapshot: log retention deletes old checkpoint and commit files mid-stream," +
-      " restart fails") {
-    // This test simulates log retention by manually deleting delta JSON files from the
-    // filesystem. With a catalog-owned commit coordinator, unbackfilled commits live in the
-    // coordinator's memory rather than on the filesystem, so deleting a prefix of versions
-    // creates an unresolvable gap that triggers the coordinator's reconciliation guard
-    // (IllegalStateException) instead of the expected DeltaFileNotFoundException.
-    assume(!catalogOwnedDefaultCreationEnabledInTests,
-      "Log retention simulation via filesystem deletion is incompatible with " +
-        "catalog-owned commit coordinators")
-    withTempDir { srcData =>
-      withTempDir { chkLocation =>
-        // Create table with 4 versions, each with 2 files, so initial snapshot has 8 AddFiles
-        (0 until 4).foreach { _ =>
-          spark.range(10).repartition(2).write
-            .format("delta").mode("append").save(srcData.getCanonicalPath)
-        }
-
-        val srcLog = DeltaLog.forTable(spark, srcData)
-        val snapshotVersion = srcLog.snapshot.version // version 3
-
-        // Start stream with maxFilesPerTrigger=1 so each batch processes only 1 file.
-        // Use StreamManualClock + AdvanceManualClock to process exactly 1 micro-batch.
-        val df = loadStreamWithOptions(
-          srcData.getCanonicalPath,
-          Map("maxFilesPerTrigger" -> "1"))
-        val clock = new StreamManualClock(System.currentTimeMillis())
-
-        // Phase 1: Process exactly 1 file from initial snapshot, then stop.
-        // The streaming checkpoint will have isInitialSnapshot=true at snapshotVersion.
-        testStream(df)(
-          StartStream(
-            trigger = Trigger.ProcessingTime("10 seconds"),
-            triggerClock = clock,
-            checkpointLocation = chkLocation.getCanonicalPath),
-          // Process exactly 1 micro-batch (1 file out of 8)
-          AdvanceManualClock(10 * 1000L),
-          // Verify we are still mid-initial-snapshot
-          AssertOnQuery { q =>
-            val offset = DeltaSourceOffset(
-              srcLog.tableId,
-              q.lastProgress.sources(0).endOffset)
-            assert(offset.isInitialSnapshot,
-              s"Expected isInitialSnapshot=true but got offset: $offset")
-            true
-          },
-          StopStream
-        )
-
-        // Phase 2: Simulate log retention cleaning up old files.
-        // Add new versions to create a checkpoint beyond the old snapshot version.
-        (0 until 10).foreach { _ =>
-          spark.range(10).write
-            .format("delta").mode("append").save(srcData.getCanonicalPath)
-        }
-        val updatedLog = DeltaLog.forTable(spark, srcData)
-        updatedLog.checkpoint()
-
-        // Delete old checkpoint and commit files at/before the original snapshot version
-        val logDir = new File(srcLog.logPath.toUri)
-        logDir.listFiles()
-          .filter(f => FileNames.isCheckpointFile(new Path(f.getAbsolutePath)))
-          .filter { f =>
-            FileNames.getFileVersion(new Path(f.getAbsolutePath)) <= snapshotVersion
-          }
-          .foreach(_.delete())
-        (0L to snapshotVersion).foreach { v =>
-          new File(FileNames.unsafeDeltaFile(srcLog.logPath, v).toUri).delete()
-        }
-
-        DeltaLog.clearCache()
-
-        // Phase 3: Restart the stream from the same checkpoint.
-        // It will try to reconstruct the snapshot at the old version (snapshotVersion),
-        // but those files are gone. This should fail, and the error should NOT be
-        // failOnDataLossException since we are in the initial snapshot stage.
-        val df2 = loadStreamWithOptions(
-          srcData.getCanonicalPath,
-          Map("maxFilesPerTrigger" -> "1"))
-
-        if (useDsv2) {
-          testStream(df2)(
-            StartStream(checkpointLocation = chkLocation.getCanonicalPath),
-            ExpectFailure[KernelException] { e =>
-              assert(e.getMessage.contains("transaction log has been truncated"))
-            }
-          )
-        } else {
-          testStream(df2)(
-            StartStream(checkpointLocation = chkLocation.getCanonicalPath),
-            ExpectFailure[DeltaFileNotFoundException] { e =>
-              assert(e.getMessage.contains("DELTA_LOG_FILE_NOT_FOUND_FOR_STREAMING_SOURCE"))
-            }
-          )
-        }
-      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Reverts delta-io/delta#6298

The PR introduced `import io.delta.kernel.exceptions.{InvalidTableException, KernelException}` into `DeltaSourceSuite.scala` under the `spark/` module (DSv1 code path). It is against our principal for only dsv2 code depending on kernel

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Revert-only change. The original tests will be re-landed with the Kernel imports moved to the appropriate `spark-unified/` (DSv2) module.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

No

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->