### PR TITLE
[kernel-spark] Fix V2 streaming partition-column NPE via reader-boundary reorder

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -46,6 +46,12 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     )
   }
 
+  /** Path-based ALTER TABLE doesn't work under V2_ENABLE_MODE=STRICT; route through V1. */
+  override protected def renameColumn(
+      tablePath: String, oldName: String, newName: String): Unit = {
+    executeInV1Mode(s"ALTER TABLE delta.`$tablePath` RENAME COLUMN $oldName TO $newName")
+  }
+
   override protected def shouldPassTests: Set[String] = Set(
     // ========== Core streaming tests ==========
     "basic",
@@ -132,7 +138,12 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "should not attempt to read a non exist version",
     "can delete old files of a snapshot without update",
     "Delta source advances with non-data inserts and generates empty dataframe for " +
-      "non-data operations"
+      "non-data operations",
+    "reading from table with multiple partition columns succeeds during restart",
+    "streaming read returns correct data from table with partition column in middle",
+    "streaming read with column pruning and partition column in middle",
+    "streaming read with column mapping id and partition column in middle",
+    "streaming read after column rename with partition column in middle"
   )
 
   override protected def shouldFailTests: Set[String] = Set(

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -131,7 +131,9 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "should not attempt to read a non exist version",
     "can delete old files of a snapshot without update",
     "Delta source advances with non-data inserts and generates empty dataframe for " +
-      "non-data operations"
+      "non-data operations",
+    "reading from table with multiple partition columns succeeds during restart",
+    "streaming read returns correct data from table with partition column in middle"
   )
 
   private lazy val shouldFailTests = Set(

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -53,6 +53,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "new commits arrive after stream initialization - with explicit startingVersion",
     "SC-11561: can consume new data without update",
     "Delta sources don't write offsets with null json",
+    "reading from partitioned table succeeds during restart",
 
     // === Schema Evolution ===
     "add column: restarting with new DataFrame should recover",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1866,6 +1866,15 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  // TODO(#6591): remove this kill switch once the V2 schema validation has soaked in production.
+  val STREAMING_SCHEMA_VALIDATION_ON_RESTART =
+    buildConf("streaming.schemaValidationOnRestart.enabled")
+      .internal()
+      .doc("Whether to validate that the analysis-time schema matches the latest snapshot " +
+        "schema when a V2 streaming query restarts from checkpoint with a stale DataFrame.")
+      .booleanConf
+      .createWithDefault(true)
+
   val LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS =
     buildConf("loadFileSystemConfigsFromDataFrameOptions")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1357,6 +1357,11 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       s"set tblproperties (${DeltaConfigs.ENABLE_EXPIRED_LOG_CLEANUP.key} = false)")
   }
 
+  /** Rename a column on a path-based Delta table. V2 overrides this to route through V1 mode. */
+  protected def renameColumn(tablePath: String, oldName: String, newName: String): Unit = {
+    sql(s"ALTER TABLE delta.`$tablePath` RENAME COLUMN $oldName TO $newName")
+  }
+
   testQuietly("startingVersion") {
     withTempDir { tableDir =>
       val tablePath = tableDir.getCanonicalPath
@@ -3213,15 +3218,16 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
   }
 
   test("reading from partitioned table succeeds during restart") {
-    // Regression test: partition columns declared in the middle of the schema (e.g.,
-    // (id, part, col3) with `part` as the partition column) must not trip the V2 restart
-    // schema check. DDL-only (no data): the restart validation runs without needing any
-    // files to be read. Data writes would trip a separate V2 partition-column read NPE
-    // (OnHeapColumnVector.getLong), tracked out-of-band.
+    // Regression: partition column `part` is in the MIDDLE of DDL on purpose. Moving it to the
+    // tail would silently bypass the V2 reorder path this test guards.
     withTempDirs { (inputDir, _, checkpointDir) =>
       val tablePath = inputDir.getCanonicalPath
       sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
         "USING delta PARTITIONED BY (part)")
+
+      Seq((1L, 10L, 100), (2L, 20L, 200), (3L, 30L, 300))
+        .toDF("id", "part", "col3")
+        .write.format("delta").mode("append").save(tablePath)
 
       def startStream(): StreamingQuery = loadStreamWithOptions(tablePath, Map.empty)
         .writeStream
@@ -3232,10 +3238,164 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val q = startStream()
       try { q.processAllAvailable() } finally { q.stop() }
 
+      Seq((4L, 40L, 400), (5L, 50L, 500))
+        .toDF("id", "part", "col3")
+        .write.format("delta").mode("append").save(tablePath)
+
       val q2 = startStream()
       try { q2.processAllAvailable() } finally { q2.stop() }
     }
   }
+
+  test("reading from table with multiple partition columns succeeds during restart") {
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      Seq((1L, "x", 10, "y", 1.5), (2L, "x", 20, "z", 2.5), (3L, "w", 30, "y", 3.5))
+        .toDF("a", "p1", "b", "p2", "c")
+        .write.format("delta").partitionBy("p2", "p1").save(tablePath)
+
+      def startStream(): StreamingQuery = loadStreamWithOptions(tablePath, Map.empty)
+        .writeStream
+        .format("noop")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+
+      val q = startStream()
+      try { q.processAllAvailable() } finally { q.stop() }
+
+      Seq((4L, "w", 40, "z", 4.5))
+        .toDF("a", "p1", "b", "p2", "c")
+        .write.format("delta").mode("append").save(tablePath)
+
+      val q2 = startStream()
+      try { q2.processAllAvailable() } finally { q2.stop() }
+    }
+  }
+
+  test("streaming read returns correct data from table with partition column in middle") {
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
+        "USING delta PARTITIONED BY (part)")
+
+      Seq((1L, 10L, 100), (2L, 20L, 200), (3L, 30L, 300))
+        .toDF("id", "part", "col3")
+        .write
+        .format("delta")
+        .mode("append")
+        .save(tablePath)
+
+      val streamingDF = loadStreamWithOptions(tablePath, Map.empty)
+      // User-facing schema must remain in DDL order (matches V1 streaming behavior).
+      assert(streamingDF.schema.fieldNames.toSeq === Seq("id", "part", "col3"))
+
+      val q = streamingDF
+        .writeStream
+        .format("memory")
+        .queryName("midPartitionStreamTest")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          sql("SELECT * FROM midPartitionStreamTest ORDER BY id"),
+          Row(1L, 10L, 100) :: Row(2L, 20L, 200) :: Row(3L, 30L, 300) :: Nil)
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
+  test("streaming read with column pruning and partition column in middle") {
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
+        "USING delta PARTITIONED BY (part)")
+      Seq((1L, 10L, 100), (2L, 20L, 200), (3L, 30L, 300))
+        .toDF("id", "part", "col3")
+        .write.format("delta").mode("append").save(tablePath)
+
+      val streamingDF = loadStreamWithOptions(tablePath, Map.empty).select("part", "id")
+      val q = streamingDF
+        .writeStream
+        .format("memory")
+        .queryName("midPartitionPruneStreamTest")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          sql("SELECT * FROM midPartitionPruneStreamTest ORDER BY id"),
+          Row(10L, 1L) :: Row(20L, 2L) :: Row(30L, 3L) :: Nil)
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
+  test("streaming read with column mapping id and partition column in middle") {
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
+        "USING delta PARTITIONED BY (part) " +
+        "TBLPROPERTIES ('delta.columnMapping.mode' = 'id')")
+      Seq((1L, 10L, 100), (2L, 20L, 200), (3L, 30L, 300))
+        .toDF("id", "part", "col3")
+        .write.format("delta").mode("append").save(tablePath)
+
+      val streamingDF = loadStreamWithOptions(tablePath, Map.empty)
+      assert(streamingDF.schema.fieldNames.toSeq === Seq("id", "part", "col3"))
+      val q = streamingDF
+        .writeStream
+        .format("memory")
+        .queryName("midPartitionCmIdStreamTest")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          sql("SELECT * FROM midPartitionCmIdStreamTest ORDER BY id"),
+          Row(1L, 10L, 100) :: Row(2L, 20L, 200) :: Row(3L, 30L, 300) :: Nil)
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
+  test("streaming read after column rename with partition column in middle") {
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, original_col INT) " +
+        "USING delta PARTITIONED BY (part) " +
+        "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')")
+      Seq((1L, 10L, 100)).toDF("id", "part", "original_col")
+        .write.format("delta").mode("append").save(tablePath)
+      renameColumn(tablePath, "original_col", "renamed_col")
+      Seq((2L, 20L, 200)).toDF("id", "part", "renamed_col")
+        .write.format("delta").mode("append").save(tablePath)
+      renameColumn(tablePath, "part", "renamed_part")
+      Seq((3L, 30L, 300)).toDF("id", "renamed_part", "renamed_col")
+        .write.format("delta").mode("append").save(tablePath)
+
+      val streamingDF = loadStreamWithOptions(tablePath, Map.empty)
+      assert(streamingDF.schema.fieldNames.toSeq === Seq("id", "renamed_part", "renamed_col"))
+      val q = streamingDF
+        .writeStream
+        .format("memory")
+        .queryName("midPartitionRenameStreamTest")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          sql("SELECT * FROM midPartitionRenameStreamTest ORDER BY id"),
+          Row(1L, 10L, 100) :: Row(2L, 20L, 200) :: Row(3L, 30L, 300) :: Nil)
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -3216,8 +3216,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     // Regression test: partition columns declared in the middle of the schema (e.g.,
     // (id, part, col3) with `part` as the partition column) must not trip the V2 restart
     // schema check. DDL-only (no data): the restart validation runs without needing any
