### PR TITLE
[BUILD] Revive faster-tests CI and cancel stale workflow runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,12 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
+
+# Cancel previous runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Build Test"

--- a/.github/workflows/disabled_publish_docs.yaml
+++ b/.github/workflows/disabled_publish_docs.yaml
@@ -7,6 +7,11 @@ name: "Publish Docs [DISABLED]"
 on:
   workflow_dispatch: # manual-only, auto triggers removed
 
+# Cancel previous runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_api_docs:
     if: false # SECURITY: disabled - supply chain attack mitigation

--- a/.github/workflows/kernel_unitycatalog_test.yaml
+++ b/.github/workflows/kernel_unitycatalog_test.yaml
@@ -20,6 +20,12 @@ on:
       - 'storage/**/*.scala'
       - 'storage/**/*.java'
       - '.github/workflows/kernel_unitycatalog_test.yaml'
+
+# Cancel previous runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Kernel Unity Catalog Tests"

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -10,6 +10,12 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
+
+# Cancel previous runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Generate Spark versions matrix from CrossSparkVersions.scala
   # This workflow tests against released versions only (no snapshots)

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -10,6 +10,12 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
+
+# Cancel previous runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # SECURITY: Temporal lockdown — refuse any package version published after this date.
   # This date is a pre-attack baseline (before the active PyPI supply chain attack).

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -10,6 +10,10 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
+# Cancel previous runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   # Generate Spark versions matrix from CrossSparkVersions.scala
   # This ensures the workflow always uses the versions defined in the build
@@ -18,8 +22,30 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       spark_versions: ${{ steps.generate.outputs.spark_versions }}
+      use_faster_tests: ${{ steps.check-faster-tests.outputs.use_faster_tests || 'false' }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Check faster-tests label authorization
+        id: check-faster-tests
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'faster-tests')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ALLOWED_USERS: '["tdas"]'
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          LABELER=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/timeline" \
+            --jq '[.[] | select(.event == "labeled" and .label.name == "faster-tests")] | last | .actor.login' || true)
+          echo "faster-tests label was added by: $LABELER"
+          if [ -z "$LABELER" ] || [ "$LABELER" = "null" ]; then
+            echo "::warning::Could not determine who added faster-tests label. Falling back to standard runners."
+            echo "use_faster_tests=false" >> $GITHUB_OUTPUT
+          elif echo "$ALLOWED_USERS" | jq -e --arg user "$LABELER" 'index($user) != null' > /dev/null 2>&1; then
+            echo "User $LABELER is authorized to use faster-tests"
+            echo "use_faster_tests=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::User $LABELER is not authorized to use faster-tests. Falling back to standard runners."
+            echo "use_faster_tests=false" >> $GITHUB_OUTPUT
+          fi
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
@@ -35,7 +61,7 @@ jobs:
 
   test:
     name: "DS: Spark ${{ matrix.spark_version }}, Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
-    runs-on: ubuntu-24.04
+    runs-on: ${{ needs.generate-matrix.outputs.use_faster_tests == 'true' && fromJson('{"group":"delta-spark-tests-runner-group","labels":["delta-spark-tests-16-core-runners"]}') || 'ubuntu-24.04' }}
     needs: generate-matrix
     strategy:
       fail-fast: false
@@ -81,7 +107,7 @@ jobs:
           fi
       - name: Run Scala/Java tests
         run: |
-          TEST_PARALLELISM_COUNT=4 python3 run-tests.py --group spark --shard ${{ matrix.shard }} --spark-version ${{ matrix.spark_version }}
+          TEST_PARALLELISM_COUNT=${{ needs.generate-matrix.outputs.use_faster_tests == 'true' && 8 || 4 }} python3 run-tests.py --group spark --shard ${{ matrix.shard }} --spark-version ${{ matrix.spark_version }}
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/spark_test_uc_master.yaml
+++ b/.github/workflows/spark_test_uc_master.yaml
@@ -18,6 +18,11 @@ on:
       - '**.md'
       - '**.txt'
 
+# Cancel previous runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-uc-master:
     name: "[Non Blocking] UC Integration Tests (UC Main)"

--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -4,6 +4,12 @@
       branches: [master, branch-*]
     pull_request:
       branches: [master, branch-*]
+
+  # Cancel previous runs when new commits are pushed
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
   jobs:
     build:
       name: "U: Scala ${{ matrix.scala }}"


### PR DESCRIPTION
## Summary
- Revive the `faster-tests` Spark CI path from #6111 on top of the current `master` workflow layout while keeping the default runner and shard behavior unchanged.
- Add concurrency cancellation across the rest of the workflows so superseded PR runs stop consuming CI capacity, while preserving the existing non-canceling docs deployment behavior.
- Recheck the current `master` Spark 4.1 shard 0/1 logs, which now both include green `DeltaTableBuilderSuite` runs, so the old `connectClient` failure from #6111 does not look like a standing baseline blocker.

## Test plan
- [ ] Let the default PR CI run without the `faster-tests` label.
- [ ] Add the `faster-tests` label and trigger a second run to validate the custom runner group and higher Spark test parallelism path.
- [x] Parse all edited workflow YAML files locally.
- [x] Recheck latest `master` Spark 4.1 shard 0/1 logs and confirm `DeltaTableBuilderSuite` passes there.