### PR TITLE
[Spark] Support DeltaOption replaceUsing/replaceOn for DataFrameWriterV1 saveAsTable() Overwrite mode

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -236,7 +236,8 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           throw DeltaErrors.operationNotSupportedException("replaceUsing")
         }
       }
-      WriteIntoDelta(
+      val writeCmd =
+        WriteIntoDelta(
         DeltaUtils.getDeltaLogFromTableOrPath(spark, existingTableOpt,
           new Path(loc), fileSystemOptions),
         operation.mode,
@@ -244,8 +245,22 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         withDb.partitionColumnNames,
         withDb.properties ++ commentOpt.map("comment" -> _),
         df,
+        // If schema is augmented (for bucketed table), use the new schema in `WriteIntoDelta`
+        // to update metadata.
         Some(tableDesc),
         schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
+      if (deltaOptions.isReplaceOnOrUsingDefined) {
+        DeltaInsertReplaceOnOrUsingCommand.createCmdForSaveAndSaveAsTable(
+          deltaTable = DeltaTableV2(
+            spark = spark,
+            path = writeCmd.deltaLog.dataPath,
+            catalogTable = Some(tableDesc)),
+          data = df,
+          writeCmd = writeCmd,
+          apiOrigin = InsertReplaceOnOrUsingAPIOrigin.DFv1SaveAsTable)
+      } else {
+        writeCmd
+      }
     }
 
     CreateDeltaTableCommand(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -236,6 +236,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           throw DeltaErrors.operationNotSupportedException("replaceUsing")
         }
       }
+      val catalogTbl = Some(tableDesc)
       val writeCmd = WriteIntoDelta(
         DeltaUtils.getDeltaLogFromTableOrPath(spark, existingTableOpt,
           new Path(loc), fileSystemOptions),
@@ -244,14 +245,14 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         withDb.partitionColumnNames,
         withDb.properties ++ commentOpt.map("comment" -> _),
         df,
-        Some(tableDesc),
+        catalogTbl,
         schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
       if (deltaOptions.isReplaceOnOrUsingDefined) {
         DeltaInsertReplaceOnOrUsingCommand.createCmdForSaveAndSaveAsTable(
           deltaTable = DeltaTableV2(
             spark = spark,
             path = writeCmd.deltaLog.dataPath,
-            catalogTable = Some(tableDesc)),
+            catalogTable = catalogTbl),
           data = df,
           writeCmd = writeCmd,
           apiOrigin = InsertReplaceOnOrUsingAPIOrigin.DFv1SaveAsTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -247,7 +247,9 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         df,
         catalogTbl,
         schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
-      if (deltaOptions.isReplaceOnOrUsingDefined) {
+      if (deltaOptions.isReplaceOnOrUsingDefined &&
+          CreateDeltaTableLikeShims.isV1WriterSaveAsTableOverwrite(
+            deltaOptions, operation.mode)) {
         DeltaInsertReplaceOnOrUsingCommand.createCmdForSaveAndSaveAsTable(
           deltaTable = DeltaTableV2(
             spark = spark,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -221,6 +221,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       )
 
     val writer = sourceQuery.map { df =>
+      val catalogTbl = Some(tableDesc)
       // For safety, only extract the file system options here, to create deltaLog.
       val fileSystemOptions = writeOptions.filter { case (k, _) =>
         DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
@@ -236,7 +237,6 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           throw DeltaErrors.operationNotSupportedException("replaceUsing")
         }
       }
-      val catalogTbl = Some(tableDesc)
       val writeCmd = WriteIntoDelta(
         DeltaUtils.getDeltaLogFromTableOrPath(spark, existingTableOpt,
           new Path(loc), fileSystemOptions),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -245,8 +245,6 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         withDb.partitionColumnNames,
         withDb.properties ++ commentOpt.map("comment" -> _),
         df,
-        // If schema is augmented (for bucketed table), use the new schema in `WriteIntoDelta`
-        // to update metadata.
         Some(tableDesc),
         schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
       if (deltaOptions.isReplaceOnOrUsingDefined) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -236,8 +236,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           throw DeltaErrors.operationNotSupportedException("replaceUsing")
         }
       }
-      val writeCmd =
-        WriteIntoDelta(
+      val writeCmd = WriteIntoDelta(
         DeltaUtils.getDeltaLogFromTableOrPath(spark, existingTableOpt,
           new Path(loc), fileSystemOptions),
         operation.mode,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveAsTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveAsTableSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row}
+
+class DeltaInsertReplaceOnDFWriterV1SaveAsTableSuite
+  extends DeltaInsertReplaceOnDFWriterTests {
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key, "true")
+
+  override protected def writeReplaceOnDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceOnCond: String,
+      targetAlias: Option[String] = None,
+      mergeSchema: Boolean = false): Unit = {
+    var writer = sourceDF
+      .write.format("delta")
+      .mode("overwrite")
+      .option("replaceOn", replaceOnCond)
+    targetAlias.foreach { alias =>
+      writer = writer.option("targetAlias", alias)
+    }
+    if (mergeSchema) {
+      writer = writer.option("mergeSchema", "true")
+    }
+    writer.saveAsTable(s"delta.`$target`")
+  }
+
+  test("saveAsTable: replaceOn with always-true condition replaces all") {
+    withTable("target") {
+      Seq((1, "original"), (2, "original"))
+        .toDF("id", "data")
+        .write.format("delta").saveAsTable("target")
+
+      Seq((10, "new1"), (20, "new2")).toDF("id", "data")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceOn", "true")
+        .saveAsTable("target")
+
+      checkAnswer(
+        spark.table("target").orderBy("id"),
+        Seq(
+          Row(10, "new1"),
+          Row(20, "new2")))
+    }
+  }
+
+  test("saveAsTable: basic replaceOn with single matching column") {
+    withTable("target") {
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "data")
+        .write.format("delta").saveAsTable("target")
+
+      Seq((1, "replaced"), (4, "new"))
+        .toDF("id", "data").as("s")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceOn", "t.id = s.id")
+        .option("targetAlias", "t")
+        .saveAsTable("target")
+
+      checkAnswer(
+        spark.table("target").orderBy("id"),
+        Seq(
+          Row(1, "replaced"),
+          Row(2, "target"),
+          Row(3, "target"),
+          Row(4, "new")))
+    }
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveAsTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveAsTableSuite.scala
@@ -90,5 +90,4 @@ class DeltaInsertReplaceOnDFWriterV1SaveAsTableSuite
           Row(4, "new")))
     }
   }
