### PR TITLE
[SPARK] Remove random prefixes from streaming test names

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -51,7 +51,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "basic",
     "initial snapshot ends at base index of next version",
     "new commits arrive after stream initialization - with explicit startingVersion",
-    "SC-11561: can consume new data without update",
+    "can consume new data without update",
     "Delta sources don't write offsets with null json",
 
     // === Schema Evolution ===
@@ -105,7 +105,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "maxBytesPerTrigger: max bytes and max files together",
     "Trigger.AvailableNow with an empty table",
     "Rate limited Delta source advances with non-data inserts",
-    "ES-445863: delta source should not hang or reprocess data when using AvailableNow",
+    "delta source should not hang or reprocess data when using AvailableNow",
     "startingVersion should work with rate time",
     "maxFilesPerTrigger: metadata checkpoint",
     "maxBytesPerTrigger: metadata checkpoint",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -997,7 +997,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  test("SC-11561: can consume new data without update") {
+  test("can consume new data without update") {
     withTempDir { inputDir =>
       val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
       withMetadata(deltaLog, StructType.fromDDL("value STRING"))
@@ -2285,7 +2285,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  test("ES-445863: delta source should not hang or reprocess data when using AvailableNow") {
+  test("delta source should not hang or reprocess data when using AvailableNow") {
     withTempDirs { (inputDir, outputDir, checkpointDir) =>
       def runQuery(): Unit = {
         val q = loadStreamWithOptions(inputDir.getCanonicalPath, Map.empty)


### PR DESCRIPTION
## Description

Removes the `SC-11561:` and `ES-445863:` prefixes from two streaming test names in `DeltaSourceSuite`, and updates the matching entries in `DeltaV2SourceSuite`'s `shouldPassTests` list. 

Before:
- `test("SC-11561: can consume new data without update")`
- `test("ES-445863: delta source should not hang or reprocess data when using AvailableNow")`

After:
- `test("can consume new data without update")`
- `test("delta source should not hang or reprocess data when using AvailableNow")`

No test logic changes.

## How was this patch tested?

Rename-only change; existing tests still run under the new names.

## Does this PR introduce _any_ user-facing changes?

No.