### PR TITLE
[Spark] Support DeltaOption replaceUsing/replaceOn for DataFrameWriterV1 insertInto() Overwrite mode

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -269,8 +269,60 @@ class DeltaAnalysis(session: SparkSession)
         protocol = protocolAfterFilteringCatalogOwnedFromSource,
         tableByPath = isTableByPath)
 
+    // Handling df.insertInto() with `replaceOn`/`replaceUsing`.
+    //
+    //
+    // Here, we match with OverwriteDelta because insertInto() with mode("overwrite")
+    // creates [[OverwriteByExpression]] in DataFrameWriter.
+    case o @ OverwriteDelta(r, d) if !o.isByName && o.origin.sqlText.isEmpty &&
+        hasReplaceOnOrUsingOption(o.writeOptions) =>
+      val writeOpts = new DeltaOptions(o.writeOptions, session.sessionState.conf)
+      if (writeOpts.replaceOn.isDefined && !session.sessionState.conf.getConf(
+          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED)) {
+        throw DeltaErrors.operationNotSupportedException("replaceOn")
+      } else if (writeOpts.replaceUsing.isDefined && !session.sessionState.conf.getConf(
+          DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED)) {
+        throw DeltaErrors.operationNotSupportedException("replaceUsing")
+      }
+      val tableRelation = r
+      val deltaTableV2 = d
+      val needsAdjustment = needsSchemaAdjustmentByOrdinal(
+        deltaTable = deltaTableV2,
+        query = o.query,
+        schema = tableRelation.schema,
+        writeOptions = o.writeOptions)
+      val projectedQuery = if (needsAdjustment) {
+        resolveQueryColumnsByOrdinal(
+          query = o.query,
+          targetAttrs = tableRelation.output,
+          deltaTable = deltaTableV2,
+          writeOptions = o.writeOptions)
+      } else {
+        DeltaInsertReplaceOnOrUsingCommand.addOrdinalAliasProjection(
+          queryToAlias = o.query, aliasAttrs = tableRelation.output)
+      }
+      val deltaOptions = new DeltaOptions(
+        CaseInsensitiveMap(deltaTableV2.options ++ o.writeOptions),
+        session.sessionState.conf)
+      val writeCmd = WriteIntoDelta(
+        deltaLog = deltaTableV2.deltaLog,
+        mode = SaveMode.Overwrite,
+        options = deltaOptions,
+        partitionColumns = Nil,
+        configuration = Map.empty,
+        data = DataFrameUtils.ofRows(session, projectedQuery),
+        catalogTableOpt = deltaTableV2.catalogTable)
+      DeltaInsertReplaceOnOrUsingCommand(
+        deltaTable = deltaTableV2,
+        query = projectedQuery,
+        writeCmd = writeCmd,
+        insertReplaceCriteriaOpt = None,
+        byName = false,
+        apiOrigin = InsertReplaceOnOrUsingAPIOrigin.DFv1InsertInto)
+
     // INSERT OVERWRITE by ordinal and df.insertInto()
     case o @ OverwriteDelta(r, d) if !o.isByName &&
+        !hasReplaceOnOrUsingOption(o.writeOptions) &&
         needsSchemaAdjustmentByOrdinal(d, o.query, r.schema, o.writeOptions) =>
       val projection = resolveQueryColumnsByOrdinal(o.query, r.output, d, o.writeOptions)
       if (projection != o.query) {
@@ -1100,6 +1152,11 @@ class DeltaAnalysis(session: SparkSession)
     existingSchemaOutput.map(_.name) != schema.map(_.name) ||
       !SchemaUtils.isReadCompatible(schema.asNullable, existingSchemaOutput.toStructType,
         typeWideningMode = getTypeWideningMode(deltaTable, writeOptions))
+  }
+  private def hasReplaceOnOrUsingOption(writeOptions: Map[String, String]): Boolean = {
+    val caseInsensitiveWriteOptions = CaseInsensitiveMap(writeOptions)
+    caseInsensitiveWriteOptions.contains(DeltaOptions.REPLACE_ON_OPTION) ||
+      caseInsensitiveWriteOptions.contains(DeltaOptions.REPLACE_USING_OPTION)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -271,7 +271,6 @@ class DeltaAnalysis(session: SparkSession)
 
     // Handling df.insertInto() with `replaceOn`/`replaceUsing`.
     //
-    //
     // Here, we match with OverwriteDelta because insertInto() with mode("overwrite")
     // creates [[OverwriteByExpression]] in DataFrameWriter.
     case o @ OverwriteDelta(r, d) if !o.isByName && o.origin.sqlText.isEmpty &&
@@ -1153,6 +1152,7 @@ class DeltaAnalysis(session: SparkSession)
       !SchemaUtils.isReadCompatible(schema.asNullable, existingSchemaOutput.toStructType,
         typeWideningMode = getTypeWideningMode(deltaTable, writeOptions))
   }
