### PR TITLE
[Spark] Reapply Jackson collection compatibility fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -755,18 +755,8 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
     // Force ALL Jackson dependencies to match the selected Spark line.
     // This overrides Jackson from Unity Catalog's transitive dependencies (e.g., Armeria).
     dependencyOverrides ++= {
-      val sparkJacksonVersion = CrossSparkVersions.getSparkVersionSpec().jacksonVersion
-      val sparkJacksonAnnotationsVersion =
-        CrossSparkVersions.getSparkVersionSpec().jacksonAnnotationsVersion
-      Seq(
-        "com.fasterxml.jackson.core" % "jackson-core" % sparkJacksonVersion,
-        "com.fasterxml.jackson.core" % "jackson-annotations" % sparkJacksonAnnotationsVersion,
-        "com.fasterxml.jackson.core" % "jackson-databind" % sparkJacksonVersion,
-        "com.fasterxml.jackson.module" %% "jackson-module-scala" % sparkJacksonVersion,
-        "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % sparkJacksonVersion,
-        "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % sparkJacksonVersion,
-        "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % sparkJacksonVersion
-      )
+      val spec = CrossSparkVersions.getSparkVersionSpec()
+      CrossSparkVersions.jacksonOverridesFor(spec.jacksonVersion, spec.jacksonAnnotationsVersion)
     },
 
     libraryDependencies ++= Seq(
@@ -974,13 +964,9 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
     // mix a newer `jackson-databind` (from a published `delta-spark` test dependency) with a
     // `jackson-module-scala` pulled from Spark 4.0, which fails at runtime with
     // `JsonMappingException: Scala module ... requires Jackson Databind version ...`.
-    Test / dependencyOverrides ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % kernelTestSparkLineJacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-annotations" % kernelTestSparkLineJacksonAnnotationsVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % kernelTestSparkLineJacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % kernelTestSparkLineJacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % kernelTestSparkLineJacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % kernelTestSparkLineJacksonVersion
+    Test / dependencyOverrides ++= CrossSparkVersions.jacksonOverridesFor(
+      kernelTestSparkLineJacksonVersion,
+      kernelTestSparkLineJacksonAnnotationsVersion
     ),
 
     // Put the shaded kernel-api JAR on the classpath (compile & test)
@@ -1105,9 +1091,12 @@ lazy val storage = (project in file("storage"))
       // Test Deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       // Jackson datatype module needed for UC SDK tests (excluded from main compile scope).
-      // Keep it aligned with the selected Spark line to avoid mixed Jackson versions in test JVMs.
+      // `storage` is consumed by `kernelDefaults` via `test->test`, so its test classpath must
+      // be compatible with the Spark line kernel tests pin against (4.0 -> Jackson 2.18.2).
+      // Using the default (Spark 4.1 / 2.20.0) here breaks `jackson-module-scala:2.18.2` at
+      // runtime in kernel tests with a strict databind-version check.
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" %
-        CrossSparkVersions.getSparkVersionSpec().jacksonVersion % "test",
+        kernelTestSparkLineJacksonVersion % "test",
     ),
 
     // Unidoc settings

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,12 @@ val sparkVersion = settingKey[String]("Spark version")
 val defaultSparkVersion = SparkVersionSpec.DEFAULT.fullVersion // Spark version to use for testing in non-delta-spark related modules
 val hadoopVersion = "3.4.2"
 val sparkVersionForKernelTest = "4.0.0"
+// Jackson versions used by Spark `sparkVersionForKernelTest` (see Spark 4.0 line in
+// `project/CrossSparkVersions.scala`). Kernel tests also pull a published
+// `io.delta:delta-spark:4.0.0` JAR, which can introduce Jackson artifacts aligned with
+// the default (Spark 4.1) build line, so we align test classpaths in kernel modules.
+val kernelTestSparkLineJacksonVersion = "2.18.2"
+val kernelTestSparkLineJacksonAnnotationsVersion = "2.18.2"
 val scalaTestVersion = "3.2.15"
 val scalaTestVersionForConnectors = "3.0.8"
 val parquet4sVersion = "1.9.4"
@@ -724,7 +730,6 @@ lazy val contribs = (project in file("contribs"))
 
 
 val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.4.1")
-val sparkUnityCatalogJacksonVersion = "2.15.4" // We are using Spark 4.0's Jackson version 2.15.x, to override Unity Catalog 0.3.0's version 2.18.x
 
 lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
   .dependsOn(spark % "compile->compile;test->test;provided->provided")
