### PR TITLE
[kernel-spark] Support schema tracking log in v2 analysis stage

### DIFF
--- a/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
+++ b/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
@@ -16,9 +16,8 @@
 
 package io.delta.internal
 
-import scala.jdk.OptionConverters._
-
 import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.read.MetadataEvolutionHandler
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 
@@ -26,30 +25,32 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.connector.catalog.Identifier
 
 /**
+ * TODO(#5319): remove this class after Spark supports directly create table reflect cdc/trackingLog
  * Plumbs read options into a V2 [[StreamingRelationV2]]'s [[SparkTable]] when those options
  * change a property the table derives from them.
  */
 class ApplyV2ReadOptions extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
-    case r @ StreamingRelationV2(_, _, sparkTable: SparkTable, extraOptions, _, _, Some(ident), _)
-        if CDCReader.isCDCRead(extraOptions)
-          && !r.output.exists(a => CDCSchemaContext.isCDCColumn(a.name)) =>
-      val newTable = sparkTable.getCatalogTable.toScala match {
-        case Some(catalogTable) => new SparkTable(ident, catalogTable, extraOptions)
-        case None => new SparkTable(ident, sparkTable.getTablePath.toString, extraOptions)
+    case s @ StreamingRelationV2(_, _, table: SparkTable, extraOptions, _, _, _, _)
+        if (CDCReader.isCDCRead(extraOptions) &&
+              !s.output.exists(a => CDCSchemaContext.isCDCColumn(a.name))) ||
+           MetadataEvolutionHandler.shouldPropagateSchemaTrackingToTable(
+             extraOptions, table.getOptions) =>
+      val merged = new java.util.HashMap[String, String]()
+      merged.putAll(table.getOptions)
+      merged.putAll(extraOptions.asCaseSensitiveMap())
+      val rebuilt = if (table.getCatalogTable.isPresent) {
+        new SparkTable(table.getIdentifier, table.getCatalogTable.get, merged)
+      } else {
+        new SparkTable(table.getIdentifier, table.getTablePath.toString, merged)
       }
-      StreamingRelationV2(
+      s.copy(
         source = None,
-        sourceName = r.sourceName,
-        table = newTable,
-        extraOptions = extraOptions,
-        output = toAttributes(newTable.schema()),
-        catalog = r.catalog,
-        identifier = Some(ident),
+        table = rebuilt,
+        output = toAttributes(rebuilt.schema),
         v1Relation = None)
   }
 }

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
@@ -21,7 +21,9 @@ import java.util.{HashMap => JHashMap}
 
 import scala.jdk.CollectionConverters._
 