+
   private def hasReplaceOnOrUsingOption(writeOptions: Map[String, String]): Boolean = {
     val caseInsensitiveWriteOptions = CaseInsensitiveMap(writeOptions)
     caseInsensitiveWriteOptions.contains(DeltaOptions.REPLACE_ON_OPTION) ||

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -247,6 +247,29 @@ trait DeltaInsertIntoTest
     }
   }
 
+  /** df.write.mode("overwrite").option("replaceOn", ...).insertInto() */
+  object DFv1InsertIntoReplaceOn extends Insert {
+    val name: String = "DFv1 insertInto() - REPLACE ON"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = false
+    val isSQL: Boolean = false
+    def runInsert(
+        columns: Seq[String],
+        whereCol: String,
+        whereValue: Int,
+        withSchemaEvolution: Boolean): Unit = {
+      withSQLConf(
+          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
+        spark.read.table("source").write.mode(mode)
+          .option("replaceOn", s"t.$whereCol = $whereValue")
+          .option("targetAlias", "t")
+          .option("mergeSchema", withSchemaEvolution.toString)
+          .format("delta")
+          .insertInto("target")
+      }
+    }
+  }
+
   /** df.write.mode("overwrite").option("replaceOn", ...).save() */
   object DFv1SaveReplaceOn extends Insert {
     val name: String = "DFv1 save() - REPLACE ON"
@@ -375,6 +398,7 @@ trait DeltaInsertIntoTest
         SQLInsertOverwritePartitionByPosition,
         SQLInsertOverwritePartitionColList,
         DFv1InsertIntoDynamicPartitionOverwrite,
+        DFv1InsertIntoReplaceOn,
         DFv1SaveReplaceOn,
         DFv2Append,
         DFv2Overwrite,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
@@ -148,7 +148,7 @@ class DeltaInsertReplaceOnDFWriterV1InsertIntoSuite
           .insertInto("nonexistent_table")
       },
       condition = "TABLE_OR_VIEW_NOT_FOUND",
-      parameters = Map("relationName" -> "`nonexistent_table`")
+      parameters = Map("relationName" -> "`default`.`nonexistent_table`")
     )
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
@@ -139,7 +139,7 @@ class DeltaInsertReplaceOnDFWriterV1InsertIntoSuite
   }
 
   test("insertInto: replaceOn on non-existing named table fails") {
-    checkError(
+    checkErrorMatchPVals(
       exception = intercept[AnalysisException] {
         Seq((1, "data")).toDF("id", "data")
           .write.format("delta")
@@ -148,7 +148,7 @@ class DeltaInsertReplaceOnDFWriterV1InsertIntoSuite
           .insertInto("nonexistent_table")
       },
       condition = "TABLE_OR_VIEW_NOT_FOUND",
-      parameters = Map("relationName" -> "`default`.`nonexistent_table`")
+      parameters = Map("relationName" -> ".*`nonexistent_table`")
     )
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
@@ -175,6 +175,27 @@ class DeltaInsertReplaceOnDFWriterV1InsertIntoSuite
     }
   }
 
+  test("insertInto: replaceOn with misaligned columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq((1, "source"), (4, "source"))
+          .toDF("data", "id"),
+        target = path,
+        replaceOnCond = "t.id >= 1",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "source"),
+          Row(4, "source")))
+    }
+  }
 
   test("insertInto: same column name with different types succeeds with implicit casting") {
     withTempDir { dir =>
@@ -195,5 +216,4 @@ class DeltaInsertReplaceOnDFWriterV1InsertIntoSuite
       )
     }
   }