-    // files to be read. Data writes would trip a separate V2 partition-column read NPE
-    // (OnHeapColumnVector.getLong), tracked out-of-band.
+    // files to be read. TODO(#6591): cover the data-path case once the partition-column
+    // read NPE is fixed.
     withTempDirs { (inputDir, _, checkpointDir) =>
       val tablePath = inputDir.getCanonicalPath
       sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
@@ -3234,6 +3234,75 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
       val q2 = startStream()
       try { q2.processAllAvailable() } finally { q2.stop() }
+    }
+  }
+
+  test("reading from table with multiple partition columns succeeds during restart") {
+    // Exercises a table with multiple partition columns interleaved with data columns, where
+    // PARTITIONED BY order differs from DDL order. Expected DDL order: (a, p1, b, p2, c).
+    // Uses DataFrame writes (V1 path) because the V2 batch write path doesn't handle
+    // partitioned writes; SQL INSERT under V2 conformance routes through V2 write and fails.
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      Seq((1L, "x", 10, "y", 1.5), (2L, "x", 20, "z", 2.5), (3L, "w", 30, "y", 3.5))
+        .toDF("a", "p1", "b", "p2", "c")
+        .write.format("delta").partitionBy("p2", "p1").save(tablePath)
+
+      def startStream() = loadStreamWithOptions(tablePath, Map.empty)
+        .writeStream
+        .format("noop")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+
+      val q = startStream()
+      try { q.processAllAvailable() } finally { q.stop() }
+
+      Seq((4L, "w", 40, "z", 4.5))
+        .toDF("a", "p1", "b", "p2", "c")
+        .write.format("delta").mode("append").save(tablePath)
+
+      val q2 = startStream()
+      try { q2.processAllAvailable() } finally { q2.stop() }
+    }
+  }
+
+  test("streaming read returns correct data from table with partition column in middle") {
+    // End-to-end regression test for the V2 partition-column NPE: when the partition column is
+    // declared in the MIDDLE of the DDL (ordinal 1), `SparkTable.schema()` (DDL order) and
+    // `SparkScan.readSchema()` (data ++ partitions) disagree. Without `ColumnReorderReadFunction`,
+    // V2 streaming codegen binds ordinals against DDL order but the reader produces batches in
+    // data++partitions order, landing on the wrong `ColumnVector` and NPE-ing in
+    // `OnHeapColumnVector.getLong`.
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
+        "USING delta PARTITIONED BY (part)")
+
+      Seq((1L, 10L, 100), (2L, 20L, 200), (3L, 30L, 300))
+        .toDF("id", "part", "col3")
+        .write
+        .format("delta")
+        .mode("append")
+        .save(tablePath)
+
+      val streamingDF = loadStreamWithOptions(tablePath, Map.empty)
+      // User-facing schema must remain in DDL order (matches V1 streaming behavior).
+      assert(streamingDF.schema.fieldNames.toSeq === Seq("id", "part", "col3"))
+
+      val q = streamingDF
+        .writeStream
+        .format("memory")
+        .queryName("midPartitionStreamTest")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          sql("SELECT * FROM midPartitionStreamTest ORDER BY id"),
+          Row(1L, 10L, 100) :: Row(2L, 20L, 200) :: Row(3L, 30L, 300) :: Nil)
+      } finally {
+        q.stop()
+      }
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -3211,6 +3211,31 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       }
     }
   }
+
+  test("reading from partitioned table succeeds during restart") {
+    // Regression test: partition columns declared in the middle of the schema (e.g.,
+    // (id, part, col3) with `part` as the partition column) must not trip the V2 restart
+    // schema check. DDL-only (no data): the restart validation runs without needing any
+    // files to be read. Data writes would trip a separate V2 partition-column read NPE
+    // (OnHeapColumnVector.getLong), tracked out-of-band.
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, part LONG, col3 INT) " +
+        "USING delta PARTITIONED BY (part)")
+
+      def startStream(): StreamingQuery = loadStreamWithOptions(tablePath, Map.empty)
+        .writeStream
+        .format("noop")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+
+      val q = startStream()
+      try { q.processAllAvailable() } finally { q.stop() }
+
+      val q2 = startStream()
+      try { q2.processAllAvailable() } finally { q2.stop() }
+    }
+  }
 }
 
 /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import io.delta.spark.internal.v2.utils.CloseableIterator;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.ProjectingInternalRow;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import scala.Function1;
