### PR TITLE
[DO NOT MERGE] [kernel-spark] Fix V2 streaming partition-column NPE via Project injection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -468,8 +468,10 @@ lazy val sparkV2 = (project in file("spark/v2"))
     Compile / compile := (Compile / compile)
       .dependsOn(kernelApi / Compile / packageBin).value,
     Test / test := (Test / test)
-      .dependsOn(kernelApi / Compile / packageBin).value,
+      .dependsOn(kernelApi / Compile / packageBin)
+      .dependsOn(LocalProject("spark") / Compile / packageBin).value,
     Test / unmanagedJars += (kernelApi / Test / packageBin).value,
+    Test / unmanagedJars += (LocalProject("spark") / Compile / packageBin).value,
     Compile / unmanagedJars ++= Seq(
       (kernelApi / Compile / packageBin).value
     ),

--- a/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -20,6 +20,7 @@ import io.delta.internal.ApplyV2Streaming
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.delta.streaming.V2StreamingSchemaReorder
 
 /**
  * An extension for Spark SQL to activate Delta SQL parser to support Delta SQL grammar.
@@ -83,6 +84,10 @@ class DeltaSparkSessionExtension extends AbstractDeltaSparkSessionExtension {
     extensions.injectResolutionRule { session =>
       new ApplyV2Streaming(session)
     }
+
+    // Post-hoc so it sees StreamingRelationV2 from both V2-catalog and V1-fallback
+    // (ApplyV2Streaming) paths. Paired with ApplyV2Streaming above.
+    extensions.injectPostHocResolutionRule { _ => V2StreamingSchemaReorder }
   }
 
   /**

--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/streaming/V2StreamingSchemaReorder.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/streaming/V2StreamingSchemaReorder.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.streaming
+
+import java.util.Locale
+
+import io.delta.spark.internal.v2.catalog.SparkTable
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
+
+/**
+ * Bridges DDL order (SparkTable.schema) and reader order (SparkScan.readSchema =
+ * data ++ partitions) for V2 streaming reads of kernel-spark SparkTable. Without it, codegen
+ * ordinals miss the right ColumnVector and NPE in OnHeapColumnVector.getLong whenever a
+ * partition column isn't last. Mirrors V1's FileSourceStrategy ProjectExec injection and the
+ * V2-batch Project wrap from V2ScanRelationPushDown.
+ *
+ * Paired with [[io.delta.internal.ApplyV2Streaming]], which produces the
+ * StreamingRelationV2(SparkTable) this rule rewrites.
+ */
+object V2StreamingSchemaReorder extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+    case s: StreamingRelationV2 if s.table.isInstanceOf[SparkTable] =>
+      reorderIfNeeded(s, s.table.asInstanceOf[SparkTable], s.output)
+  }
+
+  private def reorderIfNeeded(
+      s: StreamingRelationV2,
+      table: SparkTable,
+      output: Seq[AttributeReference]): LogicalPlan = {
+    // SparkTable only emits identity transforms today. If kernel-spark ever adds bucket/year/etc.
+    // or nested-field partitions, the rule's reader-order computation no longer matches the
+    // physical scan layout - fail loudly instead of silently re-introducing the NPE.
+    val partitionColumnNames: Seq[String] = table.partitioning.toSeq.map {
+      case IdentityTransform(FieldReference(Seq(col))) => col
+      case other =>
+        throw new IllegalStateException(
+          s"V2StreamingSchemaReorder only supports IdentityTransform partitioning on " +
+            s"single-segment column names; got: $other")
+    }
+    if (partitionColumnNames.isEmpty) {
+      return s
+    }
+
+    // Case-insensitive lookup matches SparkScanBuilder.partitionColumnSet so the rule still
+    // fires if some upstream resolution path normalizes only one side's casing.
+    def lower(name: String): String = name.toLowerCase(Locale.ROOT)
+    val outputByName = output.map(a => lower(a.name) -> a).toMap
+    val partitionNameSet = partitionColumnNames.map(lower).toSet
+
+    val dataAttrs = output.filterNot(a => partitionNameSet.contains(lower(a.name)))
+    val partitionAttrs = partitionColumnNames.flatMap(n => outputByName.get(lower(n)))
+    val readerOrderOutput = dataAttrs ++ partitionAttrs
+
+    if (readerOrderOutput.map(_.name) == output.map(_.name)) {
+      return s
+    }
+
+    // output and readerOrderOutput share AttributeReference instances, so output resolves
+    // as the project list against the reordered relation.
+    Project(output, s.copy(output = readerOrderOutput))
+  }
+}

