### PR TITLE
[Do not merge][Superseded] Revert duplicate column name error refactor to fix iceberg test regression (#6435)

### DIFF
--- a/.github/workflows/iceberg_test.yaml
+++ b/.github/workflows/iceberg_test.yaml
@@ -10,10 +10,6 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
-env:
-  # SECURITY: Temporal lockdown — refuse any package version published after this date.
-  # This date is a pre-attack baseline (before the active PyPI supply chain attack).
-  UV_EXCLUDE_NEWER: "2026-03-10T00:00:00Z"
 jobs:
   test:
     name: "DIL: Scala ${{ matrix.scala }}"
@@ -45,21 +41,10 @@ jobs:
           key: delta-sbt-cache-spark4.0-scala${{ matrix.scala }}
       - name: Set up uv
         run: bash project/scripts/install-uv.sh
-      - name: Install Job dependencies
+      - name: Install Python via uv
+        # No UV_EXCLUDE_NEWER needed: this workflow installs zero pip packages.
+        # Python is only used to run the stdlib-only run-tests.py driver.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git
-          sudo apt install libedit-dev
-          # buf v1.28.1 (2023-11-15) — SHA from official release asset:
-          # https://github.com/bufbuild/buf/releases/download/v1.28.1/sha256.txt
-          BUF_VERSION="v1.28.1"
-          BUF_SHA256="870cf492d381a967d36636fdee9da44b524ea62aad163659b8dbf16a7da56987"
-          curl -fsSL -o buf-Linux-x86_64.tar.gz \
-            "https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64.tar.gz"
-          echo "${BUF_SHA256}  buf-Linux-x86_64.tar.gz" | sha256sum -c -
-          mkdir -p ~/buf
-          tar -xzf buf-Linux-x86_64.tar.gz -C ~/buf --strip-components 1
-          rm buf-Linux-x86_64.tar.gz
           uv python install 3.8
           uv venv .venv --python 3.8
       - name: Run Scala/Java and Python tests

--- a/.github/workflows/iceberg_test.yaml
+++ b/.github/workflows/iceberg_test.yaml
@@ -1,28 +1,21 @@
-name: "Delta Iceberg Latest [DISABLED]"
-# SECURITY: All Python/PySpark workflows disabled due to active supply chain attack
-# targeting OSS package ecosystems (PyPI). C2 domains: models.litellm.cloud, checkmarx.zone
-# Date disabled: 2026-03-25
-# To re-enable: remove 'if: false' from all jobs and restore original triggers
+name: "Delta Iceberg Latest"
 on:
-  workflow_dispatch: # manual-only, auto triggers removed
-  # To re-enable, replace the above line with:
-  # push:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
-  # pull_request:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
 env:
   # SECURITY: Temporal lockdown — refuse any package version published after this date.
   # This date is a pre-attack baseline (before the active PyPI supply chain attack).
   UV_EXCLUDE_NEWER: "2026-03-10T00:00:00Z"
 jobs:
   test:
-    if: false # SECURITY: disabled - supply chain attack mitigation
     name: "DIL: Scala ${{ matrix.scala }}"
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -1,21 +1,15 @@
-name: "Delta Spark Python [DISABLED]"
-# SECURITY: All Python/PySpark workflows disabled due to active supply chain attack
-# targeting OSS package ecosystems (PyPI). C2 domains: models.litellm.cloud, checkmarx.zone
-# Date disabled: 2026-03-25
-# To re-enable: remove 'if: false' from all jobs and restore original triggers
+name: "Delta Spark Python"
 on:
-  workflow_dispatch: # manual-only, auto triggers removed
-  # To re-enable, replace the above line with:
-  # push:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
-  # pull_request:
-  #   branches: [master]
-  #   paths-ignore:
-  #     - '**.md'
-  #     - '**.txt'
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
 env:
   # SECURITY: Temporal lockdown — refuse any package version published after this date.
   # This date is a pre-attack baseline (before the active PyPI supply chain attack).
@@ -24,7 +18,6 @@ jobs:
   # Generate Spark versions matrix from CrossSparkVersions.scala
   # This workflow tests against released versions only (no snapshots)
   generate-matrix:
-    if: false # SECURITY: disabled - supply chain attack mitigation
     name: "Generate Released Spark Versions Matrix"
     runs-on: ubuntu-24.04
     outputs:
@@ -45,7 +38,6 @@ jobs:
           echo "Generated released Spark versions: $SPARK_VERSIONS"
 
   test:
-    if: false # SECURITY: disabled - supply chain attack mitigation
     name: "DSP (${{ matrix.spark_version }})"
     runs-on: ubuntu-24.04
     needs: generate-matrix

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -80,21 +80,10 @@ jobs:
           key: delta-sbt-cache-spark${{ matrix.spark_version }}-scala${{ matrix.scala }}
       - name: Set up uv
         run: bash project/scripts/install-uv.sh
-      - name: Install Job dependencies
+      - name: Set up buf
+        run: bash project/scripts/install-buf.sh
+      - name: Install Python and dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git
-          sudo apt install libedit-dev
-          # buf v1.28.1 (2023-11-15) — SHA from official release asset:
-          # https://github.com/bufbuild/buf/releases/download/v1.28.1/sha256.txt
-          BUF_VERSION="v1.28.1"
-          BUF_SHA256="870cf492d381a967d36636fdee9da44b524ea62aad163659b8dbf16a7da56987"
-          curl -fsSL -o buf-Linux-x86_64.tar.gz \
-            "https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64.tar.gz"
-          echo "${BUF_SHA256}  buf-Linux-x86_64.tar.gz" | sha256sum -c -
-          mkdir -p ~/buf
-          tar -xzf buf-Linux-x86_64.tar.gz -C ~/buf --strip-components 1
-          rm buf-Linux-x86_64.tar.gz
           uv python install 3.10
           uv venv .venv --python 3.10
           # Install hash-verified locked dependencies (see .github/ci-requirements/spark-python/)

--- a/project/scripts/install-buf.sh
+++ b/project/scripts/install-buf.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Install buf — SHA256-verified.
+# Single source of truth for version + checksum across CI workflows.
+#
+# Installs to ~/buf/bin/buf, which is the path expected by
+# dev/delta-connect-gen-protos.sh (export PATH="$PATH:~/buf/bin").
+#
+# Usage:
+#   bash project/scripts/install-buf.sh          # from repo root (CI)
+set -eu
+
+BUF_VERSION="v1.28.1"
+# SHA from official release asset:
+# https://github.com/bufbuild/buf/releases/download/v1.28.1/sha256.txt
+BUF_SHA256="870cf492d381a967d36636fdee9da44b524ea62aad163659b8dbf16a7da56987"
+
+TARBALL="buf-Linux-x86_64.tar.gz"
+
+curl -fsSL -o "$TARBALL" \
+  "https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/${TARBALL}"
+
+echo "${BUF_SHA256}  ${TARBALL}" | sha256sum -c -
+
+mkdir -p ~/buf
+tar -xzf "$TARBALL" -C ~/buf --strip-components 1
+rm "$TARBALL"
+
+~/buf/bin/buf --version

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -919,65 +919,8 @@
   },
   "DELTA_DUPLICATE_COLUMNS_FOUND" : {
     "message" : [
-      "Found duplicate column(s): <duplicateCols>."
+      "Found duplicate column(s) <coltype>: <duplicateCols>"
     ],
-    "subClass" : {
-      "ADDING_COLUMNS" : {
-        "message" : [
-          "The duplicate was found while adding columns."
-        ]
-      },
-      "CLUSTER_BY" : {
-        "message" : [
-          "The duplicate was found in CLUSTER BY."
-        ]
-      },
-      "DATA" : {
-        "message" : [
-          "The duplicate was found in the data being saved."
-        ]
-      },
-      "EXISTING_SCHEMA" : {
-        "message" : [
-          "The duplicate was found in the existing table schema."
-        ]
-      },
-      "METADATA_UPDATE" : {
-        "message" : [
-          "The duplicate was found in the metadata update."
-        ]
-      },
-      "PARTITION_COLUMNS" : {
-        "message" : [
-          "The duplicate was found in the partition columns."
-        ]
-      },
-      "PARTITION_SCHEMA" : {
-        "message" : [
-          "The duplicate was found in the partition schema."
-        ]
-      },
-      "READ_SCHEMA" : {
-        "message" : [
-          "The duplicate was found in the schema of the data being read."
-        ]
-      },
-      "REPLACING_COLUMNS" : {
-        "message" : [
-          "The duplicate was found while replacing columns."
-        ]
-      },
-      "SPECIFIED_COLUMNS" : {
-        "message" : [
-          "The duplicate was found in the specified columns."
-        ]
-      },
-      "TABLE_SCHEMA" : {
-        "message" : [
-          "The duplicate was found in the table schema."
-        ]
-      }
-    },
     "sqlState" : "42711"
   },
   "DELTA_DUPLICATE_COLUMNS_ON_INSERT" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -617,10 +617,10 @@ trait DeltaErrorsBase
       messageParameters = Array(colName, scheme))
   }
 
