### PR TITLE
[Spark] Add GeoSpatial table feature

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -45,6 +45,7 @@ object DeltaSharingUtils extends Logging {
       TimestampNTZTableFeature.name,
       TypeWideningPreviewTableFeature.name,
       TypeWideningTableFeature.name,
+      GeoSpatialTableFeature.name,
       VariantTypePreviewTableFeature.name,
       VariantTypeTableFeature.name,
       VariantShreddingPreviewTableFeature.name,
@@ -59,6 +60,7 @@ object DeltaSharingUtils extends Logging {
       TypeWideningPreviewTableFeature.name,
       TypeWideningTableFeature.name,
       VariantTypePreviewTableFeature.name,
+      GeoSpatialTableFeature.name,
       VariantTypeTableFeature.name,
       VariantShreddingPreviewTableFeature.name,
       VariantShreddingTableFeature.name

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -71,6 +71,7 @@ private[spark] class TestClientForDeltaFormatSharing(
     TimestampNTZTableFeature,
     TypeWideningPreviewTableFeature,
     TypeWideningTableFeature,
+    GeoSpatialTableFeature,
     VariantTypePreviewTableFeature,
     VariantTypeTableFeature,
     VariantShreddingPreviewTableFeature,

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -183,6 +183,12 @@
     ],
     "sqlState" : "0AKDE"
   },
+  "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE" : {
+    "message" : [
+      "Cannot drop the geospatial table feature. Recreate the table or drop columns with geometry/geography types: <colNames> and try again."
+    ],
+    "sqlState" : "0AKDE"
+  },
   "DELTA_CANNOT_EVALUATE_EXPRESSION" : {
     "message" : [
       "Cannot evaluate expression: <expression>"
@@ -1333,6 +1339,18 @@
     ],
     "sqlState" : "42K09"
   },
+  "DELTA_GEOSPATIAL_NOT_SUPPORTED" : {
+    "message" : [
+      "Geospatial types are not supported in this version of Delta Lake."
+    ],
+    "sqlState" : "0AKDC"
+  },
+  "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED" : {
+    "message" : [
+      "Geospatial type has an unsupported srid: <srid>. Delta tables only support non-negative srid values."
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_ICEBERG_COMPAT_VIOLATION" : {
     "message" : [
       "The validation of IcebergCompatV<version> has failed."
@@ -2254,6 +2272,12 @@
   "DELTA_OPERATION_NOT_ALLOWED_DETAIL" : {
     "message" : [
       "Operation not allowed: `<operation>` is not supported for Delta tables: <tableName>"
+    ],
+    "sqlState" : "0AKDC"
+  },
+  "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES" : {
+    "message" : [
+      "<operation> is not supported for data types: <dataTypeList>."
     ],
     "sqlState" : "0AKDC"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -183,6 +183,12 @@
     ],
     "sqlState" : "0AKDE"
   },
+  "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE" : {
+    "message" : [
+      "Cannot drop the geospatial table feature. Recreate the table or drop columns with geometry/geography types: <colNames> and try again."
+    ],
+    "sqlState" : "0AKDE"
+  },
   "DELTA_CANNOT_EVALUATE_EXPRESSION" : {
     "message" : [
       "Cannot evaluate expression: <expression>"
@@ -1372,6 +1378,18 @@
     ],
     "sqlState" : "42K09"
   },
+  "DELTA_GEOSPATIAL_NOT_SUPPORTED" : {
+    "message" : [
+      "Geospatial types are not supported in this version of Delta Lake."
+    ],
+    "sqlState" : "0AKDC"
+  },
+  "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED" : {
+    "message" : [
+      "Geospatial type has an unsupported srid: <srid>. Delta tables only support non-negative srid values."
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_ICEBERG_COMPAT_VIOLATION" : {
     "message" : [
       "The validation of IcebergCompatV<version> has failed."
@@ -2304,6 +2322,12 @@
   "DELTA_OPERATION_NOT_ALLOWED_DETAIL" : {
     "message" : [
       "Operation not allowed: `<operation>` is not supported for Delta tables: <tableName>"
+    ],
+    "sqlState" : "0AKDC"
+  },
+  "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES" : {
+    "message" : [
+      "<operation> is not supported for data types: <dataTypeList>."
     ],
     "sqlState" : "0AKDC"
   },

--- a/spark/src/main/scala-shims/spark-4.0/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.0/GeoTypesShim.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.shims
+
+import org.apache.spark.sql.types.DataType
+
+/**
+ * Shim for the Spark GeometryType / GeographyType catalyst types, which were introduced
+ * in Spark 4.1 (SPARK-53760). On Spark 4.0 these types do not exist, so this shim simply
+ * reports that no value is ever a geospatial type. As a result the GeoSpatial table
+ * feature is effectively a no-op on Spark 4.0.
+ */
+object GeoTypesShim {
+  /** Returns true if `dt` is `GeometryType` or `GeographyType`. */
+  def isGeoSpatialType(dt: DataType): Boolean = false
+
+  /**
+   * If `dt` is a geospatial type with an unsupported SRID, returns `Some(srid)`. Returns
+   * `None` for non-geospatial types or geospatial types with supported SRIDs.
+   */
+  def unsupportedSrid(dt: DataType): Option[Int] = None
+}

--- a/spark/src/main/scala-shims/spark-4.1/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1/GeoTypesShim.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.shims
+
+import org.apache.spark.sql.types.{DataType, GeographyType, GeometryType}
+
+/**
+ * Shim for the Spark GeometryType / GeographyType catalyst types, which were introduced
+ * in Spark 4.1 (SPARK-53760). This is the real implementation for Spark 4.1.
+ */
+object GeoTypesShim {
+  /** Returns true if `dt` is `GeometryType` or `GeographyType`. */
+  def isGeoSpatialType(dt: DataType): Boolean = dt match {
+    case _: GeometryType | _: GeographyType => true
+    case _ => false
+  }
+
+  /**
+   * If `dt` is a geospatial type with an unsupported SRID, returns `Some(srid)`. Returns
+   * `None` for non-geospatial types or geospatial types with supported SRIDs.
+   */
+  def unsupportedSrid(dt: DataType): Option[Int] = dt match {
+    case g: GeometryType if !GeometryType.isSridSupported(g.srid) => Some(g.srid)
+    case g: GeographyType if !GeographyType.isSridSupported(g.srid) => Some(g.srid)
+    case _ => None
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.2/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.2/GeoTypesShim.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.shims
+
+import org.apache.spark.sql.types.{DataType, GeographyType, GeometryType}
+
+/**
+ * Shim for the Spark GeometryType / GeographyType catalyst types, which were introduced
+ * in Spark 4.1 (SPARK-53760). This is the real implementation for Spark 4.2.
+ */
+object GeoTypesShim {
+  /** Returns true if `dt` is `GeometryType` or `GeographyType`. */
+  def isGeoSpatialType(dt: DataType): Boolean = dt match {
+    case _: GeometryType | _: GeographyType => true
+    case _ => false
+  }
+
+  /**
+   * If `dt` is a geospatial type with an unsupported SRID, returns `Some(srid)`. Returns
+   * `None` for non-geospatial types or geospatial types with supported SRIDs.
+   */
+  def unsupportedSrid(dt: DataType): Option[Int] = dt match {
+    case g: GeometryType if !GeometryType.isSridSupported(g.srid) => Some(g.srid)
+    case g: GeographyType if !GeographyType.isSridSupported(g.srid) => Some(g.srid)
+    case _ => None
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -380,6 +380,32 @@ trait DeltaErrorsBase
     )
   }
 
+  def cannotDropGeospatialFeature(cols: Seq[StructField]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE",
+      messageParameters = Array(cols.map(_.name).mkString(", ")))
+  }
+
+  def geoSpatialNotSupportedException(): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+      messageParameters = Array.empty
+    )
+  }
+
+  def operationNotSupportedForDataTypes(
+      operation: String,
+      unsupportedDataType: UnsupportedDataTypeInfo,
+      moreUnsupportedDataTypes: UnsupportedDataTypeInfo*): Throwable = {
+    val prettyMessage = (unsupportedDataType +: moreUnsupportedDataTypes)
+      .map(dt => s"${dt.column}: ${dt.dataType}")
+      .mkString("[", ", ", "]")
+    new DeltaAnalysisException(
+      errorClass = "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES",
+      messageParameters = Array(operation, prettyMessage)
+    )
+  }
+
   def checkConstraintReferToWrongColumns(colName: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_INVALID_CHECK_CONSTRAINT_REFERENCES",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -380,6 +380,19 @@ trait DeltaErrorsBase
     )
   }
 
+  def cannotDropGeospatialFeature(cols: Seq[StructField]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE",
+      messageParameters = Array(cols.map(_.name).mkString(", ")))
+  }
+
+  def geoSpatialNotSupportedException(): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+      messageParameters = Array.empty
+    )
+  }
+
   def checkConstraintReferToWrongColumns(colName: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_INVALID_CHECK_CONSTRAINT_REFERENCES",
@@ -525,6 +538,20 @@ trait DeltaErrorsBase
       errorClass = "DELTA_ZORDERING_COLUMN_DOES_NOT_EXIST",
       messageParameters = Array(colName))
   }
