### PR TITLE
[kernel-spark] Roll forward "Recognize CommitInfo action in DSv2 (#6309)"

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -122,7 +122,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     // ========== Error handling tests ==========
     "streaming query should fail when table is deleted and recreated with new id",
     "deltaSourceIgnoreDeleteError contains removeFile, version, tablePath",
-    "deltaSourceIgnoreChangesError contains removeFile, version, tablePath",
+    "deltaSourceIgnoreChangesError contains changeInfo, version, tablePath",
     "excludeRegex throws good error on bad regex pattern",
 
     // ========== Misc tests ==========

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2580,7 +2580,7 @@
   },
   "DELTA_SOURCE_TABLE_IGNORE_CHANGES" : {
     "message" : [
-      "Detected a data update (for example <file>) in the source table at version <version>. This is currently not supported. If this is going to happen regularly and you are okay to skip changes, set the option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, please restart this query with a fresh checkpoint directory. The source table can be found at path <dataPath>."
+      "Detected a data update (for example <changeInfo>) in the source table at version <version>. This is currently not supported. If this is going to happen regularly and you are okay to skip changes, set the option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, please restart this query with a fresh checkpoint directory. The source table can be found at path <dataPath>."
     ],
     "sqlState" : "0A000"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -195,11 +195,11 @@ trait DeltaErrorsBase
 
   def deltaSourceIgnoreChangesError(
       version: Long,
-      removedFile: String,
+      changeInfo: String,
       dataPath: String): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_SOURCE_TABLE_IGNORE_CHANGES",
-      messageParameters = Array(removedFile, version.toString, dataPath)
+      messageParameters = Array(changeInfo, version.toString, dataPath)
     )
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2325,7 +2325,7 @@ trait DeltaErrorsSuiteBase
       }
       checkError(e, "DELTA_SOURCE_TABLE_IGNORE_CHANGES", "0A000", Map(
         "version" -> "10",
-        "file" -> "removedFile",
+        "changeInfo" -> "removedFile",
         "dataPath" -> "tablePath"
       ))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1820,7 +1820,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  testQuietly("deltaSourceIgnoreChangesError contains removeFile, version, tablePath") {
+  testQuietly("deltaSourceIgnoreChangesError contains changeInfo, version, tablePath") {
     withTempDirs { (inputDir, outputDir, checkpointDir) =>
       Seq(1, 2, 3).toDF("x").write.format("delta").save(inputDir.toString)
       val df = loadStreamWithOptions(inputDir.toString, Map.empty)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -99,7 +99,12 @@ public class SparkMicroBatchStream
 
   private static final Set<DeltaAction> ACTION_SET =
       Collections.unmodifiableSet(
-          new HashSet<>(Arrays.asList(DeltaAction.ADD, DeltaAction.REMOVE, DeltaAction.METADATA)));
+          new HashSet<>(
+              Arrays.asList(
+                  DeltaAction.ADD,
+                  DeltaAction.REMOVE,
+                  DeltaAction.METADATA,
+                  DeltaAction.COMMITINFO)));
 
   /** Action set for CDC reads. */
   private static final Set<DeltaAction> CDC_ACTION_SET =
@@ -1092,6 +1097,7 @@ public class SparkMicroBatchStream
     boolean shouldSkipCommit = false;
     Metadata metadataAction = null;
     String removeFileActionPath = null;
+    String operation = null;
 
     try (CloseableIterator<ColumnarBatch> actionsIter = commit.getActions()) {
       while (actionsIter.hasNext()) {
@@ -1126,6 +1132,17 @@ public class SparkMicroBatchStream
                     endOffsetOpt,
                     verifyMetadataAction);
           }
+
+          // Track CommitInfo for operation details in error messages.
+          Optional<CommitInfo> commitInfoOpt = StreamingHelper.getCommitInfo(batch, rowId);
+          if (commitInfoOpt.isPresent()) {
+            CommitInfo commitInfo = commitInfoOpt.get();
+            operation =
+                commitInfo
+                    .getOperation()
+                    .map(op -> String.format("%s (%s)", op, commitInfo.getOperationParameters()))
+                    .orElse(null);
+          }
         }
       }
     } catch (IOException e) {
@@ -1135,9 +1152,9 @@ public class SparkMicroBatchStream
     if (removeFileActionPath != null) {
       if (hasFileAdd && !shouldAllowChanges) {
         // Commit contains data changes (adds + removes) and changes are disallowed.
-        // TODO(#5319): log CommitInfo action's operation instead of path
+        String changeInfo = operation != null ? operation : removeFileActionPath;
         throw (RuntimeException)
-            DeltaErrors.deltaSourceIgnoreChangesError(version, removeFileActionPath, tablePath);
+            DeltaErrors.deltaSourceIgnoreChangesError(version, changeInfo, tablePath);
       } else if (!hasFileAdd && !shouldAllowDeletes) {
         // Commit contains only removes (deletes) and deletes are disallowed.
         throw (RuntimeException)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
@@ -52,9 +52,10 @@ public class StreamingHelper {
    * Returns the index of the field with the given name in the schema of the batch. Throws an {@link
    * IllegalArgumentException} if the field is not found.
    */
-  private static int getFieldIndex(ColumnarBatch batch, String fieldName) {
-    int index = batch.getSchema().indexOf(fieldName);
-    checkArgument(index >= 0, "Field '%s' not found in schema: %s", fieldName, batch.getSchema());
+  private static int getFieldIndex(ColumnarBatch columnarBatch, String fieldName) {
+    int index = columnarBatch.getSchema().indexOf(fieldName);
+    checkArgument(
+        index >= 0, "Field '%s' not found in schema: %s", fieldName, columnarBatch.getSchema());
     return index;
   }
 
@@ -62,9 +63,9 @@ public class StreamingHelper {
    * Get the version from a {@link ColumnarBatch} of Delta log actions. Assumes all rows in the
    * batch belong to the same commit version, so it reads the version from the first row (rowId=0).
    */
-  public static long getVersion(ColumnarBatch batch) {
-    int versionColIdx = getFieldIndex(batch, "version");
-    return batch.getColumnVector(versionColIdx).getLong(0);
+  public static long getVersion(ColumnarBatch columnarBatch) {
+    int versionColIdx = getFieldIndex(columnarBatch, "version");
+    return columnarBatch.getColumnVector(versionColIdx).getLong(0);
   }
 
   /**
@@ -98,9 +99,9 @@ public class StreamingHelper {
    * FilteredColumnarBatch with selection vectors, use {@link #getAddFile(FilteredColumnarBatch,
    * int)} instead.
    */
-  private static Optional<AddFile> getAddFile(ColumnarBatch batch, int rowId) {
-    int addIdx = getFieldIndex(batch, DeltaLogActionUtils.DeltaAction.ADD.colName);
-    ColumnVector addVector = batch.getColumnVector(addIdx);
+  private static Optional<AddFile> getAddFile(ColumnarBatch columnarBatch, int rowId) {
+    int addIdx = getFieldIndex(columnarBatch, DeltaLogActionUtils.DeltaAction.ADD.colName);
+    ColumnVector addVector = columnarBatch.getColumnVector(addIdx);
     if (addVector.isNullAt(rowId)) {
       return Optional.empty();
     }
@@ -108,22 +109,22 @@ public class StreamingHelper {
     Row addFileRow = StructRow.fromStructVector(addVector, rowId);
     checkState(
         addFileRow != null,
-        String.format("Failed to extract AddFile struct from batch at rowId=%d.", rowId));
+        String.format("Failed to extract AddFile struct from columnar batch at rowId=%d.", rowId));
 
     return Optional.of(new AddFile(addFileRow));
   }
 
   /** Get AddFile action from a batch at the specified row, if present and has dataChange=true. */
-  public static Optional<AddFile> getAddFileWithDataChange(ColumnarBatch batch, int rowId) {
-    return getAddFile(batch, rowId).filter(AddFile::getDataChange);
+  public static Optional<AddFile> getAddFileWithDataChange(ColumnarBatch columnarBatch, int rowId) {
+    return getAddFile(columnarBatch, rowId).filter(AddFile::getDataChange);
   }
 
   /**
    * Get RemoveFile action from a batch at the specified row, if present and has dataChange=true.
    */
-  public static Optional<RemoveFile> getDataChangeRemove(ColumnarBatch batch, int rowId) {
-    int removeIdx = getFieldIndex(batch, DeltaLogActionUtils.DeltaAction.REMOVE.colName);
-    ColumnVector removeVector = batch.getColumnVector(removeIdx);
+  public static Optional<RemoveFile> getDataChangeRemove(ColumnarBatch columnarBatch, int rowId) {
+    int removeIdx = getFieldIndex(columnarBatch, DeltaLogActionUtils.DeltaAction.REMOVE.colName);
+    ColumnVector removeVector = columnarBatch.getColumnVector(removeIdx);
     if (removeVector.isNullAt(rowId)) {
       return Optional.empty();
     }
@@ -131,19 +132,31 @@ public class StreamingHelper {
     Row removeFileRow = StructRow.fromStructVector(removeVector, rowId);
     checkState(
         removeFileRow != null,
-        String.format("Failed to extract RemoveFile struct from batch at rowId=%d.", rowId));
+        String.format(
+            "Failed to extract RemoveFile struct from columnar batch at rowId=%d.", rowId));
 
     RemoveFile removeFile = new RemoveFile(removeFileRow);
     return removeFile.getDataChange() ? Optional.of(removeFile) : Optional.empty();
   }
 
   /** Get Metadata action from a batch at the specified row, if present. */
-  public static Optional<Metadata> getMetadata(ColumnarBatch batch, int rowId) {
-    int metadataIdx = getFieldIndex(batch, DeltaLogActionUtils.DeltaAction.METADATA.colName);
-    ColumnVector metadataVector = batch.getColumnVector(metadataIdx);
+  public static Optional<Metadata> getMetadata(ColumnarBatch columnarBatch, int rowId) {
+    int metadataIdx =
+        getFieldIndex(columnarBatch, DeltaLogActionUtils.DeltaAction.METADATA.colName);
+    ColumnVector metadataVector = columnarBatch.getColumnVector(metadataIdx);
     Metadata metadata = Metadata.fromColumnVector(metadataVector, rowId);
 
     return Optional.ofNullable(metadata);
+  }
+
+  /** Get CommitInfo action from a batch at the specified row, if present. */
+  public static Optional<CommitInfo> getCommitInfo(ColumnarBatch columnarBatch, int rowId) {
+    int commitInfoIdx =
+        getFieldIndex(columnarBatch, DeltaLogActionUtils.DeltaAction.COMMITINFO.colName);
+    ColumnVector commitInfoVector = columnarBatch.getColumnVector(commitInfoIdx);
+    CommitInfo commitInfo = CommitInfo.fromColumnVector(commitInfoVector, rowId);
+
+    return Optional.ofNullable(commitInfo);
   }
 
   /**
@@ -207,10 +220,10 @@ public class StreamingHelper {
           long version = commit.getVersion();
           try (CloseableIterator<ColumnarBatch> actionsIter = commit.getActions()) {
             while (actionsIter.hasNext()) {
-              ColumnarBatch batch = actionsIter.next();
-              int numRows = batch.getSize();
+              ColumnarBatch columnarBatch = actionsIter.next();
+              int numRows = columnarBatch.getSize();
               for (int rowId = 0; rowId < numRows; rowId++) {
-                Optional<Metadata> metadataOpt = StreamingHelper.getMetadata(batch, rowId);
+                Optional<Metadata> metadataOpt = StreamingHelper.getMetadata(columnarBatch, rowId);
                 if (metadataOpt.isPresent()) {
                   Metadata existing = versionToMetadata.putIfAbsent(version, metadataOpt.get());
                   Preconditions.checkArgument(
@@ -250,17 +263,6 @@ public class StreamingHelper {
         String.format("Failed to extract CDC struct from batch at rowId=%d.", rowId));
 
     return Optional.of(CDCDataFile.fromAddCDCFile(cdcRow, commitTimestamp));
-  }
-
-  /** Get CommitInfo action from a batch at the specified row, if present. */
-  public static Optional<CommitInfo> getCommitInfo(ColumnarBatch batch, int rowId) {
-    int commitInfoIdx = getFieldIndex(batch, DeltaLogActionUtils.DeltaAction.COMMITINFO.colName);
-    ColumnVector commitInfoVector = batch.getColumnVector(commitInfoIdx);
-    if (commitInfoVector.isNullAt(rowId)) {
-      return Optional.empty();
-    }
-    CommitInfo commitInfo = CommitInfo.fromColumnVector(commitInfoVector, rowId);
-    return Optional.ofNullable(commitInfo);
   }
 
   /** Private constructor to prevent instantiation of this utility class. */

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -866,26 +866,27 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
     AtomicInteger dsv1SuccessfulCalls = new AtomicInteger(0);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> {
-          ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> deltaChanges =
-              deltaSource.getFileChanges(
-                  fromVersion,
-                  fromIndex,
-                  isInitialSnapshot,
-                  endOffset,
-                  /* verifyMetadataAction= */ true);
-          try {
-            while (deltaChanges.hasNext()) {
-              deltaChanges.next(); // Should throw when hitting REMOVE file
-              dsv1SuccessfulCalls.incrementAndGet();
-            }
-          } finally {
-            deltaChanges.close();
-          }
-        },
-        String.format("DSv1 should throw on REMOVE for scenario: %s", testDescription));
+    UnsupportedOperationException dsv1Exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+              ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> deltaChanges =
+                  deltaSource.getFileChanges(
+                      fromVersion,
+                      fromIndex,
+                      isInitialSnapshot,
+                      endOffset,
+                      /* verifyMetadataAction= */ true);
+              try {
+                while (deltaChanges.hasNext()) {
+                  deltaChanges.next(); // Should throw when hitting REMOVE file
+                  dsv1SuccessfulCalls.incrementAndGet();
+                }
+              } finally {
+                deltaChanges.close();
+              }
+            },
+            String.format("DSv1 should throw on REMOVE for scenario: %s", testDescription));
 
     // Test DSv2 SparkMicroBatchStream
     Configuration hadoopConf = new Configuration();
@@ -895,22 +896,26 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     AtomicInteger dsv2SuccessfulCalls = new AtomicInteger(0);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> {
-          CloseableIterator<IndexedFile> kernelChanges =
-              stream.getFileChanges(
-                  fromVersion, fromIndex, isInitialSnapshot, ScalaUtils.toJavaOptional(endOffset));
-          try {
-            while (kernelChanges.hasNext()) {
-              kernelChanges.next(); // Should throw when hitting REMOVE file
-              dsv2SuccessfulCalls.incrementAndGet();
-            }
-          } finally {
-            kernelChanges.close();
-          }
-        },
-        String.format("DSv2 should throw on REMOVE for scenario: %s", testDescription));
+    UnsupportedOperationException dsv2Exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+              CloseableIterator<IndexedFile> kernelChanges =
+                  stream.getFileChanges(
+                      fromVersion,
+                      fromIndex,
+                      isInitialSnapshot,
+                      ScalaUtils.toJavaOptional(endOffset));
+              try {
+                while (kernelChanges.hasNext()) {
+                  kernelChanges.next(); // Should throw when hitting REMOVE file
+                  dsv2SuccessfulCalls.incrementAndGet();
+                }
+              } finally {
+                kernelChanges.close();
+              }
+            },
+            String.format("DSv2 should throw on REMOVE for scenario: %s", testDescription));
 
     // Verify both threw at the exact same point
     assertEquals(
@@ -920,6 +925,18 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             "DSv1 and DSv2 should throw after the same number of next() calls for scenario: %s. "
                 + "DSv1=%d, DSv2=%d",
             testDescription, dsv1SuccessfulCalls.get(), dsv2SuccessfulCalls.get()));
+
+    // Verify both error messages reference the same CommitInfo operation name.
+    // We compare only the operation name (e.g. "MERGE", "DELETE") because the full
+    // operationParameters differ in key ordering and value quoting between V1 and V2.
+    String dsv1Op = extractOperationName(dsv1Exception.getMessage());
+    String dsv2Op = extractOperationName(dsv2Exception.getMessage());
+    assertEquals(
+        dsv1Op,
+        dsv2Op,
+        String.format(
+            "DSv1 and DSv2 should report the same operation name for scenario: %s",
+            testDescription));
   }
 
   /** Provides test scenarios that generate REMOVE actions through various DML operations. */
@@ -1005,6 +1022,17 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   // ================================================================================================
 
   /**
+   * Extracts the operation name (e.g. "DELETE", "MERGE", "UPDATE") from a
+   * deltaSourceIgnoreChangesError message. Returns null if no operation name is found (e.g. for
+   * delete-only commits where the message contains a file path instead).
+   */
+  private static String extractOperationName(String errorMessage) {
+    java.util.regex.Matcher matcher =
+        java.util.regex.Pattern.compile("for example ([A-Z_ ]+?)\\s*\\(").matcher(errorMessage);
+    return matcher.find() ? matcher.group(1).trim() : null;
+  }
+
+  /**
    * Runs a parity test: verifies that DSv1 and DSv2 produce identical file changes for the given
    * option and scenario.
    */
@@ -1088,27 +1116,28 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath, options);
 
     AtomicInteger dsv1SuccessfulCalls = new AtomicInteger(0);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> {
-          ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> deltaChanges =
-              deltaSource.getFileChanges(
-                  fromVersion,
-                  fromIndex,
-                  isInitialSnapshot,
-                  endOffset,
-                  /* verifyMetadataAction= */ true);
-          try {
-            while (deltaChanges.hasNext()) {
-              deltaChanges.next();
-              dsv1SuccessfulCalls.incrementAndGet();
-            }
-          } finally {
-            deltaChanges.close();
-          }
-        },
-        String.format(
-            "DSv1 should throw on change commit with %s for: %s", optionName, testDescription));
+    UnsupportedOperationException dsv1Exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+              ClosableIterator<org.apache.spark.sql.delta.sources.IndexedFile> deltaChanges =
+                  deltaSource.getFileChanges(
+                      fromVersion,
+                      fromIndex,
+                      isInitialSnapshot,
+                      endOffset,
+                      /* verifyMetadataAction= */ true);
+              try {
+                while (deltaChanges.hasNext()) {
+                  deltaChanges.next();
+                  dsv1SuccessfulCalls.incrementAndGet();
+                }
+              } finally {
+                deltaChanges.close();
+              }
+            },
+            String.format(
+                "DSv1 should throw on change commit with %s for: %s", optionName, testDescription));
 
     // DSv2
     Configuration hadoopConf = new Configuration();