--- a/spark-unified/src/test/scala/io/delta/internal/V2StreamingSchemaReorderSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/V2StreamingSchemaReorderSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.internal
+
+import java.util.{HashMap => JHashMap}
+
+import io.delta.spark.internal.v2.catalog.SparkTable
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.delta.streaming.V2StreamingSchemaReorder
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class V2StreamingSchemaReorderSuite extends DeltaSQLCommandTest {
+
+  private def buildPlan(
+      tablePath: String,
+      ddl: String,
+      partitionedBy: String): StreamingRelationV2 = {
+    spark.sql(s"CREATE TABLE delta.`$tablePath` ($ddl) USING delta PARTITIONED BY ($partitionedBy)")
+    val ident = Identifier.of(Array("delta"), tablePath)
+    val table = new SparkTable(ident, tablePath, new JHashMap[String, String]())
+    StreamingRelationV2(
+      source = None,
+      sourceName = "delta",
+      table = table,
+      extraOptions = CaseInsensitiveStringMap.empty,
+      output = toAttributes(table.schema),
+      catalog = None,
+      identifier = Some(ident),
+      v1Relation = None)
+  }
+
+  test("rule is idempotent - second pass leaves the plan unchanged") {
+    withTempDir { dir =>
+      val plan = buildPlan(dir.getCanonicalPath, "id LONG, part LONG, col3 INT", "part")
+      val once = V2StreamingSchemaReorder.apply(plan)
+      val twice = V2StreamingSchemaReorder.apply(once)
+      assert(twice == once)
+    }
+  }
+
+  test("rule no-ops when partition column is last in DDL") {
+    withTempDir { dir =>
+      val plan = buildPlan(dir.getCanonicalPath, "id LONG, col3 INT, part LONG", "part")
+      val result = V2StreamingSchemaReorder.apply(plan)
+      assert(result == plan)
+    }
+  }
+
+  test("Project list preserves rewritten StreamingRelationV2 attribute exprIds") {
+    withTempDir { dir =>
+      val plan = buildPlan(dir.getCanonicalPath, "id LONG, part LONG, col3 INT", "part")
+      val result = V2StreamingSchemaReorder.apply(plan).asInstanceOf[Project]
+      val rewrittenRel = result.child.asInstanceOf[StreamingRelationV2]
+      val projectExprIds = result.projectList.map(_.asInstanceOf[AttributeReference].exprId).toSet
+      val relationExprIds = rewrittenRel.output.map(_.exprId).toSet
+      assert(projectExprIds == relationExprIds)
+    }
+  }
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -132,7 +132,9 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "should not attempt to read a non exist version",
     "can delete old files of a snapshot without update",
     "Delta source advances with non-data inserts and generates empty dataframe for " +
-      "non-data operations"
+      "non-data operations",
+    "reading from partitioned table succeeds during restart",
+    "streaming read returns correct data from table with partition column in middle"
   )
 
   override protected def shouldFailTests: Set[String] = Set(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -3236,6 +3236,40 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       try { q2.processAllAvailable() } finally { q2.stop() }
     }
   }
