### PR TITLE
[PROTOCOL RFC] Fix language in VariantShredding.md 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,0 @@
-# Build Systems
-
-- **universe** and **runtime** (../runtime) are **Bazel** workspaces.
-- **delta** (this repo) and **spark** are **sbt** workspaces.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Build Systems
+
+- **universe** and **runtime** (../runtime) are **Bazel** workspaces.
+- **delta** (this repo) and **spark** are **sbt** workspaces.

--- a/protocol_rfcs/variant-shredding.md
+++ b/protocol_rfcs/variant-shredding.md
@@ -36,7 +36,8 @@ typed_value | * | (optional) This can be any Parquet type, representing the data
 ## Writer Requirements for Variant Shredding
 
 When Variant Shredding is supported (`writerFeatures` field of a table's `protocol` action contains `variantShredding`), writers:
-- must respect the `delta.enableVariantShredding` table property configuration. If `delta.enableVariantShredding=false`, a column of type `variant` must not be written as a shredded Variant, but as an unshredded Variant. If `delta.enableVariantShredding=true`, the writer can choose to shred a Variant column according to the [Parquet Variant Shredding specification](https://github.com/apache/parquet-format/blob/master/VariantShredding.md)
+- must respect the `delta.enableVariantShredding` table property configuration. If `delta.enableVariantShredding` is not present or if it is set to any value other than `true`, a column of type `variant` must not be written as a shredded Variant, but as an unshredded Variant. If `delta.enableVariantShredding=true`, the writer can choose to shred a Variant column according to the [Parquet Variant Shredding specification](https://github.com/apache/parquet-format/blob/master/VariantShredding.md).
+- must ensure the `variantShredding` table feature is present in the table protocol's `writerFeatures`  and `readerFeatures` when enabling the `delta.enableVariantShredding` table property, i.e. setting `delta.enableVariantShredding=true`.
 
 ## Reader Requirements for Variant Shredding
 

--- a/protocol_rfcs/variant-shredding.md
+++ b/protocol_rfcs/variant-shredding.md
@@ -40,7 +40,7 @@ When Variant Shredding is supported (`writerFeatures` field of a table's `protoc
 
 ## Reader Requirements for Variant Shredding
 
-When Variant type is supported (`readerFeatures` field of a table's `protocol` action contains `variantShredding`), readers:
+When Variant Shredding is supported (`readerFeatures` field of a table's `protocol` action contains `variantShredding`), readers:
 - must recognize and tolerate a `variant` data type in a Delta schema
 - must recognize and correctly process a parquet schema that is either unshredded (only `metadata` and `value` struct fields) or shredded (`metadata`, `value`, and `typed_value` struct fields) when reading a Variant data type from file.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol RFC)

## Description

1. This PR replaces `Variant type` with `Variant Shredding` in the reader features section of the variant shredding RFC
2. Specifies that `enableVariantShredding` must be true in order for writes to write shredded data.
3. Specifies that `enableVariantShredding` can only be true if the table has the variantShredding table feature.

## How was this patch tested?

NA

## Does this PR introduce _any_ user-facing changes?

No