@@ -747,17 +752,22 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
     // Don't execute in parallel since we can't have multiple Sparks in the same JVM
     Test / parallelExecution := false,
 
-    // Force ALL Jackson dependencies to match Spark's Jackson version
-    // This overrides Jackson from Unity Catalog's transitive dependencies (e.g., Armeria)
-    dependencyOverrides ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % sparkUnityCatalogJacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-annotations" % sparkUnityCatalogJacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % sparkUnityCatalogJacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % sparkUnityCatalogJacksonVersion,
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % sparkUnityCatalogJacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % sparkUnityCatalogJacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % sparkUnityCatalogJacksonVersion
-    ),
+    // Force ALL Jackson dependencies to match the selected Spark line.
+    // This overrides Jackson from Unity Catalog's transitive dependencies (e.g., Armeria).
+    dependencyOverrides ++= {
+      val sparkJacksonVersion = CrossSparkVersions.getSparkVersionSpec().jacksonVersion
+      val sparkJacksonAnnotationsVersion =
+        CrossSparkVersions.getSparkVersionSpec().jacksonAnnotationsVersion
+      Seq(
+        "com.fasterxml.jackson.core" % "jackson-core" % sparkJacksonVersion,
+        "com.fasterxml.jackson.core" % "jackson-annotations" % sparkJacksonAnnotationsVersion,
+        "com.fasterxml.jackson.core" % "jackson-databind" % sparkJacksonVersion,
+        "com.fasterxml.jackson.module" %% "jackson-module-scala" % sparkJacksonVersion,
+        "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % sparkJacksonVersion,
+        "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % sparkJacksonVersion,
+        "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % sparkJacksonVersion
+      )
+    },
 
     libraryDependencies ++= Seq(
       "org.assertj" % "assertj-core" % "3.26.3" % "test",
@@ -769,7 +779,7 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
       // Lombok for generating boilerplate code
       "org.projectlombok" % "lombok" % "1.18.34" % "test",
 
-      // Unity Catalog dependencies - exclude Jackson to use Spark's Jackson 2.15.x
+      // Unity Catalog dependencies - exclude Jackson to use the selected Spark line's Jackson.
       "io.unitycatalog" %% "unitycatalog-spark" % unityCatalogVersion % "test" excludeAll(
         ExclusionRule(organization = "com.fasterxml.jackson.core"),
         ExclusionRule(organization = "com.fasterxml.jackson.module"),
@@ -960,6 +970,19 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
     // This allows generating tables with unsupported test table features in delta-spark
     Test / envVars += ("DELTA_TESTING", "1"),
 
+    // Align Jackson to the Spark line used in kernel tests (4.0.x). Without this, tests can
+    // mix a newer `jackson-databind` (from a published `delta-spark` test dependency) with a
+    // `jackson-module-scala` pulled from Spark 4.0, which fails at runtime with
+    // `JsonMappingException: Scala module ... requires Jackson Databind version ...`.
+    Test / dependencyOverrides ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-core" % kernelTestSparkLineJacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-annotations" % kernelTestSparkLineJacksonAnnotationsVersion,
+      "com.fasterxml.jackson.core" % "jackson-databind" % kernelTestSparkLineJacksonVersion,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % kernelTestSparkLineJacksonVersion,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % kernelTestSparkLineJacksonVersion,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % kernelTestSparkLineJacksonVersion
+    ),
+
     // Put the shaded kernel-api JAR on the classpath (compile & test)
     Compile / unmanagedJars += (kernelApi / Compile / packageBin).value,
     Test / unmanagedJars += (kernelApi / Compile / packageBin).value,
@@ -1081,8 +1104,10 @@ lazy val storage = (project in file("storage"))
 
       // Test Deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
-      // Jackson datatype module needed for UC SDK tests (excluded from main compile scope)
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.15.4" % "test",
+      // Jackson datatype module needed for UC SDK tests (excluded from main compile scope).
+      // Keep it aligned with the selected Spark line to avoid mixed Jackson versions in test JVMs.
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" %
+        CrossSparkVersions.getSparkVersionSpec().jacksonVersion % "test",
     ),
 
     // Unidoc settings

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -21,7 +21,20 @@ organizationName := "example"
 val scala213 = "2.13.17"
 val icebergVersion = "1.4.1"
 val unityCatalogVersion = "0.4.1"