+import io.delta.kernel.internal.SnapshotImpl
 import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -29,14 +31,14 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTableType}
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.delta.DeltaOptions
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.delta.Relocated.StreamingRelation
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
-import org.apache.spark.sql.delta.sources.{DeltaSQLConf, DeltaSourceUtils}
+import org.apache.spark.sql.delta.sources.{DeltaSourceMetadataTrackingLog, DeltaSourceUtils, DeltaSQLConf, PersistedMetadata}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.connector.catalog.Identifier
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
@@ -237,6 +239,270 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
         val once = rule.apply(plan)
         val twice = rule.apply(once)
         assert(twice eq once, "Second application should return the same plan instance")
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rebuild StreamingRelationV2 if provided schema tracking log provided
+  // ---------------------------------------------------------------------------
+
+  /** The data-schema seeded into the tracking log by [[seedSchemaLogWithExtraColumn]]. */
+  private val seededFieldNames: Seq[String] = Seq("id", "extra")
+
+  private def buildStreamingRelationV2(
+      table: SparkTable, extraOptions: Map[String, String]): StreamingRelationV2 = {
+    StreamingRelationV2(
+      source = None,
+      sourceName = "delta",
+      table = table,
+      extraOptions = new CaseInsensitiveStringMap(extraOptions.asJava),
+      output = toAttributes(table.schema),
+      catalog = None,
+      identifier = Some(table.getIdentifier),
+      v1Relation = None)
+  }
+
+  /**
+   * Pre-seed the schema-tracking log at `schemaLogPath` with a 2-column schema
+   * (`id LONG, extra STRING`) that differs from the underlying snapshot's 1-column schema
+   */
+  private def seedSchemaLogWithExtraColumn(tablePath: String, schemaLogPath: String): Unit = {
+    val deltaLog = DeltaLog.forTable(spark, tablePath)
+    val snapshotManager =
+      new PathBasedSnapshotManager(tablePath, deltaLog.newDeltaHadoopConf())
+    val tableId =
+      snapshotManager.loadLatestSnapshot.asInstanceOf[SnapshotImpl].getMetadata.getId
+    val trackingLog = DeltaSourceMetadataTrackingLog.create(
+      spark, schemaLogPath, tableId, tablePath, parameters = Map.empty[String, String])
+    val customSchemaJson =
+      """{"type":"struct","fields":[
+        |{"name":"id","type":"long","nullable":true,"metadata":{}},
+        |{"name":"extra","type":"string","nullable":true,"metadata":{}}]}""".stripMargin
+    val emptyPartitionJson = """{"type":"struct","fields":[]}"""
+    val seededEntry = PersistedMetadata(
+      tableId,
+      deltaCommitVersion = 0L,
+      dataSchemaJson = customSchemaJson,
+      partitionSchemaJson = emptyPartitionJson,
+      sourceMetadataPath = tablePath + "/_delta_log/_streaming_metadata")
+    trackingLog.writeNewMetadata(seededEntry, replaceCurrent = false)
+  }
+
+  /** Asserts the table's schema matches the entry written by [[seedSchemaLogWithExtraColumn]]. */
+  private def assertSchemaMatchesSeededLogEntry(table: SparkTable): Unit = {
+    assert(table.schema.fieldNames.toSeq == seededFieldNames)
+    assert(table.schema.fields(1).dataType == StringType)
+  }
+
+  /**
+   * Build a catalog-backed SparkTable rooted at `tableLocationUri`. Mirrors the common production
+   * path through DeltaCatalog and is the default for tests that do not specifically distinguish
+   * between path-based and catalog-based construction.
+   */
+  private def buildCatalogBasedSparkTable(
+      tableLocationUri: URI, options: JHashMap[String, String]): SparkTable = {
+    val catalogTable = createCatalogTable(tableLocationUri, ucManaged = false)
+    val identifier = Identifier.of(
+      catalogTable.identifier.database.toArray, catalogTable.identifier.table)
+    new SparkTable(identifier, catalogTable, options)
+  }
+
+  private def applyReadOptions(plan: LogicalPlan): LogicalPlan = {
+    new ApplyV2ReadOptions().apply(plan)
+  }
+
+  test("schema-tracking rebuild: path-based SparkTable picks up the persisted schema") {
+    withTempDir { tableDir =>
+      withTempDir { schemaLogDir =>
+        val tablePath = tableDir.getCanonicalPath
+        createDeltaTable(tablePath) // snapshot schema: id BIGINT
+        val schemaLogPath = schemaLogDir.getCanonicalPath
+        seedSchemaLogWithExtraColumn(tablePath, schemaLogPath)
+
+        val identifier = Identifier.of(Array("default"), "tbl")
+        val table = new SparkTable(identifier, tablePath)
+        assert(!table.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
+
+        val plan = buildStreamingRelationV2(
+          table, Map(DeltaOptions.SCHEMA_TRACKING_LOCATION -> schemaLogPath))
+        val result = applyReadOptions(plan)
+        assertV2(result)
+        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+
+        assert(rebuiltTable ne table, "rebuild should produce a new SparkTable")
+        assert(rebuiltTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
+        assert(rebuiltTable.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION) ==
+          schemaLogPath)
+        assert(!rebuiltTable.getCatalogTable.isPresent,
+          "path branch should not have catalogTable")
+        // Rebuilt schema is driven by the persisted entry, not the snapshot.
+        assertSchemaMatchesSeededLogEntry(rebuiltTable)
+        // And the rule's output is re-derived from that rebuilt schema.
+        assert(result.output.map(_.name) == seededFieldNames)
+
+        // Idempotent: re-applying the rule does not rebuild a second time.
+        val reappliedResult = applyReadOptions(result).asInstanceOf[StreamingRelationV2]
+        assert(reappliedResult.table eq rebuiltTable, "re-applying rule should not rebuild")
+      }
+    }
+  }
+
+  test("schema-tracking rebuild: catalog-based SparkTable picks up the persisted schema and " +
+      "keeps its CatalogTable") {
+    withTempDir { tableDir =>
+      withTempDir { schemaLogDir =>
+        val tablePath = tableDir.getCanonicalPath
+        createDeltaTable(tablePath)
+        val schemaLogPath = schemaLogDir.getCanonicalPath
+        seedSchemaLogWithExtraColumn(tablePath, schemaLogPath)
+
+        val table = buildCatalogBasedSparkTable(tableDir.toURI, new JHashMap[String, String]())
+        assert(!table.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
+        assert(table.getCatalogTable.isPresent)
+
+        val plan = buildStreamingRelationV2(
+          table, Map(DeltaOptions.SCHEMA_TRACKING_LOCATION -> schemaLogPath))
+        val result = applyReadOptions(plan)
+        assertV2(result)
+        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+
+        assert(rebuiltTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
+        assert(rebuiltTable.getCatalogTable.isPresent,
+          "catalog branch should keep CatalogTable")
+        assertSchemaMatchesSeededLogEntry(rebuiltTable)
+      }
+    }
+  }
+
+  test("schema-tracking rebuild: triggered by SCHEMA_TRACKING_LOCATION_ALIAS option key") {
+    withTempDir { tableDir =>
+      withTempDir { schemaLogDir =>
+        val tablePath = tableDir.getCanonicalPath
+        createDeltaTable(tablePath)
+        val schemaLogPath = schemaLogDir.getCanonicalPath
+        seedSchemaLogWithExtraColumn(tablePath, schemaLogPath)
+
+        val table = buildCatalogBasedSparkTable(tableDir.toURI, new JHashMap[String, String]())
+
+        val plan = buildStreamingRelationV2(
+          table, Map(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS -> schemaLogPath))
+        val result = applyReadOptions(plan)
+        assertV2(result)
+        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+
+        assert(rebuiltTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS))
+        assert(rebuiltTable.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS) ==
+          schemaLogPath)
+        assertSchemaMatchesSeededLogEntry(rebuiltTable)
+      }
+    }
+  }
+
+  test("schema-tracking rebuild: skipped when extraOptions has no schema-tracking option") {
+    withTempDir { tableDir =>
+      val tablePath = tableDir.getCanonicalPath
+      createDeltaTable(tablePath)
+      val table = buildCatalogBasedSparkTable(tableDir.toURI, new JHashMap[String, String]())
+
+      val plan = buildStreamingRelationV2(table, Map.empty)
+      val result = applyReadOptions(plan)
+      assert(result eq plan, "no rebuild expected when schema-tracking option not present")
+    }
+  }
+
+  test("schema-tracking rebuild: skipped when SparkTable already carries the " +
+      "schema-tracking option") {
+    withTempDir { tableDir =>
+      withTempDir { schemaLogDir =>
+        val tablePath = tableDir.getCanonicalPath
+        createDeltaTable(tablePath)
+        val schemaLogPath = schemaLogDir.getCanonicalPath
+        val tableOptions = new JHashMap[String, String]()
+        tableOptions.put(DeltaOptions.SCHEMA_TRACKING_LOCATION, schemaLogPath)
+        val table = buildCatalogBasedSparkTable(tableDir.toURI, tableOptions)
+        assert(table.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
+
+        val plan = buildStreamingRelationV2(
+          table, Map(DeltaOptions.SCHEMA_TRACKING_LOCATION -> schemaLogPath))
+        val result = applyReadOptions(plan)
+        assert(result eq plan, "no rebuild expected when table already carries the option")
+      }
+    }
+  }
+
+  test("schema-tracking via V1 StreamingRelation: option propagates through V1 -> V2 conversion") {
+    // Counterpart to the V2 rebuild tests above: those start from StreamingRelationV2 and exercise
+    // the rebuild branch. This test starts from a V1 StreamingRelation carrying the schema-tracking
+    // option in dataSource.options, and verifies the V1 -> V2 conversion branch hands the option to
+    // the new SparkTable so its schema is driven by the persisted log entry.
+    withTempDir { tableDir =>
+      withTempDir { schemaLogDir =>
+        val tablePath = tableDir.getCanonicalPath
+        createDeltaTable(tablePath)
+        val schemaLogPath = schemaLogDir.getCanonicalPath
+        seedSchemaLogWithExtraColumn(tablePath, schemaLogPath)
+
+        val catalogTable = createCatalogTable(tableDir.toURI, ucManaged = false)
+        val dataSource = DataSource(
+          sparkSession = spark,
+          userSpecifiedSchema = None,
+          className = "delta",
+          options = Map(
+            "path" -> tablePath,
+            DeltaOptions.SCHEMA_TRACKING_LOCATION -> schemaLogPath),
+          catalogTable = Some(catalogTable))
+        val plan = StreamingRelation(dataSource)
+
+        // STRICT mode forces V1 -> V2 conversion in ApplyV2Streaming.
+        withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "STRICT") {
+          val result = applyRules(plan)
+          assertV2(result)
+          val convertedTable =
+            result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+          assert(convertedTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
+          assert(convertedTable.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION) ==
+            schemaLogPath)
+          // Schema is driven by the seeded log entry, not the underlying snapshot.
+          assertSchemaMatchesSeededLogEntry(convertedTable)
+          assert(result.output.map(_.name) == seededFieldNames)
+        }
+      }
+    }
+  }
+
+  test("CDC + schema-tracking co-occurrence: single rebuild applies both transformations") {
+    withTempDir { tableDir =>
+      withTempDir { schemaLogDir =>
+        val tablePath = tableDir.getCanonicalPath
+        createDeltaTable(tablePath)
+        val schemaLogPath = schemaLogDir.getCanonicalPath
+        seedSchemaLogWithExtraColumn(tablePath, schemaLogPath)
+
+        val table = buildCatalogBasedSparkTable(tableDir.toURI, new JHashMap[String, String]())
+        val plan = buildStreamingRelationV2(table, Map(
+          DeltaOptions.SCHEMA_TRACKING_LOCATION -> schemaLogPath,
+          DeltaOptions.CDC_READ_OPTION -> "true"))
+
+        val result = applyReadOptions(plan)
+        assertV2(result)
+        val rebuilt = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+
+        // Both options land on the rebuilt table in a single pass.
+        assert(rebuilt.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION) == schemaLogPath)
+        assert(rebuilt.getOptions.get(DeltaOptions.CDC_READ_OPTION) == "true")
+        // Schema reflects both transformations: seeded log columns + appended CDC columns.
+        val expected = Seq(
+          "id", "extra",
+          CDCReader.CDC_TYPE_COLUMN_NAME,
+          CDCReader.CDC_COMMIT_VERSION,
+          CDCReader.CDC_COMMIT_TIMESTAMP)
+        assert(result.output.map(_.name) == expected,
+          s"Expected $expected, got: ${result.output.map(_.name)}")
+
+        // Idempotent: a second pass leaves the rebuilt table in place.
+        val reapplied = applyReadOptions(result).asInstanceOf[StreamingRelationV2]
+        assert(reapplied.table eq rebuilt, "re-applying rule should not rebuild")
       }
     }
   }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
