### PR TITLE
[CI] Update workflow triggers for branch rename kernel-20250227 -> branch-kernel-20250227

### DIFF
--- a/.github/workflows/disabled_spark_python_test.yaml
+++ b/.github/workflows/disabled_spark_python_test.yaml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch: # manual-only, auto triggers removed
   # To re-enable, replace the above line with:
   # push:
-  #   branches: [kernel-20250227]
+  #   branches: [branch-kernel-20250227]
   #   paths-ignore:
   #     - '**.md'
   #     - '**.txt'
   # pull_request:
-  #   branches: [kernel-20250227]
+  #   branches: [branch-kernel-20250227]
   #   paths-ignore:
   #     - '**.md'
   #     - '**.txt'

--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -1,9 +1,9 @@
 name: "Delta Kernel"
 on:
   push:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
   pull_request:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
 jobs:
   test:
     name: "DK"

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -1,9 +1,9 @@
 name: "Delta Spark Publishing and Examples"
 on:
   push:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
   pull_request:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
 jobs:
   test:
     name: "DSP&E: Scala ${{ matrix.scala }}"

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -1,9 +1,9 @@
 name: "Delta Spark Latest"
 on:
   push:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
   pull_request:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
 jobs:
   test:
     name: "DSL: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"

--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -1,9 +1,9 @@
 name: "Unidoc"
 on:
   push:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
   pull_request:
-    branches: [kernel-20250227]
+    branches: [branch-kernel-20250227]
 jobs:
   build:
     name: "U: Scala ${{ matrix.scala }}"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (CI/GitHub Actions workflows)

## Description

The branch `kernel-20250227` was renamed to `branch-kernel-20250227`. The existing
workflow files still have `branches: [kernel-20250227]` in their `push` and
`pull_request` triggers, which means CI does not trigger on pushes or PRs
targeting the renamed branch.

This PR updates the branch filter in all 4 active workflow files and the
commented-out re-enable instructions in the disabled workflow to use the
new branch name `branch-kernel-20250227`:

**Active workflows:**
- `kernel_test.yaml`
- `spark_examples_test.yaml`
- `spark_test.yaml`
- `unidoc.yaml`

**Disabled workflows (comments only):**
- `disabled_spark_python_test.yaml`

No other changes are made. `kernel_docs.yaml` (which only has
`workflow_dispatch`) and other disabled workflows are unaffected.

## How was this patch tested?

This is a CI-only change (workflow trigger branch filters). Verified by
inspecting the diff — each active workflow file has exactly two line changes
(push and pull_request branch filters), and no other content is modified.
CI will validate itself once this PR is merged and a subsequent push or PR
targets `branch-kernel-20250227`.

## Does this PR introduce _any_ user-facing changes?

No.