### PR TITLE
[Kernel-Spark] Recognize ActionsIterator interrupt signal in streaming offset path

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -47,6 +47,7 @@ import io.delta.spark.internal.v2.utils.ScalaUtils;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.utils.StreamingHelper;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.nio.channels.ClosedByInterruptException;
 import java.sql.Timestamp;
@@ -361,13 +362,11 @@ public class SparkMicroBatchStream
       isFirstBatch = false;
       return endOffset;
     } catch (Exception e) {
-      // Kernel's DefaultJsonHandler wraps ClosedByInterruptException (thrown by NIO
-      // channels on thread interrupt) inside KernelEngineException (a RuntimeException).
-      // Spark's StreamExecution.isInterruptionException recognizes
-      // ClosedByInterruptException and UncheckedIOException but not
-      // KernelEngineException. Re-wrap so Spark's isInterruptedByStop — which also
-      // verifies state == TERMINATED — handles it as a clean stream shutdown.
-      Optional<ClosedByInterruptException> interruptCause = findClosedByInterruptCause(e);
+      // Kernel wraps thread-interrupt signals into its own exception types before they escape
+      // the read path. Re-throw the JDK-standard interrupt type inside UncheckedIOException so
+      // Spark's isInterruptedByStop — which also verifies state == TERMINATED — handles it as a
+      // clean stream shutdown. See findInterruptIOException for the shapes handled.
+      Optional<IOException> interruptCause = findInterruptIOException(e);
       if (interruptCause.isPresent()) {
         throw new UncheckedIOException(interruptCause.get());
       }
@@ -494,10 +493,10 @@ public class SparkMicroBatchStream
               tablePath, fromVersion, fromIndex, endOffset),
           e);
     } catch (RuntimeException e) {
-      // Same interrupt handling as latestOffset(): Kernel wraps ClosedByInterruptException
-      // in KernelEngineException (a RuntimeException). Re-wrap as UncheckedIOException so
-      // Spark's isInterruptedByStop recognizes it as a clean shutdown.
-      Optional<ClosedByInterruptException> interruptCause = findClosedByInterruptCause(e);
+      // Same interrupt handling as latestOffset() — see findInterruptIOException for the
+      // shapes Kernel produces. Re-wrap as UncheckedIOException so Spark's isInterruptedByStop
+      // recognizes it as a clean shutdown.
+      Optional<IOException> interruptCause = findInterruptIOException(e);
       if (interruptCause.isPresent()) {
         throw new UncheckedIOException(interruptCause.get());
       }
@@ -537,15 +536,39 @@ public class SparkMicroBatchStream
   }
 
   /**
-   * If the given exception wraps a {@link ClosedByInterruptException} as its direct cause, returns
-   * it. This occurs when Spark interrupts the micro-batch thread during stream shutdown and the
-   * thread is blocked inside Kernel's {@code DefaultJsonHandler} reading delta log files via NIO
-   * channels.
+   * Detects a "clean stop" interrupt in the given exception chain and returns the JDK-standard
+   * interrupt I/O exception that should be re-thrown wrapped in {@link UncheckedIOException}, so
+   * Spark's {@code StreamExecution.isInterruptionException} (which already unwraps {@code
+   * UncheckedIOException}) recognizes it and {@code isInterruptedByStop} — which also gates on
+   * {@code state == TERMINATED} — handles it as a clean shutdown.
+   *
+   * <p>Two known shapes produced by Kernel in the streaming read path:
+   *
+   * <ol>
+   *   <li>{@link KernelEngineException} wrapping {@link ClosedByInterruptException} — produced by
+   *       {@code DefaultJsonHandler.hasNext()} when the thread is interrupted while blocked inside
+   *       an NIO channel read.
+   *   <li>{@link UncheckedIOException} wrapping {@link InterruptedIOException} — produced by {@code
+   *       ActionsIterator.next()} (#6606) when the interrupt flag is observed before the read
+   *       begins.
+   * </ol>
+   *
+   * <p>Intentionally narrow: only looks at the direct cause of {@code t} and, in shape 2, one more
+   * level inside the {@code UncheckedIOException}. If Kernel grows a new wrapping shape this
+   * returns empty and the raw exception propagates so we learn of the new shape via a test failure
+   * rather than masking it.
    */
