### PR TITLE
[Sharing] Make AvailableNow fields volatile and guard double-init in DeltaFormatSharingSource

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -200,12 +200,11 @@ case class DeltaFormatSharingSource(
   }
 
   // Whether this query is running in Trigger.AvailableNow mode.
-  // TODO: If SupportsConcurrentExecution is added, these need @volatile or synchronization.
-  private var isTriggerAvailableNow: Boolean = false
+  @volatile private var isTriggerAvailableNow: Boolean = false
 
   // The server version captured at query start for Trigger.AvailableNow. All processing is capped
   // at this version. Not persisted -- re-captured fresh on every query start.
-  private var frozenServerVersionForAvailableNow: Long = -1
+  @volatile private var frozenServerVersionForAvailableNow: Long = -1
 
   // A variable to store the latest table version on server, returned from the getTableVersion rpc.
   // Used to store the latest table version for getOrUpdateLatestTableVersion when not getting
@@ -214,6 +213,13 @@ case class DeltaFormatSharingSource(
   private var latestTableVersionOnServer: Long = -1
 
   override def prepareForTriggerAvailableNow(): Unit = {
+    if (frozenServerVersionForAvailableNow != -1) {
+      logWarning(
+        s"prepareForTriggerAvailableNow called but frozenServerVersionForAvailableNow is " +
+          s"already set to $frozenServerVersionForAvailableNow." +
+          getTableInfoForLogging
+      )
+    }
     // Capture the frozen version here rather than lazily in getOrUpdateLatestTableVersion to keep
     // that method simple (single early-return guard). Lazy capture would require two conditionals
     // inside getOrUpdateLatestTableVersion (check if already frozen + freeze after RPC).
@@ -240,6 +246,9 @@ case class DeltaFormatSharingSource(
    */
   private def getOrUpdateLatestTableVersion: Long = {
     if (isTriggerAvailableNow) {
+      require(frozenServerVersionForAvailableNow >= 0,
+        s"frozenServerVersionForAvailableNow must be >= 0 when isTriggerAvailableNow is true, " +
+          s"but got $frozenServerVersionForAvailableNow." + getTableInfoForLogging)
       return frozenServerVersionForAvailableNow
     }
     val currentTimeMillis = System.currentTimeMillis()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Sharing)

## Description

- Add @volatile to isTriggerAvailableNow and frozenServerVersionForAvailableNow (removes the TODO that deferred this until SupportsConcurrentExecution)
- Add logWarning in prepareForTriggerAvailableNow if frozenServerVersionForAvailableNow is already initialized

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
NA

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No