### PR TITLE
[Spark] Support implicit casting for DataFrame by-name writes to Delta tables

### DIFF
--- a/spark/src/main/scala/io/delta/sql/AbstractDeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/AbstractDeltaSparkSessionExtension.scala
@@ -55,6 +55,10 @@ class AbstractDeltaSparkSessionExtension extends (SparkSessionExtensions => Unit
     extensions.injectResolutionRule { session =>
       PreprocessTimeTravel(session)
     }
+    // DeltaImplicitCast handles implicit casting for dataframe by-name V2WriteCommands.
+    extensions.injectResolutionRule { session =>
+      DeltaImplicitCast(session)
+    }
     extensions.injectResolutionRule { _ => PropagateSchemaEvolutionWriteOptionShims }
     extensions.injectResolutionRule { session =>
       // To ensure the parquet field id reader is turned on, these fields are required to support

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -106,7 +106,8 @@ class DeltaAnalysis(session: SparkSession)
         targetAttrs = r.output,
         deltaTable = d,
         writeOptions = a.writeOptions,
-        allowSchemaEvolution = true)
+        allowSchemaEvolution = true,
+        isDfByNameInsert = false)
       if (projection != a.query) {
         a.copy(query = projection)
       } else {
@@ -346,7 +347,8 @@ class DeltaAnalysis(session: SparkSession)
         targetAttrs = r.output,
         deltaTable = d,
         writeOptions = o.writeOptions,
-        allowSchemaEvolution = true)
+        allowSchemaEvolution = true,
+        isDfByNameInsert = false)
       if (projection != o.query) {
         val aliases = AttributeMap(o.query.output.zip(projection.output).collect {
           case (l: AttributeReference, r: AttributeReference) if !l.sameRef(r) => (l, r)
@@ -377,7 +379,8 @@ class DeltaAnalysis(session: SparkSession)
           targetAttrs = r.output,
           deltaTable = d,
           writeOptions = o.writeOptions,
-          allowSchemaEvolution = true)
+          allowSchemaEvolution = true,
+          isDfByNameInsert = false)
       } else {
         o.query
       }
@@ -1038,19 +1041,26 @@ class DeltaAnalysis(session: SparkSession)
    * generated columns. If values of any columns are not in the query output, they must be generated
    * columns.
    */
-  private def resolveQueryColumnsByName(
+  protected def resolveQueryColumnsByName(
       query: LogicalPlan,
       targetAttrs: Seq[Attribute],
       deltaTable: DeltaTableV2,
       writeOptions: Map[String, String],
-      allowSchemaEvolution: Boolean = false): LogicalPlan = {
+      allowSchemaEvolution: Boolean = false,
+      isDfByNameInsert: Boolean): LogicalPlan = {
     // Schema evolution is only effective when mergeSchema is enabled in write options AND
-    // the feature is enabled via SQL conf.
-    val effectiveSchemaEvolution = allowSchemaEvolution &&
+    // the feature is enabled via SQL conf. For dataframe by-name queries, the schema evolution
+    // check is always deferred until after DeltaAnalysis, so avoid throwing here.
+    val effectiveSchemaEvolution = allowSchemaEvolution && (isDfByNameInsert ||
       new DeltaOptions(deltaTable.options ++ writeOptions, conf).canMergeSchema &&
-      session.conf.get(DeltaSQLConf.DELTA_INSERT_BY_NAME_SCHEMA_EVOLUTION_ENABLED)
+      session.conf.get(DeltaSQLConf.DELTA_INSERT_BY_NAME_SCHEMA_EVOLUTION_ENABLED))
 
-    insertIntoByNameMissingColumn(query, targetAttrs, deltaTable, effectiveSchemaEvolution)
+    // DataFrame by-name inserts always allow missing columns; SQL BY NAME inserts only allow
+    // them when USE_NULLS_FOR_DEFAULT_COLUMN_VALUES is set or the column has a default/generated
+    // expression. isDfByNameInsert=false signals the SQL path, which needs the stricter check.
+    if (!isDfByNameInsert) {
+      insertIntoByNameMissingColumn(query, targetAttrs, deltaTable, effectiveSchemaEvolution)
+    }
 
     // This is called before resolveOutputColumns in postHocResolutionRules, so we need to duplicate
     // the schema validation here.
@@ -1072,7 +1082,8 @@ class DeltaAnalysis(session: SparkSession)
           }
         }
       addCastToColumn(attr, targetAttr, deltaTable.name(),
-        typeWideningMode = getTypeWideningMode(deltaTable, writeOptions)
+        typeWideningMode = getTypeWideningMode(deltaTable, writeOptions),
+        byName = isDfByNameInsert
       )
     }
     Project(project, query)
@@ -1082,29 +1093,47 @@ class DeltaAnalysis(session: SparkSession)
       attr: NamedExpression,
       targetAttr: NamedExpression,
       tblName: String,
-      typeWideningMode: TypeWideningMode): NamedExpression = {
+      typeWideningMode: TypeWideningMode,
+      byName: Boolean = false): NamedExpression = {
     val expr = (attr.dataType, targetAttr.dataType) match {
       case (s, t) if s == t =>
         attr
       case (s: StructType, t: StructType) if s != t =>
-        addCastsToStructs(tblName, attr, s, t, typeWideningMode)
+        if (byName) {
+          addCastsToStructsByName(tblName, attr, s, t, typeWideningMode)
+        } else {
+          addCastsToStructsByPosition(tblName, attr, s, t, typeWideningMode)
+        }
       case (ArrayType(s: StructType, sNull: Boolean), ArrayType(t: StructType, tNull: Boolean))
         if s != t && sNull == tNull =>
-        addCastsToArrayStructs(tblName, attr, s, t, sNull, typeWideningMode)
+        addCastsToArrayStructs(tblName, attr, s, t, sNull, typeWideningMode, byName)
+      case (ArrayType(s, sNull: Boolean), ArrayType(t, tNull: Boolean)) if byName && s != t =>
+        // General array element casting for non-struct elements currently only for by-name inserts.
+        // Recursively applies addCastToColumn to each element via ArrayTransform.
+        val elementVar = NamedLambdaVariable("element", s, sNull)
+        val targetElementAttr = AttributeReference("element", t, tNull)()
+        val castedElement = addCastToColumn(
+          elementVar, targetElementAttr, tblName, typeWideningMode, byName)
+        ArrayTransform(attr, LambdaFunction(castedElement, Seq(elementVar)))
+      case (_, _: NullType) if byName =>
+        attr
       case (s: AtomicType, t: AtomicType)
         if typeWideningMode.shouldWidenTo(fromType = t, toType = s) =>
         // Keep the type from the query, the target schema will be updated to widen the existing
         // type to match it.
         attr
       case (s: MapType, t: MapType)
-        if !DataType.equalsStructurally(s, t, ignoreNullability = true) =>
+        if !DataType.equalsStructurally(s, t, ignoreNullability = true) || (byName && s != t) =>
         // only trigger addCastsToMaps if exists differences like extra fields, renaming or type
-        // differences.
-        addCastsToMaps(tblName, attr, s, t, typeWideningMode)
+        // differences. When by-name, always trigger as equalsStructurally is a positional check.
+        addCastsToMaps(tblName, attr, s, t, typeWideningMode, byName)
       case _ =>
         getCastFunction(attr, targetAttr.dataType, targetAttr.name)
     }
-    Alias(expr, targetAttr.name)(explicitMetadata = Option(targetAttr.metadata))
+    // Preserve source name when byName=true to let downstream handle normalization.
+    val fieldName = if (byName) attr.name else targetAttr.name
+    val metadata = if (byName) attr.metadata else targetAttr.metadata
+    Alias(expr, fieldName)(explicitMetadata = Option(metadata))
   }
 
   /**
@@ -1209,14 +1238,23 @@ class DeltaAnalysis(session: SparkSession)
    * of INSERT INTO. Here we check if we need to perform any schema adjustment for INSERT INTO by
    * name queries. We also check that any columns not in the list of user-specified columns must
    * have a default expression.
+   *
+   * @param isDfByNameInsert True for DataFrame by-name inserts, false for SQL by name inserts. On
+   *                         the first analyzer pass, controls two behaviors: (1) whether missing
+   *                         non-generated columns are an error, and (2) whether struct field
+   *                         comparison respects session case-sensitivity. Subsequent passes always
+   *                         see true, but it should be safe as we will have already thrown errors
+   *                         for missing columns and renamed columns for SQL inserts.
    */