+
+  def operationNotSupportedForDataTypes(
+      operation: String,
+      unsupportedDataType: UnsupportedDataTypeInfo,
+      moreUnsupportedDataTypes: UnsupportedDataTypeInfo*): Throwable = {
+    val prettyMessage = (unsupportedDataType +: moreUnsupportedDataTypes)
+      .map(dt => s"${dt.column}: ${dt.dataType}")
+      .mkString("[", ", ", "]")
+    new DeltaAnalysisException(
+      errorClass = "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES",
+      messageParameters = Array(operation, prettyMessage)
+    )
+  }
+
 
   /**
    * Throwable used when CDC options contain no 'start'.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaGeoSpatial.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaGeoSpatial.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
+import org.apache.spark.sql.delta.schema.{SchemaUtils, UnsupportedDataTypeInfo}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+object DeltaGeoSpatial {
+
+  /** Returns whether to enable geospatial features that are part of the preview scope. */
+  def isPreviewEnabled(spark: SparkSession): Boolean =
+    spark.conf.get(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED)
+
+  /**
+   * Asserts that the given table doesn't contain any geo types if flag is disabled or protocol
+   * is not supported.
+   */
+  def assertTableReadable(conf: SQLConf, protocol: Protocol, metadata: Metadata): Unit = {
+    // if metadata contains geo column
+    // but either config is disabled on protocol is not supported
+    // throw exception
+    if (containsGeoColumns(metadata.schema) &&
+        !conf.getConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED)) {
+      throw DeltaErrors.geoSpatialNotSupportedException()
+    }
+  }
+
+  /**
+   * Returns whether the protocol version supports the GeoSpatial table feature.
+   */
+  def isSupported(protocol: Protocol): Boolean =
+    protocol.isFeatureSupported(GeoSpatialPreviewTableFeature) ||
+      protocol.isFeatureSupported(GeoSpatialTableFeature)
+
+  /**
+   * Validates that the given actions are compatible with the geospatial table feature.
+   * Will throw an error if the feature is not allowed but the schema contains geospatial data.
+   */
+  def validateCommitActions(spark: SparkSession, protocol: Protocol, actions: Seq[Action]): Unit = {
+    val hasGeoSpatialMetadata = actions.exists {
+      case m: Metadata =>
+        assertSridSupported(m.schema)
+        containsGeoColumns(m.schema)
+      case _ => false
+    }
+
+    if (hasGeoSpatialMetadata) {
+      if (!isPreviewEnabled(spark) || !isSupported(protocol)) {
+        throw DeltaErrors.geoSpatialNotSupportedException()
+      }
+    }
+  }
+
+  def isGeoSpatialType(dt: DataType): Boolean = dt match {
+    case _: GeometryType | _: GeographyType => true
+    case _ => false
+  }
+
+  /**
+   * Find Geo columns in the table schema.
+   */
+  def containsGeoColumns(schema: DataType): Boolean = {
+    SchemaUtils.typeExistsRecursively(schema)(dt =>
+      DeltaGeoSpatial.isGeoSpatialType(dt)
+    )
+  }
+
+  def assertSridSupported(schema: DataType): Unit = {
+    SchemaUtils.typeExistsRecursively(schema) {
+      case g: GeometryType if !GeometryType.isSridSupported(g.srid) =>
+        throw new AnalysisException(
+          "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED",
+          Map("srid" -> g.srid.toString))
+        false
+      case g: GeographyType if !GeographyType.isSridSupported(g.srid) =>
+        throw new AnalysisException(
+          "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED",
+          Map("srid" -> g.srid.toString))
+        false
+      case _ => false
+    }
+  }
+
+  def findGeoColumnsRecursively(schema: StructType): Option[DataType] = {
+    SchemaUtils.findAnyTypeRecursively(schema)(dt =>
+      DeltaGeoSpatial.isGeoSpatialType(dt)
+    )
+  }
+
+  /**
+   * Throws not supported for columns with geospatial error if there are geospatial
+   * types in the given schema.
+   */
+  def failIfSchemaHasGeoColumn(schema: StructType, operation: String): Unit = {
+    SchemaUtils.findColumnPaths(schema)(isGeoSpatialType) match {
+      case columnPaths if columnPaths.nonEmpty =>
+        val dataTypeInfo = columnPaths.map(
+          column => UnsupportedDataTypeInfo(column._1.toString, column._2))
+        throw DeltaErrors.operationNotSupportedForDataTypes(
+          operation, dataTypeInfo.head, dataTypeInfo.tail: _*
+        )
+
+      case _ =>
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaGeoSpatial.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaGeoSpatial.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
+import org.apache.spark.sql.delta.schema.{SchemaUtils, UnsupportedDataTypeInfo}
+import org.apache.spark.sql.delta.shims.GeoTypesShim
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DataType, StructType}
+
+object DeltaGeoSpatial {
+
+  /** Returns whether to enable geospatial features that are part of the preview scope. */
+  def isPreviewEnabled(spark: SparkSession): Boolean =
+    spark.conf.get(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED)
+
+  /**
+   * Asserts that the given table doesn't contain any geo types if flag is disabled or protocol
+   * is not supported.
+   */
+  def assertTableReadable(conf: SQLConf, protocol: Protocol, metadata: Metadata): Unit = {
+    // if metadata contains geo column
+    // but either config is disabled on protocol is not supported
+    // throw exception
+    if (containsGeoColumns(metadata.schema) &&
+        !conf.getConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED)) {
+      throw DeltaErrors.geoSpatialNotSupportedException()
+    }
+  }
+
+  /**
+   * Returns whether the protocol version supports the GeoSpatial table feature.
+   */
+  def isSupported(protocol: Protocol): Boolean =
+    protocol.isFeatureSupported(GeoSpatialPreviewTableFeature) ||
+      protocol.isFeatureSupported(GeoSpatialTableFeature)
+
+  /**
+   * Validates that the given actions are compatible with the geospatial table feature.
+   * Will throw an error if the feature is not allowed but the schema contains geospatial data.
+   */
+  def validateCommitActions(spark: SparkSession, protocol: Protocol, actions: Seq[Action]): Unit = {
+    val hasGeoSpatialMetadata = actions.exists {
+      case m: Metadata =>
+        assertSridSupported(m.schema)
+        containsGeoColumns(m.schema)
+      case _ => false
+    }
+
+    if (hasGeoSpatialMetadata) {
+      if (!isPreviewEnabled(spark) || !isSupported(protocol)) {
+        throw DeltaErrors.geoSpatialNotSupportedException()
+      }
+    }
+  }
+
+  def isGeoSpatialType(dt: DataType): Boolean = GeoTypesShim.isGeoSpatialType(dt)
+
+  /**
+   * Find Geo columns in the table schema.
+   */
+  def containsGeoColumns(schema: DataType): Boolean = {
+    SchemaUtils.typeExistsRecursively(schema)(GeoTypesShim.isGeoSpatialType)
+  }
+
+  def assertSridSupported(schema: DataType): Unit = {
+    SchemaUtils.typeExistsRecursively(schema) { dt =>
+      GeoTypesShim.unsupportedSrid(dt) match {
+        case Some(srid) =>
+          throw new AnalysisException(
+            "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED",
+            Map("srid" -> srid.toString))
+        case None => false
+      }
+    }
+  }
+
+  def findGeoColumnsRecursively(schema: StructType): Option[DataType] = {
+    SchemaUtils.findAnyTypeRecursively(schema)(GeoTypesShim.isGeoSpatialType)
+  }
+
+  /**
+   * Throws not supported for columns with geospatial error if there are geospatial
+   * types in the given schema.
+   */
+  def failIfSchemaHasGeoColumn(schema: StructType, operation: String): Unit = {
+    SchemaUtils.findColumnPaths(schema)(isGeoSpatialType) match {
+      case columnPaths if columnPaths.nonEmpty =>
+        val dataTypeInfo = columnPaths.map(
+          column => UnsupportedDataTypeInfo(column._1.toString, column._2))
+        throw DeltaErrors.operationNotSupportedForDataTypes(
+          operation, dataTypeInfo.head, dataTypeInfo.tail: _*
+        )
+
+      case _ =>
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2433,6 +2433,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
     var finalActions = newMetadata.toSeq ++ newProtocol.toSeq ++ otherActions
 
+    DeltaGeoSpatial.validateCommitActions(spark, protocol, finalActions)
+
     // Block future cases of CDF + Column Mapping changes + file changes
     // This check requires having called
     // DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments which is done in the

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -32,6 +32,7 @@ import scala.util.control.NonFatal
 import com.databricks.spark.util.TagDefinition
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
 import org.apache.spark.sql.delta.ClassicColumnConversions._
+import org.apache.spark.sql.delta.DeltaGeoSpatial
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
@@ -1078,6 +1079,19 @@ trait OptimisticTransactionImpl extends TransactionHelper
         throw DeltaErrors.unsupportedDataTypes(unsupportedTypes.head, unsupportedTypes.tail: _*)
       }
     }
+
+    // even though we've just called SchemaUtils.findUnsupportedDataTypes, we didn't have
+    // spark config there.
+    // so we need to check again here.
+    if (!DeltaGeoSpatial.isPreviewEnabled(spark)) {
+      val geoTypeOpt = DeltaGeoSpatial.findGeoColumnsRecursively(metadata.schema)
+      geoTypeOpt.foreach { geoType =>
+        throw new AnalysisException("UNSUPPORTED_DATATYPE", Map("typeName" -> geoType.toString))
+      }
+    } else {
+      DeltaGeoSpatial.assertSridSupported(metadata.schema)
+    }
+
 
     if (spark.conf.get(DeltaSQLConf.DELTA_TABLE_PROPERTY_CONSTRAINTS_CHECK_ENABLED)) {
       Protocol.assertTablePropertyConstraintsSatisfied(spark, metadata, snapshot)
@@ -2494,6 +2508,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
     newMetadata = metadataUpdate1.orElse(newMetadata)
 
     var finalActions = newMetadata.toSeq ++ newProtocol.toSeq ++ otherActions
+
+    DeltaGeoSpatial.validateCommitActions(spark, protocol, finalActions)
 
     // Block future cases of CDF + Column Mapping changes + file changes
     // This check requires having called

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -621,6 +621,26 @@ case class ColumnMappingPreDowngradeCommand(table: DeltaTableV2)
   }
 }
 