-
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row}
+
+class DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite
+  extends DeltaInsertReplaceUsingDFWriterTests {
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key, "true")
+
+  override protected def writeReplaceUsingDF(
+      sourceDF: DataFrame,
+      target: String,
+      replaceUsingCols: String,
+      writeMode: String = "overwrite",
+      mergeSchema: Boolean = false,
+      options: Map[String, String] = Map.empty): Unit = {
+    var writer = sourceDF
+      .write.format("delta")
+      .mode(writeMode)
+      .option("replaceUsing", replaceUsingCols)
+    if (mergeSchema) {
+      writer = writer.option("mergeSchema", "true")
+    }
+    options.foreach { case (k, v) => writer = writer.option(k, v) }
+    writer.saveAsTable(s"delta.`$target`")
+  }
+
+  test("saveAsTable: replaceUsing with single column") {
+    withTable("target") {
+      Seq((1, "target"), (2, "target"), (3, "target"))
+        .toDF("id", "value")
+        .write.format("delta").saveAsTable("target")
+
+      Seq((1, "source"), (4, "source")).toDF("id", "value")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceUsing", "id")
+        .saveAsTable("target")
+
+      checkAnswer(
+        spark.table("target").orderBy("id"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "target"),
+          Row(4, "source")))
+    }
+  }
+
+  test("saveAsTable: replaceUsing on empty named table") {
+    withTable("target") {
+      sql("CREATE TABLE target (id INT, value STRING) USING delta")
+
+      Seq((1, "source"), (2, "source")).toDF("id", "value")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceUsing", "id")
+        .saveAsTable("target")
+
+      checkAnswer(
+        spark.table("target").orderBy("id"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "source")))
+    }
+  }
+
+  test("saveAsTable: replaceUsing on non-existent table errors") {
+    intercept[DeltaAnalysisException] {
+      Seq((1, "data1"), (2, "data2")).toDF("id", "value")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceUsing", "id")
+        .saveAsTable("new_table")
+    }
+  }
+
+  test("saveAsTable: replaceUsing with schema evolution") {
+    withTable("target") {
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").saveAsTable("target")
+
+      Seq((1, "source", 100), (3, "source", 300))
+        .toDF("id", "value", "extra")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceUsing", "id")
+        .option("mergeSchema", "true")
+        .saveAsTable("target")
+
+      checkAnswer(
+        spark.table("target").orderBy("id"),
+        Seq(
+          Row(1, "source", 100),
+          Row(2, "target", null),
+          Row(3, "source", 300)))
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite.scala
@@ -87,13 +87,18 @@ class DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite
   }
 
   test("saveAsTable: replaceUsing on non-existent table errors") {
-    intercept[DeltaAnalysisException] {
-      Seq((1, "data1"), (2, "data2")).toDF("id", "value")
-        .write.format("delta")
-        .mode("overwrite")
-        .option("replaceUsing", "id")
-        .saveAsTable("new_table")
-    }
+    checkError(
+      exception = intercept[DeltaAnalysisException] {
+        Seq((1, "data1"), (2, "data2")).toDF("id", "value")
+          .write.format("delta")
+          .mode("overwrite")
+          .option("replaceUsing", "id")
+          .saveAsTable("new_table")
+      },
+      condition = "DELTA_PATH_DOES_NOT_EXIST",
+      parameters = Map("path" -> ".*"),
+      matchPVals = true
+    )
   }
 
   test("saveAsTable: replaceUsing with schema evolution") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Following https://github.com/delta-io/delta/pull/6445, which introduces the `replaceOn`/`replaceUsing` options, and https://github.com/delta-io/delta/pull/6569, which supports these options for `save()` Overwrite mode:

1. Users can now specify the `.option('replaceOn', 'replaceOnCond')` for the DataFrameWriterV1 `saveAsTable()`.

2. Users can now specify the .`option('replaceUsing', 'replace_using_column_list')` for the `DataFrameWriterV1 saveAsTable()`.

3. Users can also now specify the `.option('targetAlias', 'targetAliasStr')`, to be able to provide an alias for the table, to be used in the `replaceOn` option.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes, please see above.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->