-  private def needsSchemaAdjustmentByName(
+  protected def needsSchemaAdjustmentByName(
       query: LogicalPlan,
       targetAttrs: Seq[Attribute],
       deltaTable: DeltaTableV2,
-      writeOptions: Map[String, String]): Boolean = {
-    insertIntoByNameMissingColumn(query, targetAttrs, deltaTable)
-    val userSpecifiedNames = if (session.sessionState.conf.caseSensitiveAnalysis) {
+      writeOptions: Map[String, String],
+      isDfByNameInsert: Boolean = false): Boolean = {
+    if (!isDfByNameInsert) insertIntoByNameMissingColumn(query, targetAttrs, deltaTable)
+    val caseSensitive = session.sessionState.conf.caseSensitiveAnalysis
+    val userSpecifiedNames = if (caseSensitive) {
       query.output.map(a => (a.name, a)).toMap
     } else {
       CaseInsensitiveMap(query.output.map(a => (a.name, a)).toMap)
@@ -1225,7 +1263,13 @@ class DeltaAnalysis(session: SparkSession)
     !SchemaUtils.isReadCompatible(
       specifiedTargetAttrs.toStructType.asNullable,
       query.output.toStructType,
-      typeWideningMode = getTypeWideningMode(deltaTable, writeOptions)
+      typeWideningMode = getTypeWideningMode(deltaTable, writeOptions),
+      // DataFrame by-name inserts allow missing nested columns; SQL inserts do not.
+      allowMissingColumns = isDfByNameInsert,
+      // DF by-name casting preserves source field names, so (correctly) respect case to avoid
+      // infinite loops.
+      caseSensitive = caseSensitive || !isDfByNameInsert,
+      allowVoidTypeChange = isDfByNameInsert
     )
   }
 
@@ -1249,9 +1293,9 @@ class DeltaAnalysis(session: SparkSession)
   }
 
   /**
-   * Recursively casts struct data types in case the source/target type differs.
+   * Recursively casts struct data types positionally in case the source/target type differs.
    */
-  private def addCastsToStructs(
+  private def addCastsToStructsByPosition(
       tableName: String,
       parent: NamedExpression,
       source: StructType,
@@ -1272,7 +1316,7 @@ class DeltaAnalysis(session: SparkSession)
           case t: StructType =>
             val subField = Alias(GetStructField(parent, i, Option(name)), targetField.name)(
               explicitMetadata = Option(metadata))
-            addCastsToStructs(tableName, subField, nested, t, typeWideningMode)
+            addCastsToStructsByPosition(tableName, subField, nested, t, typeWideningMode)
           case o =>
             val field = parent.qualifiedName + "." + name
             val targetName = parent.qualifiedName + "." + targetField.name
@@ -1321,16 +1365,86 @@ class DeltaAnalysis(session: SparkSession)
       parent.exprId, parent.qualifier, Option(parent.metadata))
   }
 
+  /**
+   * Recursively casts struct data types by matching fields by name.
+   * Unlike addCastsToStructsByPosition, this preserves source field names (i.e. capitalization)
+   * and lets downstream handle normalization.
+   */
+  private def addCastsToStructsByName(
+      tableName: String,
+      parent: NamedExpression,
+      source: StructType,
+      target: StructType,
+      typeWideningMode: TypeWideningMode): NamedExpression = {
+    val resolver = session.sessionState.conf.resolver
+    val fields = source.map { sourceField =>
+      val sourceIndex = source.fieldIndex(sourceField.name)
+      val targetFieldOpt = target.find(t => resolver(t.name, sourceField.name))
+      targetFieldOpt match {
+        case Some(targetField) =>
+          val expr = (sourceField.dataType, targetField.dataType) match {
+            // Delegate nested complex types to addCastToColumn which dispatches
+            // to the appropriate by-name handler (structs, arrays, maps).
+            case (_: StructType, _: StructType)
+                | (_: ArrayType, _: ArrayType) | (_: MapType, _: MapType)
+                if sourceField.dataType != targetField.dataType =>
+              val subField = Alias(
+                GetStructField(parent, sourceIndex, Option(sourceField.name)),
+                sourceField.name
+              )()
+              val targetAttr = AttributeReference(
+                targetField.name, targetField.dataType, targetField.nullable)()
+              addCastToColumn(subField, targetAttr, tableName, typeWideningMode, byName = true)
+
+            case (_, _: NullType) =>
+              GetStructField(parent, sourceIndex, Option(sourceField.name))
+            case (sourceType: AtomicType, targetType: AtomicType)
+              if typeWideningMode.shouldWidenTo(fromType = targetType, toType = sourceType) =>
+              GetStructField(parent, sourceIndex, Option(sourceField.name))
+
+            case _ =>
+              getCastFunction(
+                GetStructField(parent, sourceIndex, Option(sourceField.name)),
+                targetField.dataType,
+                targetField.name
+              )
+          }
+          Alias(expr, sourceField.name)(explicitMetadata = Option(sourceField.metadata))
+
+        case None =>
+          // Source field doesn't exist in target - pass through as-is.
+          Alias(
+            GetStructField(parent, sourceIndex, Option(sourceField.name)),
+            sourceField.name
+          )(explicitMetadata = Option(sourceField.metadata))
+      }
+    }
+
+    // Wrap the struct in an if statement to make sure that when a null is passed in, the struct
+    // field is null instead of a non-null struct with a null for each nested field.
+    val resultStruct = CreateStruct(fields)
+    val createStructExpr = If(IsNull(parent), Literal(null, resultStruct.dataType), resultStruct)
+    Alias(createStructExpr, parent.name)(
+      parent.exprId, parent.qualifier, Option(parent.metadata))
+  }
+
   private def addCastsToArrayStructs(
       tableName: String,
       parent: NamedExpression,
       source: StructType,
       target: StructType,
       sourceNullable: Boolean,
-      typeWideningMode: TypeWideningMode): Expression = {
-    val structConverter: (Expression, Expression) => Expression = (_, i) =>
-      addCastsToStructs(
-        tableName, Alias(GetArrayItem(parent, i), i.toString)(), source, target, typeWideningMode)
+      typeWideningMode: TypeWideningMode,
+      byName: Boolean = false): Expression = {
+    val structConverter: (Expression, Expression) => Expression = (_, i) => {
+      if (byName) {
+        addCastsToStructsByName(tableName, Alias(GetArrayItem(parent, i), i.toString)(),
+          source, target, typeWideningMode)
+      } else {
+        addCastsToStructsByPosition(tableName, Alias(GetArrayItem(parent, i), i.toString)(),
+          source, target, typeWideningMode)
+      }
+    }
     val transformLambdaFunc = {
       val elementVar = NamedLambdaVariable("elementVar", source, sourceNullable)
       val indexVar = NamedLambdaVariable("indexVar", IntegerType, false)
@@ -1355,7 +1469,8 @@ class DeltaAnalysis(session: SparkSession)
       parent: NamedExpression,
       sourceMapType: MapType,
       targetMapType: MapType,
-      typeWideningMode: TypeWideningMode): Expression = {
+      typeWideningMode: TypeWideningMode,
+      byName: Boolean = false): Expression = {
     val transformedKeys =
       if (sourceMapType.keyType != targetMapType.keyType) {
         // Create a transformation for the keys
@@ -1371,7 +1486,8 @@ class DeltaAnalysis(session: SparkSession)
               key,
               keyAttr,
               tableName,
-              typeWideningMode
+              typeWideningMode,
+              byName
             )
           LambdaFunction(castedKey, Seq(key))
         })
@@ -1394,7 +1510,8 @@ class DeltaAnalysis(session: SparkSession)
               value,
               valueAttr,
               tableName,
-              typeWideningMode
+              typeWideningMode,
+              byName
             )
           LambdaFunction(castedValue, Seq(value))
         })

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaImplicitCast.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaImplicitCast.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, ExtractV2Table}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2RelationShim
+
+/**
+ * An analyzer resolution rule that handles implicit casting for all V2WriteCommands targeting
+ * Delta tables via DataFrame by-name writes. This rule runs BEFORE [[DeltaAnalysis]].
+ */
+case class DeltaImplicitCast(session: SparkSession) extends DeltaAnalysis(session) {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!session.conf.get(DeltaSQLConf.DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS)) return plan
+    plan.resolveOperatorsDown {
+      case w @ DeltaV2WriteCommand(r, d, writeOptions)
+          if shouldApplyImplicitCast(w, r, d, writeOptions) =>
+        val projection = resolveQueryColumnsByName(
+          query = w.query,
+          targetAttrs = r.output,
+          deltaTable = d,
+          writeOptions = writeOptions,
+          allowSchemaEvolution = true,
+          isDfByNameInsert = true)
+        val newPlan = if (projection != w.query) {
+          w match {
+            case o: OverwriteByExpression =>
+              val aliases = AttributeMap(o.query.output.zip(projection.output).collect {
+                case (l: AttributeReference, r: AttributeReference) if !l.sameRef(r) => (l, r)
+              })
+              val newDeleteExpr = o.deleteExpr.transformUp {
+                case a: AttributeReference => aliases.getOrElse(a, a)
+              }
+              o.copy(deleteExpr = newDeleteExpr, query = projection)
+            case _ => w.withNewQuery(projection)
+          }
+        } else {
+          w
+        }
+        newPlan match {
+          case o: OverwritePartitionsDynamic =>
+            DeltaDynamicPartitionOverwriteCommand(r, d, o.query, o.writeOptions, o.isByName)
+          case other => other
+        }
+    }
+  }
+
+  /**
+   * Returns true if this write command is a DataFrame by-name insert that needs implicit casting.
+   * SQL inserts with requireImplicitCasting=true are handled in [[DeltaAnalysis]] instead.
+   */
+  private def shouldApplyImplicitCast(
+      w: V2WriteCommand,
+      r: DataSourceV2Relation,
+      d: DeltaTableV2,
+      writeOptions: Map[String, String]): Boolean = {
+    w.isByName &&
+    w.origin.sqlText.isEmpty &&
+    !writeOptions.get(DeltaOptions.OVERWRITE_SCHEMA_OPTION).exists(_.toBoolean) &&
+    needsSchemaAdjustmentByName(
+      query = w.query,
+      targetAttrs = r.output,
+      deltaTable = d,
+      writeOptions = writeOptions,
+      isDfByNameInsert = true)
+  }
+}
+
+/**
+ * Extractor for certain [[V2WriteCommand]] whose resolved target is a Delta table. Yields the
+ * [[DataSourceV2Relation]], the [[DeltaTableV2]], and the command's write options.
+ */
+object DeltaV2WriteCommand {
+  def unapply(
+      w: V2WriteCommand): Option[(DataSourceV2Relation, DeltaTableV2, Map[String, String])] = {
+    if (!w.query.resolved) return None
+    w match {
+      case _: AppendData | _: OverwriteByExpression | _: OverwritePartitionsDynamic =>
+      case _ => return None
+    }
+    w.table match {
+      case r @ ExtractV2Table(table: DeltaTableV2) =>
+        Some((r, table, writeOptionsOf(w)))
+      case _ => None
+    }
+  }
+
+  private def writeOptionsOf(w: V2WriteCommand): Map[String, String] = w match {
+    case a: AppendData => a.writeOptions
+    case o: OverwriteByExpression => o.writeOptions
+    case o: OverwritePartitionsDynamic => o.writeOptions
+    case _ => Map.empty
+  }
+}
+

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaImplicitCast.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaImplicitCast.scala
@@ -22,8 +22,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, ExtractV2Table}
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2RelationShim
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 /**
  * An analyzer resolution rule that handles implicit casting for all V2WriteCommands targeting
@@ -100,8 +99,8 @@ object DeltaV2WriteCommand {
       case _ => return None
     }
     w.table match {
-      case r @ ExtractV2Table(table: DeltaTableV2) =>
-        Some((r, table, writeOptionsOf(w)))
+      case r: DataSourceV2Relation if r.table.isInstanceOf[DeltaTableV2] =>
+        Some((r, r.table.asInstanceOf[DeltaTableV2], writeOptionsOf(w)))
       case _ => None
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -488,7 +488,9 @@ def normalizeColumnNamesInDataType(
       allowMissingColumns: Boolean = false,
       typeWideningMode: TypeWideningMode = TypeWideningMode.NoTypeWidening,
       newPartitionColumns: Seq[String] = Seq.empty,
-      oldPartitionColumns: Seq[String] = Seq.empty): Boolean = {
+      oldPartitionColumns: Seq[String] = Seq.empty,
+      caseSensitive: Boolean = true,
+      allowVoidTypeChange: Boolean = false): Boolean = {
 
     def isNullabilityCompatible(existingNullable: Boolean, readNullable: Boolean): Boolean = {
       if (forbidTightenNullability) {
@@ -504,7 +506,9 @@ def normalizeColumnNamesInDataType(
           isReadCompatible(e, n,
             forbidTightenNullability,
             typeWideningMode = typeWideningMode,
-            allowMissingColumns = allowMissingColumns
+            allowMissingColumns = allowMissingColumns,
+            caseSensitive = caseSensitive,
+            allowVoidTypeChange = allowVoidTypeChange
           )
         case (e: ArrayType, n: ArrayType) =>
           // if existing elements are non-nullable, so should be the new element
@@ -515,6 +519,9 @@ def normalizeColumnNamesInDataType(
           isNullabilityCompatible(e.valueContainsNull, n.valueContainsNull) &&
             isDatatypeReadCompatible(e.keyType, n.keyType) &&
             isDatatypeReadCompatible(e.valueType, n.valueType)
+        // This should only be true for dataframe by-name inserts.
+        case (_: NullType, _) if allowVoidTypeChange =>
+          true
         case (e: AtomicType, n: AtomicType)
           if typeWideningMode.shouldWidenTo(fromType = e, toType = n) => true
         case (a, b) => a == b
@@ -551,8 +558,8 @@ def normalizeColumnNamesInDataType(
       newtype.forall { newField =>
         // new fields are fine, they just won't be returned
         existingFields.get(newField.name).forall { existingField =>
-          // we know the name matches modulo case - now verify exact match
-          (existingField.name == newField.name
+          // when case-sensitive, verify exact name match (modulo case already matched)
+          ((!caseSensitive || existingField.name == newField.name)
             // if existing value is non-nullable, so should be the new value
             && isNullabilityCompatible(existingField.nullable, newField.nullable)
             // and the type of the field must be compatible, too

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3290,6 +3290,20 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .checkValues(Set("AUTO", "NONE", "STRICT"))
       .createWithDefault("AUTO")
 
+  val DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS =
+    buildConf("dml.insert.dfByName.allowImplicitCasts")
+      .internal()
+      .doc(
+        """Whether to perform implicit casting when writing to a Delta
+          |table using the DataFrame V1/2 API (e.g. df.write.save(),
+          |df.write.saveAsTable(), df.writeTo.append()) for by-name
+          |inserts. When true, data is cast to match the target table
+          |schema when there is a type mismatch. When false, the write
+          |fails on type mismatch. The casting behavior is governed by
+          |'spark.sql.storeAssignmentPolicy'.""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_STREAMING_INITIAL_SNAPSHOT_MAX_FILES =
     buildConf("streaming.initialSnapshotMaxFiles")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -672,32 +672,29 @@ class DeltaDataFrameWriterV2Suite
       a.partitionedBy($"id").tableProperty("delta.appendOnly", "true"))
   }
 
-  test("append or overwrite mode should not do implicit casting") {
+  test("saveAsTable overwrite mode should not do implicit casting") {
     val table = "not_implicit_casting"
     withTable(table) {
       spark.sql(s"CREATE TABLE $table(id bigint, p int) USING delta PARTITIONED BY (p)")
-      def verifyNotImplicitCasting(f: => Unit): Unit = {
-        val e = intercept[DeltaAnalysisException](f)
-        checkError(
-          e.getCause.asInstanceOf[DeltaAnalysisException],
-          "DELTA_MERGE_INCOMPATIBLE_DATATYPE",
-          parameters = Map("currentDataType" -> "LongType", "updateDataType" -> "IntegerType"))
-      }
-      verifyNotImplicitCasting {
-        Seq(1 -> 1).toDF("id", "p").write.mode("append").format("delta").saveAsTable(table)
-      }
-      verifyNotImplicitCasting {
+      val e = intercept[DeltaAnalysisException] {
         Seq(1 -> 1).toDF("id", "p").write.mode("overwrite").format("delta").saveAsTable(table)
       }
-      verifyNotImplicitCasting {
-        Seq(1 -> 1).toDF("id", "p").writeTo(table).append()
-      }
-      verifyNotImplicitCasting {
-        Seq(1 -> 1).toDF("id", "p").writeTo(table).overwrite($"p" === 1)
-      }
-      verifyNotImplicitCasting {
-        Seq(1 -> 1).toDF("id", "p").writeTo(table).overwritePartitions()
-      }
+      checkError(
+        e.getCause.asInstanceOf[DeltaAnalysisException],
+        "DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+        parameters = Map("currentDataType" -> "LongType", "updateDataType" -> "IntegerType"))
+    }
+  }
+
+  test("implicit casting supported for saveAsTable append and writeTo operations") {
+    val table = "implicit_casting"
+    withTable(table) {
+      spark.sql(s"CREATE TABLE $table(id bigint, p int) USING delta PARTITIONED BY (p)")
+      // All of these should succeed with implicit casting (int -> bigint)
+      Seq(1 -> 1).toDF("id", "p").write.mode("append").format("delta").saveAsTable(table)
+      Seq(1 -> 1).toDF("id", "p").writeTo(table).append()
+      Seq(1 -> 1).toDF("id", "p").writeTo(table).overwrite($"p" === 1)
+      Seq(1 -> 1).toDF("id", "p").writeTo(table).overwritePartitions()
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderAdvancedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderAdvancedSuite.scala
@@ -1,0 +1,350 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Test suite covering INSERT operations with struct fields ordered differently
+ * than in the table schema for complex nested types: structs containing arrays
+ * of structs, structs containing maps with struct values, and arrays of maps
+ * with struct values.
+ *
+ * Mirrors the structure of [[DeltaInsertIntoColumnOrderSuite]] but focuses on
+ * deeply nested types where the struct field reordering is buried inside
+ * container types (ArrayType, MapType).
+ */
+class DeltaInsertIntoColumnOrderAdvancedSuite extends DeltaInsertIntoTest {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
+  }
+
+  test("all test cases are implemented") {
+    checkAllTestCasesImplemented()
+  }
+
+  // --- struct<arr: array<struct<x, y>>>: no cast ---
+
+  for {
+    (inserts: Set[Insert], expectedAnswer) <- Seq(
+      insertsAppend ->
+        TestData("a int, s struct<arr: array<struct<x: int, y: int>>>",
+          Seq("""{ "a": 1, "s": { "arr": [{ "x": 2, "y": 3 }] } }""",
+              """{ "a": 1, "s": { "arr": [{ "x": 4, "y": 5 }] } }""")),
+      insertsOverwrite ->
+        TestData("a int, s struct<arr: array<struct<x: int, y: int>>>",
+          Seq("""{ "a": 1, "s": { "arr": [{ "x": 4, "y": 5 }] } }"""))
+    )
+  } {
+    testInserts("struct with array of structs field reordering")(
+      initialData = TestData(
+        "a int, s struct<arr: array<struct<x: int, y: int>>>",
+        Seq("""{ "a": 1, "s": { "arr": [{ "x": 2, "y": 3 }] } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData(
+        "a int, s struct<arr: array<struct<y: int, x: int>>>",
+        Seq("""{ "a": 1, "s": { "arr": [{ "y": 5, "x": 4 }] } }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+  }
+
+  // --- struct<arr: array<struct<x, y>>>: with implicit cast ---
+
+  for {
+    (inserts: Set[Insert], expectedAnswer) <- Seq(
+      insertsAppend - StreamingInsert
+        -- insertsByName.intersect(insertsDataframe) ->
+        TestData("a int, s struct<arr: array<struct<x: int, y: int>>>",
+          Seq("""{ "a": 1, "s": { "arr": [{ "x": 2, "y": 3 }] } }""",
+              """{ "a": 1, "s": { "arr": [{ "x": 5, "y": 4 }] } }""")),
+      insertsOverwrite
+        -- insertsByName.intersect(insertsDataframe) ->
+        TestData("a int, s struct<arr: array<struct<x: int, y: int>>>",
+          Seq("""{ "a": 1, "s": { "arr": [{ "x": 5, "y": 4 }] } }""")),
+      (insertsAppend.intersect(insertsByName.intersect(insertsDataframe))
+        -- insertsWithoutImplicitCastSupport - StreamingInsert) ->
+        TestData("a int, s struct<arr: array<struct<x: int, y: int>>>",
+          Seq("""{ "a": 1, "s": { "arr": [{ "x": 2, "y": 3 }] } }""",
+              """{ "a": 1, "s": { "arr": [{ "x": 4, "y": 5 }] } }""")),
+      (insertsOverwrite.intersect(insertsByName.intersect(insertsDataframe))
+        -- insertsWithoutImplicitCastSupport) ->
+        TestData("a int, s struct<arr: array<struct<x: int, y: int>>>",
+          Seq("""{ "a": 1, "s": { "arr": [{ "x": 4, "y": 5 }] } }""")),
+      Set(StreamingInsert) ->
+        TestData("a int, s struct<arr: array<struct<x: int, y: int>>>",
+          Seq("""{ "a": 1, "s": { "arr": [{ "x": 2, "y": 3 }] } }""",
+              """{ "a": 1, "s": { "arr": [{ "x": 4, "y": 5 }] } }"""))
+    )
+  } {
+    testInserts(
+      "struct with array of structs field reordering with implicit cast")(
+      initialData = TestData(
+        "a int, s struct<arr: array<struct<x: int, y: int>>>",
+        Seq("""{ "a": 1, "s": { "arr": [{ "x": 2, "y": 3 }] } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData(
+        "a int, s struct<arr: array<struct<y: long, x: int>>>",
+        Seq("""{ "a": 1, "s": { "arr": [{ "y": 5, "x": 4 }] } }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+  }
+
+  testInserts(
+    "struct with array of structs field reordering with implicit cast")(
+    initialData = TestData(
+      "a int, s struct<arr: array<struct<x: int, y: int>>>",
+      Seq("""{ "a": 1, "s": { "arr": [{ "x": 2, "y": 3 }] } }""")),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertData = TestData(
+      "a int, s struct<arr: array<struct<y: long, x: int>>>",
+      Seq("""{ "a": 1, "s": { "arr": [{ "y": 5, "x": 4 }] } }""")),
+    expectedResult = ExpectedResult.Failure(ex => {
+      checkError(ex, "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map(
+          "currentField" -> "s", "updateField" -> "s"))
+    }),
+    includeInserts = insertsWithoutImplicitCastSupport
+  )
+
+  // --- struct<m: map<string, struct<x, y>>>: no cast ---
+
+  for {
+    (inserts: Set[Insert], expectedAnswer) <- Seq(
+      insertsAppend ->
+        TestData(
+          "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "s": { "m": { "k": { "x": 2, "y": 3 } } } }""",
+            """{ "a": 1, "s": { "m": { "k": { "x": 4, "y": 5 } } } }""")),
+      insertsOverwrite ->
+        TestData(
+          "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "s": { "m": { "k": { "x": 4, "y": 5 } } } }"""))
+    )
+  } {
+    testInserts("struct with map of structs field reordering")(
+      initialData = TestData(
+        "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+        Seq(
+          """{ "a": 1, "s": { "m": { "k": { "x": 2, "y": 3 } } } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData(
+        "a int, s struct<m: map<string, struct<y: int, x: int>>>",
+        Seq(
+          """{ "a": 1, "s": { "m": { "k": { "y": 5, "x": 4 } } } }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+  }
+
+  // --- struct<m: map<string, struct<x, y>>>: with implicit cast ---
+
+  for {
+    (inserts: Set[Insert], expectedAnswer) <- Seq(
+      insertsAppend - StreamingInsert
+        -- insertsByName.intersect(insertsDataframe) ->
+        TestData(
+          "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "s": { "m": { "k": { "x": 2, "y": 3 } } } }""",
+            """{ "a": 1, "s": { "m": { "k": { "x": 5, "y": 4 } } } }""")),
+      insertsOverwrite
+        -- insertsByName.intersect(insertsDataframe) ->
+        TestData(
+          "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "s": { "m": { "k": { "x": 5, "y": 4 } } } }""")),
+      (insertsAppend.intersect(insertsByName.intersect(insertsDataframe))
+        -- insertsWithoutImplicitCastSupport - StreamingInsert) ->
+        TestData(
+          "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "s": { "m": { "k": { "x": 2, "y": 3 } } } }""",
+            """{ "a": 1, "s": { "m": { "k": { "x": 4, "y": 5 } } } }""")),
+      (insertsOverwrite.intersect(insertsByName.intersect(insertsDataframe))
+        -- insertsWithoutImplicitCastSupport) ->
+        TestData(
+          "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "s": { "m": { "k": { "x": 4, "y": 5 } } } }""")),
+      Set(StreamingInsert) ->
+        TestData(
+          "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "s": { "m": { "k": { "x": 2, "y": 3 } } } }""",
+            """{ "a": 1, "s": { "m": { "k": { "x": 4, "y": 5 } } } }"""))
+    )
+  } {
+    testInserts(
+      "struct with map of structs field reordering with implicit cast")(
+      initialData = TestData(
+        "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+        Seq(
+          """{ "a": 1, "s": { "m": { "k": { "x": 2, "y": 3 } } } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData(
+        "a int, s struct<m: map<string, struct<y: long, x: int>>>",
+        Seq(
+          """{ "a": 1, "s": { "m": { "k": { "y": 5, "x": 4 } } } }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+  }
+
+  testInserts(
+    "struct with map of structs field reordering with implicit cast")(
+    initialData = TestData(
+      "a int, s struct<m: map<string, struct<x: int, y: int>>>",
+      Seq(
+        """{ "a": 1, "s": { "m": { "k": { "x": 2, "y": 3 } } } }""")),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertData = TestData(
+      "a int, s struct<m: map<string, struct<y: long, x: int>>>",
+      Seq(
+        """{ "a": 1, "s": { "m": { "k": { "y": 5, "x": 4 } } } }""")),
+    expectedResult = ExpectedResult.Failure(ex => {
+      checkError(ex, "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map(
+          "currentField" -> "s", "updateField" -> "s"))
+    }),
+    includeInserts = insertsWithoutImplicitCastSupport
+  )
+
+  // --- array<map<string, struct<x, y>>>: no cast ---
+
+  for {
+    (inserts: Set[Insert], expectedAnswer) <- Seq(
+      insertsAppend ->
+        TestData(
+          "a int, complex array<map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "complex": [{ "k": { "x": 2, "y": 3 } }] }""",
+            """{ "a": 1, "complex": [{ "k": { "x": 4, "y": 5 } }] }""")),
+      insertsOverwrite ->
+        TestData(
+          "a int, complex array<map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "complex": [{ "k": { "x": 4, "y": 5 } }] }"""))
+    )
+  } {
+    testInserts("array of maps with struct values field reordering")(
+      initialData = TestData(
+        "a int, complex array<map<string, struct<x: int, y: int>>>",
+        Seq(
+          """{ "a": 1, "complex": [{ "k": { "x": 2, "y": 3 } }] }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData(
+        "a int, complex array<map<string, struct<y: int, x: int>>>",
+        Seq(
+          """{ "a": 1, "complex": [{ "k": { "y": 5, "x": 4 } }] }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+  }
+
+  // --- array<map<string, struct<x, y>>>: with implicit cast ---
+  // Streaming uses by-position for top-level array<map<...>>.
+
+  for {
+    (inserts: Set[Insert], expectedAnswer) <- Seq(
+      insertsAppend - StreamingInsert
+        -- insertsByName.intersect(insertsDataframe) ->
+        TestData(
+          "a int, complex array<map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "complex": [{ "k": { "x": 2, "y": 3 } }] }""",
+            """{ "a": 1, "complex": [{ "k": { "x": 5, "y": 4 } }] }""")),
+      insertsOverwrite
+        -- insertsByName.intersect(insertsDataframe) ->
+        TestData(
+          "a int, complex array<map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "complex": [{ "k": { "x": 5, "y": 4 } }] }""")),
+      (insertsAppend.intersect(insertsByName.intersect(insertsDataframe))
+        -- insertsWithoutImplicitCastSupport - StreamingInsert) ->
+        TestData(
+          "a int, complex array<map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "complex": [{ "k": { "x": 2, "y": 3 } }] }""",
+            """{ "a": 1, "complex": [{ "k": { "x": 4, "y": 5 } }] }""")),
+      (insertsOverwrite.intersect(insertsByName.intersect(insertsDataframe))
+        -- insertsWithoutImplicitCastSupport) ->
+        TestData(
+          "a int, complex array<map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "complex": [{ "k": { "x": 4, "y": 5 } }] }""")),
+      Set(StreamingInsert) ->
+        TestData(
+          "a int, complex array<map<string, struct<x: int, y: int>>>",
+          Seq(
+            """{ "a": 1, "complex": [{ "k": { "x": 2, "y": 3 } }] }""",
+            """{ "a": 1, "complex": [{ "k": { "x": 5, "y": 4 } }] }"""))
+    )
+  } {
+    testInserts(
+      "array of maps with struct values field reordering with implicit cast"
+    )(
+      initialData = TestData(
+        "a int, complex array<map<string, struct<x: int, y: int>>>",
+        Seq(
+          """{ "a": 1, "complex": [{ "k": { "x": 2, "y": 3 } }] }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData(
+        "a int, complex array<map<string, struct<y: long, x: int>>>",
+        Seq(
+          """{ "a": 1, "complex": [{ "k": { "y": 5, "x": 4 } }] }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+  }
+
+  testInserts(
+    "array of maps with struct values field reordering with implicit cast"
+  )(
+    initialData = TestData(
+      "a int, complex array<map<string, struct<x: int, y: int>>>",
+      Seq(
+        """{ "a": 1, "complex": [{ "k": { "x": 2, "y": 3 } }] }""")),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertData = TestData(
+      "a int, complex array<map<string, struct<y: long, x: int>>>",
+      Seq(
+        """{ "a": 1, "complex": [{ "k": { "y": 5, "x": 4 } }] }""")),
+    expectedResult = ExpectedResult.Failure(ex => {
+      checkError(ex, "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map(
+          "currentField" -> "complex",
+          "updateField" -> "complex"))
+    }),
+    includeInserts = insertsWithoutImplicitCastSupport
+  )
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
@@ -32,13 +32,6 @@ class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
     spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
   }
 
-  /** Collects inserts that don't support implicit casting and will fail if the input data type
-   * doesn't match the expected column type.
-   * These are all dataframe inserts that use by name resolution, except for streaming writes.
-   */
-  private val insertsWithoutImplicitCastSupport: Set[Insert] =
-    insertsByName.intersect(insertsDataframe) - StreamingInsert
-
   test("all test cases are implemented") {
     checkAllTestCasesImplemented()
   }
@@ -129,19 +122,23 @@ class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
   }
 
   for { (inserts: Set[Insert], expectedAnswer) <- Seq(
-    // When there's a type mismatch and an implicit cast is required, then all inserts use position
-    // based resolution for struct fields, except for `INSERT OVERWRITE PARTITION (partition)` and
-    // streaming insert which use name based resolution, and dataframe inserts by name which don't
-    // support implicit cast and fail - see negative test below.
-    insertsAppend - StreamingInsert ->
+    // When there's a type mismatch and an implicit cast is required, most inserts use position
+    // based resolution for struct fields. `INSERT OVERWRITE PARTITION (partition)`, streaming
+    // insert, and dataframe inserts by name use name based resolution.
+    insertsAppend - StreamingInsert -- (insertsByName.intersect(insertsDataframe)) ->
       TestData("a int, s struct <x int, y: int>",
         Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": { "x": 5, "y": 4 } }""")),
-    insertsOverwrite - SQLInsertOverwritePartitionByPosition ->
+    insertsOverwrite - SQLInsertOverwritePartitionByPosition --
+        (insertsByName.intersect(insertsDataframe)) ->
       TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 5, "y": 4 } }""")),
-    Set(StreamingInsert) ->
+    Set(StreamingInsert) ++
+        (insertsAppend.intersect(insertsByName.intersect(insertsDataframe))
+          -- insertsWithoutImplicitCastSupport) ->
       TestData("a int, s struct <x int, y: int>",
         Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
-    Set(SQLInsertOverwritePartitionByPosition) ->
+    Set(SQLInsertOverwritePartitionByPosition) ++
+        (insertsOverwrite.intersect(insertsByName.intersect(insertsDataframe))
+          -- insertsWithoutImplicitCastSupport) ->
       TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }"""))
     )
   } {
@@ -154,8 +151,7 @@ class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
       insertData = TestData("a long, s struct <y int, x: int>",
         Seq("""{ "a": 1, "s": { "y": 5, "x": 4 } }""")),
       expectedResult = ExpectedResult.Success(expectedAnswer),
-      // Inserts that don't support implicit cast are failing, these are covered in the test below.
-      includeInserts = inserts -- insertsWithoutImplicitCastSupport
+      includeInserts = inserts
     )
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoImplicitCastSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoImplicitCastSuite.scala
@@ -18,7 +18,8 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -59,10 +60,7 @@ trait DeltaInsertIntoImplicitCastTests extends DeltaInsertIntoImplicitCastBase {
         expected = new StructType()
           .add("a", LongType)
           .add("b", IntegerType)),