@@ -71,12 +71,8 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
   }
 
   // TODO(#5319): Move tests to shouldPassTests as V2 schema tracking log support is implemented.
-  override protected def shouldPassTests: Set[String] = Set.empty[String]
-
-  // All tests from StreamingSchemaEvolutionSuiteBase.
-  // Override in CDC suites to add CDC-specific tests.
-  override protected def shouldFailTests: Set[String] = Set(
-    // ========== Schema location validation ==========
+  override protected def shouldPassTests: Set[String] = Set(
+    // ========== Schema log unit test ==========
     "schema location not under checkpoint",
     "schema location same as checkpoint",
     "schema location using a different file system",
@@ -91,11 +87,18 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
     "schema / checkpoint location unit tests - " +
       "schema location and checkpoint location are the same but with explicit file scheme",
     "schema / checkpoint location unit tests - special characters in schema location",
+    "concurrent schema log modification should be detected",
+    "schema log replace current",
+    "backward-compat: latest version can read back older JSON",
+    "forward-compat: older version can read back newer JSON",
 
     // ========== Schema log core ==========
-    "multiple delta source sharing same schema log is blocked",
+    "multiple delta source sharing same schema log is blocked"
+  )
+
+  override protected def shouldFailTests: Set[String] = Set(
+    // ========== Schema log core ==========
     "schema log is applied",
-    "concurrent schema log modification should be detected",
     "schema log initialization with additive schema changes",
     "detect incompatible schema change while streaming",
     "detect incompatible schema change during first getBatch",
@@ -123,12 +126,7 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
     "unblock with sql conf",
     "schema tracking interacting with unsafe escape flag",
     "streaming with a column mapping upgrade",
-    "partition evolution",
-    "schema log replace current",
-
-    // ========== Backward/forward compatibility ==========
-    "backward-compat: latest version can read back older JSON",
-    "forward-compat: older version can read back newer JSON"
+    "partition evolution"
   )
 }
 
@@ -143,25 +141,24 @@ class DeltaV2SourceSchemaEvolutionIdColumnMappingSuite
     with DeltaV2SourceSchemaEvolutionSuiteBase
 
 // CDC suites
+// TODO(#5319): Support CDC non-additive schema evolution
+trait DeltaV2SourceSchemaEvolutionCDCSuiteBase extends DeltaV2SourceSchemaEvolutionSuiteBase {
+  self: StreamingSchemaEvolutionSuiteBase =>
+
+  override protected def shouldPassTests: Set[String] = Set.empty[String]
+
+  override protected def shouldFailTests: Set[String] =
+    super.shouldPassTests ++ super.shouldFailTests ++ Set(
+      // Additional tests from CDCStreamingSchemaEvolutionSuiteBase
+      "CDC streaming with schema evolution",
+      "protocol and configuration evolution"
+    )
+}
 
 class DeltaV2SourceSchemaEvolutionCDCNameColumnMappingSuite
   extends DeltaSourceSchemaEvolutionCDCNameColumnMappingSuite
-    with DeltaV2SourceSchemaEvolutionSuiteBase {
-
-  override protected def shouldFailTests: Set[String] = super.shouldFailTests ++ Set(
-    // Additional tests from CDCStreamingSchemaEvolutionSuiteBase
-    "CDC streaming with schema evolution",
-    "protocol and configuration evolution"
-  )
-}
+    with DeltaV2SourceSchemaEvolutionCDCSuiteBase
 
 class DeltaV2SourceSchemaEvolutionCDCIdColumnMappingSuite
   extends DeltaSourceSchemaEvolutionCDCIdColumnMappingSuite
-    with DeltaV2SourceSchemaEvolutionSuiteBase {
-
-  override protected def shouldFailTests: Set[String] = super.shouldFailTests ++ Set(
-    // Additional tests from CDCStreamingSchemaEvolutionSuiteBase
-    "CDC streaming with schema evolution",
-    "protocol and configuration evolution"
-  )
-}
+    with DeltaV2SourceSchemaEvolutionCDCSuiteBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.CloneTableStatement
 import org.apache.spark.sql.catalyst.plans.logical.RestoreTableStatement
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.streaming.WriteToStream
+import org.apache.spark.sql.catalyst.streaming.{StreamingRelationV2, WriteToStream}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttribute
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -992,9 +992,9 @@ class DeltaAnalysis(protected val session: SparkSession)
   private def verifyDeltaSourceSchemaLocation(
       inputQuery: LogicalPlan,
       checkpointLocation: String): Unit = {
-    // Maps StreamingRelation to schema location, similar to how MicroBatchExecution converts
-    // StreamingRelation to StreamingExecutionRelation.
-    val schemaLocationMap = mutable.Map[StreamingRelation, String]()
+    // Maps each Delta streaming source (V1 or V2) to its schema tracking location, similar to how
+    // MicroBatchExecution converts StreamingRelation to StreamingExecutionRelation.
+    val schemaLocationMap = mutable.Map[LogicalPlan, String]()
     val allowSchemaLocationOutsideOfCheckpoint = session.sessionState.conf.getConf(
       DeltaSQLConf.DELTA_STREAMING_ALLOW_SCHEMA_LOCATION_OUTSIDE_CHECKPOINT_LOCATION)
     inputQuery.foreach {
@@ -1020,6 +1020,25 @@ class DeltaAnalysis(protected val session: SparkSession)
             // Save schema location for this streaming relation
             schemaLocationMap.put(streamingRelation, schemaTrackingLocation.stripSuffix("/"))
           }
+      case streamingRelationV2 @ StreamingRelationV2(_, _, table, extraOptions, _, _, _, _) =>
+        val opts = extraOptions.asCaseSensitiveMap.asScala.toMap
+        DeltaDataSource.extractSchemaTrackingLocationConfig(session, opts)
+          .foreach { rootSchemaTrackingLocation =>
+            // TODO(#5319): use table path instead of name so path vs catalog access of the same
+            //  table conflicts at analysis time (matches V1). Needs a SparkTable-side accessor.
+            val tableId = table.name.replace(":", "").replace("/", "_")
+            val sourceIdOpt = opts.get(DeltaOptions.STREAMING_SOURCE_TRACKING_ID)
+            val schemaTrackingLocation =
+              DeltaSourceMetadataTrackingLog.fullMetadataTrackingLocation(
+                rootSchemaTrackingLocation, tableId, sourceIdOpt)
+            if (!allowSchemaLocationOutsideOfCheckpoint) {
+              assertSchemaTrackingLocationUnderCheckpoint(
+                checkpointLocation,
+                schemaTrackingLocation
+              )
+            }
+            schemaLocationMap.put(streamingRelationV2, schemaTrackingLocation.stripSuffix("/"))
+          }
       case _ =>
     }
 
