### PR TITLE
[DRC][2/5] Wire AbstractDeltaCatalog.loadTable to the DRC read path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -723,7 +723,11 @@ lazy val contribs = (project in file("contribs"))
   ).configureUnidoc()
 
 
-val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.4.1")
+// UC version is a SNAPSHOT because the Delta REST Catalog (DRC) API surface lives on UC master
+// ahead of any released UC version. Resolves from ~/.ivy2/local after running
+// dev/publish-uc-snapshot.sh, which pins an exact UC commit SHA (do not edit the version string
+// here without bumping the SHA in that script).
+val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.5.0-SNAPSHOT")
 val sparkUnityCatalogJacksonVersion = "2.15.4" // We are using Spark 4.0's Jackson version 2.15.x, to override Unity Catalog 0.3.0's version 2.18.x
 
 lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))

--- a/dev/publish-uc-snapshot.sh
+++ b/dev/publish-uc-snapshot.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (2026) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Publishes the Unity Catalog snapshot that Delta's DRC integration builds against.
+#
+# Delta's build.sbt pins `unityCatalogVersion` to a SNAPSHOT that resolves only from
+# ~/.ivy2/local. Before the DRC integration stack can compile in clean CI, the UC
+# repo must be cloned at a known-stable SHA and publishLocal'd. This script is the
+# reproducible source of truth for WHICH UC SHA Delta currently integrates against
+# -- do not edit build.sbt's version string without bumping UC_SHA here.
+#
+# When Yi's shared UC-SHA CI helper lands (tracked in delta-io/delta#6616), this
+# script should be replaced by a thin wrapper around it.
+#
+# Usage:
+#   ./dev/publish-uc-snapshot.sh [/path/to/checkout-dir]
+#
+# Defaults to "$HOME/.cache/delta-uc-snapshot" when no path is supplied.
+#
+
+set -euo pipefail
+
+# Pinned UC SHA. Update in lockstep with unityCatalogVersion in Delta's build.sbt.
+# Matches the DRC API surface consumed by delta/storage and delta/spark.
+UC_SHA="ae4bcf6bf588546593e19e501ca2d68759224991"
+UC_EXPECTED_VERSION="0.5.0-SNAPSHOT"
+UC_REPO_URL="https://github.com/unitycatalog/unitycatalog.git"
+CHECKOUT_DIR="${1:-$HOME/.cache/delta-uc-snapshot}"
+
+echo "==> Ensuring UC checkout at $CHECKOUT_DIR pinned to $UC_SHA"
+if [[ ! -d "$CHECKOUT_DIR/.git" ]]; then
+  mkdir -p "$(dirname "$CHECKOUT_DIR")"
+  git clone "$UC_REPO_URL" "$CHECKOUT_DIR"
+fi
+
+(
+  cd "$CHECKOUT_DIR"
+  git fetch --quiet origin "$UC_SHA" || git fetch --quiet origin
+  git checkout --detach "$UC_SHA"
+  actual_version="$(grep -E 'ThisBuild / version' version.sbt | sed -E 's/.*"(.*)".*/\1/')"
+  if [[ "$actual_version" != "$UC_EXPECTED_VERSION" ]]; then
+    echo "ERROR: UC checkout at $UC_SHA declares version $actual_version, expected $UC_EXPECTED_VERSION." >&2
+    echo "       If UC bumped its version, update UC_EXPECTED_VERSION and Delta's build.sbt in lockstep." >&2
+    exit 1
+  fi
+  echo "==> Running sbt publishLocal in $CHECKOUT_DIR"
+  # System sbt works; the UC-bundled build/sbt sometimes can't download sbt-launch.
+  if command -v sbt >/dev/null 2>&1; then
+    sbt -mem 3000 publishLocal
+  else
+    ./build/sbt publishLocal
+  fi
+)
+
+echo "==> Done. ~/.ivy2/local/io.unitycatalog/ now has $UC_EXPECTED_VERSION for Delta's build.sbt."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -43,6 +43,7 @@ import org.apache.spark.sql.delta.serverSidePlanning.ServerSidePlannedTable
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.tablefeatures.DropFeature
+import org.apache.spark.sql.delta.uccatalog.DeltaRestReadPath
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.hadoop.fs.Path
@@ -87,6 +88,39 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     val delegateField = classOf[DelegatingCatalogExtension].getDeclaredField("delegate")
     delegateField.setAccessible(true)
     delegateField.get(this).getClass.getCanonicalName.startsWith("io.unitycatalog.")
