### PR TITLE
[Kernel] ActionsIterator.next() throws InterruptedIOException on thread interrupt

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -36,6 +36,7 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -230,7 +231,11 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
       throw new IllegalStateException("Can't call `next` on a closed iterator.");
     }
     if (Thread.currentThread().isInterrupted()) {
-      throw new IllegalStateException("Thread was interrupted");
+      // Throw a typed InterruptedIOException (wrapped, since next() does not declare checked
+      // exceptions) so engines whose interrupt-handling recognizes standard JDK interrupt types
+      // (e.g. Spark's StreamExecution.isInterruptionException) treat this as a clean shutdown
+      // rather than a real error.
+      throw new UncheckedIOException(new InterruptedIOException("Thread was interrupted"));
     }
 
     if (!hasNext()) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/ActionsIteratorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/ActionsIteratorSuite.scala
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.internal.replay
 
+import java.io.{InterruptedIOException, UncheckedIOException}
 import java.util.{Collections, Optional}
 
 import scala.collection.JavaConverters._
@@ -76,5 +77,52 @@ class ActionsIteratorSuite extends AnyFunSuite with MockEngineUtils {
 
     // Verify that resources were cleaned up
     assert(iteratorClosed, "Internal iterator should be closed after exception in ActionsIterator")
+  }
+
+  /**
+   * When the calling thread is interrupted before next() begins an NIO read, ActionsIterator
+   * must surface the interrupt as a typed InterruptedIOException (wrapped in
+   * UncheckedIOException, since next() does not declare checked exceptions) so that engine
+   * interrupt-handling (e.g. Spark's StreamExecution.isInterruptionException) recognizes
+   * it as a clean shutdown rather than a real error.
+   */
+  test("ActionsIterator.next() throws InterruptedIOException when thread is interrupted") {
+    val engine = mockEngine(jsonHandler = new BaseMockJsonHandler {
+      override def readJsonFiles(
+          fileIter: CloseableIterator[FileStatus],
+          physicalSchema: StructType,
+          predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] = {
+        // Return a non-empty iterator so hasNext() succeeds and next() is reached.
+        new CloseableIterator[ColumnarBatch] {
+          override def hasNext(): Boolean = true
+          override def next(): ColumnarBatch =
+            throw new UnsupportedOperationException("next() should not be called after interrupt")
+          override def close(): Unit = {}
+        }
+      }
+    })
+
+    val testFile = FileStatus.of(
+      "/path/to/00000000000000000000.json",
+      100L,
+      System.currentTimeMillis())
+    val actionsIterator =
+      new ActionsIterator(
+        engine,
+        Collections.singletonList(testFile),
+        new StructType(),
+        Optional.empty[Predicate]())
+
+    Thread.currentThread().interrupt()
+    try {
+      val ex = intercept[UncheckedIOException] {
+        actionsIterator.next()
+      }
+      assert(ex.getCause.isInstanceOf[InterruptedIOException])
+      assert(ex.getCause.getMessage == "Thread was interrupted")
+    } finally {
+      // Clear the interrupt flag so it doesn't leak into subsequent tests.
+      Thread.interrupted()
+    }
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

`ActionsIterator.next()` throws `IllegalStateException("Thread was interrupted")` when the thread's interrupt flag is observed before an NIO read. `IllegalStateException` is the wrong JDK type — engines that key off standard interrupt types (e.g. Spark's `isInterruptionException`, which matches `InterruptedException` / `InterruptedIOException` / `ClosedByInterruptException`) don't recognize it as clean shutdown, so a `query.stop()` race surfaces as a spurious `StreamingQueryException`.

Throw `UncheckedIOException(InterruptedIOException)` instead. Spark already recognizes this as clean shutdown; every Kernel consumer benefits without connector-side workarounds.

No caller in the repo catches `IllegalStateException` specifically — broader `Exception` / `RuntimeException` catches keep working since `UncheckedIOException` extends `RuntimeException`.

Read here for the full story: https://github.com/delta-io/delta/pull/6578#issuecomment-4272089937

## How was this patch tested?

New unit test in `ActionsIteratorSuite` sets the interrupt flag and asserts `next()` throws `UncheckedIOException` wrapping `InterruptedIOException`.

## Does this PR introduce _any_ user-facing changes?

No.