-val jacksonVersion = "2.15.4"
+
+def resolveJacksonVersionForSpark(sparkVersion: String): String = sparkVersion match {
+  case v if v.startsWith("4.2") => "2.21.2"
+  case v if v.startsWith("4.1") => "2.20.0"
+  case v if v.startsWith("4.0") => "2.18.2"
+  case _ => "2.15.4"
+}
+
+def resolveJacksonAnnotationsVersionForSpark(sparkVersion: String): String = sparkVersion match {
+  case v if v.startsWith("4.2") => "2.21"
+  case v if v.startsWith("4.1") => "2.20"
+  case v if v.startsWith("4.0") => "2.18.2"
+  case _ => resolveJacksonVersionForSpark(sparkVersion)
+}
 
 val defaultDeltaVersion = {
   val versionFileContent = IO.read(file("../../version.sbt"))
@@ -80,6 +93,12 @@ val getDeltaVersion = settingKey[String](
 val getDeltaArtifactName = settingKey[String](
   s"get delta artifact name based on the delta version. either `delta-core` or `delta-spark`."
 )
+val getJacksonVersion = settingKey[String](
+  "get the Jackson version compatible with the resolved Spark version."
+)
+val getJacksonAnnotationsVersion = settingKey[String](
+  "get the jackson-annotations version compatible with the resolved Spark version."
+)
 val getIcebergSparkRuntimeArtifactName = settingKey[String](
   s"get iceberg-spark-runtime name based on the delta version."
 )
@@ -115,6 +134,14 @@ getDeltaVersion := {
 getDeltaArtifactName := {
   val deltaVersion = getDeltaVersion.value
   if (deltaVersion.charAt(0).asDigit >= 3) "delta-spark" else "delta-core"
+}
+
+getJacksonVersion := {
+  resolveJacksonVersionForSpark(resolveSparkVersion(getDeltaVersion.value))
+}
+
+getJacksonAnnotationsVersion := {
+  resolveJacksonAnnotationsVersionForSpark(resolveSparkVersion(getDeltaVersion.value))
 }
 
 val getSparkPackageSuffix = settingKey[String](
@@ -227,13 +254,14 @@ lazy val root = (project in file("."))
       )
     ),
     dependencyOverrides ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
+      "com.fasterxml.jackson.core" % "jackson-core" % getJacksonVersion.value,
+      "com.fasterxml.jackson.core" % "jackson-annotations" %
+        getJacksonAnnotationsVersion.value,
+      "com.fasterxml.jackson.core" % "jackson-databind" % getJacksonVersion.value,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % getJacksonVersion.value,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % getJacksonVersion.value,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % getJacksonVersion.value,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % getJacksonVersion.value
     ),
     extraMavenRepo,
     resolvers += Resolver.mavenLocal,

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -210,6 +210,10 @@ import Unidoc._
  * @param additionalSourceDir Optional version-specific source directory suffix (e.g., "scala-spark-3.5")
  * @param antlr4Version ANTLR version to use (e.g., "4.9.3", "4.13.1")
  * @param additionalJavaOptions Additional JVM options for tests (e.g., Java 17 --add-opens flags)
+ * @param jacksonVersion Jackson core/databind/module-scala version that Spark ships with.
+ * @param jacksonAnnotationsVersion Jackson annotations version. Tracked independently of
+ *                                  `jacksonVersion` because jackson-annotations is released on a
+ *                                  separate cadence (often trailing databind by a patch).
  */
 case class SparkVersionSpec(
   fullVersion: String,
@@ -355,6 +359,26 @@ object CrossSparkVersions extends AutoPlugin {
   def getSparkVersion(): String = getSparkVersionSpec().fullVersion
 
   /**
+   * Dependency-override entries that pin every Jackson artifact to the given versions.
+   *
+   * The list is the superset of Jackson artifacts used across any project in this repo. Sbt's
+   * `dependencyOverrides` are a no-op for artifacts not already present in the resolution graph,
+   * so it's safe to apply this full list uniformly from any project that wants a consistent
+   * Jackson line on its (compile or test) classpath.
+   */
+  def jacksonOverridesFor(
+      jacksonVersion: String,
+      jacksonAnnotationsVersion: String): Seq[ModuleID] = Seq(
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVersion,
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion,
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+  )
+
+  /**
    * Returns module name with Spark version suffix.
    * 
    * By default, ALL Spark-dependent modules include the Spark version suffix:
@@ -418,15 +442,7 @@ object CrossSparkVersions extends AutoPlugin {
         val sparkVer = sparkVersionKey.value
         val sparkSpec = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
           .getOrElse(throw new IllegalArgumentException(s"Unknown Spark version: $sparkVer"))
-        val jacksonVer = sparkSpec.jacksonVersion
-        val jacksonAnnotationsVer = sparkSpec.jacksonAnnotationsVersion
-        Seq(
-          "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVer,
-          "com.fasterxml.jackson.core" % "jackson-core" % jacksonVer,
-          "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVer,
-          "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVer,
-          "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVer
-        )
+        jacksonOverridesFor(sparkSpec.jacksonVersion, sparkSpec.jacksonAnnotationsVersion)
       }
     )
 

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -220,6 +220,7 @@ case class SparkVersionSpec(
   antlr4Version: String,
   additionalJavaOptions: Seq[String] = Seq.empty,
   jacksonVersion: String = "2.15.2",
+  jacksonAnnotationsVersion: String = "2.15.2",
   additionalResolvers: Seq[Resolver] = Seq.empty
 ) {
   /** Returns the Spark short version (e.g., "3.5", "4.0") */
@@ -269,7 +270,8 @@ object SparkVersionSpec {
     supportIceberg = true,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2"
+    jacksonVersion = "2.18.2",
+    jacksonAnnotationsVersion = "2.18.2"
   )
 
   private val spark41 = SparkVersionSpec(
@@ -280,7 +282,8 @@ object SparkVersionSpec {
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2"
+    jacksonVersion = "2.20.0",
+    jacksonAnnotationsVersion = "2.20"
   )
 
   private val spark42Snapshot = SparkVersionSpec(
@@ -291,7 +294,8 @@ object SparkVersionSpec {
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2",
+    jacksonVersion = "2.21.2",
+    jacksonAnnotationsVersion = "2.21",
     // Artifact updates in maven central for roaringbitmap stopped after 1.3.0.
     // Spark master uses 1.5.3. Relevant Spark PR here https://github.com/apache/spark/pull/52892
     additionalResolvers = Seq("jitpack" at "https://jitpack.io")
@@ -412,13 +416,14 @@ object CrossSparkVersions extends AutoPlugin {
     val jacksonOverrides = Seq(
       dependencyOverrides ++= {
         val sparkVer = sparkVersionKey.value
-        val jacksonVer = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
+        val sparkSpec = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
           .getOrElse(throw new IllegalArgumentException(s"Unknown Spark version: $sparkVer"))
-          .jacksonVersion
+        val jacksonVer = sparkSpec.jacksonVersion
+        val jacksonAnnotationsVer = sparkSpec.jacksonAnnotationsVersion
         Seq(
           "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVer,
           "com.fasterxml.jackson.core" % "jackson-core" % jacksonVer,
-          "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVer,
+          "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVer,
           "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVer,
           "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVer
         )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -851,16 +851,17 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
    */
   def validateFileListAgainstCRC(checksum: VersionChecksum, contextOpt: Option[String]): Boolean = {
     val fileSortKey = (f: AddFile) => (f.path, f.modificationTime, f.size)
-    // Jackson 2.19+ deserializes null collection values as empty collections.
-    // So we normalize null tags to empty maps before comparing file lists.
+    // Normalize null tags so state-reconstructed files (which can still surface null tags from
+    // Parquet) compare equal to CRC-deserialized files (which default to empty maps after the
+    // Jackson upgrade).
     val filesFromCrc = checksum.allFiles
       .map(_.sortBy(fileSortKey))
       .getOrElse { return true }
-      .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+      .map(_.withNormalizedTags)
     val filesFromStateReconstruction = recordFrameProfile(
         "Delta", "snapshot.allFiles") {
       allFilesViaStateReconstruction.collect().toSeq.sortBy(fileSortKey)
-    }.map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+    }.map(_.withNormalizedTags)
     if (filesFromCrc == filesFromStateReconstruction) return true
 
     val filesFromCrcWithoutStats = filesFromCrc.map(_.copy(stats = ""))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -851,11 +851,16 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
    */
   def validateFileListAgainstCRC(checksum: VersionChecksum, contextOpt: Option[String]): Boolean = {
     val fileSortKey = (f: AddFile) => (f.path, f.modificationTime, f.size)
-    val filesFromCrc = checksum.allFiles.map(_.sortBy(fileSortKey)).getOrElse { return true }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    // So we normalize null tags to empty maps before comparing file lists.
+    val filesFromCrc = checksum.allFiles
+      .map(_.sortBy(fileSortKey))
+      .getOrElse { return true }
+      .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
     val filesFromStateReconstruction = recordFrameProfile(
         "Delta", "snapshot.allFiles") {
       allFilesViaStateReconstruction.collect().toSeq.sortBy(fileSortKey)
-    }
+    }.map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
     if (filesFromCrc == filesFromStateReconstruction) return true
 
     val filesFromCrcWithoutStats = filesFromCrc.map(_.copy(stats = ""))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1336,7 +1336,7 @@ private[delta] class ConflictChecker(
   /** A helper function for pretty printing a specific partition directory. */
   protected def getPrettyPartitionMessage(partitionValues: Map[String, String]): Option[String] = {
     val partitionColumns = currentTransactionInfo.partitionSchemaAtReadTime
-    if (partitionColumns.isEmpty || partitionValues == null) {
+    if (partitionColumns.isEmpty || partitionValues == null || partitionValues.isEmpty) {
       None
     } else {
       Some(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -887,6 +887,15 @@ case class AddFile(
 
   override def wrap: SingleAction = SingleAction(add = this)
 
+  /**
+   * Returns a copy of this file with `tags` normalized to `Map.empty` when null.
+   * State reconstruction from Parquet checkpoint files can still produce null tags
+   * even after the Jackson default shifted to empty maps, so this is needed wherever
+   * reconstructed files are compared for equality against freshly-constructed ones.
+   */
+  @JsonIgnore
+  def withNormalizedTags: AddFile = if (tags == null) copy(tags = Map.empty) else this
+
   def remove: RemoveFile = removeWithTimestamp()
 
   def removeWithTimestamp(
@@ -1556,6 +1565,10 @@ case class SidecarFile(
 
   override def wrap: SingleAction = SingleAction(sidecar = this)
 
+  /** See [[AddFile.withNormalizedTags]]. */
+  @JsonIgnore
+  def withNormalizedTags: SidecarFile = if (tags == null) copy(tags = Map.empty) else this
+
   def toFileStatus(logPath: Path): FileStatus = {
     val partFilePath = new Path(FileNames.sidecarDirPath(logPath), path)
     new FileStatus(sizeInBytes, false, 0, 0, modificationTime, partFilePath)
@@ -1586,6 +1599,11 @@ case class CheckpointMetadata(
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(checkpointMetadata = this)
+
+  /** See [[AddFile.withNormalizedTags]]. */
+  @JsonIgnore
+  def withNormalizedTags: CheckpointMetadata =
+    if (tags == null) copy(tags = Map.empty) else this
 }
 
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -874,7 +874,8 @@ case class AddFile(
     modificationTime: Long,
     override val dataChange: Boolean,
     override val stats: String = null,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -1111,10 +1112,12 @@ case class RemoveFile(
     deletionTimestamp: Option[Long],
     override val dataChange: Boolean = true,
     extendedFileMetadata: Option[Boolean] = None,
-    partitionValues: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    partitionValues: Map[String, String] = Map.empty,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     size: Option[Long] = None,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -1171,7 +1174,8 @@ case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val stats: String = null) extends FileAction with HasNumRecords {
   override val dataChange = false
   @JsonIgnore
@@ -1539,15 +1543,15 @@ sealed trait CheckpointOnlyAction extends Action
  * @param path - sidecar path relative to `_delta_log/_sidecar` directory
  * @param sizeInBytes - size in bytes for the sidecar file
  * @param modificationTime - modification time of the sidecar file
- * @param tags - attributes of the sidecar file, defaults to null (which is semantically same as an
- *               empty Map). This is kept null to ensure that the field is not present in the
- *               generated json.
+ * @param tags - attributes of the sidecar file, defaults to an empty map. Both null and empty maps
+ *               are omitted from the generated json.
  */
 case class SidecarFile(
     path: String,
     sizeInBytes: Long,
     modificationTime: Long,
-    tags: Map[String, String] = null)
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty)
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(sidecar = this)
@@ -1572,13 +1576,13 @@ object SidecarFile {
  * Holds information about the Delta Checkpoint. This action will only be part of checkpoints.
  *
  * @param version version of the checkpoint
- * @param tags    attributes of the checkpoint, defaults to null (which is semantically same as an
- *                empty Map). This is kept null to ensure that the field is not present in the
- *                generated json.
+ * @param tags    attributes of the checkpoint, defaults to an empty map. Both null and empty maps
+ *                are omitted from the generated json.
  */
 case class CheckpointMetadata(
     version: Long,
-    tags: Map[String, String] = null)
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty)
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(checkpointMetadata = this)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -133,9 +133,8 @@ class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorg
   override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
     : Seq[AddFile] = {
     def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
-      if (file.tags == null) return true
       val fileIcebergCompatVersion =
-        file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
+        file.tagsOrEmpty.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
       fileIcebergCompatVersion != icebergCompatVersion.toString
     }
     files.filter(shouldRewriteToBeIcebergCompatible)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -132,11 +132,9 @@ class DeltaPurgeOperation extends DeltaReorgOperation with ReorgTableHelper {
 class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorgOperation {
   override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
     : Seq[AddFile] = {
-    def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
-      val fileIcebergCompatVersion =
-        file.tagsOrEmpty.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
-      fileIcebergCompatVersion != icebergCompatVersion.toString
-    }
+    def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean =
+      !file.tagsOrEmpty.get(AddFile.Tags.ICEBERG_COMPAT_VERSION.name)
+        .contains(icebergCompatVersion.toString)
     files.filter(shouldRewriteToBeIcebergCompatible)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -20,6 +20,8 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.NumRecordsStats
 import org.apache.spark.sql.util.ScalaExtensions._
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.commons.lang3.StringUtils
 
@@ -85,14 +87,19 @@ case class MergeStats(
 
     // Expressions used in old MERGE stats, now always Null
     updateConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     updateExprs: Seq[String],
     insertConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     insertExprs: Seq[String],
     deleteConditionExpr: String,
 
     // Newer expressions used in MERGE with any number of MATCHED/NOT MATCHED/NOT MATCHED BY SOURCE
+    @JsonInclude(Include.NON_EMPTY)
     matchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedBySourceStats: Seq[MergeClauseStats],
 
     // Timings

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -100,7 +100,11 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         stats = null,
         tags = Map.empty)
     assert(action2 === Action.fromJson(json2))
-    assert(action2.json === json2.replaceAll("\\s", ""))
+    val expectedJson =
+      """{"add":{""" +
+        """"path":"a",""" +
+        """"partitionValues":{},"size":1,"modificationTime":2,"dataChange":false}}"""
+    assert(action2.json === expectedJson)
   }
 
   // This is the same test as "removefile" in OSS, but due to a Jackson library upgrade the behavior
@@ -544,7 +548,6 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         |"modificationTime":1,
         |"dataChange":true,
         |"stats":"{\"numRecords\":3}",
-        |"tags":{},
         |"deletionVector":{
         |"storageType":"p",
         |"pathOrInlineDv":"/test.dv",
@@ -601,14 +604,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     )
 
     assert(m1.json === """{"checkpointMetadata":{"version":1}}""")
-    assert(m2.json === """{"checkpointMetadata":{"version":1,"tags":{}}}""")
+    assert(m2.json === """{"checkpointMetadata":{"version":1}}""")
     assert(m3.json ===
       """{"checkpointMetadata":{"version":1,""" +
         """"tags":{"k1":"v1","schema":"{\"type\":\"struct\",\"fields\":[]}"}}}""")
 
-    Seq(m1, m2, m3).foreach { metadata =>
-      assert(metadata === JsonUtils.fromJson[SingleAction](metadata.json).unwrap)
-    }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    assert(m2 === JsonUtils.fromJson[SingleAction](m1.json).unwrap)
+    assert(m2 === JsonUtils.fromJson[SingleAction](m2.json).unwrap)
+    assert(m3 === JsonUtils.fromJson[SingleAction](m3.json).unwrap)
   }
 
   test("SidecarFile - serialize/deserialize") {
@@ -622,15 +626,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     assert(f1.json ===
       """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3}}""")
     assert(f2.json ===
-      """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,""" +
-        """"modificationTime":3,"tags":{}}}""")
+      """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3}}""")
     assert(f3.json ===
       """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3,""" +
         """"tags":{"k1":"v1","schema":"{\"type\":\"struct\",\"fields\":[]}"}}}""".stripMargin)
 
-    Seq(f1, f2, f3).foreach { file =>
-      assert(file === JsonUtils.fromJson[SingleAction](file.json).unwrap)
-    }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    assert(f2 === JsonUtils.fromJson[SingleAction](f1.json).unwrap)
+    assert(f2 === JsonUtils.fromJson[SingleAction](f2.json).unwrap)
+    assert(f3 === JsonUtils.fromJson[SingleAction](f3.json).unwrap)
   }
 
   testActionSerDe(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
@@ -70,9 +70,17 @@ class CheckpointProviderSuite
           .underlyingCheckpointProvider
           .asInstanceOf[V2CheckpointProvider]
 
-        // Check whether these checkpoints are equivalent after being loaded
-        assert(compatCheckpoint.sidecarFiles.toSet === origCheckpoint.sidecarFiles.toSet)
-        assert(compatCheckpoint.checkpointMetadata === origCheckpoint.checkpointMetadata)
+        // Jackson 2.19+ deserializes null collection values as empty collections
+        // and we need to normalize to empty maps for comparison.
+        val compatSidecarFiles = compatCheckpoint.sidecarFiles
+          .map(sidecar => if (sidecar.tags == null) sidecar.copy(tags = Map.empty) else sidecar)
+        assert(compatSidecarFiles.toSet === origCheckpoint.sidecarFiles.toSet)
+        val compatCheckpointMetadata = if (compatCheckpoint.checkpointMetadata.tags == null) {
+          compatCheckpoint.checkpointMetadata.copy(tags = Map.empty)
+        } else {
+          compatCheckpoint.checkpointMetadata
+        }
+        assert(compatCheckpointMetadata === origCheckpoint.checkpointMetadata)
 
         val compatDf =
             deltaLog.loadIndex(compatCheckpoint.topLevelFileIndex.get, Action.logSchema)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
@@ -70,17 +70,12 @@ class CheckpointProviderSuite
           .underlyingCheckpointProvider
           .asInstanceOf[V2CheckpointProvider]
 
-        // Jackson 2.19+ deserializes null collection values as empty collections
-        // and we need to normalize to empty maps for comparison.
-        val compatSidecarFiles = compatCheckpoint.sidecarFiles
-          .map(sidecar => if (sidecar.tags == null) sidecar.copy(tags = Map.empty) else sidecar)
-        assert(compatSidecarFiles.toSet === origCheckpoint.sidecarFiles.toSet)
-        val compatCheckpointMetadata = if (compatCheckpoint.checkpointMetadata.tags == null) {
-          compatCheckpoint.checkpointMetadata.copy(tags = Map.empty)
-        } else {
-          compatCheckpoint.checkpointMetadata
-        }
-        assert(compatCheckpointMetadata === origCheckpoint.checkpointMetadata)
+        // Normalize null tags so reconstructed sidecar/metadata compare equal to freshly built
+        // instances that default to empty maps after the Jackson upgrade.
+        assert(compatCheckpoint.sidecarFiles.map(_.withNormalizedTags).toSet ===
+          origCheckpoint.sidecarFiles.toSet)
+        assert(compatCheckpoint.checkpointMetadata.withNormalizedTags ===
+          origCheckpoint.checkpointMetadata)
 
         val compatDf =
             deltaLog.loadIndex(compatCheckpoint.topLevelFileIndex.get, Action.logSchema)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -334,7 +334,7 @@ class DeltaLogSuite extends QueryTest
         createTestAddFile(encodedPath = "bar", modificationTime = System.currentTimeMillis())
       log.startTransaction().commit(otherAdd :: Nil, DeltaOperations.ManualUpdate)
 
-      assert(log.update().allFiles.collect().find(_.path == "foo")
+      assert(log.update().allFiles.collect().find(_.path == "foo").map(_.copy(tags = Map.empty))
         // `dataChange` is set to `false` after replaying logs.
         === Some(add2.copy(
           dataChange = false, baseRowId = Some(1), defaultRowCommitVersion = Some(2))))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1067,10 +1067,8 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata === newMetadata2)
         // State reconstruction should give correct results
         var expectedFileNames = Set("1", "2", "post-upgrade-file")
-        // Jackson 2.19+ deserializes null collection values as empty collections.
-        // So we convert null tags to empty maps before comparison.
         val unsafeVolatileSnapshotFiles = log.unsafeVolatileSnapshot.allFiles
-          .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+          .map(_.withNormalizedTags)
           .collect()
           .toSet
         assert(unsafeVolatileSnapshotFiles ===
@@ -1105,10 +1103,8 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsCoordinatorConf === Map.empty)
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsTableConf === Map.empty)
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file")
-        // Jackson 2.19+ deserializes null collection values as empty collections.
-        // So we convert null tags to empty maps before comparison.
         val unsafeVolatileSnapshotFiles2 = log.unsafeVolatileSnapshot.allFiles
-          .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+          .map(_.withNormalizedTags)
           .collect()
           .toSet
         assert(unsafeVolatileSnapshotFiles2 ===
@@ -1124,10 +1120,8 @@ abstract class CommitCoordinatorSuiteBase
         // Make 1 more commit, this should go to new owner
         log.startTransaction().commitManually(newMetadata3, createTestAddFile("4"))
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file", "4")
-        // Jackson 2.19+ deserializes null collection values as empty collections.
-        // So we convert null tags to empty maps before comparison.
         val unsafeVolatileSnapshotFiles3 = log.unsafeVolatileSnapshot.allFiles
-          .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+          .map(_.withNormalizedTags)
           .collect()
           .toSet
         assert(unsafeVolatileSnapshotFiles3 ===

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1067,7 +1067,13 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata === newMetadata2)
         // State reconstruction should give correct results
         var expectedFileNames = Set("1", "2", "post-upgrade-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        // Jackson 2.19+ deserializes null collection values as empty collections.
+        // So we convert null tags to empty maps before comparison.
+        val unsafeVolatileSnapshotFiles = log.unsafeVolatileSnapshot.allFiles
+          .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+          .collect()
+          .toSet
+        assert(unsafeVolatileSnapshotFiles ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         // commit-coordinator should not be invoked for commit API.
         // Register table API should not be called until the end
@@ -1099,7 +1105,13 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsCoordinatorConf === Map.empty)
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsTableConf === Map.empty)
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        // Jackson 2.19+ deserializes null collection values as empty collections.
+        // So we convert null tags to empty maps before comparison.
+        val unsafeVolatileSnapshotFiles2 = log.unsafeVolatileSnapshot.allFiles
+          .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+          .collect()
+          .toSet
+        assert(unsafeVolatileSnapshotFiles2 ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 0))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))
@@ -1112,7 +1124,13 @@ abstract class CommitCoordinatorSuiteBase
         // Make 1 more commit, this should go to new owner
         log.startTransaction().commitManually(newMetadata3, createTestAddFile("4"))
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file", "4")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        // Jackson 2.19+ deserializes null collection values as empty collections.
+        // So we convert null tags to empty maps before comparison.
+        val unsafeVolatileSnapshotFiles3 = log.unsafeVolatileSnapshot.allFiles
+          .map(file => if (file.tags == null) file.copy(tags = Map.empty) else file)
+          .collect()
+          .toSet
+        assert(unsafeVolatileSnapshotFiles3 ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 1))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))


### PR DESCRIPTION
## Summary
- Reapply the Jackson collection-compatibility changes from #5598 on current `master`, including default-empty action fields, `NON_EMPTY` JSON serialization, and null-vs-empty normalization in runtime comparisons.
- Align the Spark-specific Jackson overrides in `build.sbt` and `examples/scala/build.sbt` with the currently supported Spark 4.0 and 4.1 lines so the runtime and examples do not mix Jackson versions.
- Keep Spark 4.2 out of the active build matrix for now 
## Test plan
- [x] build/sbt "spark/testOnly org.apache.spark.sql.delta.ActionSerializerSuite org.apache.spark.sql.delta.CheckpointProviderSuite org.apache.spark.sql.delta.ChecksumSuite org.apache.spark.sql.delta.DeltaLogSuite org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsSuite"`
- [x] build/sbt -DsparkVersion=4.0.1 "spark/testOnly org.apache.spark.sql.delta.ActionSerializerSuite org.apache.spark.sql.delta.CheckpointProviderSuite org.apache.spark.sql.delta.ChecksumSuite org.apache.spark.sql.delta.DeltaLogSuite"`
- [x] `build/sbt exportSparkVersionsJson`
- [x] `python3 project/scripts/get_spark_version_info.py --all-spark-versions`
- [x] `python3 project/scripts/get_spark_version_info.py --released-spark-versions`