### PR TITLE
[CI] Widen workflow triggers to cover release branches (branch-*)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,12 +1,12 @@
 name: "Delta Build"
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/flink_test.yaml
+++ b/.github/workflows/flink_test.yaml
@@ -2,14 +2,14 @@ name: "Delta Flink"
 
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths:
       - 'flink/**'
       - 'kernel/**'
       - '!**/*.md'
       - '!**/*.txt'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths:
       - 'flink/**'
       - 'kernel/**'

--- a/.github/workflows/iceberg_test.yaml
+++ b/.github/workflows/iceberg_test.yaml
@@ -1,12 +1,12 @@
 name: "Delta Iceberg Latest"
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -2,12 +2,12 @@ name: "Delta Kernel"
 
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/kernel_unitycatalog_test.yaml
+++ b/.github/workflows/kernel_unitycatalog_test.yaml
@@ -1,7 +1,7 @@
 name: "Kernel Unity Catalog"
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths:
       - 'build.sbt'
       - 'version.sbt'
@@ -11,7 +11,7 @@ on:
       - 'storage/**/*.java'
       - '.github/workflows/kernel_unitycatalog_test.yaml'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths:
       - 'build.sbt'
       - 'version.sbt'

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -1,12 +1,12 @@
 name: "Delta Spark Publishing and Examples"
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -1,12 +1,12 @@
 name: "Delta Spark Python"
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -1,12 +1,12 @@
 name: "Delta Spark"
 on:
   push:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
-    branches: [master]
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/spark_test_uc_master.yaml
+++ b/.github/workflows/spark_test_uc_master.yaml
@@ -8,10 +8,12 @@
 name: "Delta Spark (UC Master)"
 on:
   push:
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'
   pull_request:
+    branches: [master, branch-*]
     paths-ignore:
       - '**.md'
       - '**.txt'

--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -1,9 +1,9 @@
   name: "Unidoc"
   on:
     push:
-      branches: [master]
+      branches: [master, branch-*]
     pull_request:
-      branches: [master]
+      branches: [master, branch-*]
   jobs:
     build:
       name: "U: Scala ${{ matrix.scala }}"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Update all CI workflow triggers from `branches: [master]` to `branches: [master, branch-*]` so that pushes and PRs targeting release branches also trigger CI.

With the adoption of uniform `branch-*` naming for all release branch cuts, a single glob pattern covers all current and future branches without per-branch maintenance.

**Updated workflows (10):**
- `build.yaml`, `flink_test.yaml`, `kernel_test.yaml`, `kernel_unitycatalog_test.yaml`
- `spark_examples_test.yaml`, `spark_test.yaml`, `spark_test_uc_master.yaml`, `unidoc.yaml`
- `disabled_iceberg_test.yaml`, `disabled_spark_python_test.yaml` (commented-out trigger templates for when these are re-enabled)

**Notable:** `spark_test_uc_master.yaml` previously had no `branches:` filter at all (triggered on all pushes/PRs). Now scoped to `master` + release branches to match the uniform pattern.

## How was this patch tested?

This is a trigger-only change. CI on this PR validates that the workflow YAML is syntactically correct. The `branch-*` glob will match on release branches (e.g., `branch-4.2`, `branch-4.1`) once those branches exist.

## Does this PR introduce _any_ user-facing changes?

No. CI-only change that determines which branches trigger CI workflows.