+import scala.collection.Iterator;
+import scala.runtime.AbstractFunction1;
+
+/**
+ * Reorders a Parquet reader's {@code readDataSchema ++ partitionSchema} output into the DDL field
+ * order declared by {@link SparkScan#readSchema()}.
+ */
+public class ColumnReorderReadFunction
+    extends AbstractFunction1<PartitionedFile, Iterator<InternalRow>> implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Function1<PartitionedFile, Iterator<InternalRow>> baseReadFunc;
+  private final boolean isVectorizedReader;
+  private final StructType targetSchema;
+  private final int[] reorderIndices;
+
+  private ColumnReorderReadFunction(
+      Function1<PartitionedFile, Iterator<InternalRow>> baseReadFunc,
+      boolean isVectorizedReader,
+      StructType targetSchema,
+      int[] reorderIndices) {
+    this.baseReadFunc = baseReadFunc;
+    this.isVectorizedReader = isVectorizedReader;
+    this.targetSchema = targetSchema;
+    this.reorderIndices = reorderIndices;
+  }
+
+  @Override
+  public Iterator<InternalRow> apply(PartitionedFile file) {
+    return isVectorizedReader ? applyBatch(file) : applyRow(file);
+  }
+
+  private Iterator<InternalRow> applyRow(PartitionedFile file) {
+    ProjectingInternalRow projection =
+        ProjectingInternalRow.apply(
+            targetSchema, scala.Predef.wrapIntArray(reorderIndices).toSeq());
+    return CloseableIterator.wrap(baseReadFunc.apply(file))
+        .mapCloseable(
+            row -> {
+              projection.project(row);
+              return (InternalRow) projection;
+            });
+  }
+
+  @SuppressWarnings("unchecked")
+  private Iterator<InternalRow> applyBatch(PartitionedFile file) {
+    Iterator<Object> baseIterator = (Iterator<Object>) (Iterator<?>) baseReadFunc.apply(file);
+    return (Iterator<InternalRow>)
+        (Iterator<?>)
+            CloseableIterator.wrap(baseIterator)
+                .mapCloseable(
+                    item -> {
+                      if (item instanceof ColumnarBatch) {
+                        return reorderBatch((ColumnarBatch) item);
+                      }
+                      throw new IllegalStateException(
+                          "Expected ColumnarBatch when vectorized reader is enabled, but got: "
+                              + item.getClass());
+                    });
+  }
+
+  private ColumnarBatch reorderBatch(ColumnarBatch batch) {
+    ColumnVector[] reordered = new ColumnVector[reorderIndices.length];
+    for (int i = 0; i < reorderIndices.length; i++) {
+      reordered[i] = batch.column(reorderIndices[i]);
+    }
+    return new ColumnarBatch(reordered, batch.numRows());
+  }
+
+  /**
+   * Factory method. Returns the {@code baseReadFunc} unchanged if the reorder is the identity (no
+   * permutation needed - avoids a per-batch allocation).
+   */
+  public static Function1<PartitionedFile, Iterator<InternalRow>> wrap(
+      Function1<PartitionedFile, Iterator<InternalRow>> baseReadFunc,
+      boolean isVectorizedReader,
+      StructType dataSchema,
+      StructType partitionSchema,
+      StructType targetSchema) {
+    StructType sourceSchema = readerOutputSchema(dataSchema, partitionSchema, targetSchema);
+    int[] reorderIndices = computeReorderIndices(sourceSchema, targetSchema);
+    if (isIdentityReorder(reorderIndices)) {
+      return baseReadFunc;
+    }
+    return new ColumnReorderReadFunction(
+        baseReadFunc, isVectorizedReader, targetSchema, reorderIndices);
+  }
+
+  /**
+   * Rebuilds the reader's output field layout: {@code dataSchema} fields, then {@code
+   * partitionSchema} fields, then any leftover fields from {@code targetSchema} (e.g. CDC) in the
+   * order they appear in {@code targetSchema}.
+   */
+  private static StructType readerOutputSchema(
+      StructType dataSchema, StructType partitionSchema, StructType targetSchema) {
+    Set<String> dataPartitionNames = new HashSet<>(dataSchema.fields().length);
+    for (StructField f : dataSchema.fields()) dataPartitionNames.add(f.name());
+    for (StructField f : partitionSchema.fields()) dataPartitionNames.add(f.name());
+    List<StructField> fields =
+        new ArrayList<>(
+            dataSchema.fields().length
+                + partitionSchema.fields().length
+                + targetSchema.fields().length);
+    for (StructField f : dataSchema.fields()) fields.add(f);
+    for (StructField f : partitionSchema.fields()) fields.add(f);
+    for (StructField f : targetSchema.fields()) {
+      if (!dataPartitionNames.contains(f.name())) {
+        fields.add(f);
+      }
+    }
+    return new StructType(fields.toArray(new StructField[0]));
+  }
+
+  /**
+   * For each field in {@code targetSchema}, the offset of that field (by name) in {@code
+   * sourceSchema}.
+   */
+  private static int[] computeReorderIndices(StructType sourceSchema, StructType targetSchema) {
+    StructField[] sourceFields = sourceSchema.fields();
+    StructField[] targetFields = targetSchema.fields();
+    if (sourceFields.length != targetFields.length) {
+      throw new IllegalStateException(
+          "Source schema width "
+              + sourceFields.length
+              + " does not match target schema width "
+              + targetFields.length
+              + "; reader output has columns not in the DDL-ordered output schema. source="
+              + sourceSchema
+              + ", target="
+              + targetSchema);
+    }
+    Map<String, Integer> sourceIndexByName = new HashMap<>();
+    for (int i = 0; i < sourceFields.length; i++) {
+      sourceIndexByName.put(sourceFields[i].name(), i);
+    }
+    int[] reorderIndices = new int[targetFields.length];
+    for (int i = 0; i < targetFields.length; i++) {
+      Integer idx = sourceIndexByName.get(targetFields[i].name());
+      if (idx == null) {
+        throw new IllegalStateException(
+            "Cannot reorder columns: field '"
+                + targetFields[i].name()
+                + "' exists in the DDL-ordered target schema but is missing from the source schema "
+                + sourceSchema);
+      }
+      reorderIndices[i] = idx;
+    }
+    return reorderIndices;
+  }
+
+  private static boolean isIdentityReorder(int[] reorderIndices) {
+    for (int i = 0; i < reorderIndices.length; i++) {
+      if (reorderIndices[i] != i) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import io.delta.spark.internal.v2.utils.CloseableIterator;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.ProjectingInternalRow;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import scala.Function1;
+import scala.collection.Iterator;
+import scala.runtime.AbstractFunction1;
+
+/**
+ * Wraps a Parquet reader function to reorder output columns from the underlying reader's {@code
+ * readDataSchema ++ partitionSchema} layout into the target (DDL) order advertised by {@link
+ * SparkScan#readSchema()}.
+ *
+ * <p>Needed because Spark's vectorized Parquet reader always appends partition columns at the end
+ * of each {@link ColumnarBatch}, but the streaming plan binds output attributes to {@code
+ * SparkTable.schema()} which preserves DDL order. Without this reorder, an ordinal-based downstream
+ * consumer (e.g. whole-stage codegen) can read a type-mismatched {@link ColumnVector} and NPE (see
+ * {@code OnHeapColumnVector.getLong}).
+ */
+public class ColumnReorderReadFunction
+    extends AbstractFunction1<PartitionedFile, Iterator<InternalRow>> implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Function1<PartitionedFile, Iterator<InternalRow>> baseReadFunc;
+  private final boolean isVectorizedReader;
+  private final StructType targetSchema;
+  private final int[] permutation;
+
+  private ColumnReorderReadFunction(
+      Function1<PartitionedFile, Iterator<InternalRow>> baseReadFunc,
+      boolean isVectorizedReader,
+      StructType targetSchema,
+      int[] permutation) {
+    this.baseReadFunc = baseReadFunc;
+    this.isVectorizedReader = isVectorizedReader;
+    this.targetSchema = targetSchema;
+    this.permutation = permutation;
+  }
+
+  @Override
+  public Iterator<InternalRow> apply(PartitionedFile file) {
+    return isVectorizedReader ? applyBatch(file) : applyRow(file);
+  }
+
+  private Iterator<InternalRow> applyRow(PartitionedFile file) {
+    ProjectingInternalRow projection =
+        ProjectingInternalRow.apply(targetSchema, scala.Predef.wrapIntArray(permutation).toSeq());
+    return CloseableIterator.wrap(baseReadFunc.apply(file))
+        .mapCloseable(
+            row -> {
+              projection.project(row);
+              return (InternalRow) projection;
+            });
+  }
+
+  @SuppressWarnings("unchecked")
+  private Iterator<InternalRow> applyBatch(PartitionedFile file) {
+    Iterator<Object> baseIterator = (Iterator<Object>) (Iterator<?>) baseReadFunc.apply(file);
+    return (Iterator<InternalRow>)
+        (Iterator<?>)
+            CloseableIterator.wrap(baseIterator)
+                .mapCloseable(
+                    item -> {
+                      if (item instanceof ColumnarBatch) {
+                        return reorderBatch((ColumnarBatch) item);
+                      }
+                      throw new IllegalStateException(
+                          "Expected ColumnarBatch when vectorized reader is enabled, but got: "
+                              + item.getClass());
+                    });
+  }
+
+  private ColumnarBatch reorderBatch(ColumnarBatch batch) {
+    ColumnVector[] reordered = new ColumnVector[permutation.length];
+    for (int i = 0; i < permutation.length; i++) {
+      reordered[i] = batch.column(permutation[i]);
+    }
+    return new ColumnarBatch(reordered, batch.numRows());
+  }
+
+  /**
+   * Factory method. Returns the {@code baseReadFunc} unchanged if the permutation is the identity
+   * (no reorder needed — saves a per-batch allocation).
+   */
+  public static Function1<PartitionedFile, Iterator<InternalRow>> wrap(
+      Function1<PartitionedFile, Iterator<InternalRow>> baseReadFunc,
+      boolean isVectorizedReader,
+      StructType sourceSchema,
+      StructType targetSchema) {
+    int[] permutation = computePermutation(sourceSchema, targetSchema);
+    if (isIdentity(permutation)) {
+      return baseReadFunc;
+    }
+    return new ColumnReorderReadFunction(
+        baseReadFunc, isVectorizedReader, targetSchema, permutation);
+  }
+
+  /**
+   * For each field in {@code targetSchema}, the index of that field (by name) in {@code
+   * sourceSchema}.
+   */
+  private static int[] computePermutation(StructType sourceSchema, StructType targetSchema) {
+    Map<String, Integer> sourceIndexByName = new HashMap<>();
+    StructField[] sourceFields = sourceSchema.fields();
+    for (int i = 0; i < sourceFields.length; i++) {
+      sourceIndexByName.put(sourceFields[i].name(), i);
+    }
+    StructField[] targetFields = targetSchema.fields();
+    int[] permutation = new int[targetFields.length];
+    for (int i = 0; i < targetFields.length; i++) {
+      Integer idx = sourceIndexByName.get(targetFields[i].name());
+      if (idx == null) {
+        throw new IllegalStateException(
+            "Field " + targetFields[i].name() + " from target schema not found in source schema");
+      }
+      permutation[i] = idx;
+    }
+    return permutation;
+  }
+
+  private static boolean isIdentity(int[] permutation) {
+    for (int i = 0; i < permutation.length; i++) {
+      if (permutation[i] != i) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkBatch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkBatch.java
@@ -38,6 +38,7 @@ public class SparkBatch implements Batch {
   private final StructType readDataSchema;
   private final StructType dataSchema;
   private final StructType partitionSchema;
+  private final StructType ddlOrderedReadOutputSchema;
   private final Predicate[] pushedToKernelFilters;
   private final Filter[] dataFilters;
   // Derived Sets used only for equals/hashCode: filters are AND-ed at eval time,
@@ -55,6 +56,7 @@ public class SparkBatch implements Batch {
       StructType dataSchema,
       StructType partitionSchema,
       StructType readDataSchema,
+      StructType ddlOrderedReadOutputSchema,
       List<PartitionedFile> partitionedFiles,
       Predicate[] pushedToKernelFilters,
       Filter[] dataFilters,
@@ -66,6 +68,8 @@ public class SparkBatch implements Batch {
     this.dataSchema = Objects.requireNonNull(dataSchema, "dataSchema is null");
     this.partitionSchema = Objects.requireNonNull(partitionSchema, "partitionSchema is null");
     this.readDataSchema = Objects.requireNonNull(readDataSchema, "readDataSchema is null");
+    this.ddlOrderedReadOutputSchema =
+        Objects.requireNonNull(ddlOrderedReadOutputSchema, "ddlOrderedReadOutputSchema is null");
     this.partitionedFiles =
         java.util.Collections.unmodifiableList(
             new ArrayList<>(Objects.requireNonNull(partitionedFiles, "partitionedFiles is null")));
@@ -94,6 +98,7 @@ public class SparkBatch implements Batch {
         dataSchema,
         partitionSchema,
         readDataSchema,
+        ddlOrderedReadOutputSchema,
         dataFilters,
         scalaOptions,
         hadoopConf,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -141,6 +141,7 @@ public class SparkMicroBatchStream
   private final StructType readDataSchema;
   private final StructType dataSchema;
   private final StructType partitionSchema;
+  private final StructType ddlOrderedReadOutputSchema;
   private final Filter[] dataFilters;
   private final Configuration hadoopConf;
   private final SQLConf sqlConf;
@@ -211,6 +212,7 @@ public class SparkMicroBatchStream
       StructType dataSchema,
       StructType partitionSchema,
       StructType readDataSchema,
+      StructType ddlOrderedReadOutputSchema,
       Filter[] dataFilters,
       scala.collection.immutable.Map<String, String> scalaOptions) {
     this.snapshotManager = Objects.requireNonNull(snapshotManager, "snapshotManager is null");
@@ -231,6 +233,8 @@ public class SparkMicroBatchStream
     this.dataSchema = Objects.requireNonNull(dataSchema, "dataSchema is null");
     this.partitionSchema = Objects.requireNonNull(partitionSchema, "partitionSchema is null");
     this.readDataSchema = Objects.requireNonNull(readDataSchema, "readDataSchema is null");
+    this.ddlOrderedReadOutputSchema =
+        Objects.requireNonNull(ddlOrderedReadOutputSchema, "ddlOrderedReadOutputSchema is null");
     this.dataFilters =
         Arrays.copyOf(
             Objects.requireNonNull(dataFilters, "dataFilters is null"), dataFilters.length);
@@ -515,6 +519,7 @@ public class SparkMicroBatchStream
         dataSchema,
         partitionSchema,
         readDataSchema,
+        ddlOrderedReadOutputSchema,
         dataFilters,
         scalaOptions,
         hadoopConf,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -18,6 +18,7 @@ package io.delta.spark.internal.v2.read;
 import static io.delta.kernel.internal.tablefeatures.TableFeatures.TYPE_WIDENING_RW_FEATURE;
 import static io.delta.kernel.internal.tablefeatures.TableFeatures.TYPE_WIDENING_RW_PREVIEW_FEATURE;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.delta.kernel.CommitActions;
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Scan;
@@ -83,12 +84,14 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Function2;
 import scala.Option;
 import scala.Some;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.Seq;
 import scala.collection.immutable.Seq$;
 import scala.jdk.javaapi.CollectionConverters;
+import scala.runtime.AbstractFunction2;
 import scala.util.matching.Regex;
 
 // TODO(#5318): Use DeltaErrors error framework for consistent error handling.
@@ -255,7 +258,15 @@ public class SparkMicroBatchStream
             DeltaStreamUtils.SchemaReadOptions$.MODULE$.fromSparkSession(
                 spark, isStreamingFromColumnMappingTable, isTypeWideningSupportedInProtocol),
             "schemaReadOptions is null");
-    validateSchemaCompatibilityOnStartup(dataSchema, partitionSchema, readSchemaAtSourceInit);
+    boolean shouldValidateSchemaOnRestart =
+        (Boolean)
+            spark
+                .sessionState()
+                .conf()
+                .getConf(DeltaSQLConf.STREAMING_SCHEMA_VALIDATION_ON_RESTART());
+    if (shouldValidateSchemaOnRestart) {
+      validateSchemaCompatibilityOnStartup(dataSchema, partitionSchema, readSchemaAtSourceInit);
+    }
   }
 
   @Override
@@ -1409,7 +1420,8 @@ public class SparkMicroBatchStream
    * @param partitionSchema partition columns from analysis time
    * @param snapshotSchema full table schema from the latest snapshot at stream start
    */
-  private void validateSchemaCompatibilityOnStartup(
+  @VisibleForTesting
+  static void validateSchemaCompatibilityOnStartup(
       StructType dataSchema, StructType partitionSchema, StructType snapshotSchema) {
     // Reconstruct the full analysis-time table schema from dataSchema + partitionSchema.
     // StructType is immutable — add() returns a new instance without modifying the original.
@@ -1417,11 +1429,37 @@ public class SparkMicroBatchStream
     for (StructField field : partitionSchema.fields()) {
       querySchema = querySchema.add(field);
     }
-
-    // Compare the structural schema of the analysis-time schema and snapshot schema.
-    if (!DataType.equalsStructurally(querySchema, snapshotSchema, /* ignoreNullability */ false)) {
+    // Sort both sides so a partition column declared in the middle of the table doesn't 
+    // trip the check.
+    StructType sortedQuery = sortFieldsByName(querySchema);
+    StructType sortedSnapshot = sortFieldsByName(snapshotSchema);
+    // equalsStructurally checks types + nullability but ignores field names;
+    // equalsStructurallyByName checks names but ignores types/nullability.
+    boolean typesAndNullabilityMatch =
+        DataType.equalsStructurally(sortedQuery, sortedSnapshot, /* ignoreNullability= */ false);
+    boolean namesMatch =
+        DataType.equalsStructurallyByName(sortedQuery, sortedSnapshot, CASE_INSENSITIVE_RESOLVER);
+    if (!typesAndNullabilityMatch || !namesMatch) {
       throw DeltaErrors.streamingSchemaMismatchOnRestart(querySchema, snapshotSchema);
     }
+  }
+
+  private static final Function2<String, String, Object> CASE_INSENSITIVE_RESOLVER =
+      new AbstractFunction2<String, String, Object>() {
+        @Override
+        public Object apply(String a, String b) {
+          return a.equalsIgnoreCase(b);
+        }
+      };
+
+  private static StructType sortFieldsByName(StructType schema) {
+    StructField[] fields = Arrays.copyOf(schema.fields(), schema.fields().length);
+    Arrays.sort(fields, Comparator.comparing(StructField::name));
+    StructType result = new StructType();
+    for (StructField f : fields) {
+      result = result.add(f);
+    }
+    return result;
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -32,6 +32,7 @@ import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContex
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.PartitionUtils;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.*;
@@ -100,6 +101,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   private final StructType readDataSchema;
   private final StructType dataSchema;
   private final StructType partitionSchema;
+  private final StructType ddlOrderedReadOutputSchema;
   private final Predicate[] pushedToKernelFilters;
   private final Filter[] dataFilters;
   // Derived Sets used only for equals/hashCode: filters are AND-ed at evaluation time,
@@ -136,9 +138,11 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   private final Set<org.apache.spark.sql.connector.expressions.filter.Predicate>
       appliedRuntimePredicates = new HashSet<>();
 
+  // TODO(#6743): bundle scan-level schemas into a single ScanSchemaContext.
   public SparkScan(
       DeltaSnapshotManager snapshotManager,
       Snapshot initialSnapshot,
+      StructType tableSchema,
       StructType dataSchema,
       StructType partitionSchema,
       StructType readDataSchema,
@@ -167,20 +171,16 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     this.deltaOptions = new DeltaOptions(scalaOptions, sqlConf);
     this.isCDCRead = deltaOptions.readChangeFeed();
     this.zoneId = ZoneId.of(sqlConf.sessionLocalTimeZone());
+    StructType ddlOrdered =
+        SchemaUtils.ddlOrderedOutputSchema(tableSchema, readDataSchema, partitionSchema);
+    this.ddlOrderedReadOutputSchema =
+        isCDCRead ? CDCSchemaContext.appendCDCColumns(ddlOrdered) : ddlOrdered;
   }
 
-  /**
-   * Read schema for the scan: data columns followed by partition columns, with CDC columns appended
-   * for CDC reads.
-   */
+  /** Read schema for the scan, in the table's DDL column order. */
   @Override
   public StructType readSchema() {
-    final List<StructField> fields =
-        new ArrayList<>(readDataSchema.fields().length + partitionSchema.fields().length);
-    Collections.addAll(fields, readDataSchema.fields());
-    Collections.addAll(fields, partitionSchema.fields());
-    StructType schema = new StructType(fields.toArray(new StructField[0]));
-    return isCDCRead ? CDCSchemaContext.appendCDCColumns(schema) : schema;
+    return ddlOrderedReadOutputSchema;
   }
 
   /**
@@ -239,6 +239,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
         dataSchema,
         partitionSchema,
         readDataSchema,
+        ddlOrderedReadOutputSchema,
         partitionedFiles,
         pushedToKernelFilters,
         dataFilters,
@@ -264,6 +265,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
         dataSchema,
         partitionSchema,
         readDataSchema,
+        ddlOrderedReadOutputSchema,
         dataFilters != null ? dataFilters : new Filter[0],
         scalaOptions != null ? scalaOptions : scala.collection.immutable.Map$.MODULE$.empty());
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -157,16 +157,19 @@ public class SparkScan
   }
 
   /**
-   * Read schema for the scan, which is the projection of data columns followed by partition
-   * columns.
+   * Read schema for the scan, returned in the table's original DDL column order (partition columns
+   * in their declared positions, not appended at the end).
+   *
+   * <p>Spark's streaming plan binds output attributes to {@code SparkTable.schema()} which
+   * preserves DDL order. If this method instead returned {@code readDataSchema ++ partitionSchema}
+   * (partitions-at-end), downstream ordinal-based consumers could land on a type-mismatched {@link
+   * org.apache.spark.sql.vectorized.ColumnVector} and NPE. See {@link ColumnReorderReadFunction}
+   * for the corresponding batch-level reorder that keeps the reader's output aligned with this
+   * advertised order.
    */
   @Override
   public StructType readSchema() {
-    final List<StructField> fields =
-        new ArrayList<>(readDataSchema.fields().length + partitionSchema.fields().length);
-    Collections.addAll(fields, readDataSchema.fields());
-    Collections.addAll(fields, partitionSchema.fields());
-    return new StructType(fields.toArray(new StructField[0]));
+    return PartitionUtils.ddlOrderedOutputSchema(initialSnapshot, readDataSchema, partitionSchema);
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScanBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScanBuilder.java
@@ -177,6 +177,7 @@ public class SparkScanBuilder
     return new SparkScan(
         snapshotManager,
         initialSnapshot,
+        tableSchema,
         dataSchema,
         partitionSchema,
         requiredDataSchema,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -23,6 +23,7 @@ import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
 import io.delta.spark.internal.v2.read.SparkReaderFactory;
 import io.delta.spark.internal.v2.read.cdc.CDCReadFunction;
@@ -240,6 +241,7 @@ public class PartitionUtils {
       StructType dataSchema,
       StructType partitionSchema,
       StructType readDataSchema,
+      StructType ddlOrderedReadOutputSchema,
       Filter[] dataFilters,
       scala.collection.immutable.Map<String, String> scalaOptions,
       Configuration hadoopConf,
@@ -250,6 +252,10 @@ public class PartitionUtils {
     // toUri().toString() encodes special characters (e.g., space -> %20), which causes
     // DV file path resolution failures.
     String tablePath = snapshotImpl.getDataPath().toString();
+
+    // Preserve the caller-provided readDataSchema (pre-DV/RT/CDC augmentation) for the final
+    // column-reorder wrapper below.
+    final StructType originalReadDataSchema = readDataSchema;
 
     // For CDC reads, build the schema context and augment readDataSchema with CDC columns
     // before DV wrapping so that DV column indices account for them.
@@ -336,6 +342,17 @@ public class PartitionUtils {
       }
       readFunc = CDCReadFunction.wrap(readFunc, cdcSchemaContext.get(), enableVectorizedReader);
     }
+
+    // DV and RT strip their internal helpers before yielding; CDC appends its fields at the tail.
+    // The wrapper infers the source layout from (data, partition, target) - CDC tail fields end up
+    // identity-mapped while data/partition columns are permuted into DDL order.
+    readFunc =
+        ColumnReorderReadFunction.wrap(
+            readFunc,
+            enableVectorizedReader,
+            originalReadDataSchema,
+            partitionSchema,
+            ddlOrderedReadOutputSchema);
 
     return new SparkReaderFactory(readFunc, enableVectorizedReader);
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -23,6 +23,7 @@ import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
 import io.delta.spark.internal.v2.read.SparkReaderFactory;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction;
@@ -30,8 +31,11 @@ import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContex
 import io.delta.spark.internal.v2.read.rowtracking.RowTrackingReadFunction;
 import io.delta.spark.internal.v2.read.rowtracking.RowTrackingSchemaContext;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -228,6 +232,11 @@ public class PartitionUtils {
     // DV file path resolution failures.
     String tablePath = snapshotImpl.getDataPath().toString();
 
+    // Preserve the caller-provided readDataSchema (pre-DV/RT augmentation) for the final
+    // column-reorder wrapper below. DV/RT inject + strip internal columns; from the outside,
+    // the reader chain still produces one StructField per column in (readDataSchema,partitions).
+    final StructType originalReadDataSchema = readDataSchema;
+
     boolean metadataColumnRequested =
         Arrays.stream(readDataSchema.fields())
             .anyMatch(field -> FileFormat$.MODULE$.METADATA_NAME().equals(field.name()));
@@ -294,7 +303,73 @@ public class PartitionUtils {
       readFunc = RowTrackingReadFunction.wrap(readFunc, rowTrackingSchemaContext.get());
     }
 
+    // Reorder output columns from (data ++ partitions) to the table's DDL order. Required
+    // because Spark's streaming plan binds output attributes to SparkTable.schema() (DDL
+    // order); without this reorder a downstream ordinal-based consumer can read a
+    // type-mismatched ColumnVector and NPE. No-op when partitions are already at the end.
+    // Uses the ORIGINAL readDataSchema (pre-DV/RT augmentation): DV strips its internal
+    // column and RT inserts _metadata between data and partitions, so what reaches this
+    // wrapper is logically (originalReadDataSchema ++ partitionSchema).
+    readFunc =
+        ColumnReorderReadFunction.wrap(
+            readFunc,
+            enableVectorizedReader,
+            readerOutputSchema(originalReadDataSchema, partitionSchema),
+            ddlOrderedOutputSchema(snapshot, originalReadDataSchema, partitionSchema));
+
     return new SparkReaderFactory(readFunc, enableVectorizedReader);
+  }
+
+  /**
+   * The output column layout that the underlying reader (before the reorder wrapper) produces: data
+   * columns followed by partition columns.
+   */
+  private static StructType readerOutputSchema(
+      StructType readDataSchema, StructType partitionSchema) {
+    List<StructField> fields =
+        new ArrayList<>(readDataSchema.fields().length + partitionSchema.fields().length);
+    for (StructField f : readDataSchema.fields()) {
+      fields.add(f);
+    }
+    for (StructField f : partitionSchema.fields()) {
+      fields.add(f);
+    }
+    return new StructType(fields.toArray(new StructField[0]));
+  }
+
+  /**
+   * The projection of {@code readDataSchema ∪ partitionSchema} in the table's DDL order (partition
+   * columns interleaved at their declared positions). Any field in {@code readDataSchema} that is
+   * not part of the table's persisted schema (e.g. Spark's synthetic {@code _metadata} column) is
+   * appended at the end in insertion order.
+   */
+  public static StructType ddlOrderedOutputSchema(
+      Snapshot snapshot, StructType readDataSchema, StructType partitionSchema) {
+    if (partitionSchema.fields().length == 0) {
+      // No partition columns — reader output already matches DDL order for included fields.
+      return readDataSchema;
+    }
+    StructType rawSchema =
+        io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
+            snapshot.getSchema());
+    LinkedHashMap<String, StructField> fieldsByName =
+        new LinkedHashMap<>(readDataSchema.fields().length + partitionSchema.fields().length);
+    for (StructField f : readDataSchema.fields()) {
+      fieldsByName.put(f.name(), f);
+    }
+    for (StructField f : partitionSchema.fields()) {
+      fieldsByName.put(f.name(), f);
+    }
+    List<StructField> ordered = new ArrayList<>(fieldsByName.size());
+    for (StructField f : rawSchema.fields()) {
+      StructField projected = fieldsByName.remove(f.name());
+      if (projected != null) {
+        ordered.add(projected);
+      }
+    }
+    // Append leftover fields (not in the persisted schema) preserving insertion order.
+    ordered.addAll(fieldsByName.values());
+    return new StructType(ordered.toArray(new StructField[0]));
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -38,6 +38,7 @@ import io.delta.kernel.types.TimestampType;
 import io.delta.kernel.types.VariantType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -119,6 +120,44 @@ public class SchemaUtils {
     } else {
       throw new IllegalArgumentException("unsupported data type " + kernelDataType);
     }
+  }
+
+  /**
+   * Projects the union of {@code readDataSchema} and {@code partitionSchema} into DDL order. Fields
+   * not present in {@code rawSchema} (e.g. {@code _metadata}) are appended at the tail in insertion
+   * order.
+   *
+   * @throws NullPointerException if any argument is null
+   */
+  public static org.apache.spark.sql.types.StructType ddlOrderedOutputSchema(
+      org.apache.spark.sql.types.StructType rawSchema,
+      org.apache.spark.sql.types.StructType readDataSchema,
+      org.apache.spark.sql.types.StructType partitionSchema) {
+    requireNonNull(rawSchema, "rawSchema is null");
+    requireNonNull(readDataSchema, "readDataSchema is null");
+    requireNonNull(partitionSchema, "partitionSchema is null");
+    if (partitionSchema.fields().length == 0) {
+      return readDataSchema;
+    }
+    LinkedHashMap<String, org.apache.spark.sql.types.StructField> fieldsByName =
+        new LinkedHashMap<>(readDataSchema.fields().length + partitionSchema.fields().length);
+    for (org.apache.spark.sql.types.StructField f : readDataSchema.fields()) {
+      fieldsByName.put(f.name(), f);
+    }
+    for (org.apache.spark.sql.types.StructField f : partitionSchema.fields()) {
+      fieldsByName.put(f.name(), f);
+    }
+    List<org.apache.spark.sql.types.StructField> ordered = new ArrayList<>(fieldsByName.size());
+    for (org.apache.spark.sql.types.StructField f : rawSchema.fields()) {
+      org.apache.spark.sql.types.StructField projected = fieldsByName.remove(f.name());
+      if (projected != null) {
+        ordered.add(projected);
+      }
+    }
+    // Append Spark-synthetic fields not in the persisted schema (e.g. _metadata).
+    ordered.addAll(fieldsByName.values());
+    return new org.apache.spark.sql.types.StructType(
+        ordered.toArray(new org.apache.spark.sql.types.StructField[0]));
   }
 
   //////////////////////

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
@@ -16,11 +16,16 @@
 
 package io.delta.spark.internal.v2;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.List;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
@@ -101,5 +106,222 @@ public class V2ReadTest extends V2TestBase {
     long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).count();
     // 500 odd numbers from 0-999: 1, 3, 5, ..., 999
     assertTrue(count == 500, "Expected 500 rows after DV filtering, got " + count);
+  }
+
+  /**
+   * V2 batch read works correctly with a partition column declared in the middle of the schema. The
+   * reorder wrapper applies to both batch and streaming because they share {@link
+   * io.delta.spark.internal.v2.utils.PartitionUtils#createDeltaParquetReaderFactory}; this test
+   * covers the batch side.
+   */
+  @Test
+  public void testBatchReadPartitionColumnInMiddle(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    // Schema with partition column `part` declared in the MIDDLE of the DDL (ordinal 1).
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    // User-facing schema stays in DDL order.
+    assertArrayEquals(
+        new String[] {"id", "part", "col3"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1L, 10L, 100), row(2L, 20L, 200), row(3L, 30L, 300)));
+  }
+
+  @Test
+  public void testBatchReadPartitionColumnInMiddleWithPruning(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    // Project a subset that REORDERS columns (part before id) and drops col3 from the data side.
+    check(
+        str("SELECT part, id FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(10L, 1L), row(20L, 2L), row(30L, 3L)));
+    // Project only the partition column (data-side projection is empty).
+    check(
+        str("SELECT part FROM dsv2.delta.`%s` ORDER BY part", tablePath),
+        List.of(row(10L), row(20L), row(30L)));
+    // Project only a data column (partition pruned away on the read side).
+    check(
+        str("SELECT col3 FROM dsv2.delta.`%s` ORDER BY col3", tablePath),
+        List.of(row(100), row(200), row(300)));
+  }
+
+  @Test
+  public void testBatchReadPartitionColumnInMiddleWithColumnMappingId(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part) "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'id')",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    assertArrayEquals(
+        new String[] {"id", "part", "col3"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1L, 10L, 100), row(2L, 20L, 200), row(3L, 30L, 300)));
+    // Non-identity projection through the reorder + id-mode field-id pipeline.
+    check(
+        str("SELECT part, id FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(10L, 1L), row(20L, 2L), row(30L, 3L)));
+  }
+
+  @Test
+  public void testBatchReadPartitionColumnInMiddleAfterRename(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, original_col INT) "
+                + "USING delta PARTITIONED BY (part) "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 10, 100)", tablePath));
+    // Rename a data column. Physical name on disk stays put; logical name changes.
+    spark.sql(str("ALTER TABLE delta.`%s` RENAME COLUMN original_col TO renamed_col", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (2, 20, 200)", tablePath));
+    // Rename the partition column too. The reorder matches partitionSchema by logical name.
+    spark.sql(str("ALTER TABLE delta.`%s` RENAME COLUMN part TO renamed_part", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (3, 30, 300)", tablePath));
+
+    assertArrayEquals(
+        new String[] {"id", "renamed_part", "renamed_col"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1L, 10L, 100), row(2L, 20L, 200), row(3L, 30L, 300)));
+    check(
+        str("SELECT renamed_part, id FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(10L, 1L), row(20L, 2L), row(30L, 3L)));
+  }
+
+  /**
+   * Control test: V2 batch read works when the partition column is declared at the END of the
+   * schema.
+   */
+  @Test
+  public void testBatchReadPartitionColumnAtEnd(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    // Schema with partition column `part` declared at the END of the DDL (ordinal 2).
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, col3 INT, part LONG) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 100, 10), (2, 200, 20), (3, 300, 30)", tablePath));
+
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1L, 100, 10L), row(2L, 200, 20L), row(3L, 300, 30L)));
+  }
+
+  /**
+   * Multiple partition columns interleaved with data columns, declared in reverse order in {@code
+   * PARTITIONED BY}.
+   */
+  @Test
+  public void testBatchReadMultiplePartitionColumns(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (a LONG, p1 STRING, b INT, p2 STRING, c DOUBLE) "
+                + "USING delta PARTITIONED BY (p2, p1)",
+            tablePath));
+    spark
+        .createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1L, "x", 10, "y", 1.5),
+                RowFactory.create(2L, "x", 20, "z", 2.5),
+                RowFactory.create(3L, "w", 30, "y", 3.5)),
+            new org.apache.spark.sql.types.StructType()
+                .add("a", org.apache.spark.sql.types.DataTypes.LongType)
+                .add("p1", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("b", org.apache.spark.sql.types.DataTypes.IntegerType)
+                .add("p2", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("c", org.apache.spark.sql.types.DataTypes.DoubleType))
+        .write()
+        .format("delta")
+        .mode("append")
+        .partitionBy("p2", "p1")
+        .save(tablePath);
+
+    assertArrayEquals(
+        new String[] {"a", "p1", "b", "p2", "c"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY a", tablePath),
+        List.of(
+            row(1L, "x", 10, "y", 1.5), row(2L, "x", 20, "z", 2.5), row(3L, "w", 30, "y", 3.5)));
+  }
+
+  /**
+   * Deletion vectors combined with a partition column declared in the middle of the DDL. Exercises
+   * the {@code DV -> ColumnReorder} wrap chain: when DVs are produced, DV strips its internal
+   * column from {@code data ++ partitions} and ColumnReorder then permutes into DDL order. The test
+   * asserts column ordering and surviving row content; whether the DELETE chooses DV vs file
+   * rewrite is a Delta heuristic outside this test's scope.
+   */
+  @Test
+  public void testBatchReadWithDeletionVectorAndPartitionColumnInMiddle(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, val INT) USING delta "
+                + "PARTITIONED BY (part) "
+                + "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')",
+            tablePath));
+
+    spark
+        .range(2000)
+        .selectExpr("id", "id % 2 AS part", "cast(id * 10 AS INT) AS val")
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+    // Predicate must hit a small fraction so Delta picks the DV path (low-selectivity DELETE)
+    // and must NOT be a partition predicate (id is not a partition column) so it can't drop
+    // entire files.
+    spark.sql(str("DELETE FROM delta.`%s` WHERE id < 100", tablePath));
+
+    DeltaLog deltaLog = DeltaLog.forTable(spark, tablePath);
+    long numDVs =
+        (long)
+            deltaLog
+                .update(false, Option.empty(), Option.empty())
+                .numDeletionVectorsOpt()
+                .getOrElse(() -> 0L);
+    assertTrue(
+        numDVs > 0,
+        "Expected deletion vectors to be produced; test does not exercise the "
+            + "DV path otherwise");
+
+    assertArrayEquals(
+        new String[] {"id", "part", "val"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).count();
+    assertEquals(1900L, count, "Expected 1900 surviving rows (id >= 100) after delete");
+    // Spot-check a row to verify column ordering after delete + reorder.
+    Row first = spark.sql(str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath)).first();
+    assertEquals(100L, first.getLong(0));
+    assertEquals(0L, first.getLong(1));
+    assertEquals(1000, first.getInt(2));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2ReadTest.java
@@ -16,12 +16,15 @@
 
 package io.delta.spark.internal.v2;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.List;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
@@ -149,5 +152,92 @@ public class V2ReadTest extends V2TestBase {
                           + "but found one.\nPlan:\n"
                           + explainOutput);
                 }));
+  }
+
+  /**
+   * V2 batch read works correctly with a partition column declared in the middle of the schema.
+   * Included alongside streaming tests to validate consistent behavior across batch and streaming
+   * paths (V2 batch binds output from {@code Scan.readSchema()} via {@code V2ScanRelationPushDown},
+   * so it's unaffected by the DDL/reader-order mismatch that the streaming path fixes).
+   */
+  @Test
+  public void testBatchReadPartitionColumnInMiddle(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    // Schema with partition column `part` declared in the MIDDLE of the DDL (ordinal 1).
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    // User-facing schema stays in DDL order.
+    assertArrayEquals(
+        new String[] {"id", "part", "col3"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1L, 10L, 100), row(2L, 20L, 200), row(3L, 30L, 300)));
+  }
+
+  /**
+   * Control test: V2 batch read works when the partition column is declared at the END of the
+   * schema.
+   */
+  @Test
+  public void testBatchReadPartitionColumnAtEnd(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    // Schema with partition column `part` declared at the END of the DDL (ordinal 2).
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, col3 INT, part LONG) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 100, 10), (2, 200, 20), (3, 300, 30)", tablePath));
+
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1L, 100, 10L), row(2L, 200, 20L), row(3L, 300, 30L)));
+  }
+
+  /**
+   * Multiple partition columns interleaved with data columns, declared in reverse order in {@code
+   * PARTITIONED BY}.
+   */
+  @Test
+  public void testBatchReadMultiplePartitionColumns(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (a LONG, p1 STRING, b INT, p2 STRING, c DOUBLE) "
+                + "USING delta PARTITIONED BY (p2, p1)",
+            tablePath));
+    spark
+        .createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1L, "x", 10, "y", 1.5),
+                RowFactory.create(2L, "x", 20, "z", 2.5),
+                RowFactory.create(3L, "w", 30, "y", 3.5)),
+            new org.apache.spark.sql.types.StructType()
+                .add("a", org.apache.spark.sql.types.DataTypes.LongType)
+                .add("p1", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("b", org.apache.spark.sql.types.DataTypes.IntegerType)
+                .add("p2", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("c", org.apache.spark.sql.types.DataTypes.DoubleType))
+        .write()
+        .format("delta")
+        .mode("append")
+        .partitionBy("p2", "p1")
+        .save(tablePath);
+
+    assertArrayEquals(
+        new String[] {"a", "p1", "b", "p2", "c"},
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s`", tablePath)).schema().fieldNames());
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY a", tablePath),
+        List.of(
+            row(1L, "x", 10, "y", 1.5), row(2L, "x", 20, "z", 2.5), row(3L, "w", 30, "y", 3.5)));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2RowTrackingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2RowTrackingReadTest.java
@@ -385,9 +385,98 @@ public class V2RowTrackingReadTest extends DeltaV2TestBase {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  //  Helpers
-  // ---------------------------------------------------------------------------
+  /**
+   * Row tracking with a partition column declared in the MIDDLE of the DDL. Exercises the
+   * interaction between {@code RowTrackingReadFunction} (splices {@code _metadata} between data and
+   * partition columns) and {@code ColumnReorderReadFunction} (permutes data++partitions into DDL
+   * order). Without correct layering the row-mode path would emit values from the wrong column.
+   */
+  @Test
+  public void testReadWithRowTrackingAndPartitionColumnInMiddle(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (id LONG, part STRING, value DOUBLE) USING delta "
+                + "PARTITIONED BY (part) "
+                + "TBLPROPERTIES ('delta.enableRowTracking' = 'true')",
+            path));
+    spark.sql(
+        String.format(
+            "INSERT INTO delta.`%s` VALUES (1, 'a', 10.5), (2, 'b', 20.0), (3, 'a', 30.25)", path));
+
+    org.apache.spark.sql.Dataset<Row> df =
+        spark.sql(
+            String.format(
+                "SELECT id, part, value, _metadata.row_id FROM dsv2.delta.`%s` ORDER BY id", path));
+    assertArrayEquals(new String[] {"id", "part", "value", "row_id"}, df.schema().fieldNames());
+
+    List<Row> rows = df.collectAsList();
+    assertEquals(3, rows.size());
+    assertEquals(1L, rows.get(0).getLong(0));
+    assertEquals("a", rows.get(0).getString(1));
+    assertEquals(10.5d, rows.get(0).getDouble(2), 0.0d);
+    assertEquals(2L, rows.get(1).getLong(0));
+    assertEquals("b", rows.get(1).getString(1));
+    assertEquals(20.0d, rows.get(1).getDouble(2), 0.0d);
+    assertEquals(3L, rows.get(2).getLong(0));
+    assertEquals("a", rows.get(2).getString(1));
+    assertEquals(30.25d, rows.get(2).getDouble(2), 0.0d);
+    Set<Long> rowIds = new HashSet<>();
+    for (Row row : rows) {
+      assertTrue(rowIds.add(row.getLong(3)), "row_id should be unique");
+    }
+  }
+
+  @Test
+  public void testReadWithRowTrackingAndDeletionVectorAndPartitionColumnInMiddle(
+      @TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, value INT) USING delta "
+                + "PARTITIONED BY (part) "
+                + "TBLPROPERTIES ("
+                + "'delta.enableRowTracking' = 'true', "
+                + "'delta.enableDeletionVectors' = 'true')",
+            path));
+    // Insert enough rows so DELETE picks the DV path instead of rewriting whole files.
+    spark
+        .range(1000)
+        .selectExpr("id", "id % 4 AS part", "cast(id * 10 AS INT) AS value")
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(path);
+    // Low-selectivity, non-partition predicate so Delta uses DVs.
+    spark.sql(String.format("DELETE FROM delta.`%s` WHERE id < 100", path));
+
+    DeltaLog deltaLog = DeltaLog.forTable(spark, path);
+    long numDVs =
+        (long)
+            deltaLog
+                .update(false, Option.empty(), Option.empty())
+                .numDeletionVectorsOpt()
+                .getOrElse(() -> 0L);
+    assertTrue(numDVs > 0, "Expected deletion vectors to be produced");
+
+    org.apache.spark.sql.Dataset<Row> df =
+        spark.sql(
+            String.format(
+                "SELECT id, part, value, _metadata.row_id FROM dsv2.delta.`%s` ORDER BY id", path));
+    assertArrayEquals(new String[] {"id", "part", "value", "row_id"}, df.schema().fieldNames());
+
+    List<Row> rows = df.collectAsList();
+    assertEquals(900, rows.size(), "Expected 900 surviving rows (id >= 100) after DV delete");
+    Set<Long> rowIds = new HashSet<>();
+    for (Row row : rows) {
+      long id = row.getLong(0);
+      long part = row.getLong(1);
+      int value = row.getInt(2);
+      assertEquals(id % 4, part, "Partition column should match insert formula");
+      assertEquals((int) (id * 10), value, "Value column should match insert formula");
+      assertTrue(rowIds.add(row.getLong(3)), "row_id should be unique under DV filtering");
+    }
+  }
 
   /**
    * Queries row tracking metadata via the DSv2 SQL path. V2 metadata columns are nested in

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
@@ -471,4 +471,89 @@ public class V2StreamingReadTest extends V2TestBase {
         ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"),
         "Expected DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART but got: " + ex.getMessage());
   }
+
+  @Test
+  public void testStreamingReadPartitionColumnInMiddle(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    // User-facing schema must stay in DDL order so V2 matches V1 streaming behavior.
+    assertArrayEquals(new String[] {"id", "part", "col3"}, streamingDF.schema().fieldNames());
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_middle_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, 10L, 100),
+            RowFactory.create(2L, 20L, 200),
+            RowFactory.create(3L, 30L, 300));
+    assertDataEquals(actualRows, expectedRows);
+  }
+
+  @Test
+  public void testStreamingReadPartitionColumnAtEnd(@TempDir File deltaTablePath) throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, col3 INT, part LONG) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 100, 10), (2, 200, 20), (3, 300, 30)", tablePath));
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_end_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, 100, 10L),
+            RowFactory.create(2L, 200, 20L),
+            RowFactory.create(3L, 300, 30L));
+    assertDataEquals(actualRows, expectedRows);
+  }
+
+  @Test
+  public void testStreamingReadMultiplePartitionColumns(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    // DDL order: a, p1, b, p2, c. Partition cols at positions 1 and 3; declared in reverse order.
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (a LONG, p1 STRING, b INT, p2 STRING, c DOUBLE) "
+                + "USING delta PARTITIONED BY (p2, p1)",
+            tablePath));
+    // Use DataFrame writer so partition columns are routed correctly through the V1 write path.
+    spark
+        .createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1L, "x", 10, "y", 1.5),
+                RowFactory.create(2L, "x", 20, "z", 2.5),
+                RowFactory.create(3L, "w", 30, "y", 3.5)),
+            new org.apache.spark.sql.types.StructType()
+                .add("a", org.apache.spark.sql.types.DataTypes.LongType)
+                .add("p1", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("b", org.apache.spark.sql.types.DataTypes.IntegerType)
+                .add("p2", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("c", org.apache.spark.sql.types.DataTypes.DoubleType))
+        .write()
+        .format("delta")
+        .mode("append")
+        .partitionBy("p2", "p1")
+        .save(tablePath);
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    assertArrayEquals(new String[] {"a", "p1", "b", "p2", "c"}, streamingDF.schema().fieldNames());
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_multi_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, "x", 10, "y", 1.5),
+            RowFactory.create(2L, "x", 20, "z", 2.5),
+            RowFactory.create(3L, "w", 30, "y", 3.5));
+    assertDataEquals(actualRows, expectedRows);
+  }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
@@ -469,4 +469,109 @@ public class V2StreamingReadTest extends V2TestBase {
         ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"),
         "Expected DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART but got: " + ex.getMessage());
   }
+
+  /**
+   * V2 streaming read works when the partition column is declared in the MIDDLE of the schema.
+   *
+   * <p>Previously hit a {@code NullPointerException} in {@code OnHeapColumnVector.getLong} because
+   * {@code SparkScan.readSchema()} returns {@code dataSchema ++ partitionSchema} (partitions at
+   * end) while {@code StreamingRelationV2.output} was bound from {@code SparkTable.schema()} (DDL
+   * order), so ordinal-based column vector access in the streaming codegen path landed on a
+   * type-mismatched vector. {@code ColumnReorderReadFunction} now permutes the reader's {@code
+   * ColumnarBatch}/{@code InternalRow} output to DDL order so it matches what codegen expects.
+   */
+  @Test
+  public void testStreamingReadPartitionColumnInMiddle(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)", tablePath));
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    // User-facing schema must stay in DDL order so V2 matches V1 streaming behavior.
+    assertArrayEquals(new String[] {"id", "part", "col3"}, streamingDF.schema().fieldNames());
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_middle_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, 10L, 100),
+            RowFactory.create(2L, 20L, 200),
+            RowFactory.create(3L, 30L, 300));
+    assertDataEquals(actualRows, expectedRows);
+  }
+
+  /**
+   * Control test: V2 streaming read works when the partition column is declared at the END of the
+   * schema. In this case {@code SparkScan.readSchema()} (dataSchema ++ partitionSchema) already
+   * matches {@code SparkTable.schema()} (DDL order), and the reorder is a no-op permutation.
+   */
+  @Test
+  public void testStreamingReadPartitionColumnAtEnd(@TempDir File deltaTablePath) throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, col3 INT, part LONG) "
+                + "USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 100, 10), (2, 200, 20), (3, 300, 30)", tablePath));
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_end_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, 100, 10L),
+            RowFactory.create(2L, 200, 20L),
+            RowFactory.create(3L, 300, 30L));
+    assertDataEquals(actualRows, expectedRows);
+  }
+
+  /**
+   * Multiple partition columns interleaved with data columns, declared in reverse order in {@code
+   * PARTITIONED BY}. Exercises {@code ColumnReorderReadFunction}'s permutation logic with more than
+   * one partition column and with partition-list order differing from DDL order.
+   */
+  @Test
+  public void testStreamingReadMultiplePartitionColumns(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    // DDL order: a, p1, b, p2, c. Partition cols at positions 1 and 3; declared in reverse order.
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (a LONG, p1 STRING, b INT, p2 STRING, c DOUBLE) "
+                + "USING delta PARTITIONED BY (p2, p1)",
+            tablePath));
+    // Use DataFrame writer so partition columns are routed correctly through the V1 write path.
+    spark
+        .createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1L, "x", 10, "y", 1.5),
+                RowFactory.create(2L, "x", 20, "z", 2.5),
+                RowFactory.create(3L, "w", 30, "y", 3.5)),
+            new org.apache.spark.sql.types.StructType()
+                .add("a", org.apache.spark.sql.types.DataTypes.LongType)
+                .add("p1", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("b", org.apache.spark.sql.types.DataTypes.IntegerType)
+                .add("p2", org.apache.spark.sql.types.DataTypes.StringType)
+                .add("c", org.apache.spark.sql.types.DataTypes.DoubleType))
+        .write()
+        .format("delta")
+        .mode("append")
+        .partitionBy("p2", "p1")
+        .save(tablePath);
+
+    Dataset<Row> streamingDF = spark.readStream().table(str("dsv2.delta.`%s`", tablePath));
+    assertArrayEquals(new String[] {"a", "p1", "b", "p2", "c"}, streamingDF.schema().fieldNames());
+    List<Row> actualRows = processStreamingQuery(streamingDF, "test_partition_multi_ok");
+    List<Row> expectedRows =
+        Arrays.asList(
+            RowFactory.create(1L, "x", 10, "y", 1.5),
+            RowFactory.create(2L, "x", 20, "z", 2.5),
+            RowFactory.create(3L, "w", 30, "y", 3.5));
+    assertDataEquals(actualRows, expectedRows);
+  }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunctionTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunctionTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import static io.delta.spark.internal.v2.InternalRowTestUtils.collectBatches;
+import static io.delta.spark.internal.v2.InternalRowTestUtils.mockBatchReader;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.jupiter.api.Test;
+import scala.Function1;
+import scala.collection.Iterator;
+import scala.collection.JavaConverters;
+import scala.runtime.AbstractFunction1;
+
+public class ColumnReorderReadFunctionTest {
+
+  // Reader yields (data ++ partition): (id, col3) ++ (part).
+  private static final StructType DATA_SCHEMA =
+      new StructType().add("id", DataTypes.LongType).add("col3", DataTypes.IntegerType);
+  private static final StructType PARTITION_SCHEMA =
+      new StructType().add("part", DataTypes.LongType);
+
+  /** When the target schema matches the reader's natural data ++ partition layout, wrap is noop. */
+  @Test
+  public void testWrap_identityMapping_returnsBaseReaderUnchanged() {
+    StructType natural =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType)
+            .add("part", DataTypes.LongType);
+    Function1<PartitionedFile, Iterator<InternalRow>> base = constantReader(row(1L, 100, 10L));
+    Function1<PartitionedFile, Iterator<InternalRow>> wrapped =
+        ColumnReorderReadFunction.wrap(
+            base, /* isVectorizedReader= */ false, DATA_SCHEMA, PARTITION_SCHEMA, natural);
+    assertSame(base, wrapped, "Identity mapping should skip the reorder wrapper");
+  }
+
+  /** Row-mode reorder: target advertises DDL order (id, part, col3). */
+  @Test
+  public void testWrap_rowMode_reordersFieldsByName() {
+    StructType ddlOrder =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType);
+    InternalRow input = row(1L, 100, 10L);
+    Function1<PartitionedFile, Iterator<InternalRow>> base = constantReader(input);
+    Function1<PartitionedFile, Iterator<InternalRow>> wrapped =
+        ColumnReorderReadFunction.wrap(
+            base, /* isVectorizedReader= */ false, DATA_SCHEMA, PARTITION_SCHEMA, ddlOrder);
+
+    Iterator<InternalRow> it = wrapped.apply(/* file= */ null);
+    InternalRow out = it.next();
+    assertEquals(1L, out.getLong(0), "id stays at ordinal 0");
+    assertEquals(10L, out.getLong(1), "part moved to ordinal 1");
+    assertEquals(100, out.getInt(2), "col3 moved to ordinal 2");
+  }
+
+  /**
+   * Tail fields in target that aren't in data or partition (e.g. CDC) are assumed to live at the
+   * reader's tail and identity-map; data/partition also shift into DDL order.
+   */
+  @Test
+  public void testWrap_rowMode_targetTailFieldsAreIdentityMapped() {
+    // Reader yields (id, col3, part, _change_type). Target = (id, part, col3, _change_type).
+    StructType targetWithCdcTail =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType)
+            .add("_change_type", DataTypes.StringType);
+    GenericInternalRow input = new GenericInternalRow(4);
+    input.setLong(0, 1L);
+    input.setInt(1, 100);
+    input.setLong(2, 10L);
+    input.update(3, org.apache.spark.unsafe.types.UTF8String.fromString("insert"));
+
+    Function1<PartitionedFile, Iterator<InternalRow>> wrapped =
+        ColumnReorderReadFunction.wrap(
+            constantReader(input),
+            /* isVectorizedReader= */ false,
+            DATA_SCHEMA,
+            PARTITION_SCHEMA,
+            targetWithCdcTail);
+
+    InternalRow out = wrapped.apply(/* file= */ null).next();
+    assertEquals(1L, out.getLong(0));
+    assertEquals(10L, out.getLong(1));
+    assertEquals(100, out.getInt(2));
+    assertEquals("insert", out.getUTF8String(3).toString());
+  }
+
+  @Test
+  public void testWrap_batchMode_reordersColumnVectors() {
+    StructType ddlOrder =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType);
+    int numRows = 2;
+    WritableColumnVector idCol = new OnHeapColumnVector(numRows, DataTypes.LongType);
+    WritableColumnVector col3Col = new OnHeapColumnVector(numRows, DataTypes.IntegerType);
+    WritableColumnVector partCol = new OnHeapColumnVector(numRows, DataTypes.LongType);
+    idCol.putLong(0, 1L);
+    idCol.putLong(1, 2L);
+    col3Col.putInt(0, 100);
+    col3Col.putInt(1, 200);
+    partCol.putLong(0, 10L);
+    partCol.putLong(1, 20L);
+    // Reader yields (id, col3, part).
+    ColumnarBatch batch = new ColumnarBatch(new ColumnVector[] {idCol, col3Col, partCol}, numRows);
+
+    Function1<PartitionedFile, Iterator<InternalRow>> wrapped =
+        ColumnReorderReadFunction.wrap(
+            mockBatchReader(List.of(batch)),
+            /* isVectorizedReader= */ true,
+            DATA_SCHEMA,
+            PARTITION_SCHEMA,
+            ddlOrder);
+
+    List<ColumnarBatch> result = collectBatches(wrapped.apply(/* file= */ null));
+    assertEquals(1, result.size());
+    ColumnarBatch out = result.get(0);
+    assertEquals(numRows, out.numRows());
+    assertEquals(3, out.numCols());
+    // Output layout is (id, part, col3).
+    assertEquals(1L, out.column(0).getLong(0));
+    assertEquals(2L, out.column(0).getLong(1));
+    assertEquals(10L, out.column(1).getLong(0));
+    assertEquals(20L, out.column(1).getLong(1));
+    assertEquals(100, out.column(2).getInt(0));
+    assertEquals(200, out.column(2).getInt(1));
+  }
+
+  @Test
+  public void testWrap_batchMode_throwsWhenUpstreamYieldsNonBatch() {
+    StructType ddlOrder =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType);
+    Function1<PartitionedFile, Iterator<InternalRow>> wrapped =
+        ColumnReorderReadFunction.wrap(
+            constantReader(row(1L, 100, 10L)),
+            /* isVectorizedReader= */ true,
+            DATA_SCHEMA,
+            PARTITION_SCHEMA,
+            ddlOrder);
+
+    Iterator<InternalRow> it = wrapped.apply(/* file= */ null);
+    IllegalStateException ex = assertThrows(IllegalStateException.class, it::next);
+    assertEquals(true, ex.getMessage().startsWith("Expected ColumnarBatch"));
+  }
+
+  private static InternalRow row(long id, int col3, long part) {
+    GenericInternalRow r = new GenericInternalRow(3);
+    r.setLong(0, id);
+    r.setInt(1, col3);
+    r.setLong(2, part);
+    return r;
+  }
+
+  private static Function1<PartitionedFile, Iterator<InternalRow>> constantReader(InternalRow row) {
+    return new AbstractFunction1<PartitionedFile, Iterator<InternalRow>>() {
+      @Override
+      public Iterator<InternalRow> apply(PartitionedFile file) {
+        return JavaConverters.asScalaIterator(java.util.Collections.singletonList(row).iterator());
+      }
+    };
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
@@ -862,6 +862,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         /* dataSchema= */ tableSchema,
         /* partitionSchema= */ new StructType(),
         /* readDataSchema= */ new StructType(),
+        /* ddlOrderedReadOutputSchema= */ new StructType(),
         /* dataFilters= */ new org.apache.spark.sql.sources.Filter[0],
         /* scalaOptions= */ scala.collection.immutable.Map$.MODULE$.empty());
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -24,6 +24,7 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
 import java.io.File;
 import java.nio.channels.ClosedByInterruptException;
 import java.sql.Timestamp;
@@ -2055,6 +2056,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             dataSchema,
             partitionSchema,
             dataSchema,
+            SchemaUtils.ddlOrderedOutputSchema(
+                io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
+                    snapshotManager.loadLatestSnapshot().getSchema()),
+                dataSchema,
+                partitionSchema),
             new org.apache.spark.sql.sources.Filter[0],
             Map$.MODULE$.empty());
 
@@ -2235,7 +2241,12 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             testTablePath,
             dataSchema,
             partitionSchema,
-            fullSchema,
+            dataSchema,
+            SchemaUtils.ddlOrderedOutputSchema(
+                io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
+                    snapshotManager.loadLatestSnapshot().getSchema()),
+                dataSchema,
+                partitionSchema),
             new org.apache.spark.sql.sources.Filter[0],
             Map$.MODULE$.empty());
 
@@ -3832,6 +3843,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         /* dataSchema= */ tableSchema,
         /* partitionSchema= */ new StructType(),
         /* readDataSchema= */ new StructType(),
+        /* ddlOrderedReadOutputSchema= */ new StructType(),
         /* dataFilters= */ new org.apache.spark.sql.sources.Filter[0],
         /* scalaOptions= */ scala.collection.immutable.Map$.MODULE$.empty());
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -58,6 +58,7 @@ import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
 import org.apache.spark.sql.delta.sources.ReadMaxBytes;
 import org.apache.spark.sql.delta.storage.ClosableIterator;
 import org.apache.spark.sql.delta.util.JsonUtils;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
@@ -3879,5 +3880,149 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         closedFlag.set(true);
       }
     };
+  }
+
+  // ==========================================================================
+  // validateSchemaCompatibilityOnStartup
+  // ==========================================================================
+
+  @Test
+  public void testValidateSchema_partitionColumnInMiddle_succeeds() {
+    // Reproduces the bug fixed in PR #6583: partition column declared in the middle of the
+    // table schema must not trip the structural equality check on stream restart.
+    StructType dataSchema =
+        new StructType().add("id", DataTypes.LongType).add("col3", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType().add("part", DataTypes.LongType);
+    StructType snapshotSchema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType);
+
+    assertDoesNotThrow(
+        () ->
+            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                dataSchema, partitionSchema, snapshotSchema));
+  }
+
+  @Test
+  public void testValidateSchema_partitionColumnAtEnd_succeeds() {
+    StructType dataSchema =
+        new StructType().add("id", DataTypes.LongType).add("col3", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType().add("part", DataTypes.LongType);
+    StructType snapshotSchema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType)
+            .add("part", DataTypes.LongType);
+
+    assertDoesNotThrow(
+        () ->
+            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                dataSchema, partitionSchema, snapshotSchema));
+  }
+
+  @Test
+  public void testValidateSchema_analysisHasExtraColumn_throws() {
+    StructType dataSchema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType)
+            .add("dropped", DataTypes.StringType);
+    StructType partitionSchema = new StructType().add("part", DataTypes.LongType);
+    StructType snapshotSchema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType);
+
+    DeltaIllegalStateException ex =
+        assertThrows(
+            DeltaIllegalStateException.class,
+            () ->
+                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                    dataSchema, partitionSchema, snapshotSchema));
+    assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
+  }
+
+  @Test
+  public void testValidateSchema_snapshotHasExtraColumn_throws() {
+    StructType dataSchema =
+        new StructType().add("id", DataTypes.LongType).add("col3", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType().add("part", DataTypes.LongType);
+    StructType snapshotSchema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType)
+            .add("added", DataTypes.StringType);
+
+    DeltaIllegalStateException ex =
+        assertThrows(
+            DeltaIllegalStateException.class,
+            () ->
+                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                    dataSchema, partitionSchema, snapshotSchema));
+    assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
+  }
+
+  @Test
+  public void testValidateSchema_columnTypeChanged_throws() {
+    StructType dataSchema =
+        new StructType().add("id", DataTypes.IntegerType).add("col3", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType().add("part", DataTypes.LongType);
+    StructType snapshotSchema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("part", DataTypes.LongType)
+            .add("col3", DataTypes.IntegerType);
+
+    DeltaIllegalStateException ex =
+        assertThrows(
+            DeltaIllegalStateException.class,
+            () ->
+                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                    dataSchema, partitionSchema, snapshotSchema));
+    assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
+  }
+
+  @Test
+  public void testValidateSchema_nestedStructMatches_succeeds() {
+    StructType inner = new StructType().add("x", DataTypes.IntegerType);
+    StructType dataSchema = new StructType().add("id", DataTypes.LongType).add("data", inner);
+    StructType partitionSchema = new StructType();
+    StructType snapshotSchema = new StructType().add("id", DataTypes.LongType).add("data", inner);
+
+    assertDoesNotThrow(
+        () ->
+            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                dataSchema, partitionSchema, snapshotSchema));
+  }
+
+  @Test
+  public void testValidateSchema_columnRenamed_throws() {
+    StructType dataSchema = new StructType().add("a", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType();
+    StructType snapshotSchema = new StructType().add("b", DataTypes.IntegerType);
+
+    DeltaIllegalStateException ex =
+        assertThrows(
+            DeltaIllegalStateException.class,
+            () ->
+                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                    dataSchema, partitionSchema, snapshotSchema));
+    assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
+  }
+
+  @Test
+  public void testValidateSchema_columnNameCaseDiffers_succeeds() {
+    StructType dataSchema = new StructType().add("Id", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType();
+    StructType snapshotSchema = new StructType().add("id", DataTypes.IntegerType);
+
+    assertDoesNotThrow(
+        () ->
+            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                dataSchema, partitionSchema, snapshotSchema));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
@@ -131,6 +131,11 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
         new StructType(
             new StructField[] {DataTypes.createStructField("part", DataTypes.StringType, true)});
     StructType readDataSchema = dataSchema;
+    StructType ddlOrderedReadOutputSchema =
+        SchemaUtils.ddlOrderedOutputSchema(
+            SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema()),
+            readDataSchema,
+            partitionSchema);
     Filter[] filters = new Filter[0];
     scala.collection.immutable.Map<String, String> options = Map$.MODULE$.empty();
     Configuration hadoopConf = new Configuration();
@@ -142,6 +147,7 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
             dataSchema,
             partitionSchema,
             readDataSchema,
+            ddlOrderedReadOutputSchema,
             filters,
             options,
             hadoopConf,
@@ -167,6 +173,11 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
         new StructType(
             new StructField[] {DataTypes.createStructField("part", DataTypes.StringType, true)});
     StructType readDataSchema = dataSchema;
+    StructType ddlOrderedReadOutputSchema =
+        SchemaUtils.ddlOrderedOutputSchema(
+            SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema()),
+            readDataSchema,
+            partitionSchema);
     Filter[] filters = new Filter[0];
     scala.collection.immutable.Map<String, String> options = Map$.MODULE$.empty();
     Configuration hadoopConf = new Configuration();
@@ -178,6 +189,7 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
             dataSchema,
             partitionSchema,
             readDataSchema,
+            ddlOrderedReadOutputSchema,
             filters,
             options,
             hadoopConf,
@@ -275,6 +287,157 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
     assertNotNull(partitionedFile);
     assertEquals(addFile.getSize(), partitionedFile.fileSize());
     assertEquals(1, partitionedFile.partitionValues().numFields());
+  }
+
+  @Test
+  public void testDdlOrderedOutputSchema_PartitionInMiddleInterleavedAtDdlPosition() {
+    String tablePath = getTempTablePath("ddl_order_middle_" + System.nanoTime());
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) USING delta "
+                + "PARTITIONED BY (part)",
+            tablePath));
+    Snapshot snapshot = Table.forPath(defaultEngine, tablePath).getLatestSnapshot(defaultEngine);
+
+    StructType readDataSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, true),
+              DataTypes.createStructField("col3", DataTypes.IntegerType, true)
+            });
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("part", DataTypes.LongType, true)});
+
+    StructType result =
+        SchemaUtils.ddlOrderedOutputSchema(
+            SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema()),
+            readDataSchema,
+            partitionSchema);
+    assertArrayEquals(new String[] {"id", "part", "col3"}, result.fieldNames());
+  }
+
+  @Test
+  public void testDdlOrderedOutputSchema_PartitionAtEndIsIdentity() {
+    String tablePath = getTempTablePath("ddl_order_end_" + System.nanoTime());
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (id LONG, col3 INT, part LONG) USING delta "
+                + "PARTITIONED BY (part)",
+            tablePath));
+    Snapshot snapshot = Table.forPath(defaultEngine, tablePath).getLatestSnapshot(defaultEngine);
+
+    StructType readDataSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, true),
+              DataTypes.createStructField("col3", DataTypes.IntegerType, true)
+            });
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("part", DataTypes.LongType, true)});
+
+    StructType result =
+        SchemaUtils.ddlOrderedOutputSchema(
+            SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema()),
+            readDataSchema,
+            partitionSchema);
+    assertArrayEquals(new String[] {"id", "col3", "part"}, result.fieldNames());
+  }
+
+  @Test
+  public void testDdlOrderedOutputSchema_NoPartitionsShortCircuits() {
+    String tablePath = getTempTablePath("ddl_order_no_part_" + System.nanoTime());
+    spark.sql(String.format("CREATE TABLE delta.`%s` (id LONG, col3 INT) USING delta", tablePath));
+    Snapshot snapshot = Table.forPath(defaultEngine, tablePath).getLatestSnapshot(defaultEngine);
+
+    StructType readDataSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, true),
+              DataTypes.createStructField("col3", DataTypes.IntegerType, true)
+            });
+    StructType emptyPartitions = new StructType(new StructField[0]);
+
+    StructType result =
+        SchemaUtils.ddlOrderedOutputSchema(
+            SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema()),
+            readDataSchema,
+            emptyPartitions);
+    // Returns the readDataSchema instance unchanged (short-circuit).
+    assertSame(readDataSchema, result);
+  }
+
+  @Test
+  public void testDdlOrderedOutputSchema_MetadataLeftoverAppendedAtEnd() {
+    String tablePath = getTempTablePath("ddl_order_meta_" + System.nanoTime());
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (id LONG, part LONG, col3 INT) USING delta "
+                + "PARTITIONED BY (part)",
+            tablePath));
+    Snapshot snapshot = Table.forPath(defaultEngine, tablePath).getLatestSnapshot(defaultEngine);
+
+    // _metadata is a synthetic Spark column not in the persisted schema; verify it lands at the
+    // tail in insertion order rather than being interleaved.
+    StructField metadataField =
+        DataTypes.createStructField(
+            "_metadata",
+            new StructType(
+                new StructField[] {
+                  DataTypes.createStructField("file_path", DataTypes.StringType, true)
+                }),
+            true);
+    StructType readDataSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, true),
+              DataTypes.createStructField("col3", DataTypes.IntegerType, true),
+              metadataField
+            });
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("part", DataTypes.LongType, true)});
+
+    StructType result =
+        SchemaUtils.ddlOrderedOutputSchema(
+            SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema()),
+            readDataSchema,
+            partitionSchema);
+    assertArrayEquals(new String[] {"id", "part", "col3", "_metadata"}, result.fieldNames());
+  }
+
+  @Test
+  public void testDdlOrderedOutputSchema_MultiplePartitionsInterleaved() {
+    String tablePath = getTempTablePath("ddl_order_multi_" + System.nanoTime());
+    // PARTITIONED BY order intentionally differs from DDL order to exercise both axes.
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (a LONG, p1 STRING, b INT, p2 STRING, c DOUBLE) USING delta "
+                + "PARTITIONED BY (p2, p1)",
+            tablePath));
+    Snapshot snapshot = Table.forPath(defaultEngine, tablePath).getLatestSnapshot(defaultEngine);
+
+    StructType readDataSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("a", DataTypes.LongType, true),
+              DataTypes.createStructField("b", DataTypes.IntegerType, true),
+              DataTypes.createStructField("c", DataTypes.DoubleType, true)
+            });
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("p2", DataTypes.StringType, true),
+              DataTypes.createStructField("p1", DataTypes.StringType, true)
+            });
+
+    StructType result =
+        SchemaUtils.ddlOrderedOutputSchema(
+            SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema()),
+            readDataSchema,
+            partitionSchema);
+    assertArrayEquals(new String[] {"a", "p1", "b", "p2", "c"}, result.fieldNames());
   }
 
   /** Helper to create a test Delta table. */


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6610/files) to review incremental changes.
- [stack/schema-fix](https://github.com/delta-io/delta/pull/6583) [[Files changed](https://github.com/delta-io/delta/pull/6583/files)] [MERGED]
  - [**stack/npe-fix**](https://github.com/delta-io/delta/pull/6610) [[Files changed](https://github.com/delta-io/delta/pull/6610/files)]
    - stack/schema-context
  - [stack/npe-project](https://github.com/delta-io/delta/pull/6609) [[Files changed](https://github.com/delta-io/delta/pull/6609/files)]

---------
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

V2 streaming reads NPE in `OnHeapColumnVector.getLong` when a partition column is declared **not at the end** of the DDL. `SparkTable.schema()` returns DDL order `(id, part, col3)` while `SparkScan.readSchema()` returned `dataSchema ++ partitionSchema` = `(id, col3, col)`. Streaming codegen binds ordinals against DDL order but the reader produces batches in data++partitions order → wrong `ColumnVector` → NPE.

## How was this patch tested?

- New E2E test: `DeltaSourceSuite.streaming read returns correct data from table with partition column in middle` (V1 + V2) with a `DataFrame.schema` assertion; plus `reading from table with multiple partition columns succeeds during restart`.

## Does this PR introduce _any_ user-facing changes?

No.