+case class GeospatialPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand {
+
+  /**
+   * Throws an exception if the table has geospatial types, and returns false otherwise.
+   * We currently do not remove the geospatial statistics in the current table version so no
+   * action is required.
+   */
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): PreDowngradeStatus = {
+    if (GeoSpatialPreviewTableFeature.validateDropInvariants(table, table.initialSnapshot)) {
+      return PreDowngradeStatus.DID_NOT_PERFORM_CHANGES
+    }
+    val geospatialCols = table.initialSnapshot.schema.fields
+      .filter(field => DeltaGeoSpatial.containsGeoColumns(field.dataType))
+    // We ask the user to explicitly drop the geospatial columns before the table feature
+    // can be dropped.
+    throw DeltaErrors.cannotDropGeospatialFeature(geospatialCols)
+  }
+}
+
 case class CheckConstraintsPreDowngradeTableFeatureCommand(table: DeltaTableV2)
     extends PreDowngradeTableFeatureCommand {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -590,6 +590,27 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
     true
   }
 }
+
+case class GeospatialPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand {
+
+  /**
+   * Throws an exception if the table has geospatial types, and returns false otherwise.
+   * We currently do not remove the geospatial statistics in the current table version so no
+   * action is required.
+   */
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): PreDowngradeStatus = {
+    if (GeoSpatialPreviewTableFeature.validateDropInvariants(table, table.initialSnapshot)) {
+      return PreDowngradeStatus.DID_NOT_PERFORM_CHANGES
+    }
+    val geospatialCols = table.initialSnapshot.schema.fields
+      .filter(field => DeltaGeoSpatial.containsGeoColumns(field.dataType))
+    // We ask the user to explicitly drop the geospatial columns before the table feature
+    // can be dropped.
+    throw DeltaErrors.cannotDropGeospatialFeature(geospatialCols)
+  }
+}
+
 case class ColumnMappingPreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand
     with DeltaLogging {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV1.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV1.scala
@@ -48,6 +48,7 @@ case class ProtocolMetadataAdapterV1(
 
   override def assertTableReadable(sparkSession: SparkSession): Unit = {
     TypeWidening.assertTableReadable(sparkSession.sessionState.conf, protocol, metadata)
+    DeltaGeoSpatial.assertTableReadable(sparkSession.sessionState.conf, protocol, metadata)
   }
 
   override def createRowTrackingMetadataFields(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -387,6 +387,8 @@ object TableFeature {
       IcebergCompatV1TableFeature,
       IcebergCompatV2TableFeature,
       DeletionVectorsTableFeature,
+      GeoSpatialPreviewTableFeature,
+      GeoSpatialTableFeature,
       VacuumProtocolCheckTableFeature,
       V2CheckpointTableFeature,
       RowTrackingFeature,
@@ -806,6 +808,54 @@ object VariantShreddingTableFeature
     // feature is enabled so old tables with only the preview table feature can be read.
     !protocol.isFeatureSupported(VariantShreddingPreviewTableFeature)
   }
+}
+
+/** Common base shared by the preview and geospatial table features. */
+abstract class GeoSpatialTableFeatureBase(name: String)
+  extends ReaderWriterFeature(name)
+  with RemovableFeature {
+
+  override def validateDropInvariants(table: DeltaTableV2, snapshot: Snapshot): Boolean =
+    !DeltaGeoSpatial.containsGeoColumns(snapshot.metadata.schema)
+
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
+    GeospatialPreDowngradeCommand(table)
+
+  override def actionUsesFeature(action: Action): Boolean = false
+}
+
+/**
+ * Feature used for the private preview phase of geospatial support. Tables that have this
+ * feature are still supported even after the preview.
+ */
+object GeoSpatialPreviewTableFeature
+  extends GeoSpatialTableFeatureBase(name = "geospatial-dev")
+
+/**
+ * Stable feature for geospatial support.
+ *
+ * Table feature that adds support for GeoSpatial types (Geometry and Geography).
+ * Feature is automatically added whenever schema contains any of these two types.
+ * Additionally, feature is gated behind a delta.geo.preview.enabled config.
+ */
+object GeoSpatialTableFeature
+  extends GeoSpatialTableFeatureBase(name = "geospatial")
+  with FeatureAutomaticallyEnabledByMetadata {
+  override def metadataRequiresFeatureToBeEnabled(
+      protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
+    val hasGeoColumns = DeltaGeoSpatial.containsGeoColumns(metadata.schema)
+
+    if (hasGeoColumns && !DeltaGeoSpatial.isPreviewEnabled(spark)) {
+      throw DeltaErrors.geoSpatialNotSupportedException()
+    }
+
+    hasGeoColumns &&
+    // Don't automatically enable the stable feature if the preview feature is already supported, to
+    // avoid possibly breaking old clients that only support the preview feature.
+    !protocol.isFeatureSupported(GeoSpatialPreviewTableFeature)
+  }
+
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
 }
 
 object DeletionVectorsTableFeature

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -388,6 +388,8 @@ object TableFeature {
       IcebergCompatV2TableFeature,
       IcebergCompatV3TableFeature,
       DeletionVectorsTableFeature,
+      GeoSpatialPreviewTableFeature,
+      GeoSpatialTableFeature,
       VacuumProtocolCheckTableFeature,
       V2CheckpointTableFeature,
       RowTrackingFeature,
@@ -649,6 +651,55 @@ object IdentityColumnsTableFeature
       spark: SparkSession): Boolean = {
     ColumnWithDefaultExprUtils.hasIdentityColumn(metadata.schema)
   }
+}
+
+
+/** Common base shared by the preview and geospatial table features. */
+abstract class GeoSpatialTableFeatureBase(name: String)
+  extends ReaderWriterFeature(name)
+  with RemovableFeature {
+
+  override def validateDropInvariants(table: DeltaTableV2, snapshot: Snapshot): Boolean =
+    !DeltaGeoSpatial.containsGeoColumns(snapshot.metadata.schema)
+
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
+    GeospatialPreDowngradeCommand(table)
+
+  override def actionUsesFeature(action: Action): Boolean = false
+}
+
+/**
+ * Feature used for the private preview phase of geospatial support. Tables that have this
+ * feature are still supported even after the preview.
+ */
+object GeoSpatialPreviewTableFeature
+  extends GeoSpatialTableFeatureBase(name = "geospatial-dev")
+
+/**
+ * Stable feature for geospatial support.
+ *
+ * Table feature that adds support for GeoSpatial types (Geometry and Geography).
+ * Feature is automatically added whenever schema contains any of these two types.
+ * Additionally, feature is gated behind a delta.geo.preview.enabled config.
+ */
+object GeoSpatialTableFeature
+  extends GeoSpatialTableFeatureBase(name = "geospatial")
+  with FeatureAutomaticallyEnabledByMetadata {
+  override def metadataRequiresFeatureToBeEnabled(
+      protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
+    val hasGeoColumns = DeltaGeoSpatial.containsGeoColumns(metadata.schema)
+
+    if (hasGeoColumns && !DeltaGeoSpatial.isPreviewEnabled(spark)) {
+      throw DeltaErrors.geoSpatialNotSupportedException()
+    }
+
+    hasGeoColumns &&
+    // Don't automatically enable the stable feature if the preview feature is already supported, to
+    // avoid possibly breaking old clients that only support the preview feature.
+    !protocol.isFeatureSupported(GeoSpatialPreviewTableFeature)
+  }
+
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
 }
 
 object TimestampNTZTableFeature extends ReaderWriterFeature(name = "timestampNtz")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.schema
 
+import scala.collection.immutable.Queue
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
@@ -82,6 +83,42 @@ object SchemaUtils extends DeltaLogging {
     }
 
     recurseIntoComplexTypes(schema, Nil)
+  }
+
+  /**
+   * Class to represent a nested column path.
+   */
+  private[delta] case class ColumnPath(parts: Queue[String] = Queue.empty) {
+    override def toString: String = parts.mkString(".")
+
+    def prepended(part: String): ColumnPath = ColumnPath(parts.+:(part))
+  }
+
+  /**
+   * Copied verbatim from Apache Spark.
+   *
+   * For the given dataType `dt` find all column paths that satisfy the given predicate `f`.
+   */
+  def findColumnPaths(dt: DataType)(f: DataType => Boolean): Seq[(ColumnPath, DataType)] = {
+    dt match {
+      case _ if f(dt) =>
+        Seq((ColumnPath(), dt))
+
+      case ArrayType(elementType, _) =>
+        findColumnPaths(elementType)(f).map { case (path, dt) => (path.prepended("element"), dt) }
+
+      case MapType(keyType, valueType, _) =>
+        findColumnPaths(keyType)(f).map { case (path, dt) => (path.prepended("key"), dt) } ++
+          findColumnPaths(valueType)(f).map { case (path, dt) => (path.prepended("value"), dt) }
+
+      case StructType(fields) =>
+        fields.flatMap { case StructField(name, dataType, _, _) =>
+          findColumnPaths(dataType)(f).map { case (path, dt) => (path.prepended(name), dt) }
+        }.toSeq
+
+      case _ =>
+        Nil
+    }
   }
 
   /** Copied over from DataType for visibility reasons. */
