### PR TITLE
[Spark] Fix OptimizedWriter incompatibility with external shuffle managers

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/DefaultOptimizedWriteShuffleHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/DefaultOptimizedWriteShuffleHelper.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.perf
+
+import org.apache.spark.sql.delta.util.BinPackingUtils
+
+import org.apache.spark.storage._
+
+/**
+ * Default implementation of [[OptimizedWriteShuffleHelper]] for external shuffle managers.
+ *
+ * Bin-packs whole reducers as atomic units, since `ShuffleManager.getReader()` reads entire
+ * reducer partitions and splitting a reducer across bins would cause data duplication.
+ */
+class DefaultOptimizedWriteShuffleHelper extends OptimizedWriteShuffleHelper {
+
+  override def computeBins(
+      shuffleStats: Array[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])],
+      maxBinSize: Long): Seq[Seq[BlockId]] = {
+    val blocksByReducer = shuffleStats.toSeq.flatMap(_._2)
+      .groupBy(_._1.asInstanceOf[ShuffleBlockId].reduceId)
+
+    case class ReducerData(reducerId: Int, totalSize: Long,
+        blocks: Seq[(BlockId, Long, Int)])
+    val reducerDataSeq = blocksByReducer.map { case (reducerId, blocks) =>
+      ReducerData(reducerId, blocks.map(_._2).sum, blocks)
+    }.toSeq
+
+    BinPackingUtils.binPackBySize[ReducerData, ReducerData](
+      reducerDataSeq,
+      _.totalSize,
+      identity,
+      maxBinSize).map(_.flatMap(_.blocks.map(_._1)))
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/DeltaOptimizedWriterExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/DeltaOptimizedWriterExec.scala
@@ -32,6 +32,7 @@ import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.rdd.RDD
 import org.apache.spark.shuffle._
+import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
@@ -40,6 +41,7 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics, SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
 import org.apache.spark.storage._
 import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.Utils
 
 
 /**
@@ -77,6 +79,49 @@ case class DeltaOptimizedWriterExec(
       getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_MAX_SHUFFLE_PARTITIONS))
   }
 
+  /**
+   * Whether the runtime shuffle manager is different from Spark's built-in
+   * [[SortShuffleManager]]. When true, delegate shuffle reads to
+   * `ShuffleManager.getReader()` instead of directly constructing a
+   * `ShuffleBlockFetcherIterator`, because external shuffle managers
+   * provide their own reader implementations that use their own transport protocols.
+   */
+  private lazy val hasExternalShuffleManager: Boolean = {
+    !SparkEnv.get.shuffleManager.isInstanceOf[SortShuffleManager]
+  }
+
+  /**
+   * Optional helper for external shuffle managers. Resolved from the user-specified class name
+   * in [[DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER]], or instantiated as
+   * [[DefaultOptimizedWriteShuffleHelper]] when an external shuffle manager is detected.
+   * `None` when using the default SortShuffleManager without an explicit helper config.
+   * Only used on the driver for bin-packing; not serialized to executors.
+   */
+  @transient private lazy val shuffleHelper: Option[OptimizedWriteShuffleHelper] = {
+    val configured = conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER)
+    configured.map { className =>
+      try {
+        Utils.classForName(className).getConstructor().newInstance()
+          .asInstanceOf[OptimizedWriteShuffleHelper]
+      } catch {
+        case e: ClassNotFoundException =>
+          throw new SparkException(
+            s"Could not load OptimizedWriteShuffleHelper class '$className' configured by " +
+              s"${DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER.key}. " +
+              s"Ensure the class is on the classpath and implements " +
+              s"${classOf[OptimizedWriteShuffleHelper].getName}.", e)
+        case e: Exception =>
+          throw new SparkException(
+            s"Failed to instantiate OptimizedWriteShuffleHelper class '$className' configured " +
+              s"by ${DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER.key}. " +
+              s"The class must have a no-arg constructor.", e)
+      }
+    }.orElse {
+      if (hasExternalShuffleManager) Some(new DefaultOptimizedWriteShuffleHelper())
+      else None
+    }
+  }
+
   @transient private var cachedShuffleRDD: ShuffledRowRDD = _
 
   @transient private lazy val mapTracker = SparkEnv.get.mapOutputTracker
