### PR TITLE
[Spark] Use normalize partition values in optimize

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -737,10 +737,10 @@ sealed trait FileAction extends Action {
         partitionValues,
         partitionSchema,
         timeZone,
-        parseToTypedLiterals,
+        parseToTypedLiterals && partitionSchema.nonEmpty,
         failOnParsingError = true)
 
-      if (parseToTypedLiterals) {
+      if (parseToTypedLiterals && partitionSchema.nonEmpty) {
         val stringNormalizedPartitionValues = partitionValueLiterals.map {
           case (k, v) => (k, PartitionUtils.literalToNormalizedString(
             v,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -312,7 +312,14 @@ class OptimizeExecutor(
         case None =>
           filterCandidateFileList(minFileSize, maxDeletedRowsRatio, candidateFiles)
       }
-      val partitionsToCompact = filesToProcess.groupBy(_.partitionValues).toSeq
+      // Group files by their normalized (typed) partition values so that logically equivalent
+      // but differently formatted values (e.g. timestamp variants) end up in the same group.
+      val partitionsToCompact = filesToProcess
+        .groupBy(_.normalizedPartitionValues(
+          sparkSession,
+          snapshot.metadata.physicalPartitionSchema))
+        .map { case (_, files) => (files.head.partitionValues, files) }
+        .toSeq
 
       val jobs = groupFilesIntoBins(partitionsToCompact)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableStrategy.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableStrategy.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf.{DELTA_OPTIMIZE_CLUSTERIN
 import org.apache.spark.sql.delta.zorder.ZCubeInfo
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Literal
 
 object OptimizeTableMode extends Enumeration {
   type OptimizeTableMode = Value
@@ -109,7 +110,9 @@ object OptimizeTableStrategy {
       zOrderBy: Seq[String]): OptimizeTableStrategy = getMode(snapshot, zOrderBy) match {
     case OptimizeTableMode.CLUSTERING =>
       ClusteringStrategy(
-        sparkSession, ClusteringColumnInfo.extractLogicalNames(snapshot), optimizeContext)
+        sparkSession,
+        ClusteringColumnInfo.extractLogicalNames(snapshot),
+        optimizeContext)
     case OptimizeTableMode.ZORDER => ZOrderStrategy(sparkSession, zOrderBy)
     case OptimizeTableMode.COMPACTION =>
       CompactionStrategy(sparkSession, optimizeContext)
@@ -271,7 +274,13 @@ case class ClusteringStrategy(
     // Note that ZCube.filterOutLargeZCubes requires clustered files have
     // the same clustering columns, so skippedClusteredFiles are not included.
     val smallZCubeFiles = ZCube.filterOutLargeZCubes(
-      candidateFiles.map(AddFileWithNumRecords.createFromFile), targetSize)
+      candidateFiles.map { file =>
+        assert(file.partitionValues.isEmpty, "Clustered tables are always unpartitioned")
+        AddFileWithNumRecords.createFromFile(
+          file,
+          /* normalizedPartitionValues= */ Map.empty[String, Literal])
+      },
+      targetSize)
 
     if (optimizeContext.isFull && skippedClusteredFiles.nonEmpty) {
       // Clustered files with different clustering columns have to be re-clustered.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/optimize/AddFileWithNumRecords.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/optimize/AddFileWithNumRecords.scala
@@ -18,17 +18,22 @@ package org.apache.spark.sql.delta.commands.optimize
 
 import org.apache.spark.sql.delta.actions.AddFile
 
+import org.apache.spark.sql.catalyst.expressions.Literal
+
 /**
  * Wrapper over an [AddFile] and its stats:
  * @param numPhysicalRecords The number of records physically present in the file.
  *                           Equivalent to `addFile.numTotalRecords`.
  * @param numLogicalRecords The physical number of records minus the Deletion Vector cardinality.
  *                          Equivalent to `addFile.numRecords`.
+ * @param normalizedPartitionValues The partition values of the file, parsed to their actual types
+ *                                  so they can be compared safely.
  */
 case class AddFileWithNumRecords(
   addFile: AddFile,
   numPhysicalRecords: java.lang.Long,
-  numLogicalRecords: java.lang.Long) {
+  numLogicalRecords: java.lang.Long,
+  normalizedPartitionValues: Map[String, Literal]) {
 
   /** Returns the approx size of the remaining records after excluding the deleted ones. */
   def estLogicalFileSize: Long = {
@@ -51,9 +56,15 @@ case class AddFileWithNumRecords(
 }
 
 object AddFileWithNumRecords {
-  def createFromFile(file: AddFile): AddFileWithNumRecords = {
+  def createFromFile(
+      file: AddFile,
+      normalizedPartitionValues: Map[String, Literal]): AddFileWithNumRecords = {
     val numPhysicalRecords = file.numPhysicalRecords.getOrElse(0L)
     val numLogicalRecords = file.numLogicalRecords.getOrElse(0L)
-    AddFileWithNumRecords(file, numPhysicalRecords, numLogicalRecords)
+    AddFileWithNumRecords(
+      file,
+      numPhysicalRecords,
+      numLogicalRecords,
+      normalizedPartitionValues)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.commands.{DeltaOptimizeContext, OptimizeExecutor}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -648,6 +649,58 @@ trait OptimizeCompactionSuiteBase extends QueryTest
         "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
         parameters = Map("operation" -> "OPTIMIZE")
       )
+    }
+  }
+
+  for (enableNormalization <- BOOLEAN_DOMAIN) {
+    test("optimize groups files correctly by normalized partition values, " +
+      s"enableNormalization=$enableNormalization") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_NORMALIZE_PARTITION_VALUES_ON_READ.key ->
+          enableNormalization.toString
+      ) {
+        DeltaTestUtils.withTimeZone("UTC") {
+          withTempDir { tempDir =>
+            val path = tempDir.getAbsolutePath
+            sql(s"CREATE TABLE delta.`$path` (id LONG, ts TIMESTAMP) " +
+              s"USING delta PARTITIONED BY (ts)")
+            // Insert with non-UTC format (2 files)
+            withSQLConf(DeltaSQLConf.UTC_TIMESTAMP_PARTITION_VALUES.key -> "false") {
+              sql(s"INSERT INTO delta.`$path` VALUES (0, '2000-01-01 12:00:00')")
+              sql(s"INSERT INTO delta.`$path` VALUES (1, '2000-01-01 12:00:00')")
+            }
+            // Insert with UTC format (2 files)
+            withSQLConf(DeltaSQLConf.UTC_TIMESTAMP_PARTITION_VALUES.key -> "true") {
+              sql(s"INSERT INTO delta.`$path` VALUES (2, '2000-01-01T12:00:00.000Z')")
+              sql(s"INSERT INTO delta.`$path` VALUES (3, '2000-01-01T12:00:00.000Z')")
+            }
+            val deltaLog = DeltaLog.forTable(spark, path)
+            val snapshot = deltaLog.update()
+            assert(snapshot.allFiles.count() == 4)
+
+            new OptimizeExecutor(
+              spark,
+              snapshot,
+              catalogTable = None,
+              partitionPredicate = Seq.empty,
+              zOrderByColumns = Seq.empty,
+              isAutoCompact = false,
+              DeltaOptimizeContext()
+            ).optimize()
+
+            val filesAfter = deltaLog.update().allFiles.count()
+            if (enableNormalization) {
+              // All 4 files in 1 partition.
+              assert(filesAfter == 1)
+            } else {
+              // non-UTC and UTC formats stay separate partitions.
+              assert(filesAfter == 2)
+            }
+            checkAnswer(spark.read.format("delta").load(path).select("id"),
+              Seq(Row(0), Row(1), Row(2), Row(3)))
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Use normalized partition values in OPTIMIZE runner. This can reduce number of bins if we have timestamp partition columns with different but logical equivalent timestamp formats.

Before, we were using raw string values which may have different representations for the same logical value, especially for timestamps. Normalizing them on comparison ensures that logical equivalent values are grouped together.



## How was this patch tested?
New unit test and existing optimize suite

## Does this PR introduce _any_ user-facing changes?
No
