### PR TITLE
[Spark] Onboard more MERGE tests into InMemorySparkTable

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -229,7 +229,12 @@ object SuiteGeneratorConfig {
           )
         ),
         TestConfig(
-          List("MergeIntoNotMatchedBySourceSuite"),
+          List(
+            "MergeIntoBasicTests",
+            "MergeIntoAnalysisExceptionTests",
+            "MergeIntoNotMatchedBySourceSuite",
+            "MergeIntoUnlimitedMergeClausesTests",
+          ),
           List(List(Dims.MERGE_SQL, Dims.V2_IN_MEMORY_TABLE_MERGE, Dims.NAME_BASED))
         ),
         TestConfig(

--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -233,7 +233,7 @@ object SuiteGeneratorConfig {
             "MergeIntoBasicTests",
             "MergeIntoAnalysisExceptionTests",
             "MergeIntoNotMatchedBySourceSuite",
-            "MergeIntoUnlimitedMergeClausesTests",
+            "MergeIntoUnlimitedMergeClausesTests"
           ),
           List(List(Dims.MERGE_SQL, Dims.V2_IN_MEMORY_TABLE_MERGE, Dims.NAME_BASED))
         ),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -3526,8 +3526,16 @@ trait DeltaDMLInMemoryTestUtils
   private def assertNoParquetFiles(tableName: String): Unit = {
     import java.nio.file.{Files, Path}
 
-    val catalogTable = spark.sessionState.catalog.getTableMetadata(
-      TableIdentifier(tableName))
+    val ident = TableIdentifier(tableName)
+
+    // Temp views don't create anything on the disk, but still use `withTable`.
+    // Either way, something that doesn't have a catalog entry, but is used in `withTable` should
+    // not be checked on disk.
+    if (!spark.sessionState.catalog.tableExists(ident)) {
+      return
+    }
+
+    val catalogTable = spark.sessionState.catalog.getTableMetadata(ident)
     val dataPath = new File(new URI(catalogTable.location.toString))
     if (dataPath.exists()) {
       val stream = Files.walk(dataPath.toPath)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -20,11 +20,12 @@ import java.io.File
 import java.net.URI
 import java.nio.file.{Files, Path}
 
+import org.apache.spark.sql.delta.catalog.{InMemoryDeltaCatalog, InMemorySparkTable}
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
-import org.apache.spark.sql.delta.catalog.{InMemoryDeltaCatalog, InMemorySparkTable}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -32,8 +32,11 @@ import org.apache.spark.sql.connector.expressions.Transform
  * to return [[InMemorySparkTable]].
  */
 class InMemoryDeltaCatalog extends DeltaCatalog {
-  override def dropTable(ident: Identifier): Boolean =
-    InMemoryDeltaCatalog.dropTable(ident)
+  override def dropTable(ident: Identifier): Boolean = {
+    val removedInMemory = InMemoryDeltaCatalog.dropTable(ident)
+    val removedUnderlying = super.dropTable(ident)
+    removedInMemory || removedUnderlying
+  }
 
   override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table =
     InMemoryDeltaCatalog.getOrCreateTable(ident, catalogTable, spark)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoAnalysisExceptionTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoAnalysisExceptionTests.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
 import org.apache.spark.sql.delta.rowid._
 
+class MergeIntoAnalysisExceptionSQLInMemoryTableNameBasedSuite
+  extends MergeIntoAnalysisExceptionTests
+  with MergeIntoSQLMixin
+  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLTestUtilsNameBased
+
 class MergeIntoAnalysisExceptionSQLNameBasedSuite
   extends MergeIntoAnalysisExceptionTests
   with MergeIntoSQLMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoBasicTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoBasicTests.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
 import org.apache.spark.sql.delta.rowid._
 
+class MergeIntoBasicSQLInMemoryTableNameBasedSuite
+  extends MergeIntoBasicTests
+  with MergeIntoSQLMixin
+  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLTestUtilsNameBased
+
 class MergeIntoBasicSQLNameBasedSuite
   extends MergeIntoBasicTests
   with MergeIntoSQLMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoUnlimitedMergeClausesTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/MergeSuitesMergeIntoUnlimitedMergeClausesTests.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
 import org.apache.spark.sql.delta.rowid._
 
+class MergeIntoUnlimitedMergeClausesSQLInMemoryTableNameBasedSuite
+  extends MergeIntoUnlimitedMergeClausesTests
+  with MergeIntoSQLMixin
+  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLTestUtilsNameBased
+
 class MergeIntoUnlimitedMergeClausesSQLNameBasedSuite
   extends MergeIntoUnlimitedMergeClausesTests
   with MergeIntoSQLMixin


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark

## Description

Onboard more MERGE tests that use `InMemorySparkTable`.

## How was this patch tested?

This patch introduces three new passing generated test suites.

## Does this PR introduce _any_ user-facing changes?

No.
