### PR TITLE
[Build] When MAVEN_PROXY_URL is set, also use local as a repo

### DIFF
--- a/build/sbt
+++ b/build/sbt
@@ -66,11 +66,12 @@ realpath () {
 )
 }
 
-# If MAVEN_PROXY_URL is set, use it as the sole repository for all dependencies.
+# If MAVEN_PROXY_URL is set, use it (and local) as the sole repository for all dependencies.
 if [[ -n "$MAVEN_PROXY_URL" ]]; then
   SBT_REPOSITORIES_CONFIG=$(mktemp)
   cat > "$SBT_REPOSITORIES_CONFIG" <<EOF
 [repositories]
+  local
   maven-proxy: $MAVEN_PROXY_URL
   maven-proxy-ivy: $MAVEN_PROXY_URL, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
 EOF


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
When MAVEN_PROXY_URL is set, also use local as a repo. This is needed by sbt publishLocal when using maven proxy. Otherwise an error pops up:
```
[error] (spark / publishLocal) Undefined resolver 'local'
```

## How was this patch tested?
publishLocal from local machine.

## Does this PR introduce _any_ user-facing changes?
No.