+  }
+
+  /**
+   * Delta REST Catalog (DRC) read path. Returns `Some(V1Table)` when the delegate chain
+   * contains a DRC-enabled provider; otherwise `None` so the caller falls through to
+   * `super.loadTable`. Exceptions from the DRC call propagate -- we do not silently fall
+   * back to legacy on DRC errors, which would mask real bugs after the user opted in.
+   *
+   * Emits `delta.drc.loadTable` on entry and `delta.drc.loadTable.error` on failure so the
+   * A/B rollout can distinguish DRC-path failures from legacy-path failures.
+   */
+  private def drcLoadTable(ident: Identifier): Option[Table] = {
+    try {
+      val result = DeltaRestReadPath.tryLoad(this, name(), ident)
+      if (result.isDefined) {
+        recordDeltaEvent(
+          deltaLog = null,
+          opType = "delta.drc.loadTable",
+          data = Map("catalog" -> name(), "table" -> ident.toString))
+      }
+      result
+    } catch {
+      case e: Throwable =>
+        recordDeltaEvent(
+          deltaLog = null,
+          opType = "delta.drc.loadTable.error",
+          data = Map(
+            "catalog" -> name(),
+            "table" -> ident.toString,
+            "errorClass" -> e.getClass.getName,
+            "errorMessage" -> Option(e.getMessage).getOrElse("")))
+        throw e
+    }
   }
 
   /**
@@ -290,7 +324,12 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       "DeltaCatalog", "loadTable") {
     setVariantBlockingConfigIfUC()
     try {
-      val table = super.loadTable(ident)
+      // DRC branch: when the UC catalog plugin on the delegate chain advertises a DRC
+      // TablesApi (provider.getDeltaTablesApi present), load metadata directly from the
+      // Delta REST Catalog endpoints. Otherwise fall through to the legacy UC API via
+      // super.loadTable. The Optional gate in DeltaRestReadPath.tryLoad guarantees that
+      // no HTTP client is constructed on the flag-off path.
+      val table = drcLoadTable(ident).getOrElse(super.loadTable(ident))
 
       ServerSidePlannedTable.tryCreate(spark, ident, table, isUnityCatalog).foreach { sspt =>
         return sspt

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookup.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, DelegatingCatalogExtension}
+
+/**
+ * Pure helper that walks a `CatalogPlugin`'s delegate chain and returns the first catalog that
+ * implements `DeltaRestClientProvider`. Extracted from `AbstractDeltaCatalog` so the chain-walk
+ * behaviour can be unit-tested in isolation, without needing a live Spark session or a real
+ * Delta catalog.
+ *
+ * The chain can take several shapes depending on how the catalog plugin is composed:
+ * - `this -> DeltaCatalog -> UCProxy` when Delta is on the classpath and interposed between
+ *   `UCSingleCatalog` and `UCProxy` (production OSS);
+ * - `this -> UCProxy` when Delta is absent and the UC plugin wraps UCProxy directly;
+ * - `UCSingleCatalog` itself when a consumer holds the outermost catalog (UCSingleCatalog
+ *   also implements DeltaRestClientProvider per UC PR 1509);
+ * - arbitrary wrappers interposed by Databricks-side or third-party adapters.
+ *
+ * The walk descends through `DelegatingCatalogExtension.delegate` (reflection) and stops when
+ * it (a) finds a provider, (b) hits a non-delegating, non-provider catalog, or (c) exceeds a
+ * defensive depth limit to guard against accidental cycles.
+ */
+private[delta] object DeltaRestProviderLookup {
+
+  /** Defensive cap on chain depth; in practice chains are 0-3 deep. */
+  private[uccatalog] val MAX_CHAIN_DEPTH: Int = 16
+
+  /**
+   * Returns the first `DeltaRestClientProvider` reachable by walking `catalog`'s delegate chain,
+   * or `None` if the chain does not contain one.
+   */
+  def findProvider(catalog: CatalogPlugin): Option[DeltaRestClientProvider] = {
+    if (catalog == null) return None
+    var current: Any = catalog
+    var depth = 0
+    while (current != null && depth < MAX_CHAIN_DEPTH) {
+      current match {
+        case p: DeltaRestClientProvider => return Some(p)
+        case d: DelegatingCatalogExtension => current = readDelegate(d)
+        case _ => current = null
+      }
+      depth += 1
+    }
+    None
+  }
+
+  private def readDelegate(d: DelegatingCatalogExtension): Any = {
+    val field = classOf[DelegatingCatalogExtension].getDeclaredField("delegate")
+    field.setAccessible(true)
+    field.get(d)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPath.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPath.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCDeltaRestClient}
+import io.unitycatalog.client.ApiClient
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, V1Table}
+
+/**
+ * Composes the DRC read path from its pieces: `DeltaRestProviderLookup` (walks the catalog
+ * chain) and `DeltaRestTableLoader` (builds `V1Table` from the DRC response). Exists as a
+ * standalone object so `AbstractDeltaCatalog.loadTable` does not have to choreograph the logic
+ * inline, and so the "flag off -> don't construct an HTTP client" invariant (the concern that
+ * a future regression swaps `flatMap` for `map` or adds an eager side effect before the
+ * `isPresent` check) can be asserted in a unit test with a client factory that throws on
+ * invocation.
+ */
+private[delta] object DeltaRestReadPath {
+
+  /** Default factory: real HTTP client bound to the shared `ApiClient`. */
+  private[uccatalog] val DefaultClientFactory: ApiClient => UCDeltaClient =
+    apiClient => new UCDeltaRestClient(apiClient)
+
+  /**
+   * Attempts to load a Delta table via the DRC. Returns `Some(v1Table)` when:
+   * - the catalog or its delegate chain contains a `DeltaRestClientProvider`, AND
+   * - that provider's `getDeltaTablesApi()` is present (DRC flag on).
+   *
+   * Returns `None` otherwise. In the `None` cases the `clientFactory` is NOT invoked -- callers
+   * can rely on this to avoid unwanted HTTP side effects on the flag-off path.
+   */
+  def tryLoad(
+      catalog: CatalogPlugin,
+      catalogName: String,
+      ident: Identifier,
+      clientFactory: ApiClient => UCDeltaClient = DefaultClientFactory): Option[V1Table] = {
+    DeltaRestProviderLookup.findProvider(catalog).flatMap { provider =>
+      val apiOpt = provider.getDeltaTablesApi
+      if (apiOpt.isPresent) {
+        val client = clientFactory(provider.getApiClient)
+        Some(DeltaRestTableLoader.load(catalogName, ident, client))
+      } else {
+        None
+      }
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
@@ -1,0 +1,254 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => UCArrayType,
+  DecimalType => UCDecimalType,
+  DeltaType => UCDeltaType,
+  MapType => UCMapType,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType
+}
+
+import org.apache.spark.sql.types._
+
+/**
+ * Bidirectional converter between the Delta REST Catalog (DRC) schema POJO hierarchy and Spark's
+ * `StructType`. The DRC wire format uses kebab-case (`element-type`, `contains-null`,
+ * `value-contains-null`); Delta uses camelCase (`elementType`, `containsNull`). The UC SDK POJO
+ * hierarchy handles the kebab/camel translation at (de)serialize time; this converter then walks
+ * the POJO tree directly, skipping a JSON round-trip and preserving all field metadata
+ * (`delta.columnMapping.id`, `delta.generationExpression`, CHECK-constraint expressions, column
+ * defaults) verbatim.
+ *
+ * Used on the read path (`toSparkSchema`, consumed by `DeltaRestTableLoader`) and on the write
+ * path (`toDRCColumns`, consumed by the DRC commit's `set-columns` update in a follow-up PR).
+ */
+private[delta] object DeltaRestSchemaConverter {
+
+  // --------------------------------------------------------------------------
+  // Read path: UC POJO columns -> Spark StructType
+  // --------------------------------------------------------------------------
+
+  /** Convert a DRC column list to a Spark `StructType`. Null input produces an empty schema. */
+  def toSparkSchema(columns: java.util.List[UCStructField]): StructType = {
+    if (columns == null) return new StructType()
+    StructType(columns.asScala.iterator.map(toSparkField).toArray)
+  }
+
+  private[uccatalog] def toSparkField(col: UCStructField): StructField = {
+    require(col != null, "column must not be null")
+    require(col.getName != null, "column name must not be null")
+    require(col.getType != null, s"column type must not be null for ${col.getName}")
+    val dataType = toSparkDataType(col.getType)
+    val nullable = Option(col.getNullable).map(_.booleanValue()).getOrElse(true)
+    val metadata = toSparkMetadata(col.getMetadata)
+    StructField(col.getName, dataType, nullable, metadata)
+  }
+
+  private def toSparkDataType(t: UCDeltaType): DataType = t match {
+    case p: UCPrimitiveType => primitiveFromString(p.getType)
+    case d: UCDecimalType =>
+      val precision = Option(d.getPrecision).map(_.intValue()).getOrElse(
+        throw new IllegalArgumentException("DecimalType missing precision"))
+      val scale = Option(d.getScale).map(_.intValue()).getOrElse(
+        throw new IllegalArgumentException("DecimalType missing scale"))
+      DecimalType(precision, scale)
+    case a: UCArrayType =>
+      val element = toSparkDataType(a.getElementType)
+      val containsNull = Option(a.getContainsNull).map(_.booleanValue()).getOrElse(true)
+      ArrayType(element, containsNull)
+    case m: UCMapType =>
+      val keyType = toSparkDataType(m.getKeyType)
+      val valueType = toSparkDataType(m.getValueType)
+      val valueContainsNull =
+        Option(m.getValueContainsNull).map(_.booleanValue()).getOrElse(true)
+      MapType(keyType, valueType, valueContainsNull)
+    case s: UCStructType =>
+      val fields = s.getFields.asScala.iterator.map(toSparkField).toArray
+      StructType(fields)
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unsupported DRC DeltaType subclass: ${other.getClass.getName}")
+  }
+
+  private def primitiveFromString(name: String): DataType = name match {
+    case null | "" =>
+      throw new IllegalArgumentException("Primitive type identifier must not be null or empty")
+    case "boolean" => BooleanType
+    case "tinyint" | "byte" => ByteType
+    case "smallint" | "short" => ShortType
+    case "int" | "integer" => IntegerType
+    case "long" | "bigint" => LongType
+    case "float" => FloatType
+    case "double" => DoubleType
+    case "string" => StringType
+    case "binary" => BinaryType
+    case "date" => DateType
+    case "timestamp" => TimestampType
+    case "timestamp_ntz" => TimestampNTZType
+    case "variant" => VariantType
+    case s if s.startsWith("decimal(") && s.endsWith(")") =>
+      // Defensive fallback when the wire sends a bare "decimal(p,s)" string instead of
+      // a structured DecimalType object. The UC server should prefer the structured form.
+      val inner = s.substring("decimal(".length, s.length - 1).split(",").map(_.trim)
+      require(inner.length == 2, s"Bad decimal form: $s")
+      DecimalType(inner(0).toInt, inner(1).toInt)
+    case other =>
+      throw new IllegalArgumentException(s"Unknown DRC primitive type: '$other'")
+  }
+
+  /**
+   * Passes every column-metadata key through to Spark's `Metadata` structure verbatim.
+   * Delta-specific metadata keys -- `delta.columnMapping.id`, `delta.generationExpression`,
+   * `delta.identity.*`, CHECK-constraint expressions, column defaults -- must round-trip
+   * exactly or downstream planner code (data skipping, column mapping, generated columns)
+   * silently produces wrong results.
+   */
+  private def toSparkMetadata(m: java.util.Map[String, Object]): Metadata = {
+    if (m == null || m.isEmpty) return Metadata.empty
+    val builder = new MetadataBuilder
+    m.asScala.foreach { case (k, v) => putMetadataValue(builder, k, v) }
+    builder.build()
+  }
+
+  private def putMetadataValue(
+      builder: MetadataBuilder, key: String, value: Object): Unit = value match {
+    case null => builder.putNull(key)
+    case s: String => builder.putString(key, s)
+    case b: java.lang.Boolean => builder.putBoolean(key, b.booleanValue())
+    case l: java.lang.Long => builder.putLong(key, l.longValue())
+    case i: java.lang.Integer => builder.putLong(key, i.longValue())
+    case d: java.lang.Double => builder.putDouble(key, d.doubleValue())
+    case f: java.lang.Float => builder.putDouble(key, f.doubleValue())
+    case other =>
+      // Jackson may hand back a nested LinkedHashMap or ArrayList for non-scalar metadata.
+      // Fall back to a stringified form rather than drop it silently -- losing metadata is
+      // a silent-corruption risk (see `delta.generationExpression`, column-mapping ids, ...).
+      builder.putString(key, other.toString)
+  }
+
+  // --------------------------------------------------------------------------
+  // Write path: Spark StructType -> UC POJO columns
+  // --------------------------------------------------------------------------
+
+  /**
+   * Convert a Spark `StructType` to the DRC column list used by `set-columns` in the commit
+   * path. The resulting `List[UCStructField]` wraps each column's data type in the appropriate
+   * `DeltaType` subclass (`PrimitiveType`, `DecimalType`, `ArrayType`, `MapType`, `StructType`)
+   * with the discriminator `type` field set so Jackson can serialize directly.
+   */
+  def toDRCColumns(schema: StructType): java.util.List[UCStructField] = {
+    if (schema == null) return java.util.Collections.emptyList()
+    val out = new java.util.ArrayList[UCStructField](schema.fields.length)
+    schema.fields.foreach(f => out.add(toDRCField(f)))
+    out
+  }
+
+  private[uccatalog] def toDRCField(field: StructField): UCStructField = {
+    require(field != null, "field must not be null")
+    val out = new UCStructField().name(field.name).nullable(field.nullable)
+    out.setType(toDRCDeltaType(field.dataType))
+    writeMetadata(out, field.metadata)
+    out
+  }
+
+  private def toDRCDeltaType(dt: DataType): UCDeltaType = dt match {
+    case BooleanType => primitive("boolean")
+    case ByteType => primitive("tinyint")
+    case ShortType => primitive("smallint")
+    case IntegerType => primitive("int")
+    case LongType => primitive("long")
+    case FloatType => primitive("float")
+    case DoubleType => primitive("double")
+    case StringType => primitive("string")
+    case BinaryType => primitive("binary")
+    case DateType => primitive("date")
+    case TimestampType => primitive("timestamp")
+    case TimestampNTZType => primitive("timestamp_ntz")
+    case VariantType => primitive("variant")
+    case DecimalType.Fixed(precision, scale) =>
+      val dec = new UCDecimalType().precision(precision).scale(scale)
+      dec.setType("decimal")
+      dec
+    case ArrayType(element, containsNull) =>
+      val arr = new UCArrayType()
+        .elementType(toDRCDeltaType(element))
+        .containsNull(containsNull)
+      arr.setType("array")
+      arr
+    case MapType(keyType, valueType, valueContainsNull) =>
+      val m = new UCMapType()
+        .keyType(toDRCDeltaType(keyType))
+        .valueType(toDRCDeltaType(valueType))
+        .valueContainsNull(valueContainsNull)
+      m.setType("map")
+      m
+    case st: StructType =>
+      val s = new UCStructType()
+      val fields = new java.util.ArrayList[UCStructField](st.fields.length)
+      st.fields.foreach(f => fields.add(toDRCField(f)))
+      s.setFields(fields)
+      s.setType("struct")
+      s
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unsupported Spark DataType for DRC: ${other.getClass.getName} ($other)")
+  }
+
+  private def primitive(name: String): UCPrimitiveType = {
+    val p = new UCPrimitiveType()
+    p.setType(name)
+    p
+  }
+
+  /**
+   * Serializes a Spark `Metadata` blob into UC's `Map<String, Object>` representation. Spark
+   * metadata values are scalars (string, long, double, boolean, null), nested `Metadata`
+   * blobs, or arrays of those; DRC's wire format accepts arbitrary JSON values. We preserve
+   * scalars as-is; nested metadata and arrays are serialized to their JSON string form to keep
+   * the write path lossless for keys Delta cares about.
+   */
+  private def writeMetadata(out: UCStructField, md: Metadata): Unit = {
+    if (md == null || md == Metadata.empty) return
+    // Spark's Metadata exposes a private map; json() is the stable public surface.
+    val json = md.json
+    // Parse back into (String, Object) pairs -- we reuse Jackson via a minimal parser.
+    val mapper = new com.fasterxml.jackson.databind.ObjectMapper()
+    val tree = mapper.readTree(json)
+    if (!tree.isObject) return
+    val it = tree.fields()
+    while (it.hasNext) {
+      val entry = it.next()
+      val v: AnyRef = jsonNodeToObject(entry.getValue)
+      out.putMetadataItem(entry.getKey, v)
+    }
+  }
+
+  private def jsonNodeToObject(n: com.fasterxml.jackson.databind.JsonNode): AnyRef = {
+    if (n == null || n.isNull) null
+    else if (n.isTextual) n.asText()
+    else if (n.isBoolean) java.lang.Boolean.valueOf(n.asBoolean())
+    else if (n.isIntegralNumber) java.lang.Long.valueOf(n.asLong())
+    else if (n.isFloatingPointNumber) java.lang.Double.valueOf(n.asDouble())
+    else n.toString // arrays / nested objects keep their JSON form
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
+import io.unitycatalog.client.delta.model.{LoadTableResponse, TableType => UCTableType}
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, CatalogUtils}
+import org.apache.spark.sql.connector.catalog.{Identifier, V1Table}
+
+/**
+ * Builds a Spark `V1Table` from a Delta REST Catalog (DRC) `LoadTableResponse`. Mirrors the
+ * shape of what `UCProxy.loadTable` produces today so that downstream code in
+ * `AbstractDeltaCatalog.loadTable` (`DeltaTableUtils.isDeltaTable`, `loadCatalogTable`, ...)
+ * does not need to change.
+ *
+ * Pure function of (catalog name, identifier, DRC client). Credential vending is introduced
+ * in a subsequent PR and will layer onto the same call path without changing this signature.
+ */
+private[delta] object DeltaRestTableLoader {
+
+  /** Stashed on `CatalogTable.properties` so the commit path (later PR) can assert-etag. */
+  val PROP_DRC_ETAG: String = "io.unitycatalog.drc.etag"
+  /** Stashed on `CatalogTable.properties` so the commit path can assert-table-uuid. */
+  val PROP_DRC_TABLE_ID: String = "io.unitycatalog.drc.table-id"
+  /** Latest table version per DRC response -- informational. */
+  val PROP_DRC_LATEST_VERSION: String = "io.unitycatalog.drc.latest-table-version"
+
+  /**
+   * Loads a table via the DRC client and assembles a `V1Table`.
+   *
+   * @param catalogName the Spark-side catalog name (e.g. "unity"); becomes the catalog segment
+   *                    of the returned `TableIdentifier`.
+   * @param ident the table identifier -- namespace must contain exactly the schema name.
+   * @param client the DRC client (one is constructed per load; shares the UC-owned ApiClient).
+   */
+  def load(catalogName: String, ident: Identifier, client: UCDeltaClient): V1Table = {
+    require(catalogName != null && catalogName.nonEmpty, "catalogName must be non-empty")
+    require(ident != null, "ident must not be null")
+    require(client != null, "client must not be null")
+    require(ident.namespace() != null && ident.namespace().length == 1,
+      s"DRC only supports single-level namespaces, got: ${ident}")
+
+    val schemaName = ident.namespace()(0)
+    val tableName = ident.name()
+    val response: LoadTableResponse = client.loadTable(catalogName, schemaName, tableName)
+    buildV1Table(catalogName, ident, response)
+  }
+
+  /** Visible for testing. */
+  private[uccatalog] def buildV1Table(
+      catalogName: String,
+      ident: Identifier,
+      response: LoadTableResponse): V1Table = {
+    require(response != null, "DRC loadTable response must not be null")
+    val md = Option(response.getMetadata).getOrElse(
+      throw new IllegalStateException("DRC loadTable response is missing metadata"))
+
+    val columns = Option(md.getColumns)
+      .map(_.getFields)
+      .getOrElse(java.util.Collections.emptyList())
+    val sparkSchema = DeltaRestSchemaConverter.toSparkSchema(columns)
+
+    val schemaName = ident.namespace()(0)
+    val tableIdentifier = TableIdentifier(ident.name(), Some(schemaName), Some(catalogName))
+
+    val locationUri = Option(md.getLocation).map(CatalogUtils.stringToURI)
+    val properties = Option(md.getProperties)
+      .map(_.asScala.toMap)
+      .getOrElse(Map.empty[String, String])
+
+    val enrichedProps = properties ++ Map(
+      PROP_DRC_ETAG -> Option(md.getEtag).getOrElse(""),
+      PROP_DRC_TABLE_ID -> Option(md.getTableUuid).map(_.toString).getOrElse(""),
+      PROP_DRC_LATEST_VERSION ->
+        Option(response.getLatestTableVersion).map(_.toString).getOrElse(""))
+
+    val tableType = md.getTableType match {
+      case UCTableType.MANAGED => CatalogTableType.MANAGED
+      case _ => CatalogTableType.EXTERNAL
+    }
+
+    val partitionCols = Option(md.getPartitionColumns)
+      .map(_.asScala.toSeq)
+      .getOrElse(Nil)
+
+    val catalogTable = CatalogTable(
+      identifier = tableIdentifier,
+      tableType = tableType,
+      storage = CatalogStorageFormat.empty.copy(locationUri = locationUri),
+      schema = sparkSchema,
+      provider = Some("delta"),
+      partitionColumnNames = partitionCols,
+      properties = enrichedProps
+    )
+    V1Table(catalogTable)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookupSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookupSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Optional => JOpt}
+
+import io.unitycatalog.client.ApiClient
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.TablesApi
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, DelegatingCatalogExtension, Identifier, Table}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.funsuite.AnyFunSuite
+
+class DeltaRestProviderLookupSuite extends AnyFunSuite {
+  import DeltaRestProviderLookupSuite._
+
+  test("null catalog returns None") {
+    assert(DeltaRestProviderLookup.findProvider(null).isEmpty)
+  }
+
+  test("catalog that is itself a provider returns itself") {
+    val provider = new StubProviderCatalog(flagOn = true)
+    val result = DeltaRestProviderLookup.findProvider(provider)
+    assert(result.contains(provider))
+  }
+
+  test("catalog -> delegate (provider) returns the inner provider") {
+    val provider = new StubProviderCatalog(flagOn = true)
+    val wrapper = new StubDelegatingCatalog(provider)
+    val result = DeltaRestProviderLookup.findProvider(wrapper)
+    assert(result.contains(provider))
+  }
+
+  test("catalog -> delegate -> delegate (provider) walks through wrappers") {
+    val provider = new StubProviderCatalog(flagOn = false)
+    val mid = new StubDelegatingCatalog(provider)
+    val outer = new StubDelegatingCatalog(mid)
+    val result = DeltaRestProviderLookup.findProvider(outer)
+    assert(result.contains(provider))
+  }
+
+  test("catalog without a provider in the chain returns None") {
+    val nonProvider = new StubPlainCatalog
+    val wrapper = new StubDelegatingCatalog(nonProvider)
+    assert(DeltaRestProviderLookup.findProvider(wrapper).isEmpty)
+  }
+
+  test("catalog with null delegate returns None") {
+    val wrapper = new StubDelegatingCatalog(null)
+    assert(DeltaRestProviderLookup.findProvider(wrapper).isEmpty)
+  }
+
+  test("defensive: chain deeper than MAX_CHAIN_DEPTH bails out with None") {
+    // Build a chain of non-provider delegating catalogs exceeding MAX_CHAIN_DEPTH.
+    var current: CatalogPlugin = new StubPlainCatalog
+    for (_ <- 0 until DeltaRestProviderLookup.MAX_CHAIN_DEPTH + 2) {
+      current = new StubDelegatingCatalog(current)
+    }
+    assert(DeltaRestProviderLookup.findProvider(current).isEmpty)
+  }
+}
+
+object DeltaRestProviderLookupSuite {
+
+  /** Non-delegating catalog that is itself a DeltaRestClientProvider. */
+  class StubProviderCatalog(flagOn: Boolean) extends CatalogPlugin with DeltaRestClientProvider {
+    private var catalogName: String = "stub-provider"
+    override def name(): String = catalogName
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+      this.catalogName = name
+    }
+    override def getDeltaTablesApi: JOpt[TablesApi] = {
+      if (flagOn) JOpt.of(new TablesApi()) else JOpt.empty()
+    }
+    override def getApiClient: ApiClient = new ApiClient()
+  }
+
+  /** Non-delegating plain CatalogPlugin (neither provider nor delegating). */
+  class StubPlainCatalog extends CatalogPlugin {
+    private var catalogName: String = "stub-plain"
+    override def name(): String = catalogName
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+      this.catalogName = name
+    }
+  }
+
+  /**
+   * A DelegatingCatalogExtension whose `delegate` field we set via setDelegateCatalog so the
+   * reflection walk in DeltaRestProviderLookup finds it.
+   */
+  class StubDelegatingCatalog(innerDelegate: CatalogPlugin) extends DelegatingCatalogExtension {
+    // DelegatingCatalogExtension stores the delegate via setDelegateCatalog; call it here so
+    // reflection picks it up. The cast to TableCatalog is safe because both StubProviderCatalog
+    // and StubDelegatingCatalog implement enough of the surface for the chain walk's purposes
+    // (the chain walk only reads the field, it never calls table ops).
+    if (innerDelegate != null) {
+      // DelegatingCatalogExtension.setDelegateCatalog takes a CatalogPlugin in Spark 4.x.
+      setDelegateCatalog(innerDelegate.asInstanceOf[
+        org.apache.spark.sql.connector.catalog.CatalogPlugin])
+    }
+
+    // DelegatingCatalogExtension does not override initialize/name when no delegate is set,
+    // so we bolt on trivial implementations to avoid NPEs.
+    override def name(): String = "stub-delegating"
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Arrays => JArr, Collections => JColl, Optional => JOpt, UUID}
+
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
+import io.unitycatalog.client.ApiClient
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.TablesApi
+import io.unitycatalog.client.delta.model.{
+  LoadTableResponse,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType,
+  TableMetadata,
+  TableType => UCTableType
+}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, DelegatingCatalogExtension, Identifier}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.funsuite.AnyFunSuite
+
+class DeltaRestReadPathSuite extends AnyFunSuite {
+  import DeltaRestReadPathSuite._
+
+  private val ident = Identifier.of(Array("default"), "t")
+
+  test("tryLoad returns None and does not invoke client factory when no provider on chain") {
+    val plainCatalog = new NonProviderCatalog
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(plainCatalog, "unity", ident, factory.build)
+    assert(result.isEmpty)
+    assert(factory.invocations === 0,
+      "flag-off path must not construct a UCDeltaClient " +
+        "(regression guard for flatMap/map swaps and eager side effects)")
+  }
+
+  test("tryLoad returns None and does not invoke client factory when flag is off") {
+    val provider = new FakeProvider(flagOn = false)
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(provider, "unity", ident, factory.build)
+    assert(result.isEmpty)
+    assert(factory.invocations === 0,
+      "flag-off path must not construct a UCDeltaClient")
+  }
+
+  test("tryLoad returns Some(V1Table) and invokes factory exactly once when flag is on") {
+    val provider = new FakeProvider(flagOn = true)
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(provider, "unity", ident, factory.build)
+    assert(result.isDefined)
+    assert(factory.invocations === 1)
+    assert(result.get.catalogTable.identifier.catalog.contains("unity"))
+  }
+
+  test("tryLoad walks past wrappers to find the provider") {
+    val provider = new FakeProvider(flagOn = true)
+    val outer = new WrappingCatalog(provider)
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(outer, "unity", ident, factory.build)
+    assert(result.isDefined)
+    assert(factory.invocations === 1)
+  }
+
+  test("tryLoad exceptions from the client propagate (no silent fallback)") {
+    val provider = new FakeProvider(flagOn = true)
+    val failingFactory: ApiClient => UCDeltaClient = _ => new FailingClient
+    val ex = intercept[RuntimeException] {
+      DeltaRestReadPath.tryLoad(provider, "unity", ident, failingFactory)
+    }
+    assert(ex.getMessage.contains("forced failure"))
+  }
+}
+
+object DeltaRestReadPathSuite {
+
+  private def dummyResponse: LoadTableResponse = {
+    val col = new UCStructField().name("id").nullable(true)
+    val p = new UCPrimitiveType()
+    p.setType("long")
+    col.setType(p)
+    val columns = new UCStructType()
+    columns.setType("struct")
+    columns.setFields(JArr.asList(col))
+    val md = new TableMetadata()
+      .etag("e")
+      .tableUuid(UUID.fromString("00000000-0000-0000-0000-000000000abc"))
+      .tableType(UCTableType.MANAGED)
+      .location("s3://b/p")
+      .columns(columns)
+    new LoadTableResponse().metadata(md).commits(JColl.emptyList()).latestTableVersion(0L)
+  }
+
+  class FakeProvider(flagOn: Boolean) extends CatalogPlugin with DeltaRestClientProvider {
+    override def name(): String = "fake-provider"
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
+    override def getDeltaTablesApi: JOpt[TablesApi] = {
+      if (flagOn) JOpt.of(new TablesApi()) else JOpt.empty()
+    }
+    override def getApiClient: ApiClient = new ApiClient()
+  }
+
+  class NonProviderCatalog extends CatalogPlugin {
+    override def name(): String = "plain"
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
+  }
+
+  class WrappingCatalog(innerDelegate: CatalogPlugin) extends DelegatingCatalogExtension {
+    setDelegateCatalog(innerDelegate)
+    override def name(): String = "wrapper"
+  }
+
+  class RecordingFactory(response: LoadTableResponse) {
+    var invocations = 0
+    val build: ApiClient => UCDeltaClient = _ => {
+      invocations += 1
+      new CannedClient(response)
+    }
+  }
+
+  class CannedClient(response: LoadTableResponse) extends UCDeltaClient {
+    override def loadTable(c: String, s: String, t: String): LoadTableResponse = response
+  }
+
+  class FailingClient extends UCDeltaClient {
+    override def loadTable(c: String, s: String, t: String): LoadTableResponse = {
+      throw new RuntimeException("forced failure")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
@@ -1,0 +1,382 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Collections => JColl, List => JList}
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => UCArrayType,
+  DecimalType => UCDecimalType,
+  MapType => UCMapType,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.types._
+
+class DeltaRestSchemaConverterSuite extends AnyFunSuite {
+  import DeltaRestSchemaConverterSuite._
+
+  // ---- Read path ----
+
+  test("toSparkSchema: empty/null column list yields an empty StructType") {
+    assert(DeltaRestSchemaConverter.toSparkSchema(null) === new StructType())
+    assert(DeltaRestSchemaConverter.toSparkSchema(JColl.emptyList()) === new StructType())
+  }
+
+  test("toSparkSchema: all supported primitive type identifiers") {
+    val cases = Seq(
+      "boolean" -> BooleanType,
+      "tinyint" -> ByteType,
+      "byte" -> ByteType,
+      "smallint" -> ShortType,
+      "short" -> ShortType,
+      "int" -> IntegerType,
+      "integer" -> IntegerType,
+      "long" -> LongType,
+      "bigint" -> LongType,
+      "float" -> FloatType,
+      "double" -> DoubleType,
+      "string" -> StringType,
+      "binary" -> BinaryType,
+      "date" -> DateType,
+      "timestamp" -> TimestampType,
+      "timestamp_ntz" -> TimestampNTZType,
+      "variant" -> VariantType
+    )
+    cases.foreach { case (name, expected) =>
+      val schema = DeltaRestSchemaConverter.toSparkSchema(
+        JColl.singletonList(field("c", prim(name), nullable = true)))
+      assert(schema.fields.head.dataType === expected, s"primitive $name")
+    }
+  }
+
+  test("toSparkSchema: decimal POJO preserves precision and scale") {
+    val d = new UCDecimalType().precision(38).scale(18)
+    d.setType("decimal")
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("d", d, nullable = false)))
+    assert(schema.fields.head.dataType === DecimalType(38, 18))
+    assert(!schema.fields.head.nullable)
+  }
+
+  test("toSparkSchema: bare 'decimal(p,s)' primitive string parses defensively") {
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("d", prim("decimal(10,2)"), nullable = true)))
+    assert(schema.fields.head.dataType === DecimalType(10, 2))
+  }
+
+  test("toSparkSchema: array preserves contains-null") {
+    val a = new UCArrayType().elementType(prim("long")).containsNull(false)
+    a.setType("array")
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("a", a, nullable = true)))
+    assert(schema.fields.head.dataType === ArrayType(LongType, containsNull = false))
+  }
+
+  test("toSparkSchema: map preserves value-contains-null") {
+    val m = new UCMapType()
+      .keyType(prim("string"))
+      .valueType(prim("int"))
+      .valueContainsNull(false)
+    m.setType("map")
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("m", m, nullable = true)))
+    assert(schema.fields.head.dataType ===
+      MapType(StringType, IntegerType, valueContainsNull = false))
+  }
+
+  test("toSparkSchema: nested struct preserves child field metadata") {
+    val c1 = field("c1", prim("long"), nullable = true,
+      metadata = Map(
+        "comment" -> "first-col",
+        "delta.columnMapping.id" -> java.lang.Long.valueOf(7L)))
+    val dec = new UCDecimalType().precision(10).scale(2)
+    dec.setType("decimal")
+    val c2 = field("c2", dec, nullable = false)
+    val inner = new UCStructType()
+    inner.setFields(jlist(c1, c2))
+    inner.setType("struct")
+
+    val outer = field("nested", inner, nullable = true,
+      metadata = Map("delta.generationExpression" -> "cast(c1 as int)"))
+
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(outer))
+    val top = schema.fields.head
+    assert(top.name === "nested")
+    assert(top.nullable)
+    assert(top.metadata.getString("delta.generationExpression") === "cast(c1 as int)")
+
+    val innerSt = top.dataType.asInstanceOf[StructType]
+    assert(innerSt.fields.length === 2)
+    assert(innerSt.fields(0).name === "c1")
+    assert(innerSt.fields(0).dataType === LongType)
+    assert(innerSt.fields(0).metadata.getString("comment") === "first-col")
+    assert(innerSt.fields(0).metadata.getLong("delta.columnMapping.id") === 7L)
+    assert(innerSt.fields(1).dataType === DecimalType(10, 2))
+    assert(!innerSt.fields(1).nullable)
+  }
+
+  test("toSparkSchema: deeply nested array-of-map-of-decimal round-trips case-correctly") {
+    val dec = new UCDecimalType().precision(38).scale(18)
+    dec.setType("decimal")
+    val m = new UCMapType()
+      .keyType(prim("string"))
+      .valueType(dec)
+      .valueContainsNull(false)
+    m.setType("map")
+    val a = new UCArrayType().elementType(m).containsNull(false)
+    a.setType("array")
+
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("weird", a, nullable = true)))
+    val expected = ArrayType(
+      MapType(StringType, DecimalType(38, 18), valueContainsNull = false),
+      containsNull = false)
+    assert(schema.fields.head.dataType === expected)
+  }
+
+  test("toSparkSchema: null 'nullable' defaults to true") {
+    val sf = new UCStructField().name("c")
+    sf.setType(prim("string"))
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    assert(schema.fields.head.nullable)
+  }
+
+  test("toSparkSchema: unknown primitive name fails loudly") {
+    val sf = field("c", prim("no-such-type"), nullable = true)
+    val e = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    }
+    assert(e.getMessage.contains("no-such-type"))
+  }
+
+  test("toSparkSchema: scalar metadata of multiple types is preserved") {
+    val sf = field("c", prim("long"), nullable = true,
+      metadata = Map(
+        "str" -> "x",
+        "bool" -> java.lang.Boolean.TRUE,
+        "int" -> java.lang.Integer.valueOf(42),
+        "long" -> java.lang.Long.valueOf(42L),
+        "dbl" -> java.lang.Double.valueOf(3.14),
+        "flt" -> java.lang.Float.valueOf(1.5f)))
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    val md = schema.fields.head.metadata
+    assert(md.getString("str") === "x")
+    assert(md.getBoolean("bool"))
+    assert(md.getLong("int") === 42L)
+    assert(md.getLong("long") === 42L)
+    assert(md.getDouble("dbl") === 3.14)
+    assert(md.getDouble("flt") === 1.5)
+  }
+
+  test("toSparkSchema: non-scalar metadata falls back to toString rather than dropping") {
+    val complex = new java.util.LinkedHashMap[String, String]()
+    complex.put("a", "b")
+    val sf = field("c", prim("long"), nullable = true,
+      metadata = Map("odd" -> complex))
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    assert(schema.fields.head.metadata.contains("odd"))
+  }
+
+  test("toSparkSchema: missing type fails with a readable error") {
+    val sf = new UCStructField().name("c").nullable(true)
+    val e = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    }
+    assert(e.getMessage.contains("column type must not be null"))
+  }
+
+  // ---- Write path ----
+
+  test("toDRCColumns: empty/null schema yields empty list") {
+    assert(DeltaRestSchemaConverter.toDRCColumns(null).isEmpty)
+    assert(DeltaRestSchemaConverter.toDRCColumns(new StructType()).isEmpty)
+  }
+
+  test("toDRCColumns: all supported primitive Spark types") {
+    val cases = Seq(
+      BooleanType -> "boolean",
+      ByteType -> "tinyint",
+      ShortType -> "smallint",
+      IntegerType -> "int",
+      LongType -> "long",
+      FloatType -> "float",
+      DoubleType -> "double",
+      StringType -> "string",
+      BinaryType -> "binary",
+      DateType -> "date",
+      TimestampType -> "timestamp",
+      TimestampNTZType -> "timestamp_ntz",
+      VariantType -> "variant")
+    cases.foreach { case (sparkType, expectedName) =>
+      val schema = new StructType().add("c", sparkType, nullable = true)
+      val out = DeltaRestSchemaConverter.toDRCColumns(schema)
+      assert(out.size() === 1)
+      val head = out.get(0)
+      assert(head.getName === "c")
+      assert(head.getNullable.booleanValue())
+      assert(head.getType.isInstanceOf[UCPrimitiveType], sparkType)
+      assert(head.getType.getType === expectedName, sparkType)
+    }
+  }
+
+  test("toDRCColumns: DecimalType becomes structured DecimalType POJO") {
+    val schema = new StructType().add("d", DecimalType(38, 18), nullable = false)
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala
+    val head = out.head
+    assert(!head.getNullable.booleanValue())
+    val dt = head.getType.asInstanceOf[UCDecimalType]
+    assert(dt.getType === "decimal")
+    assert(dt.getPrecision.intValue() === 38)
+    assert(dt.getScale.intValue() === 18)
+  }
+
+  test("toDRCColumns: ArrayType with containsNull=false") {
+    val schema = new StructType().add("a", ArrayType(LongType, containsNull = false))
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val arr = out.getType.asInstanceOf[UCArrayType]
+    assert(arr.getType === "array")
+    assert(!arr.getContainsNull.booleanValue())
+    assert(arr.getElementType.asInstanceOf[UCPrimitiveType].getType === "long")
+  }
+
+  test("toDRCColumns: MapType with valueContainsNull=false") {
+    val schema = new StructType().add("m",
+      MapType(StringType, IntegerType, valueContainsNull = false))
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val map = out.getType.asInstanceOf[UCMapType]
+    assert(map.getType === "map")
+    assert(!map.getValueContainsNull.booleanValue())
+    assert(map.getKeyType.asInstanceOf[UCPrimitiveType].getType === "string")
+    assert(map.getValueType.asInstanceOf[UCPrimitiveType].getType === "int")
+  }
+
+  test("toDRCColumns: nested StructType") {
+    val inner = new StructType()
+      .add("c1", LongType, nullable = true)
+      .add("c2", DecimalType(10, 2), nullable = false)
+    val schema = new StructType().add("nested", inner, nullable = true)
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val struct = out.getType.asInstanceOf[UCStructType]
+    assert(struct.getType === "struct")
+    assert(struct.getFields.size() === 2)
+    assert(struct.getFields.get(0).getName === "c1")
+    assert(struct.getFields.get(0).getType.asInstanceOf[UCPrimitiveType].getType === "long")
+    assert(struct.getFields.get(1).getName === "c2")
+    val dec = struct.getFields.get(1).getType.asInstanceOf[UCDecimalType]
+    assert(dec.getPrecision.intValue() === 10 && dec.getScale.intValue() === 2)
+  }
+
+  test("toDRCColumns: preserves scalar field metadata verbatim") {
+    val meta = new MetadataBuilder()
+      .putLong("delta.columnMapping.id", 7L)
+      .putString("comment", "hello")
+      .putBoolean("delta.generatedIdentity", true)
+      .putDouble("sampleRate", 0.5)
+      .build()
+    val schema = new StructType().add("c", LongType, nullable = true, meta)
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val md = out.getMetadata
+    assert(md.get("delta.columnMapping.id") === java.lang.Long.valueOf(7L))
+    assert(md.get("comment") === "hello")
+    assert(md.get("delta.generatedIdentity") === java.lang.Boolean.TRUE)
+    assert(md.get("sampleRate") === java.lang.Double.valueOf(0.5))
+  }
+
+  test("toDRCColumns: rejects unsupported Spark types") {
+    // A custom UDT or CalendarIntervalType would hit the default branch.
+    val schema = new StructType().add("c",
+      org.apache.spark.sql.types.CalendarIntervalType, nullable = true)
+    val e = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toDRCColumns(schema)
+    }
+    assert(e.getMessage.contains("Unsupported Spark DataType"))
+  }
+
+  // ---- Round-trip ----
+
+  test("round-trip: StructType -> UC POJO -> StructType preserves shape") {
+    val original = new StructType()
+      .add("id", LongType, nullable = false)
+      .add("name", StringType, nullable = true)
+      .add("tags", ArrayType(StringType, containsNull = false), nullable = true)
+      .add("props", MapType(StringType, IntegerType, valueContainsNull = false), nullable = true)
+      .add("nested",
+        new StructType()
+          .add("x", DoubleType, nullable = false)
+          .add("y", DecimalType(20, 10), nullable = false),
+        nullable = true)
+      .add("ts_ntz", TimestampNTZType, nullable = true)
+      .add("var", VariantType, nullable = true)
+
+    val drc = DeltaRestSchemaConverter.toDRCColumns(original)
+    val roundTripped = DeltaRestSchemaConverter.toSparkSchema(drc)
+
+    // Compare structurally: fields, types, nullability. Metadata is compared separately
+    // because our reverse writer serializes via JSON so the Metadata object identity differs.
+    assert(roundTripped.fields.length === original.fields.length)
+    original.fields.zip(roundTripped.fields).foreach { case (a, b) =>
+      assert(a.name === b.name)
+      assert(a.dataType === b.dataType, s"dataType mismatch on ${a.name}")
+      assert(a.nullable === b.nullable, s"nullable mismatch on ${a.name}")
+    }
+  }
+
+  test("round-trip: scalar metadata survives StructType -> UC -> StructType") {
+    val meta = new MetadataBuilder()
+      .putLong("delta.columnMapping.id", 42L)
+      .putString("comment", "a comment")
+      .build()
+    val original = new StructType().add("c", LongType, nullable = true, meta)
+    val drc = DeltaRestSchemaConverter.toDRCColumns(original)
+    val roundTripped = DeltaRestSchemaConverter.toSparkSchema(drc)
+    val md = roundTripped.fields.head.metadata
+    assert(md.getLong("delta.columnMapping.id") === 42L)
+    assert(md.getString("comment") === "a comment")
+  }
+}
+
+object DeltaRestSchemaConverterSuite {
+
+  def prim(name: String): UCPrimitiveType = {
+    val p = new UCPrimitiveType()
+    p.setType(name)
+    p
+  }
+
+  def field(
+      name: String,
+      dt: io.unitycatalog.client.delta.model.DeltaType,
+      nullable: Boolean,
+      metadata: Map[String, AnyRef] = Map.empty): UCStructField = {
+    val sf = new UCStructField().name(name).nullable(nullable)
+    sf.setType(dt)
+    metadata.foreach { case (k, v) => sf.putMetadataItem(k, v) }
+    sf
+  }
+
+  def jlist(fields: UCStructField*): JList[UCStructField] = {
+    val l = new java.util.ArrayList[UCStructField]()
+    fields.foreach(l.add)
+    l
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Arrays => JArr, Collections => JColl, UUID}
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
+import io.unitycatalog.client.delta.model.{
+  LoadTableResponse,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType,
+  TableMetadata,
+  TableType => UCTableType
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType}
+
+class DeltaRestTableLoaderSuite extends AnyFunSuite {
+
+  test("load() builds V1Table with schema, location, tableType, and DRC properties") {
+    val uuid = UUID.fromString("00000000-0000-0000-0000-000000000abc")
+    val response = buildResponse(
+      etag = "etag-123",
+      tableUuid = uuid,
+      tableType = UCTableType.MANAGED,
+      location = "s3://bucket/path/to/table",
+      columns = Seq(
+        field("id", "long"),
+        field("name", "string")),
+      properties = Map("delta.enableChangeDataFeed" -> "true"),
+      partitionColumns = Seq("id"),
+      latestVersion = 17L)
+
+    val client = new StubClient(response, "unity", "default", "t")
+    val ident = Identifier.of(Array("default"), "t")
+
+    val v1 = DeltaRestTableLoader.load("unity", ident, client)
+    val ct = v1.catalogTable
+
+    assert(ct.identifier.catalog.contains("unity"))
+    assert(ct.identifier.database.contains("default"))
+    assert(ct.identifier.table === "t")
+
+    assert(ct.tableType === CatalogTableType.MANAGED)
+    assert(ct.storage.locationUri.map(_.toString).contains("s3://bucket/path/to/table"))
+    assert(ct.schema.fields.length === 2)
+    assert(ct.schema.fields(0).dataType === LongType)
+    assert(ct.schema.fields(1).dataType === StringType)
+    assert(ct.partitionColumnNames === Seq("id"))
+    assert(ct.provider.contains("delta"))
+
+    assert(ct.properties("delta.enableChangeDataFeed") === "true")
+    assert(ct.properties(DeltaRestTableLoader.PROP_DRC_ETAG) === "etag-123")
+    assert(ct.properties(DeltaRestTableLoader.PROP_DRC_TABLE_ID) === uuid.toString)
+    assert(ct.properties(DeltaRestTableLoader.PROP_DRC_LATEST_VERSION) === "17")
+
+    assert(client.calls === Seq(("unity", "default", "t")))
+  }
+
+  test("load() maps non-MANAGED table type to EXTERNAL") {
+    val response = buildResponse(
+      tableType = UCTableType.EXTERNAL,
+      location = "s3://bucket/p",
+      columns = Seq(field("c", "int")),
+      properties = Map.empty,
+      partitionColumns = Nil)
+    val client = new StubClient(response, "cat", "sch", "tbl")
+    val v1 = DeltaRestTableLoader.load("cat", Identifier.of(Array("sch"), "tbl"), client)
+    assert(v1.catalogTable.tableType === CatalogTableType.EXTERNAL)
+    assert(v1.catalogTable.schema.fields.head.dataType === IntegerType)
+  }
+
+  test("load() rejects multi-level namespaces (DRC only supports single-level)") {
+    val response = buildResponse(columns = Seq(field("c", "int")))
+    val client = new StubClient(response, "cat", "s1", "t")
+    val ex = intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("cat", Identifier.of(Array("s1", "s2"), "t"), client)
+    }
+    assert(ex.getMessage.contains("single-level"))
+  }
+
+  test("load() rejects null args") {
+    val response = buildResponse()
+    val client = new StubClient(response, "c", "s", "t")
+    intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("", Identifier.of(Array("s"), "t"), client)
+    }
+    intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("c", null, client)
+    }
+    intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("c", Identifier.of(Array("s"), "t"), null)
+    }
+  }
+
+  test("buildV1Table handles null columns/properties/partition list gracefully") {
+    val md = new TableMetadata()
+      .etag("e")
+      .tableType(UCTableType.MANAGED)
+      .location("s3://b/p")
+    // columns, properties, partitionColumns left null
+    val response = new LoadTableResponse().metadata(md)
+
+    val v1 = DeltaRestTableLoader
+      .buildV1Table("cat", Identifier.of(Array("s"), "t"), response)
+    assert(v1.catalogTable.schema.fields.isEmpty)
+    assert(v1.catalogTable.partitionColumnNames.isEmpty)
+    assert(v1.catalogTable.properties(DeltaRestTableLoader.PROP_DRC_ETAG) === "e")
+  }
+
+  test("buildV1Table fails loudly when metadata block is absent") {
+    val response = new LoadTableResponse()
+    val ex = intercept[IllegalStateException] {
+      DeltaRestTableLoader
+        .buildV1Table("c", Identifier.of(Array("s"), "t"), response)
+    }
+    assert(ex.getMessage.contains("missing metadata"))
+  }
+
+  // Helpers
+  private def field(name: String, typeName: String): UCStructField = {
+    val f = new UCStructField().name(name).nullable(true)
+    val p = new UCPrimitiveType()
+    p.setType(typeName)
+    f.setType(p)
+    f
+  }
+
+  private def buildResponse(
+      etag: String = "etag-default",
+      tableUuid: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555"),
+      tableType: UCTableType = UCTableType.MANAGED,
+      location: String = "s3://b/p",
+      columns: Seq[UCStructField] = Nil,
+      properties: Map[String, String] = Map.empty,
+      partitionColumns: Seq[String] = Nil,
+      latestVersion: Long = 0L): LoadTableResponse = {
+    val columnsHolder = new UCStructType()
+    columnsHolder.setType("struct")
+    columnsHolder.setFields(JArr.asList(columns: _*))
+
+    val md = new TableMetadata()
+      .etag(etag)
+      .tableUuid(tableUuid)
+      .tableType(tableType)
+      .location(location)
+      .columns(columnsHolder)
+      .properties(properties.asJava)
+    md.setPartitionColumns(JArr.asList(partitionColumns: _*))
+
+    new LoadTableResponse()
+      .metadata(md)
+      .commits(JColl.emptyList())
+      .latestTableVersion(latestVersion)
+  }
+}
+
+/** Hand-rolled UCDeltaClient stub -- verifies call shape and returns a canned response. */
+private class StubClient(
+    response: LoadTableResponse,
+    expectedCatalog: String,
+    expectedSchema: String,
+    expectedTable: String) extends UCDeltaClient {
+  val calls = scala.collection.mutable.Buffer.empty[(String, String, String)]
+  override def loadTable(catalog: String, schema: String, table: String): LoadTableResponse = {
+    calls += ((catalog, schema, table))
+    assert(catalog == expectedCatalog)
+    assert(schema == expectedSchema)
+    assert(table == expectedTable)
+    response
+  }
+}

