### PR TITLE
[CHERRYPICK][Kernel]Support getting tableSizeBytes, numFiles by incremental crc construction

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -51,6 +51,7 @@ import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.metrics.SnapshotReport;
 import io.delta.kernel.statistics.SnapshotStatistics;
+import io.delta.kernel.statistics.TableStats;
 import io.delta.kernel.transaction.ReplaceTableTransactionBuilder;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -430,6 +431,24 @@ public class SnapshotImpl implements Snapshot {
       }
 
       return Optional.of(Snapshot.ChecksumWriteMode.FULL);
+    }
+
+    @Override
+    public Optional<Integer> getIncrementalChecksumLoadCost() {
+      return getLogSegment()
+          .getLastSeenChecksum()
+          .map(file -> (int) (version - FileNames.getFileVersion(new Path(file.getPath()))));
+    }
+
+    @Override
+    public Optional<TableStats> getTableStats(Engine engine) throws IOException {
+      Optional<CRCInfo> crc = getCurrentCrcInfo();
+      if (!crc.isPresent()) {
+        crc =
+            ChecksumUtils.tryBuildCrcIncrementally(
+                engine, getLogSegment(), logReplay.getLastSeenCrcInfo());
+      }
+      return crc.map(c -> new TableStats(c.getTableSizeBytes(), c.getNumFiles()));
     }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -359,11 +359,11 @@ public class TransactionImpl implements Transaction {
     return maxRetries + 1; // +1 because the first attempt is a try, not a retry.
   }
 
-  private boolean isBlindAppend() {
+  private Optional<Boolean> isBlindAppend() {
     // TODO: for now we hard code this to false to avoid erroneously setting this to true for a
     //  non-blind-append operation. We should revisit how to safely set this to true for actual
     //  blind appends.
-    return false;
+    return Optional.of(false);
   }
 
   private void updateMetadata(Metadata metadata) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -595,11 +595,11 @@ public class TransactionImpl implements Transaction {
     return new CommitInfo(
         generateInCommitTimestampForFirstCommitAttempt(engine, commitAttemptStartTime),
         commitAttemptStartTime, /* timestamp */
-        "Kernel-" + Meta.KERNEL_VERSION + "/" + engineInfo, /* engineInfo */
-        operation.getDescription(), /* description */
+        Optional.of("Kernel-" + Meta.KERNEL_VERSION + "/" + engineInfo), /* engineInfo */
+        Optional.of(operation.getDescription()), /* description */
         getOperationParameters(), /* operationParameters */
         isBlindAppend(), /* isBlindAppend */
-        txnId.toString(), /* txnId */
+        Optional.of(txnId.toString()), /* txnId */
         emptyMap() /* operationMetrics */);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -109,7 +109,7 @@ public class CommitInfo {
         children[4].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[4].getMap(rowId)),
-        children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId),
+        Optional.ofNullable(children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId)),
         children[6].isNullAt(rowId) ? null : children[6].getString(rowId),
         children[7].isNullAt(rowId)
             ? Collections.emptyMap()
