### PR TITLE
[Spark] Add more replaceOn/replaceUsing DataFrame writer tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -729,6 +729,61 @@ class DeltaDataFrameWriterV2Suite
     }
 
   }
+
+  test("Append: writeTo with replaceUsing option just appends") {
+    withSQLConf(
+        DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
+      spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+
+      spark.table("source").writeTo("table_name").append()
+
+      checkAnswer(
+        spark.table("table_name"),
+        Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c")))
+
+      Seq((2L, "updated"), (4L, "new")).toDF("id", "data")
+        .writeTo("table_name")
+        .option("replaceUsing", "id")
+        .append()
+
+      checkAnswer(
+        spark.table("table_name").orderBy("id", "data"),
+        Seq(
+          Row(1L, "a"),
+          Row(2L, "b"),
+          Row(2L, "updated"),
+          Row(3L, "c"),
+          Row(4L, "new")))
+    }
+  }
+
+  test("Append: writeTo with replaceOn and targetAlias option just appends") {
+    withSQLConf(
+        DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
+      spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+
+      spark.table("source").writeTo("table_name").append()
+
+      checkAnswer(
+        spark.table("table_name"),
+        Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c")))
+
+      Seq((2L, "updated"), (4L, "new")).toDF("id", "data")
+        .writeTo("table_name")
+        .option("replaceOn", "t.id = s.id")
+        .option("targetAlias", "t")
+        .append()
+
+      checkAnswer(
+        spark.table("table_name").orderBy("id", "data"),
+        Seq(
+          Row(1L, "a"),
+          Row(2L, "b"),
+          Row(2L, "updated"),
+          Row(3L, "c"),
+          Row(4L, "new")))
+    }
+  }
 }
 
 trait DeltaDataFrameWriterV2ColumnMappingSuiteBase extends DeltaColumnMappingSelectedTestMixin {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.scalatest.BeforeAndAfter
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnOrUsingDFOptionCombinationSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnOrUsingDFOptionCombinationSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.delta.DeltaOptions.{
 }
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, QueryTest, Row, SaveMode}
@@ -291,6 +292,38 @@ class DeltaInsertReplaceOnOrUsingDFOptionCombinationSuite extends QueryTest
       }
     }
 
+    for {
+      enableDynamicPartitionOverwrite <- Seq(true, false)
+      partitionOverwriteMode <- SQLConf.PartitionOverwriteMode.values
+    } {
+      val testParamsMsg =
+        s"enableDynamicPartitionOverwrite=$enableDynamicPartitionOverwrite, " +
+          s"partitionOverwriteMode=$partitionOverwriteMode"
+      test(s"SQL session config DPO should not affect `$optionName` option, " +
+          s"save DataFrameWriterV1 API, $testParamsMsg") {
+        withSQLConf(
+          DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key ->
+            enableDynamicPartitionOverwrite.toString,
+          SQLConf.PARTITION_OVERWRITE_MODE.key -> partitionOverwriteMode.toString) {
+          withTempDir { tempDir =>
+            Seq((1, "a"), (2, "b")).toDF("id", "value")
+              .write.format("delta").save(tempDir.getAbsolutePath)
+            Seq((2, "c"), (3, "d")).toDF("id", "value")
+              .write.mode(SaveMode.Overwrite).format("delta")
+              .option(optionName, optionValue)
+              .save(tempDir.getAbsolutePath)
+            checkAnswer(
+              spark.read.format("delta").load(tempDir.getAbsolutePath).orderBy("id"),
+              optionName match {
+                case REPLACE_ON_OPTION => Seq(Row(2, "c"), Row(3, "d"))
+                case REPLACE_USING_OPTION => Seq(Row(1, "a"), Row(2, "c"), Row(3, "d"))
+              }
+            )
+          }
+        }
+      }
+    }
+
     def writeSource(
         sourceDF: DataFrame,
         incompatibleOptionFn: DataFrameWriter[Row] => DataFrameWriter[Row])
@@ -349,6 +382,65 @@ class DeltaInsertReplaceOnOrUsingDFOptionCombinationSuite extends QueryTest
       }
     }
 
