### PR TITLE
Delegate to DeltaSharingSource for initialSnapshot Conversion

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
 import io.delta.sharing.client.util.ConfUtils
-import io.delta.sharing.client.model.{Table => DeltaSharingTable}
+import io.delta.sharing.client.model.{DeltaTableMetadata, Table => DeltaSharingTable}
 
 import org.apache.spark.delta.sharing.CachedTableManager
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -149,6 +149,57 @@ case class DeltaFormatSharingSource(
       CDCReader.cdcReadSchema(schemaWithoutCDC)
     } else {
       schemaWithoutCDC
+    }
+  }
+
+  // When restarting from a legacy DeltaSharingSourceOffset checkpoint that is still in the
+  // initial snapshot (isStartingVersion=true), file index ordering differs between
+  // DeltaSharingSource (sort by file ID) and DeltaSource (sort by modificationTime and path).
+  // We delegate to a DeltaSharingSource instance during the snapshot phase, then switch
+  // back to normal DeltaFormatSharingSource logic once the snapshot completes.
+  private var legacyDeltaSharingSourceOpt: Option[DeltaSharingSource] = None
+
+  /**
+   * Create the legacy DeltaSharingSource for snapshot delegation.
+   *
+   * @param snapshotVersion the initial snapshot version from the legacy checkpoint offset,
+   *                        used to fetch metadata at that version so RemoteDeltaLog is
+   *                        initialized with the correct schema.
+   */
+  private def getOrCreateLegacySource(snapshotVersion: Long): DeltaSharingSource = {
+    legacyDeltaSharingSourceOpt.getOrElse {
+      logInfo(s"Initializing legacy DeltaSharingSource for snapshot delegation at " +
+        s"version $snapshotVersion," + getTableInfoForLogging)
+      // Create a parquet-format client to fetch metadata, since RemoteDeltaLog
+      // expects parquet-format DeltaTableMetadata (with protocol/metadata fields
+      // set, not just lines).
+      val parsedPath = DeltaSharingRestClient.parsePath(
+        tablePath, options.shareCredentialsOptions)
+      val parquetClient = DeltaSharingRestClient(
+        profileFile = parsedPath.profileFile,
+        shareCredentialsOptions = options.shareCredentialsOptions,
+        forStreaming = true,
+        responseFormat = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET
+      )
+      val deltaTableMetadata = try {
+        parquetClient.getMetadata(table, versionAsOf = Some(snapshotVersion))
+      } finally {
+        parquetClient match {
+          case restClient: DeltaSharingRestClient => restClient.close()
+          case _ =>
+        }
+      }
+      val deltaLog = RemoteDeltaLog(
+        path = tablePath,
+        shareCredentialsOptions = options.shareCredentialsOptions,
+        forStreaming = true,
+        responseFormat = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET,
+        initDeltaTableMetadata = Some(deltaTableMetadata),
+        callerOrg = options.callerOrg
+      )
+      val source = DeltaSharingSource(spark, deltaLog, options)
+      legacyDeltaSharingSourceOpt = Some(source)
+      source
     }
   }
 
@@ -469,6 +520,17 @@ case class DeltaFormatSharingSource(
         case Some((offset, fromLegacy)) => (Some(offset), fromLegacy)
         case None => (None, false)
       }
+
+    // Delegate to legacy source if start offset is from a legacy checkpoint and still in the
+    // initial snapshot. Index ordering differs: DeltaSharingSource sorts by fileId, while
+    // DeltaSource sorts by modificationTime and path. Format conversion starts after the
+    // initial snapshot completes.
+    if (wasConvertedFromLegacy && startDeltaSourceOffsetOpt.exists(_.isInitialSnapshot)) {
+      logInfo(s"Delegating latestOffset to legacy DeltaSharingSource," + getTableInfoForLogging)
+      return getOrCreateLegacySource(
+        startDeltaSourceOffsetOpt.get.reservoirVersion).latestOffset(startOffset, limit)
+    }
+
     // The engine always calls getBatch for priming on restart, so
     // latestProcessedEndOffsetOption is normally valid here and points to the last processed end
     // offset in legacy format.
@@ -488,6 +550,17 @@ case class DeltaFormatSharingSource(
     }
 
     val latestTableVersion = getOrUpdateLatestTableVersion
