### PR TITLE
[Kernel][CI] Backport CommitInfo nullable handling to branch-ds-11122025

### DIFF
--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -2,9 +2,9 @@ name: "Delta Kernel"
 
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 
 # Cancel previous runs when new commits are pushed
 concurrency:

--- a/.github/workflows/kernel_unitycatalog_test.yaml
+++ b/.github/workflows/kernel_unitycatalog_test.yaml
@@ -1,9 +1,9 @@
 name: "Kernel Unity Catalog"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   test:
     name: "Kernel Unity Catalog Tests"

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -1,9 +1,9 @@
 name: "Delta Spark Publishing and Examples"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   test:
     name: "DSP&E: Scala ${{ matrix.scala }}"

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -1,9 +1,9 @@
 name: "Delta Spark Latest"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   test:
     name: "DSL: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"

--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -1,9 +1,9 @@
 name: "Unidoc"
 on:
   push:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
   pull_request:
-    branches: [ds-11122025]
+    branches: [branch-ds-11122025]
 jobs:
   build:
     name: "U: Scala ${{ matrix.scala }}"

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -359,11 +359,11 @@ public class TransactionImpl implements Transaction {
     return maxRetries + 1; // +1 because the first attempt is a try, not a retry.
   }
 
-  private boolean isBlindAppend() {
+  private Optional<Boolean> isBlindAppend() {
     // TODO: for now we hard code this to false to avoid erroneously setting this to true for a
     //  non-blind-append operation. We should revisit how to safely set this to true for actual
     //  blind appends.
-    return false;
+    return Optional.of(false);
   }
 
   private void updateMetadata(Metadata metadata) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -595,11 +595,11 @@ public class TransactionImpl implements Transaction {
     return new CommitInfo(
         generateInCommitTimestampForFirstCommitAttempt(engine, commitAttemptStartTime),
         commitAttemptStartTime, /* timestamp */
-        "Kernel-" + Meta.KERNEL_VERSION + "/" + engineInfo, /* engineInfo */
-        operation.getDescription(), /* description */
+        Optional.of("Kernel-" + Meta.KERNEL_VERSION + "/" + engineInfo), /* engineInfo */
+        Optional.of(operation.getDescription()), /* description */
         getOperationParameters(), /* operationParameters */
         isBlindAppend(), /* isBlindAppend */
-        txnId.toString(), /* txnId */
+        Optional.of(txnId.toString()), /* txnId */
         emptyMap() /* operationMetrics */);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -109,7 +109,7 @@ public class CommitInfo {
         children[4].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[4].getMap(rowId)),
-        children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId),
+        Optional.ofNullable(children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId)),
         children[6].isNullAt(rowId) ? null : children[6].getString(rowId),
         children[7].isNullAt(rowId)
             ? Collections.emptyMap()
@@ -216,7 +216,7 @@ public class CommitInfo {
   private final String engineInfo;
   private final String operation;
   private final Map<String, String> operationParameters;
-  private final boolean isBlindAppend;
+  private final Optional<Boolean> isBlindAppend;
   private final String txnId;
   private Optional<Long> inCommitTimestamp;
   private final Map<String, String> operationMetrics;
@@ -227,7 +227,7 @@ public class CommitInfo {
       String engineInfo,
       String operation,
       Map<String, String> operationParameters,
-      boolean isBlindAppend,
+      Optional<Boolean> isBlindAppend,
       String txnId,
       Map<String, String> operationMetrics) {
     this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
@@ -235,7 +235,7 @@ public class CommitInfo {
     this.engineInfo = requireNonNull(engineInfo);
     this.operation = requireNonNull(operation);
     this.operationParameters = Collections.unmodifiableMap(requireNonNull(operationParameters));
-    this.isBlindAppend = isBlindAppend;
+    this.isBlindAppend = requireNonNull(isBlindAppend);
     this.txnId = requireNonNull(txnId);
     this.operationMetrics = Collections.unmodifiableMap(requireNonNull(operationMetrics));
   }
@@ -256,7 +256,7 @@ public class CommitInfo {
     return operationParameters;
   }
 
-  public boolean getIsBlindAppend() {
+  public Optional<Boolean> getIsBlindAppend() {
     return isBlindAppend;
   }
 
@@ -289,7 +289,7 @@ public class CommitInfo {
     commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationParameters"), stringStringMapValue(operationParameters));
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend.orElse(null));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId);
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -101,16 +101,18 @@ public class CommitInfo {
       children[i] = vector.getChild(i);
     }
 
+    checkArgument(!children[1].isNullAt(rowId), "CommitInfo is missing required timestamp field");
+
     return new CommitInfo(
         Optional.ofNullable(children[0].isNullAt(rowId) ? null : children[0].getLong(rowId)),
-        children[1].isNullAt(rowId) ? null : children[1].getLong(rowId),
-        children[2].isNullAt(rowId) ? null : children[2].getString(rowId),
-        children[3].isNullAt(rowId) ? null : children[3].getString(rowId),
+        children[1].getLong(rowId),
+        Optional.ofNullable(children[2].isNullAt(rowId) ? null : children[2].getString(rowId)),
+        Optional.ofNullable(children[3].isNullAt(rowId) ? null : children[3].getString(rowId)),
         children[4].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[4].getMap(rowId)),
         Optional.ofNullable(children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId)),
-        children[6].isNullAt(rowId) ? null : children[6].getString(rowId),
+        Optional.ofNullable(children[6].isNullAt(rowId) ? null : children[6].getString(rowId)),
         children[7].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[7].getMap(rowId)));