-  static Optional<ClosedByInterruptException> findClosedByInterruptCause(Throwable t) {
+  static Optional<IOException> findInterruptIOException(Throwable t) {
+    if (t == null) {
+      return Optional.empty();
+    }
     Throwable cause = t.getCause();
     if (cause instanceof ClosedByInterruptException) {
       return Optional.of((ClosedByInterruptException) cause);
+    }
+    if (cause instanceof UncheckedIOException
+        && cause.getCause() instanceof InterruptedIOException) {
+      return Optional.of((InterruptedIOException) cause.getCause());
     }
     return Optional.empty();
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -3951,31 +3951,52 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   /**
-   * Simulates the Kernel integration path where {@code DefaultJsonHandler.hasNext()} wraps a {@link
-   * ClosedByInterruptException} inside a {@link io.delta.kernel.exceptions.KernelEngineException}.
-   * Verifies that {@code findClosedByInterruptCause} extracts the interrupt cause so {@code
-   * latestOffset()} can re-throw it as {@link java.io.UncheckedIOException} for Spark's {@code
-   * isInterruptedByStop}.
+   * Simulates the two Kernel integration paths that produce a clean-stop interrupt signal. Verifies
+   * that {@code findInterruptIOException} extracts the JDK-standard interrupt I/O exception so
+   * {@code latestOffset()} / {@code planInputPartitions()} can re-throw it as {@link
+   * java.io.UncheckedIOException} for Spark's {@code isInterruptedByStop}.
    */
   @Test
-  public void testFindClosedByInterruptCause() {
-    // KernelEngineException wrapping ClosedByInterruptException -> present
+  public void testFindInterruptIOException() {
+    // Shape 1: KernelEngineException wrapping ClosedByInterruptException — produced by
+    // DefaultJsonHandler.hasNext() when interrupted inside an NIO channel read.
     ClosedByInterruptException cbie = new ClosedByInterruptException();
     assertThat(
-            SparkMicroBatchStream.findClosedByInterruptCause(
+            SparkMicroBatchStream.findInterruptIOException(
                 new io.delta.kernel.exceptions.KernelEngineException("readJsonFile", cbie)))
         .isPresent()
         .contains(cbie);
 
+    // Shape 2: RuntimeException wrapping UncheckedIOException(InterruptedIOException) — produced
+    // by ActionsIterator.next() (Kernel PR #6606) when the interrupt flag is observed before
+    // the read begins.
+    java.io.InterruptedIOException iioe =
+        new java.io.InterruptedIOException("Thread was interrupted");
+    assertThat(
+            SparkMicroBatchStream.findInterruptIOException(
+                new RuntimeException(
+                    "Failed to process commits", new java.io.UncheckedIOException(iioe))))
+        .isPresent()
+        .contains(iioe);
+
     // Plain RuntimeException -> empty
-    assertThat(SparkMicroBatchStream.findClosedByInterruptCause(new RuntimeException("unrelated")))
+    assertThat(SparkMicroBatchStream.findInterruptIOException(new RuntimeException("unrelated")))
         .isEmpty();
 
-    // KernelEngineException wrapping a different IOException -> empty
+    // KernelEngineException wrapping a non-interrupt IOException -> empty
     assertThat(
-            SparkMicroBatchStream.findClosedByInterruptCause(
+            SparkMicroBatchStream.findInterruptIOException(
                 new io.delta.kernel.exceptions.KernelEngineException(
                     "readJsonFile", new java.io.FileNotFoundException("missing"))))
+        .isEmpty();
+
+    // UncheckedIOException wrapping a non-interrupt IOException -> empty
+    assertThat(
+            SparkMicroBatchStream.findInterruptIOException(
+                new RuntimeException(
+                    "unrelated",
+                    new java.io.UncheckedIOException(
+                        new java.io.FileNotFoundException("missing")))))
         .isEmpty();
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -3951,10 +3951,21 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   /**
-   * Simulates the two Kernel integration paths that produce a clean-stop interrupt signal. Verifies
-   * that {@code findInterruptIOException} extracts the JDK-standard interrupt I/O exception so
-   * {@code latestOffset()} / {@code planInputPartitions()} can re-throw it as {@link
-   * java.io.UncheckedIOException} for Spark's {@code isInterruptedByStop}.
+   * Simulates the two Kernel integration paths that produce a clean-stop interrupt signal:
+   *
+   * <ol>
+   *   <li>{@code KernelEngineException(ClosedByInterruptException)} from
+   *       {@code DefaultJsonHandler.hasNext()} when interrupted inside an NIO channel read.
+   *   <li>{@code RuntimeException(UncheckedIOException(InterruptedIOException))} from
+   *       {@code ActionsIterator.next()} when the interrupt flag is observed before the read
+   *       begins.
+   * </ol>
+   *
+   * <p>Verifies that {@code findInterruptIOException} extracts only those known JDK-standard
+   * interrupt I/O exceptions so {@code latestOffset()} / {@code planInputPartitions()} can re-throw
+   * them as {@link java.io.UncheckedIOException} for Spark's {@code isInterruptedByStop}. Unknown
+   * wrapping shapes intentionally return empty so the raw exception propagates and exposes the new
+   * shape in tests.
    */
   @Test
   public void testFindInterruptIOException() {
@@ -3997,6 +4008,16 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
                     "unrelated",
                     new java.io.UncheckedIOException(
                         new java.io.FileNotFoundException("missing")))))
+        .isEmpty();
+
+    // Deeper nesting is intentionally not accepted: Kernel should not double-wrap
+    // KernelEngineException, and a new nested shape should fail loudly instead of being masked.
+    ClosedByInterruptException nestedCbie = new ClosedByInterruptException();
+    assertThat(
+            SparkMicroBatchStream.findInterruptIOException(
+                new io.delta.kernel.exceptions.KernelEngineException(
+                    "outer",
+                    new io.delta.kernel.exceptions.KernelEngineException("inner", nestedCbie))))
         .isEmpty();
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamTest.java
@@ -3954,11 +3954,10 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
    * Simulates the two Kernel integration paths that produce a clean-stop interrupt signal:
    *
    * <ol>
-   *   <li>{@code KernelEngineException(ClosedByInterruptException)} from
-   *       {@code DefaultJsonHandler.hasNext()} when interrupted inside an NIO channel read.
-   *   <li>{@code RuntimeException(UncheckedIOException(InterruptedIOException))} from
-   *       {@code ActionsIterator.next()} when the interrupt flag is observed before the read
-   *       begins.
+   *   <li>{@code KernelEngineException(ClosedByInterruptException)} from {@code
+   *       DefaultJsonHandler.hasNext()} when interrupted inside an NIO channel read.
+   *   <li>{@code RuntimeException(UncheckedIOException(InterruptedIOException))} from {@code
+   *       ActionsIterator.next()} when the interrupt flag is observed before the read begins.
    * </ol>
    *
    * <p>Verifies that {@code findInterruptIOException} extracts only those known JDK-standard


### PR DESCRIPTION
## Summary

`V2StreamingReadTest.testStreamingQueryStopDoesNotSurfaceException` still flakes after #6158 because Kernel now has a second interrupt shape that `SparkMicroBatchStream` does not recognize. When the shape is missed, `query.stop()` surfaces the interrupt as:

```
StreamingQueryException: Thread was interrupted
```

and `query.exception()` is non-empty, failing the test assertion. The same race also occasionally manifests as `JUnitException: Failed to close extension context` when the interrupt-induced cleanup leaves an fd open long enough for JUnit's `@TempDir` deletion to fail.

## What changed in Kernel

#6158 covered the case Kernel originally produced: `DefaultJsonHandler.hasNext()` wrapping `ClosedByInterruptException` in `KernelEngineException` — a single direct-cause hop.

Kernel PR #6606 added a second shape inside `ActionsIterator.next()`:

```java
if (Thread.currentThread().isInterrupted()) {
  throw new UncheckedIOException(new InterruptedIOException("Thread was interrupted"));
}
```

That exception travels through the streaming offset path inside a `RuntimeException(\"Failed to process commits\", ...)`, so the helper from #6158 — which only looks for `ClosedByInterruptException` as the direct cause — returns empty and the interrupt propagates uncaught.

## Fix

Rename `findClosedByInterruptCause` → `findInterruptIOException` and teach it the second shape. The helper still looks at only the direct cause of the caught exception (one extra `getCause()` inside `UncheckedIOException` for the new shape). This keeps the design invariant from #6158: the helper handles exactly the shapes Kernel is known to produce, and if Kernel grows a new shape it returns empty so we learn of it via a test failure rather than silently masking it.

Both call sites (`latestOffset()` and `planInputPartitions()`) use the renamed helper; the rethrow-as-`UncheckedIOException` wrapping is unchanged — Spark's `StreamExecution.isInterruptionException` still recursively unwraps `UncheckedIOException` and `isInterruptedByStop` still gates on `state == TERMINATED`, so no false-positive risk.

## Test plan

- [x] Unit test `testFindInterruptIOException` covers both positive shapes (Kernel/NIO and `ActionsIterator` pre-read interrupt) and two negative shapes (unrelated `RuntimeException`, `UncheckedIOException` wrapping a non-interrupt `IOException`).
- [x] Full `SparkMicroBatchStreamTest` suite: 189 passed, 0 failed.
- [x] Local reproduction (2 parallel sbt on 2 cores, `@RepeatedTest(10)` on `testStreamingQueryStopDoesNotSurfaceException`) triggered the failure on unfixed code; does not trigger with this fix.

cc @huan233usc (designed the #6158 helper) — this keeps the one-level direct-cause invariant you proposed, just teaches it the second shape Kernel now emits.

This pull request was AI-assisted by Isaac.