+    test(s"`overwriteSchema`=false should be valid with `$optionName`" +
+        ", save DataFrameWriterV1 API") {
+      withTempDir { tempDir =>
+        Seq((1, "a"), (2, "b")).toDF("id", "value")
+          .write.format("delta").save(tempDir.getAbsolutePath)
+        Seq((2, "c"), (3, "d")).toDF("id", "value")
+          .write.mode(SaveMode.Overwrite).format("delta")
+          .option(optionName, optionValue)
+          .option(OVERWRITE_SCHEMA_OPTION, "false")
+          .save(tempDir.getAbsolutePath)
+        checkAnswer(
+          spark.read.format("delta").load(tempDir.getAbsolutePath).orderBy("id"),
+          optionName match {
+            case REPLACE_ON_OPTION => Seq(Row(2, "c"), Row(3, "d"))
+            case REPLACE_USING_OPTION => Seq(Row(1, "a"), Row(2, "c"), Row(3, "d"))
+          }
+        )
+      }
+    }
+
+    test(s"`overwriteSchema`=false should be valid with `$optionName`" +
+        ", saveAsTable DataFrameWriterV1 API") {
+      withTable("target") {
+        Seq((1, "a"), (2, "b")).toDF("id", "value")
+          .write.format("delta").saveAsTable("target")
+        Seq((2, "c"), (3, "d")).toDF("id", "value")
+          .write.mode(SaveMode.Overwrite).format("delta")
+          .option(optionName, optionValue)
+          .option(OVERWRITE_SCHEMA_OPTION, "false")
+          .saveAsTable("target")
+        checkAnswer(
+          spark.read.format("delta").table("target").orderBy("id"),
+          optionName match {
+            case REPLACE_ON_OPTION => Seq(Row(2, "c"), Row(3, "d"))
+            case REPLACE_USING_OPTION => Seq(Row(1, "a"), Row(2, "c"), Row(3, "d"))
+          }
+        )
+      }
+    }
+
+    test(s"`overwriteSchema`=false should be valid with `$optionName`" +
+        ", insertInto DataFrameWriterV1 API") {
+      withTable("target") {
+        Seq((1, "a"), (2, "b")).toDF("id", "value")
+          .write.format("delta").saveAsTable("target")
+        Seq((2, "c"), (3, "d")).toDF("id", "value")
+          .write.mode(SaveMode.Overwrite).format("delta")
+          .option(optionName, optionValue)
+          .option(OVERWRITE_SCHEMA_OPTION, "false")
+          .insertInto("target")
+        checkAnswer(
+          spark.read.format("delta").table("target").orderBy("id"),
+          optionName match {
+            case REPLACE_ON_OPTION => Seq(Row(2, "c"), Row(3, "d"))
+            case REPLACE_USING_OPTION => Seq(Row(1, "a"), Row(2, "c"), Row(3, "d"))
+          }
+        )
+      }
+    }
     test(s"`dataChange`=false should be invalid with `$optionName`" +
         ", save DataFrameWriterV1 API") {
       withTempDir { tempDir =>
@@ -412,6 +504,66 @@ class DeltaInsertReplaceOnOrUsingDFOptionCombinationSuite extends QueryTest
         checkAnswer(
           spark.read.format("delta").load(tempDir.getAbsolutePath).orderBy("id", "value"),
           Seq(Row(1, "a"), Row(2, "b"), Row(2, "c"), Row(3, "d"))
+        )
+      }
+    }
+
+    test(s"`dataChange`=true should be valid with `$optionName`" +
+        ", save DataFrameWriterV1 API") {
+      withTempDir { tempDir =>
+        Seq((1, "a"), (2, "b")).toDF("id", "value")
+          .write.format("delta").save(tempDir.getAbsolutePath)
+        Seq((2, "c"), (3, "d")).toDF("id", "value")
+          .write.mode(SaveMode.Overwrite).format("delta")
+          .option(optionName, optionValue)
+          .option(DATA_CHANGE_OPTION, "true")
+          .save(tempDir.getAbsolutePath)
+        checkAnswer(
+          spark.read.format("delta").load(tempDir.getAbsolutePath).orderBy("id"),
+          optionName match {
+            case REPLACE_ON_OPTION => Seq(Row(2, "c"), Row(3, "d"))
+            case REPLACE_USING_OPTION => Seq(Row(1, "a"), Row(2, "c"), Row(3, "d"))
+          }
+        )
+      }
+    }
+
+    test(s"`dataChange`=true should be valid with `$optionName`" +
+        ", saveAsTable DataFrameWriterV1 API") {
+      withTable("target") {
+        Seq((1, "a"), (2, "b")).toDF("id", "value")
+          .write.format("delta").saveAsTable("target")
+        Seq((2, "c"), (3, "d")).toDF("id", "value")
+          .write.mode(SaveMode.Overwrite).format("delta")
+          .option(optionName, optionValue)
+          .option(DATA_CHANGE_OPTION, "true")
+          .saveAsTable("target")
+        checkAnswer(
+          spark.read.format("delta").table("target").orderBy("id"),
+          optionName match {
+            case REPLACE_ON_OPTION => Seq(Row(2, "c"), Row(3, "d"))
+            case REPLACE_USING_OPTION => Seq(Row(1, "a"), Row(2, "c"), Row(3, "d"))
+          }
+        )
+      }
+    }
+
+    test(s"`dataChange`=true should be valid with `$optionName`" +
+        ", insertInto DataFrameWriterV1 API") {
+      withTable("target") {
+        Seq((1, "a"), (2, "b")).toDF("id", "value")
+          .write.format("delta").saveAsTable("target")
+        Seq((2, "c"), (3, "d")).toDF("id", "value")
+          .write.mode(SaveMode.Overwrite).format("delta")
+          .option(optionName, optionValue)
+          .option(DATA_CHANGE_OPTION, "true")
+          .insertInto("target")
+        checkAnswer(
+          spark.read.format("delta").table("target").orderBy("id"),
+          optionName match {
+            case REPLACE_ON_OPTION => Seq(Row(2, "c"), Row(3, "d"))
+            case REPLACE_USING_OPTION => Seq(Row(1, "a"), Row(2, "c"), Row(3, "d"))
+          }
         )
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -3424,49 +3424,63 @@ class DeltaNameColumnMappingSuite extends DeltaSuite
 
   for (insertReplaceCriteriaType <- Seq("replaceOn", "replaceUsing")) {
     test(s"$insertReplaceCriteriaType option is not yet supported with DFv1 save API") {
-      withTempDir { tempDir =>
-        checkError(
-          intercept[DeltaAnalysisException] {
-            spark.range(100).select("id").write.format("delta")
-              .mode("overwrite")
-              .option(insertReplaceCriteriaType, "true")
-              .save(tempDir.toString)
-          },
-          condition = "DELTA_OPERATION_NOT_ALLOWED",
-          sqlState = "0AKDC",
-          parameters = Map("operation" -> insertReplaceCriteriaType))
+      withSQLConf(
+          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "false",
+          DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "false") {
+        withTempDir { tempDir =>
+          checkError(
+            intercept[DeltaAnalysisException] {
+              spark.range(100).select("id").write.format("delta")
+                .mode("overwrite")
+                // For replaceOn: 'true' is a matching condition.
+                // For replaceUsing: 'true' is a matching column.
+                .option(insertReplaceCriteriaType, "true")
+                .save(tempDir.toString)
+            },
+            condition = "DELTA_OPERATION_NOT_ALLOWED",
+            sqlState = "0AKDC",
+            parameters = Map("operation" -> insertReplaceCriteriaType))
+        }
       }
     }
 
     test(s"$insertReplaceCriteriaType option is not yet supported with DFv1 insertInto") {
-      withTable("target") {
-        sql("CREATE TABLE target (id bigint, data string) USING delta")
-        val df = Seq((1L, "a"), (2L, "b"), (3L, "c")).toDF("id", "data")
-        checkError(
-          intercept[DeltaAnalysisException] {
-            df.write.format("delta")
-              .mode("overwrite")
-              .option(insertReplaceCriteriaType, "true")
-              .insertInto("target")
-          },
-          condition = "DELTA_OPERATION_NOT_ALLOWED",
-          sqlState = "0AKDC",
-          parameters = Map("operation" -> insertReplaceCriteriaType))
+      withSQLConf(
+          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "false",
+          DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "false") {
+        withTable("target") {
+          sql("CREATE TABLE target (id bigint, data string) USING delta")
+          val df = Seq((1L, "a"), (2L, "b"), (3L, "c")).toDF("id", "data")
+          checkError(
+            intercept[DeltaAnalysisException] {
+              df.write.format("delta")
+                .mode("overwrite")
+                .option(insertReplaceCriteriaType, "true")
+                .insertInto("target")
+            },
+            condition = "DELTA_OPERATION_NOT_ALLOWED",
+            sqlState = "0AKDC",
+            parameters = Map("operation" -> insertReplaceCriteriaType))
+        }
       }
     }
 
     test(s"$insertReplaceCriteriaType option is not yet supported via saveAsTable") {
-      withTable("target") {
-        checkError(
-          intercept[DeltaAnalysisException] {
-            spark.range(10).write.format("delta")
-              .option(insertReplaceCriteriaType, "true")
-              .saveAsTable("target")
-          },
-          condition = "DELTA_OPERATION_NOT_ALLOWED",
-          sqlState = "0AKDC",
-          parameters = Map("operation" -> insertReplaceCriteriaType)
-        )
+      withSQLConf(
+          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "false",
+          DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "false") {
+        withTable("target") {
+          checkError(
+            intercept[DeltaAnalysisException] {
+              spark.range(10).write.format("delta")
+                .option(insertReplaceCriteriaType, "true")
+                .saveAsTable("target")
+            },
+            condition = "DELTA_OPERATION_NOT_ALLOWED",
+            sqlState = "0AKDC",
+            parameters = Map("operation" -> insertReplaceCriteriaType)
+          )
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -1945,12 +1945,15 @@ trait DescribeDeltaHistorySuiteBase
     if (asserts.canOverwriteSchema) expected += ("canOverwriteSchema" -> "true")
     if (asserts.canMergeSchema) expected += ("canMergeSchema" -> "true")
     asserts.predicate.foreach(pred => expected += ("predicate" -> pred))
+    asserts.replaceOnCond.foreach(cond => expected += ("replaceOnCond" -> cond))
+    asserts.replaceUsingCols.foreach(cols => expected += ("replaceUsingCols" -> cols))
     assertInHistory(opParams, expected.result())
   }
 
   def assertInHistory(opParams: Map[String, String], expected: Map[String, String]): Unit = {
     val allParams = Seq(
-      "isDynamicPartitionOverwrite", "predicate", "canOverwriteSchema", "canMergeSchema"
+      "isDynamicPartitionOverwrite", "predicate", "canOverwriteSchema", "canMergeSchema",
+      "replaceUsingCols", "replaceOnCond"
     )
     expected.foreach { case (key, value) =>
       assert(opParams.get(key).exists(_.contains(value)),
@@ -2009,7 +2012,9 @@ case class WriteOptionsAssertion(
     isDynamicPartitionOverwrite: Boolean = false,
     canOverwriteSchema: Boolean = false,
     canMergeSchema: Boolean = false,
-    predicate: Option[String] = None
+    predicate: Option[String] = None,
+    replaceOnCond: Option[String] = None,
+    replaceUsingCols: Option[String] = None
 )
 
 /**
@@ -2273,6 +2278,30 @@ trait WriteOptionsTestBase {
       """)
     }
   }(WriteOptionsAssertion(isDynamicPartitionOverwrite = true))
+
+  testTableWrite("write options for saveAsTable with replaceOn option") { tableName =>
+    withSQLConf(
+      DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true"
+    ) {
+      testData(ids = Seq(6), parts = Seq(1))
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceOn", "true")
+        .saveAsTable(tableName)
+    }
+  }(WriteOptionsAssertion(replaceOnCond = Some("true")))
+
+  testTableWrite("write options for saveAsTable with replaceUsing option") { tableName =>
+    withSQLConf(
+      DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true"
+    ) {
+      testData(ids = Seq(6), parts = Seq(1))
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceUsing", "part")
+        .saveAsTable(tableName)
+    }
+  }(WriteOptionsAssertion(replaceUsingCols = Some("part")))
 }
 
 class DescribeDeltaHistorySuite


### PR DESCRIPTION
## Description

Add additional test coverage for `replaceOn`/`replaceUsing` DataFrame writer options:

- **DeltaDataFrameWriterV2Suite**: Tests verifying `writeTo.append()` ignores `replaceUsing`/`replaceOn` options
- **DeltaInsertReplaceOnOrUsingDFOptionCombinationSuite**: Tests for DPO config interaction, `overwriteSchema=false` validity, and `dataChange=true` validity with `replaceOn`/`replaceUsing`
- **DeltaSuite**: Tests verifying `replaceOn`/`replaceUsing` options are blocked when disabled via config (save, insertInto, saveAsTable)
- **DescribeDeltaHistorySuite**: Tests for write options tracking in DESCRIBE HISTORY for `saveAsTable` with `replaceOn`/`replaceUsing`, plus supporting assertion infrastructure

## How was this patch tested?

Existing and new tests.