### PR TITLE
[Spark] Add operational metrics in DESCRIBE HISTORY for `replaceOn`/`replaceUsing` `DataFrameWriter` APIs

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -133,7 +133,9 @@ object DeltaOperations {
       override val userMetadata: Option[String] = None,
       isDynamicPartitionOverwrite: Option[Boolean] = None,
       canOverwriteSchema: Option[Boolean] = None,
-      canMergeSchema: Option[Boolean] = None
+      canMergeSchema: Option[Boolean] = None,
+      replaceOnCond: Option[String] = None,
+      replaceUsingCols: Option[String] = None
   ) extends Operation(OP_WRITE) {
     override val parameters: Map[String, Any] = Map("mode" -> mode.name()
     ) ++
@@ -144,7 +146,9 @@ object DeltaOperations {
       predicate.map("predicate" -> _) ++
       isDynamicPartitionOverwrite.map("isDynamicPartitionOverwrite" -> _) ++
       canOverwriteSchema.map("canOverwriteSchema" -> _) ++
-      canMergeSchema.map("canMergeSchema" -> _)
+      canMergeSchema.map("canMergeSchema" -> _) ++
+      replaceOnCond.map("replaceOnCond" -> _) ++
+      replaceUsingCols.map(v => "replaceUsingCols" -> s"($v)")
 
     val replaceWhereMetricsEnabled = SparkSession.active.conf.get(
       DeltaSQLConf.REPLACEWHERE_METRICS_ENABLED)
@@ -154,7 +158,8 @@ object DeltaOperations {
 
     override def transformMetrics(metrics: Map[String, SQLMetric]): Map[String, String] = {
       // Need special handling for replaceWhere as it is implemented as a Write + Delete.
-      if (predicate.nonEmpty && replaceWhereMetricsEnabled) {
+      // We have special handling for replaceOn and replaceUsing as well.
+      if (shouldCollectInsertReplaceMetrics) {
         var strMetrics = super.transformMetrics(metrics)
         // find the case where deletedRows are not captured
         if (strMetrics.get("numDeletedRows").exists(_ == "0") &&
@@ -183,7 +188,7 @@ object DeltaOperations {
     }
 
     override val operationMetrics: Set[String] =
-      if (predicate.isEmpty || !replaceWhereMetricsEnabled) {
+      if (!shouldCollectInsertReplaceMetrics) {
         // Remove metrics are included to replaceWhere metrics
         // so they need to be added only when replaceWhere metrics are not presented
         val overwriteMetrics =
@@ -195,6 +200,7 @@ object DeltaOperations {
         DeltaOperationMetrics.WRITE ++ overwriteMetrics
       } else {
         // Need special handling for replaceWhere as rows/files are deleted as well.
+        // We have special handling for replaceOn and replaceUsing as well.
         DeltaOperationMetrics.WRITE_REPLACE_WHERE
       }
 
@@ -205,6 +211,11 @@ object DeltaOperations {
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
 
     override val isInPlaceFileMetadataUpdate: Option[Boolean] = Some(false)
+
+    def shouldCollectInsertReplaceMetrics: Boolean =
+      (predicate.nonEmpty && replaceWhereMetricsEnabled) ||
+        replaceOnCond.nonEmpty ||
+        replaceUsingCols.nonEmpty
 
     override def canChangePartitionColumns: Boolean = {
       // We don't have to return true if it is a new table, only on overwrite.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -247,14 +247,12 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         df,
         catalogTbl,
         schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
-      if (deltaOptions.isReplaceOnOrUsingDefined &&
-          CreateDeltaTableLikeShims.isV1WriterSaveAsTableOverwrite(
-            deltaOptions, operation.mode)) {
+      if (deltaOptions.isReplaceOnOrUsingDefined) {
         DeltaInsertReplaceOnOrUsingCommand.createCmdForSaveAndSaveAsTable(
           deltaTable = DeltaTableV2(
             spark = spark,
             path = writeCmd.deltaLog.dataPath,
-            catalogTable = catalogTbl),
+            catalogTable = Some(tableDesc)),
           data = df,
           writeCmd = writeCmd,
           apiOrigin = InsertReplaceOnOrUsingAPIOrigin.DFv1SaveAsTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -247,12 +247,14 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         df,
         catalogTbl,
         schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
-      if (deltaOptions.isReplaceOnOrUsingDefined) {
+      if (deltaOptions.isReplaceOnOrUsingDefined &&
+          CreateDeltaTableLikeShims.isV1WriterSaveAsTableOverwrite(
+            deltaOptions, operation.mode)) {
         DeltaInsertReplaceOnOrUsingCommand.createCmdForSaveAndSaveAsTable(
           deltaTable = DeltaTableV2(
             spark = spark,
             path = writeCmd.deltaLog.dataPath,
-            catalogTable = Some(tableDesc)),
+            catalogTable = catalogTbl),
           data = df,
           writeCmd = writeCmd,
           apiOrigin = InsertReplaceOnOrUsingAPIOrigin.DFv1SaveAsTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -731,7 +731,7 @@ case class CreateDeltaTableCommand(
       )
 
     // Legacy saveAsTable with Overwrite mode
-    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+    case TableCreationModes.CreateOrReplace if options.exists(_.isInsertAtomicReplaceOp) =>
       DeltaOperations.Write(
         mode = mode,
         partitionBy = Option(table.partitionColumnNames),
@@ -740,7 +740,9 @@ case class CreateDeltaTableCommand(
         isDynamicPartitionOverwrite = options.flatMap(
           o => if (Try(o.isDynamicPartitionOverwriteMode).getOrElse(false)) Some(true) else None),
         canOverwriteSchema = options.flatMap(o => if (o.canOverwriteSchema) Some(true) else None),
-        canMergeSchema = options.flatMap(o => if (o.canMergeSchema) Some(true) else None)
+        canMergeSchema = options.flatMap(o => if (o.canMergeSchema) Some(true) else None),
+        replaceOnCond = options.flatMap(_.replaceOn),
+        replaceUsingCols = options.flatMap(_.replaceUsing)
       )
 
     // New DataSourceV2 saveAsTable with overwrite mode behavior

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -119,7 +119,9 @@ case class WriteIntoDelta(
         isDynamicPartitionOverwrite =
           if (Try(options.isDynamicPartitionOverwriteMode).getOrElse(false)) Some(true) else None,
         canOverwriteSchema = if (options.canOverwriteSchema) Some(true) else None,
-        canMergeSchema = if (options.canMergeSchema) Some(true) else None
+        canMergeSchema = if (options.canMergeSchema) Some(true) else None,
+        replaceOnCond = options.replaceOn,
+        replaceUsingCols = options.replaceUsing
       )
       txn.commitIfNeeded(taggedCommitData.actions, operation, tags = taggedCommitData.stringTags)
     }
@@ -410,9 +412,12 @@ case class WriteIntoDelta(
         (newFiles, newFiles.collect { case a: AddFile => a }, Nil)
     }
 
-    // Need to handle replace where metrics separately.
-    if (maybeAliasedReplaceWhereExprsOpt.nonEmpty && replaceWhereOnDataColsEnabled &&
-        sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_METRICS_ENABLED)) {
+    val shouldRecordReplaceWhereOpMetrics =
+      maybeAliasedReplaceWhereExprsOpt.nonEmpty && replaceWhereOnDataColsEnabled &&
+      sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_METRICS_ENABLED)
+    val shouldRecordInsertReplaceOpMetrics =
+      shouldRecordReplaceWhereOpMetrics || replaceOnOrUsingExprOpt.isDefined
+    if (shouldRecordInsertReplaceOpMetrics) {
       registerInsertReplaceMetrics(sparkSession, txn, newFiles, deletedFiles)
     } else if (mode == SaveMode.Overwrite &&
         sparkSession.conf.get(DeltaSQLConf.OVERWRITE_REMOVE_METRICS_ENABLED)) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -1449,6 +1449,209 @@ trait DescribeDeltaHistorySuiteBase
     }
   }
 
+  private def createInsertReplaceTestData(
+      start: Long, end: Long, numPartitions: Int): DataFrame = {
+    spark.range(start = start, end = end, step = 1, numPartitions = numPartitions)
+      .toDF("id").selectExpr("id as id1", "id as id2")
+  }
+
+  private def getNumAddedChangeFiles(
+      deltaLog: DeltaLog,
+      enableCDF: Boolean): Int = {
+    if (enableCDF) {
+      deltaLog.getChanges(1).flatMap {
+        case (a, v) => v
+      }.filter(_.isInstanceOf[AddCDCFile])
+      .toSeq
+      .size
+    } else {
+      0
+    }
+  }
+
+  for {
+    (replaceOption, optionValue, expectedCond, opParam) <- Seq(
+      ("replaceOn", "t.id1 = s.id1 AND t.id2 = s.id2",
+        "t.id1 = s.id1 AND t.id2 = s.id2", "replaceOnCond"),
+      ("replaceUsing", "id1, id2", "(id1, id2)", "replaceUsingCols")
+    )
+  } {
+    testReplaceWhere(
+        s"save with $replaceOption operational metrics ") {
+        (enableCDF, enableStats) =>
+      withSQLConf(
+        DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true",
+        DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true"
+      ) {
+        withTempDir { dir =>
+          val path = dir.getAbsolutePath
+          val numRowsPerFile = 10
+          val numFiles = 10
+
+          createInsertReplaceTestData(
+              start = 0,
+              end = numFiles * numRowsPerFile,
+              numPartitions = numFiles)
+            .write
+            .format("delta")
+            .save(path)
+
+          createInsertReplaceTestData(
+              start = 0, end = 15, numPartitions = 2)
+            .as("s")
+            .write
+            .format("delta")
+            .mode("overwrite")
+            .option(replaceOption, optionValue)
+            .option("targetAlias", "t")
+            .save(path)
+
+          val deltaLog = DeltaLog.forTable(spark, path)
+          val deltaTable = io.delta.tables.DeltaTable.forPath(path)
+          val numAddedChangeFiles =
+            getNumAddedChangeFiles(deltaLog = deltaLog, enableCDF = enableCDF)
+          val (numAddedBytesExpected, numRemovedBytesExpected) =
+            getLastCommitNumAddedAndRemovedBytes(deltaLog)
+          val lastVersion = deltaLog.update().version
+          val numAddedFiles = deltaLog.getChanges(lastVersion)
+            .flatMap(_._2).count(_.isInstanceOf[AddFile])
+          val numRemovedFilesCount = deltaLog.getChanges(lastVersion)
+            .flatMap(_._2).count(_.isInstanceOf[RemoveFile])
+
+          if (enableStats) {
+            checkOperationMetrics(
+              expectedMetrics = Map(
+                "numFiles" -> numAddedFiles.toString,
+                "numOutputRows" -> "20",
+                "numCopiedRows" -> "5",
+                "numAddedChangeFiles" -> numAddedChangeFiles.toString,
+                "numDeletedRows" -> "15",
+                "numOutputBytes" -> numAddedBytesExpected.toString,
+                "numRemovedBytes" -> numRemovedBytesExpected.toString,
+                "numRemovedFiles" -> numRemovedFilesCount.toString
+              ),
+              operationMetrics = getOperationMetrics(deltaTable.history(1)),
+              metricsSchema = replaceWhereMetricsSchema
+            )
+          } else {
+            checkOperationMetrics(
+              expectedMetrics = Map(
+                "numFiles" -> numAddedFiles.toString,
+                "numAddedChangeFiles" -> numAddedChangeFiles.toString,
+                "numOutputBytes" -> numAddedBytesExpected.toString,
+                "numRemovedBytes" -> numRemovedBytesExpected.toString,
+                "numRemovedFiles" -> numRemovedFilesCount.toString
+              ),
+              operationMetrics = getOperationMetrics(deltaTable.history(1)),
+              metricsSchema = replaceWhereMetricsSchema.filter(!_.contains("Rows"))
+            )
+          }
+
+          checkLastOperation(
+            path,
+            expectedOperationParameters =
+              Seq("mode", "partitionBy", opParam),
+            expectedColVals = Seq("WRITE", "Overwrite", expectedCond),
+            columns =
+              Seq($"operation", $"operationParameters.mode",
+                col(s"operationParameters.$opParam")))
+        }
+      }
+    }
+  }
+
+  for {
+    (replaceOption, optionValue, expectedCond, opParam) <- Seq(
+      ("replaceOn", "t.id1 = s.id1 AND t.id2 = s.id2",
+        "t.id1 = s.id1 AND t.id2 = s.id2", "replaceOnCond"),
+      ("replaceUsing", "id1, id2", "(id1, id2)", "replaceUsingCols")
+    )
+  } {
+    testReplaceWhere(
+        s"saveAsTable with $replaceOption operational metrics ") {
+        (enableCDF, enableStats) =>
+      withSQLConf(
+        DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true",
+        DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true"
+      ) {
+        withTable("target") {
+          val numRowsPerFile = 10
+          val numFiles = 10
+
+          createInsertReplaceTestData(
+              start = 0,
+              end = numFiles * numRowsPerFile,
+              numPartitions = numFiles)
+            .write
+            .format("delta")
+            .saveAsTable("target")
+
+          createInsertReplaceTestData(
+              start = 0, end = 15, numPartitions = 2)
+            .as("s")
+            .write
+            .format("delta")
+            .mode("overwrite")
+            .option(replaceOption, optionValue)
+            .option("targetAlias", "t")
+            .saveAsTable("target")
+
+          val deltaLog = DeltaLog.forTable(spark, TableIdentifier("target"))
+          val deltaTable = io.delta.tables.DeltaTable.forName("target")
+          val numAddedChangeFiles =
+            getNumAddedChangeFiles(deltaLog = deltaLog, enableCDF = enableCDF)
+          val (numAddedBytesExpected, numRemovedBytesExpected) =
+            getLastCommitNumAddedAndRemovedBytes(deltaLog)
+          val lastVersion = deltaLog.update().version
+          val numAddedFiles = deltaLog.getChanges(lastVersion)
+            .flatMap(_._2).count(_.isInstanceOf[AddFile])
+          val numRemovedFilesCount = deltaLog.getChanges(lastVersion)
+            .flatMap(_._2).count(_.isInstanceOf[RemoveFile])
+
+          if (enableStats) {
+            checkOperationMetrics(
+              expectedMetrics = Map(
+                "numFiles" -> numAddedFiles.toString,
+                "numOutputRows" -> "20",
+                "numCopiedRows" -> "5",
+                "numAddedChangeFiles" -> numAddedChangeFiles.toString,
+                "numDeletedRows" -> "15",
+                "numOutputBytes" -> numAddedBytesExpected.toString,
+                "numRemovedBytes" -> numRemovedBytesExpected.toString,
+                "numRemovedFiles" -> numRemovedFilesCount.toString
+              ),
+              operationMetrics = getOperationMetrics(deltaTable.history(1)),
+              metricsSchema = replaceWhereMetricsSchema
+            )
+          } else {
+            checkOperationMetrics(
+              expectedMetrics = Map(
+                "numFiles" -> numAddedFiles.toString,
+                "numAddedChangeFiles" -> numAddedChangeFiles.toString,
+                "numOutputBytes" -> numAddedBytesExpected.toString,
+                "numRemovedBytes" -> numRemovedBytesExpected.toString,
+                "numRemovedFiles" -> numRemovedFilesCount.toString
+              ),
+              operationMetrics = getOperationMetrics(deltaTable.history(1)),
+              metricsSchema = replaceWhereMetricsSchema.filter(!_.contains("Rows"))
+            )
+          }
+
+          val targetPath = spark.sessionState.catalog
+            .getTableMetadata(TableIdentifier("target")).location.getPath
+          checkLastOperation(
+            targetPath,
+            expectedOperationParameters =
+              Seq("mode", "partitionBy", opParam),
+            expectedColVals = Seq("WRITE", "Overwrite", expectedCond),
+            columns =
+              Seq($"operation", $"operationParameters.mode",
+                col(s"operationParameters.$opParam")))
+        }
+      }
+    }
+  }
+
   test("replaceWhere metrics turned off - reverts to old behavior") {
     withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "true",
         DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add operational metrics in DESCRIBE HISTORY for `replaceOn`/`replaceUsing` `DataFrameWriter` APIs, similar to as was done for `replaceWhere`.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