--- a/storage/src/main/java/io/delta/storage/annotation/Unstable.java
+++ b/storage/src/main/java/io/delta/storage/annotation/Unstable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.storage.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker for APIs in {@code delta-storage} that are not yet stable. Method signatures and class
+ * shapes may change in any minor release until the API graduates. External consumers of a
+ * {@code @Unstable}-annotated type must pin exact Delta versions.
+ *
+ * <p>Storage cannot depend on {@code org.apache.spark.annotation.Unstable} because the module
+ * forbids a Spark dependency (it must remain usable by non-Spark engines like Flink and Kernel).
+ * This annotation plays the same role within the storage module and is surfaced in generated
+ * Javadoc via {@code @Documented}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.FIELD,
+    ElementType.CONSTRUCTOR,
+    ElementType.PACKAGE
+})
+public @interface Unstable {}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.annotation.Unstable;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+
+import java.io.IOException;
+
+/**
+ * Client interface for the Unity Catalog Delta REST Catalog (DRC) API. The DRC endpoints live
+ * under {@code /api/2.1/unity-catalog/delta/v1/...} on the UC server and expose Delta-native
+ * metadata (structured protocol, Delta {@code StructType} columns, domain metadata) without the
+ * JSON-roundtrip overhead of the legacy UC API.
+ *
+ * <p>Implementations wrap the UC SDK's {@code io.unitycatalog.client.delta.api.TablesApi} and
+ * share the {@link io.unitycatalog.client.ApiClient} owned by a UC catalog plugin -- the client
+ * does not own that {@code ApiClient} and must not close it.
+ *
+ * <p>The interface grows one method per PR in the DRC rollout; callers should not assume
+ * unsupported methods are merely unimplemented.
+ */
+@Unstable
+public interface UCDeltaClient {
+
+  /**
+   * Loads a table via the DRC
+   * {@code GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}} endpoint.
+   *
+   * <p>The response carries {@link LoadTableResponse#getMetadata() metadata}
+   * (schema as UC {@code StructField} POJOs, structured protocol, properties, etag),
+   * {@link LoadTableResponse#getCommits() unbackfilled commits}, and
+   * {@link LoadTableResponse#getLatestTableVersion() latest-table-version}. The UC
+   * {@code StructField} list is converted to a Spark {@code StructType} by
+   * {@code DeltaRestSchemaConverter} in the delta-spark module.
+   *
+   * @param catalog catalog name
+   * @param schema schema name
+   * @param table table name (relative to the parent schema)
+   * @return the DRC load-table response
+   * @throws IOException on network error or a non-success HTTP response from the server
+   */
+  LoadTableResponse loadTable(String catalog, String schema, String table) throws IOException;
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.annotation.Unstable;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HTTP implementation of {@link UCDeltaClient} backed by the UC SDK's Delta REST Catalog
+ * {@code TablesApi}.
+ *
+ * <p>The {@link ApiClient} is shared -- it is owned by the UC catalog plugin (via the UC-side
+ * {@code DeltaRestClientProvider}) and supplies the HTTP connection pool, auth refresh cycle,
+ * and telemetry headers. This class does not own the {@code ApiClient} and must not close it.
+ */
+@Unstable
+public class UCDeltaRestClient implements UCDeltaClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UCDeltaRestClient.class);
+
+  private final TablesApi tablesApi;
+
+  /**
+   * Constructs a client wrapping a shared {@link ApiClient}. The caller (typically
+   * {@code AbstractDeltaCatalog.loadTable}) builds this only on the DRC path, i.e. when the
+   * UC-side {@code DeltaRestClientProvider.getDeltaTablesApi()} returned a present
+   * {@code Optional}. The apiClient is not closed by this class.
+   */
+  public UCDeltaRestClient(ApiClient apiClient) {
+    Objects.requireNonNull(apiClient, "apiClient must not be null");
+    this.tablesApi = new TablesApi(apiClient);
+    // Load-bearing invariant: this class does not own the ApiClient. A leak of the shared
+    // HTTP pool is the single worst failure mode here; this log exists so that mystery
+    // leaks can be triaged by matching identity hashes across the lifetime of the JVM.
+    LOG.info("UCDeltaRestClient bound to shared ApiClient (identityHash={}) at baseUri={}",
+        System.identityHashCode(apiClient), apiClient.getBaseUri());
+  }
+
+  @Override
+  public LoadTableResponse loadTable(String catalog, String schema, String table)
+      throws IOException {
+    Objects.requireNonNull(catalog, "catalog must not be null");
+    Objects.requireNonNull(schema, "schema must not be null");
+    Objects.requireNonNull(table, "table must not be null");
+    try {
+      return tablesApi.loadTable(catalog, schema, table);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format(
+              "Failed to load DRC table %s.%s.%s (HTTP %d): %s",
+              catalog, schema, table, e.getCode(), e.getResponseBody()),
+          e);
+    }
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6643/files/194d5db44ceb285cb0c3638f0a811121a661bd78..fd3c2fd683b8f453701b472d73d5296516a21fdf) to review incremental changes.
- [stack/drc-pr1-foundation](https://github.com/delta-io/delta/pull/6642) [[Files changed](https://github.com/delta-io/delta/pull/6642/files)]
  - [**stack/drc-pr2-read-path**](https://github.com/delta-io/delta/pull/6643) [[Files changed](https://github.com/delta-io/delta/pull/6643/files/194d5db44ceb285cb0c3638f0a811121a661bd78..fd3c2fd683b8f453701b472d73d5296516a21fdf)]
    - [stack/drc-pr3-credentials](https://github.com/delta-io/delta/pull/6644) [[Files changed](https://github.com/delta-io/delta/pull/6644/files/fd3c2fd683b8f453701b472d73d5296516a21fdf..8f49d2a3a3449e9b2f07f63505d0e827fc2d2115)]
      - [stack/drc-pr4-commit-api](https://github.com/delta-io/delta/pull/6645) [[Files changed](https://github.com/delta-io/delta/pull/6645/files/8f49d2a3a3449e9b2f07f63505d0e827fc2d2115..25d49bf70fba74f9adb8ed779e27ba06a8354243)]
        - [stack/drc-pr5-commit-wiring](https://github.com/delta-io/delta/pull/6646) [[Files changed](https://github.com/delta-io/delta/pull/6646/files/25d49bf70fba74f9adb8ed779e27ba06a8354243..cf5e4dcf558006801575ff70025a2c8592f672b0)]

---------

#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Routes `AbstractDeltaCatalog.loadTable` through the DRC when the UC catalog plugin on the delegate chain advertises DRC enabled (`DeltaRestClientProvider.getDeltaTablesApi().isPresent`). Decomposes into `DeltaRestProviderLookup` (delegate chain walker), `DeltaRestTableLoader` (DRC response → `V1Table`), and `DeltaRestReadPath` (composition) — the last asserts via test that no HTTP client is constructed on the flag-off path. Emits `delta.drc.loadTable` / `.error` events; exceptions propagate rather than silently falling back.

## How was this patch tested?
18 new tests across `DeltaRestProviderLookupSuite`, `DeltaRestTableLoaderSuite`, and `DeltaRestReadPathSuite` — including the flag-off no-construction invariant. Zero regressions in existing UC-related suites.

## Does this PR introduce _any_ user-facing changes?
No behavior change when `deltaRestApi.enabled=false` (default). When true, table loads go through the DRC endpoints instead of the legacy UC API.