@@ -1118,22 +1147,24 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
 
     AtomicInteger dsv2SuccessfulCalls = new AtomicInteger(0);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> {
-          CloseableIterator<IndexedFile> kernelChanges =
-              stream.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, Optional.empty());
-          try {
-            while (kernelChanges.hasNext()) {
-              kernelChanges.next();
-              dsv2SuccessfulCalls.incrementAndGet();
-            }
-          } finally {
-            kernelChanges.close();
-          }
-        },
-        String.format(
-            "DSv2 should throw on change commit with %s for: %s", optionName, testDescription));
+    UnsupportedOperationException dsv2Exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> {
+              CloseableIterator<IndexedFile> kernelChanges =
+                  stream.getFileChanges(
+                      fromVersion, fromIndex, isInitialSnapshot, Optional.empty());
+              try {
+                while (kernelChanges.hasNext()) {
+                  kernelChanges.next();
+                  dsv2SuccessfulCalls.incrementAndGet();
+                }
+              } finally {
+                kernelChanges.close();
+              }
+            },
+            String.format(
+                "DSv2 should throw on change commit with %s for: %s", optionName, testDescription));
 
     assertEquals(
         dsv1SuccessfulCalls.get(),
@@ -1142,6 +1173,15 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             "DSv1 and DSv2 should throw after the same number of next() calls for: %s. "
                 + "DSv1=%d, DSv2=%d",
             testDescription, dsv1SuccessfulCalls.get(), dsv2SuccessfulCalls.get()));
+
+    // Verify both error messages reference the same CommitInfo operation name.
+    String dsv1Op = extractOperationName(dsv1Exception.getMessage());
+    String dsv2Op = extractOperationName(dsv2Exception.getMessage());
+    assertEquals(
+        dsv1Op,
+        dsv2Op,
+        String.format(
+            "DSv1 and DSv2 should report the same operation name for: %s", testDescription));
   }
 
   // ================================================================================================


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Re-lands the changes from https://github.com/delta-io/delta/pull/6309 (reverted in https://github.com/delta-io/delta/pull/6593) with a fix: delete duplicate `getCommitInfo`
 
<!--
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
