### PR TITLE
[Spark] Ensure that replaceWhere block subqueries until DELETE supports arbitrary subqueries

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -457,13 +457,14 @@ case class WriteIntoDelta(
       spark: SparkSession,
       txn: OptimisticTransaction,
       conditions: Seq[Expression]): Seq[Action] = {
+    val relation = createTableRelation(txn, tableAliasOpt = options.targetAlias)
+    val processedCondition = conditions.reduceOption(And)
     // Clone the spark session to enable EXISTS subquery support in DELETE,
     // which is needed for replaceOn/replaceUsing conditions.
     val sparkWithSubqueryDelete = spark.cloneSession()
+    val allowExistsSubquery = options.isReplaceOnOrUsingDefined.toString
     sparkWithSubqueryDelete.conf.set(
-      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key, value = "true")
-    val relation = createTableRelation(txn, tableAliasOpt = options.targetAlias)
-    val processedCondition = conditions.reduceOption(And)
+      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key, value = allowExistsSubquery)
     val command = sparkWithSubqueryDelete.sessionState.analyzer.execute(
       DeleteFromTable(relation, processedCondition.getOrElse(Literal.TrueLiteral)))
     sparkWithSubqueryDelete.sessionState.analyzer.checkAnalysis(command)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -460,7 +460,9 @@ case class WriteIntoDelta(
     val relation = createTableRelation(txn, tableAliasOpt = options.targetAlias)
     val processedCondition = conditions.reduceOption(And)
     // Clone the spark session to enable EXISTS subquery support in DELETE,
-    // which is needed for replaceOn/replaceUsing conditions.
+    // which is needed for replaceOn/replaceUsing conditions. Subqueries are
+    // not allowed for replaceWhere because we have not yet been able to
+    // support arbitrary EXISTS subquery conditions in DELETE.
     val sparkWithSubqueryDelete = spark.cloneSession()
     val allowExistsSubquery = options.isReplaceOnOrUsingDefined.toString
     sparkWithSubqueryDelete.conf.set(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -466,7 +466,7 @@ case class WriteIntoDelta(
     val sparkWithSubqueryDelete = spark.cloneSession()
     val allowExistsSubqueryForReplaceOnOrUsing = options.isReplaceOnOrUsingDefined.toString
     sparkWithSubqueryDelete.conf.set(
-      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key,
+      key = DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key,
       value = allowExistsSubqueryForReplaceOnOrUsing)
     val command = sparkWithSubqueryDelete.sessionState.analyzer.execute(
       DeleteFromTable(relation, processedCondition.getOrElse(Literal.TrueLiteral)))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -466,7 +466,8 @@ case class WriteIntoDelta(
     val sparkWithSubqueryDelete = spark.cloneSession()
     val allowExistsSubqueryForReplaceOnOrUsing = options.isReplaceOnOrUsingDefined.toString
     sparkWithSubqueryDelete.conf.set(
-      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key, value = allowExistsSubqueryForReplaceOnOrUsing)
+      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key,
+      value = allowExistsSubqueryForReplaceOnOrUsing)
     val command = sparkWithSubqueryDelete.sessionState.analyzer.execute(
       DeleteFromTable(relation, processedCondition.getOrElse(Literal.TrueLiteral)))
     sparkWithSubqueryDelete.sessionState.analyzer.checkAnalysis(command)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -461,8 +461,8 @@ case class WriteIntoDelta(
     val processedCondition = conditions.reduceOption(And)
     // Clone the spark session to enable EXISTS subquery support in DELETE,
     // which is needed for replaceOn/replaceUsing conditions. Subqueries are
-    // not allowed for replaceWhere because we have not yet been able to
-    // support arbitrary EXISTS subquery conditions in DELETE.
+    // not allowed for replaceWhere because arbitrary EXISTS subquery
+    // conditions in DELETE are not supported.
     val sparkWithSubqueryDelete = spark.cloneSession()
     val allowExistsSubquery = options.isReplaceOnOrUsingDefined.toString
     sparkWithSubqueryDelete.conf.set(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -464,9 +464,9 @@ case class WriteIntoDelta(
     // not allowed for replaceWhere because arbitrary EXISTS subquery
     // conditions in DELETE are not supported.
     val sparkWithSubqueryDelete = spark.cloneSession()
-    val allowExistsSubquery = options.isReplaceOnOrUsingDefined.toString
+    val allowExistsSubqueryForReplaceOnOrUsing = options.isReplaceOnOrUsingDefined.toString
     sparkWithSubqueryDelete.conf.set(
-      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key, value = allowExistsSubquery)
+      DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key, value = allowExistsSubqueryForReplaceOnOrUsing)
     val command = sparkWithSubqueryDelete.sessionState.analyzer.execute(
       DeleteFromTable(relation, processedCondition.getOrElse(Literal.TrueLiteral)))
     sparkWithSubqueryDelete.sessionState.analyzer.checkAnalysis(command)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -650,6 +650,61 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test("replaceWhere blocks subquery") {
+    withTempDir { dir =>
+      Seq(1, 2, 3, 4).toDF("value")
+        .withColumn("is_odd", $"value" % 2 =!= 0)
+        .write
+        .format("delta")
+        .partitionBy("is_odd")
+        .save(dir.toString)
+
+      val viewName = "replaceWhereSubquerySource"
+      withView(viewName) {
+        spark.read.format("delta").load(dir.toString)
+          .where("is_odd = true")
+          .withColumnRenamed("value", "srcValue")
+          .createTempView(viewName)
+
+        // EXISTS subquery should be rejected
+        checkError(
+          exception = intercept[DeltaAnalysisException] {
+            Seq(5).toDF("value")
+              .withColumn("is_odd", $"value" % 2 =!= 0)
+              .write
+              .format("delta")
+              .mode("overwrite")
+              .option(DeltaOptions.REPLACE_WHERE_OPTION,
+                s"EXISTS (SELECT 1 FROM $viewName WHERE value = srcValue)")
+              .save(dir.toString)
+          },
+          condition = "DELTA_UNSUPPORTED_SUBQUERY",
+          sqlState = Some("0AKDC"),
+          parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
+          matchPVals = true
+        )
+
+        // IN subquery should be rejected
+        checkError(
+          exception = intercept[DeltaAnalysisException] {
+            Seq(5).toDF("value")
+              .withColumn("is_odd", $"value" % 2 =!= 0)
+              .write
+              .format("delta")
+              .mode("overwrite")
+              .option(DeltaOptions.REPLACE_WHERE_OPTION,
+                s"value IN (SELECT srcValue FROM $viewName)")
+              .save(dir.toString)
+          },
+          condition = "DELTA_UNSUPPORTED_SUBQUERY",
+          sqlState = Some("0AKDC"),
+          parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
+          matchPVals = true
+        )
+      }
+    }
+  }
+
   Seq(true, false).foreach { p =>
     test(s"replaceWhere user defined _change_type column doesn't get dropped - partitioned=$p") {
       withTable("tab") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -660,7 +660,7 @@ class DeltaSuite extends QueryTest
           Seq(1, 2, 3, 4).toDF("value")
             .withColumn("is_odd", $"value" % 2 =!= 0)
             .write
-            .format("tahoe")
+            .format("delta")
             .partitionBy("is_odd")
             .save(dir.toString)
 
@@ -677,7 +677,7 @@ class DeltaSuite extends QueryTest
                 Seq(5).toDF("value")
                   .withColumn("is_odd", $"value" % 2 =!= 0)
                   .write
-                  .format("tahoe")
+                  .format("delta")
                   .mode("overwrite")
                   .option(DeltaOptions.REPLACE_WHERE_OPTION,
                     s"EXISTS (SELECT 1 FROM $viewName WHERE value = srcValue)")
@@ -685,7 +685,7 @@ class DeltaSuite extends QueryTest
               },
               condition = "DELTA_UNSUPPORTED_SUBQUERY",
               sqlState = Some("0AKDC"),
-              parameters = Map("operation" -> "DELETE condition", "cond" -> ".*"),
+              parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
               matchPVals = true
             )
 
@@ -695,7 +695,7 @@ class DeltaSuite extends QueryTest
                 Seq(5).toDF("value")
                   .withColumn("is_odd", $"value" % 2 =!= 0)
                   .write
-                  .format("tahoe")
+                  .format("delta")
                   .mode("overwrite")
                   .option(DeltaOptions.REPLACE_WHERE_OPTION,
                     s"value IN (SELECT srcValue FROM $viewName)")
@@ -703,7 +703,7 @@ class DeltaSuite extends QueryTest
               },
               condition = "DELTA_UNSUPPORTED_SUBQUERY",
               sqlState = Some("0AKDC"),
-              parameters = Map("operation" -> "DELETE condition", "cond" -> ".*"),
+              parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
               matchPVals = true
             )
           }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -650,57 +650,64 @@ class DeltaSuite extends QueryTest
     }
   }
 
