### PR TITLE
[UniForm] Add baseConvertedDeltaVersion in IcebergMetadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -3187,7 +3187,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
         new IcebergMetadata(
           metadataLocation,
           deltaAttemptVersion,
-          Instant.now.toString
+          Instant.now.toString,
+          baseConvertedDeltaVersion.map(Long.box).toJava
         )
       )
       (txnInfo.copy(convertedIcebergMetadata = Some(newDeltaUniFormIceberg)), true)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -21,6 +21,7 @@ import java.lang.{Long => JLong}
 import java.util.{List => JList, Optional}
 
 import scala.collection.JavaConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 
 // scalastyle:off import.ordering.noEmptyLine
@@ -223,34 +224,43 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     }
   }
 
-  test("Support UniForm update for tableCommitCoordinatorClient") {
-    withTempTableDir { tempDir =>
-      val log = DeltaLog.forTable(spark, tempDir.toString)
-      val logPath = log.logPath
-      val tableCommitCoordinatorClient = createTableCommitCoordinatorClient(log)
-      writeCommitZero(logPath)
+  Seq(None, Some(0L)).foreach { baseConvertedDeltaVersion =>
+    val suffix = baseConvertedDeltaVersion.map(
+      v => s"baseConvertedDeltaVersion=$v").getOrElse("no baseConvertedDeltaVersion"
+    )
+    test(s"Support UniForm update for tableCommitCoordinatorClient - $suffix") {
+      withTempTableDir { tempDir =>
+        val log = DeltaLog.forTable(spark, tempDir.toString)
+        val logPath = log.logPath
+        val tableCommitCoordinatorClient = createTableCommitCoordinatorClient(log)
+        writeCommitZero(logPath)
 
-      val icebergMetadata = new IcebergMetadata("s3://bucket/metadata/v1.json", 1L, "2025-01-01")
-      val uniformMetadata = new UniformMetadata(icebergMetadata)
-      val catalogTrackedInfo = new CatalogTrackedInfo(Optional.of(uniformMetadata))
-      val commitInfo = CommitInfo
-        .empty(version = Some(1)).withTimestamp(1).copy(inCommitTimestamp = Some(1))
-      val updatedActions = getUpdatedActionsForNonZerothCommit(commitInfo)
-      tableCommitCoordinatorClient.commit(
-        1L,
-        Iterator(commitInfo.json),
-        updatedActions,
-        tableIdentifierOpt = None,
-        catalogTrackedInfo)
-      waitForBackfill(1, tableCommitCoordinatorClient)
+        val baseVersionInJava: java.util.Optional[java.lang.Long] =
+          baseConvertedDeltaVersion.map(Long.box).toJava
+        val icebergMetadata =
+          new IcebergMetadata("s3://bucket/metadata/v1.json", 1L, "2025-01-01", baseVersionInJava)
+        val uniformMetadata = new UniformMetadata(icebergMetadata)
+        val catalogTrackedInfo = new CatalogTrackedInfo(Optional.of(uniformMetadata))
+        val commitInfo = CommitInfo
+          .empty(version = Some(1)).withTimestamp(1).copy(inCommitTimestamp = Some(1))
+        val updatedActions = getUpdatedActionsForNonZerothCommit(commitInfo)
+        tableCommitCoordinatorClient.commit(
+          1L,
+          Iterator(commitInfo.json),
+          updatedActions,
+          tableIdentifierOpt = None,
+          catalogTrackedInfo)
+        waitForBackfill(1, tableCommitCoordinatorClient)
 
-      val stored = ucCommitCoordinator.getUniformMetadata(tableUUID.toString)
-      assert(stored.isDefined)
-      assert(stored.get.getIcebergMetadata.isPresent)
-      val storedIceberg = stored.get.getIcebergMetadata.get
-      assert(storedIceberg.getMetadataLocation == "s3://bucket/metadata/v1.json")
-      assert(storedIceberg.getConvertedDeltaVersion == 1L)
-      assert(storedIceberg.getConvertedDeltaTimestamp == "2025-01-01")
+        val stored = ucCommitCoordinator.getUniformMetadata(tableUUID.toString)
+        assert(stored.isDefined)
+        assert(stored.get.getIcebergMetadata.isPresent)
+        val storedIceberg = stored.get.getIcebergMetadata.get
+        assert(storedIceberg.getMetadataLocation == "s3://bucket/metadata/v1.json")
+        assert(storedIceberg.getConvertedDeltaVersion == 1L)
+        assert(storedIceberg.getConvertedDeltaTimestamp == "2025-01-01")
+        assert(storedIceberg.getBaseConvertedDeltaVersion == baseConvertedDeltaVersion)
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -259,7 +259,7 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
         assert(storedIceberg.getMetadataLocation == "s3://bucket/metadata/v1.json")
         assert(storedIceberg.getConvertedDeltaVersion == 1L)
         assert(storedIceberg.getConvertedDeltaTimestamp == "2025-01-01")
-        assert(storedIceberg.getBaseConvertedDeltaVersion == baseConvertedDeltaVersion)
+        assert(storedIceberg.getBaseConvertedDeltaVersion == baseVersionInJava)
       }
     }
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -268,13 +268,15 @@ public class UCTokenBasedRestClient implements UCClient {
    *   <li>metadataLocation -> metadata_location</li>
    *   <li>convertedDeltaVersion -> converted_delta_version</li>
    *   <li>convertedDeltaTimestamp -> converted_delta_timestamp</li>
+   *   <li>baseConvertedDeltaVersion -> base_converted_delta_version (optional)</li>
    * </ul>
    */
   private DeltaUniformIceberg toDeltaUniformIceberg(IcebergMetadata iceberg) {
     return new DeltaUniformIceberg()
         .metadataLocation(URI.create(iceberg.getMetadataLocation()))
         .convertedDeltaVersion(iceberg.getConvertedDeltaVersion())
-        .convertedDeltaTimestamp(iceberg.getConvertedDeltaTimestamp());
+        .convertedDeltaTimestamp(iceberg.getConvertedDeltaTimestamp())
+        .baseConvertedDeltaVersion(iceberg.getBaseConvertedDeltaVersion().orElse(null));
   }
 
   /**

--- a/storage/src/main/java/io/delta/storage/commit/uniform/IcebergMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/uniform/IcebergMetadata.java
@@ -17,6 +17,7 @@
 package io.delta.storage.commit.uniform;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Metadata for Delta Uniform Iceberg conversion.
@@ -28,6 +29,7 @@ public class IcebergMetadata {
   private final String metadataLocation;
   private final long convertedDeltaVersion;
   private final String convertedDeltaTimestamp;
+  private final Optional<Long> baseConvertedDeltaVersion;
 
   /**
    * Constructs IcebergMetadata with the specified conversion details.
@@ -35,14 +37,33 @@ public class IcebergMetadata {
    * @param metadataLocation The Iceberg metadata file location (e.g., "s3://bucket/metadata/v1.json")
    * @param convertedDeltaVersion The Delta version that was converted (e.g., 1044)
    * @param convertedDeltaTimestamp The timestamp of the conversion (e.g., "2025-01-04T03:13:11.423")
+   * @param baseConvertedDeltaVersion The Delta version from which this conversion incrementally
+   *    started at, or empty if this was a full (non-incremental) conversion.
    */
   public IcebergMetadata(
-      String metadataLocation, long convertedDeltaVersion, String convertedDeltaTimestamp) {
+      String metadataLocation,
+      long convertedDeltaVersion,
+      String convertedDeltaTimestamp,
+      Optional<Long> baseConvertedDeltaVersion) {
     this.metadataLocation = Objects.requireNonNull(metadataLocation, "metadataLocation is null");
     this.convertedDeltaVersion = convertedDeltaVersion;
     this.convertedDeltaTimestamp =
         Objects.requireNonNull(convertedDeltaTimestamp, "convertedDeltaTimestamp is null");
+    this.baseConvertedDeltaVersion =
+        Objects.requireNonNull(baseConvertedDeltaVersion, "baseConvertedDeltaVersion is null");
   }
+
+    /**
+     * Constructs IcebergMetadata without a base converted delta version (full conversion).
+     *
+     * @param metadataLocation The Iceberg metadata file location
+     * @param convertedDeltaVersion The Delta version that was converted
+     * @param convertedDeltaTimestamp The timestamp of the conversion
+     */
+    public IcebergMetadata(
+        String metadataLocation, long convertedDeltaVersion, String convertedDeltaTimestamp) {
+      this(metadataLocation, convertedDeltaVersion, convertedDeltaTimestamp, Optional.empty());
+    }
 
   /** Returns the Iceberg metadata file location. */
   public String getMetadataLocation() {
@@ -57,5 +78,13 @@ public class IcebergMetadata {
   /** Returns the timestamp when the conversion occurred. */
   public String getConvertedDeltaTimestamp() {
     return convertedDeltaTimestamp;
+  }
+
+  /**
+  * Returns the Delta version from which this conversion incrementally started,
+  * or empty if this was a full (non-incremental) conversion.
+  */
+  public Optional<Long> getBaseConvertedDeltaVersion() {
+    return baseConvertedDeltaVersion;
   }
 }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -292,8 +292,7 @@ class UCTokenBasedRestClientSuite
           assert(iceberg.get("base_converted_delta_version").asLong() === base, desc)
         case None =>
           assert(
-            !iceberg.has("base_converted_delta_version") ||
-              iceberg.get("base_converted_delta_version").isNull,
+            !iceberg.has("base_converted_delta_version"),
             s"$desc: base_converted_delta_version must be absent")
       }
     }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -251,27 +251,52 @@ class UCTokenBasedRestClientSuite
 
   // uniform tests
   test("commit with uniform.iceberg sends correct snake_case JSON per all.yaml") {
-    var capturedBody: String = null
-    commitsHandler = exchange => {
-      capturedBody = readRequestBody(exchange)
-      sendJson(exchange, HttpStatus.SC_OK, "{}")
+    val cases: Seq[(String, Option[Long])] = Seq(
+      ("without baseConvertedDeltaVersion", None),
+      ("with baseConvertedDeltaVersion", Some(42L))
+    )
+
+    cases.foreach { case (desc, baseVersion) =>
+      val icebergMeta = baseVersion match {
+        case Some(base) =>
+          new IcebergMetadata(
+            "s3://bucket/metadata/v1.json", 42L, "2025-01-04T03:13:11.423Z",
+            Optional.of(java.lang.Long.valueOf(base)))
+        case None =>
+          new IcebergMetadata("s3://bucket/metadata/v1.json", 42L, "2025-01-04T03:13:11.423Z")
+      }
+
+      var capturedBody: String = null
+      commitsHandler = exchange => {
+        capturedBody = readRequestBody(exchange)
+        sendJson(exchange, HttpStatus.SC_OK, "{}")
+      }
+
+      withClient { client =>
+        client.commit(testTableId, testTableUri, Optional.of(createCommit(1L)),
+          Optional.empty(), false, Optional.empty(), Optional.empty(),
+          Optional.of(new UniformMetadata(icebergMeta)))
+      }
+
+      val json: JsonNode = objectMapper.readTree(capturedBody)
+      assert(json.get("table_id").asText() === testTableId, desc)
+      assert(!json.has("protocol"), s"$desc: protocol must not be sent")
+
+      val iceberg = json.get("uniform").get("iceberg")
+      assert(iceberg.get("metadata_location").asText() === "s3://bucket/metadata/v1.json", desc)
+      assert(iceberg.get("converted_delta_version").asLong() === 42L, desc)
+      assert(iceberg.get("converted_delta_timestamp").asText() === "2025-01-04T03:13:11.423Z", desc)
+
+      baseVersion match {
+        case Some(base) =>
+          assert(iceberg.get("base_converted_delta_version").asLong() === base, desc)
+        case None =>
+          assert(
+            !iceberg.has("base_converted_delta_version") ||
+              iceberg.get("base_converted_delta_version").isNull,
+            s"$desc: base_converted_delta_version must be absent")
+      }
     }
-
-    withClient { client =>
-      client.commit(testTableId, testTableUri, Optional.of(createCommit(1L)),
-        Optional.empty(), false, Optional.empty(), Optional.empty(),
-        Optional.of(createUniformMetadata()))
-    }
-
-    val json: JsonNode = objectMapper.readTree(capturedBody)
-    assert(json.get("table_id").asText() === testTableId)
-
-    val iceberg = json.get("uniform").get("iceberg")
-    assert(iceberg.get("metadata_location").asText() === "s3://bucket/metadata/v1.json")
-    assert(iceberg.get("converted_delta_version").asLong() === 42L)
-    assert(iceberg.get("converted_delta_timestamp").asText() === "2025-01-04T03:13:11.423Z")
-
-    assert(!json.has("protocol"), "protocol is not in the OpenAPI spec and must not be sent")
   }
 
   test("commit without uniform does not include uniform field in JSON") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Add baseConvertedDeltaVersion in IcebergMetadata. It is preparing for conflict resolution in incremental UniForm conversion

## How was this patch tested?
Add UTs
```
build/sbt -DsparkVersion=4.0 -DunityCatalogVersion=0.5.0-SNAPSHOT "storage/testOnly                
  io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClientSuite" "spark/testOnly org.apache.spark.sql.delta.coordinatedcommits.UCCommitCoordinatorClientSuite"
```