@@ -1569,6 +1606,8 @@ def normalizeColumnNamesInDataType(
     case DoubleType =>
     case StringType =>
     case DateType =>
+    case _: GeographyType =>
+    case _: GeometryType =>
     case TimestampType =>
     case TimestampNTZType =>
     case dt if dt.isInstanceOf[VariantType] =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.schema
 
+import scala.collection.immutable.Queue
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
@@ -82,6 +83,42 @@ object SchemaUtils extends DeltaLogging {
     }
 
     recurseIntoComplexTypes(schema, Nil)
+  }
+
+  /**
+   * Class to represent a nested column path.
+   */
+  private[delta] case class ColumnPath(parts: Queue[String] = Queue.empty) {
+    override def toString: String = parts.mkString(".")
+
+    def prepended(part: String): ColumnPath = ColumnPath(parts.+:(part))
+  }
+
+  /**
+   * Copied verbatim from Apache Spark.
+   *
+   * For the given dataType `dt` find all column paths that satisfy the given predicate `f`.
+   */
+  def findColumnPaths(dt: DataType)(f: DataType => Boolean): Seq[(ColumnPath, DataType)] = {
+    dt match {
+      case _ if f(dt) =>
+        Seq((ColumnPath(), dt))
+
+      case ArrayType(elementType, _) =>
+        findColumnPaths(elementType)(f).map { case (path, dt) => (path.prepended("element"), dt) }
+
+      case MapType(keyType, valueType, _) =>
+        findColumnPaths(keyType)(f).map { case (path, dt) => (path.prepended("key"), dt) } ++
+          findColumnPaths(valueType)(f).map { case (path, dt) => (path.prepended("value"), dt) }
+
+      case StructType(fields) =>
+        fields.flatMap { case StructField(name, dataType, _, _) =>
+          findColumnPaths(dataType)(f).map { case (path, dt) => (path.prepended(name), dt) }
+        }.toSeq
+
+      case _ =>
+        Nil
+    }
   }
 
   /** Copied over from DataType for visibility reasons. */