+
+  test("streaming read returns correct data from table with partition column in middle") {
+    // E2E regression for the V2 partition-column NPE fixed by V2StreamingSchemaReorder.
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
+        "USING delta PARTITIONED BY (part)")
+
+      Seq((1L, 10L, 100), (2L, 20L, 200), (3L, 30L, 300))
+        .toDF("id", "part", "col3")
+        .write
+        .format("delta")
+        .mode("append")
+        .save(tablePath)
+
+      val streamingDF = loadStreamWithOptions(tablePath, Map.empty)
+      assert(streamingDF.schema.fieldNames.toSeq === Seq("id", "part", "col3"))
+
+      val q = streamingDF
+        .writeStream
+        .format("memory")
+        .queryName("midPartitionStreamTest")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          sql("SELECT * FROM midPartitionStreamTest ORDER BY id"),
+          Row(1L, 10L, 100) :: Row(2L, 20L, 200) :: Row(3L, 30L, 300) :: Nil)
+      } finally {
+        q.stop()
+      }
+    }
+  }
 }
 
 /**

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/DeltaV2TestBase.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/DeltaV2TestBase.java
@@ -32,7 +32,7 @@ public abstract class DeltaV2TestBase {
         SparkSession.builder()
             .master("local[*]")
             .appName("SparkKernelDsv2Tests")
-            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtensionV1")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .config(
                 "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalogV1")

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
@@ -16,6 +16,7 @@
 
 package io.delta.spark.internal.v2;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -101,5 +102,26 @@ public class V2ReadTest extends V2TestBase {
     long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).count();
     // 500 odd numbers from 0-999: 1, 3, 5, ..., 999
     assertTrue(count == 500, "Expected 500 rows after DV filtering, got " + count);
+  }
+
+  /** V2 batch read confirms the streaming fix doesn't perturb the (already-correct) batch path. */
+  @Test
+  public void testBatchReadPartitionColumnInMiddle(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    // User-facing schema stays in DDL order.
+    assertArrayEquals(
+        new String[] {"id", "part", "col3"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1L, 10L, 100), row(2L, 20L, 200), row(3L, 30L, 300)));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
@@ -28,8 +28,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import org.apache.spark.sql.*;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.Literal$;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias;
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2;
 import org.apache.spark.sql.delta.DeltaIllegalStateException;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.delta.stats.StatisticsCollection;