@@ -1029,14 +1048,21 @@ class DeltaAnalysis(protected val session: SparkSession)
       .groupBy { rel => schemaLocationMap(rel) }
       .find(_._2.size > 1)
     conflictSchemaOpt.foreach { case (schemaLocation, relations) =>
-      val ds = relations.head.dataSource
       // Pick one source that has conflict to make it more actionable for the user
-      val oneTableWithConflict = ds.catalogTable
-        .map(_.identifier.toString)
-        .getOrElse {
-          // `path` must exist
-          CaseInsensitiveMap(ds.options).get("path").get
-        }
+      val oneTableWithConflict = relations.head match {
+        case streamingRelation: StreamingRelation =>
+          val ds = streamingRelation.dataSource
+          ds.catalogTable
+            .map(_.identifier.toString)
+            .getOrElse {
+              // `path` must exist
+              CaseInsensitiveMap(ds.options).get("path").get
+            }
+        case streamingRelationV2: StreamingRelationV2 =>
+          streamingRelationV2.identifier
+            .map(_.toString)
+            .getOrElse(streamingRelationV2.table.name)
+      }
       throw DeltaErrors.sourcesWithConflictingSchemaTrackingLocation(
         schemaLocation, oneTableWithConflict)
     }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/SparkTable.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/SparkTable.java
@@ -25,6 +25,7 @@ import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
+import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
 import io.delta.spark.internal.v2.read.SparkScanBuilder;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
@@ -49,6 +50,7 @@ import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.delta.SparkTableShims$;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
+import org.apache.spark.sql.delta.sources.PersistedMetadata;
 import org.apache.spark.sql.execution.datasources.FileFormat$;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
@@ -178,9 +180,29 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
     // Load the initial snapshot through the manager
     this.initialSnapshot = snapshotManager.loadLatestSnapshot();
 
-    // Schema-related metadata is lazily computed on first access within SchemaProvider
-    this.schemaProvider = new SchemaProvider(SparkSession.active(), initialSnapshot);
     this.isCDCRead = CDCReader.isCDCRead(new CaseInsensitiveStringMap(this.options));