@@ -112,14 +157,20 @@ case class DeltaOptimizedWriterExec(
     val maxBinSize =
       ByteUnit.BYTE.convertFrom(getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_BIN_SIZE), ByteUnit.MiB)
 
-    val bins = shuffleStats.toSeq.flatMap(_._2).groupBy(_._1.asInstanceOf[ShuffleBlockId].reduceId)
-      .flatMap { case (_, blocks) =>
-        BinPackingUtils.binPackBySize[(BlockId, Long, Int), BlockId](
-          blocks,
-          _._2, // size
-          _._1, // blockId
-          maxBinSize)
-      }
+    val bins = if (shuffleHelper.isDefined) {
+      shuffleHelper.get.computeBins(shuffleStats, maxBinSize)
+    } else {
+      // Default (SortShuffleManager) path: bin-pack individual blocks within each reducer
+      // for optimal file sizes.
+      shuffleStats.toSeq.flatMap(_._2).groupBy(_._1.asInstanceOf[ShuffleBlockId].reduceId)
+        .flatMap { case (_, blocks) =>
+          BinPackingUtils.binPackBySize[(BlockId, Long, Int), BlockId](
+            blocks,
+            _._2, // size
+            _._1, // blockId
+            maxBinSize)
+        }
+    }
 
     bins
       .map { bin =>
@@ -191,7 +242,8 @@ case class DeltaOptimizedWriterExec(
       sparkContext,
       shuffledRDD.dependency,
       readMetrics,
-      new OptimizedWriterBlocks(partitions))
+      new OptimizedWriterBlocks(partitions),
+      shuffleHelper.isDefined)
   }
 
   private def getConf[T](entry: ConfigEntry[T]): T = {
@@ -214,12 +266,17 @@ class OptimizedWriterBlocks(
 /**
  * A specialized implementation similar to `ShuffledRowRDD`, where a partition reads a prepared
  * set of shuffle blocks.
+ *
+ * When `useShuffleManagerReader` is true, shuffle reads are delegated to
+ * `ShuffleManager.getReader()` to ensure compatibility with external shuffle managers.
+ * Otherwise, the original `ShuffleBlockFetcherIterator` path is used.
  */
 private class DeltaOptimizedWriterRDD(
     @transient sparkContext: SparkContext,
     var dep: ShuffleDependency[Int, _, InternalRow],
     metrics: Map[String, SQLMetric],
-    @transient blocks: OptimizedWriterBlocks)
+    @transient blocks: OptimizedWriterBlocks,
+    useShuffleManagerReader: Boolean)
   extends RDD[InternalRow](sparkContext, Seq(dep)) with DeltaLogging {
 
   override def getPartitions: Array[Partition] = Array.tabulate(blocks.bins.length) { i =>
@@ -230,6 +287,49 @@ private class DeltaOptimizedWriterRDD(
     val tempMetrics = context.taskMetrics().createTempShuffleReadMetrics()
     val sqlMetricsReporter = new SQLShuffleReadMetricsReporter(tempMetrics, metrics)
 
+    if (useShuffleManagerReader) {
+      computeWithShuffleManager(split, context, sqlMetricsReporter)
+    } else {
+      computeWithBlockFetcher(split, context, sqlMetricsReporter)
+    }
+  }
+
+  /**
+   * External shuffle manager path: delegate to `ShuffleManager.getReader()` for each reducer.
+   * Each bin contains complete reducers (never partial), so reading by reducer ID produces
+   * exactly the right data without duplication.
+   */
+  private def computeWithShuffleManager(
+      split: Partition,
+      context: TaskContext,
+      sqlMetricsReporter: SQLShuffleReadMetricsReporter): Iterator[InternalRow] = {
+    val partitionBlocks = split.asInstanceOf[ShuffleBlockRDDPartition].blocks
+    val allBlocks = partitionBlocks.flatMap { case (_, blks) => blks }
+    val reducerIds = allBlocks.map(_._1.asInstanceOf[ShuffleBlockId].reduceId).distinct.sorted
+
+    val readers = reducerIds.map { reducerId =>
+      SparkEnv.get.shuffleManager.getReader(
+        dep.shuffleHandle,
+        reducerId,
+        reducerId + 1,
+        context,
+        sqlMetricsReporter)
+    }
+
+    readers.iterator.flatMap { reader =>
+      reader.read().asInstanceOf[Iterator[Product2[Int, InternalRow]]].map(_._2)
+    }
+  }
+
+  /**
+   * Default (SortShuffleManager) path: use `ShuffleBlockFetcherIterator` to fetch specific
+   * blocks directly. This allows block-level bin-packing where a single reducer's blocks
+   * can be split across multiple bins for optimal file sizes.
+   */
+  private def computeWithBlockFetcher(
+      split: Partition,
+      context: TaskContext,
+      sqlMetricsReporter: SQLShuffleReadMetricsReporter): Iterator[InternalRow] = {
     val blocks = if (context.stageAttemptNumber() > 0) {
       // We lost shuffle blocks, so we need to now get new manager addresses
       val executorTracker = SparkEnv.get.mapOutputTracker

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizedWriteShuffleHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizedWriteShuffleHelper.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.perf
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.storage._
+
+/**
+ * :: DeveloperApi ::
+ * Extension point for external shuffle services (e.g., Celeborn, Uniffle, Membrain) to customize
+ * how Delta's optimized writer computes bin-packing.
+ *
+ * The default implementation bin-packs whole reducers as atomic units. External shuffle services
+ * can provide their own implementation via
+ * `spark.databricks.delta.optimizeWrite.shuffleHelper` to leverage service-specific optimizations
+ * such as locality-aware bin-packing.
+ *
+ * Shuffle reads on executors are always delegated to `ShuffleManager.getReader()`, which is
+ * Spark's standard extension point for custom shuffle read behavior. This trait only controls
+ * the driver-side bin-packing strategy.
+ *
+ * Implementations must have a no-arg constructor.
+ */
+@DeveloperApi
+trait OptimizedWriteShuffleHelper {
+
+  /**
+   * Bin-pack shuffle blocks into groups, where each group will be written as a single output file.
+   * Called on the driver.
+   *
+   * Each bin must contain complete reducers (all blocks for a given reducer ID must be in the
+   * same bin). Splitting a reducer across bins will cause data duplication because
+   * `ShuffleManager.getReader()` reads entire reducer partitions.
+   *
+   * @param shuffleStats the shuffle output statistics: (BlockManagerId, blocks) pairs where
+   *                     each block is (BlockId, size, mapIndex)
+   * @param maxBinSize the maximum size in bytes for each bin
+   * @return bins of block IDs, where each bin becomes one output file
+   */
+  def computeBins(
+      shuffleStats: Array[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])],
+      maxBinSize: Long): Seq[Seq[BlockId]]
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2667,6 +2667,17 @@ trait DeltaSQLConfBase {
       .bytesConf(ByteUnit.MiB)
       .createWithDefault(512)
 
+  val DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER =
+    buildConf("optimizeWrite.shuffleHelper")
+      .internal()
+      .doc("Fully qualified class name of an OptimizedWriteShuffleHelper implementation. " +
+        "External shuffle services (e.g., Celeborn, Uniffle) can provide their own " +
+        "implementation to customize bin-packing and shuffle read behavior for optimized writes. " +
+        "If not set, the default implementation is used when an external shuffle manager " +
+        "is detected.")
+      .stringConf
+      .createOptional
+
   val DELTA_OPTIMIZE_CLUSTERING_MIN_CUBE_SIZE =
   buildConf("optimize.clustering.mergeStrategy.minCubeSize.threshold")
     .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizedWritesWithCustomShuffleManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizedWritesWithCustomShuffleManagerSuite.scala
@@ -1,0 +1,351 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.perf
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark._
+import org.apache.spark.shuffle._
+import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.storage._
+
+/**
+ * A shuffle manager that delegates to [[SortShuffleManager]] but tracks calls to `getReader`.
+ * This simulates the behavior of external shuffle managers (e.g., Celeborn, Uniffle, Membrain)
+ * that override `getReader` to provide their own shuffle read implementation.
+ *
+ * The test verifies that Delta's optimized writer goes through `ShuffleManager.getReader()`
+ * rather than directly constructing a `ShuffleBlockFetcherIterator`, which would bypass
+ * external shuffle managers.
+ */
+class TrackingShuffleManager(conf: SparkConf) extends ShuffleManager {
+
+  private val delegate = new SortShuffleManager(conf)
+
+  override def registerShuffle[K, V, C](
+      shuffleId: Int,
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    delegate.registerShuffle(shuffleId, dependency)
+  }
+
+  override def getWriter[K, V](
+      handle: ShuffleHandle,
+      mapId: Long,
+      context: TaskContext,
+      metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
+    delegate.getWriter(handle, mapId, context, metrics)
+  }
+
+  override def getReader[K, C](
+      handle: ShuffleHandle,
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int,
+      context: TaskContext,
+      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+    TrackingShuffleManager.getReaderCallCount.incrementAndGet()
+    delegate.getReader(handle, startMapIndex, endMapIndex,
+      startPartition, endPartition, context, metrics)
+  }
+
+  override def unregisterShuffle(shuffleId: Int): Boolean = {
+    delegate.unregisterShuffle(shuffleId)
+  }
+
+  override def shuffleBlockResolver: ShuffleBlockResolver = {
+    delegate.shuffleBlockResolver
+  }
+
+  override def stop(): Unit = {
+    delegate.stop()
+  }
+}
+
+object TrackingShuffleManager {
+  /** Tracks the number of times `getReader` is called. */
+  val getReaderCallCount = new AtomicInteger(0)
+
+  def resetCounters(): Unit = {
+    getReaderCallCount.set(0)
+  }
+}
+
+/**
+ * A custom [[OptimizedWriteShuffleHelper]] that delegates to [[DefaultOptimizedWriteShuffleHelper]]
+ * but tracks whether it was invoked, verifying the config-based injection path.
+ */
+class TrackingShuffleHelper extends DefaultOptimizedWriteShuffleHelper {
+  override def computeBins(
+      shuffleStats: Array[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])],
+      maxBinSize: Long): Seq[Seq[BlockId]] = {
+    TrackingShuffleHelper.computeBinsCallCount.incrementAndGet()
+    super.computeBins(shuffleStats, maxBinSize)
+  }
+}
+
+object TrackingShuffleHelper {
+  val computeBinsCallCount = new AtomicInteger(0)
+
+  def resetCounters(): Unit = {
+    computeBinsCallCount.set(0)
+  }
+}
+
+/**
+ * Tests that Delta's optimized writer correctly delegates to the configured ShuffleManager
+ * for shuffle reads when a non-default shuffle manager is configured, ensuring compatibility
+ * with external shuffle managers.
+ *
+ * This is a regression test for the issue where `OptimizedWriterShuffleReader` directly
+ * created `ShuffleBlockFetcherIterator` with `blockManager.blockStoreClient`, bypassing
+ * external shuffle managers entirely. See:
+ * - https://github.com/delta-io/delta/issues/4343
+ * - https://github.com/apache/uniffle/issues/2409
+ */
+class OptimizedWritesWithCustomShuffleManagerSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.manager", classOf[TrackingShuffleManager].getName)
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    TrackingShuffleManager.resetCounters()
+  }
+
+  private def checkResult(df: DataFrame, dir: String): Unit = {
+    checkAnswer(
+      spark.read.format("delta").load(dir),
+      df
+    )
+  }
+
+  test("detects non-default shuffle manager") {
+    assert(!SparkEnv.get.shuffleManager.isInstanceOf[SortShuffleManager],
+      "TrackingShuffleManager should be active, not SortShuffleManager")
+    assert(SparkEnv.get.shuffleManager.isInstanceOf[TrackingShuffleManager])
+  }
+
+  test("optimized write delegates to ShuffleManager.getReader - non-partitioned") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      TrackingShuffleManager.resetCounters()
+
+      val df = spark.range(0, 100, 1, 4).toDF()
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        df.write.format("delta").save(path)
+      }
+
+      // Verify data correctness
+      checkResult(df, path)
+
+      // Verify that getReader was called (meaning we went through the ShuffleManager)
+      assert(TrackingShuffleManager.getReaderCallCount.get() > 0,
+        "Optimized write should delegate shuffle reads to ShuffleManager.getReader() " +
+          "when a non-default shuffle manager is configured")
+    }
+  }
+
+  test("optimized write delegates to ShuffleManager.getReader - partitioned") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      TrackingShuffleManager.resetCounters()
+
+      val df = spark.range(0, 100, 1, 4).withColumn("part", $"id" % 5)
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        df.write.partitionBy("part").format("delta").save(path)
+      }
+
+      checkResult(df, path)
+
+      assert(TrackingShuffleManager.getReaderCallCount.get() > 0,
+        "Optimized write should delegate shuffle reads to ShuffleManager.getReader() " +
+          "when a non-default shuffle manager is configured")
+    }
+  }
+
+  test("optimized write produces correct file count with custom shuffle manager") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+
+      val df = spark.range(0, 100, 1, 4).withColumn("part", $"id" % 5)
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        df.write.partitionBy("part").format("delta").save(path)
+      }
+
+      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, path)
+      assert(snapshot.numOfFiles <= 5,
+        s"Expected at most 5 files (one per partition), got ${snapshot.numOfFiles}")
+
+      checkResult(df, path)
+    }
+  }
+
+  test("optimized write with multi-partition columns and custom shuffle manager") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      TrackingShuffleManager.resetCounters()
+
+      val df = spark.range(0, 100, 1, 4)
+        .withColumn("part", $"id" % 5)
+        .withColumn("part2", ($"id" / 20).cast("int"))
+
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        df.write.partitionBy("part", "part2").format("delta").save(path)
+      }
+
+      checkResult(df, path)
+
+      assert(TrackingShuffleManager.getReaderCallCount.get() > 0,
+        "Optimized write should delegate shuffle reads to ShuffleManager.getReader() " +
+          "when a non-default shuffle manager is configured")
+
+      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, path)
+      assert(snapshot.numOfFiles <= 25,
+        s"Expected at most 25 files, got ${snapshot.numOfFiles}")
+    }
+  }
+
+  test("optimized write with small bin size and custom shuffle manager") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      TrackingShuffleManager.resetCounters()
+
+      // Use a very small bin size to force multiple bins
+      val df = spark.range(0, 200, 1, 8).withColumn("part", $"id" % 3)
+      withSQLConf(
+        DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true",
+        DeltaSQLConf.DELTA_OPTIMIZE_WRITE_BIN_SIZE.key -> "1") {
+        df.write.partitionBy("part").format("delta").save(path)
+      }
+
+      checkResult(df, path)
+
+      assert(TrackingShuffleManager.getReaderCallCount.get() > 0,
+        "Optimized write should delegate shuffle reads to ShuffleManager.getReader() " +
+          "when a non-default shuffle manager is configured")
+    }
+  }
+
+  test("single partition dataframe skips optimized write with custom shuffle manager") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      TrackingShuffleManager.resetCounters()
+
+      // Single partition should bypass optimized write entirely
+      val df = spark.range(0, 20).repartition(1).withColumn("part", $"id" % 5)
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        df.write.partitionBy("part").format("delta").save(path)
+      }
+
+      checkResult(df, path)
+    }
+  }
+
+  test("append mode with custom shuffle manager") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+
+      val df1 = spark.range(0, 50, 1, 4).withColumn("part", $"id" % 5)
+      val df2 = spark.range(50, 100, 1, 4).withColumn("part", $"id" % 5)
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        df1.write.partitionBy("part").format("delta").save(path)
+        df2.write.partitionBy("part").format("delta").mode("append").save(path)
+      }
+
+      checkResult(df1.union(df2), path)
+    }
+  }
+
+  test("zero row dataframe with custom shuffle manager") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+
+      // First write some data so the table exists
+      val df = spark.range(0, 20, 1, 4).withColumn("part", $"id" % 5)
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        df.write.partitionBy("part").format("delta").save(path)
+      }
+
+      // Then write an empty dataframe
+      import org.apache.spark.sql.Row
+      import org.apache.spark.sql.types.{LongType, StructType}
+      val schema = new StructType().add("id", LongType).add("part", LongType)
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        spark.createDataFrame(sparkContext.emptyRDD[Row], schema).write.format("delta")
+          .partitionBy("part").mode("append").save(path)
+      }
+
+      // Data should be unchanged
+      checkResult(df, path)
+    }
+  }
+
+  test("custom shuffle helper loaded via config") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      TrackingShuffleHelper.resetCounters()
+
+      val df = spark.range(0, 100, 1, 4).withColumn("part", $"id" % 5)
+      withSQLConf(
+        DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true",
+        DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER.key ->
+          classOf[TrackingShuffleHelper].getName) {
+        df.write.partitionBy("part").format("delta").save(path)
+      }
+
+      checkResult(df, path)
+
+      assert(TrackingShuffleHelper.computeBinsCallCount.get() > 0,
+        "Custom shuffle helper's computeBins should have been called")
+    }
+  }
+
+  test("invalid shuffle helper class name throws exception with config context") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      val df = spark.range(0, 100, 1, 4).toDF()
+
+      val ex = intercept[SparkException] {
+        withSQLConf(
+          DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER.key ->
+            "com.nonexistent.ShuffleHelper") {
+          df.write.format("delta").save(path)
+        }
+      }
+      assert(ex.getMessage.contains("com.nonexistent.ShuffleHelper"),
+        "Error should mention the invalid class name")
+      assert(ex.getMessage.contains(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_SHUFFLE_HELPER.key),
+        "Error should mention the config key")
+    }
+  }
+}