-  def foundDuplicateColumnsException(subClass: String, duplicateCols: String): Throwable = {
+  def foundDuplicateColumnsException(colType: String, duplicateCols: String): Throwable = {
     new DeltaAnalysisException(
-      errorClass = s"DELTA_DUPLICATE_COLUMNS_FOUND.$subClass",
-      messageParameters = Array(duplicateCols))
+      errorClass = "DELTA_DUPLICATE_COLUMNS_FOUND",
+      messageParameters = Array(colType, duplicateCols))
   }
 
   def addColumnStructNotFoundException(pos: String): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -302,7 +302,7 @@ class DeltaLog private(
 
     val txn = startTransaction(catalogTable, Some(snapshot))
     try {
-      SchemaMergingUtils.checkColumnNameDuplication(txn.metadata.schema, "TABLE_SCHEMA")
+      SchemaMergingUtils.checkColumnNameDuplication(txn.metadata.schema, "in the table schema")
     } catch {
       case e: AnalysisException =>
         throw DeltaErrors.duplicateColumnsOnUpdateTable(e)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1028,7 +1028,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
   protected def assertMetadata(metadata: Metadata): Unit = {
     assert(!CharVarcharUtils.hasCharVarchar(metadata.schema),
       "The schema in Delta log should not contain char/varchar type.")
-    SchemaMergingUtils.checkColumnNameDuplication(metadata.schema, "METADATA_UPDATE")
+    SchemaMergingUtils.checkColumnNameDuplication(metadata.schema, "in the metadata update")
     if (metadata.columnMappingMode == NoMapping) {
       SchemaUtils.checkSchemaFieldNames(metadata.dataSchema, metadata.columnMappingMode)
       val partitionColCheckIsFatal =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -369,7 +369,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       }
       // Check that columns are not duplicated in the cluster by statement.
       PartitionUtils.checkColumnNameDuplication(
-        clusterBy.columnNames.map(_.toString), "CLUSTER_BY", resolver)
+        clusterBy.columnNames.map(_.toString), "in CLUSTER BY", resolver)
       // Check number of clustering columns is within allowed range.
       ClusteredTableUtils.validateNumClusteringColumns(
         clusterBy.columnNames.map(_.fieldNames.toSeq))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -654,7 +654,7 @@ case class AlterTableAddColumnsDeltaCommand(
           SchemaUtils.addColumn(schema, column, position)
       }
 
-      SchemaMergingUtils.checkColumnNameDuplication(newSchema, "ADDING_COLUMNS")
+      SchemaMergingUtils.checkColumnNameDuplication(newSchema, "in adding columns")
       SchemaUtils.checkSchemaFieldNames(newSchema, metadata.columnMappingMode)
 
       val newMetadata = metadata.copy(schemaString = newSchema.json)
@@ -1186,7 +1186,7 @@ case class AlterTableReplaceColumnsDeltaCommand(
       val newSchema = SchemaUtils.changeDataType(existingSchema, changingSchema, resolver)
         .asInstanceOf[StructType]
 
-      SchemaMergingUtils.checkColumnNameDuplication(newSchema, "REPLACING_COLUMNS")
+      SchemaMergingUtils.checkColumnNameDuplication(newSchema, "in replacing columns")
       SchemaUtils.checkSchemaFieldNames(newSchema, metadata.columnMappingMode)
 
       val newSchemaWithTypeWideningMetadata = TypeWideningMetadata.addTypeWideningMetadata(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -100,14 +100,13 @@ object SchemaMergingUtils {
    * the duplication exists.
    *
    * @param schema the schema to check for duplicates
-   * @param errorSubClass error sub-class for DELTA_DUPLICATE_COLUMNS_FOUND indicating where the
-   *                      duplicate was found (e.g. "METADATA_UPDATE", "TABLE_SCHEMA").
+   * @param colType column type name, used in an exception message
    * @param caseSensitive Whether we should exception if two columns have casing conflicts. This
    *                      should default to false for Delta.
    */
   def checkColumnNameDuplication(
       schema: StructType,
-      errorSubClass: String,
+      colType: String,
       caseSensitive: Boolean = false): Unit = {
     val columnNames = explodeNestedFieldNames(schema)
     // scalastyle:off caselocale
@@ -122,8 +121,8 @@ object SchemaMergingUtils {
         case (x, ys) if ys.length > 1 => s"$x"
       }
       throw new DeltaAnalysisException(
-        errorClass = s"DELTA_DUPLICATE_COLUMNS_FOUND.$errorSubClass",
-        messageParameters = Array(duplicateColumns.mkString(", ")))
+        errorClass = "DELTA_DUPLICATE_COLUMNS_FOUND",
+        messageParameters = Array(colType, duplicateColumns.mkString(", ")))
     }
   }
 
@@ -156,7 +155,7 @@ object SchemaMergingUtils {
       keepExistingType: Boolean = false,
       typeWideningMode: TypeWideningMode = TypeWideningMode.NoTypeWidening,
       caseSensitive: Boolean = false): StructType = {
-    checkColumnNameDuplication(dataSchema, "DATA", caseSensitive)
+    checkColumnNameDuplication(dataSchema, "in the data to save", caseSensitive)
     mergeDataTypes(
       tableSchema,
       dataSchema,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -522,24 +522,14 @@ def normalizeColumnNamesInDataType(
     }
 
     def isStructReadCompatible(existing: StructType, newtype: StructType): Boolean = {
-      // scalastyle:off caselocale
-      def checkNoDuplicateColumns(schema: StructType, errorSubClass: String): Unit = {
-        val fieldNames = schema.fieldNames
-        val lowercaseNames = fieldNames.map(_.toLowerCase).toSet
-        if (lowercaseNames.size != fieldNames.length) {
-          val duplicates = fieldNames.groupBy(_.toLowerCase).collect {
-            case (_, names) if names.length > 1 => names.mkString(", ")
-          }
-          throw DeltaErrors.foundDuplicateColumnsException(errorSubClass,
-            duplicates.mkString(", "))
-        }
-      }
-
       val existingFields = toFieldMap(existing)
-      checkNoDuplicateColumns(existing, "EXISTING_SCHEMA")
+      // scalastyle:off caselocale
       val existingFieldNames = existing.fieldNames.map(_.toLowerCase).toSet
-      checkNoDuplicateColumns(newtype, "READ_SCHEMA")
+      assert(existingFieldNames.size == existing.length,
+        "Delta tables don't allow field names that only differ by case")
       val newFields = newtype.fieldNames.map(_.toLowerCase).toSet
+      assert(newFields.size == newtype.length,
+        "Delta tables don't allow field names that only differ by case")
       // scalastyle:on caselocale
 
       if (!allowMissingColumns &&

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -447,7 +447,7 @@ private[delta] object PartitionUtils {
     }
 
     checkColumnNameDuplication(
-      normalizedPartSpec.map(_._1), "PARTITION_SCHEMA", resolver)
+      normalizedPartSpec.map(_._1), "in the partition schema", resolver)
 
     normalizedPartSpec.toMap
   }
@@ -610,7 +610,7 @@ private[delta] object PartitionUtils {
       caseSensitive: Boolean): Unit = {
     checkColumnNameDuplication(
       partitionColumns,
-      "PARTITION_COLUMNS",
+      "in the partition columns",
       caseSensitive)
 
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
@@ -712,13 +712,12 @@ private[delta] object PartitionUtils {
    * the duplication exists.
    *
    * @param columnNames column names to check
-   * @param errorSubClass error sub-class for DELTA_DUPLICATE_COLUMNS_FOUND indicating where the
-   *                      duplicate was found (e.g. "PARTITION_SCHEMA", "CLUSTER_BY").
+   * @param colType column type name, used in an exception message
    * @param resolver resolver used to determine if two identifiers are equal
    */
   def checkColumnNameDuplication(
-      columnNames: Seq[String], errorSubClass: String, resolver: Resolver): Unit = {
-    checkColumnNameDuplication(columnNames, errorSubClass, isCaseSensitiveAnalysis(resolver))
+      columnNames: Seq[String], colType: String, resolver: Resolver): Unit = {
+    checkColumnNameDuplication(columnNames, colType, isCaseSensitiveAnalysis(resolver))
   }
 
   /**
@@ -726,12 +725,11 @@ private[delta] object PartitionUtils {
    * the duplication exists.
    *
    * @param columnNames column names to check
-   * @param errorSubClass error sub-class for DELTA_DUPLICATE_COLUMNS_FOUND indicating where the
-   *                      duplicate was found (e.g. "PARTITION_COLUMNS", "CLUSTER_BY").
+   * @param colType column type name, used in an exception message
    * @param caseSensitiveAnalysis whether duplication checks should be case sensitive or not
    */
   def checkColumnNameDuplication(
-      columnNames: Seq[String], errorSubClass: String, caseSensitiveAnalysis: Boolean): Unit = {
+      columnNames: Seq[String], colType: String, caseSensitiveAnalysis: Boolean): Unit = {
     // scalastyle:off caselocale
     val names = if (caseSensitiveAnalysis) columnNames else columnNames.map(_.toLowerCase)
     // scalastyle:on caselocale
@@ -739,7 +737,7 @@ private[delta] object PartitionUtils {
       val duplicateColumns = names.groupBy(identity).collect {
         case (x, ys) if ys.length > 1 => s"`$x`"
       }
-      throw DeltaErrors.foundDuplicateColumnsException(errorSubClass,
+      throw DeltaErrors.foundDuplicateColumnsException(colType,
         duplicateColumns.mkString(", "))
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1645,10 +1645,10 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.foundDuplicateColumnsException("METADATA_UPDATE", "col1")
+        throw DeltaErrors.foundDuplicateColumnsException("integer", "col1")
       }
-      checkError(e, "DELTA_DUPLICATE_COLUMNS_FOUND.METADATA_UPDATE", "42711",
-        Map("duplicateCols" -> "col1"))
+      checkError(e, "DELTA_DUPLICATE_COLUMNS_FOUND", "42711",
+        Map("coltype" -> "integer", "duplicateCols" -> "col1"))
     }
     {
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SchemaValidationSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SchemaValidationSuite.scala
@@ -398,11 +398,10 @@ class SchemaValidationSuite
       spark.range(10).write.format("delta").saveAsTable(tblName)
     },
     actionToTest = (spark: SparkSession, tblName: String) => {
-      val e = intercept[DeltaAnalysisException] {
+      val e = intercept[AnalysisException] {
         spark.sql(s"ALTER TABLE `$tblName` ADD COLUMNS (col2 string)")
       }
-      checkError(e, "DELTA_DUPLICATE_COLUMNS_FOUND.ADDING_COLUMNS", "42711",
-        Map("duplicateCols" -> "col2"))
+      assert(e.getMessage.contains("Found duplicate column(s) in adding columns: col2"))
     },
     concurrentChange = (spark: SparkSession, tblName: String) => {
       spark.read.format("delta").table(tblName)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -107,7 +107,7 @@ class SchemaUtilsSuite extends QueryTest
       .add("dupColName", IntegerType)
       .add("b", IntegerType)
       .add("dupColName", StringType)
-    expectFailure("dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name in top level - case sensitivity") {
@@ -115,7 +115,7 @@ class SchemaUtilsSuite extends QueryTest
       .add("dupColName", IntegerType)
       .add("b", IntegerType)
       .add("dupCOLNAME", StringType)
-    expectFailure("dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name for nested column + non-nested column") {
@@ -124,7 +124,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("a", IntegerType)
         .add("b", IntegerType))
       .add("dupColName", IntegerType)
-    expectFailure("dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name for nested column + non-nested column - case sensitivity") {
@@ -133,7 +133,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("a", IntegerType)
         .add("b", IntegerType))
       .add("dupCOLNAME", IntegerType)
-    expectFailure("dupCOLNAME") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("dupCOLNAME") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name in nested level") {
@@ -143,7 +143,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("b", IntegerType)
         .add("dupColName", StringType)
       )
-    expectFailure("top.dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("top.dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name in nested level - case sensitivity") {
@@ -153,7 +153,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("b", IntegerType)
         .add("dupCOLNAME", StringType)
       )
-    expectFailure("top.dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("top.dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name in double nested level") {
@@ -165,7 +165,7 @@ class SchemaUtilsSuite extends QueryTest
           .add("dupColName", StringType))
         .add("d", IntegerType)
       )
-    expectFailure("top.b.dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("top.b.dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name in double nested array") {
@@ -177,9 +177,7 @@ class SchemaUtilsSuite extends QueryTest
           .add("dupColName", StringType))))
         .add("d", IntegerType)
       )
-    expectFailure("top.b.element.element.dupColName") {
-      checkColumnNameDuplication(schema, "TABLE_SCHEMA")
-    }
+    expectFailure("top.b.element.element.dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name in double nested map") {
@@ -191,21 +189,21 @@ class SchemaUtilsSuite extends QueryTest
         .add("top", new StructType()
           .add("b", MapType(keyType.add("dupColName", StringType), keyType))
         )
-      checkColumnNameDuplication(schema, "TABLE_SCHEMA")
+      checkColumnNameDuplication(schema, "")
     }
     expectFailure("top.b.value.dupColName") {
       val schema = new StructType()
         .add("top", new StructType()
           .add("b", MapType(keyType, keyType.add("dupColName", StringType)))
         )
-      checkColumnNameDuplication(schema, "TABLE_SCHEMA")
+      checkColumnNameDuplication(schema, "")
     }
     // This is okay
     val schema = new StructType()
       .add("top", new StructType()
         .add("b", MapType(keyType, keyType))
       )
-    checkColumnNameDuplication(schema, "TABLE_SCHEMA")
+    checkColumnNameDuplication(schema, "")
   }
 
   test("duplicate column name in nested array") {
@@ -215,7 +213,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("b", IntegerType)
         .add("dupColName", StringType))
       )
-    expectFailure("top.element.dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("top.element.dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column name in nested array - case sensitivity") {
@@ -225,7 +223,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("b", IntegerType)
         .add("dupCOLNAME", StringType))
       )
-    expectFailure("top.element.dupColName") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("top.element.dupColName") { checkColumnNameDuplication(schema, "") }
   }
 
   test("non duplicate column because of back tick") {
@@ -234,7 +232,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("a", IntegerType)
         .add("b", IntegerType))
       .add("top.a", IntegerType)
-    checkColumnNameDuplication(schema, "TABLE_SCHEMA")
+    checkColumnNameDuplication(schema, "")
   }
 
   test("non duplicate column because of back tick - nested") {
@@ -244,7 +242,7 @@ class SchemaUtilsSuite extends QueryTest
           .add("a", IntegerType)
           .add("b", IntegerType))
         .add("top.a", IntegerType))
