### PR TITLE
[Spark]  Add additional `replaceOn`/`replaceUsing` tests for `save()`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -258,7 +258,7 @@ case class WriteIntoDelta(
 
     val (newFiles, addFiles, deletedFiles) = (mode, atomicReplaceExprsOpt) match {
       case (SaveMode.Overwrite, Some(parsedPredicatesMaybeAliased))
-          if !replaceWhereOnDataColsEnabled && !options.isReplaceOnOrUsingDefined =>
+          if options.replaceWhere.isDefined && !replaceWhereOnDataColsEnabled =>
         // fall back to match on partition cols only when replaceArbitrary is disabled.
         val newFiles = txn.writeFiles(data, Some(options))
         val addFiles = newFiles.collect { case a: AddFile => a }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceOnDFWriterV1SaveSuite.scala
@@ -50,4 +50,36 @@ class DeltaInsertReplaceOnDFWriterV1SaveSuite
     }
     writer.save(target)
   }
+
+  // Misaligned column blocking only applies for replaceUsing, not replaceOn.
+  test("save - replaceOn with misaligned column positions between source and target") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      // Target schema: (id, data), id at position 0
+      Seq(
+        (1, "target"),
+        (2, "target"),
+        (3, "target"))
+        .toDF("id", "data")
+        .write.format("delta").save(path)
+      // Source schema: (data, id), id at position 1. save() inserts by name,
+      // and replaceOn also matches by name to detect rows to be deleted.
+      writeReplaceOnDF(
+        sourceDF = Seq(
+          ("source", 1),
+          ("source", 4))
+          .toDF("data", "id").as("s"),
+        target = path,
+        replaceOnCond = "t.id = s.id",
+        targetAlias = Some("t"))
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("id"),
+        Seq(
+          Row(1, "source"),
+          Row(2, "target"),
+          Row(3, "target"),
+          Row(4, "source")))
+    }
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.delta
 
-import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf
@@ -97,6 +96,28 @@ class DeltaInsertReplaceUsingDFWriterV1SaveSuite
     }
   }
 
+  test("save with replaceUsing: rejects mismatched column types without implicit casting") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      Seq((1, "target"), (2, "target"))
+        .toDF("id", "value")
+        .write.format("delta").save(path)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          writeReplaceUsingDF(
+            sourceDF = Seq((1, 100), (3, 300))
+              .toDF("id", "value"),
+            target = path,
+            replaceUsingCols = "id")
+        },
+        condition = "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map("currentField" -> ".*", "updateField" -> ".*"),
+        matchPVals = true
+      )
+    }
+  }
+
   test("save with replaceUsing: rejects Long source to Int target (no implicit narrowing)") {
     withTempDir { dir =>
       val path = dir.getAbsolutePath
@@ -160,6 +181,27 @@ class DeltaInsertReplaceUsingDFWriterV1SaveSuite
         parameters = Map("currentField" -> ".*", "updateField" -> ".*"),
         matchPVals = true
       )
+    }
+  }
+
+  test("save: replaceUsing succeeds with misaligned columns because save() is by name") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+
+      Seq((0, 1, "target"))
+        .toDF("non_match_col", "match_col", "row_origin")
+        .write.format("delta").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = Seq((1, 2, "source"))
+          .toDF("match_col", "non_match_col", "row_origin"),
+        target = path,
+        replaceUsingCols = "match_col")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).orderBy("match_col"),
+        Seq(
+          Row(2, 1, "source")))
     }
   }
 }


### PR DESCRIPTION
Co-authored-by: Isaac

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
  - Refine the partition-only fallback guard in `WriteIntoDelta` to check `replaceWhere.isDefined` instead of negating `isReplaceOnOrUsingDefined`
  - Add test for `replaceUsing` rejecting mismatched column types without implicit casting                                                        
  - Add test for `replaceUsing` succeeding with misaligned columns (`save()` is by name)                                                                     
  - Add test for `replaceOn` with misaligned column positions between source and target
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