@@ -1576,6 +1613,7 @@ def normalizeColumnNamesInDataType(
     case DoubleType =>
     case StringType =>
     case DateType =>
+    case dt if org.apache.spark.sql.delta.shims.GeoTypesShim.isGeoSpatialType(dt) =>
     case TimestampType =>
     case TimestampNTZType =>
     case dt if dt.isInstanceOf[VariantType] =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -340,9 +340,10 @@ class DeltaDataSource
   }
 
   /**
-   * Extend the default `supportsDataType` to allow VariantType.
+   * Extend the default `supportsDataType` to allow GeoSpatial types and VariantType.
    */
   override def supportsDataType(dt: DataType): Boolean = {
+    DeltaGeoSpatial.isGeoSpatialType(dt) ||
     dt.isInstanceOf[VariantType] || super.supportsDataType(dt)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3086,6 +3086,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  //////////////////
+  // GeoSpatial
+  //////////////////
+
+  val DELTA_GEO_PREVIEW_ENABLED =
+    buildConf("geo.preview.enabled")
+      .internal()
+      .doc("Enable GeoSpatial features that are part of the preview scope.")
+      .booleanConf
+      .createWithDefault(true)
+
   ///////////
   // VARIANT
   ///////////////////

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3168,6 +3168,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  //////////////////
+  // GeoSpatial
+  //////////////////
+
+  val DELTA_GEO_PREVIEW_ENABLED =
+    buildConf("geo.preview.enabled")
+      .internal()
+      .doc("Enable GeoSpatial features that are part of the preview scope.")
+      .booleanConf
+      .createWithDefault(true)
+
   ///////////
   // VARIANT
   ///////////////////

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -47,7 +47,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaErrors}
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaErrors, DeltaGeoSpatial}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -615,8 +615,10 @@ private[delta] object PartitionUtils {
 
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
       field => field.dataType match {
-        // Variant types are not orderable and thus cannot be partition columns.
-        case a: AtomicType if !a.isInstanceOf[VariantType] => // OK
+        // Variant, Geometry and Geography types are not orderable and thus cannot be partition
+        // columns.
+        case a: AtomicType
+          if !a.isInstanceOf[VariantType] && !DeltaGeoSpatial.isGeoSpatialType(a) => // OK
         case _ => throw DeltaErrors.cannotUseDataTypeForPartitionColumnError(field)
       }
     }

