### PR TITLE
[CI] Update workflow triggers for branch rename ds-11122025 -> branch-ds-11122025

### DIFF
--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -2,9 +2,9 @@ name: "Delta Kernel"
 
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 
 # Cancel previous runs when new commits are pushed
 concurrency:

--- a/.github/workflows/kernel_unitycatalog_test.yaml
+++ b/.github/workflows/kernel_unitycatalog_test.yaml
@@ -1,9 +1,9 @@
 name: "Kernel Unity Catalog"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   test:
     name: "Kernel Unity Catalog Tests"

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -1,9 +1,9 @@
 name: "Delta Spark Publishing and Examples"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   test:
     name: "DSP&E: Scala ${{ matrix.scala }}"

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -1,9 +1,9 @@
 name: "Delta Spark Latest"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   test:
     name: "DSL: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"

--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -1,9 +1,9 @@
 name: "Unidoc"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   build:
     name: "U: Scala ${{ matrix.scala }}"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (CI/GitHub Actions workflows)

## Description

The branch `ds-11122025` was renamed to `branch-ds-11122025`. The existing
workflow files still have `branches: [ds-11122025]` in their `push` and
`pull_request` triggers, which means CI does not trigger on pushes or PRs
targeting the renamed branch.

This PR updates the branch filter in all 5 active workflow files to use the
new branch name `branch-ds-11122025`:

- `kernel_test.yaml`
- `kernel_unitycatalog_test.yaml`
- `spark_examples_test.yaml`
- `spark_test.yaml`
- `unidoc.yaml`

No other changes are made. Disabled workflows (`disabled_*`) and
`kernel_docs.yaml` (which only has `workflow_dispatch`) are unaffected.

## How was this patch tested?

This is a CI-only change (workflow trigger branch filters). Verified by
inspecting the diff — each file has exactly two line changes (push and
pull_request branch filters), and no other content is modified. CI will
validate itself once this PR is merged and a subsequent push or PR targets
`branch-ds-11122025`.

## Does this PR introduce _any_ user-facing changes?

No.