### PR TITLE
[Spark] Support DeltaOption replaceUsing/replaceOn for DataFrameWriterV1 save() Overwrite mode

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1566,6 +1566,18 @@
     ],
     "sqlState" : "42802"
   },
+  "DELTA_INSERT_REPLACE_ON_AMBIGUOUS_COLUMNS_IN_CONDITION" : {
+    "message" : [
+      "Column(s) <columnNames> are ambiguous in the condition of INSERT REPLACE ON. Consider specifying an alias for these columns."
+    ],
+    "sqlState" : "42702"
+  },
+  "DELTA_INSERT_REPLACE_ON_UNRESOLVED_COLUMNS_IN_CONDITION" : {
+    "message" : [
+      "Column(s) <columnNames> cannot be resolved in the condition of INSERT REPLACE ON."
+    ],
+    "sqlState" : "42703"
+  },
   "DELTA_INVALID_AUTO_COMPACT_TYPE" : {
     "message" : [
       "Invalid auto-compact type: <value>. Allowed values are: <allowed>."
@@ -2403,6 +2415,13 @@
       "<file>"
     ],
     "sqlState" : "XXKDS"
+  },
+  "DELTA_REPLACE_ON_OR_USING_TABLE_CONSTRAINT_VIOLATION" : {
+    "message" : [
+      "Written data violates a table constraint during REPLACE ON/USING '<replaceExpression>'.",
+      "<invariantViolationMessage>"
+    ],
+    "sqlState" : "44000"
   },
   "DELTA_REPLACE_WHERE_IN_OVERWRITE" : {
     "message" : [
@@ -3449,6 +3468,12 @@
     ],
     "sqlState" : "42605"
   },
+  "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS" : {
+    "message" : [
+      "INSERT REPLACE USING has misaligned columns: <misalignedReplaceUsingCols>. The replaceUsing columns must be at the same ordinal position in both the table and the source query."
+    ],
+    "sqlState" : "42802"
+  },
   "RESERVED_CDC_COLUMNS_ON_WRITE" : {
     "message" : [
       "",
@@ -3458,6 +3483,12 @@
       "<config> to false."
     ],
     "sqlState" : "42939"
+  },
+  "UNRESOLVED_INSERT_REPLACE_USING_COLUMN" : {
+    "message" : [
+      "Column <colName> cannot be resolved in <relationType>. Did you mean one of the following? [<suggestion>]."
+    ],
+    "sqlState" : "42703"
   },
   "WRONG_COLUMN_DEFAULTS_FOR_DELTA_ALTER_TABLE_ADD_COLUMN_NOT_SUPPORTED" : {
     "message" : [

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3992,6 +3992,42 @@ trait DeltaErrorsBase
       errorClass = "DELTA_CANNOT_RESOLVE_SOURCE_COLUMN",
       messageParameters = Array(s"${UnresolvedAttribute(columnPath).name}"))
   }
+
+  def insertReplaceOnAmbiguousColumnsInCond(columnNames: Seq[String]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_INSERT_REPLACE_ON_AMBIGUOUS_COLUMNS_IN_CONDITION",
+      messageParameters = Array(columnNames.map(toSQLId).mkString(", ")))
+  }
+
+  def insertReplaceOnUnresolvedColumnsInCond(columnNames: Seq[String]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_INSERT_REPLACE_ON_UNRESOLVED_COLUMNS_IN_CONDITION",
+      messageParameters = Array(columnNames.map(toSQLId).mkString(", ")))
+  }
+
+  def unresolvedInsertReplaceUsingColumnsError(
+      colName: String, relationType: String, suggestion: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
+      messageParameters = Array(toSQLId(colName), relationType, suggestion))
+  }
+
+  def disallowInsertReplaceUsingWithMisalignedColumns(
+      misalignedReplaceUsingCols: Seq[String]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
+      messageParameters = Array(misalignedReplaceUsingCols.map(toSQLId).mkString(", ")))
+  }
+
+  def replaceOnOrUsingConstraintViolationException(
+      replaceExpression: String,
+      invariantViolation: InvariantViolationException): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_REPLACE_ON_OR_USING_TABLE_CONSTRAINT_VIOLATION",
+      messageParameters =
+        Array(replaceExpression, invariantViolation.getMessage),
+      cause = Some(invariantViolation))
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -4007,16 +4007,23 @@ trait DeltaErrorsBase
 
   def unresolvedInsertReplaceUsingColumnsError(
       colName: String, relationType: String, suggestion: String): Throwable = {
-    new DeltaAnalysisException(
+    throw new AnalysisException(
       errorClass = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
-      messageParameters = Array(toSQLId(colName), relationType, suggestion))
+      messageParameters = Map(
+        "colName" -> toSQLId(colName),
+        "relationType" -> relationType,
+        "suggestion" -> suggestion)
+    )
   }
 
   def disallowInsertReplaceUsingWithMisalignedColumns(
       misalignedReplaceUsingCols: Seq[String]): Throwable = {
-    new DeltaAnalysisException(
+    throw new AnalysisException(
       errorClass = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
-      messageParameters = Array(misalignedReplaceUsingCols.map(toSQLId).mkString(", ")))
+      messageParameters = Map(
+        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "),
+      )
+    )
   }
 
   def replaceOnOrUsingConstraintViolationException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -189,6 +189,7 @@ trait DeltaErrorsBase
            |
            |  2. Use 'startingVersion' option to skip the initial snapshot and start
            |     from a specific version""".stripMargin
+      )
     )
   }
 
@@ -423,6 +424,7 @@ trait DeltaErrorsBase
         relationPath.mkString("."),
         targetType,
         targetPath.mkString(".")
+      )
     )
   }
 
@@ -882,6 +884,7 @@ trait DeltaErrorsBase
         // updateAndMergeCastingFollowsAnsiEnabledFlag
         DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key,
         SQLConf.ANSI_ENABLED.key // ansiEnabledFlag
+      )
     )
   }
 
@@ -1064,6 +1067,7 @@ trait DeltaErrorsBase
       messageParameters = Array(
         s"${formatColumn(colName)}",
         s"${schema.map(_.name).mkString(", ")}"
+      )
     )
   }
 
@@ -1091,6 +1095,7 @@ trait DeltaErrorsBase
         operation,
         oldPartitionColumns.mkString(", "),
         newPartitionColumns.mkString(", ")
+      )
     )
   }
 
@@ -1198,6 +1203,7 @@ trait DeltaErrorsBase
         startVersion.toString,
         endVersion.toString,
         versionToLoad.toString
+      )
     )
   }
 
@@ -1541,6 +1547,7 @@ trait DeltaErrorsBase
         path.toString,
         specifiedColumns.mkString(", "),
         existingColumns.mkString(", ")
+      )
     )
   }
 
@@ -2016,6 +2023,7 @@ trait DeltaErrorsBase
         s"${current.name}",
         s"${current.dataType.sql}",
         s"${update.dataType.sql}"
+      )
     )
   }
 
@@ -2481,6 +2489,7 @@ trait DeltaErrorsBase
         additionalInfo,
         conflictingCommit.map(ci => s"\nConflicting commit: ${JsonUtils.toJson(ci)}").getOrElse(""),
         DeltaErrors.generateDocsLink(SparkEnv.get.conf, "/concurrency-control.html")
+      )
     )
   }
 
@@ -3086,6 +3095,7 @@ trait DeltaErrorsBase
         rightName,
         wrongName,
         dataTypeToString(schema)
+      )
     )
   }
 
@@ -3101,6 +3111,7 @@ trait DeltaErrorsBase
         s"$other",
         s"${SchemaUtils.prettyFieldName(column)}",
         dataTypeToString(schema)
+      )
     )
   }
 
@@ -3443,6 +3454,7 @@ trait DeltaErrorsBase
         unblockChangeConfs,
         unblockStreamConfs,
         unblockAllConfs
+      )
     )
   }
 
@@ -3559,6 +3571,7 @@ trait DeltaErrorsBase
         "Requires IcebergCompat to be explicitly enabled in order for Universal Format (Iceberg) " +
         "to be enabled on an existing table. Supported versions are IcebergCompatV1 and " +
         "IcebergCompatV2."
+      )
     )
   }
 
@@ -3568,6 +3581,7 @@ trait DeltaErrorsBase
       messageParameters = Array(
         UniversalFormat.HUDI_FORMAT,
         "Requires delete vectors to be disabled."
+      )
     )
   }
 
@@ -3577,6 +3591,7 @@ trait DeltaErrorsBase
       messageParameters = Array(
         UniversalFormat.HUDI_FORMAT,
         s"DataType: $unsupportedType is not currently supported."
+      )
     )
   }
 
@@ -3605,6 +3620,7 @@ trait DeltaErrorsBase
         currVersion.toString,
         currVersion.toString,
         maxVersion.toString
+      )
     )
   }
 
@@ -3622,6 +3638,7 @@ trait DeltaErrorsBase
         tableVersion.toString,
         (addFilesCount - addFilesWithTagsCount).toString,
         icebergCompatVersion.toString
+      )
     )
   }
 
@@ -3650,6 +3667,7 @@ trait DeltaErrorsBase
         version.toString,
         prevPartitionCols.mkString("(", ",", ")"),
         newPartitionCols.mkString("(", ",", ")")
+      )
     )
   }
 
@@ -3742,6 +3760,7 @@ trait DeltaErrorsBase
         SchemaUtils.prettyFieldName(fieldPath),
         toSQLType(oldType),
         toSQLType(newType)
+      )
     )
   }
 
@@ -4002,7 +4021,8 @@ trait DeltaErrorsBase
     throw new AnalysisException(
       errorClass = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
       messageParameters = Map(
-        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "))
+        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "),
+      )
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -4021,8 +4021,7 @@ trait DeltaErrorsBase
     throw new AnalysisException(
       errorClass = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
       messageParameters = Map(
-        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "),
-      )
+        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "))
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -4007,22 +4007,16 @@ trait DeltaErrorsBase
 
   def unresolvedInsertReplaceUsingColumnsError(
       colName: String, relationType: String, suggestion: String): Throwable = {
-    new AnalysisException(
+    new DeltaAnalysisException(
       errorClass = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
-      messageParameters = Map(
-        "colName" -> toSQLId(colName),
-        "relationType" -> relationType,
-        "suggestion" -> suggestion)
-    )
+      messageParameters = Array(toSQLId(colName), relationType, suggestion))
   }
 
   def disallowInsertReplaceUsingWithMisalignedColumns(
       misalignedReplaceUsingCols: Seq[String]): Throwable = {
-    new AnalysisException(
+    new DeltaAnalysisException(
       errorClass = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
-      messageParameters = Map(
-        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "))
-    )
+      messageParameters = Array(misalignedReplaceUsingCols.map(toSQLId).mkString(", ")))
   }
 
   def replaceOnOrUsingConstraintViolationException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -4007,7 +4007,7 @@ trait DeltaErrorsBase
 
   def unresolvedInsertReplaceUsingColumnsError(
       colName: String, relationType: String, suggestion: String): Throwable = {
-    throw new AnalysisException(
+    new AnalysisException(
       errorClass = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
       messageParameters = Map(
         "colName" -> toSQLId(colName),
@@ -4018,7 +4018,7 @@ trait DeltaErrorsBase
 
   def disallowInsertReplaceUsingWithMisalignedColumns(
       misalignedReplaceUsingCols: Seq[String]): Throwable = {
-    throw new AnalysisException(
+    new AnalysisException(
       errorClass = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
       messageParameters = Map(
         "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -189,7 +189,6 @@ trait DeltaErrorsBase
            |
            |  2. Use 'startingVersion' option to skip the initial snapshot and start
            |     from a specific version""".stripMargin
-      )
     )
   }
 
@@ -424,7 +423,6 @@ trait DeltaErrorsBase
         relationPath.mkString("."),
         targetType,
         targetPath.mkString(".")
-      )
     )
   }
 
@@ -884,7 +882,6 @@ trait DeltaErrorsBase
         // updateAndMergeCastingFollowsAnsiEnabledFlag
         DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key,
         SQLConf.ANSI_ENABLED.key // ansiEnabledFlag
-      )
     )
   }
 
@@ -1067,7 +1064,6 @@ trait DeltaErrorsBase
       messageParameters = Array(
         s"${formatColumn(colName)}",
         s"${schema.map(_.name).mkString(", ")}"
-      )
     )
   }
 
@@ -1095,7 +1091,6 @@ trait DeltaErrorsBase
         operation,
         oldPartitionColumns.mkString(", "),
         newPartitionColumns.mkString(", ")
-      )
     )
   }
 
@@ -1203,7 +1198,6 @@ trait DeltaErrorsBase
         startVersion.toString,
         endVersion.toString,
         versionToLoad.toString
-      )
     )
   }
 
@@ -1547,7 +1541,6 @@ trait DeltaErrorsBase
         path.toString,
         specifiedColumns.mkString(", "),
         existingColumns.mkString(", ")
-      )
     )
   }
 
@@ -2023,7 +2016,6 @@ trait DeltaErrorsBase
         s"${current.name}",
         s"${current.dataType.sql}",
         s"${update.dataType.sql}"
-      )
     )
   }
 
@@ -2489,7 +2481,6 @@ trait DeltaErrorsBase
         additionalInfo,
         conflictingCommit.map(ci => s"\nConflicting commit: ${JsonUtils.toJson(ci)}").getOrElse(""),
         DeltaErrors.generateDocsLink(SparkEnv.get.conf, "/concurrency-control.html")
-      )
     )
   }
 
@@ -3095,7 +3086,6 @@ trait DeltaErrorsBase
         rightName,
         wrongName,
         dataTypeToString(schema)
-      )
     )
   }
 
@@ -3111,7 +3101,6 @@ trait DeltaErrorsBase
         s"$other",
         s"${SchemaUtils.prettyFieldName(column)}",
         dataTypeToString(schema)
-      )
     )
   }
 
@@ -3454,7 +3443,6 @@ trait DeltaErrorsBase
         unblockChangeConfs,
         unblockStreamConfs,
         unblockAllConfs
-      )
     )
   }
 
@@ -3571,7 +3559,6 @@ trait DeltaErrorsBase
         "Requires IcebergCompat to be explicitly enabled in order for Universal Format (Iceberg) " +
         "to be enabled on an existing table. Supported versions are IcebergCompatV1 and " +
         "IcebergCompatV2."
-      )
     )
   }
 
@@ -3581,7 +3568,6 @@ trait DeltaErrorsBase
       messageParameters = Array(
         UniversalFormat.HUDI_FORMAT,
         "Requires delete vectors to be disabled."
-      )
     )
   }
 
@@ -3591,7 +3577,6 @@ trait DeltaErrorsBase
       messageParameters = Array(
         UniversalFormat.HUDI_FORMAT,
         s"DataType: $unsupportedType is not currently supported."
-      )
     )
   }
 
@@ -3620,7 +3605,6 @@ trait DeltaErrorsBase
         currVersion.toString,
         currVersion.toString,
         maxVersion.toString
-      )
     )
   }
 
@@ -3638,7 +3622,6 @@ trait DeltaErrorsBase
         tableVersion.toString,
         (addFilesCount - addFilesWithTagsCount).toString,
         icebergCompatVersion.toString
-      )
     )
   }
 
@@ -3667,7 +3650,6 @@ trait DeltaErrorsBase
         version.toString,
         prevPartitionCols.mkString("(", ",", ")"),
         newPartitionCols.mkString("(", ",", ")")
-      )
     )
   }
 
@@ -3760,7 +3742,6 @@ trait DeltaErrorsBase
         SchemaUtils.prettyFieldName(fieldPath),
         toSQLType(oldType),
         toSQLType(newType)
-      )
     )
   }
 
@@ -4021,8 +4002,7 @@ trait DeltaErrorsBase
     throw new AnalysisException(
       errorClass = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
       messageParameters = Map(
-        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "),
-      )
+        "misalignedReplaceUsingCols" -> misalignedReplaceUsingCols.map(toSQLId).mkString(", "))
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -50,9 +50,32 @@ trait DeltaWriteOptions
 
   import DeltaOptions._
 
+  def isInsertAtomicReplaceOp: Boolean = isReplaceOnOrUsingDefined || replaceWhere.isDefined
+
+  def isInsertPartialOverwriteOp: Boolean =
+    isInsertAtomicReplaceOp || isDynamicPartitionOverwriteMode
+
   val replaceOn: Option[String] = options.get(REPLACE_ON_OPTION)
 
   val replaceUsing: Option[String] = options.get(REPLACE_USING_OPTION)