+    // Legacy conversion edge case when the table has no version beyond the initial snapshot:
+    // - Batch 0: v1, index=0, isStartingVersion=true (mid-snapshot at v1).
+    // - Batch 1: v2, index=-1, isStartingVersion=false (snapshot finished; end offset is
+    //   startVersion+1 at the version boundary).
+    // The table only has v1 (no newer versions). getBatch priming delegates to the legacy source
+    // because the batch 0 is still in the initial snapshot, latestProcessedEndOffsetOption
+    // is empty, and latestOffset here advances to v2 with index=-1. The server has no v2, so
+    // latestOffset must return null instead of fetching files for v2 from the server.
+    if (wasConvertedFromLegacy && deltaSourceOffset.reservoirVersion > latestTableVersion) {
+      return null
+    }
     val (endingVersion, fileIdHash) = determineVersionAndHashFromLatestOffset(
       deltaSourceOffset, wasConvertedFromLegacy, latestTableVersion)
     maybeGetLatestFileChangesFromServer(
@@ -842,6 +915,28 @@ case class DeltaFormatSharingSource(
         case Some((offset, fromLegacy)) => (Some(offset), fromLegacy)
         case None => (None, false)
       }
+
+    // Delegate to legacy source if either offset is from a legacy checkpoint and either is
+    // still in the initial snapshot. Index ordering differs: DeltaSharingSource sorts by
+    // fileId, while DeltaSource sorts by modificationTime and path.
+    // Format conversion starts after the initial snapshot completes.
+    //
+    // Possible streaming restart priming cases for legacy conversion:
+    // 1. start=None, end=legacy(initial)
+    // 2. start=legacy(initial), end=legacy(initial)
+    // 3. start=legacy(initial), end=legacy(post-snapshot)
+    val needsDelegation =
+      (startConvertedFromLegacy && startDeltaOffsetOption.exists(_.isInitialSnapshot)) ||
+      (endConvertedFromLegacy && endOffset.isInitialSnapshot)
+    if (needsDelegation) {
+      val snapshotVersion = startDeltaOffsetOption.map(_.reservoirVersion)
+        .getOrElse(endOffset.reservoirVersion)
+      logInfo(s"Delegating getBatch to legacy DeltaSharingSource," + getTableInfoForLogging)
+      // Need to use table metadata at the snapshot version,
+      // and pass in legacy offset to prime the legacy source.
+      return getOrCreateLegacySource(snapshotVersion).getBatch(startOffsetOption, end)
+    }
+
     val startingOffset = getStartingOffset(startDeltaOffsetOption, Some(endOffset))
 
     val latestTableVersion = getOrUpdateLatestTableVersion
@@ -893,6 +988,7 @@ case class DeltaFormatSharingSource(
   }
 
   override def stop(): Unit = {
+    legacyDeltaSharingSourceOpt.foreach(_.stop())
     deltaSource.stop()
 
     DeltaSharingLogFileSystem.tryToCleanUpDeltaLog(deltaLogPath)
@@ -901,7 +997,16 @@ case class DeltaFormatSharingSource(
   // Calls deltaSource.commit for checks related to column mapping.
   override def commit(end: Offset): Unit = {
     logInfo(s"Commit end offset: $end," + getTableInfoForLogging)
-    val endOffset = forceToDeltaSourceOffset(end)._1
+    val (endOffset, endConvertedFromLegacy) = forceToDeltaSourceOffset(end)
+
+    if (endConvertedFromLegacy && endOffset.isInitialSnapshot) {
+      // During legacy snapshot delegation, the batch was produced by DeltaSharingSource,
+      // so delegate commit to the legacy source and return. DeltaSharingSource doesn't
+      // implement commit(), so this is a no-op for now.
+      legacyDeltaSharingSourceOpt.foreach(_.commit(end))
+      return
+    }
+
     // If DeltaSource detects a metadata change at endOffset
     // version, deltaSource.commit throws an exception so the
     // stream restarts from the checkpoint with the new schema.

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -157,7 +157,9 @@ case class DeltaFormatSharingSource(
   // DeltaSharingSource (sort by file ID) and DeltaSource (sort by modificationTime and path).
   // We delegate to a DeltaSharingSource instance during the snapshot phase, then switch
   // back to normal DeltaFormatSharingSource logic once the snapshot completes.
-  private var legacyDeltaSharingSourceOpt: Option[DeltaSharingSource] = None
+  //
+  // (snapshotVersion, DeltaSharingSource)
+  private var legacyDeltaSharingSourceOpt: Option[(Long, DeltaSharingSource)] = None
 
   /**
    * Create the legacy DeltaSharingSource for snapshot delegation.
@@ -167,7 +169,16 @@ case class DeltaFormatSharingSource(
    *                        initialized with the correct schema.
    */
   private def getOrCreateLegacySource(snapshotVersion: Long): DeltaSharingSource = {
-    legacyDeltaSharingSourceOpt.getOrElse {
+    // Safeguard: this error should never happen, as we only delegate to the legacy
+    // source for the initial snapshot.
+    legacyDeltaSharingSourceOpt.foreach { case (existingVersion, _) =>
+      if (existingVersion != snapshotVersion) {
+        throw new IllegalStateException(
+          s"Legacy DeltaSharingSource was created for snapshot version $existingVersion " +
+            s"but is now requested for version $snapshotVersion")
+      }
+    }
+    legacyDeltaSharingSourceOpt.map(_._2).getOrElse {
       logInfo(s"Initializing legacy DeltaSharingSource for snapshot delegation at " +
         s"version $snapshotVersion," + getTableInfoForLogging)
       // Create a parquet-format client to fetch metadata, since RemoteDeltaLog
@@ -198,7 +209,7 @@ case class DeltaFormatSharingSource(
         callerOrg = options.callerOrg
       )
       val source = DeltaSharingSource(spark, deltaLog, options)
-      legacyDeltaSharingSourceOpt = Some(source)
+      legacyDeltaSharingSourceOpt = Some((snapshotVersion, source))
       source
     }
   }
@@ -988,7 +999,7 @@ case class DeltaFormatSharingSource(
   }
 
   override def stop(): Unit = {
-    legacyDeltaSharingSourceOpt.foreach(_.stop())
+    legacyDeltaSharingSourceOpt.foreach(_._2.stop())
     deltaSource.stop()
 
     DeltaSharingLogFileSystem.tryToCleanUpDeltaLog(deltaLogPath)
@@ -1003,7 +1014,7 @@ case class DeltaFormatSharingSource(
       // During legacy snapshot delegation, the batch was produced by DeltaSharingSource,
       // so delegate commit to the legacy source and return. DeltaSharingSource doesn't
       // implement commit(), so this is a no-op for now.
-      legacyDeltaSharingSourceOpt.foreach(_.commit(end))
+      legacyDeltaSharingSourceOpt.foreach(_._2.commit(end))
       return
     }
 

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -110,6 +110,28 @@ class DeltaFormatSharingSourceSuite
   }
 
   /**
+   * Initialize a streaming checkpoint directory with offsets, commits, and metadata subdirs.
+   * Returns (checkpointPath, fileManager) for use with writeLegacyOffsetAndCommit.
+   */
+  private def initCheckpointDirs(
+      checkpointDir: java.io.File): (Path, CheckpointFileManager) = {
+    val checkpointPath = new Path(checkpointDir.getCanonicalPath)
+    // scalastyle:off deltahadoopconfiguration
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+    val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
+    fileManager.mkdirs(
+      new Path(checkpointPath, StreamingCheckpointConstants.DIR_NAME_OFFSETS))
+    fileManager.mkdirs(
+      new Path(checkpointPath, StreamingCheckpointConstants.DIR_NAME_COMMITS))
+    StreamMetadata.write(
+      StreamMetadata(java.util.UUID.randomUUID.toString),
+      new Path(checkpointPath, StreamingCheckpointConstants.DIR_NAME_METADATA),
+      hadoopConf)
+    (checkpointPath, fileManager)
+  }
+
+  /**
    * Write a legacy DeltaSharingSourceOffset and its corresponding commit entry
    * into a streaming checkpoint directory.
    */
@@ -317,7 +339,7 @@ class DeltaFormatSharingSourceSuite
         sql(s"INSERT INTO $deltaTableName VALUES ('p3'), ('p4')")
         val tableId = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
           .update().metadata.id
-        val sharedTableName = "shared_streaming_table_e2e"
+        val sharedTableName = "shared_parquet_table_e2e_legacy"
         val profileFile = prepareProfileFile(inputDir)
         val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
         spark.sessionState.conf.setConfString(
@@ -326,20 +348,7 @@ class DeltaFormatSharingSourceSuite
         )
 
         // Build custom checkpoint with legacy DeltaSharingSourceOffset (no parquet stream run).
-        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
-        // scalastyle:off deltahadoopconfiguration
-        val hadoopConf = spark.sessionState.newHadoopConf()
-        // scalastyle:on deltahadoopconfiguration
-        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
-        val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
-        val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
-        val metaDir = StreamingCheckpointConstants.DIR_NAME_METADATA
-        fileManager.mkdirs(new Path(checkpointPath, offsetsDir))
-        fileManager.mkdirs(new Path(checkpointPath, commitsDir))
-        val metadataPath = new Path(checkpointPath, metaDir)
-        val streamId = java.util.UUID.randomUUID.toString
-        StreamMetadata.write(
-          StreamMetadata(streamId), metadataPath, hadoopConf)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
         // Mid-version legacy offset: index=0, isStartingVersion=true
         // means we're in the middle of processing the initial snapshot
         // at v1 (processed 1 of 2 files).
@@ -356,9 +365,9 @@ class DeltaFormatSharingSourceSuite
           )).toSeq: _*
         ) {
           prepareMockedClientMetadata(deltaTableName, sharedTableName)
-          // Priming: snapshot at v1 for initial batch when resuming
-          // from legacy mid-version offset.
-          prepareMockedClientAndFileSystemResult(
+          // Legacy source needs parquet-format metadata at v1 for delegation
+          // to RemoteDeltaLog.
+          prepareMockedClientAndFileSystemResultForParquet(
             deltaTableName, sharedTableName, versionAsOf = Some(1L))
           // Mid-version: restricted to v1 only (MD5) to finish
           // remaining files in the initial snapshot.
@@ -1760,19 +1769,7 @@ class DeltaFormatSharingSourceSuite
 
         // Build checkpoint: legacy offset at version boundary (index=-1),
         // isStartingVersion=false because index=-1 means past initial snapshot.
-        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
-        // scalastyle:off deltahadoopconfiguration
-        val hadoopConf = spark.sessionState.newHadoopConf()
-        // scalastyle:on deltahadoopconfiguration
-        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
-        val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
-        val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
-        val metaDir = StreamingCheckpointConstants.DIR_NAME_METADATA
-        fileManager.mkdirs(new Path(checkpointPath, offsetsDir))
-        fileManager.mkdirs(new Path(checkpointPath, commitsDir))
-        val metadataPath = new Path(checkpointPath, metaDir)
-        val streamId = java.util.UUID.randomUUID.toString
-        StreamMetadata.write(StreamMetadata(streamId), metadataPath, hadoopConf)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
         // Batch 0: version 2, at boundary (index=-1), not initial snapshot
         writeLegacyOffsetAndCommit(fileManager, checkpointPath,
           batchId = 0, tableId, tableVersion = 2, index = -1,
@@ -1860,19 +1857,7 @@ class DeltaFormatSharingSourceSuite
           "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds", "10s")
 
         // Build checkpoint: legacy offset mid-version (index=0, not -1)
-        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
-        // scalastyle:off deltahadoopconfiguration
-        val hadoopConf = spark.sessionState.newHadoopConf()
-        // scalastyle:on deltahadoopconfiguration
-        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
-        val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
-        val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
-        val metaDir = StreamingCheckpointConstants.DIR_NAME_METADATA
-        fileManager.mkdirs(new Path(checkpointPath, offsetsDir))
-        fileManager.mkdirs(new Path(checkpointPath, commitsDir))
-        val metadataPath = new Path(checkpointPath, metaDir)
-        val streamId = java.util.UUID.randomUUID.toString
-        StreamMetadata.write(StreamMetadata(streamId), metadataPath, hadoopConf)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
 
         // Batch 0: finished processing version 0 (index=-1 means starting version 1)
         writeLegacyOffsetAndCommit(fileManager, checkpointPath,
@@ -1967,19 +1952,7 @@ class DeltaFormatSharingSourceSuite
         spark.sessionState.conf.setConfString(
           "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds", "10s")
 
-        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
-        // scalastyle:off deltahadoopconfiguration
-        val hadoopConf = spark.sessionState.newHadoopConf()
-        // scalastyle:on deltahadoopconfiguration
-        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
-        val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
-        val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
-        val metaDir = StreamingCheckpointConstants.DIR_NAME_METADATA
-        fileManager.mkdirs(new Path(checkpointPath, offsetsDir))
-        fileManager.mkdirs(new Path(checkpointPath, commitsDir))
-        val metadataPath = new Path(checkpointPath, metaDir)
-        val streamId = java.util.UUID.randomUUID.toString
-        StreamMetadata.write(StreamMetadata(streamId), metadataPath, hadoopConf)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
 
         // Version boundary (lucky case) with isStartingVersion=false
         // (index=-1 means past initial snapshot)
@@ -2055,19 +2028,7 @@ class DeltaFormatSharingSourceSuite
         spark.sessionState.conf.setConfString(
           "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds", "10s")
 
-        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
-        // scalastyle:off deltahadoopconfiguration
-        val hadoopConf = spark.sessionState.newHadoopConf()
-        // scalastyle:on deltahadoopconfiguration
-        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
-        val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
-        val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
-        val metaDir = StreamingCheckpointConstants.DIR_NAME_METADATA
-        fileManager.mkdirs(new Path(checkpointPath, offsetsDir))
-        fileManager.mkdirs(new Path(checkpointPath, commitsDir))
-        val metadataPath = new Path(checkpointPath, metaDir)
-        val streamId = java.util.UUID.randomUUID.toString
-        StreamMetadata.write(StreamMetadata(streamId), metadataPath, hadoopConf)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
 
         // Batch 0: finished processing version 0 (index=-1 means starting version 1)
         writeLegacyOffsetAndCommit(fileManager, checkpointPath,
@@ -2162,19 +2123,7 @@ class DeltaFormatSharingSourceSuite
 
         // Two committed legacy batches: batch 0 at version 1, batch 1 at version 2.
         // On restart, the engine calls getBatch(offset_0, offset_1) as priming -- both legacy.
-        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
-        // scalastyle:off deltahadoopconfiguration
-        val hadoopConf = spark.sessionState.newHadoopConf()
-        // scalastyle:on deltahadoopconfiguration
-        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
-        val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
-        val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
-        val metaDir = StreamingCheckpointConstants.DIR_NAME_METADATA
-        fileManager.mkdirs(new Path(checkpointPath, offsetsDir))
-        fileManager.mkdirs(new Path(checkpointPath, commitsDir))
-        val metadataPath = new Path(checkpointPath, metaDir)
-        val streamId = java.util.UUID.randomUUID.toString
-        StreamMetadata.write(StreamMetadata(streamId), metadataPath, hadoopConf)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
 
         // Batch 0: legacy offset at version 1 (boundary)
         writeLegacyOffsetAndCommit(fileManager, checkpointPath,
@@ -2278,19 +2227,7 @@ class DeltaFormatSharingSourceSuite
           "spark.delta.sharing.streaming.queryTableVersionIntervalSeconds", "10s")
 
         // Build checkpoint: legacy offset mid-version at version 2, index 0
-        val checkpointPath = new Path(checkpointDir.getCanonicalPath)
-        // scalastyle:off deltahadoopconfiguration
-        val hadoopConf = spark.sessionState.newHadoopConf()
-        // scalastyle:on deltahadoopconfiguration
-        val fileManager = CheckpointFileManager.create(checkpointPath, hadoopConf)
-        val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
-        val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
-        val metaDir = StreamingCheckpointConstants.DIR_NAME_METADATA
-        fileManager.mkdirs(new Path(checkpointPath, offsetsDir))
-        fileManager.mkdirs(new Path(checkpointPath, commitsDir))
-        val metadataPath = new Path(checkpointPath, metaDir)
-        val streamId = java.util.UUID.randomUUID.toString
-        StreamMetadata.write(StreamMetadata(streamId), metadataPath, hadoopConf)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
 
         // Batch 0: finished processing version 0 (index=-1 means starting version 1)
         writeLegacyOffsetAndCommit(fileManager, checkpointPath,
@@ -2367,67 +2304,349 @@ class DeltaFormatSharingSourceSuite
     }
   }
 
-  // Test convertDeltaSourceOffsetToLegacyOffset: verify that a DeltaSourceOffset
-  // is correctly converted back to a legacy DeltaSharingSourceOffset.
-  test("convertDeltaSourceOffsetToLegacyOffset produces valid legacy offset") {
-    withTempDir { tempDir =>
-      val deltaTableName = "delta_table_convert_back"
+  // ---- Legacy initial snapshot offset transition tests ----
+
+  // Legacy stream already finished the initial snapshot in the first batch.
+  // On restart, start=None and end is the legacy offset (version boundary),
+  // so the stream transitions to new format immediately.
+  test("legacy offset transition: initial snapshot completed in first batch") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_legacy_transition_1"
       withTable(deltaTableName) {
-        createTable(deltaTableName)
-        val sharedTableName = "shared_convert_back"
-        prepareMockedClientMetadata(deltaTableName, sharedTableName)
-        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
-        val profileFile = prepareProfileFile(tempDir)
-        val tableId = "test-table-convert-back"
-        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
-          val source = getSource(
-            Map("path" -> s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
-          )
-          val tableIdField = source.getClass.getDeclaredField("tableId")
-          tableIdField.setAccessible(true)
-          tableIdField.set(source, tableId)
+        sql(s"CREATE TABLE $deltaTableName (value STRING) USING DELTA")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v1a'), ('v1b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v2a'), ('v2b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v3a'), ('v3b')")
+        val tableId = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
+          .update().metadata.id
+        val sharedTableName = "shared_legacy_transition_1"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
 
-          // Use reflection to call the private convertDeltaSourceOffsetToLegacyOffset
-          val method = source.getClass.getDeclaredMethod(
-            "convertDeltaSourceOffsetToLegacyOffset",
-            classOf[DeltaSourceOffset]
-          )
-          method.setAccessible(true)
+        // Single legacy offset at batch 0: version=2, index=-1 (version boundary),
+        // isStartingVersion=false. The legacy stream finished the initial snapshot
+        // and processed through version 2 in one batch.
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
+        writeLegacyOffsetAndCommit(fileManager, checkpointPath,
+          batchId = 0, tableId, tableVersion = 2, index = -1,
+          isStartingVersion = false)
 
-          val deltaOffset = DeltaSourceOffset(
-            reservoirId = tableId,
-            reservoirVersion = 5L,
-            index = 3L,
-            isInitialSnapshot = false
-          )
-          val result = method.invoke(source, deltaOffset)
-          // Call json() via the connector Offset interface
-          val jsonMethod = result.getClass.getMethod("json")
-          val json = jsonMethod.invoke(result).asInstanceOf[String]
+        val autoResolveKey = DeltaSQLConf
+          .DELTA_SHARING_STREAMING_AUTO_RESOLVE_RESPONSE_FORMAT.key
+        withSQLConf(
+          (getDeltaSharingClassesSQLConf ++ Seq(
+            autoResolveKey -> "true"
+          )).toSeq: _*
+        ) {
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          // Priming getBatch(None, offset_0): endOffset is legacy
+          // (v2, index=-1 -> BASE_INDEX), so endVersion = 2 - 1 = 1.
+          // Needs snapshot at v1 for getFiles.
+          prepareMockedClientAndFileSystemResult(
+            deltaTableName, sharedTableName, versionAsOf = Some(1L))
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 1L, 1L)
+          // After priming, latestOffset starts from v2 and fetches v2-v3.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 2L, 3L)
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
 
-          // Verify the legacy offset JSON contains expected fields
-          assert(json.contains("\"sourceVersion\":1"), s"Expected sourceVersion:1 in $json")
-          assert(json.contains(s""""tableId":"$tableId""""), s"Expected tableId in $json")
-          assert(json.contains("\"tableVersion\":5"), s"Expected tableVersion:5 in $json")
-          assert(json.contains("\"index\":3"), s"Expected index:3 in $json")
-          assert(json.contains("\"isStartingVersion\":false"),
-            s"Expected isStartingVersion:false in $json")
-
-          // Round-trip: the legacy offset JSON should be parseable back via
-          // forceToDeltaSourceOffset
-          val autoResolveKey = DeltaSQLConf
-            .DELTA_SHARING_STREAMING_AUTO_RESOLVE_RESPONSE_FORMAT.key
-          withSQLConf(autoResolveKey -> "true") {
-            val serialized = SerializedOffset(json)
-            val (roundTripped, fromLegacy) = source.forceToDeltaSourceOffset(serialized)
-            assert(fromLegacy, "Should be detected as legacy")
-            assert(roundTripped.reservoirId === tableId)
-            assert(roundTripped.reservoirVersion === 5L)
-            // Index -1 maps to BASE_INDEX, but index 3 should stay 3
-            assert(roundTripped.index === 3L)
-            assert(!roundTripped.isInitialSnapshot)
+          val q = spark.readStream
+            .format("deltaSharing")
+            .option("responseFormat", "delta")
+            .load(tablePath)
+            .writeStream
+            .format("delta")
+            .option("checkpointLocation", checkpointDir.toString)
+            .start(outputDir.toString)
+          try {
+            q.processAllAvailable()
+          } finally {
+            q.stop()
           }
-          cleanUpDeltaSharingBlocks()
+
+          // Should get v2 and v3 data (v1 was already processed by legacy stream).
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("v2a", "v2b", "v3a", "v3b").toDF())
+
+          // Validate the final offset has transitioned to DeltaSourceOffset format.
+          val offsetLog = new OffsetSeqLog(
+            spark, s"${checkpointDir.getCanonicalPath}/offsets")
+          val (_, finalOffsetSeq) = offsetLog.getLatest().get
+          val finalJson = finalOffsetSeq.offsets.head.get.json()
+          assert(finalJson.contains("reservoirVersion"),
+            s"Expected DeltaSourceOffset (reservoirVersion) in final offset but got: $finalJson")
+          assert(!finalJson.contains("tableVersion"),
+            s"Expected no legacy tableVersion in final offset but got: $finalJson")
+        }
+      }
+    }
+  }
+
+  // Legacy stream is still processing the initial snapshot (mid-version).
+  // On restart, the start offset is a legacy initial snapshot with index > BASE_INDEX,
+  // so the stream should delegate to the legacy DeltaSharingSource to continue
+  // processing the remaining snapshot files.
+  test("legacy offset transition: snapshot still in progress, delegates to legacy source") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_legacy_transition_2"
+      withTable(deltaTableName) {
+        sql(s"CREATE TABLE $deltaTableName (value STRING) USING DELTA")
+        // Version 1: 4 files (1 row each) so index 0, 1 and 2 are mid-version.
+        spark.createDataFrame(
+          spark.sparkContext.parallelize(
+            Seq(Row("v1a"), Row("v1b"), Row("v1c"), Row("v1d")), 4),
+          new StructType().add("value", StringType)
+        ).write.insertInto(deltaTableName)
+        sql(s"INSERT INTO $deltaTableName VALUES ('v2a'), ('v2b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v3a'), ('v3b')")
+        val tableId = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
+          .update().metadata.id
+        val sharedTableName = "shared_parquet_table_legacy_transition_2"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        // Two legacy offsets still in the initial snapshot:
+        // Batch 0: v1, index=0, isStartingVersion=true (processed 1 of 4 files)
+        // Batch 1: v1, index=1, isStartingVersion=true (processed 2 of 4 files)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
+        writeLegacyOffsetAndCommit(fileManager, checkpointPath,
+          batchId = 0, tableId, tableVersion = 1, index = 0,
+          isStartingVersion = true)
+        writeLegacyOffsetAndCommit(fileManager, checkpointPath,
+          batchId = 1, tableId, tableVersion = 1, index = 1,
+          isStartingVersion = true)
+
+        val autoResolveKey = DeltaSQLConf
+          .DELTA_SHARING_STREAMING_AUTO_RESOLVE_RESPONSE_FORMAT.key
+        withSQLConf(
+          (getDeltaSharingClassesSQLConf ++ Seq(
+            autoResolveKey -> "true"
+          )).toSeq: _*
+        ) {
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          // Legacy source needs parquet-format metadata at v1 for delegation
+          // to RemoteDeltaLog.
+          prepareMockedClientAndFileSystemResultForParquet(
+            deltaTableName, sharedTableName, versionAsOf = Some(1L))
+          // Mid-version: restricted to v1 only (MD5) to finish
+          // remaining files in the initial snapshot.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 1L, 1L)
+          // After transition at v1 boundary, stream fetches v2-v3.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 1L, 3L)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 2L, 3L)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 3L, 3L)
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+          val q = spark.readStream
+            .format("deltaSharing")
+            .option("responseFormat", "delta")
+            .option("maxFilesPerTrigger", "1")
+            .load(tablePath)
+            .writeStream
+            .format("delta")
+            .option("checkpointLocation", checkpointDir.toString)
+            .start(outputDir.toString)
+          try {
+            q.processAllAvailable()
+          } finally {
+            q.stop()
+          }
+
+          // The stream finishes the remaining v1 files (2 of v1a/v1b/v1c/v1d),
+          // then processes v2 and v3.
+          val outputValues = spark.read.format("delta")
+            .load(outputDir.getCanonicalPath)
+            .collect().map(_.getString(0)).toSet
+          assert(outputValues.size == 6,
+            s"Expected 6 rows (2 remaining v1 + 2 v2 + 2 v3) but got: $outputValues")
+          assert(outputValues.intersect(Set("v1a", "v1b", "v1c", "v1d")).size == 2,
+            s"Expected exactly two of v1a/v1b/v1c/v1d from remaining v1 files " +
+              s"but got: $outputValues")
+          assert(outputValues.contains("v2a") && outputValues.contains("v2b"),
+            s"Expected v2a and v2b in output but got: $outputValues")
+          assert(outputValues.contains("v3a") && outputValues.contains("v3b"),
+            s"Expected v3a and v3b in output but got: $outputValues")
+
+          // Validate offsets 0, 1, 2, 3 are in legacy format (all v1 files)
+          // and offset 4 is in the new DeltaSourceOffset format.
+          val offsetLog = new OffsetSeqLog(
+            spark, s"${checkpointDir.getCanonicalPath}/offsets")
+          for (batchId <- 0 to 3) {
+            val legacyOffsetSeq = offsetLog.get(batchId).get
+            val legacyJson = legacyOffsetSeq.offsets.head.get.json()
+            assert(legacyJson.contains("tableVersion"),
+              s"Expected legacy offset (tableVersion) at batch $batchId " +
+                s"but got: $legacyJson")
+            assert(!legacyJson.contains("reservoirVersion"),
+              s"Expected no reservoirVersion at batch $batchId but got: $legacyJson")
+          }
+          val newOffsetSeq = offsetLog.get(4).get
+          val newJson = newOffsetSeq.offsets.head.get.json()
+          assert(newJson.contains("reservoirVersion"),
+            s"Expected DeltaSourceOffset (reservoirVersion) at batch 4 " +
+              s"but got: $newJson")
+          assert(!newJson.contains("tableVersion"),
+            s"Expected no legacy tableVersion at batch 4 but got: $newJson")
+        }
+      }
+    }
+  }
+
+  // Legacy stream start offset is still an initial snapshot, but the snapshot
+  // finishes within the last batch so the end offset reaches the version boundary
+  // (startVersion+1, index=-1). The stream transitions to new format.
+  test("legacy offset transition: snapshot finishes in last batch, transitions to new format") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_legacy_transition_3"
+      withTable(deltaTableName) {
+        sql(s"CREATE TABLE $deltaTableName (value STRING) USING DELTA")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v1a'), ('v1b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v2a'), ('v2b')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v3a'), ('v3b')")
+        val tableId = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
+          .update().metadata.id
+        val sharedTableName = "shared_parquet_table_legacy_transition_3"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        // Batch 0: v1, index=0, isStartingVersion=true (mid-snapshot at v1)
+        // Batch 1: v2, index=-1, isStartingVersion=false (snapshot finished,
+        //   end offset is startVersion+1 at the version boundary)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
+        writeLegacyOffsetAndCommit(fileManager, checkpointPath,
+          batchId = 0, tableId, tableVersion = 1, index = 0,
+          isStartingVersion = true)
+        writeLegacyOffsetAndCommit(fileManager, checkpointPath,
+          batchId = 1, tableId, tableVersion = 2, index = -1,
+          isStartingVersion = false)
+
+        val autoResolveKey = DeltaSQLConf
+          .DELTA_SHARING_STREAMING_AUTO_RESOLVE_RESPONSE_FORMAT.key
+        withSQLConf(
+          (getDeltaSharingClassesSQLConf ++ Seq(
+            autoResolveKey -> "true"
+          )).toSeq: _*
+        ) {
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          // Legacy source needs parquet-format metadata at v1 for delegation
+          // to RemoteDeltaLog.
+          prepareMockedClientAndFileSystemResultForParquet(
+            deltaTableName, sharedTableName, versionAsOf = Some(1L))
+          // Priming getBatch(offset_0, offset_1): start is legacy initial
+          // snapshot so delegates to legacy source, then latestOffset
+          // transitions to new format.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 1L, 1L)
+          // After priming, latestOffset starts from v2 and fetches v2-v3.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 2L, 3L)
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+          val q = spark.readStream
+            .format("deltaSharing")
+            .option("responseFormat", "delta")
+            .load(tablePath)
+            .writeStream
+            .format("delta")
+            .option("checkpointLocation", checkpointDir.toString)
+            .start(outputDir.toString)
+          try {
+            q.processAllAvailable()
+          } finally {
+            q.stop()
+          }
+
+          // Should get v2 and v3 data (v1 was already processed by legacy stream).
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("v2a", "v2b", "v3a", "v3b").toDF())
+
+          // Validate the final offset has transitioned to DeltaSourceOffset format.
+          val offsetLog = new OffsetSeqLog(
+            spark, s"${checkpointDir.getCanonicalPath}/offsets")
+          val (_, finalOffsetSeq) = offsetLog.getLatest().get
+          val finalJson = finalOffsetSeq.offsets.head.get.json()
+          assert(finalJson.contains("reservoirVersion"),
+            s"Expected DeltaSourceOffset (reservoirVersion) in final offset but got: $finalJson")
+          assert(!finalJson.contains("tableVersion"),
+            s"Expected no legacy tableVersion in final offset but got: $finalJson")
+        }
+      }
+    }
+  }
+
+  // Legacy stream start offset is still an initial snapshot (v1, index=0,
+  // isStartingVersion=true). The parquet delegation finishes the snapshot and
+  // reaches the version boundary (v2, index=-1, isStartingVersion=false).
+  // However, the table only has v1 -- no newer versions exist.
+  // latestOffset should detect that the converted offset's reservoirVersion exceeds
+  // the table's latest version and return null (no new data), so the query finishes.
+  test("legacy offset transition: snapshot delegates to parquet, table only has v1") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_legacy_transition_4"
+      withTable(deltaTableName) {
+        sql(s"CREATE TABLE $deltaTableName (value STRING) USING DELTA")
+        sql(s"INSERT INTO $deltaTableName VALUES ('v1a'), ('v1b')")
+        val tableId = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
+          .update().metadata.id
+        val sharedTableName = "shared_parquet_table_legacy_transition_4"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        // Batch 0: v1, index=0, isStartingVersion=true (mid-snapshot at v1)
+        // Batch 1: v2, index=-1, isStartingVersion=false (snapshot finished,
+        //   end offset is startVersion+1 at the version boundary)
+        val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
+        writeLegacyOffsetAndCommit(fileManager, checkpointPath,
+          batchId = 0, tableId, tableVersion = 1, index = 0,
+          isStartingVersion = true)
+        writeLegacyOffsetAndCommit(fileManager, checkpointPath,
+          batchId = 1, tableId, tableVersion = 2, index = -1,
+          isStartingVersion = false)
+
+        val autoResolveKey = DeltaSQLConf
+          .DELTA_SHARING_STREAMING_AUTO_RESOLVE_RESPONSE_FORMAT.key
+        withSQLConf(
+          (getDeltaSharingClassesSQLConf ++ Seq(
+            autoResolveKey -> "true"
+          )).toSeq: _*
+        ) {
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          // Legacy source needs parquet-format metadata at v1 for delegation
+          // to RemoteDeltaLog.
+          prepareMockedClientAndFileSystemResultForParquet(
+            deltaTableName, sharedTableName, versionAsOf = Some(1L))
+          // Priming getBatch(offset_0, offset_1): start is legacy initial
+          // snapshot so delegates to legacy source. Only v1 exists.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, 1L, 1L)
+          // Table only has v1, so report v1 as the latest version.
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName, Some(1L))
+
+          val q = spark.readStream
+            .format("deltaSharing")
+            .option("responseFormat", "delta")
+            .load(tablePath)
+            .writeStream
+            .format("delta")
+            .option("checkpointLocation", checkpointDir.toString)
+            .start(outputDir.toString)
+          try {
+            q.processAllAvailable()
+          } finally {
+            q.stop()
+          }
+
+          // latestOffset returned null (no new data), so no batch was
+          // executed and the output directory has no Delta log.
+          assert(!new java.io.File(outputDir, "_delta_log").exists(),
+            "Expected no Delta log in output dir since no batch should have run")
         }
       }
     }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -180,8 +180,11 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
 
   // Prepare the result(Protocol and Metadata) for client.GetMetadata for the sharedTable based on
   // the latest table info of the deltaTable, store them in BlockManager.
