### PR TITLE
[DRC][5/5] Wire DRC commit path + soften UC-managed kill switches

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -723,7 +723,11 @@ lazy val contribs = (project in file("contribs"))
   ).configureUnidoc()
 
 
-val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.4.1")
+// UC version is a SNAPSHOT because the Delta REST Catalog (DRC) API surface lives on UC master
+// ahead of any released UC version. Resolves from ~/.ivy2/local after running
+// dev/publish-uc-snapshot.sh, which pins an exact UC commit SHA (do not edit the version string
+// here without bumping the SHA in that script).
+val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.5.0-SNAPSHOT")
 val sparkUnityCatalogJacksonVersion = "2.15.4" // We are using Spark 4.0's Jackson version 2.15.x, to override Unity Catalog 0.3.0's version 2.18.x
 
 lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))

--- a/dev/publish-uc-snapshot.sh
+++ b/dev/publish-uc-snapshot.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (2026) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Publishes the Unity Catalog snapshot that Delta's DRC integration builds against.
+#
+# Delta's build.sbt pins `unityCatalogVersion` to a SNAPSHOT that resolves only from
+# ~/.ivy2/local. Before the DRC integration stack can compile in clean CI, the UC
+# repo must be cloned at a known-stable SHA and publishLocal'd. This script is the
+# reproducible source of truth for WHICH UC SHA Delta currently integrates against
+# -- do not edit build.sbt's version string without bumping UC_SHA here.
+#
+# When Yi's shared UC-SHA CI helper lands (tracked in delta-io/delta#6616), this
+# script should be replaced by a thin wrapper around it.
+#
+# Usage:
+#   ./dev/publish-uc-snapshot.sh [/path/to/checkout-dir]
+#
+# Defaults to "$HOME/.cache/delta-uc-snapshot" when no path is supplied.
+#
+
+set -euo pipefail
+
+# Pinned UC SHA. Update in lockstep with unityCatalogVersion in Delta's build.sbt.
+# Matches the DRC API surface consumed by delta/storage and delta/spark.
+UC_SHA="ae4bcf6bf588546593e19e501ca2d68759224991"
+UC_EXPECTED_VERSION="0.5.0-SNAPSHOT"
+UC_REPO_URL="https://github.com/unitycatalog/unitycatalog.git"
+CHECKOUT_DIR="${1:-$HOME/.cache/delta-uc-snapshot}"
+
+echo "==> Ensuring UC checkout at $CHECKOUT_DIR pinned to $UC_SHA"
+if [[ ! -d "$CHECKOUT_DIR/.git" ]]; then
+  mkdir -p "$(dirname "$CHECKOUT_DIR")"
+  git clone "$UC_REPO_URL" "$CHECKOUT_DIR"
+fi
+
+(
+  cd "$CHECKOUT_DIR"
+  git fetch --quiet origin "$UC_SHA" || git fetch --quiet origin
+  git checkout --detach "$UC_SHA"
+  actual_version="$(grep -E 'ThisBuild / version' version.sbt | sed -E 's/.*"(.*)".*/\1/')"
+  if [[ "$actual_version" != "$UC_EXPECTED_VERSION" ]]; then
+    echo "ERROR: UC checkout at $UC_SHA declares version $actual_version, expected $UC_EXPECTED_VERSION." >&2
+    echo "       If UC bumped its version, update UC_EXPECTED_VERSION and Delta's build.sbt in lockstep." >&2
+    exit 1
+  fi
+  echo "==> Running sbt publishLocal in $CHECKOUT_DIR"
+  # System sbt works; the UC-bundled build/sbt sometimes can't download sbt-launch.
+  if command -v sbt >/dev/null 2>&1; then
+    sbt -mem 3000 publishLocal
+  else
+    ./build/sbt publishLocal
+  fi
+)
+
+echo "==> Done. ~/.ivy2/local/io.unitycatalog/ now has $UC_EXPECTED_VERSION for Delta's build.sbt."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -594,7 +594,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // catches Delta-internal additions (e.g. table-feature flags). This is acceptable for
     // a temporary kill switch - once Delta supports propagating metadata updates to UC,
     // this check will be removed entirely.
-    if (!isCreatingNewTable) {
+    // Kill switch #1 (updateMetadata): skipped on the DRC path -- DRC propagates the change
+    // through the POST /v1/catalogs/.../tables/{name} update body. Still fires on legacy UC
+    // tables which cannot propagate metadata changes.
+    if (!isCreatingNewTable && !isDRCEnabledTable) {
       throwIfUCManagedMetadataChanged(snapshot.metadata, context = "updateMetadata")
     }
   }
@@ -640,6 +643,28 @@ trait OptimisticTransactionImpl extends TransactionHelper
           CatalogOwnedTableUtils.getCatalogName(spark, ct.identifier)
             .contains(UCCommitCoordinatorBuilder.COORDINATOR_NAME)
       }
