### PR TITLE
[DRC][3/N] UCDeltaClientImpl.loadTable with internal DRC routing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -723,7 +723,13 @@ lazy val contribs = (project in file("contribs"))
   ).configureUnidoc()
 
 
-val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.4.1")
+// Bumped to 0.5.0-SNAPSHOT for the DeltaRestClientProvider interface landed in UC at SHA
+// ae4bcf6 (UC PR #1509). The Delta REST Catalog (DRC) integration on the Delta side
+// requires this provider interface. Until UC 0.5.0 is published to Maven Central, the
+// snapshot is resolved from ~/.ivy2/local -- run UC's `sbt client/publishLocal server/publishLocal
+// spark/publishLocal` to populate. CI coverage is unblocked by the UC-SHA pin scaffolding in
+// delta-io/delta#6616 (setup_unitycatalog_main.sh + ensurePinnedUnityCatalog).
+val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.5.0-SNAPSHOT")
 val sparkUnityCatalogJacksonVersion = "2.15.4" // We are using Spark 4.0's Jackson version 2.15.x, to override Unity Catalog 0.3.0's version 2.18.x
 
 lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => DrcArrayType,
+  DecimalType => DrcDecimalType,
+  DeltaType => DrcDeltaType,
+  MapType => DrcMapType,
+  PrimitiveType => DrcPrimitiveType,
+  StructField => DrcStructField,
+  StructType => DrcStructType
+}
+
+import org.apache.spark.sql.types._
+
+/**
+ * Converts a Delta REST Catalog (DRC) column list -- a `java.util.List` of UC SDK POJOs -- into
+ * a Spark `StructType` without a JSON round-trip. This is the read-path fast path called from
+ * `DRCMetadataAdapter` consumers.
+ *
+ * Only the forward direction (DRC -> Spark) is implemented in this PR; the reverse direction
+ * (Spark -> DRC) lands in the write-path PR where intent-based schema emission matters.
+ */
+private[delta] object DeltaRestSchemaConverter {
+
+  /**
+   * Convert a DRC column list into a Spark `StructType`. Throws `IllegalArgumentException` on
+   * an unknown primitive name or a `DeltaType` subclass the Delta-Spark side does not recognise
+   * -- callers should not catch-and-coerce; an unknown type means the UC server has rolled
+   * forward past the pinned SDK and the pin needs to be bumped.
+   */
+  def toSparkSchema(drcColumns: java.util.List[DrcStructField]): StructType = {
+    require(drcColumns != null, "DRC column list must be non-null")
+    StructType(drcColumns.asScala.map(toSparkField).toArray)
+  }
+
+  private def toSparkField(drc: DrcStructField): StructField = {
+    require(drc.getName != null, "DRC column name must be non-null")
+    require(drc.getType != null, s"DRC column '${drc.getName}' has null type")
+    require(drc.getNullable != null, s"DRC column '${drc.getName}' has null 'nullable'")
+    val metadata = toSparkMetadata(drc.getMetadata)
+    StructField(drc.getName, toSparkDataType(drc.getType), drc.getNullable, metadata)
+  }
+
+  private def toSparkDataType(drc: DrcDeltaType): DataType = drc match {
+    case p: DrcPrimitiveType => parsePrimitive(p.getType)
+    case d: DrcDecimalType =>
+      require(d.getPrecision != null, "decimal type missing precision")
+      require(d.getScale != null, "decimal type missing scale")
+      DecimalType(d.getPrecision, d.getScale)
+    case a: DrcArrayType =>
+      require(a.getElementType != null, "array type missing element-type")
+      require(a.getContainsNull != null, "array type missing contains-null")
+      ArrayType(toSparkDataType(a.getElementType), a.getContainsNull)
+    case m: DrcMapType =>
+      require(m.getKeyType != null, "map type missing key-type")
+      require(m.getValueType != null, "map type missing value-type")
+      require(m.getValueContainsNull != null, "map type missing value-contains-null")
+      MapType(
+        toSparkDataType(m.getKeyType), toSparkDataType(m.getValueType), m.getValueContainsNull)
+    case s: DrcStructType =>
+      require(s.getFields != null, "struct type missing fields")
+      StructType(s.getFields.asScala.map(toSparkField).toArray)
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unsupported DRC DeltaType subclass: ${other.getClass.getName}. " +
+          "The pinned UC SDK may be ahead of the Delta-Spark converter -- bump the Delta side.")
+  }
+
+  private def parsePrimitive(name: String): DataType = name match {
+    case "string" => StringType
+    case "long" => LongType
+    case "integer" => IntegerType
+    case "short" => ShortType
+    case "byte" => ByteType
+    case "double" => DoubleType
+    case "float" => FloatType
+    case "boolean" => BooleanType
+    case "binary" => BinaryType
+    case "date" => DateType
+    case "timestamp" => TimestampType
+    case "timestamp_ntz" => TimestampNTZType
+    case null =>
+      throw new IllegalArgumentException("DRC primitive type name is null")
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unknown DRC primitive type name: '$other'. Add a case to " +
+          "DeltaRestSchemaConverter.parsePrimitive or bump the UC pin if this is a new type.")
+  }
+
+  private def toSparkMetadata(raw: java.util.Map[String, Object]): Metadata = {
+    if (raw == null || raw.isEmpty) return Metadata.empty
+    val b = new MetadataBuilder
+    raw.asScala.foreach { case (k, v) => v match {
+      case null => b.putNull(k)
+      case s: String => b.putString(k, s)
+      case l: java.lang.Long => b.putLong(k, l)
+      case i: java.lang.Integer => b.putLong(k, i.longValue)
+      case sh: java.lang.Short => b.putLong(k, sh.longValue)
+      case by: java.lang.Byte => b.putLong(k, by.longValue)
+      case bl: java.lang.Boolean => b.putBoolean(k, bl)
+      case d: java.lang.Double => b.putDouble(k, d)
+      case f: java.lang.Float => b.putDouble(k, f.doubleValue)
+      case other => b.putString(k, String.valueOf(other))
+    }}
+    b.build()
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Collections, List => JList, Map => JMap}
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => DrcArrayType,
+  DecimalType => DrcDecimalType,
+  DeltaType => DrcDeltaType,
+  MapType => DrcMapType,
+  PrimitiveType => DrcPrimitiveType,
+  StructField => DrcStructField,
+  StructType => DrcStructType
+}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types._
+
+class DeltaRestSchemaConverterSuite extends SparkFunSuite {
+
+  private def prim(name: String): DrcPrimitiveType = {
+    val p = new DrcPrimitiveType(); p.setType(name); p
+  }
+  private def field(name: String, dt: DrcDeltaType, nullable: Boolean = true,
+      meta: JMap[String, Object] = Collections.emptyMap()): DrcStructField = {
+    val f = new DrcStructField()
+    f.setName(name); f.setType(dt); f.setNullable(nullable); f.setMetadata(meta); f
+  }
+  private def cols(fs: DrcStructField*): JList[DrcStructField] = fs.toList.asJava
+
+  test("primitive types round-trip through the forward converter") {
+    val expected = Seq(
+      "string" -> StringType, "long" -> LongType, "integer" -> IntegerType,
+      "short" -> ShortType, "byte" -> ByteType, "double" -> DoubleType,
+      "float" -> FloatType, "boolean" -> BooleanType, "binary" -> BinaryType,
+      "date" -> DateType, "timestamp" -> TimestampType, "timestamp_ntz" -> TimestampNTZType)
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      cols(expected.map { case (n, _) => field(n, prim(n)) }: _*))
+    assert(schema.fields.length == expected.length)
+    expected.zip(schema.fields).foreach { case ((n, dt), f) =>
+      assert(f.name == n); assert(f.dataType == dt); assert(f.nullable)
+    }
+  }
+
+  test("decimal preserves precision and scale") {
+    val d = new DrcDecimalType(); d.setPrecision(18); d.setScale(4)
+    val schema = DeltaRestSchemaConverter.toSparkSchema(cols(field("amt", d)))
+    assert(schema("amt").dataType == DecimalType(18, 4))
+  }
+
+  test("array preserves containsNull") {
+    val a = new DrcArrayType(); a.setElementType(prim("string")); a.setContainsNull(false)
+    val schema = DeltaRestSchemaConverter.toSparkSchema(cols(field("tags", a)))
+    assert(schema("tags").dataType == ArrayType(StringType, containsNull = false))
+  }
+
+  test("map preserves valueContainsNull") {
+    val m = new DrcMapType()
+    m.setKeyType(prim("string")); m.setValueType(prim("long")); m.setValueContainsNull(false)
+    val schema = DeltaRestSchemaConverter.toSparkSchema(cols(field("props", m)))
+    assert(schema("props").dataType == MapType(StringType, LongType, valueContainsNull = false))
+  }
+
+  test("nested struct walks recursively") {
+    val inner = new DrcStructType(); inner.setFields(cols(field("x", prim("long"))))
+    val schema = DeltaRestSchemaConverter.toSparkSchema(cols(field("outer", inner)))
+    val outer = schema("outer").dataType.asInstanceOf[StructType]
+    assert(outer("x").dataType == LongType)
+  }
+
+  test("nullability and column metadata are preserved") {
+    val meta: JMap[String, Object] = Map[String, Object](
+      "delta.columnMapping.id" -> java.lang.Long.valueOf(7L),
+      "comment" -> "user id").asJava
+    val schema = DeltaRestSchemaConverter.toSparkSchema(
+      cols(field("id", prim("long"), nullable = false, meta)))
+    val f = schema("id")
+    assert(!f.nullable)
+    assert(f.metadata.getLong("delta.columnMapping.id") == 7L)
+    assert(f.metadata.getString("comment") == "user id")
+  }
+
+  test("unknown primitive name fails loud") {
+    val ex = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(cols(field("x", prim("variant_v9000"))))
+    }
+    assert(ex.getMessage.contains("Unknown DRC primitive"))
+  }
+
+  test("null type on a field fails loud") {
+    val f = new DrcStructField(); f.setName("x"); f.setType(null); f.setNullable(true)
+    val ex = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(cols(f))
+    }
+    assert(ex.getMessage.contains("null type"))
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.actions;
+
+/**
+ * Storage-level view of a Delta {@code DomainMetadata} action. Used by
+ * {@code UCDeltaClient.createTable} and the DRC commit path to pass per-domain configuration
+ * (e.g. {@code delta.clustering}, {@code delta.rowTracking}) as first-class structured
+ * parameters rather than flattening into the properties map.
+ *
+ * <p>Mirrors the Spark-side {@code org.apache.spark.sql.delta.actions.DomainMetadata} case
+ * class, but lives in storage so that non-Spark consumers (Kernel, Flink) and the Java DRC
+ * client can manipulate domain metadata without pulling Spark in.
+ */
+public interface AbstractDomainMetadata {
+
+  /** Unique domain name, e.g. {@code "delta.clustering"}. */
+  String getDomain();
+
+  /** Opaque per-domain configuration JSON. */
+  String getConfiguration();
+
+  /** {@code true} if this action removes the domain from the table. */
+  boolean isRemoved();
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapter.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.unitycatalog.client.delta.model.StructField;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link AbstractMetadata} implementation that carries a Delta REST Catalog table's schema as
+ * the raw UC SDK POJO column list, without the JSON round-trip that the legacy read path
+ * imposes.
+ *
+ * <p>The DRC read path never serializes schema to JSON on the way from UC to Spark. Instead:
+ * <ol>
+ *   <li>{@code UCDeltaClientImpl.loadTable} constructs a {@code DRCMetadataAdapter} from the UC
+ *       SDK {@code LoadTableResponse}.</li>
+ *   <li>Delta-Spark pattern-matches on the concrete type, calls {@link #getDRCColumns()} to
+ *       retrieve the POJO list, and feeds it to {@code DeltaRestSchemaConverter} for direct
+ *       conversion to {@code StructType}.</li>
+ * </ol>
+ *
+ * <p><b>{@link #getSchemaString()} returns a deterministic empty-struct stub in v1</b> rather
+ * than throwing. Delta-Spark consumers on the DRC read path MUST use {@link #getDRCColumns()}
+ * via a type cast -- the Javadoc on that method is the binding contract. The stub exists only
+ * so that framework defensive calls (logging, {@code equals}/{@code toString} in IDEs, metric
+ * tags, error-path formatters) do not bring down a read. A one-time WARN is emitted the first
+ * time the stub is returned so that a bug report from Kernel/Flink after the clarifications §6
+ * audit lands has a signal to correlate against; the proper JSON serializer is tracked there.
+ *
+ * <p>Immutable; the columns, partition list, and configuration map are all defensively copied
+ * and returned unmodifiable so that mutations from the DRC SDK layer cannot leak into consumers.
+ */
+public final class DRCMetadataAdapter implements AbstractMetadata {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DRCMetadataAdapter.class);
+  private static final String DELTA_PROVIDER = "delta";
+  private static final String EMPTY_STRUCT_JSON = "{\"type\":\"struct\",\"fields\":[]}";
+
+  /**
+   * Per-instance gate for the one-time WARN. Static across the JVM would be too noisy for unit
+   * tests; per-instance gives one warning per table-load which is plenty to surface a misuse.
+   */
+  private final AtomicBoolean loggedSchemaStringStub = new AtomicBoolean(false);
+
+  private final String id;
+  private final String name;
+  private final String description;
+  private final List<StructField> drcColumns;
+  private final List<String> partitionColumns;
+  private final Map<String, String> configuration;
+  private final Long createdTime;
+
+  public DRCMetadataAdapter(
+      String id,
+      String name,
+      String description,
+      List<StructField> drcColumns,
+      List<String> partitionColumns,
+      Map<String, String> configuration,
+      Long createdTime) {
+    this.id = Objects.requireNonNull(id, "id");
+    this.name = name;
+    this.description = description;
+    this.drcColumns = Collections.unmodifiableList(
+        Objects.requireNonNull(drcColumns, "drcColumns"));
+    this.partitionColumns = Collections.unmodifiableList(
+        Objects.requireNonNull(partitionColumns, "partitionColumns"));
+    this.configuration = Collections.unmodifiableMap(
+        new HashMap<>(Objects.requireNonNull(configuration, "configuration")));
+    this.createdTime = createdTime;
+  }
+
+  /**
+   * Returns the DRC-native structured column list straight from the UC SDK, bypassing any JSON
+   * serialization. Callers on the Delta-Spark read path MUST use this method (after a type cast
+   * from {@link AbstractMetadata}) rather than {@link #getSchemaString()}.
+   */
+  public List<StructField> getDRCColumns() {
+    return drcColumns;
+  }
+
+  @Override public String getId() { return id; }
+  @Override public String getName() { return name; }
+  @Override public String getDescription() { return description; }
+  @Override public String getProvider() { return DELTA_PROVIDER; }
+  @Override public Map<String, String> getFormatOptions() { return Collections.emptyMap(); }
+  @Override public List<String> getPartitionColumns() { return partitionColumns; }
+  @Override public Map<String, String> getConfiguration() { return configuration; }
+  @Override public Long getCreatedTime() { return createdTime; }
+
+  /**
+   * Returns a deterministic empty-struct JSON stub. This method is NOT the DRC read-path's
+   * schema accessor -- see the class-level Javadoc and {@link #getDRCColumns()}. A one-time
+   * WARN is emitted on first invocation per instance so that an unintended caller (typically
+   * a framework logging or formatting path) surfaces during testing without crashing
+   * production. A real JSON fallback is tracked under design-doc clarifications §6.
+   */
+  @Override
+  public String getSchemaString() {
+    if (loggedSchemaStringStub.compareAndSet(false, true)) {
+      LOG.warn("DRCMetadataAdapter.getSchemaString() invoked on table id={}. Returning an "
+          + "empty-struct stub; Delta-Spark read-path consumers must use getDRCColumns() "
+          + "instead. If this WARN originates from non-Spark code (Kernel, Flink, logging "
+          + "framework), file an issue under clarifications §6 (owner TBD).", id);
+    }
+    return EMPTY_STRUCT_JSON;
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.GetCommitsResponse;
+import io.delta.storage.commit.TableDescriptor;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.commit.uniform.UniformMetadata;
+
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Extended UC client interface for Delta table operations. Adds DRC-aware {@link #loadTable},
+ * {@link #createTable}, and typed {@link #commit} overloads on top of the legacy
+ * {@link UCClient} interface. Implementations choose DRC or legacy internally based on whether
+ * the UC-side {@code DeltaRestClientProvider} exposes a {@code TablesApi} -- callers never
+ * branch on the flag.
+ *
+ * <p>Extends {@code UCClient} so that the existing {@code UCCommitCoordinatorClient} can hold
+ * a single field ({@code UCClient ucClient}) that is polymorphically either a legacy impl or a
+ * DRC-aware one, without a refactor of the commit-coordinator constructor. The richer DRC
+ * methods added here are invoked by callers that know they have a {@code UCDeltaClient}
+ * (wired via {@code UCDeltaClientProvider}); the inherited {@code UCClient} methods continue
+ * to service the legacy commit path unchanged.
+ *
+ * <p>This interface is the full skeleton -- every RPC method any caller will reach for the DRC
+ * integration lives here. Only the read path ({@link #loadTable}) has a production
+ * implementation in this stack; {@link #createTable} and the typed {@link #commit} overloads
+ * throw {@link UnsupportedOperationException} from the impl until the PR that wires each one
+ * lands. Freezing the shape in one reviewable PR lets reviewers evaluate the architecture
+ * before any commit-path logic lands.
+ */
+public interface UCDeltaClient extends UCClient {
+
+  /**
+   * Reports whether this client would currently route the next DRC-specific RPC through DRC
+   * endpoints. Resolved against the underlying {@code DeltaRestClientProvider.getDeltaTablesApi()}
+   * on every call, so mid-session flag flips take effect immediately.
+   *
+   * <p><b>Allowed uses:</b> logging, metric tagging, tests, and softening UC-managed kill
+   * switches on the DRC path (clarifications §2). <b>Not allowed:</b> picking between DRC and
+   * legacy code paths at the caller layer -- the whole point of this interface is that the
+   * routing is internal.
+   */
+  boolean isDRCEnabled();
+
+  /**
+   * Casts or wraps a {@link UCClient} into a {@link UCDeltaClient}. Used by
+   * {@code UCCommitCoordinatorBuilder} when it receives a plain {@code UCClient} from the
+   * legacy factory but the rest of the stack wants the richer contract.
+   *
+   * <p>Callers that have already obtained a {@code UCDeltaClient} (via
+   * {@code UCDeltaClientProvider}) do not need to go through this helper.
+   *
+   * <p>The wrapping path for a legacy {@code UCTokenBasedRestClient} is implemented in the
+   * PR that ships {@code UCTokenBasedDeltaRestClient} -- throwing
+   * {@link IllegalArgumentException} for any other {@code UCClient} subclass makes an
+   * accidental-legacy-path silently-succeeds scenario surface as a loud error.
+   */
+  static UCDeltaClient fromLegacyClient(UCClient ucClient) {
+    if (ucClient instanceof UCDeltaClient) {
+      return (UCDeltaClient) ucClient;
+    }
+    throw new IllegalArgumentException(
+        "UCClient is not a UCDeltaClient: "
+            + (ucClient == null ? "null" : ucClient.getClass().getName())
+            + ". The DRC-aware wrapping path for UCTokenBasedRestClient lands alongside "
+            + "UCTokenBasedDeltaRestClient in a follow-up PR.");
+  }
+
+  /**
+   * Response from {@link #loadTable(String, String, String, String, URI, Optional, Optional)}.
+   * Carries the full table state -- commits + etag + metadata + credentials -- so that a
+   * single DRC RPC can hydrate a caller that would otherwise have needed
+   * {@code getTable} + {@code getCommits} + {@code getCredentials} separately.
+   *
+   * <p>On the DRC path all fields are populated. On the legacy path (which this interface can
+   * cover via {@link #fromLegacyClient}), {@code protocol}, {@code metadata}, and
+   * {@code credentials} are {@code null} because the legacy APIs don't return them at load
+   * time -- the caller reads them from the Delta log instead. The nullability mix is
+   * intentional per Yili's POC (#6575); documented at the accessors.
+   */
+  final class LoadTableResponse {
+    private final GetCommitsResponse commitsResponse;
+    private final String etag;
+    private final String location;
+    private final String tableId;
+    private final String tableType;
+    private final Map<String, String> properties;
+    private final AbstractProtocol protocol;
+    private final AbstractMetadata metadata;
+    private final Map<String, String> credentials;
+
+    /** Full DRC-path constructor. */
+    public LoadTableResponse(
+        GetCommitsResponse commitsResponse, String etag,
+        String location, String tableId, String tableType,
+        Map<String, String> properties,
+        AbstractProtocol protocol, AbstractMetadata metadata,
+        Map<String, String> credentials) {
+      this.commitsResponse = commitsResponse;
+      this.etag = etag;
+      this.location = location;
+      this.tableId = tableId;
+      this.tableType = tableType;
+      this.properties = properties;
+      this.protocol = protocol;
+      this.metadata = metadata;
+      this.credentials = credentials;
+    }
+
+    /** Legacy / commit-path constructor -- no protocol, metadata, or credentials. */
+    public LoadTableResponse(
+        GetCommitsResponse commitsResponse, String etag,
+        String location, String tableId, String tableType,
+        Map<String, String> properties) {
+      this(commitsResponse, etag, location, tableId, tableType,
+          properties, null, null, null);
+    }
+
+    public GetCommitsResponse getCommitsResponse() { return commitsResponse; }
+    public String getEtag() { return etag; }
+    public String getLocation() { return location; }
+    public String getTableId() { return tableId; }
+    public String getTableType() { return tableType; }
+    public Map<String, String> getProperties() { return properties; }
+    /** DRC protocol, or {@code null} if loaded via commit path. */
+    public AbstractProtocol getProtocol() { return protocol; }
+    /** DRC metadata, or {@code null} if loaded via commit path. */
+    public AbstractMetadata getMetadata() { return metadata; }
+    /**
+     * Temporary storage credentials as Hadoop-style properties (e.g. {@code fs.s3a.access.key},
+     * {@code fs.s3a.secret.key}). Empty map if credential vending is unavailable or not needed.
+     */
+    public Map<String, String> getCredentials() {
+      return credentials != null ? credentials : Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Loads a table's full state from UC. Returns commits + etag + metadata + credentials in one
+   * call on the DRC path; on the legacy path, combines {@code getTable} and {@code getCommits}.
+   * Callers use this instead of {@link UCClient#getCommits(String, URI, Optional, Optional)}
+   * whenever they need the etag -- the DRC commit path asserts etag where present.
+   */
+  LoadTableResponse loadTable(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Long> startVersion, Optional<Long> endVersion)
+      throws IOException;
+
+  /**
+   * Creates a table in UC with structured protocol, schema, and domain metadata. Replaces the
+   * legacy {@link UCClient#finalizeCreate} path (which only supports the flat
+   * {@link UCClient.ColumnDef} schema representation) for DRC-aware callers. Legacy callers
+   * continue to use {@code finalizeCreate} unchanged via inheritance.
+   */
+  void createTable(
+      String catalog, String schema, String table, String location,
+      AbstractMetadata metadata, AbstractProtocol protocol,
+      boolean isManaged, String dataSourceFormat,
+      List<? extends AbstractDomainMetadata> domainMetadata)
+      throws CommitFailedException;
+
+  /**
+   * Commits via the Spark V1 {@link TableDescriptor} path. Same contract as
+   * {@link UCClient#commit(String, URI, Optional, Optional, boolean, Optional, Optional, Optional)}
+   * but carries the extra DRC-required context: the old metadata and old protocol observed at
+   * load time (for intent-based diffing), and the optional etag (for the DRC
+   * {@code assert-etag} requirement per clarifications §3).
+   */
+  void commit(
+      TableDescriptor tableDesc, Path logPath,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException;
+
+  /**
+   * Commits via the Kernel V2 path: explicit catalog / schema / table identifiers rather than
+   * a {@link TableDescriptor}. Same contract as the Spark V1 overload otherwise.
+   */
+  void commit(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<UniformMetadata> uniform,
+      Optional<String> etag)
+      throws IOException, CommitFailedException;
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClient.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.GetCommitsResponse;
+import io.delta.storage.commit.TableDescriptor;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.commit.uniform.UniformMetadata;
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.DeltaRestClientProvider;
+import io.unitycatalog.client.delta.api.TablesApi;
+// NOTE: io.unitycatalog.client.delta.model.LoadTableResponse is fully-qualified below because
+// it collides with UCDeltaClient.LoadTableResponse (inner class) in this subclass's scope.
+import io.unitycatalog.client.delta.model.TableMetadata;
+
+import org.apache.hadoop.fs.Path;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Production {@link UCDeltaClient} implementation. Extends {@link UCTokenBasedRestClient} so
+ * that the legacy {@link UCClient} methods (commit, getCommits, getMetastoreId, finalizeCreate,
+ * close) come for free -- {@link UCCommitCoordinatorClient} continues to hold a
+ * {@code UCClient} field and does not need to change signature until the commit-path PR wires
+ * the typed overloads.
+ *
+ * <p>The DRC-specific methods added by {@link UCDeltaClient} route through the
+ * {@link DeltaRestClientProvider}'s {@code TablesApi} -- resolved on every call so mid-session
+ * flag flips (via the UC-side {@code spark.sql.catalog.<catalog>.deltaRestApi.enabled}) take
+ * effect immediately without reconstructing the client.
+ *
+ * <p><b>Method scope in this PR.</b> Only {@link #loadTable(String, String, String, String,
+ * URI, Optional, Optional)} is wired. {@link #createTable} and the typed {@link #commit}
+ * overloads throw {@link UnsupportedOperationException} until the PRs that wire them land:
+ * createTable with the post-v1 CREATE PR, typed commits with the etag-plumbing and intent-diff
+ * PRs. Legacy {@code UCClient.commit} (inherited) continues to service the existing commit
+ * path unchanged; on DRC-enabled tables, that legacy path remains in use until the typed
+ * overrides land.
+ */
+public final class UCTokenBasedDeltaRestClient extends UCTokenBasedRestClient
+    implements UCDeltaClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UCTokenBasedDeltaRestClient.class);
+
+  private final DeltaRestClientProvider drcProvider;
+  /** Last-logged routing decision -- logs on transitions, not just the first call. */
+  private final AtomicReference<Boolean> lastLoggedRoute = new AtomicReference<>(null);
+  private final AtomicLong drcLoadTableCount = new AtomicLong();
+  private final AtomicLong legacyLoadTableCount = new AtomicLong();
+
+  /**
+   * Constructs a DRC-aware client that shares an {@link ApiClient} with the UC catalog plugin.
+   * Legacy UC API calls go through the inherited {@link UCTokenBasedRestClient} machinery;
+   * DRC calls go through {@code drcProvider.getDeltaTablesApi()}. Both ultimately talk to the
+   * same UC server via the same HTTP pool.
+   */
+  public UCTokenBasedDeltaRestClient(ApiClient apiClient, DeltaRestClientProvider drcProvider) {
+    super(apiClient);
+    this.drcProvider = Objects.requireNonNull(drcProvider, "drcProvider");
+  }
+
+  @Override
+  public boolean isDRCEnabled() {
+    return drcProvider.getDeltaTablesApi().isPresent();
+  }
+
+  @Override
+  public UCDeltaClient.LoadTableResponse loadTable(
+      String catalog, String schema, String table,
+      String ucTableId, URI tableUri,
+      Optional<Long> startVersion, Optional<Long> endVersion) throws IOException {
+    Objects.requireNonNull(catalog, "catalog"); require(!catalog.isEmpty(), "catalog empty");
+    Objects.requireNonNull(schema, "schema");   require(!schema.isEmpty(),  "schema empty");
+    Objects.requireNonNull(table, "table");     require(!table.isEmpty(),   "table empty");
+
+    final Optional<TablesApi> api = drcProvider.getDeltaTablesApi();
+    if (api.isPresent()) {
+      logRoutingTransition(true);
+      drcLoadTableCount.incrementAndGet();
+      return loadTableDRC(api.get(), catalog, schema, table);
+    } else {
+      logRoutingTransition(false);
+      legacyLoadTableCount.incrementAndGet();
+      // Legacy load = getTable + getCommits composition. Ships alongside the typed commit
+      // overloads in a follow-up PR; for now, the catalog layer reaches UCProxy directly
+      // when DRC is off and never invokes this method.
+      throw new UnsupportedOperationException(
+          "UCDeltaClient.loadTable legacy fallback not yet wired; caller must gate on "
+              + "isDRCEnabled() until the commit-path PR lands the getTable+getCommits "
+              + "composition.");
+    }
+  }
+
+  private UCDeltaClient.LoadTableResponse loadTableDRC(
+      TablesApi api, String catalog, String schema, String table) throws IOException {
+    final io.unitycatalog.client.delta.model.LoadTableResponse resp;
+    try {
+      resp = api.loadTable(catalog, schema, table);
+    } catch (ApiException e) {
+      throw translateApiException(e, catalog, schema, table);
+    }
+    require(resp != null,
+        "DRC loadTable returned a null response for " + fqn(catalog, schema, table));
+    require(resp.getLatestTableVersion() != null,
+        "DRC loadTable response missing required 'latest-table-version'");
+    final TableMetadata meta = resp.getMetadata();
+    require(meta != null, "DRC loadTable response missing required 'metadata'");
+    require(meta.getTableUuid() != null,
+        "DRC loadTable response missing required 'metadata.table-uuid'");
+    require(meta.getColumns() != null && meta.getColumns().getFields() != null,
+        "DRC loadTable response missing required 'metadata.columns'");
+    // Commit translation lands in the etag-plumbing PR. Fail loud if the server returns
+    // unbackfilled commits today -- silent stale snapshots are worse than a surfaced gap.
+    require(resp.getCommits() == null || resp.getCommits().isEmpty(),
+        "DRC loadTable response carried " + (resp.getCommits() == null
+            ? 0 : resp.getCommits().size())
+            + " unbackfilled commits; commit translation is not yet wired");
+
+    final DRCMetadataAdapter adapter = new DRCMetadataAdapter(
+        meta.getTableUuid().toString(),
+        /* name */ table,
+        /* description */ null,
+        meta.getColumns().getFields(),
+        meta.getPartitionColumns() != null
+            ? meta.getPartitionColumns() : Collections.emptyList(),
+        meta.getProperties() != null ? meta.getProperties() : Collections.emptyMap(),
+        meta.getCreatedTime());
+
+    // GetCommitsResponse constructor takes (commits, latestTableVersion). Pass an empty list
+    // here -- unbackfilled-commit translation is tracked by the require above.
+    final GetCommitsResponse commitsResponse = new GetCommitsResponse(
+        Collections.emptyList(), resp.getLatestTableVersion());
+
+    return new UCDeltaClient.LoadTableResponse(
+        commitsResponse,
+        meta.getEtag(),
+        meta.getLocation(),
+        meta.getTableUuid().toString(),
+        meta.getTableType() != null ? meta.getTableType().toString() : null,
+        adapter.getConfiguration(),
+        /* protocol  -- derived from log in SnapshotManagement */ null,
+        adapter,
+        /* credentials -- separate RPC in v1, inlined in a later PR */ null);
+  }
+
+  // -------------------- createTable + commits (not yet wired) --------------------
+
+  @Override
+  public void createTable(
+      String catalog, String schema, String table, String location,
+      AbstractMetadata metadata, AbstractProtocol protocol,
+      boolean isManaged, String dataSourceFormat,
+      List<? extends AbstractDomainMetadata> domainMetadata) throws CommitFailedException {
+    throw new UnsupportedOperationException(
+        "UCDeltaClient.createTable lands with the CREATE-TABLE PR (post-v1 stack).");
+  }
+
+  @Override
+  public void commit(
+      TableDescriptor tableDesc, Path logPath,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion, boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<UniformMetadata> uniform, Optional<String> etag)
+      throws IOException, CommitFailedException {
+    throw new UnsupportedOperationException(
+        "UCDeltaClient.commit (Spark V1) lands with the commit-path PR.");
+  }
+
+  @Override
+  public void commit(
+      String catalog, String schema, String table, String ucTableId, URI tableUri,
+      Optional<Commit> commit, Optional<Long> lastKnownBackfilledVersion, boolean disown,
+      Optional<AbstractMetadata> oldMetadata, Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> oldProtocol, Optional<AbstractProtocol> newProtocol,
+      Optional<UniformMetadata> uniform, Optional<String> etag)
+      throws IOException, CommitFailedException {
+    throw new UnsupportedOperationException(
+        "UCDeltaClient.commit (Kernel V2) lands with the commit-path PR.");
+  }
+
+  // -------------------- helpers --------------------
+
+  private void logRoutingTransition(boolean drc) {
+    final Boolean prev = lastLoggedRoute.getAndSet(drc);
+    if (prev == null) {
+      LOG.info("UCTokenBasedDeltaRestClient routing resolved: {}", drc ? "DRC" : "LEGACY");
+    } else if (prev.booleanValue() != drc) {
+      LOG.info("UCTokenBasedDeltaRestClient routing transition: {} -> {}",
+          prev ? "DRC" : "LEGACY", drc ? "DRC" : "LEGACY");
+    }
+  }
+
+  private static IOException translateApiException(ApiException e, String c, String s, String t) {
+    final int code = e.getCode();
+    final String body = Optional.ofNullable(e.getResponseBody()).orElse("");
+    final String fqn = fqn(c, s, t);
+    if (code == 404) {
+      return new FileNotFoundException(
+          "DRC loadTable: table not found " + fqn + ": " + body);
+    }
+    return new IOException(String.format(
+        "DRC loadTable failed for %s (HTTP %d): %s", fqn, code, body), e);
+  }
+
+  private static String fqn(String c, String s, String t) { return c + "." + s + "." + t; }
+
+  private static void require(boolean cond, String msg) {
+    if (!cond) throw new IllegalStateException(msg);
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -129,6 +129,19 @@ public class UCTokenBasedRestClient implements UCClient {
   }
 
   /**
+   * Package-private constructor for DRC-aware subclasses that share a pre-built
+   * {@link ApiClient} with the UC catalog plugin (see
+   * {@code io.unitycatalog.client.delta.DeltaRestClientProvider#getApiClient()}). Avoids a
+   * duplicate HTTP pool for Delta vs UC.
+   */
+  UCTokenBasedRestClient(ApiClient apiClient) {
+    Objects.requireNonNull(apiClient, "apiClient must not be null");
+    this.deltaCommitsApi = new DeltaCommitsApi(apiClient);
+    this.metastoresApi = new MetastoresApi(apiClient);
+    this.tablesApi = new TablesApi(apiClient);
+  }
+
+  /**
    * Ensures the client has not been closed. Must be called before any API operation.
    */
   private void ensureOpen() {

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapterSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapterSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.util.Collections
+
+import io.unitycatalog.client.delta.model.{PrimitiveType, StructField}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class DRCMetadataAdapterSuite extends AnyFunSuite {
+
+  private def newAdapter(): DRCMetadataAdapter = {
+    val p = new PrimitiveType(); p.setType("long")
+    val f = new StructField()
+    f.setName("id"); f.setType(p); f.setNullable(false); f.setMetadata(Collections.emptyMap())
+    new DRCMetadataAdapter(
+      /* id */ "uuid-1",
+      /* name */ "t",
+      /* description */ null,
+      java.util.Collections.singletonList(f),
+      Collections.emptyList(),
+      Collections.emptyMap(),
+      /* createdTime */ 0L)
+  }
+
+  test("getSchemaString returns a deterministic empty-struct stub, not an exception") {
+    // Load-bearing: the DRC read path's real schema accessor is getDRCColumns(), but framework
+    // defensive calls (logging, toString in debuggers, metric tags) must not crash. The stub is
+    // stable so callers that DO consume it get predictable behavior.
+    val a = newAdapter()
+    val s1 = a.getSchemaString
+    assert(s1 == "{\"type\":\"struct\",\"fields\":[]}")
+    // Stable across repeated calls.
+    assert(a.getSchemaString == s1)
+    assert(a.getSchemaString == s1)
+  }
+
+  test("getDRCColumns is the real schema accessor and returns the underlying POJO list") {
+    val a = newAdapter()
+    assert(a.getDRCColumns.size == 1)
+    assert(a.getDRCColumns.get(0).getName == "id")
+  }
+
+  test("partition columns and configuration are returned as unmodifiable views") {
+    val a = new DRCMetadataAdapter("id", "n", null,
+      Collections.emptyList(),
+      java.util.Arrays.asList("p1"),
+      Collections.singletonMap("k", "v"),
+      0L)
+    intercept[UnsupportedOperationException] { a.getPartitionColumns.add("p2") }
+    intercept[UnsupportedOperationException] { a.getConfiguration.put("k2", "v2") }
+  }
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedDeltaRestClientSuite.scala
@@ -1,0 +1,189 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.io.{FileNotFoundException, IOException}
+import java.net.URI
+import java.util.{Collections, Optional, UUID}
+
+import io.unitycatalog.client.{ApiClient, ApiException}
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.TablesApi
+import io.unitycatalog.client.delta.model.{
+  LoadTableResponse,
+  PrimitiveType,
+  StructField,
+  StructType,
+  TableMetadata
+}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class UCTokenBasedDeltaRestClientSuite extends AnyFunSuite {
+
+  private def primField(name: String, ptype: String, nullable: Boolean): StructField = {
+    val p = new PrimitiveType(); p.setType(ptype)
+    val f = new StructField(); f.setName(name); f.setType(p); f.setNullable(nullable)
+    f.setMetadata(Collections.emptyMap()); f
+  }
+
+  private def okResponse(): LoadTableResponse = {
+    val st = new StructType()
+    st.setFields(java.util.Arrays.asList(
+      primField("id", "long", nullable = false),
+      primField("name", "string", nullable = true)))
+    val meta = new TableMetadata()
+    meta.setTableUuid(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+    meta.setColumns(st); meta.setEtag("etag-1")
+    meta.setLocation("s3://bucket/path")
+    meta.setProperties(new java.util.HashMap[String, String]() {{
+      put("delta.minReaderVersion", "1"); put("delta.minWriterVersion", "2")
+      put("delta.feature.catalogManaged", "supported")
+    }})
+    meta.setPartitionColumns(Collections.emptyList())
+    meta.setCreatedTime(12345L)
+    val resp = new LoadTableResponse()
+    resp.setMetadata(meta); resp.setLatestTableVersion(42L)
+    resp.setCommits(Collections.emptyList()); resp
+  }
+
+  private def provider(api: Option[TablesApi]): DeltaRestClientProvider =
+    new DeltaRestClientProvider {
+      override def getDeltaTablesApi: Optional[TablesApi] = api match {
+        case Some(a) => Optional.of(a); case None => Optional.empty()
+      }
+      override def getApiClient: ApiClient = throw new UnsupportedOperationException("unused")
+    }
+
+  private class StubApi(onLoad: () => LoadTableResponse) extends TablesApi(new ApiClient()) {
+    override def loadTable(catalog: String, schema: String, table: String): LoadTableResponse =
+      onLoad.apply()
+  }
+  private class FailingApi(ex: ApiException) extends TablesApi(new ApiClient()) {
+    override def loadTable(c: String, s: String, t: String): LoadTableResponse = throw ex
+  }
+
+  private def client(api: Option[TablesApi]): UCTokenBasedDeltaRestClient =
+    new UCTokenBasedDeltaRestClient(new ApiClient(), provider(api))
+
+  private val anyUri = URI.create("s3://bucket/path")
+
+  test("DRC path: response is translated to DRCMetadataAdapter") {
+    val c = client(Some(new StubApi(() => okResponse())))
+    assert(c.isDRCEnabled)
+    val resp = c.loadTable(
+      "cat", "sch", "tbl",
+      /* ucTableId */ null, anyUri, Optional.empty(), Optional.empty())
+    assert(resp.getCommitsResponse.getLatestTableVersion == 42L)
+    assert(resp.getEtag == "etag-1")
+    assert(resp.getLocation == "s3://bucket/path")
+    val adapter = resp.getMetadata.asInstanceOf[DRCMetadataAdapter]
+    assert(adapter.getDRCColumns.size == 2)
+    assert(adapter.getDRCColumns.get(0).getName == "id")
+    // Protocol is not populated from loadTable response in v1 -- SnapshotManagement derives it
+    // from the commit log. Populating here would silently force reader-feature support for
+    // writer-only features.
+    assert(resp.getProtocol == null)
+  }
+
+  test("flag off: loadTable throws UnsupportedOperation, isDRCEnabled is false") {
+    val c = client(None)
+    assert(!c.isDRCEnabled)
+    intercept[UnsupportedOperationException] {
+      c.loadTable("c", "s", "t", null, anyUri, Optional.empty(), Optional.empty())
+    }
+  }
+
+  test("null required field (metadata.columns) fails loud") {
+    val badResp: LoadTableResponse = {
+      val r = okResponse(); r.getMetadata.setColumns(null); r
+    }
+    val c = client(Some(new StubApi(() => badResp)))
+    val ex = intercept[IllegalStateException] {
+      c.loadTable("c", "s", "t", null, anyUri, Optional.empty(), Optional.empty())
+    }
+    assert(ex.getMessage.contains("metadata.columns"))
+  }
+
+  test("unbackfilled commits in response fail loud (translation not yet wired)") {
+    val r = okResponse()
+    r.setCommits(java.util.Arrays.asList(
+      new io.unitycatalog.client.delta.model.DeltaCommit()))
+    val c = client(Some(new StubApi(() => r)))
+    val ex = intercept[IllegalStateException] {
+      c.loadTable("c", "s", "t", null, anyUri, Optional.empty(), Optional.empty())
+    }
+    assert(ex.getMessage.contains("unbackfilled commits"))
+  }
+
+  test("404 translates to FileNotFoundException") {
+    val api = new FailingApi(
+      new ApiException(404, "not found", null.asInstanceOf[java.net.http.HttpHeaders], "not found"))
+    val ex = intercept[FileNotFoundException] {
+      client(Some(api)).loadTable("c", "s", "t", null, anyUri, Optional.empty(), Optional.empty())
+    }
+    assert(ex.getMessage.contains("not found"))
+  }
+
+  test("500 translates to IOException (not FileNotFoundException)") {
+    val api = new FailingApi(
+      new ApiException(500, "boom", null.asInstanceOf[java.net.http.HttpHeaders], "boom"))
+    val ex = intercept[IOException] {
+      client(Some(api)).loadTable("c", "s", "t", null, anyUri, Optional.empty(), Optional.empty())
+    }
+    assert(!ex.isInstanceOf[FileNotFoundException])
+    assert(ex.getMessage.contains("HTTP 500"))
+  }
+
+  test("flag flip mid-session re-routes on the next call (no caching)") {
+    val apiRef = new java.util.concurrent.atomic.AtomicReference[Optional[TablesApi]](
+      Optional.empty())
+    val flippingProvider = new DeltaRestClientProvider {
+      override def getDeltaTablesApi: Optional[TablesApi] = apiRef.get()
+      override def getApiClient: ApiClient = throw new UnsupportedOperationException("unused")
+    }
+    val c = new UCTokenBasedDeltaRestClient(new ApiClient(), flippingProvider)
+    assert(!c.isDRCEnabled)
+    apiRef.set(Optional.of(new StubApi(() => okResponse())))
+    assert(c.isDRCEnabled)
+    val resp = c.loadTable("c", "s", "t", null, anyUri, Optional.empty(), Optional.empty())
+    assert(resp.getTableId == "00000000-0000-0000-0000-000000000001")
+  }
+
+  test("createTable and typed commits throw UnsupportedOperation until later PRs") {
+    val c = client(Some(new StubApi(() => okResponse())))
+    intercept[UnsupportedOperationException] {
+      c.createTable("cat", "sch", "tbl", "s3://x",
+        null.asInstanceOf[io.delta.storage.commit.actions.AbstractMetadata],
+        null.asInstanceOf[io.delta.storage.commit.actions.AbstractProtocol],
+        true, "delta", Collections.emptyList())
+    }
+    intercept[UnsupportedOperationException] {
+      c.commit(null.asInstanceOf[io.delta.storage.commit.TableDescriptor],
+        null.asInstanceOf[org.apache.hadoop.fs.Path],
+        Optional.empty(), Optional.empty(), false,
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Optional.empty(), Optional.empty())
+    }
+    intercept[UnsupportedOperationException] {
+      c.commit("cat", "sch", "tbl", "uuid", anyUri,
+        Optional.empty(), Optional.empty(), false,
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Optional.empty(), Optional.empty())
+    }
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6650/files/46e9edc50f4d582cc56a00682c84fd64add45e44..f57301e88c983205e7d120608031e08d3724106a) to review incremental changes.
- [stack/drc/01-interface](https://github.com/delta-io/delta/pull/6648) [[Files changed](https://github.com/delta-io/delta/pull/6648/files)]
  - [stack/drc/02-adapter](https://github.com/delta-io/delta/pull/6649) [[Files changed](https://github.com/delta-io/delta/pull/6649/files/acd2b755d3e918a1bac1bd149130587491bf9311..46e9edc50f4d582cc56a00682c84fd64add45e44)]
    - [**stack/drc/03-impl-load**](https://github.com/delta-io/delta/pull/6650) [[Files changed](https://github.com/delta-io/delta/pull/6650/files/46e9edc50f4d582cc56a00682c84fd64add45e44..f57301e88c983205e7d120608031e08d3724106a)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

Production implementation of UCDeltaClient. The DRC/legacy routing decision
lives entirely inside this class and is re-evaluated on every call via the
DeltaRestClientProvider, so a mid-session flag flip (common in tests) takes
effect on the next invocation without reconstructing the client.

loadTable is the only method wired in this PR:
- DRC path: delegates to TablesApi.loadTable, translates the response into a
  DRCMetadataAdapter + a protocol derived from properties (UC PR #1487
  removed the structured protocol from the loadTable response -- the v1 read
  path reconstructs it from delta.minReaderVersion / delta.minWriterVersion /
  delta.feature.*).
- Flag off: throws UnsupportedOperation. Catalog-side wiring (a later PR)
  does not invoke this method when DRC is off; legacy reads still flow
  through UCProxy.

Fail-loud contract at the translation boundary: missing
latest-table-version, metadata, table-uuid, or columns all throw
IllegalStateException with the field name -- silent NPEs in downstream Spark
code are worse than an explicit bug report. 404 responses map to
FileNotFoundException; 409/429/500 remain IOException until the commit-path
PR introduces typed Delta exceptions where they actually matter.

Observability: routing decision is INFO-logged exactly once via AtomicBoolean
and a per-route counter (drcLoadTableCount / legacyLoadTableCount) supports
rollout triage. Six-test coverage exercises both routes, null-field
fail-loud, 404 and 500 translations, and a mid-session flag flip.
## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