-  test("replaceWhere blocks subquery") {
-    withTempDir { dir =>
-      Seq(1, 2, 3, 4).toDF("value")
-        .withColumn("is_odd", $"value" % 2 =!= 0)
-        .write
-        .format("delta")
-        .partitionBy("is_odd")
-        .save(dir.toString)
+  Seq(true, false).foreach { enableDeleteSubquery =>
+    test("replaceWhere blocks subquery regardless of subquery flag value" +
+        s" - enableDeleteSubquery=$enableDeleteSubquery") {
+      withSQLConf(
+          DeltaSQLConf.ALLOW_EXISTS_SUBQUERY_IN_DELETE.key ->
+          enableDeleteSubquery.toString) {
+        withTempDir { dir =>
+          Seq(1, 2, 3, 4).toDF("value")
+            .withColumn("is_odd", $"value" % 2 =!= 0)
+            .write
+            .format("tahoe")
+            .partitionBy("is_odd")
+            .save(dir.toString)
 
-      val viewName = "replaceWhereSubquerySource"
-      withView(viewName) {
-        spark.read.format("delta").load(dir.toString)
-          .where("is_odd = true")
-          .withColumnRenamed("value", "srcValue")
-          .createTempView(viewName)
+          val viewName = "replaceWhereSubquerySource"
+          withView(viewName) {
+            spark.read.format("delta").load(dir.toString)
+              .where("is_odd = true")
+              .withColumnRenamed("value", "srcValue")
+              .createTempView(viewName)
 
-        // EXISTS subquery should be rejected
-        checkError(
-          exception = intercept[DeltaAnalysisException] {
-            Seq(5).toDF("value")
-              .withColumn("is_odd", $"value" % 2 =!= 0)
-              .write
-              .format("delta")
-              .mode("overwrite")
-              .option(DeltaOptions.REPLACE_WHERE_OPTION,
-                s"EXISTS (SELECT 1 FROM $viewName WHERE value = srcValue)")
-              .save(dir.toString)
-          },
-          condition = "DELTA_UNSUPPORTED_SUBQUERY",
-          sqlState = Some("0AKDC"),
-          parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
-          matchPVals = true
-        )
+            // EXISTS subquery should be rejected regardless of the subquery flag
+            checkError(
+              exception = intercept[DeltaAnalysisException] {
+                Seq(5).toDF("value")
+                  .withColumn("is_odd", $"value" % 2 =!= 0)
+                  .write
+                  .format("tahoe")
+                  .mode("overwrite")
+                  .option(DeltaOptions.REPLACE_WHERE_OPTION,
+                    s"EXISTS (SELECT 1 FROM $viewName WHERE value = srcValue)")
+                  .save(dir.toString)
+              },
+              condition = "DELTA_UNSUPPORTED_SUBQUERY",
+              sqlState = Some("0AKDC"),
+              parameters = Map("operation" -> "DELETE condition", "cond" -> ".*"),
+              matchPVals = true
+            )
 
-        // IN subquery should be rejected
-        checkError(
-          exception = intercept[DeltaAnalysisException] {
-            Seq(5).toDF("value")
-              .withColumn("is_odd", $"value" % 2 =!= 0)
-              .write
-              .format("delta")
-              .mode("overwrite")
-              .option(DeltaOptions.REPLACE_WHERE_OPTION,
-                s"value IN (SELECT srcValue FROM $viewName)")
-              .save(dir.toString)
-          },
-          condition = "DELTA_UNSUPPORTED_SUBQUERY",
-          sqlState = Some("0AKDC"),
-          parameters = Map("operation" -> "DELETE", "cond" -> ".*"),
-          matchPVals = true
-        )
+            // IN subquery should be rejected regardless of the subquery flag
+            checkError(
+              exception = intercept[DeltaAnalysisException] {
+                Seq(5).toDF("value")
+                  .withColumn("is_odd", $"value" % 2 =!= 0)
+                  .write
+                  .format("tahoe")
+                  .mode("overwrite")
+                  .option(DeltaOptions.REPLACE_WHERE_OPTION,
+                    s"value IN (SELECT srcValue FROM $viewName)")
+                  .save(dir.toString)
+              },
+              condition = "DELTA_UNSUPPORTED_SUBQUERY",
+              sqlState = Some("0AKDC"),
+              parameters = Map("operation" -> "DELETE condition", "cond" -> ".*"),
+              matchPVals = true
+            )
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Ensure that `replaceWhere` block subqueries until DELETE supports arbitrary subqueries.

removeFiles in WriteIntoDelta is used by replaceWhere/replaceOn/replaceUsing.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
