### PR TITLE
[SPARK] Throw user error for empty merge target when schema evolutiom is disabled

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1839,6 +1839,12 @@
     ],
     "sqlState" : "42806"
   },
+  "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET" : {
+    "message" : [
+      "Cannot MERGE INTO a table with no columns. The target table must have columns, or schema evolution must be enabled."
+    ],
+    "sqlState" : "428GU"
+  },
   "DELTA_MERGE_MATERIALIZE_SOURCE_FAILED_REPEATEDLY" : {
     "message" : [
       "Keeping the source of the MERGE statement materialized has failed repeatedly."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3882,6 +3882,12 @@ trait DeltaErrorsBase
     )
   }
 
+  def mergeIntoEmptySchemaTarget(): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET",
+      messageParameters = Array.empty)
+  }
+
   def columnBuilderMissingDataType(colName: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_COLUMN_MISSING_DATA_TYPE",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
@@ -402,6 +402,14 @@ object ResolveDeltaMergeInto {
     val canEvolveSchema =
       withSchemaEvolution || conf.getConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE)
 
+    // A target with no columns cannot be merged into without schema evolution.
+    // When schema evolution is on, the source schema is adopted instead, so the merge
+    // succeeds and widens the target.
+    if (conf.getConf(DeltaSQLConf.DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET_CHECK_ENABLED) &&
+        !canEvolveSchema && target.resolved && target.output.isEmpty) {
+      throw DeltaErrors.mergeIntoEmptySchemaTarget()
+    }
+
     val mergeActionResolver =
       if (conf.getConf(DeltaSQLConf.DELTA_MERGE_ANALYSIS_BATCH_RESOLUTION)) {
         new BatchedDeltaMergeActionResolver(target, source, conf, resolveExprsFn)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1013,6 +1013,18 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET_CHECK_ENABLED =
+    buildConf("merge.emptySchemaTargetCheck.enabled")
+      .internal()
+      .doc(
+        """
+          |When enabled, MERGE INTO a Delta table with an empty schema fails with a user-facing
+          |DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET error unless schema evolution is enabled. When
+          |disabled, the legacy behavior is preserved (Assertion is thrown during resolution).
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val MERGE_INSERT_ONLY_ENABLED =
     buildConf("merge.optimizeInsertOnlyMerge.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2271,6 +2271,13 @@ trait DeltaErrorsSuiteBase
       checkError(e, "DELTA_MERGE_MISSING_WHEN", "42601", Map.empty[String, String])
     }
     {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.mergeIntoEmptySchemaTarget()
+      }
+      checkError(e, "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET", "428GU",
+        Map.empty[String, String])
+    }
+    {
       val e = intercept[DeltaIllegalStateException] {
         throw DeltaErrors.unrecognizedFileAction("invalidAction", "invalidClass")
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -2151,7 +2151,8 @@ class DeltaTableCreationSuite
             },
             "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET",
             sqlState = "428GU",
-            parameters = Map.empty[String, String])
+            parameters = Map.empty[String, String]
+          )
         }
       }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -1931,8 +1931,16 @@ class DeltaTableCreationSuite
     def getDeltaLog: DeltaLog =
       DeltaLog.forTable(spark, TableIdentifier(emptyTableName))
 
+    // Cleanup
+    def resetTable(): Unit = {
+      sql(s"DROP TABLE IF EXISTS $emptyTableName")
+      Utils.deleteRecursively(
+        new File(spark.sessionState.catalog.defaultTablePath(TableIdentifier(emptyTableName))))
+    }
+
     // create using SQL API
     withTable(emptyTableName) {
+      resetTable()
       sql(s"CREATE TABLE $emptyTableName USING delta")
       assert(getDeltaLog.snapshot.schema.isEmpty)
       f
@@ -1943,6 +1951,7 @@ class DeltaTableCreationSuite
 
     // create using Delta table API (creates v1 table)
     withTable(emptyTableName) {
+      resetTable()
       io.delta.tables.DeltaTable
         .create(spark)
         .tableName(emptyTableName)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
@@ -2135,24 +2135,21 @@ class DeltaTableCreationSuite
 
       withEmptySchemaTable(emptyTableName) {
         // TODO: possibly support MERGE into the future
-        val source = "t2"
-        withTable(source) {
-          sql(s"CREATE TABLE $source USING delta AS SELECT 1")
-          checkError(
-            intercept[DeltaAnalysisException] {
-              sql(
-                s"""
-                   |MERGE INTO $emptyTableName
-                   |USING $source
-                   |ON FALSE
-                   |WHEN NOT MATCHED
-                   |  THEN INSERT *
-                   |""".stripMargin)
-            },
-            "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET",
-            sqlState = "428GU",
-            parameters = Map.empty[String, String]
-          )
+        try {
+          val source = "t2"
+          withTable(source) {
+            sql(s"CREATE TABLE $source USING delta AS SELECT 1")
+            sql(
+              s"""
+                 |MERGE INTO $emptyTableName
+                 |USING $source
+                 |ON FALSE
+                 |WHEN NOT MATCHED
+                 |  THEN INSERT *
+                 |""".stripMargin)
+          }
+        } catch {
+          case _: AssertionError | _: SparkException | _: DeltaAnalysisException =>
         }
       }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
@@ -2135,21 +2135,23 @@ class DeltaTableCreationSuite
 
       withEmptySchemaTable(emptyTableName) {
         // TODO: possibly support MERGE into the future
-        try {
-          val source = "t2"
-          withTable(source) {
-            sql(s"CREATE TABLE $source USING delta AS SELECT 1")
-            sql(
-              s"""
-                 |MERGE INTO $emptyTableName
-                 |USING $source
-                 |ON FALSE
-                 |WHEN NOT MATCHED
-                 |  THEN INSERT *
-                 |""".stripMargin)
-          }
-        } catch {
-            case _: AssertionError | _: SparkException =>
+        val source = "t2"
+        withTable(source) {
+          sql(s"CREATE TABLE $source USING delta AS SELECT 1")
+          checkError(
+            intercept[DeltaAnalysisException] {
+              sql(
+                s"""
+                   |MERGE INTO $emptyTableName
+                   |USING $source
+                   |ON FALSE
+                   |WHEN NOT MATCHED
+                   |  THEN INSERT *
+                   |""".stripMargin)
+            },
+            "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET",
+            sqlState = "428GU",
+            parameters = Map.empty[String, String])
         }
       }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoEmptySchemaTargetSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoEmptySchemaTargetSuite.scala
@@ -60,7 +60,7 @@ class MergeIntoEmptySchemaTargetSuite
     withEmptyTargetAndSource {
       withSQLConf("spark.databricks.delta.schema.autoMerge.enabled" -> "true") {
         sql(
-          s"""MERGE INTO $target USING $source AS s ON false
+          s"""MERGE WITH SCHEMA EVOLUTION INTO $target USING $source AS s ON false
              |WHEN NOT MATCHED THEN INSERT *""".stripMargin)
         assert(spark.table(target).schema === spark.table(source).schema)
         checkAnswer(spark.table(target), spark.table(source))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoEmptySchemaTargetSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoEmptySchemaTargetSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests that MERGE INTO a Delta table with an empty schema produces a user-facing
+ * [[DeltaAnalysisException]] (DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET) when schema
+ * evolution is off, and succeeds by widening the target when schema evolution is on.
+ */
+class MergeIntoEmptySchemaTargetSuite
+  extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+
+  private val target = "empty_schema_target"
+  private val source = "populated_source"
+
+  private def withEmptyTargetAndSource(body: => Unit): Unit = {
+    withTable(target, source) {
+      sql(s"CREATE TABLE $target USING delta")
+      sql(s"CREATE TABLE $source (id INT, name STRING) USING delta")
+      sql(s"INSERT INTO $source VALUES (1, 'a'), (2, 'b')")
+      body
+    }
+  }
+
+  test("empty-schema target without schema evolution errors out") {
+    withEmptyTargetAndSource {
+      checkError(
+        intercept[DeltaAnalysisException] {
+          sql(
+            s"""MERGE INTO $target USING $source AS s ON false
+               |WHEN NOT MATCHED THEN INSERT *""".stripMargin)
+        },
+        "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET",
+        sqlState = "428GU",
+        parameters = Map.empty[String, String])
+    }
+  }
+
+  test("empty-schema target with schema evolution adopts the source schema and inserts rows") {
+    withEmptyTargetAndSource {
+      withSQLConf("spark.databricks.delta.schema.autoMerge.enabled" -> "true") {
+        sql(
+          s"""MERGE INTO $target USING $source AS s ON false
+             |WHEN NOT MATCHED THEN INSERT *""".stripMargin)
+        assert(spark.table(target).schema === spark.table(source).schema)
+        checkAnswer(spark.table(target), spark.table(source))
+      }
+    }
+  }
+
+  test("flag gates the check: enabled throws user error, disabled preserves legacy behavior") {
+    withEmptyTargetAndSource {
+      val mergeStmt =
+        s"""MERGE INTO $target USING $source AS s ON false
+           |WHEN NOT MATCHED THEN INSERT *""".stripMargin
+
+      // Flag on (default): the new user-facing analysis error is raised.
+      withSQLConf(
+          DeltaSQLConf.DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET_CHECK_ENABLED.key -> "true") {
+        checkError(
+          intercept[DeltaAnalysisException](sql(mergeStmt)),
+          "DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET",
+          sqlState = "428GU",
+          parameters = Map.empty[String, String])
+      }
+
+      // Flag off: the legacy code path runs and fails with an internal AssertionError
+      // (wrapped by Spark's runCommand in a SparkException) instead of the friendly error.
+      withSQLConf(
+          DeltaSQLConf.DELTA_MERGE_INTO_EMPTY_SCHEMA_TARGET_CHECK_ENABLED.key -> "false") {
+        val thrown = intercept[Throwable](sql(mergeStmt))
+        def hasAssertionErrorCause(t: Throwable): Boolean =
+          t != null && (t.isInstanceOf[AssertionError] || hasAssertionErrorCause(t.getCause))
+        assert(hasAssertionErrorCause(thrown),
+          s"expected legacy AssertionError in cause chain, got: $thrown")
+      }
+    }
+  }
+}


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Throw user error for merge queries with empty target schemas and schema evolution disabled
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UTs
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
