### PR TITLE
[Spark] Remove vague 'Edge case' wording from spark/v2 comments

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -1335,7 +1335,7 @@ public class SparkMicroBatchStream
   /**
    * Check read-incompatible schema changes during stream (re)start so we could fail fast.
    *
-   * <p>This is called ONCE during the first latestOffset call to catch edge cases that normal
+   * <p>This is called ONCE during the first latestOffset call to catch cases that normal
    * per-commit validation (checkReadIncompatibleSchemaChanges) misses.
    *
    * <p><b>Why needed?</b> Normal validation only checks commits with metadata actions. If a stream

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -1335,8 +1335,8 @@ public class SparkMicroBatchStream
   /**
    * Check read-incompatible schema changes during stream (re)start so we could fail fast.
    *
-   * <p>This is called ONCE during the first latestOffset call to catch cases that normal
-   * per-commit validation (checkReadIncompatibleSchemaChanges) misses.
+   * <p>This is called ONCE during the first latestOffset call to catch cases that normal per-commit
+   * validation (checkReadIncompatibleSchemaChanges) misses.
    *
    * <p><b>Why needed?</b> Normal validation only checks commits with metadata actions. If a stream
    * starts at version 1 with the latest version is version 3 and there is a schema change at

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -3179,7 +3179,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
    * Test that verifies DSv1 and DSv2 throw errors when the starting snapshot has an incompatible
    * schema change that gets reverted before the latest version.
    *
-   * <p>Edge case: checkReadIncompatibleSchemaChange only checks metadata actions, so it misses the
+   * <p>Scenario: checkReadIncompatibleSchemaChange only checks metadata actions, so it misses the
    * incompatible intermediate state (id → userId → id). The
    * checkReadIncompatibleSchemaChangeOnStreamStartOnce method catches this by validating each
    * snapshot in the range.

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -2146,7 +2146,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             Optional.of(10000L),
             "With both limits"),
 
-        // Edge cases
+        // start and end version equals
         Arguments.of(
             /* fromVersion= */ 3L,
             /* toVersion= */ 3L,

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/utils/CatalogTableTestUtils.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/utils/CatalogTableTestUtils.scala
@@ -36,7 +36,7 @@ object CatalogTableTestUtils {
    * @param properties table properties (default: empty)
    * @param storageProperties storage properties (default: empty)
    * @param locationUri optional storage location URI
-   * @param nullStorage if true, sets storage to null (for edge case testing)
+   * @param nullStorage if true, sets storage to null (for null storage testing)
    * @param nullStorageProperties if true, sets storage properties to null
    */
   def createCatalogTable(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Remove the vague "Edge case(s)" phrasing from Javadoc / Scaladoc / inline
comments in `spark/v2`, replacing each with wording that describes the
specific scenario instead:

- `SparkMicroBatchStreamTest.java`
  - `// Edge cases` -> `// start and end version equals` (above the
    `fromVersion == toVersion` parameterized case).
  - `<p>Edge case:` -> `<p>Scenario:` on the `testSchemaEvolution_onStreamStartOnce`
    Javadoc.
- `SparkMicroBatchStream.java`
  - `catch edge cases that normal per-commit validation misses` ->
    `catch cases that normal per-commit validation misses`.
- `CatalogTableTestUtils.scala`
  - `(for edge case testing)` -> `(for null storage testing)` on the
    `nullStorage` param doc.

Comment-only changes; no behavioral differences.

## How was this patch tested?

Comment-only change; no test changes required.

## Does this PR introduce _any_ user-facing changes?

No.