-      // The following insert operations don't implicitly cast the data but fail instead - see
-      // following test covering failure for these cases. We should change this to offer consistent
-      // behavior across all inserts.
-      excludeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      excludeInserts = insertsWithoutImplicitCastSupport,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -75,13 +73,13 @@ trait DeltaInsertIntoImplicitCastTests extends DeltaInsertIntoImplicitCastBase {
       expectedResult = ExpectedResult.Failure { ex =>
         checkError(
           ex,
-           "DELTA_FAILED_TO_MERGE_FIELDS",
+          "DELTA_FAILED_TO_MERGE_FIELDS",
           parameters = Map(
             "currentField" -> "a",
             "updateField" -> "a"
         ))
       },
-      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      includeInserts = insertsWithoutImplicitCastSupport,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -102,7 +100,7 @@ trait DeltaInsertIntoImplicitCastTests extends DeltaInsertIntoImplicitCastBase {
       // The following insert operations don't implicitly cast the data but fail instead - see
       // following test covering failure for these cases. We should change this to offer consistent
       // behavior across all inserts.
-      excludeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      excludeInserts = insertsWithoutImplicitCastSupport,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -117,13 +115,13 @@ trait DeltaInsertIntoImplicitCastTests extends DeltaInsertIntoImplicitCastBase {
       expectedResult = ExpectedResult.Failure { ex =>
         checkError(
           ex,
-           "DELTA_FAILED_TO_MERGE_FIELDS",
+          "DELTA_FAILED_TO_MERGE_FIELDS",
           parameters = Map(
             "currentField" -> "a",
             "updateField" -> "a"
         ))
       },
-      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      includeInserts = insertsWithoutImplicitCastSupport,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -144,7 +142,7 @@ trait DeltaInsertIntoImplicitCastTests extends DeltaInsertIntoImplicitCastBase {
       // The following insert operations don't implicitly cast the data but fail instead - see
       // following test covering failure for these cases. We should change this to offer consistent
       // behavior across all inserts.
-      excludeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      excludeInserts = insertsWithoutImplicitCastSupport,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -159,15 +157,126 @@ trait DeltaInsertIntoImplicitCastTests extends DeltaInsertIntoImplicitCastBase {
       expectedResult = ExpectedResult.Failure { ex =>
         checkError(
           ex,
-           "DELTA_FAILED_TO_MERGE_FIELDS",
+          "DELTA_FAILED_TO_MERGE_FIELDS",
           parameters = Map(
             "currentField" -> "m",
             "updateField" -> "m"
         ))
       },
-      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      includeInserts = insertsWithoutImplicitCastSupport,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
+  }
+
+  // Verify that dataframe by-name struct field resolution inside arrays works correctly when the
+  // array element nullability differs between source and target. Uses createDataFrame with explicit
+  // schemas to guarantee containsNull is exactly as specified (JSON reader may normalize it).
+  for {
+    (sourceContainsNull, targetContainsNull) <- Seq((false, true), (true, false))
+  } {
+    test("implicit cast with array element nullability mismatch " +
+        s"(source=$sourceContainsNull, target=$targetContainsNull)") {
+      val tableSchema = new StructType()
+        .add("key", IntegerType)
+        .add("a", ArrayType(new StructType()
+          .add("x", IntegerType)
+          .add("y", IntegerType), containsNull = targetContainsNull))
+      // Source has fields reordered (y before x) and y is long (needs cast to int).
+      val insertSchema = new StructType()
+        .add("key", IntegerType)
+        .add("a", ArrayType(new StructType()
+          .add("y", LongType)
+          .add("x", IntegerType), containsNull = sourceContainsNull))
+
+      withTable("target") {
+        spark.createDataFrame(
+          spark.sparkContext.emptyRDD[Row], tableSchema)
+          .write.format("delta").saveAsTable("target")
+
+        val sourceData = spark.createDataFrame(
+          java.util.Arrays.asList(Row(1, Seq(Row(5L, 4)))), insertSchema)
+        assert(sourceData.schema("a").dataType.asInstanceOf[ArrayType].containsNull
+          == sourceContainsNull, "source containsNull not preserved")
+
+        sourceData.writeTo("target").append()
+        // Expects by-name resolution (x=4, y=5). Without the fix,
+        // positional casting swaps the values (x=5, y=4).
+        checkAnswer(
+          spark.read.table("target"),
+          spark.createDataFrame(
+            java.util.Arrays.asList(Row(1, Seq(Row(4, 5)))), tableSchema))
+      }
+    }
+  }
+
+  // Tests that DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS controls implicit casting for df-by-name
+  // writes: when false, the write fails on type mismatch; when true, casting proceeds normally.
+  // Non-df-by-name writes (SQL inserts and df-by-position) always succeed regardless of the flag.
+  // save() and saveAsTable() overwrite are excluded since they don't support implicit casting.
+  for (allowImplicitCasts <- BOOLEAN_DOMAIN) {
+    testInserts("insert with implicit up and down cast on top-level fields, " +
+        s"DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS=$allowImplicitCasts")(
+      initialData = TestData("a long, b int", Seq("""{ "a": 1, "b": 2 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = if (allowImplicitCasts) {
+        ExpectedResult.Success(
+          expected = new StructType()
+            .add("a", LongType)
+            .add("b", IntegerType))
+      } else {
+        ExpectedResult.Failure()
+      },
+      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert --
+        insertsWithoutImplicitCastSupport,
+      confs = Seq(
+        DeltaSQLConf.DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS.key -> allowImplicitCasts.toString)
+    )
+
+    testInserts("insert with implicit up and down cast on top-level fields, " +
+        s"DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS=$allowImplicitCasts")(
+      initialData = TestData("a long, b int", Seq("""{ "a": 1, "b": 2 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Success(
+        expected = new StructType()
+          .add("a", LongType)
+          .add("b", IntegerType)),
+      excludeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      confs = Seq(
+        DeltaSQLConf.DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS.key -> allowImplicitCasts.toString)
+    )
+
+    // save() and saveAsTable() overwrite always fail regardless of the flag since they don't
+    // go through DeltaImplicitCast.
+    testInserts("insert with implicit up and down cast on top-level fields, " +
+        s"DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS=$allowImplicitCasts")(
+      initialData = TestData("a long, b int", Seq("""{ "a": 1, "b": 2 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Failure(),
+      includeInserts = insertsWithoutImplicitCastSupport,
+      confs = Seq(
+        DeltaSQLConf.DELTA_DF_WRITE_ALLOW_IMPLICIT_CASTS.key -> allowImplicitCasts.toString)
+    )
+  }
+
+  // Make sure that unresolved expressions (i.e. UpCast) in the query are NOT resolved during
+  // Delta's analysis steps.
+  test("df by-name overwrite with safe upcast under strict store assignment policy") {
+    withTable("target") {
+      TestData("a int, b double", Seq("""{ "a": 1, "b": 2.0 }""")).toDF
+        .write.format("delta").saveAsTable("target")
+      withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> "strict") {
+        TestData("a int, b int", Seq("""{ "a": 1, "b": 3 }""")).toDF
+          .writeTo("target").overwrite(lit(true))
+        checkAnswer(spark.table("target"),
+          TestData("a int, b double", Seq("""{ "a": 1, "b": 3.0 }""")).toDF)
+      }
+    }
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
@@ -99,7 +99,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
       overwriteWhere = "a" -> 1,
       insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
       expectedResult = ExpectedResult.Failure(ex => {
-        // The missing column isn't an issue, but dataframe inserts by name (except streaming) don't
+        // The missing column isn't an issue, but save() and saveAsTable() overwrite don't
         // support implicit casting to reconcile the type mismatch.
         checkError(
           ex,
@@ -109,7 +109,24 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
             "updateField" -> "a"
           ))
       }),
-      includeInserts = insertsByName.intersect(insertsDataframe) - StreamingInsert,
+      includeInserts = insertsWithoutImplicitCastSupport,
+      withSchemaEvolution = schemaEvolution
+    )
+
+    // Other df-by-name inserts (DFv2, saveAsTable append) support implicit casting.
+    testInserts(s"insert with implicit cast and missing top-level column," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a long, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Success(
+        expected = new StructType()
+          .add("a", LongType)
+          .add("b", IntegerType)
+          .add("c", IntegerType)),
+      includeInserts = insertsByName.intersect(insertsDataframe) - StreamingInsert --
+        insertsWithoutImplicitCastSupport,
       withSchemaEvolution = schemaEvolution
     )
 
@@ -122,7 +139,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
       insertData =
         TestData("a int, s struct<y: long>", Seq("""{ "a": 1, "s": { "y": 5 } }""")),
       expectedResult = ExpectedResult.Failure(ex => {
-        // The missing column isn't an issue, but dataframe inserts by name (except streaming) don't
+        // The missing column isn't an issue, but save() and saveAsTable() overwrite don't
         // support implicit casting to reconcile the type mismatch.
         checkError(
           ex,
@@ -132,11 +149,11 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
             "updateField" -> "s"
           ))
       }),
-      includeInserts = insertsByName.intersect(insertsDataframe) - StreamingInsert,
+      includeInserts = insertsWithoutImplicitCastSupport,
       withSchemaEvolution = schemaEvolution
     )
 
-  testInserts(s"insert with implicit cast and missing nested field," +
+    testInserts(s"insert with implicit cast and missing nested field," +
       s"schemaEvolution=$schemaEvolution")(
       initialData =
         TestData("a int, s struct<x: int, y: int>", Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
@@ -144,15 +161,16 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
       overwriteWhere = "a" -> 1,
       insertData =
         TestData("a int, s struct<y: long>", Seq("""{ "a": 1, "s": { "y": 5 } }""")),
-      // Missing nested fields are allowed when writing to a delta streaming sink when there's a
-      // type mismatch, same as when there's no type mismatch.
+      // Missing nested fields are allowed when writing to a delta streaming sink or using DFv2 and
+      // saveAsTable(Append) when there's a type mismatch, same as when there's no type mismatch.
       expectedResult = ExpectedResult.Success(
         expected = new StructType()
           .add("a", IntegerType)
           .add("s", new StructType()
             .add("x", IntegerType)
             .add("y", IntegerType))),
-      includeInserts = Set(StreamingInsert),
+      includeInserts = insertsByName.intersect(insertsDataframe) --
+        insertsWithoutImplicitCastSupport,
       withSchemaEvolution = schemaEvolution
     )
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -97,8 +97,9 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
     )
 
 
-    // Adding new top-level columns with schema evolution is allowed for all inserts, but dataframe
-    // inserts by name don't support implicit casting and will fail due to the type mismatch.
+    // Adding new top-level columns with schema evolution is allowed for all inserts.
+    // save() and saveAsTable() overwrite don't support implicit casting and will fail.
+    // SQL inserts by-name have different error messages and are covered in a separate test below.
     testInserts(s"insert with extra top-level column and implicit cast," +
       s"schemaEvolution=$schemaEvolution")(
       initialData = TestData("a int, b int", Seq("""{ "a": 1, "b": 2 }""")),
@@ -116,7 +117,8 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
           checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
         })
       },
-      includeInserts = insertsByPosition + StreamingInsert,
+      excludeInserts = insertsSQL.intersect(insertsByName) ++
+        insertsWithoutImplicitCastSupport,
       withSchemaEvolution = schemaEvolution
     )
 
@@ -135,7 +137,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             "updateField" -> "b"
           ))
       }),
-      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      includeInserts = insertsWithoutImplicitCastSupport,
       withSchemaEvolution = schemaEvolution
     )
 
@@ -252,13 +254,13 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
           checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
         })
       },
-      includeInserts = insertsSQL ++ insertsByPosition + StreamingInsert -- Seq(
+      excludeInserts = Set(
         // It's not possible to specify a column that doesn't exist in the target using SQL with an
         // explicit column list.
         SQLInsertColList(SaveMode.Append),
         SQLInsertColList(SaveMode.Overwrite),
-        SQLInsertOverwritePartitionColList
-      ),
+        SQLInsertOverwritePartitionColList) ++
+        insertsWithoutImplicitCastSupport,
       withSchemaEvolution = schemaEvolution
     )
 
@@ -278,7 +280,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             "updateField" -> "s"
           ))
       }),
-      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
+      includeInserts = insertsWithoutImplicitCastSupport,
       withSchemaEvolution = schemaEvolution
     )
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -428,6 +428,20 @@ trait DeltaInsertIntoTest
   protected lazy val (insertsAppend, insertsOverwrite): (Set[Insert], Set[Insert]) =
     allInsertTypes.partition(_.mode == SaveMode.Append)
 
+  /**
+   * Collects inserts that don't support implicit casting: save() (all modes) and saveAsTable()
+   * overwrite. These go through SaveIntoDataSourceCommand / ReplaceTableAsSelect which are not
+   * handled by [[DeltaImplicitCast]]. Note that saveAsTable(Append) is NOT in this set because
+   * it routes through AppendData (a V2WriteCommand) which IS handled by [[DeltaImplicitCast]].
+   */
+  protected lazy val insertsWithoutImplicitCastSupport: Set[Insert] = Set(
+    DFv1Save(SaveMode.Append),
+    DFv1Save(SaveMode.Overwrite),
+    DFv1SaveReplaceOn,
+    DFv1SaveAsTable(SaveMode.Overwrite)
+  )
+
+
   /** Collects all test cases defined, aggregated by test name. Used in
    * [[checkAllTestCasesImplemented]] below to ensure each test covers all existing insert types.
    */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -847,7 +847,7 @@ trait GeneratedColumnSuiteBase
     testSchema(Seq(f6, f6x, f8), Set("c6", "c8"))
   }
 
-  test("disallow column type evolution") {
+  test("generated columns - implicit cast preserves column type") {
     withTableName("disallow_column_type_evolution") { table =>
     // "HASH(c1)" returns different results for INT and LONG. For example, "SELECT hash(32767)"
     // returns 1249274084, but "SELECT hash(32767L)" returns -860381306. Hence we should
@@ -856,26 +856,20 @@ trait GeneratedColumnSuiteBase
         Map("c2" -> "HASH(c1)"), Nil)
       val tableSchema = spark.table(table).schema
       Seq(32767).toDF("c1").write.format("delta").mode("append").saveAsTable(table)
-      assert(tableSchema == spark.table(table).schema)
-      // Insert a LONG to `c1` should fail rather than changing the `c1` type to LONG.
-      checkError(
-        intercept[AnalysisException] {
-          Seq(32767.toLong).toDF("c1").write.format("delta").mode("append")
-            .option("mergeSchema", "true")
-            .saveAsTable(table)
-        },
-        "DELTA_GENERATED_COLUMNS_DATA_TYPE_MISMATCH",
-        parameters = Map(
-          "columnName" -> "c1",
-          "columnType" -> "INT",
-          "dataType" -> "BIGINT",
-          "generatedColumns" -> "c2 -> HASH(c1)"
-        ))
-      checkAnswer(spark.table(table), Row(32767, 1249274084) :: Nil)
+      assert(tableSchema === spark.table(table).schema)
+      // With implicit casting, inserting a LONG will cast to INT and succeed
+      Seq(32767.toLong).toDF("c1").write.format("delta").mode("append")
+        .option("mergeSchema", "true")
+        .saveAsTable(table)
+      // Schema should remain unchanged (still INT)
+      assert(tableSchema === spark.table(table).schema)
+      // Both rows should have the same hash since the LONG was cast to INT
+      checkAnswer(spark.table(table),
+        Row(32767, 1249274084) :: Row(32767, 1249274084) :: Nil)
     }
   }
 
-  test("disallow column type evolution - nesting") {
+  test("generated columns - implicit cast preserves column type with nesting") {
     withTableName("disallow_column_type_evolution") { table =>
       createTable(table, None, "a SMALLINT, c1 STRUCT<a: SMALLINT>, c2 INT",
         Map("c2" -> "HASH(a)"), Nil)
@@ -883,7 +877,7 @@ trait GeneratedColumnSuiteBase
       Seq(32767.toShort).toDF("a")
         .selectExpr("a", "named_struct('a', a) as c1")
         .write.format("delta").mode("append").saveAsTable(table)
-      assert(tableSchema == spark.table(table).schema)
+      assert(tableSchema === spark.table(table).schema)
 
       // INSERT an INT to `c1.a` should not fail
       Seq((32767.toShort, 32767)).toDF("a", "c1a")
@@ -892,23 +886,17 @@ trait GeneratedColumnSuiteBase
         .option("mergeSchema", "true")
         .saveAsTable(table)
 
-      // Insert an INT to `a` should fail rather than changing the `a` type to INT
-      checkError(
-        intercept[AnalysisException] {
-          Seq((32767, 32767)).toDF("a", "c1a")
-            .selectExpr("a", "named_struct('a', c1a) as c1")
-            .write.format("delta").mode("append")
-            .option("mergeSchema", "true")
-            .saveAsTable(table)
-        },
-        "DELTA_GENERATED_COLUMNS_DATA_TYPE_MISMATCH",
-        parameters = Map(
-          "columnName" -> "a",
-          "columnType" -> "SMALLINT",
-          "dataType" -> "INT",
-          "generatedColumns" -> "c2 -> HASH(a)"
-        )
-      )
+      // Insert an INT to `a` should succeed - it will cast to SMALLINT
+      Seq((32767, 32767)).toDF("a", "c1a")
+        .selectExpr("a", "named_struct('a', c1a) as c1")
+        .write.format("delta").mode("append")
+        .option("mergeSchema", "true")
+        .saveAsTable(table)
+
+      // Schema should remain unchanged (still SMALLINT)
+      assert(tableSchema === spark.table(table).schema)
+      // Verify all rows were inserted with proper casting
+      assert(spark.table(table).count() === 3)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add implicit casting support for DataFrame by-name writes (`df.writeTo().append()`, `df.writeTo().overwrite()`, `df.writeTo().overwritePartitions()`) targeting Delta tables. Previously, these writes would fail on type mismatches; now data is cast to match the target table schema, governed by `spark.sql.storeAssignmentPolicy`.

This is implemented as a new analyzer rule DeltaImplicitCast that runs before DeltaAnalysis and handles all V2WriteCommands for Delta tables via the DataFrame API.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
New test suites covering implicit casting behavior across all DataFrame and SQL insert operations, including column reordering, struct field resolution, nested types, and store assignment policy interactions.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes. DataFrame by-name writes to Delta tables now implicitly cast data to match the target table schema instead of failing on type mismatches. The casting behavior is controlled by the existing `spark.sql.storeAssignmentPolicy` config. This applies to `df.writeTo().append()`, `df.writeTo().overwrite()`, and `df.writeTo().overwritePartitions()`.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