### PR DESCRIPTION
Which Delta project/connector is this regarding?

- [x] Spark

## Description

Delta's OptimizedWriter (DeltaOptimizedWriterExec) is incompatible with external shuffle managers such as Celeborn, Uniffle, and Membrain. The shuffle write path correctly delegates to the configured ShuffleManager, but the read path in OptimizedWriterShuffleReader directly constructs a ShuffleBlockFetcherIterator with SparkEnv.get.blockManager.blockStoreClient, bypassing the configured ShuffleManager entirely. External shuffle managers override ShuffleManager.getReader() to return their own reader implementations; by skipping this API, Delta's optimized writer causes FetchFailedException when it tries to connect to virtual executor addresses that only exist in the external shuffle service.

This fix detects at runtime whether a non-default shuffle manager is active (via instanceof check against SortShuffleManager) and branches accordingly:

- Default path (SortShuffleManager): completely unchanged. Block-level bin-packing and ShuffleBlockFetcherIterator are preserved as-is.
- External shuffle manager path: delegates to ShuffleManager.getReader(), bin-packs whole reducers as atomic units (since getReader reads entire reducer partitions)

 Additionally, an OptimizedWriteShuffleHelper trait (@DeveloperApi) is introduced as a driver-side extension point for bin-packing strategy. External shuffle services can provide their own implementation via spark.databricks.delta.optimizeWrite.shuffleHelper (internal config). The trait only covers computeBins(); shuffle reads on executors always go through ShuffleManager.getReader(), which is Spark's standard extension point for custom shuffle read behavior.
    
No new configuration is required for the basic fix. The fix activates automatically when spark.shuffle.manager is set to a non-default value.

Resolves #4343

## How was this patch tested?

Added OptimizedWritesWithCustomShuffleManagerSuite (11 tests) using a TrackingShuffleManager that wraps SortShuffleManager and verifies ShuffleManager.getReader() is called. Tests cover:
 - Non-partitioned and partitioned writes
 - Multi-partition columns
 - Small bin size forcing multiple bins
 - Single-partition bypass
 - Append mode
 - Zero-row DataFrame edge case
 - Custom helper loaded via optimizeWrite.shuffleHelper config
 - Invalid helper class name error handling


All 18 existing OptimizedWritesSuite tests pass unchanged, confirming the default SortShuffleManager path has zero behavioral change.

## Does this PR introduce _any_ user-facing changes?

No change for users on the default SortShuffleManager. For users with a non-default spark.shuffle.manager (e.g., Celeborn, Uniffle, Membrain), optimized writes now work correctly instead of failing with FetchFailedException. This is a bugfix — previously these users had to disable optimized writes entirely.

A new internal config spark.databricks.delta.optimizeWrite.shuffleHelper is added for external shuffle services that want to provide custom bin-packing strategies.