-  private[spark] def prepareMockedClientMetadata(deltaTable: String, sharedTable: String): Unit = {
-    val snapshotToUse = getSnapshotToUse(deltaTable, None)
+  private[spark] def prepareMockedClientMetadata(
+      deltaTable: String,
+      sharedTable: String,
+      versionAsOf: Option[Long] = None): Unit = {
+    val snapshotToUse = getSnapshotToUse(deltaTable, versionAsOf)
     val dsProtocol: DeltaSharingProtocol = DeltaSharingProtocol(snapshotToUse.protocol)
     val dsMetadata: DeltaSharingMetadata = DeltaSharingMetadata(
       deltaMetadata = snapshotToUse.metadata
@@ -189,7 +192,8 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
 
     // Put the metadata in blockManager for DeltaSharingClient to return for getMetadata.
     DeltaSharingUtils.overrideIteratorBlock[String](
-      blockId = TestClientForDeltaFormatSharing.getBlockId(sharedTable, "getMetadata"),
+      blockId = TestClientForDeltaFormatSharing.getBlockId(
+        sharedTable, "getMetadata", versionAsOf = versionAsOf),
       values = Seq(dsProtocol.json, dsMetadata.json).toIterator
     )
   }

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -223,6 +223,11 @@ private[spark] class TestClientForDeltaFormatSharing(
       endingVersion.isDefined,
       "endingVersion is not defined. This shouldn't happen in unit test."
     )
+    assert(
+      startingVersion <= endingVersion.get,
+      s"startingVersion($startingVersion) is greater than " +
+        s"endingVersion(${endingVersion.get}). This shouldn't happen in unit test."
+    )
     val tableFullName = s"${table.share}.${table.schema}.${table.name}"
     TestClientForDeltaFormatSharing.requestedFormat.put(tableFullName, responseFormat)
     TestClientForDeltaFormatSharing.fileIdHashHistory.synchronized {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Sharing)

## Description

- Add legacy snapshot delegation in `DeltaFormatSharingSource` for streams restarting from a legacy `DeltaSharingSourceOffset` checkpoint that is still in the initial snapshot (`isStartingVersion=true`). File index ordering differs between `DeltaSharingSource` (sort by fileId) and `DeltaSource` (sort by modificationTime and path), so we delegate to a `DeltaSharingSource` instance during the snapshot phase and switch back to `DeltaFormatSharingSource` once the snapshot completes.
- Introduce `getOrCreateLegacySource` which creates a parquet-format `DeltaSharingRestClient` to fetch metadata and initializes a `RemoteDeltaLog`/`DeltaSharingSource` for delegation. A parquet-format client is required because `RemoteDeltaLog` expects `DeltaTableMetadata` with `protocol`/`metadata` fields set (parquet format), not just `lines` (delta format).
- Add delegation logic in both `latestOffset` and `getBatch`: when the start offset is a legacy initial snapshot, delegate to the legacy source; when both start and end are legacy initial snapshots, delegate in `getBatch` as well.
- Add `initCheckpointDirs` test utility to reduce boilerplate for checkpoint directory setup across tests.

## How was this patch tested?

- **Test 1 — "initial snapshot completed in first batch"**: Legacy stream finished the initial snapshot in one batch (batch 0 at version boundary). On restart, `start=None` and `end` is the legacy offset at `version+1`. Verifies the stream transitions to new `DeltaSourceOffset` format and processes remaining versions.
- **Test 2 — "snapshot still in progress, delegates to legacy source"**: Legacy stream is mid-snapshot with 2 of 3 files processed (batch 0=v1/index=0, batch 1=v1/index=1, both `isStartingVersion=true`). Verifies delegation to `DeltaSharingSource` to finish the remaining snapshot file, then transitions to new format for subsequent versions.
- **Test 3 — "snapshot finishes in last batch, transitions to new format"**: Start offset is legacy initial snapshot (v1/index=0/`isStartingVersion=true`), end offset reached version boundary (v2/index=-1/`isStartingVersion=false`). Verifies the stream delegates for priming, then transitions to new format.
- Updated existing E2E test "parquet streaming checkpoint then restart with delta streaming" to use parquet-format metadata preparation for the legacy delegation path.

## Does this PR introduce _any_ user-facing changes?

No