### PR TITLE
[Spark] Add empty line between package and license header to CatalogTableTestUtils

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/CatalogTableTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/CatalogTableTestUtils.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.spark.sql.delta.util
 
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -83,5 +84,3 @@ object CatalogTableTestUtils {
       properties = scalaProps)
   }
 }
-
-


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark

## Description

A purely cosmetic change -- adding an empty line between the license header and the package spec at top of one line. All other files in the repo have that empty line.

## How was this patch tested?

Does not require testing.

## Does this PR introduce _any_ user-facing changes?

No.