-    checkColumnNameDuplication(schema, "TABLE_SCHEMA")
+    checkColumnNameDuplication(schema, "")
   }
 
   test("duplicate column with back ticks - nested") {
@@ -253,7 +251,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("top.a", StringType)
         .add("b", IntegerType)
         .add("top.a", IntegerType))
-    expectFailure("first.`top.a`") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("first.`top.a`") { checkColumnNameDuplication(schema, "") }
   }
 
   test("duplicate column with back ticks - nested and case sensitivity") {
@@ -262,7 +260,7 @@ class SchemaUtilsSuite extends QueryTest
         .add("TOP.a", StringType)
         .add("b", IntegerType)
         .add("top.a", IntegerType))
-    expectFailure("first.`top.a`") { checkColumnNameDuplication(schema, "TABLE_SCHEMA") }
+    expectFailure("first.`top.a`") { checkColumnNameDuplication(schema, "") }
   }
 
   /////////////////////////////

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -708,8 +708,9 @@ trait ClusteredTableDDLSuiteBase
       val e2 = intercept[DeltaAnalysisException] {
         sql(s"ALTER TABLE $testTable CLUSTER BY (id, id)")
       }
-      checkError(e2, "DELTA_DUPLICATE_COLUMNS_FOUND.CLUSTER_BY", "42711",
-        Map("duplicateCols" -> "`id`"))
+      assert(e2.getErrorClass == "DELTA_DUPLICATE_COLUMNS_FOUND")
+      assert(e2.getSqlState == "42711")
+      assert(e2.getMessageParametersArray === Array("in CLUSTER BY", "`id`"))
     }
   }
 


### PR DESCRIPTION
This PR has been superseded by a fix-forward PR: https://github.com/delta-io/delta/pull/6615

> **PR Stack** (merge bottom-to-top):
> | # | PR | Layer diff |
> |---|-----|------------|
> | 1 | #6604 — Re-enable iceberg_test + spark_python_test | [diff](https://github.com/seewishnew/delta/compare/master...re-enable-ci-tests) |
> | 2 | #6612 — Trim iceberg_test dependencies | [diff](https://github.com/seewishnew/delta/compare/re-enable-ci-tests...trim-iceberg-deps) |
> | 3 | #6613 — Trim spark_python_test dependencies | [diff](https://github.com/seewishnew/delta/compare/trim-iceberg-deps...trim-spark-python-deps) |
> | 4 | #6605 — Revert #6435 (iceberg regression) | [diff](https://github.com/seewishnew/delta/compare/trim-spark-python-deps...revert-pr6435-iceberg-regression) |