+
+    Optional<PersistedMetadata> persistedMetadata =
+        MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
+            SparkSession.active(),
+            (SnapshotImpl) initialSnapshot,
+            options,
+            snapshotManager,
+            kernelEngine);
+
+    StructType rawSchema;
+    List<String> partitionColumnNames;
+    if (persistedMetadata.isPresent()) {
+      PersistedMetadata persisted = persistedMetadata.get();
+      rawSchema = persisted.dataSchema();
+      partitionColumnNames = Arrays.asList(persisted.partitionSchema().fieldNames());
+    } else {
+      rawSchema = SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
+      partitionColumnNames = new ArrayList<>(initialSnapshot.getPartitionColumnNames());
+    }
+    // Schema-related metadata is lazily computed on first access within SchemaProvider
+    this.schemaProvider =
+        new SchemaProvider(SparkSession.active(), rawSchema, partitionColumnNames);
   }
 
   /**
@@ -217,6 +239,24 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
    */
   public Path getTablePath() {
     return new Path(tablePath);
+  }
+
+  /**
+   * Returns the V2 identifier this table was constructed with.
+   *
+   * @return Identifier provided at construction
+   */
+  public Identifier getIdentifier() {
+    return identifier;
+  }
+
+  /**
+   * Returns the merged options (catalog storage + user options) this table was constructed with.
+   *
+   * @return Map of merged catalog storage and user options
+   */
+  public Map<String, String> getOptions() {
+    return options;
   }
 
   /**
@@ -384,20 +424,20 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
    */
   private static class SchemaProvider {
     private final SparkSession sparkSession;
-    private final Snapshot snapshot;
+    private final StructType rawSchema;
+    private final List<String> partColNames;
 
     // Lazily computed fields
     private boolean initialized = false;
-    private StructType rawSchema;
     private StructType publicSchema;
-    private List<String> partColNames;
     private StructType dataSchema;
     private StructType partitionSchema;
     private Transform[] partitionTransforms;
 
-    SchemaProvider(SparkSession sparkSession, Snapshot snapshot) {
+    SchemaProvider(SparkSession sparkSession, StructType rawSchema, List<String> partColNames) {
       this.sparkSession = sparkSession;
-      this.snapshot = snapshot;
+      this.rawSchema = rawSchema;
+      this.partColNames = Collections.unmodifiableList(new ArrayList<>(partColNames));
     }
 
     private synchronized void ensureInitialized() {
@@ -405,16 +445,10 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
         return;
       }
 
-      // Convert Kernel schema to Spark schema - keep all metadata for internal use
-      this.rawSchema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
-
       // Create public schema by removing internal metadata (for schema() method)
       this.publicSchema =
           DeltaTableUtils.removeInternalDeltaMetadata(
               sparkSession, DeltaTableUtils.removeInternalWriterMetadata(sparkSession, rawSchema));
-
-      this.partColNames =
-          Collections.unmodifiableList(new ArrayList<>(snapshot.getPartitionColumnNames()));
 
       final List<StructField> dataFields = new ArrayList<>();
       final List<StructField> partitionFields = new ArrayList<>();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -16,6 +16,7 @@
 package io.delta.spark.internal.v2.read;
 
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -25,6 +26,7 @@ import io.delta.kernel.utils.CloseableIterator.BreakableFilterResult;
 import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
 import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
 import io.delta.spark.internal.v2.utils.StreamingHelper;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.delta.DeltaColumnMapping$;
@@ -39,6 +42,8 @@ import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.delta.TypeWideningMode;
 import org.apache.spark.sql.delta.schema.SchemaUtils$;
+import org.apache.spark.sql.delta.sources.DeltaDataSource$;
+import org.apache.spark.sql.delta.sources.DeltaSQLConf;
 import org.apache.spark.sql.delta.sources.DeltaSourceMetadataEvolutionSupport$;
 import org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
@@ -46,6 +51,7 @@ import org.apache.spark.sql.delta.sources.DeltaStreamUtils;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractProtocol;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
@@ -53,8 +59,9 @@ import scala.collection.immutable.Seq;
 import scala.collection.immutable.Seq$;
 
 /**
- * V2 port of V1's {@code DeltaSourceMetadataEvolutionSupport} trait. Handles metadata evolution
- * (schema, table configuration, or protocol changes) for the v2 Delta streaming source.
+ * TODO(#5319): Support CDC V2 port of V1's {@code DeltaSourceMetadataEvolutionSupport} trait.
+ * Handles metadata evolution (schema, table configuration, or protocol changes) for the v2 Delta
+ * streaming source.
  *
  * <p>To safely evolve schema mid-stream, this class intercepts streaming at several stages to:
  *
@@ -397,7 +404,10 @@ public class MetadataEvolutionHandler {
   }
 
   /**
-   * V2 port of V1's {@code
+   * Picks the most recent metadata and most supportive protocol in {@code [startVersion,
+   * endVersion]} to seed the tracking log; throws if any earlier change is incompatible.
+   *
+   * <p>V2 port of V1's {@code
    * DeltaSourceMetadataEvolutionSupport.validateAndResolveMetadataForLogInitialization}.
    */
   private ValidatedMetadataAndProtocol validateAndResolveMetadataForLogInitialization(
@@ -469,5 +479,113 @@ public class MetadataEvolutionHandler {
       this.metadata = metadata;
       this.protocol = protocol;
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Static utilities
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the persisted metadata from the schema-tracking log if configured, else empty.
+   *
+   * <p>The persisted metadata is the source of truth for the analyzed schema. With {@code
+   * mergeConsecutiveSchemaChanges=true}, the merger folds consecutive metadata-only commits and
+   * writes the merged entry back to the durable schema log; the execution-time {@link
+   * SparkMicroBatchStream} then re-reads the same merged entry via {@link
+   * DeltaSourceMetadataTrackingLog#getCurrentTrackedMetadata}.
+   */
+  public static Optional<PersistedMetadata> getPersistedMetadataForMicroBatchStream(
+      SparkSession spark,
+      SnapshotImpl snapshot,
+      Map<String, String> options,
+      DeltaSnapshotManager snapshotManager,
+      Engine engine) {
+    boolean mergeConsecutiveSchemaChanges =
+        (boolean)
+            spark
+                .sessionState()
+                .conf()
+                .getConf(
+                    DeltaSQLConf
+                        .DELTA_STREAMING_ENABLE_SCHEMA_TRACKING_MERGE_CONSECUTIVE_CHANGES());
+    Option<DeltaSourceMetadataTrackingLog> trackingLog =
+        getMetadataTrackingLogForMicroBatchStream(
+            spark,
+            snapshot,
+            options,
+            snapshotManager,
+            engine,
+            SparkMicroBatchStream.ACTION_SET,
+            /* sourceMetadataPathOpt= */ Option.empty(),
+            mergeConsecutiveSchemaChanges);
+    if (trackingLog.isEmpty()) {
+      return Optional.empty();
+    }
+    Option<PersistedMetadata> persisted = trackingLog.get().getCurrentTrackedMetadata();
+    return persisted.isDefined() ? Optional.of(persisted.get()) : Optional.empty();
+  }
+
+  /**
+   * Returns true when the read options carry a schema-tracking location but the table's own options
+   * do not — i.e. the {@code SparkTable} was built before the user-supplied {@code
+   * schemaTrackingLocation}/{@code schemaLocation} option was observed, so callers must rebuild the
+   * table with the option folded in for its schema to be driven by the tracking log.
+   */
+  public static boolean shouldPropagateSchemaTrackingToTable(
+      CaseInsensitiveStringMap readOptions, Map<String, String> tableOptions) {
+    CaseInsensitiveStringMap tableOptionsCI = new CaseInsensitiveStringMap(tableOptions);
+    boolean inReadOptions =
+        readOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION())
+            || readOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS());
+    boolean inTableOptions =
+        tableOptionsCI.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION())
+            || tableOptionsCI.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS());
+    return inReadOptions && !inTableOptions;
+  }
+
+  /**
+   * Builds the tracking log from streaming options: empty when {@code schemaTrackingLocation} is
+   * unset; throws when it is set but schema tracking is disabled in config.
+   *
+   * <p>V2 port of V1's {@code DeltaDataSource.getMetadataTrackingLogForDeltaSource}.
+   */
+  public static Option<DeltaSourceMetadataTrackingLog> getMetadataTrackingLogForMicroBatchStream(
+      SparkSession spark,
+      SnapshotImpl snapshot,
+      Map<String, String> options,
+      DeltaSnapshotManager snapshotManager,
+      Engine engine,
+      Set<DeltaLogActionUtils.DeltaAction> mergeActionSet,
+      Option<String> sourceMetadataPathOpt,
+      boolean mergeConsecutiveSchemaChanges) {
+    Option<String> locationOpt =
+        DeltaDataSource$.MODULE$.extractSchemaTrackingLocationConfig(
+            spark, ScalaUtils.toScalaMap(options));
+    if (locationOpt.isEmpty()) {
+      return Option.empty();
+    }
+    String location = locationOpt.get();
+    if (!(boolean)
+        spark
+            .sessionState()
+            .conf()
+            .getConf(DeltaSQLConf.DELTA_STREAMING_ENABLE_SCHEMA_TRACKING())) {
+      throw new UnsupportedOperationException(
+          "Schema tracking location is not supported for Delta streaming source");
+    }
+
+    String tablePath = snapshot.getPath();
+    return Option.apply(
+        DeltaSourceMetadataTrackingLog.create(
+            spark,
+            location,
+            snapshot.getMetadata().getId(),
+            tablePath,
+            ScalaUtils.toScalaMap(options),
+            sourceMetadataPathOpt,
+            // TODO(#5319): Implement v2 consecutiveSchema schema changes merger
+            /* mergeConsecutiveSchemaChanges= */ false,
+            /* consecutiveSchemaChangesMerger= */ Option.empty(),
+            /* initMetadataLogEagerly= */ true));
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -97,13 +97,14 @@ public class SparkMicroBatchStream
 
   private static final Logger logger = LoggerFactory.getLogger(SparkMicroBatchStream.class);
 
-  private static final Set<DeltaAction> ACTION_SET =
+  public static final Set<DeltaAction> ACTION_SET =
       Collections.unmodifiableSet(
           new HashSet<>(
               Arrays.asList(
                   DeltaAction.ADD,
                   DeltaAction.REMOVE,
                   DeltaAction.METADATA,
+                  DeltaAction.PROTOCOL,
                   DeltaAction.COMMITINFO)));
 
   /** Action set for CDC reads. */

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -75,7 +75,10 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
               DeltaOptions.EXCLUDE_REGEX_OPTION(),
               DeltaOptions.FAIL_ON_DATA_LOSS_OPTION(),
               DeltaOptions.CDC_READ_OPTION(),
-              DeltaOptions.CDC_READ_OPTION_LEGACY()));
+              DeltaOptions.CDC_READ_OPTION_LEGACY(),
+              DeltaOptions.SCHEMA_TRACKING_LOCATION(),
+              DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS(),
+              DeltaOptions.STREAMING_SOURCE_TRACKING_ID()));
 
   private static final Set<String> UNSUPPORTED_STREAMING_OPTIONS =
       Collections.unmodifiableSet(
@@ -83,9 +86,6 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
               Arrays.asList(
                   DeltaOptions.CDC_END_VERSION().toLowerCase(),
                   DeltaOptions.CDC_END_TIMESTAMP().toLowerCase(),
-                  DeltaOptions.SCHEMA_TRACKING_LOCATION().toLowerCase(),
-                  DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS().toLowerCase(),
-                  DeltaOptions.STREAMING_SOURCE_TRACKING_ID().toLowerCase(),
                   DeltaOptions.ALLOW_SOURCE_COLUMN_DROP().toLowerCase(),
                   DeltaOptions.ALLOW_SOURCE_COLUMN_RENAME().toLowerCase(),
                   DeltaOptions.ALLOW_SOURCE_COLUMN_TYPE_CHANGE().toLowerCase())));

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/SparkTableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/SparkTableTest.java
@@ -21,10 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
+import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -35,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.Path;
@@ -45,7 +53,11 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.delta.catalog.DeltaTableV2;
+import org.apache.spark.sql.delta.sources.DeltaSQLConf;
+import org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog;
+import org.apache.spark.sql.delta.sources.PersistedMetadata;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -559,5 +571,183 @@ public class SparkTableTest extends DeltaV2TestBase {
     assertFalse(names.contains(CDCSchemaContext.CDC_COMMIT_VERSION), "unexpected _commit_version");
     assertFalse(
         names.contains(CDCSchemaContext.CDC_COMMIT_TIMESTAMP), "unexpected _commit_timestamp");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Schema-tracking-aware schema construction
+  // ---------------------------------------------------------------------------
+
+  /** Empty schema-tracking log → snapshot schema is used as fallback. */
+  @Test
+  public void testSchemaTracking_emptyLogFallsBackToSnapshotSchema(@TempDir File tempDir) {
+    String tablePath = new File(tempDir, "table").getAbsolutePath();
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    String tableName =
+        "test_schema_tracking_empty_log_" + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'",
+            tableName, tablePath));
+
+    Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
+    Map<String, String> options = new HashMap<>();
+    options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
+
+    SparkTable table = new SparkTable(identifier, tablePath, options);
+
+    StructType schema = table.schema();
+    assertEquals(2, schema.fields().length);
+    assertEquals("id", schema.fields()[0].name());
+    assertEquals("name", schema.fields()[1].name());
+  }
+
+  /**
+   * Verifies that pre-seeded persisted metadata (older snapshot, fewer columns) overrides the
+   * current snapshot schema (which has been evolved with ALTER TABLE).
+   */
+  private void verifyPersistedEntryDrivesSparkTableSchema(
+      File tempDir, String optionKey, String tableNameSuffix, boolean usePathBasedConstructor) {
+    String tablePath = new File(tempDir, "table").getAbsolutePath();
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    String tableName =
+        "test_schema_tracking_persisted_override_"
+            + tableNameSuffix
+            + "_"
+            + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta "
+                + "PARTITIONED BY (name) LOCATION '%s'",
+            tableName, tablePath));
+
+    // Capture v0 metadata BEFORE evolving the table.
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
+    SnapshotImpl snapshotV0 = (SnapshotImpl) snapshotManager.loadSnapshotAt(0L);
+    Metadata metadataV0 = snapshotV0.getMetadata();
+    Protocol protocolV0 = snapshotV0.getProtocol();
+    String tableId = metadataV0.getId();
+
+    // Seed the schema log with v0's metadata (id INT data, name STRING partition).
+    DeltaSourceMetadataTrackingLog trackingLog =
+        DeltaSourceMetadataTrackingLog.create(
+            spark,
+            schemaLogPath,
+            tableId,
+            tablePath,
+            scala.collection.immutable.Map$.MODULE$.empty(),
+            scala.Option.empty(),
+            /* mergeConsecutiveSchemaChanges= */ false,
+            /* consecutiveSchemaChangesMerger= */ scala.Option.empty(),
+            /* initMetadataLogEagerly= */ true);
+    PersistedMetadata seededEntry =
+        PersistedMetadata.apply(
+            tableId,
+            0L,
+            new KernelMetadataAdapter(metadataV0),
+            new KernelProtocolAdapter(protocolV0),
+            tablePath + "/_delta_log/_streaming_metadata");
+    trackingLog.writeNewMetadata(seededEntry, false);
+
+    // Evolve the table — version 1 has an extra non-partition column.
+    spark.sql(String.format("ALTER TABLE %s ADD COLUMNS (value DOUBLE)", tableName));
+
+    // Construct SparkTable with the schema-tracking option pointing at the seeded log. The
+    // snapshot is at v1 (3 columns) but the persisted entry is at v0 (2 columns). Default to
+    // the catalog-table constructor since that's how production code typically loads the table.
+    Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
+    Map<String, String> options = new HashMap<>();
+    options.put(optionKey, schemaLogPath);
+    SparkTable table;
+    if (usePathBasedConstructor) {
+      table = new SparkTable(identifier, tablePath, options);
+    } else {
+      CatalogTable catalogTable;
+      try {
+        catalogTable =
+            spark.sessionState().catalog().getTableMetadata(new TableIdentifier(tableName));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      table = new SparkTable(identifier, catalogTable, options);
+    }
+
+    // Persisted metadata wins: schema reflects v0 (2 columns), not v1 (3 columns).
+    // Public schema layout is data fields followed by partition fields, so [id, name].
+    StructType schema = table.schema();
+    assertEquals(2, schema.fields().length, "Persisted entry should override snapshot schema");
+    assertEquals("id", schema.fields()[0].name());
+    assertEquals("name", schema.fields()[1].name());
+
+    // Partition column from the persisted entry's partitionSchema is also honored.
+    Transform[] partitioning = table.partitioning();
+    assertEquals(
+        1, partitioning.length, "Should have one partition column from the persisted entry");
+    assertEquals(
+        "name",
+        partitioning[0].references()[0].describe(),
+        "Partition column should be 'name' from the persisted entry");
+  }
+
+  /** Persisted entry overrides the snapshot schema when SCHEMA_TRACKING_LOCATION is set. */
+  @Test
+  public void testSchemaTracking_persistedEntryOverridesSnapshotSchema(@TempDir File tempDir) {
+    verifyPersistedEntryDrivesSparkTableSchema(
+        tempDir,
+        DeltaOptions.SCHEMA_TRACKING_LOCATION(),
+        "primary_key",
+        /* usePathBasedConstructor= */ false);
+  }
+
+  /** Alias key triggers the same code path. */
+  @Test
+  public void testSchemaTracking_persistedEntryOverridesSnapshotSchemaWithAliasKey(
+      @TempDir File tempDir) {
+    verifyPersistedEntryDrivesSparkTableSchema(
+        tempDir,
+        DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS(),
+        "alias_key",
+        /* usePathBasedConstructor= */ false);
+  }
+
+  /** Path-based constructor honors the persisted entry too. */
+  @Test
+  public void testSchemaTracking_persistedEntryOverridesSnapshotSchemaWithPathBasedConstructor(
+      @TempDir File tempDir) {
+    verifyPersistedEntryDrivesSparkTableSchema(
+        tempDir,
+        DeltaOptions.SCHEMA_TRACKING_LOCATION(),
+        "path_based_constructor",
+        /* usePathBasedConstructor= */ true);
+  }
+
+  /** Setting the option while the feature flag is off throws at construction. */
+  @Test
+  public void testSchemaTracking_throwsWhenFeatureFlagDisabled(@TempDir File tempDir)
+      throws Exception {
+    String tablePath = new File(tempDir, "table").getAbsolutePath();
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    String tableName =
+        "test_schema_tracking_feature_flag_disabled_"
+            + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format("CREATE TABLE %s (id INT) USING delta LOCATION '%s'", tableName, tablePath));
+
+    Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
+    Map<String, String> options = new HashMap<>();
+    options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
+
+    withSQLConf(
+        DeltaSQLConf.DELTA_STREAMING_ENABLE_SCHEMA_TRACKING().key(),
+        "false",
+        () -> {
+          UnsupportedOperationException ex =
+              assertThrows(
+                  UnsupportedOperationException.class,
+                  () -> new SparkTable(identifier, tablePath, options));
+          assertEquals(
+              "Schema tracking location is not supported for Delta streaming source",
+              ex.getMessage());
+        });
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
@@ -42,14 +42,20 @@ import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
 import java.io.File;
 import java.util.*;