@@ -470,5 +475,114 @@ public class V2StreamingReadTest extends V2TestBase {
     assertTrue(
         ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"),
         "Expected DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART but got: " + ex.getMessage());
+  }
+
+  /** Regression for the V2 streaming partition-column NPE fixed by V2StreamingSchemaReorder. */
+  @Test
+  public void testStreamingReadPartitionColumnInMiddle(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    // User-facing schema must stay in DDL order so V2 matches V1 streaming behavior.
+    assertArrayEquals(new String[] {"id", "part", "col3"}, streamingDF.schema().fieldNames());
+
+    // Assert plan shape directly so a regression that silently disables the rule (e.g., a
+    // SparkTable rename) is caught even when row-equality would coincidentally pass. The
+    // analyzed plan is SubqueryAlias > Project > StreamingRelationV2 for readStream().table.
+    LogicalPlan analyzed = streamingDF.queryExecution().analyzed();
+    LogicalPlan unaliased =
+        analyzed instanceof SubqueryAlias ? ((SubqueryAlias) analyzed).child() : analyzed;
+    assertTrue(
+        unaliased instanceof Project,
+        "Expected Project below any SubqueryAlias; got:\n" + analyzed.treeString());
+    LogicalPlan child = ((Project) unaliased).child();
+    assertTrue(
+        child instanceof StreamingRelationV2,
+        "Expected Project's child to be StreamingRelationV2; got:\n" + child.treeString());
+    List<String> relOutputNames =
+        JavaConverters.seqAsJavaList(child.output()).stream()
+            .map(Attribute::name)
+            .collect(Collectors.toList());
+    assertEquals(
+        Arrays.asList("id", "col3", "part"),
+        relOutputNames,
+        "Expected StreamingRelationV2.output in reader order");
+
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_middle_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, 10L, 100),
+            RowFactory.create(2L, 20L, 200),
+            RowFactory.create(3L, 30L, 300));
+    assertDataEquals(actualRows, expectedRows);
+  }
+
+  /** Interleaved partition columns declared in reverse of DDL order. */
+  @Test
+  public void testStreamingReadMultiplePartitionColumns(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (a LONG, p1 STRING, b INT, p2 STRING, c DOUBLE) "
+                + "USING delta PARTITIONED BY (p2, p1)",
+            tablePath));
+    spark
+        .createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1L, "x", 10, "y", 1.5),
+                RowFactory.create(2L, "x", 20, "z", 2.5),
+                RowFactory.create(3L, "w", 30, "y", 3.5)),
+            new org.apache.spark.sql.types.StructType()
+                .add("a", org.apache.spark.sql.types.DataTypes.LongType)
+                .add("p1", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("b", org.apache.spark.sql.types.DataTypes.IntegerType)
+                .add("p2", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("c", org.apache.spark.sql.types.DataTypes.DoubleType))
+        .write()
+        .format("delta")
+        .mode("append")
+        .partitionBy("p2", "p1")
+        .save(tablePath);
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    assertArrayEquals(new String[] {"a", "p1", "b", "p2", "c"}, streamingDF.schema().fieldNames());
+
+    // Plan-shape canary so a regression that silently disables the rule is caught even when
+    // row-equality coincidentally passes.
+    LogicalPlan analyzed = streamingDF.queryExecution().analyzed();
+    LogicalPlan unaliased =
+        analyzed instanceof SubqueryAlias ? ((SubqueryAlias) analyzed).child() : analyzed;
+    assertTrue(
+        unaliased instanceof Project,
+        "Expected Project below any SubqueryAlias; got:\n" + analyzed.treeString());
+    LogicalPlan child = ((Project) unaliased).child();
+    assertTrue(
+        child instanceof StreamingRelationV2,
+        "Expected Project's child to be StreamingRelationV2; got:\n" + child.treeString());
+    List<String> relOutputNames =
+        JavaConverters.seqAsJavaList(child.output()).stream()
+            .map(Attribute::name)
+            .collect(Collectors.toList());
+    assertEquals(
+        Arrays.asList("a", "b", "c", "p2", "p1"),
+        relOutputNames,
+        "Expected StreamingRelationV2.output in reader order (data ++ partitions)");
+
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_multi_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, "x", 10, "y", 1.5),
+            RowFactory.create(2L, "x", 20, "z", 2.5),
+            RowFactory.create(3L, "w", 30, "y", 3.5));
+    assertDataEquals(actualRows, expectedRows);
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2TestBase.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2TestBase.java
@@ -59,7 +59,7 @@ public abstract class V2TestBase {
         new SparkConf()
             .set("spark.sql.catalog.dsv2", "io.delta.spark.internal.v2.catalog.TestCatalog")
             .set("spark.sql.catalog.dsv2.base_path", tempDir.getAbsolutePath())
-            .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtensionV1")
+            .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .set(
                 "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalogV1")

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
@@ -60,7 +60,7 @@ public class SparkGoldenTableTest {
         new SparkConf()
             .set("spark.sql.catalog.dsv2", "io.delta.spark.internal.v2.catalog.TestCatalog")
             .set("spark.sql.catalog.dsv2.base_path", tempDir.getAbsolutePath())
-            .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtensionV1")
+            .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .set(
                 "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalogV1")


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6609/files) to review incremental changes.
- [stack/schema-fix](https://github.com/delta-io/delta/pull/6583) [[Files changed](https://github.com/delta-io/delta/pull/6583/files)] [MERGED]
  - [stack/npe-fix](https://github.com/delta-io/delta/pull/6610) [[Files changed](https://github.com/delta-io/delta/pull/6610/files)]
  - [**stack/npe-project**](https://github.com/delta-io/delta/pull/6609) [[Files changed](https://github.com/delta-io/delta/pull/6609/files)]

---------
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

V2 streaming reads NPE in `OnHeapColumnVector.getLong` when a partition column is declared **not at the end** of the DDL. `SparkTable.schema()` returns DDL order `(id, part, col3)` while `SparkScan.readSchema()` returns `dataSchema ++ partitionSchema` = `(id, col3, part)`. Streaming codegen binds ordinals against DDL order but the reader produces batches in data++partitions order → wrong `ColumnVector` → NPE.

This PR introduces `V2StreamingSchemaReorder`, a post-hoc resolution rule that rebinds `StreamingRelationV2.output` to reader order and wraps the relation in a `Project` that re-emits attributes in DDL order. Mirrors V1's pattern (Spark's `FileSourceStrategy` auto-inserts a `ProjectExec` above `FileSourceScanExec` for the same reason). Scoped to kernel-spark `SparkTable` via class-name check since sparkV1 can't compile-time-depend on sparkV2.

## How was this patch tested?

- New E2E test: `DeltaSourceSuite.streaming read returns correct data from table with partition column in middle` (V1 + V2 via `DeltaV2SourceSuite`) with a `DataFrame.schema` assertion.

## Does this PR introduce _any_ user-facing changes?

No.