### PR TITLE
[CI] Re-enable iceberg_test and spark_python_test CI workflows

### DIFF
--- a/.github/workflows/iceberg_test.yaml
+++ b/.github/workflows/iceberg_test.yaml
@@ -1,28 +1,21 @@
-name: "Delta Iceberg Latest [DISABLED]"
-# SECURITY: All Python/PySpark workflows disabled due to active supply chain attack
-# targeting OSS package ecosystems (PyPI). C2 domains: models.litellm.cloud, checkmarx.zone
-# Date disabled: 2026-03-25
-# To re-enable: remove 'if: false' from all jobs and restore original triggers
+name: "Delta Iceberg Latest"
 on:
-  workflow_dispatch: # manual-only, auto triggers removed
-  # To re-enable, replace the above line with:
-  # push:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
-  # pull_request:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
 env:
   # SECURITY: Temporal lockdown — refuse any package version published after this date.
   # This date is a pre-attack baseline (before the active PyPI supply chain attack).
   UV_EXCLUDE_NEWER: "2026-03-10T00:00:00Z"
 jobs:
   test:
-    if: false # SECURITY: disabled - supply chain attack mitigation
     name: "DIL: Scala ${{ matrix.scala }}"
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -1,21 +1,15 @@
-name: "Delta Spark Python [DISABLED]"
-# SECURITY: All Python/PySpark workflows disabled due to active supply chain attack
-# targeting OSS package ecosystems (PyPI). C2 domains: models.litellm.cloud, checkmarx.zone
-# Date disabled: 2026-03-25
-# To re-enable: remove 'if: false' from all jobs and restore original triggers
+name: "Delta Spark Python"
 on:
-  workflow_dispatch: # manual-only, auto triggers removed
-  # To re-enable, replace the above line with:
-  # push:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
-  # pull_request:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
 env:
   # SECURITY: Temporal lockdown — refuse any package version published after this date.
   # This date is a pre-attack baseline (before the active PyPI supply chain attack).
@@ -24,7 +18,6 @@ jobs:
   # Generate Spark versions matrix from CrossSparkVersions.scala
   # This workflow tests against released versions only (no snapshots)
   generate-matrix:
-    if: false # SECURITY: disabled - supply chain attack mitigation
     name: "Generate Released Spark Versions Matrix"
     runs-on: ubuntu-24.04
     outputs:
@@ -45,7 +38,6 @@ jobs:
           echo "Generated released Spark versions: $SPARK_VERSIONS"
 
   test:
-    if: false # SECURITY: disabled - supply chain attack mitigation
     name: "DSP (${{ matrix.spark_version }})"
     runs-on: ubuntu-24.04
     needs: generate-matrix


### PR DESCRIPTION
> **PR Stack** (merge bottom-to-top):
> | # | PR | Layer diff |
> |---|-----|------------|
> | 1 | #6604 — Re-enable iceberg_test + spark_python_test | [diff](https://github.com/seewishnew/delta/compare/master...re-enable-ci-tests) |
> | 2 | #6612 — Trim iceberg_test dependencies | [diff](https://github.com/seewishnew/delta/compare/re-enable-ci-tests...trim-iceberg-deps) |
> | 3 | #6613 — Trim spark_python_test dependencies | [diff](https://github.com/seewishnew/delta/compare/trim-iceberg-deps...trim-spark-python-deps) |
> | 4 | #6605 — Revert #6435 (iceberg regression) | [diff](https://github.com/seewishnew/delta/compare/trim-spark-python-deps...revert-pr6435-iceberg-regression) |