-
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1InsertIntoSuite.scala
@@ -1,0 +1,199 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+/**
+ * Tests replaceOn via DataFrameWriterV1 insertInto() API.
+ * Reuses shared tests from [[DeltaInsertReplaceOnDFWriterTests]] using
+ * delta.`/path` syntax for insertInto, and adds insertInto-specific tests.
+ */
+class DeltaInsertReplaceOnDFWriterV1InsertIntoSuite
+  extends DeltaInsertReplaceOnDFWriterTests {
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key, "true")
+
+  override protected def writeReplaceOnDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceOnCond: String,
+      targetAlias: Option[String] = None,
+      mergeSchema: Boolean = false): Unit = {
+    var writer = sourceDF
+      .write.format("delta")
+      .mode("overwrite")
+      .option("replaceOn", replaceOnCond)
+    targetAlias.foreach { alias =>
+      writer = writer.option("targetAlias", alias)
+    }
+    if (mergeSchema) {
+      writer = writer.option("mergeSchema", "true")
+    }
+    writer.insertInto(s"delta.`$target`")
+  }
+
+  override protected def excluded: Seq[String] = super.excluded ++ Seq(
+    // insertInto requires exact column arity match; fewer source columns is
+    // not allowed unlike save() which fills missing columns with null.
+    "replaceOn with fewer source columns fills missing target columns with null",
+    // insertInto resolves columns by position and does implicit casting,
+    // so type mismatch doesn't trigger DELTA_FAILED_TO_MERGE_FIELDS.
+    "same column name with different types fails schema merge",
+    // This test relies on by name column resolution while insertInto is
+    // by position.
+    "replaceOn with different schemas, without mergeSchema fails",
+    // This test relies on by name column resolution while insertInto is
+    // by position. The new column is aligned positionally with the
+    // table column, while it is different by name.
+    "replaceOn null-safe equality matching between existing columns " +
+      "with NULL values and new columns with NULL values"
+  )
+
+  test("insertInto: replaceOn on empty table via path") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq.empty[(Int, String)].toDF("id", "data")
+        .write.format("delta").save(path)
+
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          (1, "new1"),
+          (2, "new2"))
+          .toDF("id", "data"),
+        target = path,
+        replaceOnCond = "true")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "new1"),
+          Row(2, "new2")))
+    }
+  }
+
+  test("insertInto: replaceOn on empty named table") {
+    withTable("target") {
+      sql("CREATE TABLE target (id INT, data STRING) USING delta")
+
+      Seq((1, "new1"), (2, "new2")).toDF("id", "data")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceOn", "true")
+        .insertInto("target")
+
+      checkAnswer(
+        spark.table("target").orderBy("id"),
+        Seq(
+          Row(1, "new1"),
+          Row(2, "new2")))
+    }
+  }
+
+  test("insertInto: replaceOn on non-empty named table") {
+    withTable("target") {
+      Seq(
+        (1, "original1"),
+        (2, "original2"),
+        (3, "original3"))
+        .toDF("id", "data")
+        .write.format("delta").saveAsTable("target")
+
+      Seq((1, "updated1"), (4, "new4")).toDF("id", "data").as("s")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceOn", "t.id = s.id")
+        .option("targetAlias", "t")
+        .insertInto("target")
+
+      checkAnswer(
+        spark.table("target").orderBy("id"),
+        Seq(
+          Row(1, "updated1"),
+          Row(2, "original2"),
+          Row(3, "original3"),
+          Row(4, "new4")))
+    }
+  }
+
+  test("insertInto: replaceOn on non-existing named table fails") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        Seq((1, "data")).toDF("id", "data")
+          .write.format("delta")
+          .mode("overwrite")
+          .option("replaceOn", "true")
+          .insertInto("nonexistent_table")
+      },
+      condition = "TABLE_OR_VIEW_NOT_FOUND",
+      parameters = Map("relationName" -> "`nonexistent_table`")
+    )
+  }
+
+  test("insertInto: replaceOn with swapped column order") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, 100), (2, 200), (3, 300))
+        .toDF("col1", "col2")
+        .write.format("delta").save(path)
+      writeReplaceOnDF(
+        sourceDF = Seq((10, 1), (40, 4))
+          .toDF("col2", "col1").as("s"),
+        target = path,
+        replaceOnCond = "t.col1 = s.col1",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("col1"),
+        Seq(
+          Row(2, 200),
+          Row(3, 300),
+          Row(10, 1),
+          Row(40, 4)))
+    }
+  }
+
+
+  test("insertInto: same column name with different types succeeds with implicit casting") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target")).toDF("id", "data").write.format("delta").save(path)
+      // insertInto resolves by position and does implicit casting (String "1" -> Int 1).
+      writeReplaceOnDF(
+        sourceDF = Seq(("1", "source"))
+          .toDF("id", "data")
+          .as("s"),
+        target = path,
+        replaceOnCond = "t.id = s.id",
+        targetAlias = Some("t")
+      )
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(Row(1, "source"))
+      )
+    }
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+/**
+ * Tests replaceUsing via DataFrameWriterV1 insertInto() API.
+ * Reuses shared tests from [[DeltaInsertReplaceUsingDFWriterTests]] using
+ * delta.`/path` syntax for insertInto, and adds insertInto-specific tests.
+ */
+class DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite
+  extends DeltaInsertReplaceUsingDFWriterTests {
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key, "true")
+
+  override protected def writeReplaceUsingDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceUsingCols: String,
+      writeMode: String = "overwrite",
+      mergeSchema: Boolean = false,
+      options: Map[String, String] = Map.empty): Unit = {
+    var writer = sourceDF
+      .write.format("delta")
+      .mode(writeMode)
+      .option("replaceUsing", replaceUsingCols)
+    if (mergeSchema) {
+      writer = writer.option("mergeSchema", "true")
+    }
+    options.foreach { case (k, v) => writer = writer.option(k, v) }
+    writer.insertInto(s"delta.`$target`")
+  }
+
+  override protected def excluded: Seq[String] = super.excluded ++ Seq(
+    // insertInto requires exact column arity match. These tests use source
+    // with fewer columns than target, which is not supported by insertInto.
+    "replaceUsing with fewer source columns fills missing target columns with null",
+    "replaceUsing column exists in table but not in source errors",
+    // This test relies on by name column resolution while insertInto is
+    // by position.
+    "replaceUsing errors when source has completely different column names"
+  )
+
+  test("insertInto: replaceUsing with same schema and aligned USING columns") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "a_target"), (2, "b_target"), (3, "c_target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "a_source"), (4, "d_source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "a_source"),
+          Row(2, "b_target"),
+          Row(3, "c_target"),
+          Row(4, "d_source")))
+    }
+  }
+
+
+  test("insertInto: replaceUsing with implicit type widening (Int source to Long target)") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1L, "target"), (2L, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (3, "source"))
+          .toDF("id", "value"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "source")))
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite.scala
@@ -107,27 +107,6 @@ class DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite
     }
   }
 