+import java.util.stream.Stream;
 import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.delta.DeltaRuntimeException;
+import org.apache.spark.sql.delta.sources.DeltaSQLConf;
 import org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
 import org.apache.spark.sql.delta.sources.DeltaStreamUtils;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import scala.Option;
 
 /** Unit tests for {@link MetadataEvolutionHandler}. */
@@ -968,5 +974,224 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
         "DELTA_STREAMING_SCHEMA_LOG_INIT_FAILED_INCOMPATIBLE_METADATA",
         ex.getErrorClass(),
         "Should throw incompatible-metadata error when range contains a column drop");
+  }
+
+  // ---------------------------------------------------------------------------
+  // getMetadataTrackingLogForMicroBatchStream
+  //
+  // Builds the tracking log from streaming options: empty when SCHEMA_TRACKING_LOCATION
+  // (or its alias) is unset; throws when set but the feature flag is off; otherwise
+  // returns a usable log.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Sets up a fresh empty Delta table at {@code tempDir/table} and invokes {@link
+   * MetadataEvolutionHandler#getMetadataTrackingLogForMicroBatchStream} with the given options. The
+   * other 5 arguments to the function are constants for these tests.
+   */
+  private Option<DeltaSourceMetadataTrackingLog> invokeGetTrackingLog(
+      File tempDir, Map<String, String> options) {
+    String tablePath = new File(tempDir, "table").getAbsolutePath();
+    String tableName = "t_" + UUID.randomUUID().toString().replace('-', '_');
+    createEmptyTestTable(tablePath, tableName);
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
+    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    return MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
+        spark,
+        snapshot,
+        options,
+        snapshotManager,
+        defaultEngine,
+        SparkMicroBatchStream.ACTION_SET,
+        Option.empty(),
+        /* mergeConsecutiveSchemaChanges= */ false);
+  }
+
+  /** No schema-tracking option → Option.empty. */
+  @Test
+  public void testGetTrackingLog_returnsEmptyWhenNoSchemaTrackingOption(@TempDir File tempDir) {
+    Option<DeltaSourceMetadataTrackingLog> result =
+        invokeGetTrackingLog(tempDir, Collections.emptyMap());
+    assertTrue(result.isEmpty());
+  }
+
+  /** Throws with the documented message when the feature flag is off. */
+  @Test
+  public void testGetTrackingLog_throwsWhenFeatureFlagDisabled(@TempDir File tempDir)
+      throws Exception {
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    Map<String, String> options = new HashMap<>();
+    options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
+
+    withSQLConf(
+        DeltaSQLConf.DELTA_STREAMING_ENABLE_SCHEMA_TRACKING().key(),
+        "false",
+        () -> {
+          UnsupportedOperationException ex =
+              assertThrows(
+                  UnsupportedOperationException.class,
+                  () -> invokeGetTrackingLog(tempDir, options));
+          assertEquals(
+              "Schema tracking location is not supported for Delta streaming source",
+              ex.getMessage());
+        });
+  }
+
+  /** SCHEMA_TRACKING_LOCATION set → returns a usable tracking log. */
+  @Test
+  public void testGetTrackingLog_returnsLogWhenSchemaTrackingLocationSet(@TempDir File tempDir) {
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    Map<String, String> options = new HashMap<>();
+    options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
+
+    Option<DeltaSourceMetadataTrackingLog> result = invokeGetTrackingLog(tempDir, options);
+    assertTrue(result.isDefined());
+    assertTrue(result.get().getCurrentTrackedMetadata().isEmpty());
+  }
+
+  /** Alias key ("schemaLocation") is also recognized. */
+  @Test
+  public void testGetTrackingLog_returnsLogWhenSchemaTrackingLocationAliasSet(
+      @TempDir File tempDir) {
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    Map<String, String> options = new HashMap<>();
+    options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS(), schemaLogPath);
+
+    Option<DeltaSourceMetadataTrackingLog> result = invokeGetTrackingLog(tempDir, options);
+    assertTrue(result.isDefined());
+    assertTrue(result.get().getCurrentTrackedMetadata().isEmpty());
+  }
+
+  /** Option key lookup is case-insensitive (matches V1's CaseInsensitiveStringMap behavior). */
+  @Test
+  public void testGetTrackingLog_caseInsensitiveOptionKey(@TempDir File tempDir) {
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    Map<String, String> options = new HashMap<>();
+    // Canonical key is "schemaTrackingLocation"; use a different casing here.
+    options.put("SCHEMATRACKINGLOCATION", schemaLogPath);
+
+    Option<DeltaSourceMetadataTrackingLog> result = invokeGetTrackingLog(tempDir, options);
+    assertTrue(result.isDefined());
+    assertTrue(result.get().getCurrentTrackedMetadata().isEmpty());
+  }
+
+  // ---------------------------------------------------------------------------
+  // shouldPropagateSchemaTrackingToTable
+  //
+  // True iff the read options carry SCHEMA_TRACKING_LOCATION (or its alias) AND
+  // the table options do not.
+  // ---------------------------------------------------------------------------
+
+  private static Stream<Arguments> shouldPropagateSchemaTrackingCases() {
+    String canonical = DeltaOptions.SCHEMA_TRACKING_LOCATION();
+    String alias = DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS();
+    return Stream.of(
+        // (readKey, tableKey, expected)
+        // Neither side carries the option -> no propagation needed.
+        Arguments.of(null, null, false),
+        // Read side has the option, table side does not -> propagate. Both option keys
+        // are recognized on the read side.
+        Arguments.of(canonical, null, true),
+        Arguments.of(alias, null, true),
+        // Table side carries the option (canonical or alias) -> already propagated.
+        Arguments.of(canonical, canonical, false),
+        Arguments.of(canonical, alias, false),
+        // Option lookups on both sides are case-insensitive.
+        Arguments.of(canonical.toUpperCase(), null, true),
+        Arguments.of(canonical, canonical.toUpperCase(), false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldPropagateSchemaTrackingCases")
+  public void testShouldPropagateSchemaTrackingToTable(
+      String readKey, String tableKey, boolean expected) {
+    Map<String, String> readOptionsMap = new HashMap<>();
+    if (readKey != null) {
+      readOptionsMap.put(readKey, "/some/path");
+    }
+    CaseInsensitiveStringMap readOptions = new CaseInsensitiveStringMap(readOptionsMap);
+
+    Map<String, String> tableOptions = new HashMap<>();
+    if (tableKey != null) {
+      tableOptions.put(tableKey, "/some/path");
+    }
+
+    assertEquals(
+        expected,
+        MetadataEvolutionHandler.shouldPropagateSchemaTrackingToTable(readOptions, tableOptions));
+  }
+
+  // ---------------------------------------------------------------------------
+  // getPersistedMetadataForMicroBatchStream
+  //
+  // Thin wrapper over getMetadataTrackingLogForMicroBatchStream that pulls the
+  // mergeConsecutiveSchemaChanges conf and returns the current persisted entry.
+  // ---------------------------------------------------------------------------
+
+  /** Sets up a fresh table and invokes the persisted-metadata helper with the given options. */
+  private Optional<PersistedMetadata> invokeGetPersistedMetadata(
+      File tempDir, Map<String, String> options) {
+    String tablePath = new File(tempDir, "table").getAbsolutePath();
+    String tableName = "t_" + UUID.randomUUID().toString().replace('-', '_');
+    createEmptyTestTable(tablePath, tableName);
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
+    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    return MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
+        spark, snapshot, options, snapshotManager, defaultEngine);
+  }
+
+  /** Schema-tracking set but the log has no entry → empty. */
+  @Test
+  public void testGetPersistedMetadata_returnsEmptyWhenLogIsEmpty(@TempDir File tempDir) {
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    Map<String, String> options = new HashMap<>();
+    options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
+    assertFalse(invokeGetPersistedMetadata(tempDir, options).isPresent());
+  }
+
+  /** Schema-tracking set and the log has a seeded entry → returns that entry. */
+  @Test
+  public void testGetPersistedMetadata_returnsSeededEntry(@TempDir File tempDir) {
+    String tablePath = new File(tempDir, "table").getAbsolutePath();
+    String tableName = "t_" + UUID.randomUUID().toString().replace('-', '_');
+    createEmptyTestTable(tablePath, tableName);
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
+    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    Map<String, String> options = new HashMap<>();
+    options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
+
+    // Open the log through the same code path the util uses, then seed an entry.
+    DeltaSourceMetadataTrackingLog trackingLog =
+        MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
+                spark,
+                snapshot,
+                options,
+                snapshotManager,
+                defaultEngine,
+                SparkMicroBatchStream.ACTION_SET,
+                Option.empty(),
+                /* mergeConsecutiveSchemaChanges= */ false)
+            .get();
+    // Use a non-zero version so it's distinct from a default-init entry.
+    long seededVersion = 42L;
+    PersistedMetadata seeded =
+        PersistedMetadata.apply(
+            snapshot.getMetadata().getId(),
+            seededVersion,
+            new KernelMetadataAdapter(snapshot.getMetadata()),
+            new KernelProtocolAdapter(snapshot.getProtocol()),
+            tablePath + "/_delta_log/_streaming_metadata");
+    trackingLog.writeNewMetadata(seeded, false);
+
+    Optional<PersistedMetadata> result =
+        MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
+            spark, snapshot, options, snapshotManager, defaultEngine);
+    assertTrue(result.isPresent());
+    assertEquals(seededVersion, result.get().deltaCommitVersion());
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -733,7 +733,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     // Test with blocked DeltaOptions, supported options, and custom user options
     Map<String, String> javaOptions = new HashMap<>();
     javaOptions.put("startingVersion", "0");
-    javaOptions.put("schemaTrackingLocation", "/tmp/schema-tracking");
+    javaOptions.put("endingTimestamp", "2024-01-01");
     javaOptions.put("myCustomOption", "value");
     scala.collection.immutable.Map<String, String> mixedOptions =
         ScalaUtils.toScalaMap(javaOptions);
@@ -747,10 +747,11 @@ public class SparkScanTest extends DeltaV2TestBase {
     // Verify exact error message - only the blocked option should appear
     // Note: DeltaOptions uses CaseInsensitiveMap which lowercases keys during iteration
     assertEquals(
-        "The following streaming options are not supported: [schematrackinglocation]. "
+        "The following streaming options are not supported: [endingtimestamp]. "
             + "Supported options are: [startingVersion, startingTimestamp, maxFilesPerTrigger, "
             + "maxBytesPerTrigger, ignoreFileDeletion, ignoreChanges, ignoreDeletes, "
-            + "skipChangeCommits, excludeRegex, failOnDataLoss, readChangeFeed, readChangeData].",
+            + "skipChangeCommits, excludeRegex, failOnDataLoss, readChangeFeed, readChangeData, "
+            + "schemaTrackingLocation, schemaLocation, streamingSourceTrackingId].",
         exception.getMessage());
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6570/files) to review incremental changes.
- [stack/SparkMetadataAdapter](https://github.com/delta-io/delta/pull/6546) [[Files changed](https://github.com/delta-io/delta/pull/6546/files)] [MERGED]
  - [stack/RefactorMetadataTrackingLog](https://github.com/delta-io/delta/pull/6550) [[Files changed](https://github.com/delta-io/delta/pull/6550/files)] [MERGED]
    - [stack/RefactorDeltaSourceMetadataEvolutionSupport](https://github.com/delta-io/delta/pull/6562) [[Files changed](https://github.com/delta-io/delta/pull/6562/files)] [MERGED]
      - [stack/MetadataEvolutionHandler2](https://github.com/delta-io/delta/pull/6563) [[Files changed](https://github.com/delta-io/delta/pull/6563/files)] [MERGED]
        - [**stack/NonAdditiveSchemaEvolution2**](https://github.com/delta-io/delta/pull/6570) [[Files changed](https://github.com/delta-io/delta/pull/6570/files)]
          - [stack/NonAdditiveSchemaEvolution3](https://github.com/delta-io/delta/pull/6697) [[Files changed](https://github.com/delta-io/delta/pull/6697/files/b7f6c8ebfc0882e7e2cc580f09f376be23a8d43d..dbb6246c14be1ab7f017ad9fc26455ae599ee676)]
            - [stack/consecutiveSchemaChangesMerger](https://github.com/delta-io/delta/pull/6698) [[Files changed](https://github.com/delta-io/delta/pull/6698/files/dbb6246c14be1ab7f017ad9fc26455ae599ee676..4bf2fa3fa828bcab0b56c4c26ca51ee9cc40b482)]
              - [stack/SchemaTrackingWithCDC](https://github.com/delta-io/delta/pull/6801) [[Files changed](https://github.com/delta-io/delta/pull/6801/files/4bf2fa3fa828bcab0b56c4c26ca51ee9cc40b482..a78a4ac2bc9a52605278a36b98804230258c12a2)]
              - [stack/V1V2MixTest](https://github.com/delta-io/delta/pull/6759) [[Files changed](https://github.com/delta-io/delta/pull/6759/files/7f9b7f2724b2245ab7380908616303cf7ea95fca..e146cdc9ebb0572e8b0a928cc6dd3bfdc198d984)]

---------
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

PR 5/7 in the non-additive schema evolution for V2 streaming connector stack.

Wire schema tracking into V2's analysis path so the analyzed plan reflects the persisted (evolved) schema instead of the live snapshot schema.

- `DeltaAnalysis.verifyDeltaSourceSchemaLocation`: extend the duplicate-schema-location check to also visit `StreamingRelationV2`, keyed on the V2 `Table.name`.
- `SparkTable`: open `DeltaSourceMetadataTrackingLog` once during construction (gated on `mergeConsecutiveSchemaChanges`) and seed `SchemaProvider` from the persisted metadata, so analysis-time `schema()` matches what the stream will read at runtime.
- `ApplyV2ReadOptions` (renamed from `ApplyV2Streaming`): generalize the CDC-only rebuild to also fire when `schemaTrackingLocation` arrives via `extraOptions` on the catalog `readStream.table()` path; rebuild `SparkTable` with merged options so the schema-log lookup actually fires.
- `MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream`: V2 port of V1's helper, reused by `SparkTable` (analysis) and `SparkScan` (execution).

## How was this patch tested?

`SparkTableTest`, `MetadataEvolutionHandlerTest`, `ApplyV2ReadOptionsSuite`. Unified `DeltaV2SourceSchemaEvolutionSuite` updated.

## Does this PR introduce _any_ user-facing changes?

No.
