### PR TITLE
[Protocol] Clarify Default Columns wording around explicit NULL

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2382,7 +2382,7 @@ Enablement:
 When enabled:
 - The `metadata` for the column in the table schema MAY contain the key `CURRENT_DEFAULT`.
 - The value of `CURRENT_DEFAULT` SHOULD be parsed as a SQL expression.
-- Writers MUST enforce that before writing any rows to the table, for each such requested row that lacks any explicit value (including NULL) for columns with default values, the writing system will assign the result of evaluating the default value expression for each such column as the value for that column in the row. By the same token, if the engine specified the explicit `DEFAULT` SQL keyword for any column, the expression result must be substituted in the same way.
+- Writers MUST enforce that before writing any rows to the table, for each column with a default value that lacks an explicit value in a requested row, the writing system will assign the result of evaluating the default value expression as the value for that column in the row. An explicitly-provided NULL counts as an explicit value and MUST be preserved as-is; the default expression MUST NOT be substituted in that case. By the same token, if the engine specified the explicit `DEFAULT` SQL keyword for any column, the expression result must be substituted in the same way.
 - All columns of `variant` type must default to null.
 
 ## Identity Columns


### PR DESCRIPTION
**Before.** The Default Columns section says:

> ...for each such requested row that lacks any explicit value (including NULL) for columns with default values, the writing system will assign [the default]...

**Why it's open to interpretation.** `(including NULL)` can attach to either "explicit value" or "lacks", giving opposite behavior when a user writes `INSERT INTO t VALUES (1, NULL)` on `t(a, b INT DEFAULT 42)`:
- attached to "explicit value" → NULL is a value → default NOT substituted (NULL preserved).
- attached to "lacks" → NULL is a form of absence → default IS substituted (NULL → 42).

**What Spark does.** It preserves NULL. [`ColumnWithDefaultExprUtils`](https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala) keys substitution off the input DataFrame's *schema* (column names), not its values — so an all-NULL column passes through untouched.

**What this PR does.** Drops `(including NULL)` and adds one explicit clause stating that an explicitly-provided NULL counts as an explicit value and must be preserved. Also restructures the sentence to iterate column-first (matching the impl). Wording-only; no behavior change.