@@ -213,22 +215,22 @@ public class CommitInfo {
   //////////////////////////////////
 
   private final long timestamp;
-  private final String engineInfo;
-  private final String operation;
+  private final Optional<String> engineInfo;
+  private final Optional<String> operation;
   private final Map<String, String> operationParameters;
   private final Optional<Boolean> isBlindAppend;
-  private final String txnId;
+  private final Optional<String> txnId;
   private Optional<Long> inCommitTimestamp;
   private final Map<String, String> operationMetrics;
 
   public CommitInfo(
       Optional<Long> inCommitTimestamp,
       long timestamp,
-      String engineInfo,
-      String operation,
+      Optional<String> engineInfo,
+      Optional<String> operation,
       Map<String, String> operationParameters,
       Optional<Boolean> isBlindAppend,
-      String txnId,
+      Optional<String> txnId,
       Map<String, String> operationMetrics) {
     this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
     this.timestamp = timestamp;
@@ -244,11 +246,11 @@ public class CommitInfo {
     return timestamp;
   }
 
-  public String getEngineInfo() {
+  public Optional<String> getEngineInfo() {
     return engineInfo;
   }
 
-  public String getOperation() {
+  public Optional<String> getOperation() {
     return operation;
   }
 
@@ -260,7 +262,7 @@ public class CommitInfo {
     return isBlindAppend;
   }
 
-  public String getTxnId() {
+  public Optional<String> getTxnId() {
     return txnId;
   }
 
@@ -285,12 +287,12 @@ public class CommitInfo {
     Map<Integer, Object> commitInfo = new HashMap<>();
     commitInfo.put(COL_NAME_TO_ORDINAL.get("inCommitTimestamp"), inCommitTimestamp.orElse(null));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("timestamp"), timestamp);
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo);
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo.orElse(null));
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation.orElse(null));
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationParameters"), stringStringMapValue(operationParameters));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend.orElse(null));
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId.orElse(null));
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -313,12 +313,15 @@ public class ChecksumUtils {
 
             CommitInfo commitInfo = CommitInfo.fromColumnVector(commitInfoVector, i);
             if (commitInfo == null
-                || !INCREMENTAL_SUPPORTED_OPS.contains(commitInfo.getOperation())) {
+                || !commitInfo
+                    .getOperation()
+                    .filter(INCREMENTAL_SUPPORTED_OPS::contains)
+                    .isPresent()) {
               logger.info(
                   "Falling back to full replay after {}ms: "
                       + "unsupported operation '{}' for version {}",
                   System.currentTimeMillis() - startTime,
-                  commitInfo != null ? commitInfo.getOperation() : "null",
+                  commitInfo != null ? commitInfo.getOperation().orElse("null") : "null",
                   newVersion);
               return Optional.empty();
             }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -48,7 +48,7 @@ trait ActionUtils extends VectorTestUtils {
       "engineInfo",
       "operation",
       Collections.emptyMap(), // operationParameters
-      false, // isBlindAppend
+      Optional.of(false), // isBlindAppend
       "txnId",
       Collections.emptyMap() // operationMetrics
     )

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -45,11 +45,11 @@ trait ActionUtils extends VectorTestUtils {
     new CommitInfo(
       if (ictEnabled) Optional.of(1L) else Optional.empty(), // ICT
       1L, // timestamp
-      "engineInfo",
-      "operation",
+      Optional.of("engineInfo"),
+      Optional.of("operation"),
       Collections.emptyMap(), // operationParameters
       Optional.of(false), // isBlindAppend
-      "txnId",
+      Optional.of("txnId"),
       Collections.emptyMap() // operationMetrics
     )
   }


### PR DESCRIPTION
## Summary
- backport the upstream `CommitInfo` nullability fixes from `#6079` and `#6130` onto `branch-ds-11122025`
- make incremental checksum replay tolerate nullable `commitInfo` fields instead of throwing inside `CommitInfo.fromColumnVector`
- carry the same workflow trigger-branch rename from `#6581` so GitHub Actions will actually start on PRs targeting `branch-ds-11122025`
- bring over `DefaultJsonHandlerSuite` coverage for missing `isBlindAppend`, `engineInfo`, `operation`, and `txnId`

## Test plan
- [x] `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 sbt -Dsbt.log.noformat=true 'kernelDefaults/testOnly io.delta.kernel.defaults.SnapshotChecksumStatisticsAndWriteSuite -- -z "remove action without size => empty"'`
- [x] `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 sbt -Dsbt.log.noformat=true 'kernelDefaults/testOnly io.delta.kernel.defaults.engine.DefaultJsonHandlerSuite -- -z "CommitInfo"'`
- [x] confirmed that the original CI failure on `#6581` reproduces locally on a clean `branch-ds-11122025` checkout before this backport and no longer reproduces after it

## Context
This branch temporarily includes the same workflow filter fix as `#6581` because otherwise PRs targeting `branch-ds-11122025` do not start CI at all. The kernel fix remains the main functional change; the workflow update is included here to let GitHub validate the backport end-to-end.