--- a/spark/src/test/scala-shims/spark-4.1/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.1/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+/**
+ * Tests for the GeoSpatial table feature in the Delta Spark connector. Verifies:
+ *  - Auto-enablement of the [[GeoSpatialTableFeature]] when a geospatial column is present.
+ *  - Required protocol versions (3, 7).
+ *  - SRID validation at commit time.
+ *  - Removability contract (drop is rejected while geospatial columns still exist).
+ *
+ * Note: this suite lives under the spark-4.1 test shim directory because Spark's
+ * `GeometryType` / `GeographyType` catalyst types were only added in Spark 4.1
+ * (SPARK-53760). The GeoSpatial table feature is therefore a no-op on Spark 4.0.
+ */
+class DeltaGeoSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaSQLTestUtils {
+
+  // Default SRID used in Parquet/Iceberg/Delta specs (OGC:CRS84).
+  private val DefaultSrid = 4326
+
+  private def metadataWithSchema(schema: StructType): Metadata = {
+    Metadata(schemaString = schema.json)
+  }
+
+  test("containsGeoColumns detects top-level geometry and geography columns") {
+    val schemaGeom = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val schemaGeog = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val schemaPlain = new StructType()
+      .add("id", IntegerType)
+      .add("s", StringType)
+
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeom))
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeog))
+    assert(!DeltaGeoSpatial.containsGeoColumns(schemaPlain))
+  }
+
+  test("containsGeoColumns detects nested geospatial columns") {
+    val nested = new StructType()
+      .add("outer", new StructType().add("inner", GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(nested))
+
+    val arr = new StructType().add("xs", ArrayType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(arr))
+
+    val map = new StructType().add("m", MapType(StringType, GeographyType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(map))
+  }
+
+  test("findGeoColumnsRecursively returns the first matching type") {
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val result = DeltaGeoSpatial.findGeoColumnsRecursively(schema)
+    assert(result.isDefined)
+    assert(result.get.isInstanceOf[GeographyType])
+  }
+
+  test("assertSridSupported passes for default fixed SRIDs") {
+    val schema = new StructType()
+      .add("g1", GeometryType(DefaultSrid))
+      .add("g2", GeographyType(DefaultSrid))
+    DeltaGeoSpatial.assertSridSupported(schema)
+  }
+
+  test("isGeoSpatialType returns true for geometry and geography") {
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeographyType(DefaultSrid)))
+    assert(!DeltaGeoSpatial.isGeoSpatialType(StringType))
+  }
+
+  test("DeltaDataSource accepts GeoSpatial types via supportsDataType") {
+    val ds = new sources.DeltaDataSource
+    assert(ds.supportsDataType(GeometryType(DefaultSrid)))
+    assert(ds.supportsDataType(GeographyType(DefaultSrid)))
+  }
+
+  test("isSupported checks both preview and stable features") {
+    val protoNone = Protocol(3, 7)
+    val protoStable = Protocol(3, 7).withFeature(GeoSpatialTableFeature)
+    val protoPreview = Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!DeltaGeoSpatial.isSupported(protoNone))
+    assert(DeltaGeoSpatial.isSupported(protoStable))
+    assert(DeltaGeoSpatial.isSupported(protoPreview))
+  }
+
+  test("GeoSpatialTableFeature is a reader+writer feature with min protocol (3, 7)") {
+    assert(GeoSpatialTableFeature.isReaderWriterFeature)
+    assert(GeoSpatialTableFeature.minReaderVersion == 3)
+    assert(GeoSpatialTableFeature.minWriterVersion == 7)
+    assert(GeoSpatialTableFeature.name == "geospatial")
+    assert(GeoSpatialPreviewTableFeature.name == "geospatial-dev")
+  }
+
+  test("Both GeoSpatial features are registered in allSupportedFeaturesMap") {
+    assert(TableFeature.featureNameToFeature("geospatial").contains(GeoSpatialTableFeature))
+    assert(TableFeature.featureNameToFeature("geospatial-dev")
+      .contains(GeoSpatialPreviewTableFeature))
+  }
+
+  test("metadataRequiresFeatureToBeEnabled is true iff schema has geospatial columns") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val withoutGeo = metadataWithSchema(new StructType().add("s", StringType))
+    assert(GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withGeo, spark))
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withoutGeo, spark))
+  }
+
+  test("stable feature does not auto-enable when preview feature is already supported") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val protocolWithPreview =
+      Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      protocolWithPreview, withGeo, spark))
+  }
+
+  test("automaticallyUpdateProtocolOfExistingTables returns true") {
+    assert(GeoSpatialTableFeature.automaticallyUpdateProtocolOfExistingTables)
+  }
+
+  test("creating a table with a geometry column auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(protocol.isFeatureSupported(GeoSpatialTableFeature),
+        s"Expected GeoSpatialTableFeature in protocol but got: $protocol")
+      assert(protocol.minReaderVersion >= GeoSpatialTableFeature.minReaderVersion)
+      assert(protocol.minWriterVersion >= GeoSpatialTableFeature.minWriterVersion)
+    }
+  }
+
+  test("creating a table without geospatial columns does not enable GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT, s STRING) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(!protocol.isFeatureSupported(GeoSpatialTableFeature))
+      assert(!protocol.isFeatureSupported(GeoSpatialPreviewTableFeature))
+    }
+  }
+
+  test("ALTER TABLE ADD COLUMN with geography auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      assert(!getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+      sql(s"ALTER TABLE tbl ADD COLUMN g GEOGRAPHY($DefaultSrid)")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+    }
+  }
+
+  test("PartitionUtils rejects GeoSpatial type as a partition column") {
+    // Geometry / Geography are not orderable and thus cannot be partition columns. Delta's
+    // `util/PartitionUtils.validatePartitionColumn` is the write-path backstop; the catalog
+    // (DDL) path goes through Spark's own `PartitioningUtils` which is out of Delta's hands.
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val ex = intercept[DeltaAnalysisException] {
+      util.PartitionUtils.validatePartitionColumn(schema, Seq("g"), caseSensitive = false)
+    }
+    assert(ex.getErrorClass == "DELTA_INVALID_PARTITION_COLUMN_TYPE",
+      s"Unexpected error class: ${ex.getErrorClass}")
+  }
+
+  test("commit fails when geo column is added and preview conf is disabled") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val ex = intercept[SparkThrowable] {
+          sql(s"ALTER TABLE tbl ADD COLUMN g GEOMETRY($DefaultSrid)")
+        }
+        assert(ex.getErrorClass == "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("read fails when table has geo column and preview conf is disabled") {
+    // Covers the read-path guard wired through [[ProtocolMetadataAdapterV1.assertTableReadable]]:
+    // a `SELECT *` against a table with a geo column triggers DeltaParquetFileFormat
+    // construction, which invokes [[DeltaGeoSpatial.assertTableReadable]] and throws when the
+    // preview config is off.
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val ex = intercept[SparkThrowable] {
+          sql("SELECT * FROM tbl").collect()
+        }
+        assert(ex.getErrorClass == "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("assertMetadata refuses a geo column in a committed Metadata action when preview is off") {
+    // Covers the inline guard in [[OptimisticTransactionImpl.assertMetadata]].
+    // The standard DDL path hits [[GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled]]
+    // first - see the test above - so we exercise the inline guard by committing a Metadata
+    // action directly, which routes through `prepareCommit -> updateMetadataAndProtocolWith-
+    // RequiredFeatures -> assertMetadata` before the table-feature gate runs.
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val log = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+        val txn = log.startTransaction()
+        val geoSchema = new StructType()
+          .add("id", IntegerType)
+          .add("g", GeometryType(DefaultSrid))
+        val geoMetadata = txn.snapshot.metadata.copy(schemaString = geoSchema.json)
+
+        val ex = intercept[SparkThrowable] {
+          txn.commit(Seq(geoMetadata), DeltaOperations.ManualUpdate)
+        }
+        assert(ex.getErrorClass == "UNSUPPORTED_DATATYPE",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("DROP FEATURE is rejected while geospatial columns remain in the schema") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+
+      val ex = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE tbl DROP FEATURE ${GeoSpatialTableFeature.name}")
+      }
+      assert(ex.getErrorClass == "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE",
+        s"Unexpected error class: ${ex.getErrorClass}")
+      assert(ex.getMessage.contains("g"))
+    }
+  }
+
+  test("validateDropInvariants returns true after geospatial columns are dropped") {
+    withTable("tbl") {
+      sql(
+        s"""CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta
+           |TBLPROPERTIES('delta.columnMapping.mode' = 'name')""".stripMargin)
+      val tableBefore = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(!GeoSpatialTableFeature.validateDropInvariants(
+        tableBefore, tableBefore.initialSnapshot))
+
+      sql("ALTER TABLE tbl DROP COLUMN g")
+      val tableAfter = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(GeoSpatialTableFeature.validateDropInvariants(
+        tableAfter, tableAfter.initialSnapshot))
+    }
+  }
+
+  test("actionUsesFeature returns false for all actions (history protection disabled)") {
+    val geoMeta = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val plainMeta = metadataWithSchema(new StructType().add("s", StringType))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(geoMeta))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(plainMeta))
+    assert(!GeoSpatialPreviewTableFeature.actionUsesFeature(geoMeta))
+  }
+}