-  test("insertInto: replaceUsing with misaligned USING columns, disallow conf disabled") {
-    withTempDir { dir =>
-      val path = dir.getAbsolutePath
-      Seq((1, 0, "target"), (2, 0, "target"))
-        .toDF("match_col", "non_match_col", "row_origin")
-        .write.format("delta").save(path)
-
-      writeReplaceUsingDF(
-        sourceDF = Seq((10, 1, "source"))
-          .toDF("non_match_col", "match_col", "row_origin"),
-        target = path,
-        replaceUsingCols = "match_col")
-
-      checkAnswer(
-        spark.read.format("delta").load(path).orderBy("match_col"),
-        Seq(
-          Row(2, 0, "target"),
-          Row(10, 1, "source")))
-    }
-  }
-
   test("insertInto: replaceUsing with aligned USING column but mismatched " +
       "non-USING column names, which triggers schemaAdjustment") {
     withTempDir { dir =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite.scala
@@ -87,6 +87,70 @@ class DeltaInsertReplaceUsingDFWriterV1InsertIntoSuite
     }
   }
 
+  test("insertInto: replaceUsing with misaligned column names fails") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, 0, "target"))
+        .toDF("match_col", "non_match_col", "row_origin")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((2, 1, "source"))
+              .toDF("non_match_col", "match_col", "row_origin"),
+            target = path,
+            replaceUsingCols = "match_col")
+        },
+        condition = "INSERT_REPLACE_USING_DISALLOW_MISALIGNED_COLUMNS",
+        parameters = Map("misalignedReplaceUsingCols" -> "`match_col`"))
+    }
+  }
+
+  test("insertInto: replaceUsing with misaligned USING columns, disallow conf disabled") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, 0, "target"), (2, 0, "target"))
+        .toDF("match_col", "non_match_col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((10, 1, "source"))
+          .toDF("non_match_col", "match_col", "row_origin"),
+        target = path,
+        replaceUsingCols = "match_col")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("match_col"),
+        Seq(
+          Row(2, 0, "target"),
+          Row(10, 1, "source")))
+    }
+  }
+
+  test("insertInto: replaceUsing with aligned USING column but mismatched " +
+      "non-USING column names, which triggers schemaAdjustment") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "target_data")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, "source"), (4, "source"))
+          .toDF("id", "source_data"),
+        target = path,
+        replaceUsingCols = "id")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "target"),
+          Row(4, "source")))
+    }
+  }
 
   test("insertInto: replaceUsing with implicit type widening (Int source to Long target)") {
     withTempDir { dir =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Following https://github.com/delta-io/delta/pull/6445, which introduces the `replaceOn`/`replaceUsing` options, and https://github.com/delta-io/delta/pull/6569, which supports these options for `save()` Overwrite mode:

1. Users can now specify the `.option('replaceOn', 'replaceOnCond')` for the DataFrameWriterV1 `insertInto()`.

2. Users can now specify the .`option('replaceUsing', 'replace_using_column_list')` for the `DataFrameWriterV1 insertInto()`.

3. Users can also now specify the `.option('targetAlias', 'targetAliasStr')`, to be able to provide an alias for the table, to be used in the `replaceOn` option.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes, please see above.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->