@@ -216,7 +216,7 @@ public class CommitInfo {
   private final String engineInfo;
   private final String operation;
   private final Map<String, String> operationParameters;
-  private final boolean isBlindAppend;
+  private final Optional<Boolean> isBlindAppend;
   private final String txnId;
   private Optional<Long> inCommitTimestamp;
   private final Map<String, String> operationMetrics;
@@ -227,7 +227,7 @@ public class CommitInfo {
       String engineInfo,
       String operation,
       Map<String, String> operationParameters,
-      boolean isBlindAppend,
+      Optional<Boolean> isBlindAppend,
       String txnId,
       Map<String, String> operationMetrics) {
     this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
@@ -235,7 +235,7 @@ public class CommitInfo {
     this.engineInfo = requireNonNull(engineInfo);
     this.operation = requireNonNull(operation);
     this.operationParameters = Collections.unmodifiableMap(requireNonNull(operationParameters));
-    this.isBlindAppend = isBlindAppend;
+    this.isBlindAppend = requireNonNull(isBlindAppend);
     this.txnId = requireNonNull(txnId);
     this.operationMetrics = Collections.unmodifiableMap(requireNonNull(operationMetrics));
   }
@@ -256,7 +256,7 @@ public class CommitInfo {
     return operationParameters;
   }
 
-  public boolean getIsBlindAppend() {
+  public Optional<Boolean> getIsBlindAppend() {
     return isBlindAppend;
   }
 
@@ -289,7 +289,7 @@ public class CommitInfo {
     commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationParameters"), stringStringMapValue(operationParameters));
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend.orElse(null));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId);
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -101,16 +101,18 @@ public class CommitInfo {
       children[i] = vector.getChild(i);
     }
 
+    checkArgument(!children[1].isNullAt(rowId), "CommitInfo is missing required timestamp field");
+
     return new CommitInfo(
         Optional.ofNullable(children[0].isNullAt(rowId) ? null : children[0].getLong(rowId)),
-        children[1].isNullAt(rowId) ? null : children[1].getLong(rowId),
-        children[2].isNullAt(rowId) ? null : children[2].getString(rowId),
-        children[3].isNullAt(rowId) ? null : children[3].getString(rowId),
+        children[1].getLong(rowId),
+        Optional.ofNullable(children[2].isNullAt(rowId) ? null : children[2].getString(rowId)),
+        Optional.ofNullable(children[3].isNullAt(rowId) ? null : children[3].getString(rowId)),
         children[4].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[4].getMap(rowId)),
         Optional.ofNullable(children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId)),
-        children[6].isNullAt(rowId) ? null : children[6].getString(rowId),
+        Optional.ofNullable(children[6].isNullAt(rowId) ? null : children[6].getString(rowId)),
         children[7].isNullAt(rowId)
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[7].getMap(rowId)));
@@ -213,22 +215,22 @@ public class CommitInfo {
   //////////////////////////////////
 
   private final long timestamp;
-  private final String engineInfo;
-  private final String operation;
+  private final Optional<String> engineInfo;
+  private final Optional<String> operation;
   private final Map<String, String> operationParameters;
   private final Optional<Boolean> isBlindAppend;
-  private final String txnId;
+  private final Optional<String> txnId;
   private Optional<Long> inCommitTimestamp;
   private final Map<String, String> operationMetrics;
 
   public CommitInfo(
       Optional<Long> inCommitTimestamp,
       long timestamp,
-      String engineInfo,
-      String operation,
+      Optional<String> engineInfo,
+      Optional<String> operation,
       Map<String, String> operationParameters,
       Optional<Boolean> isBlindAppend,
-      String txnId,
+      Optional<String> txnId,
       Map<String, String> operationMetrics) {
     this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
     this.timestamp = timestamp;
@@ -244,11 +246,11 @@ public class CommitInfo {
     return timestamp;
   }
 
-  public String getEngineInfo() {
+  public Optional<String> getEngineInfo() {
     return engineInfo;
   }
 
-  public String getOperation() {
+  public Optional<String> getOperation() {
     return operation;
   }
 
@@ -260,7 +262,7 @@ public class CommitInfo {
     return isBlindAppend;
   }
 
-  public String getTxnId() {
+  public Optional<String> getTxnId() {
     return txnId;
   }
 
@@ -285,12 +287,12 @@ public class CommitInfo {
     Map<Integer, Object> commitInfo = new HashMap<>();
     commitInfo.put(COL_NAME_TO_ORDINAL.get("inCommitTimestamp"), inCommitTimestamp.orElse(null));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("timestamp"), timestamp);
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo);
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo.orElse(null));
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation.orElse(null));
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationParameters"), stringStringMapValue(operationParameters));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend.orElse(null));
-    commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId);
+    commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId.orElse(null));
     commitInfo.put(
         COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -285,12 +285,15 @@ public class ChecksumUtils {
 
             CommitInfo commitInfo = CommitInfo.fromColumnVector(commitInfoVector, i);
             if (commitInfo == null
-                || !INCREMENTAL_SUPPORTED_OPS.contains(commitInfo.getOperation())) {
+                || !commitInfo
+                    .getOperation()
+                    .filter(INCREMENTAL_SUPPORTED_OPS::contains)
+                    .isPresent()) {
               logger.info(
                   "Falling back to full replay after {}ms: "
                       + "unsupported operation '{}' for version {}",
                   System.currentTimeMillis() - startTime,
-                  commitInfo != null ? commitInfo.getOperation() : "null",
+                  commitInfo != null ? commitInfo.getOperation().orElse("null") : "null",
                   newVersion);
               return Optional.empty();
             }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -120,7 +120,11 @@ public class ChecksumUtils {
     // Try to build CRC incrementally if possible
     Optional<CRCInfo> incrementallyBuiltCrc =
         lastSeenCrcInfo.isPresent()
-            ? buildCrcInfoIncrementally(lastSeenCrcInfo.get(), engine, logSegmentAtVersion)
+            ? buildCrcInfoIncrementally(
+                lastSeenCrcInfo.get(),
+                engine,
+                logSegmentAtVersion,
+                /* canBuildWithOnlyRequiredFields */ false)
             : Optional.empty();
 
     // Use incrementally built CRC if available, otherwise do full log replay
@@ -131,6 +135,25 @@ public class ChecksumUtils {
 
     ChecksumWriter checksumWriter = new ChecksumWriter(logSegmentAtVersion.getLogPath());
     checksumWriter.writeCheckSum(engine, crcInfo);
+  }
+
+  /**
+   * Attempts to incrementally compute the CRC at the segment's version by replaying subsequent
+   * delta files from the given base CRC. Returns {@link Optional#empty()} when the base CRC is
+   * absent or the incremental build is not possible.
+   *
+   * @param engine The engine to use for file operations
+   * @param logSegment The log segment to process
+   * @param lastSeenCrcInfo The last available CRC info to build upon, typically from {@link
+   *     io.delta.kernel.internal.replay.LogReplay#getLastSeenCrcInfo()}
+   * @return The incrementally-built CRC info, or empty
+   */
+  public static Optional<CRCInfo> tryBuildCrcIncrementally(
+      Engine engine, LogSegment logSegment, Optional<CRCInfo> lastSeenCrcInfo) throws IOException {
+    return lastSeenCrcInfo.isPresent()
+        ? buildCrcInfoIncrementally(
+            lastSeenCrcInfo.get(), engine, logSegment, /* canBuildWithOnlyRequiredFields */ true)
+        : Optional.empty();
   }
 
   /**
@@ -215,19 +238,24 @@ public class ChecksumUtils {
    * @param lastSeenCrcInfo The last available CRC info to build upon
    * @param engine The engine to use for file operations
    * @param logSegment The log segment to process
+   * @param canBuildWithOnlyRequiredFields If true, allows building CRC with only required fields.
+   *     Tolerates missing optional fields.
    * @return Optional containing the new CRC info, or empty if fallback is needed
    */
   private static Optional<CRCInfo> buildCrcInfoIncrementally(
-      CRCInfo lastSeenCrcInfo, Engine engine, LogSegment logSegment) throws IOException {
+      CRCInfo lastSeenCrcInfo,
+      Engine engine,
+      LogSegment logSegment,
+      boolean canBuildWithOnlyRequiredFields)
+      throws IOException {
     long startTime = System.currentTimeMillis();
-    // Can only build incrementally if we have domain metadata and file size histogram
-    if (!lastSeenCrcInfo.getDomainMetadata().isPresent()) {
+    if (!canBuildWithOnlyRequiredFields && !lastSeenCrcInfo.getDomainMetadata().isPresent()) {
       logger.info(
           "Falling back to full replay after {}ms: detected current crc missing domain metadata.",
           System.currentTimeMillis() - startTime);
       return Optional.empty();
     }
-    if (!lastSeenCrcInfo.getFileSizeHistogram().isPresent()) {
+    if (!canBuildWithOnlyRequiredFields && !lastSeenCrcInfo.getFileSizeHistogram().isPresent()) {
       logger.info(
           "Falling back to full replay after {}ms: "
               + "detected current crc missing file size histogram.",
@@ -332,22 +360,30 @@ public class ChecksumUtils {
       }
     }
 
-    // Merge with existing domain metadata
-    lastSeenCrcInfo
-        .getDomainMetadata()
-        .get()
-        .forEach(
-            dm -> {
-              if (!state.domainMetadataMap.containsKey(dm.getDomain())) {
-                state.domainMetadataMap.put(dm.getDomain(), dm);
-              }
-            });
-
-    // Filter to only non-removed domain metadata
-    Set<DomainMetadata> finalDomainMetadata = getNonRemovedDomainMetadata(state);
+    // Merge with existing domain metadata if available
+    Optional<Set<DomainMetadata>> finalDomainMetadata;
+    if (lastSeenCrcInfo.getDomainMetadata().isPresent()) {
+      lastSeenCrcInfo
+          .getDomainMetadata()
+          .get()
+          .forEach(
+              dm -> {
+                if (!state.domainMetadataMap.containsKey(dm.getDomain())) {
+                  state.domainMetadataMap.put(dm.getDomain(), dm);
+                }
+              });
+      finalDomainMetadata = Optional.of(getNonRemovedDomainMetadata(state));
+    } else {
+      finalDomainMetadata = Optional.empty();
+    }
     logger.info(
         "Successfully completed incremental CRC computation in {} ms",
         System.currentTimeMillis() - startTime);
+    Optional<FileSizeHistogram> finalHistogram =
+        lastSeenCrcInfo
+            .getFileSizeHistogram()
+            .map(h -> state.addedFileSizeHistogram.plus(h).minus(state.removedFileSizeHistogram));
+
     // Build and return the new CRC info
     return Optional.of(
         new CRCInfo(
@@ -357,12 +393,8 @@ public class ChecksumUtils {
             state.tableSizeByte.longValue() + lastSeenCrcInfo.getTableSizeBytes(),
             state.fileCount.longValue() + lastSeenCrcInfo.getNumFiles(),
             Optional.empty(),
-            Optional.of(finalDomainMetadata),
-            Optional.of(
-                state
-                    .addedFileSizeHistogram
-                    .plus(lastSeenCrcInfo.getFileSizeHistogram().get())
-                    .minus(state.removedFileSizeHistogram))));
+            finalDomainMetadata,
+            finalHistogram));
   }
 
   /** Processes an add file record and updates the state tracker. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -170,13 +170,21 @@ public class LogReplay {
   }
 
   /**
+   * Returns the last-seen CRC info from the log segment if available. Lazily loads and caches the
+   * CRC file on first access. Returns empty if no CRC file exists in the log segment.
+   */
+  public Optional<CRCInfo> getLastSeenCrcInfo() {
+    return lazyLatestCrcInfo.get();
+  }
+
+  /**
    * Returns the CRC info for the current snapshot version if available. Lazily loads and caches the
    * CRC file on first access. Returns empty if no CRC file exists at the snapshot version.
    */
   public Optional<CRCInfo> getCrcInfoAtSnapshotVersion() {
     // TODO: We should first just check if the checksum file in the LogSegment is at this snapshot
     //       version.
-    return lazyLatestCrcInfo.get().filter(crcInfo -> crcInfo.getVersion() == getVersion());
+    return getLastSeenCrcInfo().filter(crcInfo -> crcInfo.getVersion() == getVersion());
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/SnapshotStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/SnapshotStatistics.java
@@ -18,6 +18,8 @@ package io.delta.kernel.statistics;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.engine.Engine;
+import java.io.IOException;
 import java.util.Optional;
 
 /** Provides statistics and metadata about a {@link Snapshot}. */
@@ -41,6 +43,34 @@ public interface SnapshotStatistics {
    * @return the recommended checksum write mode, or empty if checksum already exists
    */
   Optional<Snapshot.ChecksumWriteMode> getChecksumWriteMode();
+
+  /**
+   * Returns the estimated cost of loading checksum information incrementally.
+   *
+   * <ul>
+   *   <li>{@code Optional.of(N)} – CRC exists in the log segment, where {@code N} is the number of
+   *       delta versions between the last seen checksum version and the snapshot version
+   *   <li>{@link Optional#empty()} – no CRC file exists in the log segment
+   * </ul>
+   *
+   * @return the estimated number of delta files to read, or empty if unavailable
+   */
+  Optional<Integer> getIncrementalChecksumLoadCost();
+
+  /**
+   * Returns {@link TableStats} for the current snapshot version.
+   *
+   * <p>Returns {@link Optional#empty()} when:
+   *
+   * <ul>
+   *   <li>No checksum file exists in the log segment.
+   *   <li>A checksum file exists but the TableStats cannot be incrementally computed from it to the
+   *       current snapshot version.
+   * </ul>
+   *
+   * @param engine the engine to use for reading files
+   */
+  Optional<TableStats> getTableStats(Engine engine) throws IOException;
 
   // TODO: getNumUnpublishedCatalogCommits
   // TODO: getNumDeltasSinceLastCheckpoint

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/TableStats.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/statistics/TableStats.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.statistics;
+
+import io.delta.kernel.annotation.Evolving;
+
+/** Aggregate table-level statistics */
+@Evolving
+public class TableStats {
+
+  private final long tableSizeBytes;
+  private final long numFiles;
+
+  public TableStats(long tableSizeBytes, long numFiles) {
+    this.tableSizeBytes = tableSizeBytes;
+    this.numFiles = numFiles;
+  }
+
+  /**
+   * Total size of the table in bytes, calculated as the sum of the {@code size} field of all live
+   * {@code add} actions. See <a
+   * href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file-schema">Checksum
+   * File Schema</a>.
+   */
+  public long getTableSizeBytes() {
+    return tableSizeBytes;
+  }
+
+  /**
+   * Number of live {@code add} actions in this table version after action reconciliation. See <a
+   * href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file-schema">Checksum
+   * File Schema</a>.
+   */
+  public long getNumFiles() {
+    return numFiles;
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -48,7 +48,7 @@ trait ActionUtils extends VectorTestUtils {
       "engineInfo",
       "operation",
       Collections.emptyMap(), // operationParameters
-      false, // isBlindAppend
+      Optional.of(false), // isBlindAppend
       "txnId",
       Collections.emptyMap() // operationMetrics
     )

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/ActionUtils.scala
@@ -45,11 +45,11 @@ trait ActionUtils extends VectorTestUtils {
     new CommitInfo(
       if (ictEnabled) Optional.of(1L) else Optional.empty(), // ICT
       1L, // timestamp
-      "engineInfo",
-      "operation",
+      Optional.of("engineInfo"),
+      Optional.of("operation"),
       Collections.emptyMap(), // operationParameters
       Optional.of(false), // isBlindAppend
-      "txnId",
+      Optional.of("txnId"),
       Collections.emptyMap() // operationMetrics
     )
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/SnapshotChecksumStatisticsAndWriteSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/SnapshotChecksumStatisticsAndWriteSuite.scala
@@ -15,19 +15,30 @@
  */
 package io.delta.kernel.defaults
 
-import io.delta.kernel.{Operation, TableManager}
+import java.util.Optional
+
+import scala.jdk.CollectionConverters._
+
+import io.delta.kernel.{Operation, Table, TableManager, Transaction}
 import io.delta.kernel.Snapshot.ChecksumWriteMode
-import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.data.Row
+import io.delta.kernel.defaults.utils.WriteUtils
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.types.IntegerType.INTEGER
-import io.delta.kernel.types.StructType
-import io.delta.kernel.utils.CloseableIterable.emptyIterable
+import io.delta.kernel.expressions.Literal
+import io.delta.kernel.hook.PostCommitHook.PostCommitHookType
+import io.delta.kernel.internal.InternalScanFileUtils
+import io.delta.kernel.internal.actions.{CommitInfo, RemoveFile, SingleAction}
+import io.delta.kernel.internal.checksum.ChecksumReader
+import io.delta.kernel.internal.data.GenericRow
+import io.delta.kernel.internal.util.FileNames
+import io.delta.kernel.internal.util.Utils.{singletonCloseableIterator, toCloseableIterator}
+import io.delta.kernel.utils.CloseableIterable
+import io.delta.kernel.utils.CloseableIterable.{emptyIterable, inMemoryIterable}
+import io.delta.kernel.utils.FileStatus
 
 import org.scalatest.funsuite.AnyFunSuite
 
-class SnapshotChecksumStatisticsAndWriteSuite extends AnyFunSuite with TestUtils {
-
-  val testSchema = new StructType().add("id", INTEGER)
+class SnapshotChecksumStatisticsAndWriteSuite extends AnyFunSuite with WriteUtils {
 
   private def assertCrcExistsAtLatest(engine: Engine, tablePath: String): Unit = {
     val latestSnapshot = TableManager.loadSnapshot(tablePath).build(engine)
@@ -280,6 +291,175 @@ class SnapshotChecksumStatisticsAndWriteSuite extends AnyFunSuite with TestUtils
       // This simulates a concurrent write scenario where another writer already wrote the CRC
       assert(postCommitSnapshot.getStatistics.getChecksumWriteMode.get == ChecksumWriteMode.SIMPLE)
       postCommitSnapshot.writeChecksum(engine, ChecksumWriteMode.SIMPLE) // should be a no-op
+    }
+  }
+
+  //////////////////////////
+  // getTableStats tests  //
+  //////////////////////////
+
+  /**
+   * Creates a table with versions 0-14, CRC files at 0-14, and a checkpoint at version 10.
+   * Versions 1-10 append data, versions 11-12 remove files, versions 13-14 append again.
+   * Passes (path, engine, expectedNumFiles, expectedTableSizeBytes) at version 14 to the test
+   * function.
+   */
+  private def withTableWithCrcAndCheckpoint(
+      f: (String, Engine, Long, Long) => Unit): Unit = {
+    withTempDirAndEngine { (path, engine) =>
+      val txn0 = TableManager.buildCreateTableTransaction(
+        path,
+        testSchema,
+        "x").build(engine)
+      val result0 = txn0.commit(engine, emptyIterable())
+      result0.getPostCommitSnapshot.get().writeChecksum(engine, ChecksumWriteMode.SIMPLE)
+
+      var postCommitSnapshot = result0.getPostCommitSnapshot.get()
+
+      def stageAppendActions(txn: Transaction): CloseableIterable[Row] = {
+        val data = generateData(testSchema, Seq.empty, Map.empty, 10, 1)
+        getAppendActions(txn, Seq((Map.empty[String, Literal], data)))
+      }
+
+      def commitAndAdvance(dataActions: CloseableIterable[Row]): Unit = {
+        val txn = postCommitSnapshot
+          .buildUpdateTableTransaction("x", Operation.WRITE).build(engine)
+        val result = txn.commit(engine, dataActions)
+        postCommitSnapshot = result.getPostCommitSnapshot.get()
+        postCommitSnapshot.writeChecksum(engine, ChecksumWriteMode.SIMPLE)
+        result.getPostCommitHooks.forEach { hook =>
+          if (hook.getType == PostCommitHookType.CHECKPOINT) {
+            hook.threadSafeInvoke(engine)
+          }
+        }
+      }
+
+      // Versions 1-10: append data (1 file each)
+      for (_ <- 1 to 10) {
+        val txn = postCommitSnapshot
+          .buildUpdateTableTransaction("x", Operation.WRITE).build(engine)
+        commitAndAdvance(stageAppendActions(txn))
+      }
+
+      // Versions 11-12: remove one file each
+      for (_ <- 11 to 12) {
+        val scanFileRows = collectScanFileRows(postCommitSnapshot.getScanBuilder.build())
+        val fileStatus = InternalScanFileUtils.getAddFileStatus(scanFileRows.head)
+        val removePath = InternalScanFileUtils.getFilePath(scanFileRows.head)
+        val removeRow = new GenericRow(
+          RemoveFile.FULL_SCHEMA,
+          Map[Integer, Object](
+            Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("path")) -> removePath,
+            Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("deletionTimestamp")) ->
+              Long.box(System.currentTimeMillis()),
+            Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("dataChange")) ->
+              Boolean.box(true),
+            Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("size")) ->
+              Long.box(fileStatus.getSize)).asJava)
+        commitAndAdvance(inMemoryIterable(
+          singletonCloseableIterator(SingleAction.createRemoveFileSingleAction(removeRow))))
+      }
+
+      // Versions 13-14: append data again
+      for (_ <- 13 to 14) {
+        val txn = postCommitSnapshot
+          .buildUpdateTableTransaction("x", Operation.WRITE).build(engine)
+        commitAndAdvance(stageAppendActions(txn))
+      }
+
+      val logPath = new io.delta.kernel.internal.fs.Path(path + "/_delta_log")
+      val crcInfo = ChecksumReader.tryReadChecksumFile(
+        engine,
+        FileStatus.of(FileNames.checksumFile(logPath, 14).toString)).get()
+      f(path, engine, crcInfo.getNumFiles, crcInfo.getTableSizeBytes)
+    }
+  }
+
+  test("No CRC in log segment => getTableStats empty, load cost empty") {
+    withTableWithCrcAndCheckpoint { (path, engine, _, _) =>
+      deleteChecksumFileForTable(path, (10 to 14))
+      val snapshot = Table.forPath(engine, path).getSnapshotAsOfVersion(engine, 14)
+      val stats = snapshot.getStatistics
+      assert(!stats.getTableStats(engine).isPresent)
+      assert(!stats.getIncrementalChecksumLoadCost.isPresent)
+    }
+  }
+
+  test("CRC exists at current version => getTableStats present, load cost 0") {
+    withTableWithCrcAndCheckpoint { (path, engine, expectedNumFiles, expectedTableSize) =>
+      val snapshot = Table.forPath(engine, path).getSnapshotAsOfVersion(engine, 14)
+      val stats = snapshot.getStatistics
+      val tableStats = stats.getTableStats(engine)
+      assert(tableStats.isPresent)
+      assert(tableStats.get().getNumFiles === expectedNumFiles)
+      assert(tableStats.get().getTableSizeBytes === expectedTableSize)
+      assert(stats.getIncrementalChecksumLoadCost === java.util.Optional.of(0))
+    }
+  }
+
+  test("CRC between checkpoint and current, success => getTableStats present, load cost N") {
+    withTableWithCrcAndCheckpoint { (path, engine, expectedNumFiles, expectedTableSize) =>
+      deleteChecksumFileForTable(path, (12 to 14))
+      val snapshot = Table.forPath(engine, path).getSnapshotAsOfVersion(engine, 14)
+      val stats = snapshot.getStatistics
+      val tableStats = stats.getTableStats(engine)
+      assert(tableStats.isPresent)
+      assert(tableStats.get().getNumFiles === expectedNumFiles)
+      assert(tableStats.get().getTableSizeBytes === expectedTableSize)
+      // CRC at v11, snapshot at v14 => cost = 14 - 11 = 3
+      assert(stats.getIncrementalChecksumLoadCost === java.util.Optional.of(3))
+    }
+  }
+
+  test("getTableStats: CRC between checkpoint and current, " +
+    "remove action without size => empty") {
+    withTableWithCrcAndCheckpoint { (path, engine, _, _) =>
+      val snapshot14 = TableManager.loadSnapshot(path).build(engine)
+      val scanFileRows = collectScanFileRows(snapshot14.getScanBuilder.build())
+      val removePath = InternalScanFileUtils.getFilePath(scanFileRows.head)
+
+      // Write delta log directly - Kernel's commit API validates remove size,
+      // but we need a remove without size to test incremental checksum fallback
+      val commitInfoRow = new GenericRow(
+        CommitInfo.FULL_SCHEMA,
+        Map[Integer, Object](
+          Integer.valueOf(CommitInfo.FULL_SCHEMA.indexOf("timestamp")) ->
+            Long.box(System.currentTimeMillis()),
+          Integer.valueOf(CommitInfo.FULL_SCHEMA.indexOf("operation")) -> "WRITE").asJava)
+      val removeRow = new GenericRow(
+        RemoveFile.FULL_SCHEMA,
+        Map[Integer, Object](
+          Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("path")) -> removePath,
+          Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("deletionTimestamp")) ->
+            Long.box(System.currentTimeMillis()),
+          Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("dataChange")) ->
+            Boolean.box(true)).asJava)
+      val logPath = new io.delta.kernel.internal.fs.Path(path + "/_delta_log")
+      engine.getJsonHandler.writeJsonFileAtomically(
+        FileNames.deltaFile(logPath, 15),
+        toCloseableIterator(
+          Iterator(
+            SingleAction.createCommitInfoSingleAction(commitInfoRow),
+            SingleAction.createRemoveFileSingleAction(removeRow)).asJava),
+        false)
+
+      deleteChecksumFileForTable(path, Seq(15))
+      val snapshot = Table.forPath(engine, path).getSnapshotAsOfVersion(engine, 15)
+      assert(!snapshot.getStatistics.getTableStats(engine).isPresent)
+    }
+  }
+
+  test("getTableStats: CRC between checkpoint and current, " +
+    "unsupported operation => empty") {
+    withTableWithCrcAndCheckpoint { (path, engine, _, _) =>
+      val snapshot14 = TableManager.loadSnapshot(path).build(engine)
+      val txn = snapshot14
+        .buildUpdateTableTransaction("x", Operation.MANUAL_UPDATE).build(engine)
+      txn.commit(engine, emptyIterable())
+
+      deleteChecksumFileForTable(path, Seq(15))
+      val snapshot = Table.forPath(engine, path).getSnapshotAsOfVersion(engine, 15)
+      assert(!snapshot.getStatistics.getTableStats(engine).isPresent)
     }
   }
 }

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
@@ -25,6 +25,7 @@ import io.delta.kernel.Operation
 import io.delta.kernel.Snapshot
 import io.delta.kernel.Snapshot.ChecksumWriteMode
 import io.delta.kernel.engine.Engine
+import io.delta.kernel.internal.SnapshotImpl
 import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.utils.CloseableIterable
 import io.delta.storage.commit.{Commit, GetCommitsResponse}

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
@@ -159,6 +159,67 @@ class UCE2ESuite extends AnyFunSuite with UCCatalogManagedTestUtils {
     }
   }
 
+  test("getTableStats on CCV2 table with unbackfilled commits") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      val ucCatalogManagedClient = new UCCatalogManagedClient(ucClient)
+
+      // CREATE -- v0.json (published)
+      val result0 = ucCatalogManagedClient
+        .buildCreateTableTransaction(testUcTableId, tablePath, testSchema, "test-engine")
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable())
+      ucClient.insertTableDataAfterCreate(testUcTableId)
+      val postCommit0 = result0.getPostCommitSnapshot.get()
+      postCommit0.writeChecksum(engine, ChecksumWriteMode.SIMPLE)
+
+      // WRITE v1, v2 -- staged commits (unbackfilled) with actual data + CRC
+      var currentSnapshot: Snapshot = postCommit0
+      for (i <- 1 to 2) {
+        currentSnapshot = writeDataAndVerify(
+          engine,
+          currentSnapshot,
+          ucClient,
+          expCommitVersion = i,
+          expNumCatalogCommits = i)
+        currentSnapshot.writeChecksum(engine, ChecksumWriteMode.SIMPLE)
+      }
+
+      // WRITE v3 -- staged commit with data but NO CRC
+      val txn3 = currentSnapshot
+        .buildUpdateTableTransaction("engineInfo", Operation.WRITE)
+        .build(engine)
+      val result3 = commitAppendData(engine, txn3, seqOfUnpartitionedDataBatch1)
+      currentSnapshot = result3.getPostCommitSnapshot.get()
+
+      // Capture expected values from the post-commit snapshot
+      // Assert CRC is present in post-commit snapshot
+      assert(currentSnapshot.getStatistics.getChecksumWriteMode.get == ChecksumWriteMode.SIMPLE)
+      val postCommitCrc = currentSnapshot.asInstanceOf[SnapshotImpl].getCurrentCrcInfo()
+      assert(postCommitCrc.isPresent)
+      val expectedNumFiles = postCommitCrc.get().getNumFiles
+      val expectedTableSizeBytes = postCommitCrc.get().getTableSizeBytes
+
+      // Load fresh snapshot -- v1-v3 are ratified but unbackfilled catalog commits
+      val freshSnapshot = loadSnapshot(ucCatalogManagedClient, engine, testUcTableId, tablePath)
+      assert(freshSnapshot.getVersion === 3)
+      assert(freshSnapshot.getLogSegment.getMaxPublishedDeltaVersion.get() === 0)
+      val tableData = ucClient.getTableDataElseThrow(testUcTableId)
+      assert(tableData.getMaxRatifiedVersion === 3)
+      assert(tableData.getCommits.size === 3)
+
+      // getTableStats should match the post-commit snapshot even with unbackfilled commits
+      val stats = freshSnapshot.getStatistics
+      val tableStats = stats.getTableStats(engine)
+      assert(tableStats.isPresent)
+      assert(tableStats.get().getNumFiles === expectedNumFiles)
+      assert(tableStats.get().getTableSizeBytes === expectedTableSizeBytes)
+      // CRC at v2, snapshot at v3 => incremental load cost = 1
+      assert(stats.getIncrementalChecksumLoadCost === java.util.Optional.of(1))
+    }
+  }
+
   test("don't read versions past maxCatalogVersion even if they exist on filesystem") {
     withTempDirAndEngine { case (tablePathUnresolved, engine) =>
       val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Cherry pick of https://github.com/delta-io/delta/pull/6406. The tests in https://github.com/delta-io/delta/pull/6406 depends on https://github.com/delta-io/delta/pull/6079 and https://github.com/delta-io/delta/pull/6130 to make `engineInfo`, `txnId`, and `isBlindAppend` optional in `commitInfo`, this PR cherry-pick them as well.

Except for cherry-pick, this PR adds only one line: an import in `kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala`, this is required to run the UT for https://github.com/delta-io/delta/pull/6406.
```
import io.delta.kernel.internal.SnapshotImpl
```



https://github.com/delta-io/delta/pull/6406 Provided a new class `TableStats` with `tableSizeBytes` and `numFiles`. Added support to generate `TableStats` incrementally from last seen CRC. Added api to expose the "cost" for the incremental generation.

https://github.com/delta-io/delta/pull/6079 and https://github.com/delta-io/delta/pull/6130 make `engineInfo`, `txnId`, and `isBlindAppend` optional in `commitInfo`
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Tested:
1. CRC exists only before last checkpoint
2. CRC exists at current version
3. CRC between checkpoint and current version
4. CRC between checkpoint and current, incremental build fail bc a `remove` without size.
5. CRC between checkpoint and current, incremental build fail bc the commit uses an operation not in the allowlist.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