--- a/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+/**
+ * Tests for the GeoSpatial table feature in the Delta Spark connector. Verifies:
+ *  - Auto-enablement of the [[GeoSpatialTableFeature]] when a geospatial column is present.
+ *  - Required protocol versions (3, 7).
+ *  - SRID validation at commit time.
+ *  - Removability contract (drop is rejected while geospatial columns still exist).
+ *
+ * Note: this suite lives under the spark-4.1 test shim directory because Spark's
+ * `GeometryType` / `GeographyType` catalyst types were only added in Spark 4.1
+ * (SPARK-53760). The GeoSpatial table feature is therefore a no-op on Spark 4.0.
+ */
+class DeltaGeoSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaSQLTestUtils {
+
+  // Default SRID used in Parquet/Iceberg/Delta specs (OGC:CRS84).
+  private val DefaultSrid = 4326
+
+  private def metadataWithSchema(schema: StructType): Metadata = {
+    Metadata(schemaString = schema.json)
+  }
+
+  test("containsGeoColumns detects top-level geometry and geography columns") {
+    val schemaGeom = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val schemaGeog = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val schemaPlain = new StructType()
+      .add("id", IntegerType)
+      .add("s", StringType)
+
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeom))
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeog))
+    assert(!DeltaGeoSpatial.containsGeoColumns(schemaPlain))
+  }
+
+  test("containsGeoColumns detects nested geospatial columns") {
+    val nested = new StructType()
+      .add("outer", new StructType().add("inner", GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(nested))
+
+    val arr = new StructType().add("xs", ArrayType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(arr))
+
+    val map = new StructType().add("m", MapType(StringType, GeographyType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(map))
+  }
+
+  test("findGeoColumnsRecursively returns the first matching type") {
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val result = DeltaGeoSpatial.findGeoColumnsRecursively(schema)
+    assert(result.isDefined)
+    assert(result.get.isInstanceOf[GeographyType])
+  }
+
+  test("assertSridSupported passes for default fixed SRIDs") {
+    val schema = new StructType()
+      .add("g1", GeometryType(DefaultSrid))
+      .add("g2", GeographyType(DefaultSrid))
+    DeltaGeoSpatial.assertSridSupported(schema)
+  }
+
+  test("isGeoSpatialType returns true for geometry and geography") {
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeographyType(DefaultSrid)))
+    assert(!DeltaGeoSpatial.isGeoSpatialType(StringType))
+  }
+
+  test("DeltaDataSource accepts GeoSpatial types via supportsDataType") {
+    val ds = new sources.DeltaDataSource
+    assert(ds.supportsDataType(GeometryType(DefaultSrid)))
+    assert(ds.supportsDataType(GeographyType(DefaultSrid)))
+  }
+
+  test("isSupported checks both preview and stable features") {
+    val protoNone = Protocol(3, 7)
+    val protoStable = Protocol(3, 7).withFeature(GeoSpatialTableFeature)
+    val protoPreview = Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!DeltaGeoSpatial.isSupported(protoNone))
+    assert(DeltaGeoSpatial.isSupported(protoStable))
+    assert(DeltaGeoSpatial.isSupported(protoPreview))
+  }
+
+  test("GeoSpatialTableFeature is a reader+writer feature with min protocol (3, 7)") {
+    assert(GeoSpatialTableFeature.isReaderWriterFeature)
+    assert(GeoSpatialTableFeature.minReaderVersion == 3)
+    assert(GeoSpatialTableFeature.minWriterVersion == 7)
+    assert(GeoSpatialTableFeature.name == "geospatial")
+    assert(GeoSpatialPreviewTableFeature.name == "geospatial-dev")
+  }
+
+  test("Both GeoSpatial features are registered in allSupportedFeaturesMap") {
+    assert(TableFeature.featureNameToFeature("geospatial").contains(GeoSpatialTableFeature))
+    assert(TableFeature.featureNameToFeature("geospatial-dev")
+      .contains(GeoSpatialPreviewTableFeature))
+  }
+
+  test("metadataRequiresFeatureToBeEnabled is true iff schema has geospatial columns") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val withoutGeo = metadataWithSchema(new StructType().add("s", StringType))
+    assert(GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withGeo, spark))
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withoutGeo, spark))
+  }
+
+  test("stable feature does not auto-enable when preview feature is already supported") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val protocolWithPreview =
+      Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      protocolWithPreview, withGeo, spark))
+  }
+
+  test("automaticallyUpdateProtocolOfExistingTables returns true") {
+    assert(GeoSpatialTableFeature.automaticallyUpdateProtocolOfExistingTables)
+  }
+
+  test("creating a table with a geometry column auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(protocol.isFeatureSupported(GeoSpatialTableFeature),
+        s"Expected GeoSpatialTableFeature in protocol but got: $protocol")
+      assert(protocol.minReaderVersion >= GeoSpatialTableFeature.minReaderVersion)
+      assert(protocol.minWriterVersion >= GeoSpatialTableFeature.minWriterVersion)
+    }
+  }
+
+  test("creating a table without geospatial columns does not enable GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT, s STRING) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(!protocol.isFeatureSupported(GeoSpatialTableFeature))
+      assert(!protocol.isFeatureSupported(GeoSpatialPreviewTableFeature))
+    }
+  }
+
+  test("ALTER TABLE ADD COLUMN with geography auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      assert(!getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+      sql(s"ALTER TABLE tbl ADD COLUMN g GEOGRAPHY($DefaultSrid)")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+    }
+  }
+
+  test("PartitionUtils rejects GeoSpatial type as a partition column") {
+    // Geometry / Geography are not orderable and thus cannot be partition columns. Delta's
+    // `util/PartitionUtils.validatePartitionColumn` is the write-path backstop; the catalog
+    // (DDL) path goes through Spark's own `PartitioningUtils` which is out of Delta's hands.
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val ex = intercept[DeltaAnalysisException] {
+      util.PartitionUtils.validatePartitionColumn(schema, Seq("g"), caseSensitive = false)
+    }
+    assert(ex.getErrorClass == "DELTA_INVALID_PARTITION_COLUMN_TYPE",
+      s"Unexpected error class: ${ex.getErrorClass}")
+  }
+
+  test("commit fails when geo column is added and preview conf is disabled") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val ex = intercept[SparkThrowable] {
+          sql(s"ALTER TABLE tbl ADD COLUMN g GEOMETRY($DefaultSrid)")
+        }
+        assert(ex.getErrorClass == "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("read fails when table has geo column and preview conf is disabled") {
+    // Covers the read-path guard wired through [[ProtocolMetadataAdapterV1.assertTableReadable]]:
+    // a `SELECT *` against a table with a geo column triggers DeltaParquetFileFormat
+    // construction, which invokes [[DeltaGeoSpatial.assertTableReadable]] and throws when the
+    // preview config is off.
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val ex = intercept[SparkThrowable] {
+          sql("SELECT * FROM tbl").collect()
+        }
+        assert(ex.getErrorClass == "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("assertMetadata refuses a geo column in a committed Metadata action when preview is off") {
+    // Covers the inline guard in [[OptimisticTransactionImpl.assertMetadata]].
+    // The standard DDL path hits [[GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled]]
+    // first - see the test above - so we exercise the inline guard by committing a Metadata
+    // action directly, which routes through `prepareCommit -> updateMetadataAndProtocolWith-
+    // RequiredFeatures -> assertMetadata` before the table-feature gate runs.
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val log = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+        val txn = log.startTransaction()
+        val geoSchema = new StructType()
+          .add("id", IntegerType)
+          .add("g", GeometryType(DefaultSrid))
+        val geoMetadata = txn.snapshot.metadata.copy(schemaString = geoSchema.json)
+
+        val ex = intercept[SparkThrowable] {
+          txn.commit(Seq(geoMetadata), DeltaOperations.ManualUpdate)
+        }
+        assert(ex.getErrorClass == "UNSUPPORTED_DATATYPE",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("DROP FEATURE is rejected while geospatial columns remain in the schema") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+
+      val ex = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE tbl DROP FEATURE ${GeoSpatialTableFeature.name}")
+      }
+      assert(ex.getErrorClass == "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE",
+        s"Unexpected error class: ${ex.getErrorClass}")
+      assert(ex.getMessage.contains("g"))
+    }
+  }
+
+  test("validateDropInvariants returns true after geospatial columns are dropped") {
+    withTable("tbl") {
+      sql(
+        s"""CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta
+           |TBLPROPERTIES('delta.columnMapping.mode' = 'name')""".stripMargin)
+      val tableBefore = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(!GeoSpatialTableFeature.validateDropInvariants(
+        tableBefore, tableBefore.initialSnapshot))
+
+      sql("ALTER TABLE tbl DROP COLUMN g")
+      val tableAfter = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(GeoSpatialTableFeature.validateDropInvariants(
+        tableAfter, tableAfter.initialSnapshot))
+    }
+  }
+
+  test("actionUsesFeature returns false for all actions (history protection disabled)") {
+    val geoMeta = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val plainMeta = metadataWithSchema(new StructType().add("s", StringType))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(geoMeta))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(plainMeta))
+    assert(!GeoSpatialPreviewTableFeature.actionUsesFeature(geoMeta))
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+/**
+ * Tests for the GeoSpatial table feature in the Delta Spark connector. Verifies:
+ *  - Auto-enablement of the [[GeoSpatialTableFeature]] when a geospatial column is present.
+ *  - Required protocol versions (3, 7).
+ *  - SRID validation at commit time.
+ *  - Removability contract (drop is rejected while geospatial columns still exist).
+ */
+class DeltaGeoSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaSQLTestUtils {
+
+  // Default SRID used in Parquet/Iceberg/Delta specs (OGC:CRS84).
+  private val DefaultSrid = 4326
+
+  private def metadataWithSchema(schema: StructType): Metadata = {
+    Metadata(schemaString = schema.json)
+  }
+
+  test("containsGeoColumns detects top-level geometry and geography columns") {
+    val schemaGeom = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val schemaGeog = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val schemaPlain = new StructType()
+      .add("id", IntegerType)
+      .add("s", StringType)
+
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeom))
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeog))
+    assert(!DeltaGeoSpatial.containsGeoColumns(schemaPlain))
+  }
+
+  test("containsGeoColumns detects nested geospatial columns") {
+    val nested = new StructType()
+      .add("outer", new StructType().add("inner", GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(nested))
+
+    val arr = new StructType().add("xs", ArrayType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(arr))
+
+    val map = new StructType().add("m", MapType(StringType, GeographyType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(map))
+  }
+
+  test("findGeoColumnsRecursively returns the first matching type") {
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val result = DeltaGeoSpatial.findGeoColumnsRecursively(schema)
+    assert(result.isDefined)
+    assert(result.get.isInstanceOf[GeographyType])
+  }
+
+  test("assertSridSupported passes for default fixed SRIDs") {
+    val schema = new StructType()
+      .add("g1", GeometryType(DefaultSrid))
+      .add("g2", GeographyType(DefaultSrid))
+    DeltaGeoSpatial.assertSridSupported(schema)
+  }
+
+  test("isGeoSpatialType returns true for geometry and geography") {
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeographyType(DefaultSrid)))
+    assert(!DeltaGeoSpatial.isGeoSpatialType(StringType))
+  }
+
+  test("isSupported checks both preview and stable features") {
+    val protoNone = Protocol(3, 7)
+    val protoStable = Protocol(3, 7).withFeature(GeoSpatialTableFeature)
+    val protoPreview = Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!DeltaGeoSpatial.isSupported(protoNone))
+    assert(DeltaGeoSpatial.isSupported(protoStable))
+    assert(DeltaGeoSpatial.isSupported(protoPreview))
+  }
+
+  test("GeoSpatialTableFeature is a reader+writer feature with min protocol (3, 7)") {
+    assert(GeoSpatialTableFeature.isReaderWriterFeature)
+    assert(GeoSpatialTableFeature.minReaderVersion == 3)
+    assert(GeoSpatialTableFeature.minWriterVersion == 7)
+    assert(GeoSpatialTableFeature.name == "geospatial")
+    assert(GeoSpatialPreviewTableFeature.name == "geospatial-dev")
+  }
+
+  test("Both GeoSpatial features are registered in allSupportedFeaturesMap") {
+    assert(TableFeature.featureNameToFeature("geospatial").contains(GeoSpatialTableFeature))
+    assert(TableFeature.featureNameToFeature("geospatial-dev")
+      .contains(GeoSpatialPreviewTableFeature))
+  }
+
+  test("metadataRequiresFeatureToBeEnabled is true iff schema has geospatial columns") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val withoutGeo = metadataWithSchema(new StructType().add("s", StringType))
+    assert(GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withGeo, spark))
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withoutGeo, spark))
+  }
+
+  test("stable feature does not auto-enable when preview feature is already supported") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val protocolWithPreview =
+      Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      protocolWithPreview, withGeo, spark))
+  }
+
+  test("automaticallyUpdateProtocolOfExistingTables returns true") {
+    assert(GeoSpatialTableFeature.automaticallyUpdateProtocolOfExistingTables)
+  }
+
+  test("creating a table with a geometry column auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(protocol.isFeatureSupported(GeoSpatialTableFeature),
+        s"Expected GeoSpatialTableFeature in protocol but got: $protocol")
+      assert(protocol.minReaderVersion >= GeoSpatialTableFeature.minReaderVersion)
+      assert(protocol.minWriterVersion >= GeoSpatialTableFeature.minWriterVersion)
+    }
+  }
+
+  test("creating a table without geospatial columns does not enable GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT, s STRING) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(!protocol.isFeatureSupported(GeoSpatialTableFeature))
+      assert(!protocol.isFeatureSupported(GeoSpatialPreviewTableFeature))
+    }
+  }
+
+  test("ALTER TABLE ADD COLUMN with geography auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      assert(!getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+      sql(s"ALTER TABLE tbl ADD COLUMN g GEOGRAPHY($DefaultSrid)")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+    }
+  }
+
+  test("commit fails when geo column is added and preview conf is disabled") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val ex = intercept[SparkThrowable] {
+          sql(s"ALTER TABLE tbl ADD COLUMN g GEOMETRY($DefaultSrid)")
+        }
+        assert(ex.getErrorClass == "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("DROP FEATURE is rejected while geospatial columns remain in the schema") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+
+      val ex = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE tbl DROP FEATURE ${GeoSpatialTableFeature.name}")
+      }
+      assert(ex.getErrorClass == "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE",
+        s"Unexpected error class: ${ex.getErrorClass}")
+      assert(ex.getMessage.contains("g"))
+    }
+  }
+
+  test("validateDropInvariants returns true after geospatial columns are dropped") {
+    withTable("tbl") {
+      sql(
+        s"""CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta
+           |TBLPROPERTIES('delta.columnMapping.mode' = 'name')""".stripMargin)
+      val tableBefore = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(!GeoSpatialTableFeature.validateDropInvariants(
+        tableBefore, tableBefore.initialSnapshot))
+
+      sql("ALTER TABLE tbl DROP COLUMN g")
+      val tableAfter = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(GeoSpatialTableFeature.validateDropInvariants(
+        tableAfter, tableAfter.initialSnapshot))
+    }
+  }
+
+  test("actionUsesFeature returns false for all actions (history protection disabled)") {
+    val geoMeta = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val plainMeta = metadataWithSchema(new StructType().add("s", StringType))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(geoMeta))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(plainMeta))
+    assert(!GeoSpatialPreviewTableFeature.actionUsesFeature(geoMeta))
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

Part of https://github.com/delta-io/delta/issues/6622.

## Description

Adds the `GeoSpatial` table feature to the Delta Spark connector. This is the core plumbing that gates all geospatial functionality (tables containing `GeometryType` or `GeographyType` columns) behind the table feature protocol. Note that the geo feature is a `ReaderWriterFeature` (reader v3, writer v7).

## How was this patch tested?

Added appropriate unit tests under `DeltaGeoSuite`.

## Does this PR introduce _any_ user-facing changes?

Yes. Delta Spark now recognizes the `geospatial` and `geospatial-dev` table features.