+  /** Parses the replaceUsing option into a list of distinct column names. */
+  def parsedReplaceUsingColsList: Option[Seq[String]] = {
+    replaceUsing.map { cols =>
+      // limit = -1 preserves trailing empty strings so we can detect trailing commas.
+      // scalastyle:off
+      val parsed =
+        cols.split(/* separator = */ ",", /* limit = */ -1).map(_.trim).toSeq.distinct
+      // scalastyle:on
+      if (parsed.exists(_.isEmpty)) {
+        throw DeltaErrors.illegalDeltaOptionException(
+          name = REPLACE_USING_OPTION,
+          input = cols,
+          explain = "must not contain empty column names")
+      }
+      parsed
+    }
+  }
+
 
   def isReplaceOnOrUsingDefined: Boolean =
     replaceOn.isDefined || replaceUsing.isDefined
@@ -284,6 +307,10 @@ object DeltaOptions extends DeltaLogging {
    * e.g., .option("targetAlias", "t").option("replaceOn", "t.id = s.id").
    */
   val TARGET_ALIAS_OPTION = "targetAlias"
+
+  /** Internal alias used by replaceUsing for column resolution. Not for external use. */
+  private[delta] val REPLACE_USING_INTERNAL_TABLE_ALIAS = "__replace_using_table_alias__"
+
 
   /** An option to overwrite only the data that matches predicates over partition columns. */
   val REPLACE_WHERE_OPTION = "replaceWhere"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -58,6 +58,7 @@ trait DeltaWriteOptions
   val replaceOn: Option[String] = options.get(REPLACE_ON_OPTION)
 
   val replaceUsing: Option[String] = options.get(REPLACE_USING_OPTION)
+
   /** Parses the replaceUsing option into a list of distinct column names. */
   def parsedReplaceUsingColsList: Option[Seq[String]] = {
     replaceUsing.map { cols =>
@@ -75,7 +76,6 @@ trait DeltaWriteOptions
       parsed
     }
   }
-
 
   def isReplaceOnOrUsingDefined: Boolean =
     replaceOn.isDefined || replaceUsing.isDefined
@@ -310,7 +310,6 @@ object DeltaOptions extends DeltaLogging {
 
   /** Internal alias used by replaceUsing for column resolution. Not for external use. */
   private[delta] val REPLACE_USING_INTERNAL_TABLE_ALIAS = "__replace_using_table_alias__"
-
 
   /** An option to overwrite only the data that matches predicates over partition columns. */
   val REPLACE_WHERE_OPTION = "replaceWhere"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaInsertReplaceOnOrUsingCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaInsertReplaceOnOrUsingCommand.scala
@@ -50,8 +50,6 @@ case class DeltaInsertReplaceOnOrUsingCommand(
 
   private val commandStats = InsertReplaceOnOrUsingStats()
 
-
-
   override def run(sparkSession: SparkSession): Seq[Row] = {
     withMaterializeRetryAndStats(sparkSession) { preparedWriteCmd =>
       val runResult = preparedWriteCmd.run(sparkSession)
@@ -117,8 +115,6 @@ case class DeltaInsertReplaceOnOrUsingCommand(
       sparkSession: SparkSession,
       materializedDf: DataFrame,
       insertReplaceCriteria: InsertReplaceCriteria): WriteIntoDelta = {
-
-
     /**
      * For REPLACE USING, an internal table alias is required to ensure certain attributes
      * resolve to the target table, not the query, when we construct the EXISTS condition.
@@ -178,20 +174,20 @@ case class DeltaInsertReplaceOnOrUsingCommand(
         s"Unexpected InsertReplaceCriteria: $other")
     }
 
-        prepareMergeSource(
-          spark = sparkSession,
-          source = originalQueryBeforeSchemaAdjustmentProjection,
-          condition = replaceOnOrUsingCond,
-          matchedClauses = Seq.empty,
-          notMatchedClauses = Seq.empty,
-          isInsertOnly = false)
+    prepareMergeSource(
+      spark = sparkSession,
+      source = originalQueryBeforeSchemaAdjustmentProjection,
+      condition = replaceOnOrUsingCond,
+      matchedClauses = Seq.empty,
+      notMatchedClauses = Seq.empty,
+      isInsertOnly = false)
 
-      // TODO: Despite the name, getMergeSource obtains the materialized source for
-      // INSERT REPLACE ON/USING operations. It will have a more appropriate name when we fully
-      // refactor the source materialization logic.
-      DataFrameUtils.ofRows(
-        sparkSession,
-        Project(schemaAdjustmentProjectionList, getMergeSource.df.queryExecution.analyzed))
+    // TODO: Despite the name, getMergeSource obtains the materialized source for
+    // INSERT REPLACE ON/USING operations. It will have a more appropriate name when we fully
+    // refactor the source materialization logic.
+    DataFrameUtils.ofRows(
+      sparkSession,
+      Project(schemaAdjustmentProjectionList, getMergeSource.df.queryExecution.analyzed))
   }
 
   private def checkShouldMaterializeSource(sparkSession: SparkSession): Boolean = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaInsertReplaceOnOrUsingCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaInsertReplaceOnOrUsingCommand.scala
@@ -1,0 +1,388 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.{DataFrameUtils, DeltaErrors, DeltaLog, DeltaOptions, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.DMLUtils.TaggedCommitData
+import org.apache.spark.sql.delta.commands.InsertReplaceOnOrUsingAPIOrigin.InsertReplaceOnOrUsingAPIOrigin
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import org.apache.commons.lang3.StringUtils
+
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, EqualTo, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
+
+case class DeltaInsertReplaceOnOrUsingCommand(
+    deltaTable: DeltaTableV2,
+    query: LogicalPlan,
+    writeCmd: WriteIntoDelta,
+    insertReplaceCriteriaOpt: Option[InsertReplaceCriteria],
+    byName: Boolean,
+    apiOrigin: InsertReplaceOnOrUsingAPIOrigin)
+  extends LeafRunnableCommand
+  with WriteIntoDeltaLike
+  with InsertReplaceOnMaterializeSource
+  {
+
+  private val commandStats = InsertReplaceOnOrUsingStats()
+
+
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    withMaterializeRetryAndStats(sparkSession) { preparedWriteCmd =>
+      val runResult = preparedWriteCmd.run(sparkSession)
+      recordWriteStats(preparedWriteCmd,
+        writeMetrics = Map.empty)
+      runResult
+    }
+  }
+
+  /**
+   * Resolve the [[InsertReplaceCriteria]] for this command. The SQL path already provided
+   * the criteria so we use it directly. Otherwise, for DF paths, we parse from
+   * the user-provided 'replaceOn' or 'replaceUsing' option.
+   */
+  private def resolveInsertReplaceCriteria(
+      sparkSession: SparkSession): InsertReplaceCriteria = {
+    insertReplaceCriteriaOpt.getOrElse {
+      if (writeCmd.options.replaceOn.isDefined) {
+        val parsedCond =
+          sparkSession.sessionState.sqlParser.parseExpression(writeCmd.options.replaceOn.get)
+        InsertReplaceOn(parsedCond, writeCmd.options.targetAlias)
+      } else {
+        if (writeCmd.options.replaceUsing.isEmpty) {
+          throw new IllegalStateException(
+            "Expected replaceOn or replaceUsing option to be specified")
+        }
+        InsertReplaceUsing(writeCmd.options.parsedReplaceUsingColsList.get)
+      }
+    }
+  }
+
+  override val deltaLog: DeltaLog = writeCmd.deltaLog
+  override val configuration: Map[String, String] = writeCmd.configuration
+  // This is the original user-input DataFrame (before materialization).
+  override val data: DataFrame = writeCmd.data
+
+  override def withNewWriterConfiguration(
+      updatedConfiguration: Map[String, String]): WriteIntoDeltaLike = {
+    val updatedWriteCmd = writeCmd.withNewWriterConfiguration(updatedConfiguration) match {
+      case writeIntoDelta: WriteIntoDelta => writeIntoDelta
+      case other => throw new IllegalStateException(
+        s"Unexpected WriteIntoDeltaLike type: ${other.getClass.getName}")
+    }
+    copy(writeCmd = updatedWriteCmd.asInstanceOf[WriteIntoDelta])
+  }
+
+  /** Called by [[CreateDeltaTableCommand]] in the saveAsTable() path. */
+  override def writeAndReturnCommitData(
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession,
+      clusterBySpecOpt: Option[ClusterBySpec] = None,
+      isTableReplace: Boolean = false): TaggedCommitData[Action] = {
+    withMaterializeRetryAndStats(sparkSession) { preparedWriteCmd =>
+      val commitData = preparedWriteCmd.writeAndReturnCommitData(
+        txn, sparkSession, clusterBySpecOpt, isTableReplace)
+      recordWriteStats(preparedWriteCmd,
+        writeMetrics = Map.empty)
+      commitData
+    }
+  }
+
+  private def prepareWriteCmd(
+      sparkSession: SparkSession,
+      materializedDf: DataFrame,
+      insertReplaceCriteria: InsertReplaceCriteria): WriteIntoDelta = {
+
+
+    /**
+     * For REPLACE USING, an internal table alias is required to ensure certain attributes
+     * resolve to the target table, not the query, when we construct the EXISTS condition.
+     * Without it, column resolution incorrectly references all the attributes to the nearest
+     * possible relation, which is the query.
+     */
+    val tableAliasOption: Map[String, String] = insertReplaceCriteria match {
+      case InsertReplaceOn(_, aliasOpt) =>
+        aliasOpt.map(DeltaOptions.TARGET_ALIAS_OPTION -> _).toMap
+      case _: InsertReplaceUsing =>
+        Map(DeltaOptions.TARGET_ALIAS_OPTION -> DeltaOptions.REPLACE_USING_INTERNAL_TABLE_ALIAS)
+      case other => throw new IllegalStateException(
+        s"Unexpected InsertReplaceCriteria: $other")
+    }
+
+    val deltaOptions = new DeltaOptions(
+      CaseInsensitiveMap[String](
+        writeCmd.options.options ++
+        tableAliasOption),
+      sparkSession.sessionState.conf
+    )
+
+    writeCmd.copy(
+      options = deltaOptions,
+      data = materializedDf,
+      isInsertReplaceUsingByName = byName && insertReplaceCriteria.isInstanceOf[InsertReplaceUsing])
+  }
+
+  /**
+   * Materialize the source query and restore the [[Project]] node on top.
+   *
+   * The projection is temporarily removed so that materialization doesn't produce
+   * an RDD scan at the top level, which would break REPLACE ON/USING analysis.
+   */
+  private def materializeSource(
+      sparkSession: SparkSession,
+      insertReplaceCriteria: InsertReplaceCriteria): DataFrame = {
+    commandStats.replaceCriteria = StringUtils.abbreviate(
+      insertReplaceCriteria match {
+        case InsertReplaceOn(cond, _) => cond.sql
+        case InsertReplaceUsing(cols) => cols.mkString(", ")
+        case other => throw new IllegalStateException(
+          s"Unexpected InsertReplaceCriteria: $other")
+      },
+      2048)
+
+    val Project(schemaAdjustmentProjectionList, originalQueryBeforeSchemaAdjustmentProjection) =
+      query
+
+    // This is the matching condition of the INSERT REPLACE ON/USING operation.
+    val replaceOnOrUsingCond: Expression = insertReplaceCriteria match {
+      case InsertReplaceOn(cond, _) => cond
+      case InsertReplaceUsing(cols) => cols.map(col => EqualTo(UnresolvedAttribute(col),
+        UnresolvedAttribute(Seq(
+          DeltaOptions.REPLACE_USING_INTERNAL_TABLE_ALIAS, col)))).reduce(And)
+      case other => throw new IllegalStateException(
+        s"Unexpected InsertReplaceCriteria: $other")
+    }
+
+        prepareMergeSource(
+          spark = sparkSession,
+          source = originalQueryBeforeSchemaAdjustmentProjection,
+          condition = replaceOnOrUsingCond,
+          matchedClauses = Seq.empty,
+          notMatchedClauses = Seq.empty,
+          isInsertOnly = false)
+
+      // TODO: Despite the name, getMergeSource obtains the materialized source for
+      // INSERT REPLACE ON/USING operations. It will have a more appropriate name when we fully
+      // refactor the source materialization logic.
+      DataFrameUtils.ofRows(
+        sparkSession,
+        Project(schemaAdjustmentProjectionList, getMergeSource.df.queryExecution.analyzed))
+  }
+
+  private def checkShouldMaterializeSource(sparkSession: SparkSession): Boolean = {
+    val (shouldMaterialize, materializeReason) =
+      shouldMaterializeSource(sparkSession, source = query, isInsertOnly = false)
+    commandStats.materializeSourceReason = Some(materializeReason.toString)
+    shouldMaterialize
+  }
+
+  private def executeWithRetry(
+      sparkSession: SparkSession,
+      runOperationFunc: SparkSession => Seq[Row]): Seq[Row] = {
+    val shouldMaterialize = checkShouldMaterializeSource(sparkSession)
+    if (!shouldMaterialize) {
+      runOperationFunc(sparkSession)
+    } else {
+      runWithMaterializedSourceLostRetries(
+        spark = sparkSession,
+        deltaLog = deltaTable.deltaLog,
+        metrics = Map.empty,
+        runOperationFunc = runOperationFunc)
+    }
+  }
+
+  private def withMaterializeRetryAndStats[T](
+      sparkSession: SparkSession)(
+      executeAndRecordStats: WriteIntoDelta => T): T = {
+    recordReplaceOnOrUsingStats(sparkSession) {
+      val insertReplaceCriteria = resolveInsertReplaceCriteria(sparkSession)
+      var resultOpt: Option[T] = None
+
+      executeWithRetry(sparkSession, runOperationFunc = { spark =>
+        val materializedDf = materializeSource(spark, insertReplaceCriteria)
+        val preparedWriteCmd = prepareWriteCmd(spark, materializedDf, insertReplaceCriteria)
+        resultOpt = Some(executeAndRecordStats(preparedWriteCmd))
+        Seq.empty
+      })
+
+      resultOpt.getOrElse(throw new IllegalStateException(
+        "executeWithRetry did not invoke the operation function"))
+    }
+  }
+
+  private def recordReplaceOnOrUsingStats[T](sparkSession: SparkSession)(func: => T): T = {
+    val commandStartTimeMs = System.currentTimeMillis()
+    commandStats.apiOrigin = apiOrigin.toString
+    try {
+      func
+    } catch {
+      case NonFatal(ex) =>
+        commandStats.exceptionMsg = Some(ex.getMessage)
+        throw ex
+    } finally {
+      commandStats.totalExecutionTimeMs = System.currentTimeMillis() - commandStartTimeMs
+      recordDeltaEvent(
+        deltaLog = deltaTable.deltaLog,
+        opType = "delta.insertReplaceOnOrUsing.stats",
+        data = commandStats)
+    }
+  }
+
+  private def recordWriteStats(
+      lastWriteCmd: WriteIntoDelta,
+      writeMetrics: Map[String, SQLMetric]): Unit = {
+    commandStats.materializeSourceAttempts = Some(attempt)
+
+    def getMetricValueIfExists(key: String): Option[Long] = writeMetrics.get(key).map(_.value)
+    commandStats.numFiles = getMetricValueIfExists("numFiles")
+    commandStats.numOutputBytes = getMetricValueIfExists("numOutputBytes")
+    commandStats.numOutputRows = getMetricValueIfExists("numOutputRows")
+    commandStats.numRemovedFiles = getMetricValueIfExists("numRemovedFiles")
+    commandStats.numDeletedRows = getMetricValueIfExists("numDeletedRows")
+    commandStats.numRemovedBytes = getMetricValueIfExists("numRemovedBytes")
+    commandStats.numAddedChangeFiles = getMetricValueIfExists("numAddedChangeFiles")
+    commandStats.numCopiedRows = getMetricValueIfExists("numCopiedRows")
+  }
+}
+
+object DeltaInsertReplaceOnOrUsingCommand {
+  /**
+   * Adds a [[Project]] node on top of the query that aliases each query column to
+   * the corresponding provided attribute name by ordinal position.
+   * This ensures the query plan has the [[Project]] node at the top required by
+   * [[DeltaAnalysis]]).
+   */
+  private[delta] def addOrdinalAliasProjection(
+      queryToAlias: LogicalPlan, aliasAttrs: Seq[Attribute]): Project = {
+    val projectAliasList = queryToAlias.output.zipWithIndex.map {
+      case (queryAttr, index) =>
+        if (index < aliasAttrs.length) {
+          Alias(queryAttr, aliasAttrs(index).name)()
+        } else {
+          queryAttr
+        }
+    }
+    Project(projectAliasList, queryToAlias)
+  }
+
+  /**
+   * Creates a [[DeltaInsertReplaceOnOrUsingCommand]] for DataFrameWriterV1 save() and
+   * saveAsTable() with replaceOn/replaceUsing options.
+   *
+   * df.save() and df.saveAsTable() bypass [[DeltaAnalysis]] and never add a
+   * projection, so this method calls [[addOrdinalAliasProjection]] to add an
+   * identity projection. Since save()/saveAsTable() resolve columns by name (not by
+   * position), the projection preserves the original source column names while
+   * ensuring the Project node structure that is required by REPLACE ON/USING
+   *
+   * For SQL INSERT REPLACE ON/USING and df.insertInto() that go through
+   * [[DeltaAnalysis]], the rule may add a schema adjustment projection,
+   * so the projection handling is different (see [[DeltaAnalysis]] for
+   * their implementation for REPLACE ON/USING).
+   */
+  private[delta] def createCmdForSaveAndSaveAsTable(
+      deltaTable: DeltaTableV2,
+      data: DataFrame,
+      writeCmd: WriteIntoDelta,
+      apiOrigin: InsertReplaceOnOrUsingAPIOrigin
+  ): DeltaInsertReplaceOnOrUsingCommand = {
+    val dataQueryExecAnalyzed = data.queryExecution.analyzed
+    DeltaInsertReplaceOnOrUsingCommand(
+      deltaTable = deltaTable,
+      query = addOrdinalAliasProjection(
+        queryToAlias = dataQueryExecAnalyzed,
+        aliasAttrs = dataQueryExecAnalyzed.output),
+      writeCmd = writeCmd,
+      insertReplaceCriteriaOpt = None,
+      byName = true,
+      apiOrigin = apiOrigin)
+  }
+}
+
+/** Stats for a SQL/DataFrame INSERT REPLACE ON/USING operation */
+private[delta] case class InsertReplaceOnOrUsingStats(
+    var apiOrigin: String = "",
+    var materializeSourceReason: Option[String] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var materializeSourceAttempts: Option[Long] = None,
+    var materializeSourceTimeMs: Long = 0,
+    var replaceCriteria: String = "",
+    var isDeleteInsertParallelized: Option[Boolean] = None,
+    var deleteStepTimeMs: Long = 0,
+    var insertStepTimeMs: Long = 0,
+    var totalExecutionTimeMs: Long = 0,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numFiles: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numOutputBytes: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numOutputRows: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numRemovedFiles: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numDeletedRows: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numRemovedBytes: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numAddedChangeFiles: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    var numCopiedRows: Option[Long] = None,
+    var exceptionMsg: Option[String] = None
+)
+
+object InsertReplaceOnOrUsingAPIOrigin extends Enumeration {
+  type InsertReplaceOnOrUsingAPIOrigin = Value
+  val DFv1InsertInto: Value = Value("DFv1InsertInto")
+  val DFv1Save: Value = Value("DFv1Save")
+  val DFv1SaveAsTable: Value = Value("DFv1SaveAsTable")
+}
+
+sealed abstract class InsertReplaceCriteria
+case class InsertReplaceOn(cond: Expression, tableAliasOpt: Option[String])
+  extends InsertReplaceCriteria
+case class InsertReplaceUsing(cols: Seq[String]) extends InsertReplaceCriteria
+
+object InsertReplaceUsingMisalignedColumnsEventInfo {
+  def disallowMisalignedReplaceUsingCols(
+      resolver: (String, String) => Boolean,
+      replaceUsingCols: Seq[String],
+      tableRelation: LogicalPlan,
+      queryRelation: LogicalPlan,
+      isByName: Boolean,
+      conf: SQLConf): Unit = {
+    if (!isByName) {
+      val misaligned = replaceUsingCols.collect {
+        case col if tableRelation.output.indexWhere(a => resolver(a.name, col)) !=
+            queryRelation.output.indexWhere(a => resolver(a.name, col)) => col
+      }
+      if (misaligned.nonEmpty) {
+        throw DeltaErrors.disallowInsertReplaceUsingWithMisalignedColumns(misaligned)
+      }
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/InsertReplaceOnMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/InsertReplaceOnMaterializeSource.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.delta.commands.merge.MergeIntoMaterializeSource
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.SparkSession
+
+trait InsertReplaceOnMaterializeSource extends MergeIntoMaterializeSource {
+  override protected def operation: String = "INSERT REPLACE ON/USING"
+
+  override protected def enableColumnPruningBeforeMaterialize: Boolean = false
+
+  override protected def materializeSourceErrorOpType: String =
+    InsertReplaceOnOrUsingMaterializeSourceError.OP_TYPE
+
+  override protected def getMaterializeSourceMode(spark: SparkSession): String =
+    spark.conf.get(DeltaSQLConf.INSERT_REPLACE_ON_OR_USING_MATERIALIZE_SOURCE)
+
+}
+
+object InsertReplaceOnOrUsingMaterializeSourceError {
+  val OP_TYPE = "delta.dml.insertReplaceOnOrUsing.materializeSourceError"
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -86,7 +86,8 @@ case class WriteIntoDelta(
     override val configuration: Map[String, String],
     override val data: DataFrame,
     val catalogTableOpt: Option[CatalogTable] = None,
-    schemaInCatalog: Option[StructType] = None
+    schemaInCatalog: Option[StructType] = None,
+    isInsertReplaceUsingByName: Boolean = false
     )
   extends LeafRunnableCommand
   with ImplicitMetadataOperation
@@ -141,9 +142,9 @@ case class WriteIntoDelta(
         DeltaLog.assertRemovable(txn.snapshot)
       }
     }
-    val isReplaceWhere = mode == SaveMode.Overwrite && options.replaceWhere.nonEmpty
     val finalClusterBySpecOpt =
-      if (mode == SaveMode.Append || isReplaceWhere) {
+      if (mode == SaveMode.Append ||
+          (isOverwriteOperation && options.isInsertAtomicReplaceOp)) {
         clusterBySpecOpt.foreach { clusterBySpec =>
           ClusteredTableUtils.validateClusteringColumnsInSnapshot(txn.snapshot, clusterBySpec)
         }
@@ -182,7 +183,7 @@ case class WriteIntoDelta(
     val newDomainMetadata = getNewDomainMetadata(
       txn,
       canUpdateMetadata,
-      isReplacingTable = isOverwriteOperation && options.replaceWhere.isEmpty,
+      isReplacingTable = isOverwriteOperation && !options.isInsertAtomicReplaceOp,
       finalClusterBySpecOpt
     )
 
@@ -231,14 +232,31 @@ case class WriteIntoDelta(
         replaceWhereOnDataColsEnabled = replaceWhereOnDataColsEnabled,
         mode = mode)
 
+    val replaceOnOrUsingExprOpt = if (options.isReplaceOnOrUsingDefined && isOverwriteOperation) {
+      Some(Seq(getReplaceOnOrUsingExprOpt(
+        sparkSession, txn, options, isInsertReplaceUsingByName)))
+    } else {
+      None
+    }
+
+    val containsDataFilters = if (options.replaceWhere.isDefined) {
+      containsDataFiltersInReplaceWhere
+    } else {
+      // replaceOn/Using deletes rows that satisfy an EXISTS subquery, which is a data filter.
+      options.isReplaceOnOrUsingDefined
+    }
+
     if (txn.readVersion < 0) {
       // Initialize the log path
       deltaLog.createLogDirectoriesIfNotExists()
     }
 
-    val (newFiles, addFiles, deletedFiles) = (mode, maybeAliasedReplaceWhereExprsOpt) match {
+    val atomicReplaceExprsOpt =
+      replaceOnOrUsingExprOpt.orElse(maybeAliasedReplaceWhereExprsOpt)
+
+    val (newFiles, addFiles, deletedFiles) = (mode, atomicReplaceExprsOpt) match {
       case (SaveMode.Overwrite, Some(parsedPredicatesMaybeAliased))
-          if !replaceWhereOnDataColsEnabled =>
+          if !replaceWhereOnDataColsEnabled && !options.isReplaceOnOrUsingDefined =>
         // fall back to match on partition cols only when replaceArbitrary is disabled.
         val newFiles = txn.writeFiles(data, Some(options))
         val addFiles = newFiles.collect { case a: AddFile => a }
@@ -266,14 +284,23 @@ case class WriteIntoDelta(
         }
         (newFiles, addFiles, txn.filterFiles(strippedTargetAliasPredicates).map(_.remove))
       case (SaveMode.Overwrite, Some(conditions)) if txn.snapshot.version >= 0 =>
-        // Strip alias because check constraint is applied against unaliased table schema.
-        val constraints = extractConstraints(
-          sparkSession = sparkSession,
-          exprs = stripTargetAliasIfExists(
+        assert(options.replaceWhere.isDefined || options.isReplaceOnOrUsingDefined,
+          "Either 'replaceWhere' or 'replaceOn' must be specified.")
+        val constraints = if (options.replaceWhere.isDefined) {
+          // Strip alias because check constraint is applied against unaliased table schema.
+          extractConstraints(
             sparkSession = sparkSession,
-            exprs = conditions,
-            targetAlias = options.targetAlias))
+            exprs = stripTargetAliasIfExists(
+              sparkSession = sparkSession,
+              exprs = conditions,
+              targetAlias = options.targetAlias))
+        } else {
+          Seq.empty
+        }
 
+        val cdcEnabled = CDCReader.isCDCEnabledOnTable(txn.metadata, sparkSession) &&
+          (options.isReplaceOnOrUsingDefined ||
+            sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_DATACOLUMNS_WITH_CDF_ENABLED))
         val removedFileActions = removeFiles(sparkSession, txn, conditions)
         val cdcExistsInRemoveOp = removedFileActions.exists(_.isInstanceOf[AddCDCFile])
 
@@ -282,9 +309,8 @@ case class WriteIntoDelta(
         // the CDF protocol requires either (i) all CDF data are generated explicitly as AddCDCFile,
         // or (ii) all CDF data can be deduced from [[AddFile]] and [[RemoveFile]].
         val dataToWrite =
-          if (containsDataFiltersInReplaceWhere &&
-              CDCReader.isCDCEnabledOnTable(txn.metadata, sparkSession) &&
-              sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_DATACOLUMNS_WITH_CDF_ENABLED) &&
+          if (containsDataFilters &&
+              cdcEnabled &&
               cdcExistsInRemoveOp) {
             var dataWithDefaultExprs = data
             // Add identity columns if they are not in `data`.
@@ -329,10 +355,11 @@ case class WriteIntoDelta(
             data
           }
         val newFiles = try txn.writeFiles(dataToWrite, Some(options), constraints) catch {
-          case e: InvariantViolationException =>
-            throw DeltaErrors.replaceWhereMismatchException(
-              options.replaceWhere.get,
-              e)
+          case e: InvariantViolationException if options.replaceWhere.isDefined =>
+            throw DeltaErrors.replaceWhereMismatchException(options.replaceWhere.get, e)
+          case e: InvariantViolationException if options.isReplaceOnOrUsingDefined =>
+            throw DeltaErrors.replaceOnOrUsingConstraintViolationException(
+              options.replaceOn.orElse(options.replaceUsing).get, e)
         }
         (newFiles,
           newFiles.collect { case a: AddFile => a },
@@ -384,7 +411,7 @@ case class WriteIntoDelta(
     // Need to handle replace where metrics separately.
     if (maybeAliasedReplaceWhereExprsOpt.nonEmpty && replaceWhereOnDataColsEnabled &&
         sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_METRICS_ENABLED)) {
-      registerReplaceWhereMetrics(sparkSession, txn, newFiles, deletedFiles)
+      registerInsertReplaceMetrics(sparkSession, txn, newFiles, deletedFiles)
     } else if (mode == SaveMode.Overwrite &&
         sparkSession.conf.get(DeltaSQLConf.OVERWRITE_REMOVE_METRICS_ENABLED)) {
       registerOverwriteRemoveMetrics(sparkSession, txn, deletedFiles)
@@ -423,13 +450,19 @@ case class WriteIntoDelta(
       spark: SparkSession,
       txn: OptimisticTransaction,
       conditions: Seq[Expression]): Seq[Action] = {
+    // Clone the spark session to enable EXISTS subquery support in DELETE,
+    // which is needed for replaceOn/replaceUsing conditions.
+    val sparkWithSubqueryDelete = spark.cloneSession()
+    sparkWithSubqueryDelete.conf.set(
+      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key, value = "true")
     val relation = createTableRelation(txn, tableAliasOpt = options.targetAlias)
     val processedCondition = conditions.reduceOption(And)
-    val command = spark.sessionState.analyzer.execute(
+    val command = sparkWithSubqueryDelete.sessionState.analyzer.execute(
       DeleteFromTable(relation, processedCondition.getOrElse(Literal.TrueLiteral)))
-    spark.sessionState.analyzer.checkAnalysis(command)
+    sparkWithSubqueryDelete.sessionState.analyzer.checkAnalysis(command)
+    val deleteCmd = command.asInstanceOf[DeleteCommand]
     val (deleteActions, deleteMetrics) =
-      command.asInstanceOf[DeleteCommand].performDelete(spark, txn.deltaLog, txn)
+      deleteCmd.performDelete(sparkWithSubqueryDelete, txn.deltaLog, txn)
     recordDeltaEvent(
       deltaLog,
       "delta.dml.write.removeFiles.stats",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -251,6 +251,8 @@ case class WriteIntoDelta(
       deltaLog.createLogDirectoriesIfNotExists()
     }
 
+    assert(maybeAliasedReplaceWhereExprsOpt.isEmpty || replaceOnOrUsingExprOpt.isEmpty,
+      "replaceWhere, replaceOn or replaceUsing cannot be specified at the same time.")
     val atomicReplaceExprsOpt =
       replaceOnOrUsingExprOpt.orElse(maybeAliasedReplaceWhereExprsOpt)
 
@@ -285,7 +287,7 @@ case class WriteIntoDelta(
         (newFiles, addFiles, txn.filterFiles(strippedTargetAliasPredicates).map(_.remove))
       case (SaveMode.Overwrite, Some(conditions)) if txn.snapshot.version >= 0 =>
         assert(options.replaceWhere.isDefined || options.isReplaceOnOrUsingDefined,
-          "Either 'replaceWhere' or 'replaceOn' must be specified.")
+          "Either 'replaceWhere', 'replaceOn', or `replaceUsing` must be specified.")
         val constraints = if (options.replaceWhere.isDefined) {
           // Strip alias because check constraint is applied against unaliased table schema.
           extractConstraints(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -448,7 +448,7 @@ trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
             colName = replaceUsingAttr.name,
             relationType = "table",
             suggestion = tableRelation.schema.fieldNames.sorted
-              .map(n => s"`$n`").mkString(", "))
+              .map(DeltaErrors.toSQLId).mkString(", "))
         }
 
         if (!isAttrExistsInQuery) {
@@ -456,7 +456,7 @@ trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
             colName = replaceUsingAttr.name,
             relationType = "query",
             suggestion = originalQueryBeforeSchemaAdjustmentProjection
-              .schema.fieldNames.sorted.map(n => s"`$n`").mkString(", "))
+              .schema.fieldNames.sorted.map(DeltaErrors.toSQLId).mkString(", "))
         }
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -447,7 +447,8 @@ trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
           throw DeltaErrors.unresolvedInsertReplaceUsingColumnsError(
             colName = replaceUsingAttr.name,
             relationType = "table",
-            suggestion = tableRelation.schema.fieldNames.sorted.mkString(", "))
+            suggestion = tableRelation.schema.fieldNames.sorted
+              .map(n => s"`$n`").mkString(", "))
         }
 
         if (!isAttrExistsInQuery) {
@@ -455,7 +456,7 @@ trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
             colName = replaceUsingAttr.name,
             relationType = "query",
             suggestion = originalQueryBeforeSchemaAdjustmentProjection
-              .schema.fieldNames.sorted.mkString(", "))
+              .schema.fieldNames.sorted.map(n => s"`$n`").mkString(", "))
         }
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.errors.QueryCompilationErrors.toSQLId
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, EqualTo, Exists, Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -448,7 +449,7 @@ trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
             colName = replaceUsingAttr.name,
             relationType = "table",
             suggestion = tableRelation.schema.fieldNames.sorted
-              .map(DeltaErrors.toSQLId).mkString(", "))
+              .map(toSQLId).mkString(", "))
         }
 
         if (!isAttrExistsInQuery) {
@@ -456,7 +457,7 @@ trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
             colName = replaceUsingAttr.name,
             relationType = "query",
             suggestion = originalQueryBeforeSchemaAdjustmentProjection
-              .schema.fieldNames.sorted.map(DeltaErrors.toSQLId).mkString(", "))
+              .schema.fieldNames.sorted.map(toSQLId).mkString(", "))
         }
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -459,7 +459,6 @@ trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
         }
       }
 
-
       InsertReplaceUsingMisalignedColumnsEventInfo.disallowMisalignedReplaceUsingCols(
         sparkSession.sessionState.conf.resolver,
         replaceUsingCols,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.commands
 
+import scala.collection.mutable.ArrayBuffer
+
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta.DeltaErrors
@@ -23,6 +25,7 @@ import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaOptions
 import org.apache.spark.sql.delta.DeltaTableUtils
 import org.apache.spark.sql.delta.OptimisticTransaction
+import org.apache.spark.sql.delta.util.AnalysisHelper
 import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.actions.AddCDCFile
 import org.apache.spark.sql.delta.actions.AddFile
@@ -36,15 +39,16 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, EqualTo, Exists, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
+import org.apache.spark.sql.execution.metric.SQLMetric
 
 /**
  * An interface for writing [[data]] into Delta tables.
  */
-trait WriteIntoDeltaLike extends DeltaCommand {
+trait WriteIntoDeltaLike extends DeltaCommand with AnalysisHelper {
   /**
    * A helper method to create a new instances of [[WriteIntoDeltaLike]] with
    * updated [[configuration]].
@@ -123,7 +127,7 @@ trait WriteIntoDeltaLike extends DeltaCommand {
    * @param newFiles - AddFile and AddCDCFile added by write job
    * @param deleteActions - AddFile, RemoveFile, AddCDCFile added by Delete job
    */
-  protected def registerReplaceWhereMetrics(
+  protected def registerInsertReplaceMetrics(
       spark: SparkSession,
       txn: OptimisticTransaction,
       newFiles: Seq[Action],
@@ -336,5 +340,156 @@ trait WriteIntoDeltaLike extends DeltaCommand {
       throw DeltaErrors.incompatibleDataFrameOptions(
         DeltaOptions.DATA_CHANGE_OPTION, replaceOnOrUsingOption)
     }
+  }
+
+  /**
+   * Parses the .option("replaceOn") condition or the .options("replaceUsing") columns
+   * and constructs an EXISTS subquery:
+   *   EXISTS (SELECT 1 FROM inserting_data WHERE replaceOnCond/replaceUsingCond)
+   * Here, `replaceOnCond` comes from the .option("replaceOn"), while `replaceUsingCond`
+   * generates an equality condition for each column in .option("replaceUsing"),
+   * matching query and table columns, combined with AND.
+   *
+   * This expression is used to identify and delete matching rows in the target table,
+   * a step in the atomic replace commands (REPLACE ON/USING).
+   *
+   * Note:
+   * 1. Only query columns are resolved here.
+   * 2. Table columns are resolved during the actual delete, i.e.
+   * [[WriteIntoDelta.removeFiles]],
+   * because resolving them earlier would cause the [[LogicalRelation]] created
+   * in the delete step to not recognize the columns due to already assigned
+   * exprId, even if they are logically identical.
+   */
+  protected def getReplaceOnOrUsingExprOpt(
+      sparkSession: SparkSession,
+      txn: OptimisticTransaction,
+      options: DeltaOptions,
+      isInsertReplaceUsingByName: Boolean = false): Expression = {
+    require(options.isReplaceOnOrUsingDefined, "This function should only be called when the " +
+      "replaceOn/replaceUsing option is defined.")
+    require(options.replaceUsing.isEmpty ||
+        options.targetAlias.contains(DeltaOptions.REPLACE_USING_INTERNAL_TABLE_ALIAS),
+      s"replaceUsing requires targetAlias=${DeltaOptions.REPLACE_USING_INTERNAL_TABLE_ALIAS}" +
+        s" set by DeltaInsertReplaceOnOrUsingCommand, but got targetAlias=${options.targetAlias}.")
+    val tableRelation = createTableRelation(txn, options.targetAlias)
+
+    def checkColumnExistenceIn(relation: LogicalPlan, attrNameParts: Seq[String]): Boolean = {
+      relation.resolve(attrNameParts, sparkSession.sessionState.conf.resolver).isDefined
+    }
+
+    // There is a projection on top of the original query schema to match the table
+    // column names and types, we need to see the original query in order to have
+    // the original column names, to resolve the replaceOn matching condition.
+    val originalQueryBeforeSchemaAdjustmentProjection = data.queryExecution.analyzed match {
+      case Project(_, child) => child
+      case otherDataQueryPlan =>
+        throw new IllegalStateException(
+          s"Expected a Project node on top of the analyzed query plan for replaceOn/replaceUsing " +
+            s"resolution, but found: $otherDataQueryPlan")
+    }
+
+    val (uniqueTableRelationAttrs, queryResolvedConditions) = if (options.replaceOn.isDefined) {
+      val replaceOnMatchingConds =
+        options.replaceOn.map(parsePredicates(sparkSession, _)).get
+
+      val replaceOnAttrs =
+        replaceOnMatchingConds.flatMap(_.references).map(_.asInstanceOf[UnresolvedAttribute])
+      val ambiguousColumnsInCond = ArrayBuffer[String]()
+      val unresolvedColumnsInCond = ArrayBuffer[String]()
+      replaceOnAttrs.foreach { replaceOnAttr =>
+        val isAttrExistsInTable = checkColumnExistenceIn(
+          relation = tableRelation, replaceOnAttr.nameParts)
+
+        val isAttrExistsInQuery = checkColumnExistenceIn(
+          relation = originalQueryBeforeSchemaAdjustmentProjection, replaceOnAttr.nameParts)
+
+        if (isAttrExistsInTable && isAttrExistsInQuery) {
+          ambiguousColumnsInCond += replaceOnAttr.sql
+        }
+
+        if (!isAttrExistsInTable && !isAttrExistsInQuery) {
+          unresolvedColumnsInCond += replaceOnAttr.sql
+        }
+      }
+
+      if (ambiguousColumnsInCond.nonEmpty) {
+        throw DeltaErrors.insertReplaceOnAmbiguousColumnsInCond(
+          ambiguousColumnsInCond.distinct.toSeq)
+      }
+
+      if (unresolvedColumnsInCond.nonEmpty) {
+        throw DeltaErrors.insertReplaceOnUnresolvedColumnsInCond(
+          unresolvedColumnsInCond.distinct.toSeq)
+      }
+
+      val uniqueTableRelationAttrs = replaceOnAttrs.filter { replaceOnAttr =>
+        checkColumnExistenceIn(relation = tableRelation, replaceOnAttr.nameParts)
+      }.distinct
+
+      val queryResolvedConditions = tryResolveReferencesForExpressions(sparkSession)(
+        exprs = replaceOnMatchingConds,
+        plansProvidingAttrs = Seq(originalQueryBeforeSchemaAdjustmentProjection))
+
+      (uniqueTableRelationAttrs, queryResolvedConditions)
+    } else {
+      val replaceUsingCols = options.parsedReplaceUsingColsList.get
+
+      val replaceUsingAttrs = replaceUsingCols.map(UnresolvedAttribute(_))
+      replaceUsingAttrs.foreach { replaceUsingAttr =>
+        val isAttrExistsInTable = checkColumnExistenceIn(
+          relation = tableRelation, replaceUsingAttr.nameParts)
+
+        val isAttrExistsInQuery = checkColumnExistenceIn(
+          relation = originalQueryBeforeSchemaAdjustmentProjection, replaceUsingAttr.nameParts)
+
+        if (!isAttrExistsInTable) {
+          throw DeltaErrors.unresolvedInsertReplaceUsingColumnsError(
+            colName = replaceUsingAttr.name,
+            relationType = "table",
+            suggestion = tableRelation.schema.fieldNames.sorted.mkString(", "))
+        }
+
+        if (!isAttrExistsInQuery) {
+          throw DeltaErrors.unresolvedInsertReplaceUsingColumnsError(
+            colName = replaceUsingAttr.name,
+            relationType = "query",
+            suggestion = originalQueryBeforeSchemaAdjustmentProjection
+              .schema.fieldNames.sorted.mkString(", "))
+        }
+      }
+
+
+      InsertReplaceUsingMisalignedColumnsEventInfo.disallowMisalignedReplaceUsingCols(
+        sparkSession.sessionState.conf.resolver,
+        replaceUsingCols,
+        tableRelation = tableRelation,
+        queryRelation = originalQueryBeforeSchemaAdjustmentProjection,
+        isByName = isInsertReplaceUsingByName,
+        conf = sparkSession.sessionState.conf)
+
+      val uniqueTableRelationAttrs =
+        replaceUsingCols.map(col => UnresolvedAttribute(Seq(options.targetAlias.get, col))).distinct
+
+      // For REPLACE USING, an internal table alias is required to ensure certain attributes
+      // resolve to the target table, not the query. Without it, column resolution incorrectly
+      // references all the attributes to the query.
+      val queryResolvedConditions = replaceUsingCols.map(replaceUsingCol => EqualTo(
+        left = UnresolvedAttribute(Seq(options.targetAlias.get, replaceUsingCol)),
+        right = originalQueryBeforeSchemaAdjustmentProjection.output.find(queryAttr =>
+          sparkSession.sessionState.analyzer.resolver(queryAttr.name, replaceUsingCol)).get))
+
+      (uniqueTableRelationAttrs, queryResolvedConditions)
+    }
+
+    Exists(
+      plan = Project(
+        projectList = Seq(Alias(child = Literal(1), "__dummy_name_for_a_constant")()),
+        child = Filter(
+          condition = queryResolvedConditions.reduce(And),
+          child = originalQueryBeforeSchemaAdjustmentProjection
+        )
+      ),
+      outerAttrs = uniqueTableRelationAttrs)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -25,7 +25,10 @@ import com.databricks.spark.util.DatabricksLogging
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
-import org.apache.spark.sql.delta.commands.WriteIntoDelta
+import org.apache.spark.sql.delta.commands.{
+  DeltaInsertReplaceOnOrUsingCommand,
+  InsertReplaceOnOrUsingAPIOrigin,
+  WriteIntoDelta}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -259,18 +262,30 @@ class DeltaDataSource
         throw DeltaErrors.operationNotSupportedException("replaceUsing")
       }
     }
-    WriteIntoDelta(
+    val writeCmd = WriteIntoDelta(
       deltaLog = deltaLog,
       mode = mode,
-      deltaOptions,
+      options = deltaOptions,
       partitionColumns = partitionColumns,
       configuration = DeltaConfigs.validateConfigurations(
         parameters.filterKeys(_.startsWith("delta.")).toMap),
       data = data,
       // empty catalogTable is acceptable as the code path is only for path based writes
       // (df.write.save("path")) which does not need to use/update catalog
-      catalogTableOpt = None
-      ).run(sqlContext.sparkSession)
+      catalogTableOpt = None)
+    val finalWriteCmd = if (deltaOptions.isReplaceOnOrUsingDefined) {
+      DeltaInsertReplaceOnOrUsingCommand.createCmdForSaveAndSaveAsTable(
+        deltaTable = DeltaTableV2(
+          spark = sqlContext.sparkSession,
+          path = deltaLog.dataPath,
+          catalogTable = None),
+        data = data,
+        writeCmd = writeCmd,
+        apiOrigin = InsertReplaceOnOrUsingAPIOrigin.DFv1Save)
+    } else {
+      writeCmd
+    }
+    finalWriteCmd.run(sqlContext.sparkSession)
 
     deltaLog.createRelation(catalogTableOpt = catalogTableOpt)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1078,6 +1078,20 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
     final val list = Set(NONE, ALL, AUTO)
   }
 
+  val INSERT_REPLACE_ON_OR_USING_MATERIALIZE_SOURCE =
+    buildConf("insertReplaceOnOrUsing.materializeSource")
+      .internal()
+      .doc("When to materialize the source plan during INSERT REPLACE ON/USING execution. " +
+        "The value 'none' means source will never be materialized. " +
+        "The value 'all' means source will always be materialized. " +
+        "The value 'auto' means sources will not be materialized when they are certain to be " +
+        "deterministic."
+      )
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .checkValues(MergeMaterializeSource.list)
+      .createWithDefault(MergeMaterializeSource.AUTO)
+
   val MERGE_MATERIALIZE_SOURCE =
     buildConf("merge.materializeSource")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -247,6 +247,30 @@ trait DeltaInsertIntoTest
     }
   }
 
+  /** df.write.mode("overwrite").option("replaceOn", ...).save() */
+  object DFv1SaveReplaceOn extends Insert {
+    val name: String = "DFv1 save() - REPLACE ON"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = true
+    val isSQL: Boolean = false
+    def runInsert(
+        columns: Seq[String],
+        whereCol: String,
+        whereValue: Int,
+        withSchemaEvolution: Boolean): Unit = {
+      withSQLConf(
+          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier("target"))
+        spark.read.table("source").write.mode(mode)
+          .option("replaceOn", s"t.$whereCol = $whereValue")
+          .option("targetAlias", "t")
+          .option("mergeSchema", withSchemaEvolution.toString)
+          .format("delta")
+          .save(deltaLog.dataPath.toString)
+      }
+    }
+  }
+
   /** df.write.mode(mode).option("partitionOverwriteMode", "dynamic").insertInto() */
   object DFv1InsertIntoDynamicPartitionOverwrite extends Insert {
     val name: String = s"DFv1 insertInto() - dynamic partition overwrite"
@@ -351,6 +375,7 @@ trait DeltaInsertIntoTest
         SQLInsertOverwritePartitionByPosition,
         SQLInsertOverwritePartitionColList,
         DFv1InsertIntoDynamicPartitionOverwrite,
+        DFv1SaveReplaceOn,
         DFv2Append,
         DFv2Overwrite,
         DFv2OverwritePartition,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterTests.scala
@@ -1,0 +1,1302 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
+import org.apache.spark.sql.delta.commands.{InsertReplaceOnOrUsingMaterializeSourceError, InsertReplaceOnOrUsingStats}
+import org.apache.spark.sql.delta.commands.merge.{MergeIntoMaterializeSourceError, MergeIntoMaterializeSourceErrorType, MergeIntoMaterializeSourceReason}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.functions.{lit, rand, udf}
+import org.apache.spark.storage.StorageLevel
+
+/**
+ * Common tests for replaceOn option via DataFrame APIs
+ * (save(), insertInto(), and saveAsTable()).
+ */
+trait DeltaInsertReplaceOnDFWriterTests
+  extends DeltaInsertReplaceOnOrUsingTestUtils {
+  import testImplicits._
+
+  /**
+   * Write the sourceDF to the target with replaceOn.
+   */
+  protected def writeReplaceOnDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceOnCond: String,
+      targetAlias: Option[String] = None,
+      mergeSchema: Boolean = false): Unit
+
+  // Basic replaceOn behavior.
+  test("replaceOn with always-true condition replaces all rows") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "original1"),
+        (2, "original2"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (10, "new1"),
+          (20, "new2"))
+          .toDF("id", "data"),
+        target = path,
+        replaceOnCond = "true")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(10, "new1"),
+          Row(20, "new2")))
+    }
+  }
+
+  test("replaceOn with always-false condition appends all rows") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "original1"),
+        (2, "original2"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (10, "new1"),
+          (20, "new2"))
+          .toDF("id", "data"),
+        target = path,
+        replaceOnCond = "false")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "original1"),
+          Row(2, "original2"),
+          Row(10, "new1"),
+          Row(20, "new2")))
+    }
+  }
+
+  test("basic replaceOn with single matching column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target1"),
+        (1, "target2"),
+        (3, "target"))
+        .toDF("col1", "row_origin")
+        .write.format("delta").save(path)
+
+      val sourceDF = Seq(
+        ("source1"),
+        ("source2"))
+        .toDF("row_origin")
+        .withColumn("col1", lit(null).cast("int"))
+        .select($"col1", $"row_origin")
+        .union(
+          Seq(
+            (1, "source"),
+            (2, "source1"),
+            (2, "source2"),
+            (2, "source3"))
+            .toDF("col1", "row_origin"))
+
+      writeReplaceOnDF(
+        sourceDF = sourceDF.as("s"),
+        target = path,
+        replaceOnCond = "t.col1 = s.col1",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Seq(
+          Row(null, "source1"),
+          Row(null, "source2"),
+          Row(1, "source"),
+          Row(2, "source1"),
+          Row(2, "source2"),
+          Row(2, "source3"),
+          Row(3, "target")))
+    }
+  }
+
+  test("replaceOn with multiple matching columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, 1, "target"),
+        (1, 2, "target"),
+        (2, 1, "target"))
+        .toDF("col1", "col2", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, 1, "source"),
+          (1, 2, "source"),
+          (3, 3, "source"))
+          .toDF("col1", "col2", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.col1 = s.col1 AND t.col2 = s.col2",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, 1, "source") ::
+          Row(1, 2, "source") ::
+          Row(2, 1, "target") ::
+          Row(3, 3, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn with duplicate rows in source") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"))
+        .toDF("col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source1"),
+          (1, "source2"),
+          (1, "source3"),
+          (3, "source"))
+          .toDF("col", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.col = s.col",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source1") ::
+          Row(1, "source2") ::
+          Row(1, "source3") ::
+          Row(2, "target") ::
+          Row(3, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn with empty target table") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq.empty[(Int, String)].toDF("col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (2, "source"))
+          .toDF("col", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.col = s.col",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn with empty source") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (2, "target"))
+        .toDF("col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq.empty[(Int, String)].toDF("col", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.col = s.col",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "target") ::
+          Row(2, "target") ::
+          Row(2, "target") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn with filtered source") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (2, "target"),
+        (3, "target"),
+        (3, "target"),
+        (3, "target"))
+        .toDF("col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (2, "source"),
+          (3, "source"))
+          .toDF("col", "row_origin").filter($"col" <= 2).as("s"),
+        target = path,
+        replaceOnCond = "t.col = s.col",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "source") ::
+          Row(3, "target") ::
+          Row(3, "target") ::
+          Row(3, "target") ::
+          Nil)
+    }
+  }
+
+  // Data layout: partitioned, clustered, normal tables.
+  for (dataLayoutType <- DataLayoutType.values) {
+    test(s"replaceOn with ${dataLayoutType.toString} table") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        val targetData = Seq(
+          (0, 0, 0, "target"),
+          (2, 2, 2, "target"),
+          (2, 2, 2, "target"),
+          (3, 3, 3, "target"),
+          (3, 3, 3, "target"),
+          (3, 3, 3, "target"))
+          .toDF("col1", "col2", "col3", "row_origin")
+
+        dataLayoutType match {
+          case DataLayoutType.PARTITIONED =>
+            targetData.write.format("delta")
+              .partitionBy("col1", "col2").save(path)
+          case DataLayoutType.CLUSTERED =>
+            targetData.write.format("delta")
+              .clusterBy("col1", "col2").save(path)
+          case DataLayoutType.NORMAL =>
+            targetData.write.format("delta").save(path)
+        }
+
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, 1, 1, "source"),
+            (2, 2, 2, "source"),
+            (3, 3, 3, "source"))
+            .toDF("col1", "col2", "col3", "row_origin").as("s"),
+          target = path,
+          replaceOnCond = "t.col1 = s.col1",
+          targetAlias = Some("t"))
+
+        checkAnswer(
+          spark.read.format("delta").load(path),
+          Row(0, 0, 0, "target") ::
+            Row(1, 1, 1, "source") ::
+            Row(2, 2, 2, "source") ::
+            Row(3, 3, 3, "source") ::
+            Nil)
+      }
+    }
+  }
+
+  // Condition variations: NULL-safe equality, one-sided, IN predicate, functions.
+  test("replaceOn with NULL-safe equality condition") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq[(Option[Int], Option[Int], String)](
+        (None, None, "target"),
+        (None, Some(1), "target"),
+        (Some(1), None, "target"),
+        (Some(2), Some(3), "target"))
+        .toDF("col1", "col2", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq[(Option[Int], Option[Int], String)](
+          (None, None, "source"),
+          (None, Some(2), "source"),
+          (Some(1), None, "source"),
+          (Some(3), None, "source"))
+          .toDF("col1", "col2", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.col1 <=> s.col1",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(null, null, "source") ::
+          Row(null, 2, "source") ::
+          Row(1, null, "source") ::
+          Row(2, 3, "target") ::
+          Row(3, null, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn with condition referencing only target side") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (-1, "target"),
+        (1, "target"),
+        (2, "target"),
+        (2, "target"),
+        (3, "target"),
+        (3, "target"),
+        (3, "target"))
+        .toDF("col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (0, "source"),
+          (1, "source"),
+          (2, "source"),
+          (3, "source"))
+          .toDF("col", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.col >= 1",
+        targetAlias = Some("t"))
+      // All target rows with col >= 1 are replaced; col = -1 is kept.
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(-1, "target") ::
+          Row(0, "source") ::
+          Row(1, "source") ::
+          Row(2, "source") ::
+          Row(3, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn with condition referencing only source side") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (-1, "target"),
+        (1, "target"),
+        (2, "target"),
+        (2, "target"),
+        (3, "target"),
+        (3, "target"),
+        (3, "target"))
+        .toDF("col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (0, "source"),
+          (1, "source"),
+          (2, "source"),
+          (3, "source"))
+          .toDF("col", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "s.col >= 1",
+        targetAlias = Some("t"))
+      // Source has rows with col >= 1, so the condition is true for every
+      // target row. All target rows are replaced.
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(0, "source") ::
+          Row(1, "source") ::
+          Row(2, "source") ::
+          Row(3, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn with IN predicate in condition") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (2, "target"),
+        (3, "target"),
+        (3, "target"),
+        (3, "target"))
+        .toDF("col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (2, "source"),
+          (3, "source"))
+          .toDF("col", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.col IN (2)",
+        targetAlias = Some("t"))
+      // Only target rows with col = 2 are replaced. Others are kept, and
+      // non-matching source rows are appended.
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "target") ::
+          Row(1, "source") ::
+          Row(2, "source") ::
+          Row(3, "target") ::
+          Row(3, "target") ::
+          Row(3, "target") ::
+          Row(3, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceOn condition with function (e.g., abs)") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (-1, "target"),
+        (2, "target"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+      // abs(t.id) = abs(s.id): rows with id=1 and id=-1 both match source id=1
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (3, "source"))
+          .toDF("id", "data").as("s"),
+        target = path,
+        replaceOnCond = "abs(t.id) = abs(s.id)",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "source")))
+    }
+  }
+
+  // Schema evolution: new columns, missing columns, different column names.
+  test("replaceOn with mergeSchema adds new columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source", 100),
+          (3, "source", 300))
+          .toDF("id", "data", "extra").as("s"),
+        target = path,
+        replaceOnCond = "t.id = s.id",
+        targetAlias = Some("t"),
+        mergeSchema = true)
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "source", 100),
+          Row(2, "target", null),
+          Row(3, "source", 300)))
+    }
+  }
+
+  test("replaceOn with fewer source columns fills missing target columns with null") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target", 10),
+        (2, "target", 20))
+        .toDF("id", "data", "extra")
+        .write.format("delta").save(path)
+      // Source has fewer columns (id, data), missing "extra" gets null
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (3, "source"))
+          .toDF("id", "data").as("s"),
+        target = path,
+        replaceOnCond = "t.id = s.id",
+        targetAlias = Some("t"),
+        mergeSchema = true)
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "source", null),
+          Row(2, "target", 20),
+          Row(3, "source", null)))
+    }
+  }
+
+  test("replaceOn with mergeSchema referencing new columns in condition") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (-1, -1, "target"),
+        (1, 1, "target"),
+        (2, 2, "target"),
+        (2, 2, "target"),
+        (4, 4, "target"),
+        (4, 4, "target"),
+        (4, 4, "target"),
+        (4, 4, "target"))
+        .toDF("col1", "col2", "row_origin")
+        .write.format("delta").save(path)
+      // Source adds two new columns (col3, col4) and the condition
+      // references them.
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (0, 0, "source", 0, 0),
+          (1, 1, "source", 1, 1),
+          (2, 2, "source", 2, 2),
+          (3, 3, "source", 3, 3))
+          .toDF("col1", "col2", "row_origin", "col3", "col4").as("s"),
+        target = path,
+        replaceOnCond = "t.col1 = s.col3 AND t.col2 = s.col4",
+        targetAlias = Some("t"),
+        mergeSchema = true)
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(-1, -1, "target", null, null) ::
+          Row(0, 0, "source", 0, 0) ::
+          Row(1, 1, "source", 1, 1) ::
+          Row(2, 2, "source", 2, 2) ::
+          Row(3, 3, "source", 3, 3) ::
+          Row(4, 4, "target", null, null) ::
+          Row(4, 4, "target", null, null) ::
+          Row(4, 4, "target", null, null) ::
+          Row(4, 4, "target", null, null) ::
+          Nil)
+    }
+  }
+
+  test("replaceOn null-safe equality matching between existing columns " +
+      "with NULL values and new columns with NULL values") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      // Target has (id, row_origin). Some rows have id=null.
+      // Source also has (id, row_origin) with id=null.
+      // Using <=> so null matches null.
+      Seq[(Option[Int], String)](
+        (Some(1), "target"),
+        (None, "target_null"),
+        (Some(3), "target"))
+        .toDF("id", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq[(Option[Int], String)](
+          (None, "source_null"),
+          (Some(1), "source"))
+          .toDF("id", "row_origin").as("s"),
+        target = path,
+        replaceOnCond = "t.id <=> s.id",
+        targetAlias = Some("t"))
+
+      // id=null in source matches id=null in target via <=>.
+      // id=1 in source matches id=1 in target.
+      // id=3 in target is not matched, so it remains.
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(null, "source_null"),
+          Row(1, "source"),
+          Row(3, "target")))
+    }
+  }
+
+  // Source data variety: spark.table(), spark.sql().
+  test("replaceOn with source from spark.table()") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      withTable("source") {
+        Seq(
+          (1, "target"),
+          (2, "target"),
+          (3, "target"))
+          .toDF("id", "data")
+          .write.format("delta").save(path)
+
+        sql("CREATE TABLE source (id INT, data STRING) USING parquet")
+        sql(
+          "INSERT INTO source VALUES " +
+            "(1, 'source'), (2, 'source'), (4, 'source')")
+
+        writeReplaceOnDF(
+          sourceDF = spark.table("source").as("s"),
+          target = path,
+          replaceOnCond = "t.id = s.id",
+          targetAlias = Some("t"))
+
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          Seq(
+            Row(1, "source"),
+            Row(2, "source"),
+            Row(3, "target"),
+            Row(4, "source")))
+      }
+    }
+  }
+
+  test("replaceOn with source from spark.sql()") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      withTable("source") {
+        Seq(
+          (1, "target"),
+          (2, "target"),
+          (3, "target"))
+          .toDF("id", "data")
+          .write.format("delta").save(path)
+
+        sql("CREATE TABLE source (id INT, data STRING) USING parquet")
+        sql("INSERT INTO source VALUES (1, 'source'), (4, 'source')")
+
+        writeReplaceOnDF(
+          sourceDF = spark.sql("SELECT * FROM source").as("s"),
+          target = path,
+          replaceOnCond = "t.id = s.id",
+          targetAlias = Some("t"))
+
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          Seq(
+            Row(1, "source"),
+            Row(2, "target"),
+            Row(3, "target"),
+            Row(4, "source")))
+      }
+    }
+  }
+
+  // Alias resolution: targetAlias, compound conditions.
+  test("replaceOn with targetAlias and source .as resolves ambiguous columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "original1"),
+        (2, "original2"),
+        (3, "original3"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "updated"),
+          (4, "new"))
+          .toDF("id", "data").as("s"),
+        target = path,
+        replaceOnCond = "t.id = s.id",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "updated"),
+          Row(2, "original2"),
+          Row(3, "original3"),
+          Row(4, "new")))
+    }
+  }
+
+  test("targetAlias resolves ambiguity with compound AND condition") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "a", "target"),
+        (2, "b", "target"))
+        .toDF("id", "key", "data")
+        .write.format("delta").save(path)
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "a", "source"),
+          (3, "c", "source"))
+          .toDF("id", "key", "data").as("s"),
+        target = path,
+        replaceOnCond = "t.id = s.id AND t.key = s.key",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "a", "source"),
+          Row(2, "b", "target"),
+          Row(3, "c", "source")))
+    }
+  }
+
+  // Error cases: ambiguous columns, unresolvable columns, type/schema mismatches.
+  test("ambiguous: identical alias for target and source") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"))
+        .toDF("col1", "row_origin")
+        .write.format("delta").save(path)
+      // Both target and source aliased as "s". s.col1 resolves to both.
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"),
+            (2, "source"))
+            .toDF("col1", "row_origin").as("s"),
+          target = path,
+          replaceOnCond = "s.col1 = s.col1",
+          targetAlias = Some("s"))
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_AMBIGUOUS_COLUMNS_IN_CONDITION",
+        sqlState = Some("42702"),
+        parameters = Map("columnNames" -> "`s`.`col1`"))
+    }
+  }
+
+  test("ambiguous: no source alias, bare 'id' on both sides") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (3, "target"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+      // Even without .as(), bare 'id' on both sides is ambiguous.
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"),
+            (4, "source"))
+            .toDF("id", "data"),
+          target = path,
+          replaceOnCond = "id = id")
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_AMBIGUOUS_COLUMNS_IN_CONDITION",
+        sqlState = Some("42702"),
+        parameters = Map("columnNames" -> "`id`"))
+    }
+  }
+
+  test("replaceOn with unresolvable column errors") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, 10),
+        (2, 20))
+        .toDF("col1", "col2")
+        .write.format("delta").save(path)
+
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq((1, 100)).toDF("col1", "col2"),
+          target = path,
+          replaceOnCond = "nonexistent_col = 1")
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_UNRESOLVED_COLUMNS_IN_CONDITION",
+        sqlState = Some("42703"),
+        parameters = Map("columnNames" -> "`nonexistent_col`"))
+    }
+  }
+
+  test("replaceOn condition uses aliases for both sides but user forgot targetAlias option") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target1"),
+        (2, "target2"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"))
+            .toDF("col1", "data").as("s"),
+          target = path,
+          replaceOnCond = "t.col1 = s.col1")
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_UNRESOLVED_COLUMNS_IN_CONDITION",
+        sqlState = Some("42703"),
+        parameters = Map("columnNames" -> "`t`.`col1`"))
+    }
+  }
+
+  test("replaceOn condition uses aliases for both sides but user forgot source .as alias") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target1"),
+        (2, "target2"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"))
+            .toDF("col1", "data"),
+          target = path,
+          replaceOnCond = "t.col1 = s.col1",
+          targetAlias = Some("t"))
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_UNRESOLVED_COLUMNS_IN_CONDITION",
+        sqlState = Some("42703"),
+        parameters = Map("columnNames" -> "`s`.`col1`"))
+    }
+  }
+
+  test("replaceOn condition uses aliases for both sides but user forgot both aliases") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target1"),
+        (2, "target2"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"))
+            .toDF("col1", "data"),
+          target = path,
+          replaceOnCond = "t.col1 = s.col1")
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_UNRESOLVED_COLUMNS_IN_CONDITION",
+        sqlState = Some("42703"),
+        parameters = Map("columnNames" -> "`t`.`col1`, `s`.`col1`"))
+    }
+  }
+
+  test("ambiguous: compound condition, all columns overlap") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "a"),
+        (2, "b"))
+        .toDF("id", "key")
+        .write.format("delta").save(path)
+      // Source has identical schema (id, key), both without alias
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq((1, "x")).toDF("id", "key").as("s"),
+          target = path,
+          replaceOnCond = "id = s.id AND key = s.key",
+          targetAlias = Some("t"))
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_AMBIGUOUS_COLUMNS_IN_CONDITION",
+        sqlState = Some("42702"),
+        parameters = Map("columnNames" -> "`id`, `key`"))
+    }
+  }
+
+  test("ambiguous: multiple overlapping columns, only one without alias") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a", 10)).toDF("id", "key", "value")
+        .write.format("delta").save(path)
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq((1, "a", 99))
+            .toDF("id", "key", "amount").as("s"),
+          target = path,
+          replaceOnCond = "t.id = s.id AND key = s.key",
+          targetAlias = Some("t"),
+          mergeSchema = true)
+      }
+      checkError(exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_AMBIGUOUS_COLUMNS_IN_CONDITION",
+        sqlState = Some("42702"),
+        parameters = Map("columnNames" -> "`key`"))
+    }
+  }
+
+  test("same column name with different types fails schema merge") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target")).toDF("id", "data")
+        .write.format("delta").save(path)
+      // Source has (id: string, data: string), type mismatch on 'id'
+      // fails before reaching the ambiguity check
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(("1", "source"))
+            .toDF("id", "data").as("s"),
+          target = path,
+          replaceOnCond = "id = s.id",
+          targetAlias = Some("t"))
+      }
+      checkError(exception = e,
+        condition = "DELTA_FAILED_TO_MERGE_FIELDS",
+        sqlState = Some("22005"),
+        parameters = Map(
+          "currentField" -> "id",
+          "updateField" -> "id"))
+    }
+  }
+
+  test("replaceOn with different schemas, without mergeSchema fails") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      // Target has (col2, row_origin), source has (col1, row_origin).
+      // Without mergeSchema, the schema mismatch is rejected.
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (3, "target"))
+        .toDF("col2", "row_origin")
+        .write.format("delta").save(path)
+
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"),
+            (4, "source"))
+            .toDF("col1", "row_origin").as("s"),
+          target = path,
+          replaceOnCond = "t.col2 = s.col1",
+          targetAlias = Some("t"))
+      }
+      checkError(exception = e,
+        condition = "DELTA_METADATA_MISMATCH",
+        sqlState = Some("42KDG"))
+    }
+  }
+
+  // targetAlias edge cases: wrong alias, case sensitivity, weird alias values.
+  test("replaceOn with wrong targetAlias errors on unresolved columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+      // Condition references "t" but targetAlias is set to "y",
+      // so t.col1 cannot be resolved against either side.
+      val e = intercept[DeltaAnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"))
+            .toDF("col1", "data").as("s"),
+          target = path,
+          replaceOnCond = "t.col1 = s.col1",
+          targetAlias = Some("y"))
+      }
+      checkError(
+        exception = e,
+        condition =
+          "DELTA_INSERT_REPLACE_ON_UNRESOLVED_COLUMNS_IN_CONDITION",
+        sqlState = Some("42703"),
+        parameters = Map("columnNames" -> "`t`.`col1`"))
+    }
+  }
+
+  test("replaceOn targetAlias is case insensitive") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (3, "target"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+      // Condition uses lowercase "t" but targetAlias is uppercase "T".
+      // Spark resolves aliases case insensitively by default.
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (4, "source"))
+          .toDF("col1", "data").as("s"),
+        target = path,
+        replaceOnCond = "t.col1 = s.col1",
+        targetAlias = Some("T"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("col1"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "target"),
+          Row(4, "source")))
+    }
+  }
+
+  test("replaceOn with numeric targetAlias '22' resolves with backticks") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (3, "target"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (4, "source"))
+          .toDF("col1", "data").as("s"),
+        target = path,
+        replaceOnCond = "`22`.col1 = s.col1",
+        targetAlias = Some("22"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("col1"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "target"),
+          Row(4, "source")))
+    }
+  }
+
+  test("replaceOn with numeric targetAlias '22' without backticks fails on type extraction") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+      // Without backticks, "22.col1" is parsed as integer literal 22 with
+      // a field extraction of "col1", which fails because INT is not a complex type.
+      val e = intercept[org.apache.spark.sql.AnalysisException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"))
+            .toDF("col1", "data").as("s"),
+          target = path,
+          replaceOnCond = "22.col1 = s.col1",
+          targetAlias = Some("22"))
+      }
+      checkError(
+        exception = e,
+        condition = "INVALID_EXTRACT_BASE_FIELD_TYPE",
+        sqlState = Some("42000"),
+        parameters = Map("base" -> "\"22\"", "other" -> "\"INT\""))
+    }
+  }
+
+  test("replaceOn with space containing targetAlias 'hello world' resolves with backticks") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (3, "target"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "source"),
+          (4, "source"))
+          .toDF("col1", "data").as("s"),
+        target = path,
+        replaceOnCond = "`hello world`.col1 = s.col1",
+        targetAlias = Some("hello world"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("col1"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "target"),
+          Row(4, "source")))
+    }
+  }
+
+  test("replaceOn with space containing targetAlias without backticks fails to parse") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "target"),
+        (2, "target"))
+        .toDF("col1", "data")
+        .write.format("delta").save(path)
+      // Without backticks, "hello world.col1" cannot be parsed as a valid expression.
+      val e = intercept[ParseException] {
+        writeReplaceOnDF(
+          sourceDF = Seq(
+            (1, "source"))
+            .toDF("col1", "data").as("s"),
+          target = path,
+          replaceOnCond = "hello world.col1 = s.col1",
+          targetAlias = Some("hello world"))
+      }
+      checkError(
+        exception = e,
+        condition = "PARSE_SYNTAX_ERROR",
+        sqlState = Some("42601"),
+        parameters = Map("error" -> "'.'", "hint" -> ""))
+    }
+  }
+
+
+  private def testMaterializedSourceUnpersist(
+      targetPath: String, sourceViewName: String, numKills: Int): Seq[UsageRecord] = {
+    val maxAttempts = spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_MAX_ATTEMPTS)
+    val killerThreadJoinTimeoutMs = 10000
+    val killerIntervalMs = 1
+
+    Seq.tabulate(100)(i => (i, "target")).toDF("id", "row_origin")
+      .write.format("delta").save(targetPath)
+    Seq.tabulate(20)(i => (i + 100, "source")).toDF("id", "row_origin")
+      .createOrReplaceTempView(sourceViewName)
+
+    @volatile var finished = false
+    @volatile var invalidStorageLevel: Option[String] = None
+    val killerThread = new Thread() {
+      override def run(): Unit = {
+        val seenSources = mutable.Set[Int]()
+        while (!finished) {
+          sparkContext.getPersistentRDDs.foreach { case (rddId, rdd) =>
+            if (rdd.name == "mergeMaterializedSource") {
+              if (!seenSources.contains(rddId)) {
+                seenSources.add(rddId)
+              }
+              if (seenSources.size > numKills) {
+                finished = true
+              } else if (rdd.isCheckpointed) {
+                val expectedStorageLevel = StorageLevel.fromString(
+                  if (seenSources.size == 1) {
+                    spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL)
+                  } else if (seenSources.size == 2) {
+                    spark.conf.get(
+                      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL_FIRST_RETRY)
+                  } else {
+                    spark.conf.get(
+                      DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_RDD_STORAGE_LEVEL_RETRY)
+                  })
+                val rddStorageLevel = rdd.getStorageLevel
+                if (rddStorageLevel != expectedStorageLevel) {
+                  invalidStorageLevel =
+                    Some(s"For attempt ${seenSources.size} expected " +
+                      s"$expectedStorageLevel but got $rddStorageLevel")
+                  finished = true
+                }
+                rdd.unpersist(blocking = false)
+              }
+            }
+          }
+          Thread.sleep(killerIntervalMs)
+        }
+      }
+    }
+    killerThread.start()
+
+    val events = Log4jUsageLogger.track {
+      try {
+        writeReplaceOnDF(
+          sourceDF = spark.table(sourceViewName).as("s"),
+          target = targetPath,
+          replaceOnCond = "t.id = s.id",
+          targetAlias = Some("t"))
+      } catch {
+        case NonFatal(ex) =>
+          if (numKills < maxAttempts) throw ex
+      } finally {
+        finished = true
+        killerThread.join(killerThreadJoinTimeoutMs)
+        assert(!killerThread.isAlive)
+      }
+    }.filter(_.metric == MetricDefinitions.EVENT_TAHOE.name)
+
+    assert(invalidStorageLevel.isEmpty, invalidStorageLevel.toString)
+    events
+  }
+
+  {
+    val maxAttempts = DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_MAX_ATTEMPTS.defaultValue.get
+
+    for (kills <- 1 to maxAttempts - 1) {
+      test(s"materialize source unpersist with $kills kill attempts succeeds") {
+        withTempDir { dir =>
+          withView("source") {
+            val allDeltaEvents = testMaterializedSourceUnpersist(
+              targetPath = dir.getAbsolutePath, sourceViewName = "source", numKills = kills)
+            val events = allDeltaEvents.filter(
+              _.tags.get("opType").contains("delta.insertReplaceOnOrUsing.stats"))
+            assert(events.length === 1, s"allDeltaEvents:\n$allDeltaEvents")
+            val stats =
+              JsonUtils.fromJson[InsertReplaceOnOrUsingStats](events(0).blob)
+            assert(stats.materializeSourceAttempts.isDefined,
+              s"stats:\n$stats")
+            assert(stats.materializeSourceAttempts.get === kills + 1,
+              s"stats:\n$stats")
+
+            checkAnswer(
+              spark.read.format("delta").load(dir.getAbsolutePath).orderBy("id"),
+              (0 until 120).map(id =>
+                Row(id, if (id < 100) "target" else "source")))
+          }
+        }
+      }
+    }
+
+    test(s"materialize source unpersist with $maxAttempts kill attempts fails") {
+      withTempDir { dir =>
+        withView("source") {
+          val allDeltaEvents = testMaterializedSourceUnpersist(
+            targetPath = dir.getAbsolutePath, sourceViewName = "source",
+            numKills = maxAttempts)
+          val events = allDeltaEvents.filter(_.tags.get("opType")
+            .contains(InsertReplaceOnOrUsingMaterializeSourceError.OP_TYPE))
+          assert(events.length === 1, s"allDeltaEvents:\n$allDeltaEvents")
+          val error =
+            JsonUtils.fromJson[MergeIntoMaterializeSourceError](events(0).blob)
+          assert(error.errorType ===
+            MergeIntoMaterializeSourceErrorType.RDD_BLOCK_LOST.toString)
+          assert(error.attempt === maxAttempts)
+        }
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Tests replaceOn via DataFrameWriterV1 save() API.
+ */
+class DeltaInsertReplaceOnDFWriterV1SaveSuite
+  extends DeltaInsertReplaceOnDFWriterTests {
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key, "true")
+
+  override protected def writeReplaceOnDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceOnCond: String,
+      targetAlias: Option[String] = None,
+      mergeSchema: Boolean = false): Unit = {
+    var writer = sourceDF
+      .write.format("delta")
+      .mode("overwrite")
+      .option("replaceOn", replaceOnCond)
+    targetAlias.foreach { alias =>
+      writer = writer.option("targetAlias", alias)
+    }
+    if (mergeSchema) {
+      writer = writer.option("mergeSchema", "true")
+    }
+    writer.save(target)
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveSuite.scala
@@ -50,5 +50,4 @@ class DeltaInsertReplaceOnDFWriterV1SaveSuite
     }
     writer.save(target)
   }
-
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnOrUsingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnOrUsingTestUtils.scala
@@ -22,10 +22,12 @@ import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 trait DeltaInsertReplaceOnOrUsingTestUtils
   extends QueryTest
-  with SharedSparkSession {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   protected def createTable(
      tableName: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnOrUsingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnOrUsingTestUtils.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile}
+import org.apache.spark.sql.delta.commands.InsertReplaceOnOrUsingStats
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+trait DeltaInsertReplaceOnOrUsingTestUtils
+  extends QueryTest
+  with SharedSparkSession {
+
+  protected def createTable(
+     tableName: String,
+     tableCols: Seq[String],
+     partCols: Seq[String] = Seq.empty,
+     clusterCols: Seq[String] = Seq.empty): Unit = {
+    assert(partCols.isEmpty || clusterCols.isEmpty,
+      "Cannot specify both partitioning and clustering for a table.")
+    sql(
+      s"""
+         |CREATE TABLE $tableName ${tableCols.mkString("(", ",", ")")}
+         |USING delta
+         |${if (partCols.nonEmpty) s"PARTITIONED BY ${partCols.mkString("(", ",", ")")}" else ""}
+         |${if (clusterCols.nonEmpty) s"CLUSTER BY ${clusterCols.mkString("(", ",", ")")}" else ""}
+         |""".stripMargin)
+  }
+
+  protected def insertValues(tableName: String, rows: Seq[String]): Unit = {
+    sql(
+      s"""
+         |INSERT INTO $tableName
+         |VALUES ${rows.mkString(", ")}
+         |""".stripMargin)
+  }
+
+  protected def executeInsertReplaceOn(
+      tableName: String,
+      matchingCond: String,
+      sourceQuery: String,
+      byName: Boolean = false): Unit = {
+    val byNameClause = if (byName) "BY NAME" else ""
+    sql(
+      s"""
+         |INSERT INTO $tableName $byNameClause
+         |REPLACE ON $matchingCond
+         |$sourceQuery
+         |""".stripMargin)
+  }
+
+  protected def getLastCommitNumAddedAndRemovedBytes(deltaLog: DeltaLog): (Long, Long) = {
+    val changes = deltaLog.getChanges(deltaLog.update().version).flatMap(_._2).toSeq
+    val addedBytes = changes.collect { case a: AddFile => a.size }.sum
+    val removedBytes = changes.collect { case r: RemoveFile => r.getFileSize }.sum
+
+    (addedBytes, removedBytes)
+  }
+
+  object DataLayoutType extends Enumeration {
+    type DataLayoutType = Value
+    val PARTITIONED, CLUSTERED, NORMAL = Value
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
@@ -269,8 +269,8 @@ trait DeltaInsertReplaceUsingDFWriterTests
       val result = spark.read.format("delta").load(path).orderBy("value")
       // NULL rows are not matched by = comparison, so target_null stays
       checkAnswer(result,
-        Seq(Row(null, "source_null"), Row(null, "target_null"),
-            Row(1, "source"), Row(2, "target")))
+        Seq(Row(1, "source"), Row(null, "source_null"),
+            Row(2, "target"), Row(null, "target_null")))
 
       val deltaLog = DeltaLog.forTable(spark, path)
       val version = deltaLog.update().version
@@ -1135,28 +1135,26 @@ trait DeltaInsertReplaceUsingDFWriterTests
     }
   }
 
-  test("replaceUsing should fail when NOT NULL constraint is violated") {
+  test("replaceUsing should fail when CHECK constraint is violated") {
     withTempDir { dir =>
       val path = dir.getAbsolutePath
-      Seq((1, "a"), (2, "b")).toDF("id", "value")
+      Seq((1, 10), (2, 20)).toDF("id", "value")
         .write.format("delta").save(path)
-
-      sql(s"ALTER TABLE delta.`$path` CHANGE COLUMN id SET NOT NULL")
+      sql(s"ALTER TABLE delta.`$path` ADD CONSTRAINT positive_value CHECK (value > 0)")
 
       checkError(
         exception = intercept[AnalysisException] {
           writeReplaceUsingDF(
-            sourceDF = Seq((null, "source"))
-              .toDF("id", "value")
-              .selectExpr("CAST(id AS INT)", "value"),
+            sourceDF = Seq((1, -5)).toDF("id", "value"),
             target = path,
             replaceUsingCols = "id")
         },
         condition = "DELTA_REPLACE_ON_OR_USING_TABLE_CONSTRAINT_VIOLATION",
+        sqlState = Some("44000"),
         parameters = Map(
           "replaceExpression" -> ".*",
           "invariantViolationMessage" ->
-            "(?s).*DELTA_NOT_NULL_CONSTRAINT_VIOLATED.*"),
+            "(?s)\\[DELTA_VIOLATE_CONSTRAINT_WITH_VALUES\\] .*"),
         matchPVals = true
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
@@ -1162,9 +1162,6 @@ trait DeltaInsertReplaceUsingDFWriterTests
     }
   }
 
-  // Usage stats and logging
-
-
   test("source is materialized during replaceUsing") {
     withTempDir { dir =>
       val path = dir.getAbsolutePath

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
@@ -1,0 +1,1545 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
+import org.apache.spark.sql.functions.{col, concat, count, lit}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Common tests for replaceUsing option via DataFrame APIs (save(), insertInto(),
+ * and saveAsTable()).
+ */
+trait DeltaInsertReplaceUsingDFWriterTests
+  extends DeltaInsertReplaceOnOrUsingTestUtils {
+  import testImplicits._
+
+  /**
+   * Write the sourceDF to the target with replaceUsing.
+   */
+  protected def writeReplaceUsingDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceUsingCols: String,
+      writeMode: String = "overwrite",
+      mergeSchema: Boolean = false,
+      options: Map[String, String] = Map.empty): Unit
+
+  // Basic replaceUsing operations
+
+  test("replaceUsing with single column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (2, "source"), (4, "source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "source") ::
+          Row(3, "target") ::
+          Row(4, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing with multiple columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a", "target"), (1, "b", "target"), (2, "a", "target"))
+        .toDF("id", "key", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "a", "source"), (2, "b", "source"), (3, "a", "source"))
+          .toDF("id", "key", "value"),
+        target = path,
+        replaceUsingCols = "id, key")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "a", "source") ::
+          Row(1, "b", "target") ::
+          Row(2, "a", "target") ::
+          Row(2, "b", "source") ::
+          Row(3, "a", "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing with CDF enabled") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val numRowsPerFile = 10
+      val numFiles = 10
+      spark.range(0, numFiles * numRowsPerFile, 1, numFiles).toDF("id")
+        .write.format("delta")
+        .option(DeltaConfigs.CHANGE_DATA_FEED.key, true)
+        .save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = spark.range(0, 15).toDF("id"),
+        target = path,
+        replaceUsingCols = "id")
+
+      val replaceRowIds = Seq.range(0, 15, 1).toSet
+      val preRowIds = Seq.range(0, numFiles * numRowsPerFile).toSet
+      val postRowIDs = (preRowIds -- replaceRowIds).toSeq ++ replaceRowIds.toSeq
+      checkAnswer(spark.read.format("delta").load(path).select("id"), postRowIDs.toDF("id"))
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val version = deltaLog.update().version
+      val changesDF = CDCReader.changesToBatchDF(deltaLog, version, version, spark)
+        .select("id", CDCReader.CDC_TYPE_COLUMN_NAME)
+      val expectedAnswerDF =
+        replaceRowIds.toSeq.toDF("id")
+          .withColumn(CDCReader.CDC_TYPE_COLUMN_NAME, lit(CDCReader.CDC_TYPE_DELETE))
+          .union(
+            replaceRowIds.toSeq.toDF("id")
+              .withColumn(CDCReader.CDC_TYPE_COLUMN_NAME, lit(CDCReader.CDC_TYPE_INSERT)))
+      checkAnswer(changesDF, expectedAnswerDF)
+    }
+  }
+
+
+  test("replaceUsing with CDF enabled and no matching rows") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta")
+        .option(DeltaConfigs.CHANGE_DATA_FEED.key, true)
+        .save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((3, "source"), (4, "source")).toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(Row(1, "target"), Row(2, "target"), Row(3, "source"), Row(4, "source")))
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val version = deltaLog.update().version
+      val changesDF = CDCReader.changesToBatchDF(deltaLog, version, version, spark)
+        .select("id", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      // No deletes because no rows matched, only inserts
+      val expectedCDC =
+        Seq((3, "source", CDCReader.CDC_TYPE_INSERT),
+            (4, "source", CDCReader.CDC_TYPE_INSERT))
+          .toDF("id", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      checkAnswer(changesDF, expectedCDC)
+    }
+  }
+
+  test("replaceUsing with CDF enabled and all rows matching") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta")
+        .option(DeltaConfigs.CHANGE_DATA_FEED.key, true)
+        .save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (2, "source")).toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(Row(1, "source"), Row(2, "source")))
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val version = deltaLog.update().version
+      val changesDF = CDCReader.changesToBatchDF(deltaLog, version, version, spark)
+        .select("id", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      val expectedCDC =
+        Seq((1, "target", CDCReader.CDC_TYPE_DELETE_STRING),
+            (2, "target", CDCReader.CDC_TYPE_DELETE_STRING),
+            (1, "source", CDCReader.CDC_TYPE_INSERT),
+            (2, "source", CDCReader.CDC_TYPE_INSERT))
+          .toDF("id", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      checkAnswer(changesDF, expectedCDC)
+    }
+  }
+
+  test("replaceUsing with CDF enabled on multi-column key") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a", "target"), (1, "b", "target"), (2, "a", "target"))
+        .toDF("id", "key", "value")
+        .write.format("delta")
+        .option(DeltaConfigs.CHANGE_DATA_FEED.key, true)
+        .save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "a", "source")).toDF("id", "key", "value"),
+        target = path,
+        replaceUsingCols = "id, key")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id", "key"),
+        Seq(Row(1, "a", "source"), Row(1, "b", "target"), Row(2, "a", "target")))
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val version = deltaLog.update().version
+      val changesDF = CDCReader.changesToBatchDF(deltaLog, version, version, spark)
+        .select("id", "key", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      val expectedCDC =
+        Seq((1, "a", "target", CDCReader.CDC_TYPE_DELETE_STRING),
+            (1, "a", "source", CDCReader.CDC_TYPE_INSERT))
+          .toDF("id", "key", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      checkAnswer(changesDF, expectedCDC)
+    }
+  }
+
+
+  test("replaceUsing with CDF enabled and duplicate source rows matching same target") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta")
+        .option(DeltaConfigs.CHANGE_DATA_FEED.key, true)
+        .save(path)
+
+      // Source has two rows with id=1, both match target row id=1
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source_a"), (1, "source_b")).toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      val result = spark.read.format("delta").load(path).orderBy("id", "value")
+      checkAnswer(result,
+        Seq(Row(1, "source_a"), Row(1, "source_b"), Row(2, "target")))
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val version = deltaLog.update().version
+      val changesDF = CDCReader.changesToBatchDF(deltaLog, version, version, spark)
+        .select("id", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      // Target row id=1 should appear as DELETE exactly once
+      val deleteCount = changesDF
+        .filter(col(CDCReader.CDC_TYPE_COLUMN_NAME) === CDCReader.CDC_TYPE_DELETE_STRING)
+        .count()
+      assert(deleteCount === 1, "Expected exactly one DELETE CDC record for the matched target row")
+    }
+  }
+
+  test("replaceUsing with CDF enabled and NULL values in matching columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((Some(1), "target"), (None, "target_null"), (Some(2), "target"))
+        .toDF("id", "value")
+        .write.format("delta")
+        .option(DeltaConfigs.CHANGE_DATA_FEED.key, true)
+        .save(path)
+
+      // Source has a NULL id; EXISTS with NULL = NULL is false, so NULL row is not matched
+      writeReplaceUsingDF(
+        sourceDF = Seq((Some(1), "source"), (None, "source_null")).toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      val result = spark.read.format("delta").load(path).orderBy("value")
+      // NULL rows are not matched by = comparison, so target_null stays
+      checkAnswer(result,
+        Seq(Row(null, "source_null"), Row(null, "target_null"),
+            Row(1, "source"), Row(2, "target")))
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val version = deltaLog.update().version
+      val changesDF = CDCReader.changesToBatchDF(deltaLog, version, version, spark)
+        .select("id", "value", CDCReader.CDC_TYPE_COLUMN_NAME)
+      // Only id=1 should have DELETE CDC, NULL rows should not be deleted
+      val deleteCDC = changesDF
+        .filter(col(CDCReader.CDC_TYPE_COLUMN_NAME) === CDCReader.CDC_TYPE_DELETE_STRING)
+      checkAnswer(deleteCDC.select("id", "value"),
+        Seq(Row(1, "target")))
+    }
+  }
+
+  test("replaceUsing with empty source") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq.empty[(Int, String)].toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "target") :: Row(2, "target") :: Nil)
+    }
+  }
+
+  test("replaceUsing on empty but existing target") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq.empty[(Int, String)].toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (2, "source"), (3, "source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") :: Row(2, "source") :: Row(3, "source") :: Nil)
+    }
+  }
+
+  // Data matching semantics
+
+  test("replaceUsing with NULL values in matching column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((Some(1), "target"), (None, "target_null"), (Some(3), "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((Some(1), "source"), (None, "source_null"), (Some(4), "source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(null, "target_null") ::
+          Row(null, "source_null") ::
+          Row(1, "source") ::
+          Row(3, "target") ::
+          Row(4, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing with NULL values in multiple matching columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq[(Option[Int], Option[Int], String)](
+        (None, None, "target"),
+        (Some(1), None, "target"),
+        (Some(1), Some(2), "target"),
+        (Some(1), Some(3), "target"))
+        .toDF("col1", "col2", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq[(Option[Int], Option[Int], String)](
+          (None, None, "source"),
+          (Some(1), None, "source"),
+          (None, Some(1), "source"),
+          (Some(1), Some(2), "source"),
+          (Some(2), Some(3), "source"))
+          .toDF("col1", "col2", "value"),
+        target = path,
+        replaceUsingCols = "col1, col2")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(null, null, "target") ::
+          Row(null, null, "source") ::
+          Row(1, null, "target") ::
+          Row(1, null, "source") ::
+          Row(null, 1, "source") ::
+          Row(1, 2, "source") ::
+          Row(1, 3, "target") ::
+          Row(2, 3, "source") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing with string matching column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(("US", "Dylan"), ("UK", "Jennie"), ("IT", "Julia"))
+        .toDF("country", "name")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq(("US", "Sophie"), ("UK", "Oliver"), ("JP", "Yuki"))
+          .toDF("country", "name"),
+        target = path,
+        replaceUsingCols = "country")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row("US", "Sophie") ::
+          Row("UK", "Oliver") ::
+          Row("JP", "Yuki") ::
+          Row("IT", "Julia") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing replaces all matching rows when target has duplicates") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target1"), (1, "target2"), (2, "target1"), (2, "target2"),
+        (2, "target3"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (2, "source")).toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") :: Row(2, "source") :: Row(3, "target") :: Nil)
+    }
+  }
+
+  test("replaceUsing with filtered source only replaces matching subset") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (2, "target"), (3, "target"),
+        (3, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      val source = Seq((1, "source"), (2, "source"), (3, "source"))
+        .toDF("id", "value")
+        .filter($"id" <= 2)
+
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "source") ::
+          Row(3, "target") ::
+          Row(3, "target") ::
+          Row(3, "target") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing matches on non-adjacent columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, 10, 100, "target"),
+        (1, 20, 200, "target"),
+        (2, 30, 100, "target"),
+        (3, 40, 300, "target")
+      ).toDF("col1", "col2", "col3", "origin")
+        .write.format("delta").save(path)
+
+      val source = Seq(
+        (1, 99, 100, "source"),
+        (2, 99, 200, "source")
+      ).toDF("col1", "col2", "col3", "origin")
+
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "col1, col3")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, 99, 100, "source") ::
+          Row(1, 20, 200, "target") ::
+          Row(2, 30, 100, "target") ::
+          Row(2, 99, 200, "source") ::
+          Row(3, 40, 300, "target") :: Nil)
+    }
+  }
+
+  // Clustered and partitioned tables
+
+  test("replaceUsing on clustered table with matching on clustering column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a", "target"), (1, "b", "target"), (2, "a", "target"), (3, "a", "target"))
+        .toDF("cluster", "key", "value")
+        .write.format("delta").clusterBy("cluster").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "a", "source"), (2, "b", "source"), (4, "a", "source"))
+          .toDF("cluster", "key", "value"),
+        target = path,
+        replaceUsingCols = "cluster")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "a", "source") ::
+          Row(2, "b", "source") ::
+          Row(4, "a", "source") ::
+          Row(3, "a", "target") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing on clustered table with matching on non-clustering column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "a", "target"),
+        (1, "b", "target"),
+        (2, "a", "target"),
+        (3, "c", "target")
+      ).toDF("cluster", "key", "value")
+        .write.format("delta").clusterBy("cluster").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "a", "source"), (2, "b", "source"), (4, "d", "source"))
+          .toDF("cluster", "key", "value"),
+        target = path,
+        replaceUsingCols = "key")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "a", "source") ::
+          Row(2, "b", "source") ::
+          Row(4, "d", "source") ::
+          Row(3, "c", "target") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing on partitioned table with matching on partition column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a", "target"), (1, "b", "target"), (2, "a", "target"), (3, "a", "target"))
+        .toDF("part", "key", "value")
+        .write.format("delta").partitionBy("part").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "a", "source"), (2, "b", "source"), (4, "a", "source"))
+          .toDF("part", "key", "value"),
+        target = path,
+        replaceUsingCols = "part")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "a", "source") ::
+          Row(2, "b", "source") ::
+          Row(4, "a", "source") ::
+          Row(3, "a", "target") ::
+          Nil)
+    }
+  }
+
+  test("replaceUsing on partitioned table with matching on non-partition column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(
+        (1, "a", "target"),
+        (1, "b", "target"),
+        (2, "a", "target"),
+        (3, "c", "target")
+      ).toDF("part", "key", "value")
+        .write.format("delta").partitionBy("part").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "a", "source"), (2, "b", "source"), (4, "d", "source"))
+          .toDF("part", "key", "value"),
+        target = path,
+        replaceUsingCols = "key")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "a", "source") ::
+          Row(2, "b", "source") ::
+          Row(4, "d", "source") ::
+          Row(3, "c", "target") ::
+          Nil
+      )
+    }
+  }
+
+  // Column resolution and schema compatibility
+
+  test("replaceUsing with case insensitive column resolution") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        Seq((1, "target"), (2, "target"), (3, "target"))
+          .toDF("id", "value")
+          .write.format("delta").save(path)
+
+        writeReplaceUsingDF(
+          sourceDF = Seq((1, "source"), (4, "source"))
+            .toDF("ID", "VALUE"),
+          target = path,
+          replaceUsingCols = "ID")
+
+        checkAnswer(
+          spark.read.format("delta").load(path),
+          Row(1, "source") ::
+            Row(2, "target") ::
+            Row(3, "target") ::
+            Row(4, "source") ::
+            Nil
+        )
+      }
+    }
+  }
+
+  test("replaceUsing with case sensitive column resolution errors on casing mismatch") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        Seq((1, "target"), (2, "target"))
+          .toDF("id", "value")
+          .write.format("delta").save(path)
+
+        checkError(
+          exception = intercept[AnalysisException] {
+            writeReplaceUsingDF(
+              sourceDF = Seq((1, "source"), (4, "source"))
+                .toDF("ID", "VALUE"),
+              target = path,
+              replaceUsingCols = "ID")
+          },
+          condition = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
+          parameters = Map(
+            "colName" -> "`ID`",
+            "relationType" -> ".*",
+            "suggestion" -> ".*"),
+          matchPVals = true
+        )
+      }
+    }
+  }
+
+  test("replaceUsing with duplicate column references") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (3, "source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id, id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "target") ::
+          Row(3, "source") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing errors when source has extra columns without mergeSchema") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source", 100), (3, "source", 300))
+              .toDF("id", "value", "extra"),
+            target = path,
+            replaceUsingCols = "id")
+        },
+        condition = "DELTA_METADATA_MISMATCH",
+        parameters = Map.empty[String, String]
+      )
+    }
+  }
+
+  test("replaceUsing with fewer source columns fills missing target columns with null") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq(1, 3).toDF("id"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, null) ::
+          Row(2, "target") ::
+          Row(3, null) ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing errors when source has completely different column names") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source"), (3, "source"))
+              .toDF("key", "data"),
+            target = path,
+            replaceUsingCols = "key")
+        },
+        condition = "DELTA_METADATA_MISMATCH",
+        parameters = Map.empty[String, String]
+      )
+    }
+  }
+
+  test("replaceUsing with schema evolution") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source", 100), (3, "source", 300))
+          .toDF("id", "value", "new_col"),
+        target = path,
+        replaceUsingCols = "id",
+        mergeSchema = true)
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source", 100) ::
+          Row(2, "target", null) ::
+          Row(3, "source", 300) ::
+          Nil
+      )
+    }
+  }
+
+  // Column validation errors
+
+  test("replaceUsing column not in source and target errors") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source"), (2, "source")).toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "nonexistent_col")
+        },
+        condition = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
+        parameters = Map(
+          "colName" -> "`nonexistent_col`",
+          "relationType" -> "table",
+          "suggestion" -> ".*"),
+        matchPVals = true
+      )
+    }
+  }
+
+  test("replaceUsing column exists in table but not in source errors") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target", "us"), (2, "target", "eu"))
+        .toDF("id", "value", "region")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source"), (3, "source"))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "region")
+        },
+        condition = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
+        parameters = Map(
+          "colName" -> "`region`",
+          "relationType" -> "query",
+          "suggestion" -> ".*"),
+        matchPVals = true
+      )
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "target", "us") ::
+          Row(2, "target", "eu") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing on non-existent path errors") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath + "/new_table"
+      checkError(
+        exception = intercept[DeltaAnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "a"), (2, "b"), (3, "c"))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "id")
+        },
+        condition = "DELTA_PATH_DOES_NOT_EXIST",
+        parameters = Map("path" -> ".*"),
+        matchPVals = true
+      )
+    }
+  }
+
+  // Type compatibility
+
+  test("replaceUsing col with source having wider data type than target") {
+    withSQLConf(
+        DeltaConfigs.ENABLE_TYPE_WIDENING.defaultTablePropertyKey -> "true") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        Seq(125.toByte, 126.toByte, 127.toByte).toDF("col")
+          .withColumn("value", lit("target"))
+          .write.format("delta").save(path)
+
+        writeReplaceUsingDF(
+          sourceDF = Seq(126.toShort, 127.toShort, 10000.toShort).toDF("col")
+            .withColumn("value", lit("source")),
+          target = path,
+          replaceUsingCols = "col",
+          mergeSchema = true)
+
+        checkAnswer(
+          spark.read.format("delta").load(path),
+          Row(125, "target") ::
+            Row(126, "source") ::
+            Row(127, "source") ::
+            Row(10000, "source") ::
+            Nil
+        )
+      }
+    }
+  }
+
+  test("replaceUsing col with target having wider data type than source") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq(126.toShort, 127.toShort, 10000.toShort).toDF("col")
+        .withColumn("value", lit("target"))
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq(125.toByte, 126.toByte, 127.toByte).toDF("col")
+          .withColumn("value", lit("source")),
+        target = path,
+        replaceUsingCols = "col")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(125, "source") ::
+          Row(126, "source") ::
+          Row(127, "source") ::
+          Row(10000, "target") ::
+          Nil
+      )
+    }
+  }
+
+  // Source DataFrame transformations
+
+  test("replaceUsing with source from parquet table") {
+    withTempDir { targetDir =>
+      withTempDir { sourceDir =>
+        val targetPath = targetDir.getAbsolutePath
+        val sourcePath = sourceDir.getAbsolutePath
+
+        Seq((1, "target"), (2, "target"), (3, "target"))
+          .toDF("id", "value")
+          .write.format("delta").save(targetPath)
+
+        Seq((1, "source"), (4, "source"))
+          .toDF("id", "value")
+          .write.format("parquet").mode("overwrite").save(sourcePath)
+
+        writeReplaceUsingDF(
+          sourceDF = spark.read.format("parquet").load(sourcePath),
+          target = targetPath,
+          replaceUsingCols = "id")
+
+        checkAnswer(
+          spark.read.format("delta").load(targetPath),
+          Row(1, "source") ::
+            Row(2, "target") ::
+            Row(3, "target") ::
+            Row(4, "source") ::
+            Nil
+        )
+      }
+    }
+  }
+
+  test("replaceUsing self-referencing (read and write same table)") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = spark.read.format("delta").load(path)
+          .filter($"id" <= 2)
+          .withColumn("value", lit("self_updated")),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "self_updated") ::
+          Row(2, "self_updated") ::
+          Row(3, "target") ::
+          Nil
+      )
+    }
+  }
+
+  test("DataFrame alias before write does not affect replaceUsing") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (4, "source"))
+          .toDF("id", "value")
+          .alias("some_alias"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Row(4, "source") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing with source from Delta table read") {
+    withTempDir { targetDir =>
+      withTempDir { sourceDir =>
+        val targetPath = targetDir.getAbsolutePath
+        val sourcePath = sourceDir.getAbsolutePath
+
+        Seq((1, "target"), (2, "target"), (3, "target"))
+          .toDF("id", "value")
+          .write.format("delta").save(targetPath)
+
+        Seq((1, "source"), (4, "source"))
+          .toDF("id", "value")
+          .write.format("delta").save(sourcePath)
+
+        writeReplaceUsingDF(
+          sourceDF = spark.read.format("delta").load(sourcePath),
+          target = targetPath,
+          replaceUsingCols = "id")
+
+        checkAnswer(
+          spark.read.format("delta").load(targetPath),
+          Row(1, "source") ::
+            Row(2, "target") ::
+            Row(3, "target") ::
+            Row(4, "source") ::
+            Nil
+        )
+      }
+    }
+  }
+
+  test("replaceUsing with source from join") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      val left = Seq((1, "left"), (4, "left")).toDF("id", "label")
+      val right = Seq((1, "right"), (4, "right")).toDF("id", "tag")
+      val source = left.join(right, "id")
+        .select($"id", $"label".as("value"))
+
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "left") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Row(4, "left") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing with source from groupBy aggregation") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      val source = Seq((1, "a"), (1, "b"), (4, "c"))
+        .toDF("id", "item")
+        .groupBy("id")
+        // scalastyle:off countstring
+        .agg(concat(lit("agg_"), count("*").cast("string")).as("value"))
+        // scalastyle:on countstring
+
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "agg_2") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Row(4, "agg_1") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing with source from union") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      val part1 = Seq((1, "source1")).toDF("id", "value")
+      val part2 = Seq((4, "source2")).toDF("id", "value")
+      val source = part1.union(part2)
+
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source1") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Row(4, "source2") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing with source from select/withColumn") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      val source = Seq((1, 100), (4, 400))
+        .toDF("id", "num")
+        .withColumn("value", concat(lit("val_"), $"num".cast("string")))
+        .select("id", "value")
+
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "val_100") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Row(4, "val_400") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing with source from sql() query") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      Seq((1, "source"), (4, "source")).toDF("id", "value").createOrReplaceTempView("src")
+      val source = sql("SELECT id, value FROM src")
+
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Row(4, "source") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing should fail when NOT NULL constraint is violated") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a"), (2, "b")).toDF("id", "value")
+        .write.format("delta").save(path)
+
+      sql(s"ALTER TABLE delta.`$path` CHANGE COLUMN id SET NOT NULL")
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((null, "source"))
+              .toDF("id", "value")
+              .selectExpr("CAST(id AS INT)", "value"),
+            target = path,
+            replaceUsingCols = "id")
+        },
+        condition = "DELTA_REPLACE_ON_OR_USING_TABLE_CONSTRAINT_VIOLATION",
+        parameters = Map(
+          "replaceExpression" -> ".*",
+          "invariantViolationMessage" ->
+            "(?s).*DELTA_NOT_NULL_CONSTRAINT_VIOLATED.*"),
+        matchPVals = true
+      )
+    }
+  }
+
+  // Usage stats and logging
+
+
+  test("source is materialized during replaceUsing") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value").write.format("delta").save(path)
+
+      val source = Seq((1, "source"), (4, "source")).toDF("id", "value")
+      writeReplaceUsingDF(
+        sourceDF = source,
+        target = path,
+        replaceUsingCols = "id")
+    }
+  }
+
+  // Table constraints and option handling
+
+  test("replaceUsing is blocked on appendOnly table") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta")
+        .option("delta.appendOnly", "true")
+        .save(path)
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "target") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Nil
+      )
+
+      checkError(
+        exception = intercept[DeltaUnsupportedOperationException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source"), (4, "source"))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "id")
+        },
+        condition = "DELTA_CANNOT_MODIFY_APPEND_ONLY",
+        parameters = Map("table_name" -> ".*", "config" -> "delta.appendOnly"),
+        matchPVals = true
+      )
+
+      // Data unchanged after blocked operation.
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "target") ::
+          Row(2, "target") ::
+          Row(3, "target") ::
+          Nil
+      )
+    }
+  }
+
+  test("replaceUsing does not apply delta config options to existing table") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      assert(!DeltaConfigs.IS_APPEND_ONLY.fromMetaData(deltaLog.update().metadata))
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (3, "source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id",
+        options = Map("delta.appendOnly" -> "true"))
+
+      // appendOnly is not enabled because replaceUsing doesn't update table metadata.
+      assert(!DeltaConfigs.IS_APPEND_ONLY.fromMetaData(deltaLog.update().metadata))
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "source") ::
+          Row(2, "target") ::
+          Row(3, "source") ::
+          Nil
+      )
+    }
+  }
+
+  test("DPO kill switch does not block replaceUsing") {
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "false") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        Seq((0, "target"), (1, "target"))
+          .toDF("id", "value")
+          .write.format("delta").save(path)
+
+        writeReplaceUsingDF(
+          sourceDF = Seq((1, "source"), (2, "source")).toDF("id", "value"),
+          target = path,
+          replaceUsingCols = "id")
+
+        checkAnswer(
+          spark.read.format("delta").load(path),
+          Row(0, "target") ::
+            Row(1, "source") ::
+            Row(2, "source") ::
+            Nil
+        )
+      }
+    }
+  }
+
+  for (partitionOverwriteMode <- Seq("static", "dynamic")) {
+    test(s"SQL Conf partitionOverwriteMode=$partitionOverwriteMode " +
+        "does not affect replaceUsing") {
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> partitionOverwriteMode) {
+        withTempDir { dir =>
+          val path = dir.getAbsolutePath
+          Seq((0, "target"), (1, "target"))
+            .toDF("id", "value")
+            .write.format("delta").save(path)
+
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source"), (2, "source")).toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "id")
+
+          checkAnswer(
+            spark.read.format("delta").load(path),
+            Row(0, "target") :: Row(1, "source") :: Row(2, "source") :: Nil)
+        }
+      }
+    }
+  }
+
+  test("replaceUsing with empty string errors") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[DeltaIllegalArgumentException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source"), (3, "source"))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "")
+        },
+        condition = "DELTA_ILLEGAL_OPTION",
+        sqlState = Some("42616"),
+        parameters = Map(
+          "name" -> "replaceUsing",
+          "input" -> "",
+          "explain" -> "must not contain empty column names")
+      )
+    }
+  }
+
+  for (optionValue <- Seq(",", "id,,value", "id,", ",id")) {
+    test(s"replaceUsing with empty column name errors: '$optionValue'") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        Seq((1, "target"), (2, "target"))
+          .toDF("id", "value")
+          .write.format("delta").save(path)
+
+        checkError(
+          exception = intercept[DeltaIllegalArgumentException] {
+            writeReplaceUsingDF(
+              sourceDF = Seq((1, "source"), (3, "source"))
+                .toDF("id", "value"),
+              target = path,
+              replaceUsingCols = optionValue)
+          },
+          condition = "DELTA_ILLEGAL_OPTION",
+          sqlState = Some("42616"),
+          parameters = Map(
+            "name" -> "replaceUsing",
+            "input" -> optionValue,
+            "explain" -> "must not contain empty column names")
+        )
+      }
+    }
+  }
+
+  // Option parsing robustness
+
+  for (optionValue <- Seq(
+      "id,key",
+      "id ,key",
+      "id, key",
+      "id , key",
+      " id , key ",
+      "id,  key",
+      "  id  ,  key  ")) {
+    test(s"replaceUsing option parsing is robust: '$optionValue'") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        Seq((1, "a", "target"), (2, "b", "target"))
+          .toDF("id", "key", "value")
+          .write.format("delta").save(path)
+
+        writeReplaceUsingDF(
+          sourceDF = Seq((1, "a", "source"))
+            .toDF("id", "key", "value"),
+          target = path,
+          replaceUsingCols = optionValue)
+
+        checkAnswer(
+          spark.read.format("delta").load(path),
+          Row(1, "a", "source") ::
+            Row(2, "b", "target") ::
+            Nil
+        )
+      }
+    }
+  }
+
+  test("replaceUsing preserves table properties") {
+    withTable("target") {
+      sql("""CREATE TABLE target (id INT, data STRING) USING delta
+             TBLPROPERTIES ('custom.key' = 'value', 'delta.enableChangeDataFeed' = 'true')""")
+      sql("INSERT INTO target VALUES (1, 'old')")
+
+      val path = DeltaLog.forTable(spark, spark.sessionState.catalog
+        .getTableMetadata(spark.sessionState.sqlParser
+          .parseTableIdentifier("target"))).dataPath.toString
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "new")).toDF("id", "data"),
+        target = path,
+        replaceUsingCols = "id")
+
+      val props = sql("SHOW TBLPROPERTIES target").collect()
+        .map(r => r.getString(0) -> r.getString(1)).toMap
+      assert(props("custom.key") === "value")
+      assert(props("delta.enableChangeDataFeed") === "true")
+    }
+  }
+
+
+  test("replaceUsing with userMetadata preserves metadata in commit") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target")).toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (3, "source")).toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id",
+        options = Map(DeltaOptions.USER_METADATA_OPTION -> "replaceUsingMeta"))
+
+      val history = io.delta.tables.DeltaTable.forPath(spark, path)
+        .history(1).as[DeltaHistory].head
+      assert(history.userMetadata === Some("replaceUsingMeta"))
+    }
+  }
+
+  test("replaceUsing with targetAlias replaces data normally") {
+    // User-provided targetAlias is silently overridden by the internal alias for replaceUsing,
+    // since replaceUsing takes top-level column names, not expressions that could reference a
+    // table alias.
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (3, "source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id",
+        options = Map("targetAlias" -> "t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(Row(1, "source"), Row(2, "target"), Row(3, "source")))
+    }
+  }
+
+  test("replaceUsing rejects multi-part columns - struct column") {
+    // replaceUsing only accepts top-level column names. Multi-part names like "x.id"
+    // (struct field references) are not supported and fail during column resolution.
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      spark.sql(
+        """SELECT named_struct('id', 1) x, 'a' value
+          |UNION ALL
+          |SELECT named_struct('id', 2) x, 'b' value""".stripMargin)
+        .write.format("delta").save(path)
+
+      val sourceDF = spark.sql("SELECT named_struct('id', 1) x, 'c' value")
+
+      val e = intercept[NoSuchElementException] {
+        writeReplaceUsingDF(
+          sourceDF = sourceDF,
+          target = path,
+          replaceUsingCols = "x.id")
+      }
+      assert(e.getMessage.contains("None.get"))
+    }
+  }
+
+  test("replaceUsing rejects multi-part columns with targetAlias") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a"), (2, "b")).toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "c")).toDF("id", "value").alias("t"),
+            target = path,
+            replaceUsingCols = "t.id",
+            options = Map("targetAlias" -> "t"))
+        },
+        condition = "UNRESOLVED_INSERT_REPLACE_USING_COLUMN",
+        parameters = Map(
+          "colName" -> "`t`.`id`",
+          "relationType" -> "table",
+          "suggestion" -> "`id`, `value`")
+      )
+    }
+  }
+
+  test("replaceUsing option key is case insensitive") {
+    Seq("REPLACEUSING", "replaceusing", "ReplaceUsing", "rEpLaCeUsInG").foreach { key =>
+      withClue(s"option key: $key") {
+        withTempDir { dir =>
+          val path = dir.getAbsolutePath
+          Seq((1, "original"), (2, "original"))
+            .toDF("id", "value")
+            .write.format("delta").save(path)
+
+          Seq((1, "updated"))
+            .toDF("id", "value")
+            .write.format("delta")
+            .mode("overwrite")
+            .option(key, "id")
+            .save(path)
+
+          checkAnswer(
+            spark.read.format("delta").load(path),
+            Seq(Row(1, "updated"), Row(2, "original")))
+        }
+      }
+    }
+  }
+
+  test("replaceUsing in Append mode does not do selective overwrite") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (3, "source")).toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id",
+        writeMode = "append")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id", "value"),
+        Row(1, "source") ::
+          Row(1, "target") ::
+          Row(2, "target") ::
+          Row(3, "source") ::
+          Nil
+      )
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
@@ -1484,7 +1484,7 @@ trait DeltaInsertReplaceUsingDFWriterTests
         parameters = Map(
           "colName" -> "`t`.`id`",
           "relationType" -> "table",
-          "suggestion" -> "id, value")
+          "suggestion" -> "`id`, `value`")
       )
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
@@ -1484,7 +1484,7 @@ trait DeltaInsertReplaceUsingDFWriterTests
         parameters = Map(
           "colName" -> "`t`.`id`",
           "relationType" -> "table",
-          "suggestion" -> "`id`, `value`")
+          "suggestion" -> "id, value")
       )
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
+import org.apache.spark.sql.functions.struct
+import org.apache.spark.sql.internal.SQLConf
+
+class DeltaInsertReplaceUsingDFWriterV1SaveSuite
+  extends DeltaInsertReplaceUsingDFWriterTests {
+
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key, "true")
+
+  override protected def writeReplaceUsingDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceUsingCols: String,
+      writeMode: String = "overwrite",
+      mergeSchema: Boolean = false,
+      options: Map[String, String] = Map.empty): Unit = {
+    var writer = sourceDF
+      .write.format("delta")
+      .mode(writeMode)
+      .option("replaceUsing", replaceUsingCols)
+    if (mergeSchema) {
+      writer = writer.option("mergeSchema", "true")
+    }
+    options.foreach { case (k, v) => writer = writer.option(k, v) }
+    writer.save(target)
+  }
+
+  test("save with replaceUsing: inserts by name with misaligned column positions") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+
+      Seq((1, "a_target", "b_target"), (2, "a_target", "b_target"))
+        .toDF("id", "col_a", "col_b")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "b_source", "a_source"), (3, "b_source", "a_source"))
+          .toDF("id", "col_b", "col_a"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, "a_source", "b_source") ::
+          Row(2, "a_target", "b_target") ::
+          Row(3, "a_source", "b_source") ::
+          Nil
+      )
+    }
+  }
+
+  test("save with replaceUsing: inserts struct fields by name") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target_a", "target_b"))
+        .toDF("id", "a", "b")
+        .select($"id", struct($"a", $"b").as("info"))
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source_b", "source_a"))
+          .toDF("id", "b", "a")
+          .select($"id", struct($"a", $"b").as("info")),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row(1, Row("source_a", "source_b")) ::
+          Nil
+      )
+    }
+  }
+
+
+  test("save with replaceUsing: rejects Long source to Int target (no implicit narrowing)") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1L, "source"), (3L, "source"))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "id")
+        },
+        condition = "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map("currentField" -> ".*", "updateField" -> ".*"),
+        matchPVals = true
+      )
+    }
+  }
+
+  test("save with replaceUsing: rejects type mismatch on non-replaceUsing column") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1L, "source"), (3L, "source"))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "value")
+        },
+        condition = "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map("currentField" -> ".*", "updateField" -> ".*"),
+        matchPVals = true
+      )
+    }
+  }
+
+  test("save with replaceUsing: rejects Int source to Long target (no implicit widening)") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1L, "target"), (2L, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, "source"), (3, "source"))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "id")
+        },
+        condition = "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map("currentField" -> ".*", "updateField" -> ".*"),
+        matchPVals = true
+      )
+    }
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
@@ -97,7 +97,6 @@ class DeltaInsertReplaceUsingDFWriterV1SaveSuite
     }
   }
 
-
   test("save with replaceUsing: rejects Long source to Int target (no implicit narrowing)") {
     withTempDir { dir =>
       val path = dir.getAbsolutePath
@@ -163,5 +162,4 @@ class DeltaInsertReplaceUsingDFWriterV1SaveSuite
       )
     }
   }
-
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Following https://github.com/delta-io/delta/pull/6445, which introduces the `replaceOn`/`replaceUsing` options

1. Users can now specify the `.option('replaceOn', 'replaceOnCond')` for the DataFrameWriterV1 `save()`, and also other DataFrameWriterV1 APIs `insertInto()` and `saveAsTable()` in the subsequent PRs.

2. Users can now specify the .`option('replaceUsing', 'replace_using_column_list')` for the `DataFrameWriterV1 save()`.

3. Users can also now specify the `.option('targetAlias', 'targetAliasStr')`, to be able to provide an alias for the table, to be used in the `replaceOn` option.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes, please see above.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->