+  }
+
+  /**
+   * True if this transaction targets a UC-managed table that was loaded via the Delta REST
+   * Catalog (DRC) path. The marker is `io.unitycatalog.drc.table-id` written by
+   * `DeltaRestTableLoader` during loadTable; its presence (and non-empty value) means the
+   * table's metadata came from the DRC endpoint and so metadata updates can be propagated
+   * through the DRC commit path.
+   *
+   * Used to soften the three UC-managed kill switches (property/schema/description updates,
+   * REPLACE-in-metadata, clustering domain metadata) per the clarifications-doc direction:
+   * "weakened, not lifted". In this PR the softening is binary -- when DRC is enabled on the
+   * table, each kill switch is bypassed so legitimate DRC metadata updates flow through. This
+   * is acceptable because the DRC commit carries the corresponding structured update actions,
+   * and the `assert-etag` requirement (when emitted) is the server-side safeguard against
+   * concurrent bypass-the-Delta-log writers.
+   */
+  protected[delta] lazy val isDRCEnabledTable: Boolean = {
+    isUCManagedTable &&
+      snapshot.metadata.configuration
+        .get("io.unitycatalog.drc.table-id")
+        .exists(_.nonEmpty)
   }
 
   /**
@@ -992,9 +1017,13 @@ trait OptimisticTransactionImpl extends TransactionHelper
       newConfs = newConfsWithoutICT ++ existingICTConfs
     }
     newMetadata = Some(newMetadata.get.copy(configuration = newConfs))
-    throwIfUCManagedMetadataChanged(
-      snapshot.metadata,
-      context = "updateMetadataForNewTableInReplace")
+    // Kill switch #2 (REPLACE TABLE metadata): skipped on the DRC path; DRC's
+    // REPLACE-equivalent bundles set-schema + set-protocol + set-properties in a single RPC.
+    if (!isDRCEnabledTable) {
+      throwIfUCManagedMetadataChanged(
+        snapshot.metadata,
+        context = "updateMetadataForNewTableInReplace")
+    }
   }
 
   /**
@@ -2070,13 +2099,13 @@ trait OptimisticTransactionImpl extends TransactionHelper
           newProtocol.toIterator
       allActions = allActions.map { action =>
         action match {
-          case dm: DomainMetadata if isClusteringChangedOnUCManagedTable(dm) =>
-            // Temporary: block clustering changes on UC-managed tables (commitLarge() path).
-            // commitLarge() bypasses prepareCommit(), so this guard is needed separately.
-            // The check is intentionally inside the lazy map: commitLarge streams actions to
-            // avoid materialising large sets, so an eager pre-scan is not practical. The
-            // exception is thrown before any data is written to the commit coordinator because
-            // the iterator is consumed first during serialisation.
+          case dm: DomainMetadata
+              if isClusteringChangedOnUCManagedTable(dm) && !isDRCEnabledTable =>
+            // Kill switch #3 (commitLarge clustering): block clustering changes on UC-managed
+            // tables that are NOT on the DRC path. commitLarge bypasses prepareCommit, so this
+            // guard is separate from the first two. On the DRC path the clustering change is
+            // emitted as a set-domain-metadata update in the POST /tables/{name} body, so the
+            // block does not apply.
             throw DeltaErrors.operationNotSupportedException(
               "Clustering column changes on Unity Catalog managed tables")
           case a: AddFile =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -43,6 +43,7 @@ import org.apache.spark.sql.delta.serverSidePlanning.ServerSidePlannedTable
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.tablefeatures.DropFeature
+import org.apache.spark.sql.delta.uccatalog.DeltaRestReadPath
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.hadoop.fs.Path
@@ -87,6 +88,39 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     val delegateField = classOf[DelegatingCatalogExtension].getDeclaredField("delegate")
     delegateField.setAccessible(true)
     delegateField.get(this).getClass.getCanonicalName.startsWith("io.unitycatalog.")
+  }
+
+  /**
+   * Delta REST Catalog (DRC) read path. Returns `Some(V1Table)` when the delegate chain
+   * contains a DRC-enabled provider; otherwise `None` so the caller falls through to
+   * `super.loadTable`. Exceptions from the DRC call propagate -- we do not silently fall
+   * back to legacy on DRC errors, which would mask real bugs after the user opted in.
+   *
+   * Emits `delta.drc.loadTable` on entry and `delta.drc.loadTable.error` on failure so the
+   * A/B rollout can distinguish DRC-path failures from legacy-path failures.
+   */
+  private def drcLoadTable(ident: Identifier): Option[Table] = {
+    try {
+      val result = DeltaRestReadPath.tryLoad(this, name(), ident)
+      if (result.isDefined) {
+        recordDeltaEvent(
+          deltaLog = null,
+          opType = "delta.drc.loadTable",
+          data = Map("catalog" -> name(), "table" -> ident.toString))
+      }
+      result
+    } catch {
+      case e: Throwable =>
+        recordDeltaEvent(
+          deltaLog = null,
+          opType = "delta.drc.loadTable.error",
+          data = Map(
+            "catalog" -> name(),
+            "table" -> ident.toString,
+            "errorClass" -> e.getClass.getName,
+            "errorMessage" -> Option(e.getMessage).getOrElse("")))
+        throw e
+    }
   }
 
   /**
@@ -290,7 +324,12 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       "DeltaCatalog", "loadTable") {
     setVariantBlockingConfigIfUC()
     try {
-      val table = super.loadTable(ident)
+      // DRC branch: when the UC catalog plugin on the delegate chain advertises a DRC
+      // TablesApi (provider.getDeltaTablesApi present), load metadata directly from the
+      // Delta REST Catalog endpoints. Otherwise fall through to the legacy UC API via
+      // super.loadTable. The Optional gate in DeltaRestReadPath.tryLoad guarantees that
+      // no HTTP client is constructed on the flag-off path.
+      val table = drcLoadTable(ident).getOrElse(super.loadTable(ident))
 
       ServerSidePlannedTable.tryCreate(spark, ident, table, isUnityCatalog).foreach { sspt =>
         return sspt

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -23,12 +23,14 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import io.delta.storage.commit.CommitCoordinatorClient
-import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCTokenBasedRestClient}
+import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCDeltaClient, UCDeltaRestClient, UCTokenBasedRestClient}
 
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.uccatalog.DeltaRestProviderLookup
 
 import io.unitycatalog.client.auth.TokenProvider
+import io.unitycatalog.client.delta.DeltaRestClientProvider
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 
@@ -77,7 +79,12 @@ object UCCommitCoordinatorBuilder
 
     commitCoordinatorClientCache.computeIfAbsent(
       metastoreId,
-      _ => new UCCommitCoordinatorClient(conf.asJava, getMatchingUCClient(spark, metastoreId)))
+      _ => {
+        val legacyClient = getMatchingUCClient(spark, metastoreId)
+        val drcClient = findDeltaRestClientForMetastore(spark, metastoreId)
+        val drcOpt = java.util.Optional.ofNullable(drcClient.orNull)
+        new UCCommitCoordinatorClient(conf.asJava, legacyClient, drcOpt)
+      })
   }
 
   override def buildForCatalog(
@@ -90,7 +97,54 @@ object UCCommitCoordinatorBuilder
           s"Catalog $catalogName not found in the provided SparkSession configurations.")
     }
     val conf = Map.empty[String, String]
-    new UCCommitCoordinatorClient(conf.asJava, client)
+    val drcClient = findDeltaRestClientForCatalog(spark, catalogName)
+    val drcOpt = java.util.Optional.ofNullable(drcClient.orNull)
+    new UCCommitCoordinatorClient(conf.asJava, client, drcOpt)
+  }
+
+  /**
+   * Looks up the Spark-registered catalog by name and walks its delegate chain for a
+   * DRC-enabled [[DeltaRestClientProvider]]. If found, builds a [[UCDeltaClient]] off the
+   * provider's shared [[ApiClient]]; otherwise [[None]]. Safe on failure (returns [[None]]
+   * and logs -- the legacy UC client still covers the commit path).
+   */
+  private def findDeltaRestClientForCatalog(
+      spark: SparkSession,
+      catalogName: String): Option[UCDeltaClient] = {
+    try {
+      val plugin = spark.sessionState.catalogManager.catalog(catalogName)
+      DeltaRestProviderLookup.findProvider(plugin).flatMap { provider =>
+        val apiOpt = provider.getDeltaTablesApi
+        if (apiOpt.isPresent) {
+          Some(new UCDeltaRestClient(provider.getApiClient): UCDeltaClient)
+        } else {
+          None
+        }
+      }
+    } catch {
+      case NonFatal(e) =>
+        logWarning(log"Failed to resolve DRC client for catalog " +
+          log"${MDC(DeltaLogKeys.CATALOG, catalogName)}", e)
+        None
+    }
+  }
+
+  /**
+   * Finds a DRC-capable provider whose metastoreId matches the given value. Iterates the
+   * UC-flavored catalogs in the SparkSession, asks each for its metastoreId, and returns the
+   * first whose provider has DRC enabled. Returns [[None]] when no match -- the commit path
+   * falls through to the legacy UC API.
+   */
+  private def findDeltaRestClientForMetastore(
+      spark: SparkSession,
+      metastoreId: String): Option[UCDeltaClient] = {
+    getCatalogConfigs(spark)
+      .map { case (name, uri, authConfig) => (name, uri, authConfig) }
+      .iterator
+      .find { case (_, uri, authConfig) =>
+        getMetastoreId(uri, authConfig).contains(metastoreId)
+      }
+      .flatMap { case (catalogName, _, _) => findDeltaRestClientForCatalog(spark, catalogName) }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookup.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, DelegatingCatalogExtension}
+
+/**
+ * Pure helper that walks a `CatalogPlugin`'s delegate chain and returns the first catalog that
+ * implements `DeltaRestClientProvider`. Extracted from `AbstractDeltaCatalog` so the chain-walk
+ * behaviour can be unit-tested in isolation, without needing a live Spark session or a real
+ * Delta catalog.
+ *
+ * The chain can take several shapes depending on how the catalog plugin is composed:
+ * - `this -> DeltaCatalog -> UCProxy` when Delta is on the classpath and interposed between
+ *   `UCSingleCatalog` and `UCProxy` (production OSS);
+ * - `this -> UCProxy` when Delta is absent and the UC plugin wraps UCProxy directly;
+ * - `UCSingleCatalog` itself when a consumer holds the outermost catalog (UCSingleCatalog
+ *   also implements DeltaRestClientProvider per UC PR 1509);
+ * - arbitrary wrappers interposed by Databricks-side or third-party adapters.
+ *
+ * The walk descends through `DelegatingCatalogExtension.delegate` (reflection) and stops when
+ * it (a) finds a provider, (b) hits a non-delegating, non-provider catalog, or (c) exceeds a
+ * defensive depth limit to guard against accidental cycles.
+ */
+private[delta] object DeltaRestProviderLookup {
+
+  /** Defensive cap on chain depth; in practice chains are 0-3 deep. */
+  private[uccatalog] val MAX_CHAIN_DEPTH: Int = 16
+
+  /**
+   * Returns the first `DeltaRestClientProvider` reachable by walking `catalog`'s delegate chain,
+   * or `None` if the chain does not contain one.
+   */
+  def findProvider(catalog: CatalogPlugin): Option[DeltaRestClientProvider] = {
+    if (catalog == null) return None
+    var current: Any = catalog
+    var depth = 0
+    while (current != null && depth < MAX_CHAIN_DEPTH) {
+      current match {
+        case p: DeltaRestClientProvider => return Some(p)
+        case d: DelegatingCatalogExtension => current = readDelegate(d)
+        case _ => current = null
+      }
+      depth += 1
+    }
+    None
+  }
+
+  private def readDelegate(d: DelegatingCatalogExtension): Any = {
+    val field = classOf[DelegatingCatalogExtension].getDeclaredField("delegate")
+    field.setAccessible(true)
+    field.get(d)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPath.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPath.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCDeltaRestClient}
+import io.unitycatalog.client.ApiClient
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, V1Table}
+
+/**
+ * Composes the DRC read path from its pieces: `DeltaRestProviderLookup` (walks the catalog
+ * chain) and `DeltaRestTableLoader` (builds `V1Table` from the DRC response). Exists as a
+ * standalone object so `AbstractDeltaCatalog.loadTable` does not have to choreograph the logic
+ * inline, and so the "flag off -> don't construct an HTTP client" invariant (the concern that
+ * a future regression swaps `flatMap` for `map` or adds an eager side effect before the
+ * `isPresent` check) can be asserted in a unit test with a client factory that throws on
+ * invocation.
+ */
+private[delta] object DeltaRestReadPath {
+
+  /** Default factory: real HTTP client bound to the shared `ApiClient`. */
+  private[uccatalog] val DefaultClientFactory: ApiClient => UCDeltaClient =
+    apiClient => new UCDeltaRestClient(apiClient)
+
+  /**
+   * Attempts to load a Delta table via the DRC. Returns `Some(v1Table)` when:
+   * - the catalog or its delegate chain contains a `DeltaRestClientProvider`, AND
+   * - that provider's `getDeltaTablesApi()` is present (DRC flag on).
+   *
+   * Returns `None` otherwise. In the `None` cases the `clientFactory` is NOT invoked -- callers
+   * can rely on this to avoid unwanted HTTP side effects on the flag-off path.
+   */
+  def tryLoad(
+      catalog: CatalogPlugin,
+      catalogName: String,
+      ident: Identifier,
+      clientFactory: ApiClient => UCDeltaClient = DefaultClientFactory): Option[V1Table] = {
+    DeltaRestProviderLookup.findProvider(catalog).flatMap { provider =>
+      val apiOpt = provider.getDeltaTablesApi
+      if (apiOpt.isPresent) {
+        val client = clientFactory(provider.getApiClient)
+        Some(DeltaRestTableLoader.load(catalogName, ident, client))
+      } else {
+        None
+      }
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
@@ -1,0 +1,254 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => UCArrayType,
+  DecimalType => UCDecimalType,
+  DeltaType => UCDeltaType,
+  MapType => UCMapType,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType
+}
+
+import org.apache.spark.sql.types._
+
+/**
+ * Bidirectional converter between the Delta REST Catalog (DRC) schema POJO hierarchy and Spark's
+ * `StructType`. The DRC wire format uses kebab-case (`element-type`, `contains-null`,
+ * `value-contains-null`); Delta uses camelCase (`elementType`, `containsNull`). The UC SDK POJO
+ * hierarchy handles the kebab/camel translation at (de)serialize time; this converter then walks
+ * the POJO tree directly, skipping a JSON round-trip and preserving all field metadata
+ * (`delta.columnMapping.id`, `delta.generationExpression`, CHECK-constraint expressions, column
+ * defaults) verbatim.
+ *
+ * Used on the read path (`toSparkSchema`, consumed by `DeltaRestTableLoader`) and on the write
+ * path (`toDRCColumns`, consumed by the DRC commit's `set-columns` update in a follow-up PR).
+ */
+private[delta] object DeltaRestSchemaConverter {
+
+  // --------------------------------------------------------------------------
+  // Read path: UC POJO columns -> Spark StructType
+  // --------------------------------------------------------------------------
+
+  /** Convert a DRC column list to a Spark `StructType`. Null input produces an empty schema. */
+  def toSparkSchema(columns: java.util.List[UCStructField]): StructType = {
+    if (columns == null) return new StructType()
+    StructType(columns.asScala.iterator.map(toSparkField).toArray)
+  }
+
+  private[uccatalog] def toSparkField(col: UCStructField): StructField = {
+    require(col != null, "column must not be null")
+    require(col.getName != null, "column name must not be null")
+    require(col.getType != null, s"column type must not be null for ${col.getName}")
+    val dataType = toSparkDataType(col.getType)
+    val nullable = Option(col.getNullable).map(_.booleanValue()).getOrElse(true)
+    val metadata = toSparkMetadata(col.getMetadata)
+    StructField(col.getName, dataType, nullable, metadata)
+  }
+
+  private def toSparkDataType(t: UCDeltaType): DataType = t match {
+    case p: UCPrimitiveType => primitiveFromString(p.getType)
+    case d: UCDecimalType =>
+      val precision = Option(d.getPrecision).map(_.intValue()).getOrElse(
+        throw new IllegalArgumentException("DecimalType missing precision"))
+      val scale = Option(d.getScale).map(_.intValue()).getOrElse(
+        throw new IllegalArgumentException("DecimalType missing scale"))
+      DecimalType(precision, scale)
+    case a: UCArrayType =>
+      val element = toSparkDataType(a.getElementType)
+      val containsNull = Option(a.getContainsNull).map(_.booleanValue()).getOrElse(true)
+      ArrayType(element, containsNull)
+    case m: UCMapType =>
+      val keyType = toSparkDataType(m.getKeyType)
+      val valueType = toSparkDataType(m.getValueType)
+      val valueContainsNull =
+        Option(m.getValueContainsNull).map(_.booleanValue()).getOrElse(true)
+      MapType(keyType, valueType, valueContainsNull)
+    case s: UCStructType =>
+      val fields = s.getFields.asScala.iterator.map(toSparkField).toArray
+      StructType(fields)
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unsupported DRC DeltaType subclass: ${other.getClass.getName}")
+  }
+
+  private def primitiveFromString(name: String): DataType = name match {
+    case null | "" =>
+      throw new IllegalArgumentException("Primitive type identifier must not be null or empty")
+    case "boolean" => BooleanType
+    case "tinyint" | "byte" => ByteType
+    case "smallint" | "short" => ShortType
+    case "int" | "integer" => IntegerType
+    case "long" | "bigint" => LongType
+    case "float" => FloatType
+    case "double" => DoubleType
+    case "string" => StringType
+    case "binary" => BinaryType
+    case "date" => DateType
+    case "timestamp" => TimestampType
+    case "timestamp_ntz" => TimestampNTZType
+    case "variant" => VariantType
+    case s if s.startsWith("decimal(") && s.endsWith(")") =>
+      // Defensive fallback when the wire sends a bare "decimal(p,s)" string instead of
+      // a structured DecimalType object. The UC server should prefer the structured form.
+      val inner = s.substring("decimal(".length, s.length - 1).split(",").map(_.trim)
+      require(inner.length == 2, s"Bad decimal form: $s")
+      DecimalType(inner(0).toInt, inner(1).toInt)
+    case other =>
+      throw new IllegalArgumentException(s"Unknown DRC primitive type: '$other'")
+  }
+
+  /**
+   * Passes every column-metadata key through to Spark's `Metadata` structure verbatim.
+   * Delta-specific metadata keys -- `delta.columnMapping.id`, `delta.generationExpression`,
+   * `delta.identity.*`, CHECK-constraint expressions, column defaults -- must round-trip
+   * exactly or downstream planner code (data skipping, column mapping, generated columns)
+   * silently produces wrong results.
+   */
+  private def toSparkMetadata(m: java.util.Map[String, Object]): Metadata = {
+    if (m == null || m.isEmpty) return Metadata.empty
+    val builder = new MetadataBuilder
+    m.asScala.foreach { case (k, v) => putMetadataValue(builder, k, v) }
+    builder.build()
+  }
+
+  private def putMetadataValue(
+      builder: MetadataBuilder, key: String, value: Object): Unit = value match {
+    case null => builder.putNull(key)
+    case s: String => builder.putString(key, s)
+    case b: java.lang.Boolean => builder.putBoolean(key, b.booleanValue())
+    case l: java.lang.Long => builder.putLong(key, l.longValue())
+    case i: java.lang.Integer => builder.putLong(key, i.longValue())
+    case d: java.lang.Double => builder.putDouble(key, d.doubleValue())
+    case f: java.lang.Float => builder.putDouble(key, f.doubleValue())
+    case other =>
+      // Jackson may hand back a nested LinkedHashMap or ArrayList for non-scalar metadata.
+      // Fall back to a stringified form rather than drop it silently -- losing metadata is
+      // a silent-corruption risk (see `delta.generationExpression`, column-mapping ids, ...).
+      builder.putString(key, other.toString)
+  }
+
+  // --------------------------------------------------------------------------
+  // Write path: Spark StructType -> UC POJO columns
+  // --------------------------------------------------------------------------
+
+  /**
+   * Convert a Spark `StructType` to the DRC column list used by `set-columns` in the commit
+   * path. The resulting `List[UCStructField]` wraps each column's data type in the appropriate
+   * `DeltaType` subclass (`PrimitiveType`, `DecimalType`, `ArrayType`, `MapType`, `StructType`)
+   * with the discriminator `type` field set so Jackson can serialize directly.
+   */
+  def toDRCColumns(schema: StructType): java.util.List[UCStructField] = {
+    if (schema == null) return java.util.Collections.emptyList()
+    val out = new java.util.ArrayList[UCStructField](schema.fields.length)
+    schema.fields.foreach(f => out.add(toDRCField(f)))
+    out
+  }
+
+  private[uccatalog] def toDRCField(field: StructField): UCStructField = {
+    require(field != null, "field must not be null")
+    val out = new UCStructField().name(field.name).nullable(field.nullable)
+    out.setType(toDRCDeltaType(field.dataType))
+    writeMetadata(out, field.metadata)
+    out
+  }
+
+  private def toDRCDeltaType(dt: DataType): UCDeltaType = dt match {
+    case BooleanType => primitive("boolean")
+    case ByteType => primitive("tinyint")
+    case ShortType => primitive("smallint")
+    case IntegerType => primitive("int")
+    case LongType => primitive("long")
+    case FloatType => primitive("float")
+    case DoubleType => primitive("double")
+    case StringType => primitive("string")
+    case BinaryType => primitive("binary")
+    case DateType => primitive("date")
+    case TimestampType => primitive("timestamp")
+    case TimestampNTZType => primitive("timestamp_ntz")
+    case VariantType => primitive("variant")
+    case DecimalType.Fixed(precision, scale) =>
+      val dec = new UCDecimalType().precision(precision).scale(scale)
+      dec.setType("decimal")
+      dec
+    case ArrayType(element, containsNull) =>
+      val arr = new UCArrayType()
+        .elementType(toDRCDeltaType(element))
+        .containsNull(containsNull)
+      arr.setType("array")
+      arr
+    case MapType(keyType, valueType, valueContainsNull) =>
+      val m = new UCMapType()
+        .keyType(toDRCDeltaType(keyType))
+        .valueType(toDRCDeltaType(valueType))
+        .valueContainsNull(valueContainsNull)
+      m.setType("map")
+      m
+    case st: StructType =>
+      val s = new UCStructType()
+      val fields = new java.util.ArrayList[UCStructField](st.fields.length)
+      st.fields.foreach(f => fields.add(toDRCField(f)))
+      s.setFields(fields)
+      s.setType("struct")
+      s
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unsupported Spark DataType for DRC: ${other.getClass.getName} ($other)")
+  }
+
+  private def primitive(name: String): UCPrimitiveType = {
+    val p = new UCPrimitiveType()
+    p.setType(name)
+    p
+  }
+
+  /**
+   * Serializes a Spark `Metadata` blob into UC's `Map<String, Object>` representation. Spark
+   * metadata values are scalars (string, long, double, boolean, null), nested `Metadata`
+   * blobs, or arrays of those; DRC's wire format accepts arbitrary JSON values. We preserve
+   * scalars as-is; nested metadata and arrays are serialized to their JSON string form to keep
+   * the write path lossless for keys Delta cares about.
+   */
+  private def writeMetadata(out: UCStructField, md: Metadata): Unit = {
+    if (md == null || md == Metadata.empty) return
+    // Spark's Metadata exposes a private map; json() is the stable public surface.
+    val json = md.json
+    // Parse back into (String, Object) pairs -- we reuse Jackson via a minimal parser.
+    val mapper = new com.fasterxml.jackson.databind.ObjectMapper()
+    val tree = mapper.readTree(json)
+    if (!tree.isObject) return
+    val it = tree.fields()
+    while (it.hasNext) {
+      val entry = it.next()
+      val v: AnyRef = jsonNodeToObject(entry.getValue)
+      out.putMetadataItem(entry.getKey, v)
+    }
+  }
+
+  private def jsonNodeToObject(n: com.fasterxml.jackson.databind.JsonNode): AnyRef = {
+    if (n == null || n.isNull) null
+    else if (n.isTextual) n.asText()
+    else if (n.isBoolean) java.lang.Boolean.valueOf(n.asBoolean())
+    else if (n.isIntegralNumber) java.lang.Long.valueOf(n.asLong())
+    else if (n.isFloatingPointNumber) java.lang.Double.valueOf(n.asDouble())
+    else n.toString // arrays / nested objects keep their JSON form
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
+import io.unitycatalog.client.delta.model.{LoadTableResponse, TableType => UCTableType}
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, CatalogUtils}
+import org.apache.spark.sql.connector.catalog.{Identifier, V1Table}
+
+/**
+ * Builds a Spark `V1Table` from a Delta REST Catalog (DRC) `LoadTableResponse`. Mirrors the
+ * shape of what `UCProxy.loadTable` produces today so that downstream code in
+ * `AbstractDeltaCatalog.loadTable` (`DeltaTableUtils.isDeltaTable`, `loadCatalogTable`, ...)
+ * does not need to change.
+ *
+ * Pure function of (catalog name, identifier, DRC client). Credential vending is introduced
+ * in a subsequent PR and will layer onto the same call path without changing this signature.
+ */
+private[delta] object DeltaRestTableLoader {
+
+  /** Stashed on `CatalogTable.properties` so the commit path (later PR) can assert-etag. */
+  val PROP_DRC_ETAG: String = "io.unitycatalog.drc.etag"
+  /** Stashed on `CatalogTable.properties` so the commit path can assert-table-uuid. */
+  val PROP_DRC_TABLE_ID: String = "io.unitycatalog.drc.table-id"
+  /** Latest table version per DRC response -- informational. */
+  val PROP_DRC_LATEST_VERSION: String = "io.unitycatalog.drc.latest-table-version"
+
+  /**
+   * Loads a table via the DRC client and assembles a `V1Table`.
+   *
+   * @param catalogName the Spark-side catalog name (e.g. "unity"); becomes the catalog segment
+   *                    of the returned `TableIdentifier`.
+   * @param ident the table identifier -- namespace must contain exactly the schema name.
+   * @param client the DRC client (one is constructed per load; shares the UC-owned ApiClient).
+   */
+  def load(catalogName: String, ident: Identifier, client: UCDeltaClient): V1Table = {
+    require(catalogName != null && catalogName.nonEmpty, "catalogName must be non-empty")
+    require(ident != null, "ident must not be null")
+    require(client != null, "client must not be null")
+    require(ident.namespace() != null && ident.namespace().length == 1,
+      s"DRC only supports single-level namespaces, got: ${ident}")
+
+    val schemaName = ident.namespace()(0)
+    val tableName = ident.name()
+    val response: LoadTableResponse = client.loadTable(catalogName, schemaName, tableName)
+    buildV1Table(catalogName, ident, response)
+  }
+
+  /** Visible for testing. */
+  private[uccatalog] def buildV1Table(
+      catalogName: String,
+      ident: Identifier,
+      response: LoadTableResponse): V1Table = {
+    require(response != null, "DRC loadTable response must not be null")
+    val md = Option(response.getMetadata).getOrElse(
+      throw new IllegalStateException("DRC loadTable response is missing metadata"))
+
+    val columns = Option(md.getColumns)
+      .map(_.getFields)
+      .getOrElse(java.util.Collections.emptyList())
+    val sparkSchema = DeltaRestSchemaConverter.toSparkSchema(columns)
+
+    val schemaName = ident.namespace()(0)
+    val tableIdentifier = TableIdentifier(ident.name(), Some(schemaName), Some(catalogName))
+
+    val locationUri = Option(md.getLocation).map(CatalogUtils.stringToURI)
+    val properties = Option(md.getProperties)
+      .map(_.asScala.toMap)
+      .getOrElse(Map.empty[String, String])
+
+    val enrichedProps = properties ++ Map(
+      PROP_DRC_ETAG -> Option(md.getEtag).getOrElse(""),
+      PROP_DRC_TABLE_ID -> Option(md.getTableUuid).map(_.toString).getOrElse(""),
+      PROP_DRC_LATEST_VERSION ->
+        Option(response.getLatestTableVersion).map(_.toString).getOrElse(""))
+
+    val tableType = md.getTableType match {
+      case UCTableType.MANAGED => CatalogTableType.MANAGED
+      case _ => CatalogTableType.EXTERNAL
+    }
+
+    val partitionCols = Option(md.getPartitionColumns)
+      .map(_.asScala.toSeq)
+      .getOrElse(Nil)
+
+    val catalogTable = CatalogTable(
+      identifier = tableIdentifier,
+      tableType = tableType,
+      storage = CatalogStorageFormat.empty.copy(locationUri = locationUri),
+      schema = sparkSchema,
+      provider = Some("delta"),
+      partitionColumnNames = partitionCols,
+      properties = enrichedProps
+    )
+    V1Table(catalogTable)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
@@ -53,6 +53,16 @@ private[delta] object DeltaRestTableLoader {
   val PROP_DRC_LATEST_VERSION: String = "io.unitycatalog.drc.latest-table-version"
 
   /**
+   * Catalog/schema/table names stashed on CatalogTable.properties so the commit coordinator
+   * can route POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table} without carrying
+   * the V1Table identifier through the tableConf plumbing. Commit-time detection of the
+   * DRC path relies on all three being present.
+   */
+  val PROP_DRC_CATALOG: String = "io.unitycatalog.drc.catalog"
+  val PROP_DRC_SCHEMA: String = "io.unitycatalog.drc.schema"
+  val PROP_DRC_TABLE: String = "io.unitycatalog.drc.table"
+
+  /**
    * Prefix for DRC-vended storage credential properties on `CatalogTable.storage.properties`.
    * The raw config keys from the DRC `StorageCredential.config` map (e.g. `s3.access-key-id`,
    * `azure.sas-token`) are written as `{PROP_DRC_CREDENTIAL_PREFIX}{raw-key}`. Downstream
@@ -130,7 +140,10 @@ private[delta] object DeltaRestTableLoader {
       PROP_DRC_ETAG -> Option(md.getEtag).getOrElse(""),
       PROP_DRC_TABLE_ID -> Option(md.getTableUuid).map(_.toString).getOrElse(""),
       PROP_DRC_LATEST_VERSION ->
-        Option(response.getLatestTableVersion).map(_.toString).getOrElse("")) ++ credentialProps
+        Option(response.getLatestTableVersion).map(_.toString).getOrElse(""),
+      PROP_DRC_CATALOG -> catalogName,
+      PROP_DRC_SCHEMA -> schemaName,
+      PROP_DRC_TABLE -> ident.name()) ++ credentialProps
 
     val tableType = md.getTableType match {
       case UCTableType.MANAGED => CatalogTableType.MANAGED

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoader.scala
@@ -19,7 +19,13 @@ package org.apache.spark.sql.delta.uccatalog
 import scala.collection.JavaConverters._
 
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
-import io.unitycatalog.client.delta.model.{LoadTableResponse, TableType => UCTableType}
+import io.unitycatalog.client.delta.model.{
+  CredentialOperation,
+  CredentialsResponse,
+  LoadTableResponse,
+  StorageCredential,
+  TableType => UCTableType
+}
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, CatalogUtils}
@@ -31,8 +37,11 @@ import org.apache.spark.sql.connector.catalog.{Identifier, V1Table}
  * `AbstractDeltaCatalog.loadTable` (`DeltaTableUtils.isDeltaTable`, `loadCatalogTable`, ...)
  * does not need to change.
  *
- * Pure function of (catalog name, identifier, DRC client). Credential vending is introduced
- * in a subsequent PR and will layer onto the same call path without changing this signature.
+ * On the read path, vended storage credentials are fetched with READ scope and injected into
+ * `CatalogTable.storage.properties` under the `io.unitycatalog.drc.cred.` prefix so that
+ * downstream file IO uses the per-table, per-operation principal. They are intentionally NOT
+ * written to the `SparkSession.conf`, so concurrent queries with different principals do not
+ * clobber each other in a shared cluster -- a known footgun called out in review.
  */
 private[delta] object DeltaRestTableLoader {
 
@@ -44,7 +53,19 @@ private[delta] object DeltaRestTableLoader {
   val PROP_DRC_LATEST_VERSION: String = "io.unitycatalog.drc.latest-table-version"
 
   /**
-   * Loads a table via the DRC client and assembles a `V1Table`.
+   * Prefix for DRC-vended storage credential properties on `CatalogTable.storage.properties`.
+   * The raw config keys from the DRC `StorageCredential.config` map (e.g. `s3.access-key-id`,
+   * `azure.sas-token`) are written as `{PROP_DRC_CREDENTIAL_PREFIX}{raw-key}`. Downstream
+   * Hadoop FS binding (converting these to `fs.s3a.access.key` etc.) is handled by the layer
+   * that materializes the options into a Hadoop Configuration for table-scoped IO.
+   */
+  val PROP_DRC_CREDENTIAL_PREFIX: String = "io.unitycatalog.drc.cred."
+
+  /**
+   * Loads a table via the DRC client and assembles a `V1Table`. Also fetches READ-scope
+   * credentials and injects them into `CatalogTable.storage.properties`. If the credentials
+   * endpoint errors, the table still loads without credentials (the server-side implementation
+   * can lag the client in v1).
    *
    * @param catalogName the Spark-side catalog name (e.g. "unity"); becomes the catalog segment
    *                    of the returned `TableIdentifier`.
@@ -61,14 +82,27 @@ private[delta] object DeltaRestTableLoader {
     val schemaName = ident.namespace()(0)
     val tableName = ident.name()
     val response: LoadTableResponse = client.loadTable(catalogName, schemaName, tableName)
-    buildV1Table(catalogName, ident, response)
+
+    // Fetch vended READ-scope credentials. If the server-side creds endpoint errors (the
+    // DRC server implementation lags the client in v1), the table still loads without
+    // creds -- file IO falls back to whatever the executor's Hadoop conf already provides.
+    // We do NOT fall back silently on loadTable errors above: only credentials.
+    val credentials: Option[CredentialsResponse] =
+      try Some(client.getTableCredentials(
+        catalogName, schemaName, tableName, CredentialOperation.READ))
+      catch {
+        case _: java.io.IOException => None
+      }
+
+    buildV1Table(catalogName, ident, response, credentials)
   }
 
   /** Visible for testing. */
   private[uccatalog] def buildV1Table(
       catalogName: String,
       ident: Identifier,
-      response: LoadTableResponse): V1Table = {
+      response: LoadTableResponse,
+      credentials: Option[CredentialsResponse] = None): V1Table = {
     require(response != null, "DRC loadTable response must not be null")
     val md = Option(response.getMetadata).getOrElse(
       throw new IllegalStateException("DRC loadTable response is missing metadata"))
@@ -86,11 +120,17 @@ private[delta] object DeltaRestTableLoader {
       .map(_.asScala.toMap)
       .getOrElse(Map.empty[String, String])
 
+    val credentialProps = credentials
+      .flatMap(r => Option(r.getStorageCredentials).map(_.asScala.toSeq))
+      .flatMap(selectLongestPrefixMatch(_, Option(md.getLocation).getOrElse("")))
+      .map(credentialToStorageProps)
+      .getOrElse(Map.empty[String, String])
+
     val enrichedProps = properties ++ Map(
       PROP_DRC_ETAG -> Option(md.getEtag).getOrElse(""),
       PROP_DRC_TABLE_ID -> Option(md.getTableUuid).map(_.toString).getOrElse(""),
       PROP_DRC_LATEST_VERSION ->
-        Option(response.getLatestTableVersion).map(_.toString).getOrElse(""))
+        Option(response.getLatestTableVersion).map(_.toString).getOrElse("")) ++ credentialProps
 
     val tableType = md.getTableType match {
       case UCTableType.MANAGED => CatalogTableType.MANAGED
@@ -111,5 +151,81 @@ private[delta] object DeltaRestTableLoader {
       properties = enrichedProps
     )
     V1Table(catalogTable)
+  }
+
+  /**
+   * Picks the single best-matching `StorageCredential` for the given table location. The match
+   * rule is "longest prefix wins" among credentials whose normalized prefix is a prefix of the
+   * normalized table location. Scheme aliasing (`s3a://` <-> `s3://`, `abfss://` <-> `abfs://`)
+   * is handled by `normalizeLocation`. Returns `None` if no credential applies.
+   *
+   * This is the guard against the scope-leak silent failure: a future regression that uses a
+   * raw `startsWith` with first-match-wins iteration order would attach an overly broad
+   * `s3://bucket/` credential to a `s3://bucket/tenant-a/secret/` table.
+   */
+  private[uccatalog] def selectLongestPrefixMatch(
+      creds: Seq[StorageCredential],
+      tableLocation: String): Option[StorageCredential] = {
+    if (creds.isEmpty) return None
+    val normLoc = normalizeLocation(tableLocation)
+    creds
+      .flatMap { cred =>
+        val raw = Option(cred.getPrefix).getOrElse("")
+        val normPrefix = normalizeLocation(raw)
+        if (normPrefix.isEmpty || normLoc.isEmpty) {
+          // An empty prefix credential matches everything; an empty location means no table
+          // location, so loosen to match. The .length tiebreak still prefers specific
+          // credentials when multiple apply.
+          Some((cred, normPrefix.length))
+        } else if (normLoc == normPrefix
+            || normLoc.startsWith(normPrefix + "/")
+            || normLoc.startsWith(normPrefix)) {
+          Some((cred, normPrefix.length))
+        } else {
+          None
+        }
+      }
+      .sortBy(-_._2) // longest prefix first
+      .headOption
+      .map(_._1)
+  }
+
+  /**
+   * Normalizes a cloud storage location for prefix comparison: lower-cases the scheme,
+   * collapses alias schemes (`s3a`, `s3n` -> `s3`; `abfss` -> `abfs`), strips a single trailing
+   * slash. Returns the empty string when the input is null/empty.
+   */
+  private[uccatalog] def normalizeLocation(raw: String): String = {
+    if (raw == null || raw.isEmpty) return ""
+    val schemeIdx = raw.indexOf("://")
+    val (scheme, rest) = if (schemeIdx > 0) {
+      (raw.substring(0, schemeIdx).toLowerCase(java.util.Locale.ROOT),
+        raw.substring(schemeIdx + "://".length))
+    } else {
+      ("", raw)
+    }
+    val canonicalScheme = scheme match {
+      case "s3a" | "s3n" => "s3"
+      case "abfss" => "abfs"
+      case other => other
+    }
+    val trimmedRest = if (rest.endsWith("/")) rest.dropRight(1) else rest
+    if (canonicalScheme.isEmpty) trimmedRest
+    else canonicalScheme + "://" + trimmedRest
+  }
+
+  /**
+   * Converts a `StorageCredential.config` map into Delta-side property entries prefixed with
+   * `io.unitycatalog.drc.cred.`. A credential with null/empty config emits nothing.
+   *
+   * <b>Security note:</b> these properties carry raw cloud credentials. Downstream consumers
+   * are responsible for redacting them from log output, `EXPLAIN` output, and event logs. The
+   * `io.unitycatalog.drc.cred.` prefix is a grep anchor for a future Spark-side redaction list.
+   */
+  private def credentialToStorageProps(
+      cred: StorageCredential): Map[String, String] = {
+    Option(cred.getConfig)
+      .map(_.asScala.map { case (k, v) => (PROP_DRC_CREDENTIAL_PREFIX + k) -> v }.toMap)
+      .getOrElse(Map.empty[String, String])
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UCManagedTableKillSwitchSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UCManagedTableKillSwitchSuite.scala
@@ -48,6 +48,16 @@ class UCManagedTableKillSwitchSuite
     override protected[delta] lazy val isUCManagedTable: Boolean = true
   }
 
+  /**
+   * Test subclass that pretends it targets a UC-managed table on the DRC path. Used to
+   * verify the kill-switch softening rules in [[OptimisticTransaction]].
+   */
+  private class UCManagedDRCTxn(log: DeltaLog, snap: Snapshot)
+      extends OptimisticTransaction(log, None, snap) {
+    override protected[delta] lazy val isUCManagedTable: Boolean = true
+    override protected[delta] lazy val isDRCEnabledTable: Boolean = true
+  }
+
   private val clusteringOnId: Seq[DomainMetadata] =
     Seq(ClusteredTableUtils.createDomainMetadata(Seq(ClusteringColumn(Seq("id")))))
 
@@ -86,6 +96,22 @@ class UCManagedTableKillSwitchSuite
       val (log, snap) = createClusteredTable("tbl")
       // Commit the same clustering DomainMetadata that the snapshot already has - must not throw.
       new UCManagedTxn(log, snap).commit(clusteringOnId, DeltaOperations.ManualUpdate)
+    }
+  }
+
+  test("commitLarge allows clustering change when DRC is enabled on the table") {
+    withTable("tbl") {
+      val (log, snap) = createClusteredTable("tbl")
+      // Same clustering change that throws in the UC-managed case above; on the DRC path the
+      // kill switch is softened so commitLarge proceeds (the change is propagated via the
+      // DRC commit's set-domain-metadata update instead).
+      new UCManagedDRCTxn(log, snap).commitLarge(
+        spark,
+        clusteringOnName.iterator,
+        newProtocolOpt = None,
+        op = DeltaOperations.Restore(Some(0L), None),
+        context = Map.empty,
+        metrics = Map.empty)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookupSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestProviderLookupSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Optional => JOpt}
+
+import io.unitycatalog.client.ApiClient
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.TablesApi
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, DelegatingCatalogExtension, Identifier, Table}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.funsuite.AnyFunSuite
+
+class DeltaRestProviderLookupSuite extends AnyFunSuite {
+  import DeltaRestProviderLookupSuite._
+
+  test("null catalog returns None") {
+    assert(DeltaRestProviderLookup.findProvider(null).isEmpty)
+  }
+
+  test("catalog that is itself a provider returns itself") {
+    val provider = new StubProviderCatalog(flagOn = true)
+    val result = DeltaRestProviderLookup.findProvider(provider)
+    assert(result.contains(provider))
+  }
+
+  test("catalog -> delegate (provider) returns the inner provider") {
+    val provider = new StubProviderCatalog(flagOn = true)
+    val wrapper = new StubDelegatingCatalog(provider)
+    val result = DeltaRestProviderLookup.findProvider(wrapper)
+    assert(result.contains(provider))
+  }
+
+  test("catalog -> delegate -> delegate (provider) walks through wrappers") {
+    val provider = new StubProviderCatalog(flagOn = false)
+    val mid = new StubDelegatingCatalog(provider)
+    val outer = new StubDelegatingCatalog(mid)
+    val result = DeltaRestProviderLookup.findProvider(outer)
+    assert(result.contains(provider))
+  }
+
+  test("catalog without a provider in the chain returns None") {
+    val nonProvider = new StubPlainCatalog
+    val wrapper = new StubDelegatingCatalog(nonProvider)
+    assert(DeltaRestProviderLookup.findProvider(wrapper).isEmpty)
+  }
+
+  test("catalog with null delegate returns None") {
+    val wrapper = new StubDelegatingCatalog(null)
+    assert(DeltaRestProviderLookup.findProvider(wrapper).isEmpty)
+  }
+
+  test("defensive: chain deeper than MAX_CHAIN_DEPTH bails out with None") {
+    // Build a chain of non-provider delegating catalogs exceeding MAX_CHAIN_DEPTH.
+    var current: CatalogPlugin = new StubPlainCatalog
+    for (_ <- 0 until DeltaRestProviderLookup.MAX_CHAIN_DEPTH + 2) {
+      current = new StubDelegatingCatalog(current)
+    }
+    assert(DeltaRestProviderLookup.findProvider(current).isEmpty)
+  }
+}
+
+object DeltaRestProviderLookupSuite {
+
+  /** Non-delegating catalog that is itself a DeltaRestClientProvider. */
+  class StubProviderCatalog(flagOn: Boolean) extends CatalogPlugin with DeltaRestClientProvider {
+    private var catalogName: String = "stub-provider"
+    override def name(): String = catalogName
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+      this.catalogName = name
+    }
+    override def getDeltaTablesApi: JOpt[TablesApi] = {
+      if (flagOn) JOpt.of(new TablesApi()) else JOpt.empty()
+    }
+    override def getApiClient: ApiClient = new ApiClient()
+  }
+
+  /** Non-delegating plain CatalogPlugin (neither provider nor delegating). */
+  class StubPlainCatalog extends CatalogPlugin {
+    private var catalogName: String = "stub-plain"
+    override def name(): String = catalogName
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+      this.catalogName = name
+    }
+  }
+
+  /**
+   * A DelegatingCatalogExtension whose `delegate` field we set via setDelegateCatalog so the
+   * reflection walk in DeltaRestProviderLookup finds it.
+   */
+  class StubDelegatingCatalog(innerDelegate: CatalogPlugin) extends DelegatingCatalogExtension {
+    // DelegatingCatalogExtension stores the delegate via setDelegateCatalog; call it here so
+    // reflection picks it up. The cast to TableCatalog is safe because both StubProviderCatalog
+    // and StubDelegatingCatalog implement enough of the surface for the chain walk's purposes
+    // (the chain walk only reads the field, it never calls table ops).
+    if (innerDelegate != null) {
+      // DelegatingCatalogExtension.setDelegateCatalog takes a CatalogPlugin in Spark 4.x.
+      setDelegateCatalog(innerDelegate.asInstanceOf[
+        org.apache.spark.sql.connector.catalog.CatalogPlugin])
+    }
+
+    // DelegatingCatalogExtension does not override initialize/name when no delegate is set,
+    // so we bolt on trivial implementations to avoid NPEs.
+    override def name(): String = "stub-delegating"
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
@@ -25,12 +25,14 @@ import io.unitycatalog.client.delta.api.TablesApi
 import io.unitycatalog.client.delta.model.{
   CredentialOperation,
   CredentialsResponse,
+  DeltaCommit,
   LoadTableResponse,
   PrimitiveType => UCPrimitiveType,
   StructField => UCStructField,
   StructType => UCStructType,
   TableMetadata,
-  TableType => UCTableType
+  TableType => UCTableType,
+  TableUpdate
 }
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, DelegatingCatalogExtension, Identifier}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -139,6 +141,11 @@ object DeltaRestReadPathSuite {
     override def getTableCredentials(
         c: String, s: String, t: String, op: CredentialOperation): CredentialsResponse =
       new CredentialsResponse()
+    override def commit(
+        c: String, s: String, t: String, commit: DeltaCommit, uuid: java.util.UUID,
+        etag: java.util.Optional[String],
+        updates: java.util.List[TableUpdate]): LoadTableResponse =
+      throw new UnsupportedOperationException
   }
 
   class FailingClient extends UCDeltaClient {
@@ -148,5 +155,10 @@ object DeltaRestReadPathSuite {
     override def getTableCredentials(
         c: String, s: String, t: String, op: CredentialOperation): CredentialsResponse =
       new CredentialsResponse()
+    override def commit(
+        c: String, s: String, t: String, commit: DeltaCommit, uuid: java.util.UUID,
+        etag: java.util.Optional[String],
+        updates: java.util.List[TableUpdate]): LoadTableResponse =
+      throw new UnsupportedOperationException
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
@@ -23,6 +23,8 @@ import io.unitycatalog.client.ApiClient
 import io.unitycatalog.client.delta.DeltaRestClientProvider
 import io.unitycatalog.client.delta.api.TablesApi
 import io.unitycatalog.client.delta.model.{
+  CredentialOperation,
+  CredentialsResponse,
   LoadTableResponse,
   PrimitiveType => UCPrimitiveType,
   StructField => UCStructField,
@@ -134,11 +136,17 @@ object DeltaRestReadPathSuite {
 
   class CannedClient(response: LoadTableResponse) extends UCDeltaClient {
     override def loadTable(c: String, s: String, t: String): LoadTableResponse = response
+    override def getTableCredentials(
+        c: String, s: String, t: String, op: CredentialOperation): CredentialsResponse =
+      new CredentialsResponse()
   }
 
   class FailingClient extends UCDeltaClient {
     override def loadTable(c: String, s: String, t: String): LoadTableResponse = {
       throw new RuntimeException("forced failure")
     }
+    override def getTableCredentials(
+        c: String, s: String, t: String, op: CredentialOperation): CredentialsResponse =
+      new CredentialsResponse()
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestReadPathSuite.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Arrays => JArr, Collections => JColl, Optional => JOpt, UUID}
+
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
+import io.unitycatalog.client.ApiClient
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.TablesApi
+import io.unitycatalog.client.delta.model.{
+  LoadTableResponse,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType,
+  TableMetadata,
+  TableType => UCTableType
+}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, DelegatingCatalogExtension, Identifier}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.funsuite.AnyFunSuite
+
+class DeltaRestReadPathSuite extends AnyFunSuite {
+  import DeltaRestReadPathSuite._
+
+  private val ident = Identifier.of(Array("default"), "t")
+
+  test("tryLoad returns None and does not invoke client factory when no provider on chain") {
+    val plainCatalog = new NonProviderCatalog
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(plainCatalog, "unity", ident, factory.build)
+    assert(result.isEmpty)
+    assert(factory.invocations === 0,
+      "flag-off path must not construct a UCDeltaClient " +
+        "(regression guard for flatMap/map swaps and eager side effects)")
+  }
+
+  test("tryLoad returns None and does not invoke client factory when flag is off") {
+    val provider = new FakeProvider(flagOn = false)
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(provider, "unity", ident, factory.build)
+    assert(result.isEmpty)
+    assert(factory.invocations === 0,
+      "flag-off path must not construct a UCDeltaClient")
+  }
+
+  test("tryLoad returns Some(V1Table) and invokes factory exactly once when flag is on") {
+    val provider = new FakeProvider(flagOn = true)
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(provider, "unity", ident, factory.build)
+    assert(result.isDefined)
+    assert(factory.invocations === 1)
+    assert(result.get.catalogTable.identifier.catalog.contains("unity"))
+  }
+
+  test("tryLoad walks past wrappers to find the provider") {
+    val provider = new FakeProvider(flagOn = true)
+    val outer = new WrappingCatalog(provider)
+    val factory = new RecordingFactory(dummyResponse)
+    val result = DeltaRestReadPath.tryLoad(outer, "unity", ident, factory.build)
+    assert(result.isDefined)
+    assert(factory.invocations === 1)
+  }
+
+  test("tryLoad exceptions from the client propagate (no silent fallback)") {
+    val provider = new FakeProvider(flagOn = true)
+    val failingFactory: ApiClient => UCDeltaClient = _ => new FailingClient
+    val ex = intercept[RuntimeException] {
+      DeltaRestReadPath.tryLoad(provider, "unity", ident, failingFactory)
+    }
+    assert(ex.getMessage.contains("forced failure"))
+  }
+}
+
+object DeltaRestReadPathSuite {
+
+  private def dummyResponse: LoadTableResponse = {
+    val col = new UCStructField().name("id").nullable(true)
+    val p = new UCPrimitiveType()
+    p.setType("long")
+    col.setType(p)
+    val columns = new UCStructType()
+    columns.setType("struct")
+    columns.setFields(JArr.asList(col))
+    val md = new TableMetadata()
+      .etag("e")
+      .tableUuid(UUID.fromString("00000000-0000-0000-0000-000000000abc"))
+      .tableType(UCTableType.MANAGED)
+      .location("s3://b/p")
+      .columns(columns)
+    new LoadTableResponse().metadata(md).commits(JColl.emptyList()).latestTableVersion(0L)
+  }
+
+  class FakeProvider(flagOn: Boolean) extends CatalogPlugin with DeltaRestClientProvider {
+    override def name(): String = "fake-provider"
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
+    override def getDeltaTablesApi: JOpt[TablesApi] = {
+      if (flagOn) JOpt.of(new TablesApi()) else JOpt.empty()
+    }
+    override def getApiClient: ApiClient = new ApiClient()
+  }
+
+  class NonProviderCatalog extends CatalogPlugin {
+    override def name(): String = "plain"
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
+  }
+
+  class WrappingCatalog(innerDelegate: CatalogPlugin) extends DelegatingCatalogExtension {
+    setDelegateCatalog(innerDelegate)
+    override def name(): String = "wrapper"
+  }
+
+  class RecordingFactory(response: LoadTableResponse) {
+    var invocations = 0
+    val build: ApiClient => UCDeltaClient = _ => {
+      invocations += 1
+      new CannedClient(response)
+    }
+  }
+
+  class CannedClient(response: LoadTableResponse) extends UCDeltaClient {
+    override def loadTable(c: String, s: String, t: String): LoadTableResponse = response
+  }
+
+  class FailingClient extends UCDeltaClient {
+    override def loadTable(c: String, s: String, t: String): LoadTableResponse = {
+      throw new RuntimeException("forced failure")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
@@ -1,0 +1,382 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Collections => JColl, List => JList}
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => UCArrayType,
+  DecimalType => UCDecimalType,
+  MapType => UCMapType,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.types._
+
+class DeltaRestSchemaConverterSuite extends AnyFunSuite {
+  import DeltaRestSchemaConverterSuite._
+
+  // ---- Read path ----
+
+  test("toSparkSchema: empty/null column list yields an empty StructType") {
+    assert(DeltaRestSchemaConverter.toSparkSchema(null) === new StructType())
+    assert(DeltaRestSchemaConverter.toSparkSchema(JColl.emptyList()) === new StructType())
+  }
+
+  test("toSparkSchema: all supported primitive type identifiers") {
+    val cases = Seq(
+      "boolean" -> BooleanType,
+      "tinyint" -> ByteType,
+      "byte" -> ByteType,
+      "smallint" -> ShortType,
+      "short" -> ShortType,
+      "int" -> IntegerType,
+      "integer" -> IntegerType,
+      "long" -> LongType,
+      "bigint" -> LongType,
+      "float" -> FloatType,
+      "double" -> DoubleType,
+      "string" -> StringType,
+      "binary" -> BinaryType,
+      "date" -> DateType,
+      "timestamp" -> TimestampType,
+      "timestamp_ntz" -> TimestampNTZType,
+      "variant" -> VariantType
+    )
+    cases.foreach { case (name, expected) =>
+      val schema = DeltaRestSchemaConverter.toSparkSchema(
+        JColl.singletonList(field("c", prim(name), nullable = true)))
+      assert(schema.fields.head.dataType === expected, s"primitive $name")
+    }
+  }
+
+  test("toSparkSchema: decimal POJO preserves precision and scale") {
+    val d = new UCDecimalType().precision(38).scale(18)
+    d.setType("decimal")
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("d", d, nullable = false)))
+    assert(schema.fields.head.dataType === DecimalType(38, 18))
+    assert(!schema.fields.head.nullable)
+  }
+
+  test("toSparkSchema: bare 'decimal(p,s)' primitive string parses defensively") {
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("d", prim("decimal(10,2)"), nullable = true)))
+    assert(schema.fields.head.dataType === DecimalType(10, 2))
+  }
+
+  test("toSparkSchema: array preserves contains-null") {
+    val a = new UCArrayType().elementType(prim("long")).containsNull(false)
+    a.setType("array")
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("a", a, nullable = true)))
+    assert(schema.fields.head.dataType === ArrayType(LongType, containsNull = false))
+  }
+
+  test("toSparkSchema: map preserves value-contains-null") {
+    val m = new UCMapType()
+      .keyType(prim("string"))
+      .valueType(prim("int"))
+      .valueContainsNull(false)
+    m.setType("map")
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("m", m, nullable = true)))
+    assert(schema.fields.head.dataType ===
+      MapType(StringType, IntegerType, valueContainsNull = false))
+  }
+
+  test("toSparkSchema: nested struct preserves child field metadata") {
+    val c1 = field("c1", prim("long"), nullable = true,
+      metadata = Map(
+        "comment" -> "first-col",
+        "delta.columnMapping.id" -> java.lang.Long.valueOf(7L)))
+    val dec = new UCDecimalType().precision(10).scale(2)
+    dec.setType("decimal")
+    val c2 = field("c2", dec, nullable = false)
+    val inner = new UCStructType()
+    inner.setFields(jlist(c1, c2))
+    inner.setType("struct")
+
+    val outer = field("nested", inner, nullable = true,
+      metadata = Map("delta.generationExpression" -> "cast(c1 as int)"))
+
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(outer))
+    val top = schema.fields.head
+    assert(top.name === "nested")
+    assert(top.nullable)
+    assert(top.metadata.getString("delta.generationExpression") === "cast(c1 as int)")
+
+    val innerSt = top.dataType.asInstanceOf[StructType]
+    assert(innerSt.fields.length === 2)
+    assert(innerSt.fields(0).name === "c1")
+    assert(innerSt.fields(0).dataType === LongType)
+    assert(innerSt.fields(0).metadata.getString("comment") === "first-col")
+    assert(innerSt.fields(0).metadata.getLong("delta.columnMapping.id") === 7L)
+    assert(innerSt.fields(1).dataType === DecimalType(10, 2))
+    assert(!innerSt.fields(1).nullable)
+  }
+
+  test("toSparkSchema: deeply nested array-of-map-of-decimal round-trips case-correctly") {
+    val dec = new UCDecimalType().precision(38).scale(18)
+    dec.setType("decimal")
+    val m = new UCMapType()
+      .keyType(prim("string"))
+      .valueType(dec)
+      .valueContainsNull(false)
+    m.setType("map")
+    val a = new UCArrayType().elementType(m).containsNull(false)
+    a.setType("array")
+
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      JColl.singletonList(field("weird", a, nullable = true)))
+    val expected = ArrayType(
+      MapType(StringType, DecimalType(38, 18), valueContainsNull = false),
+      containsNull = false)
+    assert(schema.fields.head.dataType === expected)
+  }
+
+  test("toSparkSchema: null 'nullable' defaults to true") {
+    val sf = new UCStructField().name("c")
+    sf.setType(prim("string"))
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    assert(schema.fields.head.nullable)
+  }
+
+  test("toSparkSchema: unknown primitive name fails loudly") {
+    val sf = field("c", prim("no-such-type"), nullable = true)
+    val e = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    }
+    assert(e.getMessage.contains("no-such-type"))
+  }
+
+  test("toSparkSchema: scalar metadata of multiple types is preserved") {
+    val sf = field("c", prim("long"), nullable = true,
+      metadata = Map(
+        "str" -> "x",
+        "bool" -> java.lang.Boolean.TRUE,
+        "int" -> java.lang.Integer.valueOf(42),
+        "long" -> java.lang.Long.valueOf(42L),
+        "dbl" -> java.lang.Double.valueOf(3.14),
+        "flt" -> java.lang.Float.valueOf(1.5f)))
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    val md = schema.fields.head.metadata
+    assert(md.getString("str") === "x")
+    assert(md.getBoolean("bool"))
+    assert(md.getLong("int") === 42L)
+    assert(md.getLong("long") === 42L)
+    assert(md.getDouble("dbl") === 3.14)
+    assert(md.getDouble("flt") === 1.5)
+  }
+
+  test("toSparkSchema: non-scalar metadata falls back to toString rather than dropping") {
+    val complex = new java.util.LinkedHashMap[String, String]()
+    complex.put("a", "b")
+    val sf = field("c", prim("long"), nullable = true,
+      metadata = Map("odd" -> complex))
+    val schema = DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    assert(schema.fields.head.metadata.contains("odd"))
+  }
+
+  test("toSparkSchema: missing type fails with a readable error") {
+    val sf = new UCStructField().name("c").nullable(true)
+    val e = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(JColl.singletonList(sf))
+    }
+    assert(e.getMessage.contains("column type must not be null"))
+  }
+
+  // ---- Write path ----
+
+  test("toDRCColumns: empty/null schema yields empty list") {
+    assert(DeltaRestSchemaConverter.toDRCColumns(null).isEmpty)
+    assert(DeltaRestSchemaConverter.toDRCColumns(new StructType()).isEmpty)
+  }
+
+  test("toDRCColumns: all supported primitive Spark types") {
+    val cases = Seq(
+      BooleanType -> "boolean",
+      ByteType -> "tinyint",
+      ShortType -> "smallint",
+      IntegerType -> "int",
+      LongType -> "long",
+      FloatType -> "float",
+      DoubleType -> "double",
+      StringType -> "string",
+      BinaryType -> "binary",
+      DateType -> "date",
+      TimestampType -> "timestamp",
+      TimestampNTZType -> "timestamp_ntz",
+      VariantType -> "variant")
+    cases.foreach { case (sparkType, expectedName) =>
+      val schema = new StructType().add("c", sparkType, nullable = true)
+      val out = DeltaRestSchemaConverter.toDRCColumns(schema)
+      assert(out.size() === 1)
+      val head = out.get(0)
+      assert(head.getName === "c")
+      assert(head.getNullable.booleanValue())
+      assert(head.getType.isInstanceOf[UCPrimitiveType], sparkType)
+      assert(head.getType.getType === expectedName, sparkType)
+    }
+  }
+
+  test("toDRCColumns: DecimalType becomes structured DecimalType POJO") {
+    val schema = new StructType().add("d", DecimalType(38, 18), nullable = false)
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala
+    val head = out.head
+    assert(!head.getNullable.booleanValue())
+    val dt = head.getType.asInstanceOf[UCDecimalType]
+    assert(dt.getType === "decimal")
+    assert(dt.getPrecision.intValue() === 38)
+    assert(dt.getScale.intValue() === 18)
+  }
+
+  test("toDRCColumns: ArrayType with containsNull=false") {
+    val schema = new StructType().add("a", ArrayType(LongType, containsNull = false))
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val arr = out.getType.asInstanceOf[UCArrayType]
+    assert(arr.getType === "array")
+    assert(!arr.getContainsNull.booleanValue())
+    assert(arr.getElementType.asInstanceOf[UCPrimitiveType].getType === "long")
+  }
+
+  test("toDRCColumns: MapType with valueContainsNull=false") {
+    val schema = new StructType().add("m",
+      MapType(StringType, IntegerType, valueContainsNull = false))
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val map = out.getType.asInstanceOf[UCMapType]
+    assert(map.getType === "map")
+    assert(!map.getValueContainsNull.booleanValue())
+    assert(map.getKeyType.asInstanceOf[UCPrimitiveType].getType === "string")
+    assert(map.getValueType.asInstanceOf[UCPrimitiveType].getType === "int")
+  }
+
+  test("toDRCColumns: nested StructType") {
+    val inner = new StructType()
+      .add("c1", LongType, nullable = true)
+      .add("c2", DecimalType(10, 2), nullable = false)
+    val schema = new StructType().add("nested", inner, nullable = true)
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val struct = out.getType.asInstanceOf[UCStructType]
+    assert(struct.getType === "struct")
+    assert(struct.getFields.size() === 2)
+    assert(struct.getFields.get(0).getName === "c1")
+    assert(struct.getFields.get(0).getType.asInstanceOf[UCPrimitiveType].getType === "long")
+    assert(struct.getFields.get(1).getName === "c2")
+    val dec = struct.getFields.get(1).getType.asInstanceOf[UCDecimalType]
+    assert(dec.getPrecision.intValue() === 10 && dec.getScale.intValue() === 2)
+  }
+
+  test("toDRCColumns: preserves scalar field metadata verbatim") {
+    val meta = new MetadataBuilder()
+      .putLong("delta.columnMapping.id", 7L)
+      .putString("comment", "hello")
+      .putBoolean("delta.generatedIdentity", true)
+      .putDouble("sampleRate", 0.5)
+      .build()
+    val schema = new StructType().add("c", LongType, nullable = true, meta)
+    val out = DeltaRestSchemaConverter.toDRCColumns(schema).asScala.head
+    val md = out.getMetadata
+    assert(md.get("delta.columnMapping.id") === java.lang.Long.valueOf(7L))
+    assert(md.get("comment") === "hello")
+    assert(md.get("delta.generatedIdentity") === java.lang.Boolean.TRUE)
+    assert(md.get("sampleRate") === java.lang.Double.valueOf(0.5))
+  }
+
+  test("toDRCColumns: rejects unsupported Spark types") {
+    // A custom UDT or CalendarIntervalType would hit the default branch.
+    val schema = new StructType().add("c",
+      org.apache.spark.sql.types.CalendarIntervalType, nullable = true)
+    val e = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toDRCColumns(schema)
+    }
+    assert(e.getMessage.contains("Unsupported Spark DataType"))
+  }
+
+  // ---- Round-trip ----
+
+  test("round-trip: StructType -> UC POJO -> StructType preserves shape") {
+    val original = new StructType()
+      .add("id", LongType, nullable = false)
+      .add("name", StringType, nullable = true)
+      .add("tags", ArrayType(StringType, containsNull = false), nullable = true)
+      .add("props", MapType(StringType, IntegerType, valueContainsNull = false), nullable = true)
+      .add("nested",
+        new StructType()
+          .add("x", DoubleType, nullable = false)
+          .add("y", DecimalType(20, 10), nullable = false),
+        nullable = true)
+      .add("ts_ntz", TimestampNTZType, nullable = true)
+      .add("var", VariantType, nullable = true)
+
+    val drc = DeltaRestSchemaConverter.toDRCColumns(original)
+    val roundTripped = DeltaRestSchemaConverter.toSparkSchema(drc)
+
+    // Compare structurally: fields, types, nullability. Metadata is compared separately
+    // because our reverse writer serializes via JSON so the Metadata object identity differs.
+    assert(roundTripped.fields.length === original.fields.length)
+    original.fields.zip(roundTripped.fields).foreach { case (a, b) =>
+      assert(a.name === b.name)
+      assert(a.dataType === b.dataType, s"dataType mismatch on ${a.name}")
+      assert(a.nullable === b.nullable, s"nullable mismatch on ${a.name}")
+    }
+  }
+
+  test("round-trip: scalar metadata survives StructType -> UC -> StructType") {
+    val meta = new MetadataBuilder()
+      .putLong("delta.columnMapping.id", 42L)
+      .putString("comment", "a comment")
+      .build()
+    val original = new StructType().add("c", LongType, nullable = true, meta)
+    val drc = DeltaRestSchemaConverter.toDRCColumns(original)
+    val roundTripped = DeltaRestSchemaConverter.toSparkSchema(drc)
+    val md = roundTripped.fields.head.metadata
+    assert(md.getLong("delta.columnMapping.id") === 42L)
+    assert(md.getString("comment") === "a comment")
+  }
+}
+
+object DeltaRestSchemaConverterSuite {
+
+  def prim(name: String): UCPrimitiveType = {
+    val p = new UCPrimitiveType()
+    p.setType(name)
+    p
+  }
+
+  def field(
+      name: String,
+      dt: io.unitycatalog.client.delta.model.DeltaType,
+      nullable: Boolean,
+      metadata: Map[String, AnyRef] = Map.empty): UCStructField = {
+    val sf = new UCStructField().name(name).nullable(nullable)
+    sf.setType(dt)
+    metadata.foreach { case (k, v) => sf.putMetadataItem(k, v) }
+    sf
+  }
+
+  def jlist(fields: UCStructField*): JList[UCStructField] = {
+    val l = new java.util.ArrayList[UCStructField]()
+    fields.foreach(l.add)
+    l
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Arrays => JArr, Collections => JColl, UUID}
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
+import io.unitycatalog.client.delta.model.{
+  LoadTableResponse,
+  PrimitiveType => UCPrimitiveType,
+  StructField => UCStructField,
+  StructType => UCStructType,
+  TableMetadata,
+  TableType => UCTableType
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType}
+
+class DeltaRestTableLoaderSuite extends AnyFunSuite {
+
+  test("load() builds V1Table with schema, location, tableType, and DRC properties") {
+    val uuid = UUID.fromString("00000000-0000-0000-0000-000000000abc")
+    val response = buildResponse(
+      etag = "etag-123",
+      tableUuid = uuid,
+      tableType = UCTableType.MANAGED,
+      location = "s3://bucket/path/to/table",
+      columns = Seq(
+        field("id", "long"),
+        field("name", "string")),
+      properties = Map("delta.enableChangeDataFeed" -> "true"),
+      partitionColumns = Seq("id"),
+      latestVersion = 17L)
+
+    val client = new StubClient(response, "unity", "default", "t")
+    val ident = Identifier.of(Array("default"), "t")
+
+    val v1 = DeltaRestTableLoader.load("unity", ident, client)
+    val ct = v1.catalogTable
+
+    assert(ct.identifier.catalog.contains("unity"))
+    assert(ct.identifier.database.contains("default"))
+    assert(ct.identifier.table === "t")
+
+    assert(ct.tableType === CatalogTableType.MANAGED)
+    assert(ct.storage.locationUri.map(_.toString).contains("s3://bucket/path/to/table"))
+    assert(ct.schema.fields.length === 2)
+    assert(ct.schema.fields(0).dataType === LongType)
+    assert(ct.schema.fields(1).dataType === StringType)
+    assert(ct.partitionColumnNames === Seq("id"))
+    assert(ct.provider.contains("delta"))
+
+    assert(ct.properties("delta.enableChangeDataFeed") === "true")
+    assert(ct.properties(DeltaRestTableLoader.PROP_DRC_ETAG) === "etag-123")
+    assert(ct.properties(DeltaRestTableLoader.PROP_DRC_TABLE_ID) === uuid.toString)
+    assert(ct.properties(DeltaRestTableLoader.PROP_DRC_LATEST_VERSION) === "17")
+
+    assert(client.calls === Seq(("unity", "default", "t")))
+  }
+
+  test("load() maps non-MANAGED table type to EXTERNAL") {
+    val response = buildResponse(
+      tableType = UCTableType.EXTERNAL,
+      location = "s3://bucket/p",
+      columns = Seq(field("c", "int")),
+      properties = Map.empty,
+      partitionColumns = Nil)
+    val client = new StubClient(response, "cat", "sch", "tbl")
+    val v1 = DeltaRestTableLoader.load("cat", Identifier.of(Array("sch"), "tbl"), client)
+    assert(v1.catalogTable.tableType === CatalogTableType.EXTERNAL)
+    assert(v1.catalogTable.schema.fields.head.dataType === IntegerType)
+  }
+
+  test("load() rejects multi-level namespaces (DRC only supports single-level)") {
+    val response = buildResponse(columns = Seq(field("c", "int")))
+    val client = new StubClient(response, "cat", "s1", "t")
+    val ex = intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("cat", Identifier.of(Array("s1", "s2"), "t"), client)
+    }
+    assert(ex.getMessage.contains("single-level"))
+  }
+
+  test("load() rejects null args") {
+    val response = buildResponse()
+    val client = new StubClient(response, "c", "s", "t")
+    intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("", Identifier.of(Array("s"), "t"), client)
+    }
+    intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("c", null, client)
+    }
+    intercept[IllegalArgumentException] {
+      DeltaRestTableLoader.load("c", Identifier.of(Array("s"), "t"), null)
+    }
+  }
+
+  test("buildV1Table handles null columns/properties/partition list gracefully") {
+    val md = new TableMetadata()
+      .etag("e")
+      .tableType(UCTableType.MANAGED)
+      .location("s3://b/p")
+    // columns, properties, partitionColumns left null
+    val response = new LoadTableResponse().metadata(md)
+
+    val v1 = DeltaRestTableLoader
+      .buildV1Table("cat", Identifier.of(Array("s"), "t"), response)
+    assert(v1.catalogTable.schema.fields.isEmpty)
+    assert(v1.catalogTable.partitionColumnNames.isEmpty)
+    assert(v1.catalogTable.properties(DeltaRestTableLoader.PROP_DRC_ETAG) === "e")
+  }
+
+  test("buildV1Table fails loudly when metadata block is absent") {
+    val response = new LoadTableResponse()
+    val ex = intercept[IllegalStateException] {
+      DeltaRestTableLoader
+        .buildV1Table("c", Identifier.of(Array("s"), "t"), response)
+    }
+    assert(ex.getMessage.contains("missing metadata"))
+  }
+
+  // Helpers
+  private def field(name: String, typeName: String): UCStructField = {
+    val f = new UCStructField().name(name).nullable(true)
+    val p = new UCPrimitiveType()
+    p.setType(typeName)
+    f.setType(p)
+    f
+  }
+
+  private def buildResponse(
+      etag: String = "etag-default",
+      tableUuid: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555"),
+      tableType: UCTableType = UCTableType.MANAGED,
+      location: String = "s3://b/p",
+      columns: Seq[UCStructField] = Nil,
+      properties: Map[String, String] = Map.empty,
+      partitionColumns: Seq[String] = Nil,
+      latestVersion: Long = 0L): LoadTableResponse = {
+    val columnsHolder = new UCStructType()
+    columnsHolder.setType("struct")
+    columnsHolder.setFields(JArr.asList(columns: _*))
+
+    val md = new TableMetadata()
+      .etag(etag)
+      .tableUuid(tableUuid)
+      .tableType(tableType)
+      .location(location)
+      .columns(columnsHolder)
+      .properties(properties.asJava)
+    md.setPartitionColumns(JArr.asList(partitionColumns: _*))
+
+    new LoadTableResponse()
+      .metadata(md)
+      .commits(JColl.emptyList())
+      .latestTableVersion(latestVersion)
+  }
+}
+
+/** Hand-rolled UCDeltaClient stub -- verifies call shape and returns a canned response. */
+private class StubClient(
+    response: LoadTableResponse,
+    expectedCatalog: String,
+    expectedSchema: String,
+    expectedTable: String) extends UCDeltaClient {
+  val calls = scala.collection.mutable.Buffer.empty[(String, String, String)]
+  override def loadTable(catalog: String, schema: String, table: String): LoadTableResponse = {
+    calls += ((catalog, schema, table))
+    assert(catalog == expectedCatalog)
+    assert(schema == expectedSchema)
+    assert(table == expectedTable)
+    response
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
@@ -24,6 +24,7 @@ import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
 import io.unitycatalog.client.delta.model.{
   CredentialOperation,
   CredentialsResponse,
+  DeltaCommit,
   LoadTableResponse,
   PrimitiveType => UCPrimitiveType,
   StorageCredential,
@@ -31,7 +32,8 @@ import io.unitycatalog.client.delta.model.{
   StructField => UCStructField,
   StructType => UCStructType,
   TableMetadata,
-  TableType => UCTableType
+  TableType => UCTableType,
+  TableUpdate
 }
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -334,5 +336,17 @@ private class StubClient(
     credCalls += ((catalog, schema, table, operation))
     credentialsError.foreach(throw _)
     credentials.getOrElse(new CredentialsResponse())
+  }
+
+  override def commit(
+      catalog: String,
+      schema: String,
+      table: String,
+      commit: DeltaCommit,
+      tableUuid: java.util.UUID,
+      etag: java.util.Optional[String],
+      metadataUpdates: java.util.List[TableUpdate]): LoadTableResponse = {
+    throw new UnsupportedOperationException(
+      "commit is exercised by UCDeltaRestClientCommitSuite, not this stub")
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestTableLoaderSuite.scala
@@ -22,8 +22,12 @@ import scala.collection.JavaConverters._
 
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient
 import io.unitycatalog.client.delta.model.{
+  CredentialOperation,
+  CredentialsResponse,
   LoadTableResponse,
   PrimitiveType => UCPrimitiveType,
+  StorageCredential,
+  StorageCredentialConfig,
   StructField => UCStructField,
   StructType => UCStructType,
   TableMetadata,
@@ -36,6 +40,8 @@ import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType}
 
 class DeltaRestTableLoaderSuite extends AnyFunSuite {
+
+  // ---- Core loadTable -> V1Table ----
 
   test("load() builds V1Table with schema, location, tableType, and DRC properties") {
     val uuid = UUID.fromString("00000000-0000-0000-0000-000000000abc")
@@ -137,7 +143,118 @@ class DeltaRestTableLoaderSuite extends AnyFunSuite {
     assert(ex.getMessage.contains("missing metadata"))
   }
 
-  // Helpers
+  // ---- Credential injection ----
+
+  test("load() injects matching vended credentials as io.unitycatalog.drc.cred.* props") {
+    val creds = buildCredentials(
+      prefix = "s3://bucket/path",
+      config = Map(
+        "s3.access-key-id" -> "AKIA",
+        "s3.secret-access-key" -> "secret",
+        "s3.session-token" -> "token"))
+    val response = buildResponse(
+      location = "s3://bucket/path/to/table",
+      columns = Seq(field("id", "long")))
+    val client = new StubClient(response, "unity", "default", "t",
+      credentials = Some(creds))
+    val v1 = DeltaRestTableLoader.load(
+      "unity", Identifier.of(Array("default"), "t"), client)
+    val props = v1.catalogTable.properties
+    assert(props("io.unitycatalog.drc.cred.s3.access-key-id") === "AKIA")
+    assert(props("io.unitycatalog.drc.cred.s3.secret-access-key") === "secret")
+    assert(props("io.unitycatalog.drc.cred.s3.session-token") === "token")
+    assert(client.credCalls ===
+      Seq(("unity", "default", "t", CredentialOperation.READ)))
+  }
+
+  test("load() filters out credentials whose prefix does not cover the table location") {
+    val creds = buildCredentials(
+      prefix = "s3://OTHER-BUCKET",
+      config = Map("s3.access-key-id" -> "nope"))
+    val response = buildResponse(
+      location = "s3://bucket/path/to/table",
+      columns = Seq(field("id", "long")))
+    val client = new StubClient(response, "c", "s", "t",
+      credentials = Some(creds))
+    val v1 = DeltaRestTableLoader.load("c", Identifier.of(Array("s"), "t"), client)
+    val props = v1.catalogTable.properties
+    assert(!props.contains("io.unitycatalog.drc.cred.s3.access-key-id"))
+  }
+
+  test("load() gracefully omits credentials when the creds endpoint errors") {
+    val response = buildResponse(
+      location = "s3://b/p",
+      columns = Seq(field("id", "long")))
+    val client = new StubClient(response, "c", "s", "t",
+      credentialsError = Some(new java.io.IOException("creds endpoint not implemented")))
+    val v1 = DeltaRestTableLoader.load("c", Identifier.of(Array("s"), "t"), client)
+    // DRC properties are still present -- load() did not fail the whole request.
+    assert(v1.catalogTable.properties.contains(DeltaRestTableLoader.PROP_DRC_ETAG))
+    // No cred props leaked.
+    assert(v1.catalogTable.properties.keys.forall(
+      !_.startsWith(DeltaRestTableLoader.PROP_DRC_CREDENTIAL_PREFIX)))
+  }
+
+  test("load() picks the longest-prefix credential when multiple credentials match") {
+    val broad = new StorageCredential()
+      .prefix("s3://bucket")
+      .operation(CredentialOperation.READ)
+    val broadCfg = new StorageCredentialConfig()
+    broadCfg.put("s3.access-key-id", "BROAD")
+    broad.setConfig(broadCfg)
+
+    val narrow = new StorageCredential()
+      .prefix("s3://bucket/tenant-a")
+      .operation(CredentialOperation.READ)
+    val narrowCfg = new StorageCredentialConfig()
+    narrowCfg.put("s3.access-key-id", "NARROW")
+    narrow.setConfig(narrowCfg)
+
+    val resp = new CredentialsResponse()
+      .storageCredentials(JArr.asList(broad, narrow))
+
+    val response = buildResponse(
+      location = "s3://bucket/tenant-a/some-table",
+      columns = Seq(field("id", "long")))
+    val client = new StubClient(response, "c", "s", "t", credentials = Some(resp))
+    val v1 = DeltaRestTableLoader.load("c", Identifier.of(Array("s"), "t"), client)
+    val ak = v1.catalogTable.properties("io.unitycatalog.drc.cred.s3.access-key-id")
+    assert(ak === "NARROW", "longest-prefix credential must win")
+  }
+
+  test("load() normalizes s3a:// scheme to s3:// for prefix matching") {
+    val cred = new StorageCredential()
+      .prefix("s3a://bucket/path")  // server uses s3a://
+      .operation(CredentialOperation.READ)
+    val cfg = new StorageCredentialConfig()
+    cfg.put("s3.access-key-id", "A")
+    cred.setConfig(cfg)
+
+    val resp = new CredentialsResponse().storageCredentials(JArr.asList(cred))
+    val response = buildResponse(
+      location = "s3://bucket/path/table",  // table location uses s3://
+      columns = Seq(field("id", "long")))
+    val client = new StubClient(response, "c", "s", "t", credentials = Some(resp))
+    val v1 = DeltaRestTableLoader.load("c", Identifier.of(Array("s"), "t"), client)
+    assert(v1.catalogTable.properties("io.unitycatalog.drc.cred.s3.access-key-id") === "A")
+  }
+
+  test("normalizeLocation strips trailing slash and collapses scheme aliases") {
+    assert(DeltaRestTableLoader.normalizeLocation(null) === "")
+    assert(DeltaRestTableLoader.normalizeLocation("") === "")
+    assert(DeltaRestTableLoader.normalizeLocation("s3://b/p/") === "s3://b/p")
+    assert(DeltaRestTableLoader.normalizeLocation("s3://b/p") === "s3://b/p")
+    assert(DeltaRestTableLoader.normalizeLocation("s3a://b/p") === "s3://b/p")
+    assert(DeltaRestTableLoader.normalizeLocation("s3n://b/p") === "s3://b/p")
+    assert(DeltaRestTableLoader.normalizeLocation(
+      "abfss://c@a.dfs.core.windows.net/p") ===
+      "abfs://c@a.dfs.core.windows.net/p")
+    assert(DeltaRestTableLoader.normalizeLocation("S3://Bucket/Path") ===
+      "s3://Bucket/Path", "scheme is lower-cased, path is preserved")
+  }
+
+  // ---- Helpers ----
+
   private def field(name: String, typeName: String): UCStructField = {
     val f = new UCStructField().name(name).nullable(true)
     val p = new UCPrimitiveType()
@@ -173,6 +290,19 @@ class DeltaRestTableLoaderSuite extends AnyFunSuite {
       .commits(JColl.emptyList())
       .latestTableVersion(latestVersion)
   }
+
+  private def buildCredentials(
+      prefix: String,
+      config: Map[String, String]): CredentialsResponse = {
+    val cfg = new StorageCredentialConfig()
+    config.foreach { case (k, v) => cfg.put(k, v) }
+    val sc = new StorageCredential()
+      .prefix(prefix)
+      .operation(CredentialOperation.READ)
+      .config(cfg)
+    new CredentialsResponse()
+      .storageCredentials(JColl.singletonList(sc))
+  }
 }
 
 /** Hand-rolled UCDeltaClient stub -- verifies call shape and returns a canned response. */
@@ -180,13 +310,29 @@ private class StubClient(
     response: LoadTableResponse,
     expectedCatalog: String,
     expectedSchema: String,
-    expectedTable: String) extends UCDeltaClient {
+    expectedTable: String,
+    credentials: Option[CredentialsResponse] = None,
+    credentialsError: Option[java.io.IOException] = None) extends UCDeltaClient {
   val calls = scala.collection.mutable.Buffer.empty[(String, String, String)]
-  override def loadTable(catalog: String, schema: String, table: String): LoadTableResponse = {
+  val credCalls = scala.collection.mutable.Buffer
+    .empty[(String, String, String, CredentialOperation)]
+
+  override def loadTable(
+      catalog: String, schema: String, table: String): LoadTableResponse = {
     calls += ((catalog, schema, table))
     assert(catalog == expectedCatalog)
     assert(schema == expectedSchema)
     assert(table == expectedTable)
     response
+  }
+
+  override def getTableCredentials(
+      catalog: String,
+      schema: String,
+      table: String,
+      operation: CredentialOperation): CredentialsResponse = {
+    credCalls += ((catalog, schema, table, operation))
+    credentialsError.foreach(throw _)
+    credentials.getOrElse(new CredentialsResponse())
   }
 }

--- a/storage/src/main/java/io/delta/storage/annotation/Unstable.java
+++ b/storage/src/main/java/io/delta/storage/annotation/Unstable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.storage.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker for APIs in {@code delta-storage} that are not yet stable. Method signatures and class
+ * shapes may change in any minor release until the API graduates. External consumers of a
+ * {@code @Unstable}-annotated type must pin exact Delta versions.
+ *
+ * <p>Storage cannot depend on {@code org.apache.spark.annotation.Unstable} because the module
+ * forbids a Spark dependency (it must remain usable by non-Spark engines like Flink and Kernel).
+ * This annotation plays the same role within the storage module and is surfaced in generated
+ * Javadoc via {@code @Documented}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.FIELD,
+    ElementType.CONSTRUCTOR,
+    ElementType.PACKAGE
+})
+public @interface Unstable {}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DeltaRestMetadataDiff.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DeltaRestMetadataDiff.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.annotation.Unstable;
+import io.unitycatalog.client.delta.model.DeltaProtocol;
+import io.unitycatalog.client.delta.model.RemovePropertiesUpdate;
+import io.unitycatalog.client.delta.model.SetPartitionColumnsUpdate;
+import io.unitycatalog.client.delta.model.SetPropertiesUpdate;
+import io.unitycatalog.client.delta.model.SetProtocolUpdate;
+import io.unitycatalog.client.delta.model.SetSchemaUpdate;
+import io.unitycatalog.client.delta.model.StructType;
+import io.unitycatalog.client.delta.model.TableUpdate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Computes {@link TableUpdate}s from old/new metadata snapshots for the DRC commit path.
+ *
+ * <p>The DRC wire format distinguishes <b>intent-based</b> updates (properties -- changed keys
+ * only) from <b>full-replacement</b> updates (protocol, schema, partition columns). Intent-based
+ * means the wire carries only what changed; full-replacement carries the entire new value and
+ * relies on {@code AssertEtag} (when attached by the caller) to guard against concurrent writes.
+ *
+ * <p>Pure function; no I/O. Inputs are UC SDK POJOs -- callers in the spark module use the
+ * reverse {@code DeltaRestSchemaConverter} to turn a Spark {@code StructType} into the UC
+ * {@code StructType} expected by {@link #columnsUpdate}.
+ */
+@Unstable
+public final class DeltaRestMetadataDiff {
+
+  private DeltaRestMetadataDiff() {}
+
+  /**
+   * Intent-based diff of two property maps. Returns 0, 1, or 2 updates:
+   * <ul>
+   *   <li>A {@link SetPropertiesUpdate} for keys whose value is present in {@code newProps} and
+   *       either absent from {@code oldProps} or differs in value;</li>
+   *   <li>A {@link RemovePropertiesUpdate} for keys present in {@code oldProps} but missing
+   *       from {@code newProps};</li>
+   *   <li>Unchanged keys contribute nothing.</li>
+   * </ul>
+   *
+   * <p>Uses {@code containsKey} so "key added with explicit null value" is distinguished from
+   * "unchanged key". A null input map is treated as an empty map.
+   */
+  public static List<TableUpdate> propertyUpdates(
+      Map<String, String> oldProps,
+      Map<String, String> newProps) {
+    Map<String, String> oldSafe = oldProps == null ? Collections.emptyMap() : oldProps;
+    Map<String, String> newSafe = newProps == null ? Collections.emptyMap() : newProps;
+
+    Map<String, String> upserts = new HashMap<>();
+    for (Map.Entry<String, String> e : newSafe.entrySet()) {
+      boolean oldHasKey = oldSafe.containsKey(e.getKey());
+      String oldVal = oldSafe.get(e.getKey());
+      if (!oldHasKey || !Objects.equals(oldVal, e.getValue())) {
+        upserts.put(e.getKey(), e.getValue());
+      }
+    }
+    Set<String> removals = new LinkedHashSet<>();
+    for (String k : oldSafe.keySet()) {
+      if (!newSafe.containsKey(k)) {
+        removals.add(k);
+      }
+    }
+
+    List<TableUpdate> out = new ArrayList<>();
+    if (!upserts.isEmpty()) {
+      out.add(new SetPropertiesUpdate().updates(upserts));
+    }
+    if (!removals.isEmpty()) {
+      out.add(new RemovePropertiesUpdate().removals(new ArrayList<>(removals)));
+    }
+    return out;
+  }
+
+  /**
+   * Full-replacement diff for protocol. Returns a {@link SetProtocolUpdate} with the new
+   * protocol if {@code oldProtocol} is absent or differs from {@code newProtocol}, otherwise
+   * {@link Optional#empty()}. Equality uses {@link DeltaProtocol#equals}.
+   */
+  public static Optional<TableUpdate> protocolUpdate(
+      Optional<DeltaProtocol> oldProtocol,
+      DeltaProtocol newProtocol) {
+    Objects.requireNonNull(newProtocol, "newProtocol must not be null");
+    Objects.requireNonNull(oldProtocol, "oldProtocol Optional must not be null");
+    if (oldProtocol.isPresent() && oldProtocol.get().equals(newProtocol)) {
+      return Optional.empty();
+    }
+    TableUpdate u = new SetProtocolUpdate().protocol(newProtocol);
+    return Optional.of(u);
+  }
+
+  /**
+   * Full-replacement diff for schema. Returns a {@link SetSchemaUpdate} with the new columns
+   * when {@code oldColumns} is absent or differs from {@code newColumns}, otherwise
+   * {@link Optional#empty()}. Equality uses {@link StructType#equals} which recurses through
+   * nested fields (the UC model's generated equals).
+   */
+  public static Optional<TableUpdate> columnsUpdate(
+      Optional<StructType> oldColumns,
+      StructType newColumns) {
+    Objects.requireNonNull(newColumns, "newColumns must not be null");
+    Objects.requireNonNull(oldColumns, "oldColumns Optional must not be null");
+    if (oldColumns.isPresent() && oldColumns.get().equals(newColumns)) {
+      return Optional.empty();
+    }
+    TableUpdate u = new SetSchemaUpdate().columns(newColumns);
+    return Optional.of(u);
+  }
+
+  /**
+   * Full-replacement diff for partition columns. Returns a {@link SetPartitionColumnsUpdate}
+   * with the new list when it differs from {@code oldPartitionColumns}, otherwise
+   * {@link Optional#empty()}. A null input list is treated as an empty list; order of columns
+   * is significant (partition order affects on-disk layout).
+   */
+  public static Optional<TableUpdate> partitionColumnsUpdate(
+      Optional<List<String>> oldPartitionColumns,
+      List<String> newPartitionColumns) {
+    Objects.requireNonNull(oldPartitionColumns,
+        "oldPartitionColumns Optional must not be null");
+    List<String> newSafe = newPartitionColumns == null
+        ? Collections.emptyList()
+        : newPartitionColumns;
+    List<String> oldSafe = oldPartitionColumns.orElse(Collections.emptyList());
+    if (oldPartitionColumns.isPresent() && oldSafe.equals(newSafe)) {
+      return Optional.empty();
+    }
+    TableUpdate u = new SetPartitionColumnsUpdate().partitionColumns(newSafe);
+    return Optional.of(u);
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -38,6 +38,10 @@ import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
 import io.delta.storage.internal.FileNameUtils;
 import io.delta.storage.internal.LogStoreErrors;
+import io.unitycatalog.client.delta.model.DeltaCommit;
+import io.unitycatalog.client.delta.model.DeltaProtocol;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.TableUpdate;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -51,9 +55,32 @@ import org.slf4j.LoggerFactory;
  */
 public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
   public UCCommitCoordinatorClient(Map<String, String> conf, UCClient ucClient) {
+    this(conf, ucClient, Optional.empty());
+  }
+
+  /**
+   * Constructor with an optional {@link UCDeltaClient}. When present, commits for tables that
+   * were loaded via DRC (tableConf carries the DRC catalog/schema/table markers) are routed to
+   * {@link UCDeltaClient#commit} instead of the legacy {@link UCClient#commit} path.
+   */
+  public UCCommitCoordinatorClient(
+      Map<String, String> conf,
+      UCClient ucClient,
+      Optional<UCDeltaClient> ucDeltaClient) {
     this.conf = conf;
     this.ucClient = ucClient;
+    this.ucDeltaClient = ucDeltaClient;
   }
+
+  /**
+   * Tableconf markers written by {@code DeltaRestTableLoader} during loadTable; reading them
+   * here is how the commit coordinator routes a commit to DRC vs the legacy UC API without
+   * a second catalog lookup. All three must be present for DRC routing to kick in.
+   */
+  public static final String DRC_CATALOG_KEY = "io.unitycatalog.drc.catalog";
+  public static final String DRC_SCHEMA_KEY = "io.unitycatalog.drc.schema";
+  public static final String DRC_TABLE_KEY = "io.unitycatalog.drc.table";
+  public static final String DRC_ETAG_KEY = "io.unitycatalog.drc.etag";
 
   /**
    * Logger for UCCommitCoordinatorClient class operations and diagnostics.
@@ -146,6 +173,15 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
   /** Unity Catalog client instance for interacting with UC services. */
   public final UCClient ucClient;
 
+  /**
+   * Delta REST Catalog client; present only when the catalog plugin backing this coordinator
+   * is a DRC-enabled {@code DeltaRestClientProvider}. Commits for tables that carry DRC
+   * tableConf markers route through this client; all other commits fall through to
+   * {@link #ucClient}. Owned by the provider (the ApiClient lifecycle is the provider's
+   * responsibility) -- this class must NOT close it.
+   */
+  public final Optional<UCDeltaClient> ucDeltaClient;
+
   /** Configuration map containing settings for the coordinator client. */
   public final Map<String, String> conf;
 
@@ -165,6 +201,156 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       throw new IllegalStateException("UC Table ID not found in " + tableConf);
     }
     return tableConf.get(UC_TABLE_ID_KEY);
+  }
+
+  /**
+   * Returns true iff this coordinator has a DRC client AND the table was loaded via DRC
+   * (tableConf carries the DRC catalog/schema/table markers written by DeltaRestTableLoader).
+   * If any of the three markers is missing or empty, the table falls through to the legacy
+   * UC commit path.
+   *
+   * Package-private for testing.
+   */
+  boolean isDRCTable(TableDescriptor tableDesc) {
+    if (!ucDeltaClient.isPresent()) return false;
+    Map<String, String> tableConf = tableDesc.getTableConf();
+    String catalog = tableConf.get(DRC_CATALOG_KEY);
+    String schema = tableConf.get(DRC_SCHEMA_KEY);
+    String table = tableConf.get(DRC_TABLE_KEY);
+    return catalog != null && !catalog.isEmpty()
+        && schema != null && !schema.isEmpty()
+        && table != null && !table.isEmpty();
+  }
+
+  /**
+   * DRC commit flow: writes the staged commit file, builds the {@link DeltaCommit},
+   * synthesizes metadata-update diffs that the storage module can compute without Spark
+   * types (property + protocol), and calls {@link UCDeltaClient#commit}. Schema and
+   * partition-column diffs require a Spark-side reverse converter and are threaded through
+   * via the {@code catalogTrackedInfo} plumbing in a separate PR against the
+   * OptimisticTransaction.
+   *
+   * <p>The resulting {@link CommitResponse} has the same shape as the legacy path; the DRC
+   * {@code LoadTableResponse}'s refreshed etag is discarded in v1 (etag is optional per
+   * clarifications §3; Epic 7 hardens this).
+   */
+  protected CommitResponse commitViaDRC(
+      LogStore logStore,
+      Configuration hadoopConf,
+      TableDescriptor tableDesc,
+      long commitVersion,
+      Iterator<String> actions,
+      UpdatedActions updatedActions) throws CommitFailedException {
+    Path logPath = tableDesc.getLogPath();
+    if (commitVersion == 0) {
+      throw new CommitFailedException(
+          false /* retryable */,
+          false /* conflict */,
+          "Commit version 0 must go via filesystem.");
+    }
+    Map<String, String> tableConf = tableDesc.getTableConf();
+    String tableId = extractUCTableId(tableDesc);
+    String catalog = tableConf.get(DRC_CATALOG_KEY);
+    String schema = tableConf.get(DRC_SCHEMA_KEY);
+    String table = tableConf.get(DRC_TABLE_KEY);
+    String etagRaw = tableConf.get(DRC_ETAG_KEY);
+    Optional<String> etag = (etagRaw != null && !etagRaw.isEmpty())
+        ? Optional.of(etagRaw) : Optional.empty();
+    UUID tableUuid;
+    try {
+      tableUuid = UUID.fromString(tableId);
+    } catch (IllegalArgumentException e) {
+      throw new CommitFailedException(
+          false /* retryable */,
+          false /* conflict */,
+          "DRC commit: table ID in tableConf is not a valid UUID: " + tableId,
+          e);
+    }
+
+    // Write the staged commit file first so its (fileName, fileSize, fileModTime) are known.
+    FileStatus commitFile;
+    try {
+      commitFile = CoordinatedCommitsUtils.writeUnbackfilledCommitFile(
+          logStore,
+          hadoopConf,
+          logPath.toString(),
+          commitVersion,
+          actions,
+          UUID.randomUUID().toString());
+    } catch (IOException e) {
+      throw new CommitFailedException(
+          true /* retryable */,
+          false /* conflict */,
+          "DRC commit: failed to write commit file: " + e.getMessage(),
+          e);
+    }
+    long commitTimestamp = updatedActions.getCommitInfo().getCommitTimestamp();
+
+    DeltaCommit deltaCommit = new DeltaCommit()
+        .version(commitVersion)
+        .timestamp(commitTimestamp)
+        .fileName(commitFile.getPath().getName())
+        .fileSize(commitFile.getLen())
+        .fileModificationTimestamp(commitFile.getModificationTime());
+
+    // Property + protocol diffs: computed purely from storage-level types.
+    // Schema + partition-column diffs require Spark types and are NOT emitted by the storage
+    // commit coordinator; OptimisticTransaction emits them separately on top of this commit
+    // via the catalog catalog-managed path (tracked in a follow-on PR).
+    List<TableUpdate> metadataUpdates = new ArrayList<>();
+    AbstractMetadata oldMeta = updatedActions.getOldMetadata();
+    AbstractMetadata newMeta = updatedActions.getNewMetadata();
+    if (oldMeta != newMeta) {
+      metadataUpdates.addAll(DeltaRestMetadataDiff.propertyUpdates(
+          oldMeta == null ? null : oldMeta.getConfiguration(),
+          newMeta == null ? null : newMeta.getConfiguration()));
+    }
+    AbstractProtocol oldProto = updatedActions.getOldProtocol();
+    AbstractProtocol newProto = updatedActions.getNewProtocol();
+    if (oldProto != newProto && newProto != null) {
+      DeltaRestMetadataDiff.protocolUpdate(
+              Optional.ofNullable(oldProto).map(UCCommitCoordinatorClient::toDRCProtocol),
+              toDRCProtocol(newProto))
+          .ifPresent(metadataUpdates::add);
+    }
+
+    LOG.info("DRC commit: {}.{}.{} version={} tableId={} updates={}",
+        catalog, schema, table, commitVersion, tableId, metadataUpdates.size());
+
+    try {
+      LoadTableResponse resp = ucDeltaClient.get().commit(
+          catalog, schema, table, deltaCommit, tableUuid, etag, metadataUpdates);
+      // Best-effort: log the refreshed etag so operators can observe advancement even though
+      // we don't currently plumb it back into SnapshotManagement.
+      if (resp != null && resp.getMetadata() != null && resp.getMetadata().getEtag() != null) {
+        LOG.debug("DRC commit refreshed etag for {}.{}.{}: {}",
+            catalog, schema, table, resp.getMetadata().getEtag());
+      }
+    } catch (IOException e) {
+      throw new CommitFailedException(
+          true /* retryable */,
+          false /* conflict */,
+          "DRC commit failed: " + e.getMessage(),
+          e);
+    }
+    return new CommitResponse(new Commit(commitVersion, commitFile, commitTimestamp));
+  }
+
+  /**
+   * Translates Delta's storage-level {@link AbstractProtocol} into the UC DRC
+   * {@link DeltaProtocol} POJO. The field shapes align 1:1.
+   */
+  private static DeltaProtocol toDRCProtocol(AbstractProtocol proto) {
+    DeltaProtocol out = new DeltaProtocol()
+        .minReaderVersion(proto.getMinReaderVersion())
+        .minWriterVersion(proto.getMinWriterVersion());
+    if (proto.getReaderFeatures() != null) {
+      out.readerFeatures(new ArrayList<>(proto.getReaderFeatures()));
+    }
+    if (proto.getWriterFeatures() != null) {
+      out.writerFeatures(new ArrayList<>(proto.getWriterFeatures()));
+    }
+    return out;
   }
 
   /**
@@ -336,6 +522,13 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Iterator<String> actions,
       CatalogTrackedInfo catalogTrackedInfo,
       UpdatedActions updatedActions) throws CommitFailedException {
+    // DRC branch: when a UCDeltaClient is available and the table's tableConf carries the
+    // DRC markers written by DeltaRestTableLoader, route the commit to the DRC endpoint
+    // POST /v1/catalogs/.../tables/{name} instead of the legacy UC commit path.
+    if (isDRCTable(tableDesc)) {
+      return commitViaDRC(
+          logStore, hadoopConf, tableDesc, commitVersion, actions, updatedActions);
+    }
     Path logPath = tableDesc.getLogPath();
     Map<String, String> coordinatedCommitsTableConf = tableDesc.getTableConf();
     checkVersionSupported(coordinatedCommitsTableConf, false /* compareRead */);

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -17,6 +17,8 @@
 package io.delta.storage.commit.uccommitcoordinator;
 
 import io.delta.storage.annotation.Unstable;
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.CredentialsResponse;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
 
 import java.io.IOException;
@@ -55,4 +57,29 @@ public interface UCDeltaClient {
    * @throws IOException on network error or a non-success HTTP response from the server
    */
   LoadTableResponse loadTable(String catalog, String schema, String table) throws IOException;
+
+  /**
+   * Vends temporary cloud-storage credentials for a table via DRC
+   * {@code GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials}.
+   *
+   * <p>The returned {@link CredentialsResponse#getStorageCredentials() storage-credentials} list
+   * carries one or more {@link io.unitycatalog.client.delta.model.StorageCredential} entries,
+   * each keyed by a storage path prefix and operation scope. Callers pick the most specific
+   * credential (longest-matching prefix) and inject its config into per-query Hadoop/Spark
+   * properties -- never into the session-global config, so concurrent queries with different
+   * principals do not clobber each other.
+   *
+   * @param catalog catalog name
+   * @param schema schema name
+   * @param table table name
+   * @param operation {@link CredentialOperation#READ} for queries, {@link
+   *     CredentialOperation#READ_WRITE} for writes
+   * @return the credentials response
+   * @throws IOException on network error or a non-success HTTP response
+   */
+  CredentialsResponse getTableCredentials(
+      String catalog,
+      String schema,
+      String table,
+      CredentialOperation operation) throws IOException;
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.annotation.Unstable;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+
+import java.io.IOException;
+
+/**
+ * Client interface for the Unity Catalog Delta REST Catalog (DRC) API. The DRC endpoints live
+ * under {@code /api/2.1/unity-catalog/delta/v1/...} on the UC server and expose Delta-native
+ * metadata (structured protocol, Delta {@code StructType} columns, domain metadata) without the
+ * JSON-roundtrip overhead of the legacy UC API.
+ *
+ * <p>Implementations wrap the UC SDK's {@code io.unitycatalog.client.delta.api.TablesApi} and
+ * share the {@link io.unitycatalog.client.ApiClient} owned by a UC catalog plugin -- the client
+ * does not own that {@code ApiClient} and must not close it.
+ *
+ * <p>The interface grows one method per PR in the DRC rollout; callers should not assume
+ * unsupported methods are merely unimplemented.
+ */
+@Unstable
+public interface UCDeltaClient {
+
+  /**
+   * Loads a table via the DRC
+   * {@code GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}} endpoint.
+   *
+   * <p>The response carries {@link LoadTableResponse#getMetadata() metadata}
+   * (schema as UC {@code StructField} POJOs, structured protocol, properties, etag),
+   * {@link LoadTableResponse#getCommits() unbackfilled commits}, and
+   * {@link LoadTableResponse#getLatestTableVersion() latest-table-version}. The UC
+   * {@code StructField} list is converted to a Spark {@code StructType} by
+   * {@code DeltaRestSchemaConverter} in the delta-spark module.
+   *
+   * @param catalog catalog name
+   * @param schema schema name
+   * @param table table name (relative to the parent schema)
+   * @return the DRC load-table response
+   * @throws IOException on network error or a non-success HTTP response from the server
+   */
+  LoadTableResponse loadTable(String catalog, String schema, String table) throws IOException;
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -19,9 +19,14 @@ package io.delta.storage.commit.uccommitcoordinator;
 import io.delta.storage.annotation.Unstable;
 import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.delta.model.CredentialsResponse;
+import io.unitycatalog.client.delta.model.DeltaCommit;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.TableUpdate;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Client interface for the Unity Catalog Delta REST Catalog (DRC) API. The DRC endpoints live
@@ -82,4 +87,45 @@ public interface UCDeltaClient {
       String schema,
       String table,
       CredentialOperation operation) throws IOException;
+
+  /**
+   * Submits a CCv2 commit via DRC
+   * {@code POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}}.
+   *
+   * <p>The request body carries:
+   * <ul>
+   *   <li>{@code requirements}: always an {@code AssertTableUUID} with {@code tableUuid}, and
+   *       an {@code AssertEtag} when {@code etag.isPresent()}; etag is optional in v1 per the
+   *       Apr-17 clarifications and the concurrency gap is a known tradeoff until Epic 7;</li>
+   *   <li>{@code updates}: a single {@code AddCommitUpdate} wrapping {@link DeltaCommit},
+   *       followed by the caller-supplied {@code metadataUpdates} in order. The
+   *       {@code AddCommitUpdate} always comes first so the server processes the commit before
+   *       applying the metadata mutations within the same atomic RPC.</li>
+   * </ul>
+   *
+   * <p>{@link DeltaRestMetadataDiff} produces the {@code metadataUpdates} list from old/new
+   * metadata, protocol, schema, and partition-column snapshots. Pass
+   * {@link java.util.Collections#emptyList()} for a pure data commit.
+   *
+   * @param catalog catalog name
+   * @param schema schema name
+   * @param table table name
+   * @param commit the Delta commit to append
+   * @param tableUuid table UUID from an earlier {@link #loadTable}; used as the
+   *     {@code AssertTableUUID} requirement
+   * @param etag optional etag from an earlier load; when present the server rejects the commit
+   *     if the table's etag has advanced between load and commit
+   * @param metadataUpdates additional {@code TableUpdate}s to include in the same request
+   * @return the DRC update-table response carrying the refreshed metadata and etag
+   * @throws IOException on network error, HTTP non-success, or UC rejection (etag or UUID
+   *     mismatch, rate limit, resource exhaustion, etc.)
+   */
+  LoadTableResponse commit(
+      String catalog,
+      String schema,
+      String table,
+      DeltaCommit commit,
+      UUID tableUuid,
+      Optional<String> etag,
+      List<TableUpdate> metadataUpdates) throws IOException;
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.annotation.Unstable;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HTTP implementation of {@link UCDeltaClient} backed by the UC SDK's Delta REST Catalog
+ * {@code TablesApi}.
+ *
+ * <p>The {@link ApiClient} is shared -- it is owned by the UC catalog plugin (via the UC-side
+ * {@code DeltaRestClientProvider}) and supplies the HTTP connection pool, auth refresh cycle,
+ * and telemetry headers. This class does not own the {@code ApiClient} and must not close it.
+ */
+@Unstable
+public class UCDeltaRestClient implements UCDeltaClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UCDeltaRestClient.class);
+
+  private final TablesApi tablesApi;
+
+  /**
+   * Constructs a client wrapping a shared {@link ApiClient}. The caller (typically
+   * {@code AbstractDeltaCatalog.loadTable}) builds this only on the DRC path, i.e. when the
+   * UC-side {@code DeltaRestClientProvider.getDeltaTablesApi()} returned a present
+   * {@code Optional}. The apiClient is not closed by this class.
+   */
+  public UCDeltaRestClient(ApiClient apiClient) {
+    Objects.requireNonNull(apiClient, "apiClient must not be null");
+    this.tablesApi = new TablesApi(apiClient);
+    // Load-bearing invariant: this class does not own the ApiClient. A leak of the shared
+    // HTTP pool is the single worst failure mode here; this log exists so that mystery
+    // leaks can be triaged by matching identity hashes across the lifetime of the JVM.
+    LOG.info("UCDeltaRestClient bound to shared ApiClient (identityHash={}) at baseUri={}",
+        System.identityHashCode(apiClient), apiClient.getBaseUri());
+  }
+
+  @Override
+  public LoadTableResponse loadTable(String catalog, String schema, String table)
+      throws IOException {
+    Objects.requireNonNull(catalog, "catalog must not be null");
+    Objects.requireNonNull(schema, "schema must not be null");
+    Objects.requireNonNull(table, "table must not be null");
+    try {
+      return tablesApi.loadTable(catalog, schema, table);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format(
+              "Failed to load DRC table %s.%s.%s (HTTP %d): %s",
+              catalog, schema, table, e.getCode(), e.getResponseBody()),
+          e);
+    }
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
@@ -21,12 +21,23 @@ import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.delta.api.TablesApi;
 import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.AddCommitUpdate;
+import io.unitycatalog.client.delta.model.AssertEtag;
+import io.unitycatalog.client.delta.model.AssertTableUUID;
 import io.unitycatalog.client.delta.model.CredentialOperation;
 import io.unitycatalog.client.delta.model.CredentialsResponse;
+import io.unitycatalog.client.delta.model.DeltaCommit;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.TableRequirement;
+import io.unitycatalog.client.delta.model.TableUpdate;
+import io.unitycatalog.client.delta.model.UpdateTableRequest;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,5 +111,60 @@ public class UCDeltaRestClient implements UCDeltaClient {
               catalog, schema, table, operation, e.getCode(), e.getResponseBody()),
           e);
     }
+  }
+
+  @Override
+  public LoadTableResponse commit(
+      String catalog,
+      String schema,
+      String table,
+      DeltaCommit commit,
+      UUID tableUuid,
+      Optional<String> etag,
+      List<TableUpdate> metadataUpdates) throws IOException {
+    Objects.requireNonNull(catalog, "catalog must not be null");
+    Objects.requireNonNull(schema, "schema must not be null");
+    Objects.requireNonNull(table, "table must not be null");
+    Objects.requireNonNull(commit, "commit must not be null");
+    Objects.requireNonNull(tableUuid, "tableUuid must not be null");
+    Objects.requireNonNull(etag, "etag Optional must not be null (use Optional.empty())");
+    Objects.requireNonNull(metadataUpdates, "metadataUpdates must not be null (use empty list)");
+
+    UpdateTableRequest request = buildCommitRequest(commit, tableUuid, etag, metadataUpdates);
+    try {
+      return tablesApi.updateTable(catalog, schema, table, request);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format(
+              "DRC commit failed for %s.%s.%s (HTTP %d): %s",
+              catalog, schema, table, e.getCode(), e.getResponseBody()),
+          e);
+    }
+  }
+
+  /**
+   * Package-private for tests: assembles the {@link UpdateTableRequest} body used by
+   * {@link #commit}. Exposed separately so tests can assert {@code requirements} and
+   * {@code updates} list composition without standing up an HTTP server.
+   */
+  static UpdateTableRequest buildCommitRequest(
+      DeltaCommit commit,
+      UUID tableUuid,
+      Optional<String> etag,
+      List<TableUpdate> metadataUpdates) {
+    Objects.requireNonNull(commit, "commit must not be null");
+    Objects.requireNonNull(tableUuid, "tableUuid must not be null");
+    Objects.requireNonNull(etag, "etag Optional must not be null (use Optional.empty())");
+    Objects.requireNonNull(metadataUpdates, "metadataUpdates must not be null (use empty list)");
+
+    List<TableRequirement> requirements = new ArrayList<>();
+    requirements.add(new AssertTableUUID().uuid(tableUuid));
+    etag.ifPresent(e -> requirements.add(new AssertEtag().etag(e)));
+
+    List<TableUpdate> updates = new ArrayList<>();
+    updates.add(new AddCommitUpdate().commit(commit));
+    updates.addAll(metadataUpdates);
+
+    return new UpdateTableRequest().requirements(requirements).updates(updates);
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClient.java
@@ -20,6 +20,9 @@ import io.delta.storage.annotation.Unstable;
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.api.TemporaryCredentialsApi;
+import io.unitycatalog.client.delta.model.CredentialOperation;
+import io.unitycatalog.client.delta.model.CredentialsResponse;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
 
 import java.io.IOException;
@@ -42,6 +45,7 @@ public class UCDeltaRestClient implements UCDeltaClient {
   private static final Logger LOG = LoggerFactory.getLogger(UCDeltaRestClient.class);
 
   private final TablesApi tablesApi;
+  private final TemporaryCredentialsApi credentialsApi;
 
   /**
    * Constructs a client wrapping a shared {@link ApiClient}. The caller (typically
@@ -52,6 +56,7 @@ public class UCDeltaRestClient implements UCDeltaClient {
   public UCDeltaRestClient(ApiClient apiClient) {
     Objects.requireNonNull(apiClient, "apiClient must not be null");
     this.tablesApi = new TablesApi(apiClient);
+    this.credentialsApi = new TemporaryCredentialsApi(apiClient);
     // Load-bearing invariant: this class does not own the ApiClient. A leak of the shared
     // HTTP pool is the single worst failure mode here; this log exists so that mystery
     // leaks can be triaged by matching identity hashes across the lifetime of the JVM.
@@ -72,6 +77,27 @@ public class UCDeltaRestClient implements UCDeltaClient {
           String.format(
               "Failed to load DRC table %s.%s.%s (HTTP %d): %s",
               catalog, schema, table, e.getCode(), e.getResponseBody()),
+          e);
+    }
+  }
+
+  @Override
+  public CredentialsResponse getTableCredentials(
+      String catalog,
+      String schema,
+      String table,
+      CredentialOperation operation) throws IOException {
+    Objects.requireNonNull(catalog, "catalog must not be null");
+    Objects.requireNonNull(schema, "schema must not be null");
+    Objects.requireNonNull(table, "table must not be null");
+    Objects.requireNonNull(operation, "operation must not be null");
+    try {
+      return credentialsApi.getTableCredentials(operation, catalog, schema, table);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format(
+              "Failed to fetch DRC credentials for %s.%s.%s op=%s (HTTP %d): %s",
+              catalog, schema, table, operation, e.getCode(), e.getResponseBody()),
           e);
     }
   }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/DeltaRestMetadataDiffSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/DeltaRestMetadataDiffSuite.scala
@@ -1,0 +1,221 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.util.{Arrays => JArr, Collections => JColl, Optional}
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  DeltaProtocol,
+  PrimitiveType => UCPrimitiveType,
+  RemovePropertiesUpdate,
+  SetPartitionColumnsUpdate,
+  SetPropertiesUpdate,
+  SetProtocolUpdate,
+  SetSchemaUpdate,
+  StructField => UCStructField,
+  StructType => UCStructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+class DeltaRestMetadataDiffSuite extends AnyFunSuite {
+
+  // ---- propertyUpdates ----
+
+  test("propertyUpdates: identical maps produce no updates") {
+    val m = Map("k" -> "v", "a" -> "b").asJava
+    val out = DeltaRestMetadataDiff.propertyUpdates(m, m).asScala
+    assert(out.isEmpty)
+  }
+
+  test("propertyUpdates: null inputs behave as empty maps") {
+    assert(DeltaRestMetadataDiff.propertyUpdates(null, null).isEmpty)
+    val m = JColl.singletonMap("k", "v")
+    val addedOnly = DeltaRestMetadataDiff.propertyUpdates(null, m).asScala
+    assert(addedOnly.length == 1)
+    assert(addedOnly.head.isInstanceOf[SetPropertiesUpdate])
+    val removedOnly = DeltaRestMetadataDiff.propertyUpdates(m, null).asScala
+    assert(removedOnly.length == 1)
+    assert(removedOnly.head.isInstanceOf[RemovePropertiesUpdate])
+  }
+
+  test("propertyUpdates emits SetPropertiesUpdate with only changed keys") {
+    val oldProps = Map("a" -> "1", "b" -> "2").asJava
+    val newProps = Map("a" -> "1", "b" -> "99", "c" -> "3").asJava
+    val out = DeltaRestMetadataDiff.propertyUpdates(oldProps, newProps).asScala
+    assert(out.length == 1)
+    val sp = out.head.asInstanceOf[SetPropertiesUpdate]
+    val upserts = sp.getUpdates.asScala.toMap
+    assert(upserts == Map("b" -> "99", "c" -> "3"))
+    assert(!upserts.contains("a"))
+  }
+
+  test("propertyUpdates emits RemovePropertiesUpdate with only removed keys") {
+    val oldProps = Map("keep" -> "1", "drop1" -> "2", "drop2" -> "3").asJava
+    val newProps = Map("keep" -> "1").asJava
+    val out = DeltaRestMetadataDiff.propertyUpdates(oldProps, newProps).asScala
+    assert(out.length == 1)
+    val rp = out.head.asInstanceOf[RemovePropertiesUpdate]
+    val removed = rp.getRemovals.asScala.toSet
+    assert(removed == Set("drop1", "drop2"))
+  }
+
+  test("propertyUpdates emits both Set and Remove when both apply, Set first") {
+    val oldProps = Map("a" -> "1", "b" -> "2").asJava
+    val newProps = Map("a" -> "CHANGED", "c" -> "3").asJava
+    val out = DeltaRestMetadataDiff.propertyUpdates(oldProps, newProps).asScala
+    assert(out.length == 2)
+    assert(out(0).isInstanceOf[SetPropertiesUpdate])
+    assert(out(1).isInstanceOf[RemovePropertiesUpdate])
+    val sp = out(0).asInstanceOf[SetPropertiesUpdate]
+    assert(sp.getUpdates.asScala.toMap == Map("a" -> "CHANGED", "c" -> "3"))
+    val rp = out(1).asInstanceOf[RemovePropertiesUpdate]
+    assert(rp.getRemovals.asScala.toSet == Set("b"))
+  }
+
+  test("propertyUpdates: null value vs absent key are distinct") {
+    val oldProps = Map.empty[String, String].asJava
+    val withNull = new java.util.HashMap[String, String]()
+    withNull.put("k", null)
+    val out = DeltaRestMetadataDiff.propertyUpdates(oldProps, withNull).asScala
+    // A null new value is still a "different" value relative to absent -- containsKey check
+    // distinguishes the two.
+    assert(out.length == 1)
+    val sp = out.head.asInstanceOf[SetPropertiesUpdate]
+    assert(sp.getUpdates.containsKey("k"))
+    assert(sp.getUpdates.get("k") === null)
+  }
+
+  // ---- protocolUpdate ----
+
+  test("protocolUpdate: returns empty when old == new") {
+    val p = new DeltaProtocol().minReaderVersion(1).minWriterVersion(2)
+    val result = DeltaRestMetadataDiff.protocolUpdate(Optional.of(p), p)
+    assert(!result.isPresent)
+  }
+
+  test("protocolUpdate: returns SetProtocolUpdate when versions differ") {
+    val oldP = new DeltaProtocol().minReaderVersion(1).minWriterVersion(2)
+    val newP = new DeltaProtocol().minReaderVersion(3).minWriterVersion(7)
+    val result = DeltaRestMetadataDiff.protocolUpdate(Optional.of(oldP), newP)
+    assert(result.isPresent)
+    val sp = result.get.asInstanceOf[SetProtocolUpdate]
+    assert(sp.getProtocol.getMinReaderVersion == 3)
+    assert(sp.getProtocol.getMinWriterVersion == 7)
+  }
+
+  test("protocolUpdate: returns SetProtocolUpdate when old is absent (initial commit)") {
+    val newP = new DeltaProtocol().minReaderVersion(3).minWriterVersion(7)
+    val result = DeltaRestMetadataDiff.protocolUpdate(Optional.empty(), newP)
+    assert(result.isPresent)
+    assert(result.get.isInstanceOf[SetProtocolUpdate])
+  }
+
+  test("protocolUpdate rejects null newProtocol") {
+    intercept[NullPointerException] {
+      DeltaRestMetadataDiff.protocolUpdate(Optional.empty(), null)
+    }
+  }
+
+  // ---- columnsUpdate ----
+
+  test("columnsUpdate: returns empty when old == new") {
+    val s = struct("c" -> "long")
+    val result = DeltaRestMetadataDiff.columnsUpdate(Optional.of(s), s)
+    assert(!result.isPresent)
+  }
+
+  test("columnsUpdate: returns SetSchemaUpdate when schema differs") {
+    val oldS = struct("a" -> "long")
+    val newS = struct("a" -> "long", "b" -> "string")
+    val result = DeltaRestMetadataDiff.columnsUpdate(Optional.of(oldS), newS)
+    assert(result.isPresent)
+    val su = result.get.asInstanceOf[SetSchemaUpdate]
+    assert(su.getColumns.getFields.size() == 2)
+    assert(su.getColumns.getFields.get(1).getName == "b")
+  }
+
+  test("columnsUpdate: initial commit with no old schema returns a full SetSchemaUpdate") {
+    val newS = struct("c" -> "long")
+    val result = DeltaRestMetadataDiff.columnsUpdate(Optional.empty(), newS)
+    assert(result.isPresent)
+    assert(result.get.isInstanceOf[SetSchemaUpdate])
+  }
+
+  test("columnsUpdate rejects null newColumns") {
+    intercept[NullPointerException] {
+      DeltaRestMetadataDiff.columnsUpdate(Optional.empty(), null)
+    }
+  }
+
+  // ---- partitionColumnsUpdate ----
+
+  test("partitionColumnsUpdate: returns empty when old == new (in order)") {
+    val same = JArr.asList("year", "month")
+    val result = DeltaRestMetadataDiff.partitionColumnsUpdate(Optional.of(same), same)
+    assert(!result.isPresent)
+  }
+
+  test("partitionColumnsUpdate: order change yields a new full-replacement update") {
+    val oldP = JArr.asList("year", "month")
+    val newP = JArr.asList("month", "year")
+    val result = DeltaRestMetadataDiff.partitionColumnsUpdate(Optional.of(oldP), newP)
+    assert(result.isPresent)
+    val spc = result.get.asInstanceOf[SetPartitionColumnsUpdate]
+    assert(spc.getPartitionColumns.asScala.toSeq === Seq("month", "year"))
+  }
+
+  test("partitionColumnsUpdate: adding partitioning to a non-partitioned table") {
+    val result = DeltaRestMetadataDiff.partitionColumnsUpdate(
+      Optional.of(JColl.emptyList[String]()),
+      JArr.asList("year"))
+    assert(result.isPresent)
+  }
+
+  test("partitionColumnsUpdate: initial commit (oldOpt empty) always emits") {
+    val result = DeltaRestMetadataDiff.partitionColumnsUpdate(
+      Optional.empty(),
+      JArr.asList("year"))
+    assert(result.isPresent)
+  }
+
+  test("partitionColumnsUpdate: null new list treated as empty") {
+    val result = DeltaRestMetadataDiff.partitionColumnsUpdate(
+      Optional.of(JArr.asList("y")), null)
+    assert(result.isPresent)
+    val spc = result.get.asInstanceOf[SetPartitionColumnsUpdate]
+    assert(spc.getPartitionColumns.isEmpty)
+  }
+
+  // ---- helpers ----
+
+  private def struct(fields: (String, String)*): UCStructType = {
+    val arr = new java.util.ArrayList[UCStructField]()
+    fields.foreach { case (name, primName) =>
+      val p = new UCPrimitiveType()
+      p.setType(primName)
+      val f = new UCStructField().name(name).nullable(true)
+      f.setType(p)
+      arr.add(f)
+    }
+    val s = new UCStructType()
+    s.setFields(arr)
+    s.setType("struct")
+    s
+  }
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClientDRCRoutingSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClientDRCRoutingSuite.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.net.URI
+import java.util.{Collections => JColl, Map => JMap, Optional, UUID}
+
+import scala.collection.JavaConverters._
+
+import io.delta.storage.commit.{Commit, CommitFailedException, GetCommitsResponse, TableDescriptor, TableIdentifier}
+import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.uniform.UniformMetadata
+import io.unitycatalog.client.delta.model.{CredentialOperation, CredentialsResponse, DeltaCommit, LoadTableResponse, TableUpdate}
+import org.apache.hadoop.fs.Path
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Unit tests for the DRC routing decision inside [[UCCommitCoordinatorClient]] -- isDRCTable
+ * correctly detects tables that were loaded via the DRC path (tableConf carries the DRC
+ * catalog/schema/table markers written by DeltaRestTableLoader) and falls through otherwise.
+ *
+ * These tests cover the precondition that gates commitViaDRC; the end-to-end DRC commit flow
+ * (write commit file + call TablesApi.updateTable) has its request-shape coverage in
+ * [[UCDeltaRestClientCommitSuite]] (PR 4).
+ */
+class UCCommitCoordinatorClientDRCRoutingSuite extends AnyFunSuite {
+
+  private val stubUCClient = new NoopUCClient
+  private val stubDRC = new NoopDeltaClient
+
+  private def coord(withDRC: Boolean): UCCommitCoordinatorClient = {
+    val drcOpt: Optional[UCDeltaClient] =
+      if (withDRC) Optional.of(stubDRC.asInstanceOf[UCDeltaClient]) else Optional.empty()
+    new UCCommitCoordinatorClient(JColl.emptyMap[String, String](), stubUCClient, drcOpt)
+  }
+
+  private def descriptor(tableConf: Map[String, String]): TableDescriptor = {
+    val logPath = new Path("s3://bucket/path/_delta_log")
+    new TableDescriptor(logPath, Optional.empty[TableIdentifier](), tableConf.asJava)
+  }
+
+  test("isDRCTable: DRC client absent -> false even when markers present") {
+    val desc = descriptor(Map(
+      "io.unitycatalog.drc.catalog" -> "unity",
+      "io.unitycatalog.drc.schema" -> "default",
+      "io.unitycatalog.drc.table" -> "t",
+      "io.unitycatalog.tableId" -> UUID.randomUUID().toString))
+    assert(!coord(withDRC = false).isDRCTable(desc))
+  }
+
+  test("isDRCTable: DRC client present + all three markers -> true") {
+    val desc = descriptor(Map(
+      "io.unitycatalog.drc.catalog" -> "unity",
+      "io.unitycatalog.drc.schema" -> "default",
+      "io.unitycatalog.drc.table" -> "t",
+      "io.unitycatalog.tableId" -> UUID.randomUUID().toString))
+    assert(coord(withDRC = true).isDRCTable(desc))
+  }
+
+  test("isDRCTable: missing catalog marker -> false (falls through to legacy)") {
+    val desc = descriptor(Map(
+      "io.unitycatalog.drc.schema" -> "default",
+      "io.unitycatalog.drc.table" -> "t"))
+    assert(!coord(withDRC = true).isDRCTable(desc))
+  }
+
+  test("isDRCTable: empty catalog marker -> false") {
+    val desc = descriptor(Map(
+      "io.unitycatalog.drc.catalog" -> "",
+      "io.unitycatalog.drc.schema" -> "default",
+      "io.unitycatalog.drc.table" -> "t"))
+    assert(!coord(withDRC = true).isDRCTable(desc))
+  }
+
+  test("isDRCTable: missing any one of the three markers -> false") {
+    Seq("io.unitycatalog.drc.catalog", "io.unitycatalog.drc.schema",
+        "io.unitycatalog.drc.table").foreach { missingKey =>
+      val full = Map(
+        "io.unitycatalog.drc.catalog" -> "unity",
+        "io.unitycatalog.drc.schema" -> "default",
+        "io.unitycatalog.drc.table" -> "t")
+      val desc = descriptor(full - missingKey)
+      assert(!coord(withDRC = true).isDRCTable(desc),
+        s"expected isDRCTable=false when $missingKey is absent")
+    }
+  }
+}
+
+/** Minimal UCClient stub -- never called in these tests (we don't invoke the commit path). */
+private class NoopUCClient extends UCClient {
+  override def getMetastoreId(): String = throw new UnsupportedOperationException
+  override def commit(
+      tableId: String, tableUri: URI, commit: Optional[Commit],
+      lastKnownBackfilledVersion: Optional[java.lang.Long], disown: Boolean,
+      newMetadata: Optional[AbstractMetadata], newProtocol: Optional[AbstractProtocol],
+      uniform: Optional[UniformMetadata]): Unit = throw new UnsupportedOperationException
+  override def getCommits(
+      tableId: String, tableUri: URI,
+      startVersion: Optional[java.lang.Long],
+      endVersion: Optional[java.lang.Long]): GetCommitsResponse =
+    throw new UnsupportedOperationException
+  override def finalizeCreate(
+      tableName: String, catalogName: String, schemaName: String,
+      storageLocation: String, columns: java.util.List[UCClient.ColumnDef],
+      properties: JMap[String, String]): Unit = throw new UnsupportedOperationException
+  override def close(): Unit = ()
+}
+
+/** Minimal UCDeltaClient stub -- never called in these tests. */
+private class NoopDeltaClient extends UCDeltaClient {
+  override def loadTable(c: String, s: String, t: String): LoadTableResponse =
+    throw new UnsupportedOperationException
+  override def getTableCredentials(
+      c: String, s: String, t: String, op: CredentialOperation): CredentialsResponse =
+    throw new UnsupportedOperationException
+  override def commit(
+      c: String, s: String, t: String, commit: DeltaCommit, uuid: UUID,
+      etag: Optional[String], updates: java.util.List[TableUpdate]): LoadTableResponse =
+    throw new UnsupportedOperationException
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClientCommitSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaRestClientCommitSuite.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.util.{Collections => JColl, Optional, UUID}
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  AddCommitUpdate,
+  AssertEtag,
+  AssertTableUUID,
+  DeltaCommit,
+  SetPropertiesUpdate,
+  TableUpdate
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Unit tests for {@link UCDeltaRestClient#buildCommitRequest}. The method is package-private
+ * so we can assert the shape of the generated {@code UpdateTableRequest} (requirements + updates
+ * composition) without standing up an HTTP server.
+ *
+ * Field sets validated here are derived from the UC DRC OpenAPI spec at UC SHA ae4bcf6.
+ * Re-verify these shape assertions when the UC server implements the
+ * {@code POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}} handler.
+ */
+class UCDeltaRestClientCommitSuite extends AnyFunSuite {
+
+  private val tableUuid = UUID.fromString("11111111-2222-3333-4444-555555555555")
+
+  private def commit(): DeltaCommit = new DeltaCommit()
+    .version(7L)
+    .timestamp(1_700_000_000_000L)
+    .fileName("_staged_commits/0000000000000000007.some-uuid.json")
+    .fileSize(1234L)
+    .fileModificationTimestamp(1_700_000_000_100L)
+
+  test("buildCommitRequest: without etag, requirements = [AssertTableUUID]") {
+    val req = UCDeltaRestClient.buildCommitRequest(
+      commit(), tableUuid, Optional.empty[String](), JColl.emptyList[TableUpdate]())
+
+    val reqs = req.getRequirements.asScala
+    assert(reqs.length == 1)
+    reqs.head match {
+      case a: AssertTableUUID => assert(a.getUuid == tableUuid)
+      case other => fail(s"Expected AssertTableUUID, got ${other.getClass.getName}")
+    }
+
+    val updates = req.getUpdates.asScala
+    assert(updates.length == 1)
+    updates.head match {
+      case u: AddCommitUpdate =>
+        val c = u.getCommit
+        assert(c.getVersion == 7L)
+        assert(c.getFileName.endsWith(".some-uuid.json"))
+        assert(c.getFileSize == 1234L)
+      case other => fail(s"Expected AddCommitUpdate, got ${other.getClass.getName}")
+    }
+  }
+
+  test("buildCommitRequest: with etag, requirements = [AssertTableUUID, AssertEtag]") {
+    val req = UCDeltaRestClient.buildCommitRequest(
+      commit(), tableUuid, Optional.of("CAES-etag"), JColl.emptyList[TableUpdate]())
+
+    val reqs = req.getRequirements.asScala
+    assert(reqs.length == 2)
+    reqs(0) match {
+      case a: AssertTableUUID => assert(a.getUuid == tableUuid)
+      case other => fail(s"Expected AssertTableUUID, got ${other.getClass.getName}")
+    }
+    reqs(1) match {
+      case e: AssertEtag => assert(e.getEtag == "CAES-etag")
+      case other => fail(s"Expected AssertEtag, got ${other.getClass.getName}")
+    }
+  }
+
+  test("buildCommitRequest rejects null arguments") {
+    intercept[NullPointerException] {
+      UCDeltaRestClient.buildCommitRequest(
+        null, tableUuid, Optional.empty(), JColl.emptyList[TableUpdate]())
+    }
+    intercept[NullPointerException] {
+      UCDeltaRestClient.buildCommitRequest(
+        commit(), null, Optional.empty(), JColl.emptyList[TableUpdate]())
+    }
+    intercept[NullPointerException] {
+      UCDeltaRestClient.buildCommitRequest(
+        commit(), tableUuid, null, JColl.emptyList[TableUpdate]())
+    }
+    intercept[NullPointerException] {
+      UCDeltaRestClient.buildCommitRequest(
+        commit(), tableUuid, Optional.empty(), null)
+    }
+  }
+
+  test("buildCommitRequest appends metadata updates AFTER the AddCommitUpdate") {
+    val setProps: TableUpdate = new SetPropertiesUpdate()
+      .updates(java.util.Collections.singletonMap("delta.enableChangeDataFeed", "true"))
+    val req = UCDeltaRestClient.buildCommitRequest(
+      commit(),
+      tableUuid,
+      Optional.empty[String](),
+      java.util.Arrays.asList(setProps))
+    val updates = req.getUpdates.asScala
+    assert(updates.length == 2)
+    assert(updates(0).isInstanceOf[AddCommitUpdate])
+    assert(updates(1).isInstanceOf[SetPropertiesUpdate])
+    val sp = updates(1).asInstanceOf[SetPropertiesUpdate]
+    assert(sp.getUpdates.asScala.toMap ===
+      Map("delta.enableChangeDataFeed" -> "true"))
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6646/files/25d49bf70fba74f9adb8ed779e27ba06a8354243..cf5e4dcf558006801575ff70025a2c8592f672b0) to review incremental changes.
- [stack/drc-pr1-foundation](https://github.com/delta-io/delta/pull/6642) [[Files changed](https://github.com/delta-io/delta/pull/6642/files)]
  - [stack/drc-pr2-read-path](https://github.com/delta-io/delta/pull/6643) [[Files changed](https://github.com/delta-io/delta/pull/6643/files/194d5db44ceb285cb0c3638f0a811121a661bd78..fd3c2fd683b8f453701b472d73d5296516a21fdf)]
    - [stack/drc-pr3-credentials](https://github.com/delta-io/delta/pull/6644) [[Files changed](https://github.com/delta-io/delta/pull/6644/files/fd3c2fd683b8f453701b472d73d5296516a21fdf..8f49d2a3a3449e9b2f07f63505d0e827fc2d2115)]
      - [stack/drc-pr4-commit-api](https://github.com/delta-io/delta/pull/6645) [[Files changed](https://github.com/delta-io/delta/pull/6645/files/8f49d2a3a3449e9b2f07f63505d0e827fc2d2115..25d49bf70fba74f9adb8ed779e27ba06a8354243)]
        - [**stack/drc-pr5-commit-wiring**](https://github.com/delta-io/delta/pull/6646) [[Files changed](https://github.com/delta-io/delta/pull/6646/files/25d49bf70fba74f9adb8ed779e27ba06a8354243..cf5e4dcf558006801575ff70025a2c8592f672b0)]

---------
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`UCCommitCoordinatorBuilder` discovers a DRC-capable `DeltaRestClientProvider` and passes the resulting `UCDeltaClient` to `UCCommitCoordinatorClient`, which routes commits for tables marked DRC in `tableConf` through `commitViaDRC` — writes the staged commit file, synthesizes property + protocol diffs via `DeltaRestMetadataDiff`, and calls `ucDeltaClient.commit`. Softens the three UC-managed kill switches in `OptimisticTransaction` (updateMetadata, REPLACE-in-metadata, commitLarge clustering) when `isDRCEnabledTable` is true — on the DRC path, metadata/schema/clustering updates propagate through the commit envelope so blocking them would break legitimate writes.

## How was this patch tested?
`UCCommitCoordinatorClientDRCRoutingSuite` (5) covers `isDRCTable` detection across every permutation of marker/client presence. `UCManagedTableKillSwitchSuite` gains "commitLarge allows clustering change when DRC is enabled on the table". Zero regressions in 41 storage tests, 47 uccatalog spark tests, `UCCommitCoordinatorBuilderSuite`, or `DeltaCatalogSuite`.

## Does this PR introduce _any_ user-facing changes?
No.
