### PR TITLE
[DRC][3/N] UCDeltaClientImpl.loadTable with internal routing + fail-loud asserts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -723,7 +723,10 @@ lazy val contribs = (project in file("contribs"))
   ).configureUnidoc()
 
 
-val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.4.1")
+// 0.5.0-SNAPSHOT is required for io.unitycatalog.client.delta.model.* (DRC SDK types
+// generated from delta.yaml). The 0.4.1 release predates DRC. Override via
+// -DunityCatalogVersion=... for local dev until UC 0.5.0 releases.
+val unityCatalogVersion = sys.props.getOrElse("unityCatalogVersion", "0.5.0-SNAPSHOT")
 val sparkUnityCatalogJacksonVersion = "2.15.4" // We are using Spark 4.0's Jackson version 2.15.x, to override Unity Catalog 0.3.0's version 2.18.x
 
 lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverter.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import scala.collection.JavaConverters._
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => DrcArrayType,
+  DecimalType => DrcDecimalType,
+  DeltaType => DrcDeltaType,
+  MapType => DrcMapType,
+  PrimitiveType => DrcPrimitiveType,
+  StructField => DrcStructField,
+  StructType => DrcStructType
+}
+
+import org.apache.spark.sql.types._
+
+/**
+ * Converts a Delta REST Catalog (DRC) column list -- a `java.util.List` of UC SDK POJOs
+ * -- into a Spark `StructType` without a JSON round-trip. The read-path fast path from
+ * `DRCMetadataAdapter.getDRCColumns()` directly into `StructType`.
+ *
+ * Forward direction (DRC -> Spark) only. The reverse (Spark -> DRC) lands in the
+ * write-path PR where intent-based schema emission matters.
+ *
+ * <p>Unknown primitive names or unrecognised `DeltaType` subclasses throw
+ * `IllegalArgumentException`. Callers must not catch-and-coerce: an unknown type means
+ * the UC server has rolled forward past the pinned SDK, and the Delta-side pin needs to
+ * be bumped.
+ */
+private[delta] object DeltaRestSchemaConverter {
+
+  def toSparkSchema(drcColumns: java.util.List[DrcStructField]): StructType = {
+    require(drcColumns != null, "DRC column list must be non-null")
+    StructType(drcColumns.asScala.map(toSparkField).toArray)
+  }
+
+  private def toSparkField(drc: DrcStructField): StructField = {
+    require(drc.getName != null, "DRC column name must be non-null")
+    require(drc.getType != null, s"DRC column '${drc.getName}' has null type")
+    require(drc.getNullable != null, s"DRC column '${drc.getName}' has null 'nullable'")
+    StructField(
+      drc.getName,
+      toSparkDataType(drc.getType),
+      drc.getNullable,
+      toSparkMetadata(drc.getMetadata))
+  }
+
+  private def toSparkDataType(drc: DrcDeltaType): DataType = drc match {
+    case p: DrcPrimitiveType =>
+      parsePrimitive(p.getType)
+    case d: DrcDecimalType =>
+      require(d.getPrecision != null, "decimal type missing precision")
+      require(d.getScale != null, "decimal type missing scale")
+      DecimalType(d.getPrecision, d.getScale)
+    case a: DrcArrayType =>
+      require(a.getElementType != null, "array type missing element-type")
+      require(a.getContainsNull != null, "array type missing contains-null")
+      ArrayType(toSparkDataType(a.getElementType), a.getContainsNull)
+    case m: DrcMapType =>
+      require(m.getKeyType != null, "map type missing key-type")
+      require(m.getValueType != null, "map type missing value-type")
+      require(m.getValueContainsNull != null, "map type missing value-contains-null")
+      MapType(
+        toSparkDataType(m.getKeyType),
+        toSparkDataType(m.getValueType),
+        m.getValueContainsNull)
+    case s: DrcStructType =>
+      require(s.getFields != null, "struct type missing fields")
+      StructType(s.getFields.asScala.map(toSparkField).toArray)
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unsupported DRC DeltaType subclass: ${other.getClass.getName}. " +
+          "The pinned UC SDK may be ahead of the Delta-Spark converter -- bump the Delta side.")
+  }
+
+  private def parsePrimitive(name: String): DataType = name match {
+    case "string" => StringType
+    case "long" => LongType
+    case "integer" => IntegerType
+    case "short" => ShortType
+    case "byte" => ByteType
+    case "double" => DoubleType
+    case "float" => FloatType
+    case "boolean" => BooleanType
+    case "binary" => BinaryType
+    case "date" => DateType
+    case "timestamp" => TimestampType
+    case "timestamp_ntz" => TimestampNTZType
+    case null =>
+      throw new IllegalArgumentException("DRC primitive type name is null")
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unknown DRC primitive type name: '$other'. Add a case to " +
+          "DeltaRestSchemaConverter.parsePrimitive or bump the UC pin if this is a new type.")
+  }
+
+  private def toSparkMetadata(raw: java.util.Map[String, Object]): Metadata = {
+    if (raw == null || raw.isEmpty) return Metadata.empty
+    val b = new MetadataBuilder
+    raw.asScala.foreach { case (k, v) =>
+      v match {
+        case null => b.putNull(k)
+        case s: String => b.putString(k, s)
+        case l: java.lang.Long => b.putLong(k, l)
+        case i: java.lang.Integer => b.putLong(k, i.longValue)
+        case sh: java.lang.Short => b.putLong(k, sh.longValue)
+        case by: java.lang.Byte => b.putLong(k, by.longValue)
+        case bl: java.lang.Boolean => b.putBoolean(k, bl)
+        case d: java.lang.Double => b.putDouble(k, d)
+        case f: java.lang.Float => b.putDouble(k, f.doubleValue)
+        case other => b.putString(k, String.valueOf(other))
+      }
+    }
+    b.build()
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uccatalog/DeltaRestSchemaConverterSuite.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uccatalog
+
+import java.util.{Arrays, Collections, HashMap}
+
+import io.unitycatalog.client.delta.model.{
+  ArrayType => DrcArrayType,
+  DecimalType => DrcDecimalType,
+  MapType => DrcMapType,
+  PrimitiveType => DrcPrimitiveType,
+  StructField => DrcStructField,
+  StructType => DrcStructType
+}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.types._
+
+class DeltaRestSchemaConverterSuite extends AnyFunSuite {
+
+  // --- helpers --------------------------------------------------------------
+
+  private def prim(name: String): DrcPrimitiveType = {
+    val p = new DrcPrimitiveType(); p.setType(name); p
+  }
+
+  private def field(
+      name: String,
+      dtype: io.unitycatalog.client.delta.model.DeltaType,
+      nullable: Boolean,
+      metadata: java.util.Map[String, Object] = Collections.emptyMap()): DrcStructField = {
+    val f = new DrcStructField()
+    f.setName(name); f.setType(dtype); f.setNullable(nullable); f.setMetadata(metadata); f
+  }
+
+  private def convert(fields: DrcStructField*): StructType =
+    DeltaRestSchemaConverter.toSparkSchema(Arrays.asList(fields: _*))
+
+  // --- primitives -----------------------------------------------------------
+
+  test("all supported primitives map correctly") {
+    val expected = Seq(
+      ("string", StringType), ("long", LongType), ("integer", IntegerType),
+      ("short", ShortType), ("byte", ByteType), ("double", DoubleType),
+      ("float", FloatType), ("boolean", BooleanType), ("binary", BinaryType),
+      ("date", DateType), ("timestamp", TimestampType), ("timestamp_ntz", TimestampNTZType))
+    expected.foreach { case (drcName, sparkType) =>
+      val s = convert(field("c", prim(drcName), nullable = true))
+      assert(s.fields(0).dataType == sparkType, s"mismatch for $drcName")
+    }
+  }
+
+  test("unknown primitive name fails loud") {
+    val ex = intercept[IllegalArgumentException] {
+      convert(field("c", prim("unknown_type_xyz"), nullable = true))
+    }
+    assert(ex.getMessage.contains("unknown_type_xyz"))
+    assert(ex.getMessage.contains("bump the UC pin"))
+  }
+
+  test("null primitive name fails loud (rather than silently defaulting)") {
+    intercept[IllegalArgumentException] {
+      convert(field("c", prim(null), nullable = true))
+    }
+  }
+
+  // --- decimal --------------------------------------------------------------
+
+  test("decimal carries precision and scale") {
+    val d = new DrcDecimalType(); d.setPrecision(10); d.setScale(2)
+    val s = convert(field("c", d, nullable = false))
+    assert(s.fields(0).dataType == DecimalType(10, 2))
+    assert(!s.fields(0).nullable)
+  }
+
+  test("decimal without precision or scale fails loud") {
+    val d1 = new DrcDecimalType(); d1.setScale(2)
+    intercept[IllegalArgumentException] { convert(field("c", d1, nullable = true)) }
+    val d2 = new DrcDecimalType(); d2.setPrecision(10)
+    intercept[IllegalArgumentException] { convert(field("c", d2, nullable = true)) }
+  }
+
+  // --- array / map / nested struct -----------------------------------------
+
+  test("ArrayType carries elementType and containsNull") {
+    val a = new DrcArrayType(); a.setElementType(prim("long")); a.setContainsNull(false)
+    val s = convert(field("c", a, nullable = true))
+    assert(s.fields(0).dataType == ArrayType(LongType, containsNull = false))
+  }
+
+  test("MapType carries key, value, and valueContainsNull") {
+    val m = new DrcMapType()
+    m.setKeyType(prim("string")); m.setValueType(prim("long")); m.setValueContainsNull(true)
+    val s = convert(field("c", m, nullable = true))
+    assert(s.fields(0).dataType == MapType(StringType, LongType, valueContainsNull = true))
+  }
+
+  test("nested StructType recursively converted") {
+    val inner = new DrcStructType()
+    inner.setFields(Arrays.asList(
+      field("x", prim("long"), nullable = false),
+      field("y", prim("string"), nullable = true)))
+    val s = convert(field("c", inner, nullable = true))
+    s.fields(0).dataType match {
+      case st: StructType =>
+        assert(st.fields.length == 2)
+        assert(st.fields(0) == StructField("x", LongType, nullable = false))
+        assert(st.fields(1) == StructField("y", StringType, nullable = true))
+      case other =>
+        fail(s"expected StructType, got $other")
+    }
+  }
+
+  // --- column metadata ------------------------------------------------------
+
+  test("column metadata carries delta.columnMapping.id (critical for column mapping)") {
+    val md = new HashMap[String, Object](); md.put("delta.columnMapping.id", java.lang.Long.valueOf(7L))
+    val s = convert(field("c", prim("string"), nullable = true, metadata = md))
+    assert(s.fields(0).metadata.getLong("delta.columnMapping.id") == 7L)
+  }
+
+  test("empty column metadata round-trips as Metadata.empty") {
+    val s = convert(field("c", prim("string"), nullable = true))
+    assert(s.fields(0).metadata == Metadata.empty)
+  }
+
+  test("null column metadata is treated as empty (no NPE)") {
+    val s = convert(field("c", prim("string"), nullable = true, metadata = null))
+    assert(s.fields(0).metadata == Metadata.empty)
+  }
+
+  test("mixed-type metadata values convert to the right Spark metadata types") {
+    val md = new HashMap[String, Object]()
+    md.put("s", "hi")
+    md.put("b", java.lang.Boolean.TRUE)
+    md.put("i", java.lang.Integer.valueOf(3))
+    md.put("d", java.lang.Double.valueOf(1.5))
+    val s = convert(field("c", prim("long"), nullable = true, metadata = md))
+    val m = s.fields(0).metadata
+    assert(m.getString("s") == "hi")
+    assert(m.getBoolean("b"))
+    assert(m.getLong("i") == 3L)
+    assert(m.getDouble("d") == 1.5)
+  }
+
+  // --- null-safety / fail-loud ---------------------------------------------
+
+  test("null column list fails loud") {
+    intercept[IllegalArgumentException] { DeltaRestSchemaConverter.toSparkSchema(null) }
+  }
+
+  test("null field name / type / nullable flag all fail loud with the column name") {
+    val f1 = new DrcStructField(); f1.setName(null); f1.setType(prim("long"))
+    intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(Arrays.asList(f1))
+    }
+    val f2 = new DrcStructField(); f2.setName("c"); f2.setType(null)
+    val ex2 = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(Arrays.asList(f2))
+    }
+    assert(ex2.getMessage.contains("'c'"))
+    val f3 = new DrcStructField()
+    f3.setName("c"); f3.setType(prim("long")); f3.setNullable(null)
+    val ex3 = intercept[IllegalArgumentException] {
+      DeltaRestSchemaConverter.toSparkSchema(Arrays.asList(f3))
+    }
+    assert(ex3.getMessage.contains("'c'"))
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapter.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapter.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.unitycatalog.client.delta.model.StructField;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link AbstractMetadata} implementation that carries a Delta REST Catalog (DRC) table's
+ * schema as the raw UC SDK POJO column list, avoiding the JSON round-trip imposed by the
+ * legacy read path.
+ *
+ * <p><b>Fast path (DRC read).</b> {@code UCDeltaClientImpl.loadTable} constructs this
+ * adapter from the UC SDK {@code TableMetadata}. Delta-Spark pattern-matches on the
+ * concrete type, calls {@link #getDRCColumns()} to retrieve the POJO list, and feeds it
+ * to {@code DeltaRestSchemaConverter} for direct conversion to {@code StructType}. No
+ * JSON in the middle.
+ *
+ * <p><b>{@link #getSchemaString()} is a deterministic empty-struct stub in v1.</b> Spark
+ * read-path consumers MUST use {@link #getDRCColumns()} via a type cast from
+ * {@link AbstractMetadata}. The stub exists so that framework defensive callers (logging,
+ * {@code toString}, error formatters, metric tags) do not crash a read when they reach
+ * past the adapter's preferred interface. A once-per-instance WARN surfaces unintended
+ * use without stopping the session. A real JSON fallback is tracked in design-doc
+ * clarifications §6 pending the Kernel/Flink consumer audit.
+ *
+ * <p><b>Internal.</b> Consumers outside the DRC read path should not depend on this
+ * class directly; cast through {@link AbstractMetadata} and {@code getDRCColumns()}.
+ *
+ * <p>Immutable -- columns, partition list, and configuration are defensively copied at
+ * construction and returned via unmodifiable views so that mutations on the UC SDK side
+ * cannot leak into downstream consumers.
+ */
+public final class DRCMetadataAdapter implements AbstractMetadata {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DRCMetadataAdapter.class);
+  private static final String DELTA_PROVIDER = "delta";
+  private static final String EMPTY_STRUCT_JSON = "{\"type\":\"struct\",\"fields\":[]}";
+
+  // Per-instance so that one stray caller per table surfaces one WARN -- correlatable
+  // in bug reports. JVM-wide would be too quiet with multiple loaded tables.
+  private final AtomicBoolean loggedSchemaStringStub = new AtomicBoolean(false);
+
+  private final String id;
+  private final String name;
+  private final String description;
+  private final List<StructField> drcColumns;
+  private final List<String> partitionColumns;
+  private final Map<String, String> configuration;
+  private final Long createdTime;
+
+  public DRCMetadataAdapter(
+      String id,
+      String name,
+      String description,
+      List<StructField> drcColumns,
+      List<String> partitionColumns,
+      Map<String, String> configuration,
+      Long createdTime) {
+    this.id = Objects.requireNonNull(id, "id");
+    this.name = name;
+    this.description = description;
+    this.drcColumns = Collections.unmodifiableList(
+        new ArrayList<>(Objects.requireNonNull(drcColumns, "drcColumns")));
+    this.partitionColumns = Collections.unmodifiableList(
+        new ArrayList<>(Objects.requireNonNull(partitionColumns, "partitionColumns")));
+    this.configuration = Collections.unmodifiableMap(
+        new HashMap<>(Objects.requireNonNull(configuration, "configuration")));
+    this.createdTime = createdTime;
+  }
+
+  /**
+   * Returns the DRC-native structured column list straight from the UC SDK. Consumers on
+   * the Delta-Spark read path MUST use this method (after a type cast from
+   * {@link AbstractMetadata}) rather than {@link #getSchemaString()}.
+   */
+  public List<StructField> getDRCColumns() {
+    return drcColumns;
+  }
+
+  @Override public String getId() { return id; }
+  @Override public String getName() { return name; }
+  @Override public String getDescription() { return description; }
+  @Override public String getProvider() { return DELTA_PROVIDER; }
+  @Override public Map<String, String> getFormatOptions() { return Collections.emptyMap(); }
+  @Override public List<String> getPartitionColumns() { return partitionColumns; }
+  @Override public Map<String, String> getConfiguration() { return configuration; }
+  @Override public Long getCreatedTime() { return createdTime; }
+
+  /**
+   * Returns an empty-struct JSON stub. This is NOT the DRC read-path schema accessor --
+   * see {@link #getDRCColumns()} and the class-level Javadoc. A one-time WARN is emitted
+   * on first invocation per instance so that unintended callers surface during testing;
+   * a proper JSON fallback is tracked in design-doc clarifications §6.
+   */
+  @Override
+  public String getSchemaString() {
+    if (loggedSchemaStringStub.compareAndSet(false, true)) {
+      LOG.warn("DRCMetadataAdapter.getSchemaString() invoked on table id={}. Returning an "
+          + "empty-struct stub; Delta-Spark read-path consumers must use getDRCColumns() "
+          + "instead. If this WARN originates from non-Spark code (Kernel, Flink, logging "
+          + "framework), file an issue under clarifications §6.", id);
+    }
+    return EMPTY_STRUCT_JSON;
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCreateStagingTableResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCreateStagingTableResponse.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.actions.AbstractProtocol;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Response from phase-1 of the managed-table create flow. Carries the server-allocated
+ * table UUID, the vended storage location, storage credentials for writing the initial
+ * commit, the required protocol (features the server requires the client to enable), and
+ * the required properties the server will set on the created table.
+ *
+ * <p>All fields are non-null by construction; empty lists/maps are valid values.
+ */
+public final class UCCreateStagingTableResponse {
+
+  private final String tableId;
+  private final String location;
+  private final List<UCStorageCredential> storageCredentials;
+  private final AbstractProtocol requiredProtocol;
+  private final Map<String, String> requiredProperties;
+
+  public UCCreateStagingTableResponse(
+      String tableId,
+      String location,
+      List<UCStorageCredential> storageCredentials,
+      AbstractProtocol requiredProtocol,
+      Map<String, String> requiredProperties) {
+    this.tableId = Objects.requireNonNull(tableId, "tableId");
+    this.location = Objects.requireNonNull(location, "location");
+    this.storageCredentials = Collections.unmodifiableList(
+        Objects.requireNonNull(storageCredentials, "storageCredentials"));
+    this.requiredProtocol = Objects.requireNonNull(requiredProtocol, "requiredProtocol");
+    this.requiredProperties = Collections.unmodifiableMap(
+        Objects.requireNonNull(requiredProperties, "requiredProperties"));
+  }
+
+  public String getTableId() { return tableId; }
+  public String getLocation() { return location; }
+  public List<UCStorageCredential> getStorageCredentials() { return storageCredentials; }
+  public AbstractProtocol getRequiredProtocol() { return requiredProtocol; }
+  public Map<String, String> getRequiredProperties() { return requiredProperties; }
+
+  @Override
+  public String toString() {
+    return "UCCreateStagingTableResponse{tableId='" + tableId + "', location='" + location
+        + "', credentialCount=" + storageCredentials.size()
+        + ", requiredPropertyKeys=" + requiredProperties.keySet() + '}';
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCredentialOperation.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCredentialOperation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+/**
+ * Operation scope for a credential-vending request. Mirrors the UC SDK's
+ * {@code CredentialOperation} but lives in storage so the UC SDK type does not leak
+ * through {@link UCDeltaClient} signatures.
+ */
+public enum UCCredentialOperation {
+  /** Read-only credentials: permits listing and reading data files. */
+  READ,
+  /** Read + write credentials: permits adding, removing, and overwriting data files. */
+  READ_WRITE
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCredentialsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCredentialsResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Response envelope for all three credential-vending entry points on
+ * {@link UCDeltaClient}: {@code getTableCredentials}, {@code getStagingTableCredentials},
+ * and {@code getPathCredentials}.
+ */
+public final class UCCredentialsResponse {
+
+  private final List<UCStorageCredential> credentials;
+
+  public UCCredentialsResponse(List<UCStorageCredential> credentials) {
+    this.credentials = Collections.unmodifiableList(
+        Objects.requireNonNull(credentials, "credentials"));
+  }
+
+  public List<UCStorageCredential> getCredentials() { return credentials; }
+
+  @Override
+  public String toString() {
+    return "UCCredentialsResponse{credentialCount=" + credentials.size() + '}';
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Unified Delta-Spark client for Unity Catalog communication across both the catalog path
+ * ({@code loadTable} / {@code createTable} / list / drop / rename) and the commit path
+ * ({@code commit} / staging credentials). Collapses the two historical clients --
+ * {@code UCProxy} (catalog, Scala) and {@code UCClient} (commit, Java) -- behind one
+ * interface so that one HTTP connection, one auth context, and one in-memory view of table
+ * state are shared.
+ *
+ * <p><b>Routing contract.</b> Whether a call routes to the Delta REST Catalog (DRC) v1
+ * endpoints or the legacy UC endpoints is decided inside the implementation on every call.
+ * Callers must not branch on {@link #isDRCEnabled()} to pick between code paths -- that is
+ * the exact pattern this interface exists to prevent. {@code isDRCEnabled()} is for
+ * observability and for softening UC-managed kill switches on the DRC path.
+ *
+ * <p><b>Signature discipline.</b> Every method parameter and every return type is a Delta
+ * storage type ({@link AbstractMetadata}, {@link AbstractProtocol}, {@link Commit}) or a
+ * Delta-owned DTO ({@link UCLoadTableResponse} and siblings). No {@code
+ * io.unitycatalog.client.*} type leaks through this interface so that non-Spark consumers
+ * (Kernel, Flink) can depend on it without pulling in the UC SDK.
+ *
+ * <p><b>Threading.</b> Implementations must be safe for concurrent use by Spark task
+ * threads within one {@code SparkSession}; one instance is shared across all of them via
+ * the session-scoped registry.
+ *
+ * <p><b>Extends {@link UCClient} for migration.</b> Everything that already holds a
+ * {@code UCClient} reference -- most importantly {@code UCCommitCoordinatorClient} --
+ * can be handed a {@code UCDeltaClient} without a refactor. The inherited path-based
+ * {@code commit} / {@code getCommits} / {@code finalizeCreate} / {@code getMetastoreId}
+ * are the LEGACY surface; the methods added here are the DRC surface. The DRC
+ * {@link #commit} is an overload of the legacy {@code commit}: different parameter
+ * shape, different semantics (intent-based vs full-replacement), different return type
+ * ({@link UCLoadTableResponse} vs void). Callers choose which shape matches their need.
+ *
+ * <p><b>Stability: evolving.</b> Method set grows per-PR during DRC rollout; consumers
+ * outside Delta should not implement this interface directly.
+ */
+public interface UCDeltaClient extends UCClient {
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Loads a table's full metadata state from Unity Catalog.
+   *
+   * <p>DRC path: {@code GET /delta/v1/catalogs/{c}/schemas/{s}/tables/{t}}. The response
+   * carries structured metadata, unbackfilled commits, the server etag (optional in v1),
+   * and {@code latest-table-version}. The response's {@code protocol} field has been
+   * removed from the DRC spec; callers see a protocol derived from the
+   * {@code delta.minReaderVersion} / {@code delta.minWriterVersion} / {@code
+   * delta.feature.*} properties on the returned metadata.
+   *
+   * <p>Legacy path: not routed through this client -- legacy load goes through
+   * {@code UCProxy.loadTable} directly on the catalog side. Implementations throw
+   * {@link UnsupportedOperationException} when invoked with DRC disabled; catalog-side
+   * wiring must gate via {@link #isDRCEnabled()} before calling.
+   */
+  UCLoadTableResponse loadTable(String catalog, String schema, String table)
+      throws IOException;
+
+  /**
+   * Paginated listing of tables in a schema. Page size is advisory (server may cap it).
+   */
+  UCListTablesResponse listTables(
+      String catalog, String schema, Optional<String> pageToken, Optional<Integer> maxResults)
+      throws IOException;
+
+  // ---------------------------------------------------------------------------
+  // Create (two-phase managed table flow)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Phase 1: allocate a UUID, a storage location, vended credentials, and a required
+   * protocol / required properties envelope for a new managed table. The caller writes the
+   * initial {@code 0.json} commit to the vended location before calling
+   * {@link #createTable}.
+   */
+  UCCreateStagingTableResponse createStagingTable(
+      String catalog, String schema, String name) throws IOException;
+
+  /**
+   * Phase 2: promote a staged managed table to a registered table with schema, protocol,
+   * properties, and (optional) domain metadata. The initial commit written during phase 1
+   * is referenced by {@code initialCommit}.
+   *
+   * <p>{@code properties} MUST be the raw {@code metaData.configuration} map -- server-
+   * derived keys ({@code delta.feature.*}, {@code delta.minReaderVersion}, {@code
+   * delta.lastUpdateVersion}, {@code clusteringColumns}, {@code is_managed_location})
+   * MUST NOT appear. Implementations enforce this at the boundary and fail loud.
+   */
+  UCLoadTableResponse createTable(
+      String catalog,
+      String schema,
+      String name,
+      AbstractMetadata metadata,
+      AbstractProtocol protocol,
+      List<UCDomainMetadata> domainMetadata,
+      Commit initialCommit) throws IOException;
+
+  // ---------------------------------------------------------------------------
+  // Write
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Commits to a registered managed table. Bundles the staged commit and any metadata
+   * updates into a single atomic RPC.
+   *
+   * <p>The implementation computes intent-based diffs between {@code oldMetadata} and
+   * {@code newMetadata} across four axes: description (comment), partition columns,
+   * schema, and raw properties. {@code protocol} is full-replacement when
+   * {@code oldProtocol != newProtocol}. Domain metadata is per-domain intent-based using
+   * {@code oldDomainMetadata} and {@code newDomainMetadata}.
+   *
+   * <p>Requirements emitted:
+   * <ul>
+   *   <li>{@code assert-table-uuid} -- always.</li>
+   *   <li>{@code assert-etag} -- only when {@code etag} is present. Absent etag is
+   *       accepted in v1 (concurrency gap documented in design clarifications §3).</li>
+   * </ul>
+   *
+   * <p>The returned {@link UCLoadTableResponse} reflects the post-commit state including
+   * the new server etag.
+   */
+  UCLoadTableResponse commit(
+      String catalog,
+      String schema,
+      String table,
+      Optional<String> etag,
+      Commit commit,
+      AbstractMetadata oldMetadata,
+      AbstractMetadata newMetadata,
+      AbstractProtocol oldProtocol,
+      AbstractProtocol newProtocol,
+      List<UCDomainMetadata> oldDomainMetadata,
+      List<UCDomainMetadata> newDomainMetadata) throws IOException;
+
+  // ---------------------------------------------------------------------------
+  // Admin
+  // ---------------------------------------------------------------------------
+
+  void dropTable(String catalog, String schema, String table) throws IOException;
+
+  void renameTable(String catalog, String schema, String oldName, String newName)
+      throws IOException;
+
+  // ---------------------------------------------------------------------------
+  // Credentials
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Vends storage credentials scoped to a registered table for the given operation. READ
+   * returns read-only credentials; READ_WRITE returns credentials that permit writes. The
+   * returned credentials have a server-assigned TTL.
+   */
+  UCCredentialsResponse getTableCredentials(
+      String catalog, String schema, String table, UCCredentialOperation operation)
+      throws IOException;
+
+  /**
+   * Vends storage credentials for the location returned by {@link #createStagingTable}
+   * before the table is promoted. Used during phase 1 to write the initial commit.
+   */
+  UCCredentialsResponse getStagingTableCredentials(String tableId) throws IOException;
+
+  /**
+   * Vends credentials scoped to a raw path (used for external tables and cross-table
+   * operations like RESTORE).
+   */
+  UCCredentialsResponse getPathCredentials(String location, UCCredentialOperation operation)
+      throws IOException;
+
+  // ---------------------------------------------------------------------------
+  // Introspection / lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns {@code true} when DRC routing is active. Resolved on every call from the
+   * underlying provider so that flag flips take effect immediately without client
+   * reconstruction. Use for logging, metrics, and softening UC-managed kill switches --
+   * NOT for picking between code paths at the caller.
+   */
+  boolean isDRCEnabled();
+
+  /**
+   * Releases resources owned by this wrapper. Does NOT close the underlying UC SDK
+   * {@code ApiClient}; that HTTP pool is owned by the UC catalog plugin and outlives any
+   * single {@code UCDeltaClient} instance.
+   */
+  @Override
+  void close() throws IOException;
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientImpl.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientImpl.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.GetCommitsResponse;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.commit.uniform.UniformMetadata;
+import io.unitycatalog.client.ApiException;
+import io.unitycatalog.client.delta.DeltaRestClientProvider;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.TableMetadata;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Production implementation of {@link UCDeltaClient}. All routing between the legacy UC
+ * API and the Delta REST Catalog (DRC) API lives here -- callers always call the
+ * interface and get the right behavior transparently.
+ *
+ * <p>Routing is re-evaluated on every call via
+ * {@link DeltaRestClientProvider#getDeltaTablesApi()} so that flipping the UC-side flag
+ * {@code spark.sql.catalog.<catalog>.deltaRestApi.enabled} takes effect immediately.
+ * The client holds the provider rather than a cached {@code TablesApi} reference for
+ * this reason.
+ *
+ * <p><b>v1 scope.</b> Only {@link #loadTable(String, String, String)} is wired as a new
+ * DRC method. Every other new DRC method throws {@link UnsupportedOperationException}
+ * with a pointer to the PR where it lands. The catalog-side wiring (future PR) gates on
+ * {@link #isDRCEnabled()} before invoking {@code loadTable}; flag-off loads still route
+ * through {@code UCProxy} on the Scala side -- the legacy {@code loadTable} path has no
+ * storage-side implementation to route to.
+ *
+ * <p><b>Legacy {@link UCClient} methods.</b> Because {@link UCDeltaClient} extends
+ * {@code UCClient}, this impl must honor the inherited path-based methods
+ * ({@code getMetastoreId}, {@code commit}, {@code getCommits}, {@code finalizeCreate}).
+ * They are delegated to a {@link UCClient} injected at construction so that existing
+ * commit-path callers ({@code UCCommitCoordinatorClient}) can receive a
+ * {@code UCDeltaClient} without a refactor. When no legacy client is supplied the
+ * delegated methods throw {@link UnsupportedOperationException}; full legacy-to-DRC
+ * re-routing inside {@code commit} lands in the commit-path PR.
+ *
+ * <p><b>Internal.</b> Not part of the interface contract; consumers must depend on
+ * {@link UCDeltaClient} only.
+ */
+public final class UCDeltaClientImpl implements UCDeltaClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UCDeltaClientImpl.class);
+
+  private final DeltaRestClientProvider provider;
+  /** Absent during DRC-only tests; present once callers wire legacy plumbing through. */
+  private final Optional<UCClient> legacyClient;
+
+  /**
+   * Last-logged routing decision. We log on TRANSITIONS so that a long-lived client
+   * outliving a flag flip surfaces the change in logs. Null means we have not logged yet;
+   * {@code true}/{@code false} records the last observed routing direction.
+   */
+  private final AtomicReference<Boolean> lastLoggedRoute = new AtomicReference<>(null);
+
+  // Minimum viable path-taken telemetry per design clarifications §8. Exposed via
+  // getters below for future metrics wiring.
+  private final AtomicLong drcLoadTableCount = new AtomicLong();
+  private final AtomicLong legacyLoadTableCount = new AtomicLong();
+
+  /**
+   * DRC-only constructor. Inherited {@link UCClient} methods throw
+   * {@link UnsupportedOperationException}; use the two-arg constructor to wire legacy
+   * plumbing.
+   */
+  public UCDeltaClientImpl(DeltaRestClientProvider provider) {
+    this(provider, null);
+  }
+
+  /**
+   * Full constructor. The injected {@code legacyClient} receives all inherited
+   * {@link UCClient} method calls; new DRC methods on this class route independently
+   * via {@link DeltaRestClientProvider}.
+   */
+  public UCDeltaClientImpl(DeltaRestClientProvider provider, UCClient legacyClient) {
+    this.provider = Objects.requireNonNull(provider, "provider");
+    this.legacyClient = Optional.ofNullable(legacyClient);
+    LOG.debug("UCDeltaClientImpl constructed (legacyClientPresent={}); routing resolved "
+        + "per call.", this.legacyClient.isPresent());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Introspection
+  // ---------------------------------------------------------------------------
+
+  @Override
+  public boolean isDRCEnabled() {
+    return provider.getDeltaTablesApi().isPresent();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  @Override
+  public UCLoadTableResponse loadTable(String catalog, String schema, String table)
+      throws IOException {
+    requireNonEmpty(catalog, "catalog");
+    requireNonEmpty(schema, "schema");
+    requireNonEmpty(table, "table");
+
+    Optional<TablesApi> api = provider.getDeltaTablesApi();
+    if (api.isPresent()) {
+      logRoutingTransition(true);
+      drcLoadTableCount.incrementAndGet();
+      return loadTableDRC(api.get(), catalog, schema, table);
+    } else {
+      logRoutingTransition(false);
+      legacyLoadTableCount.incrementAndGet();
+      // Catalog-side wiring must gate on isDRCEnabled() before invoking -- legacy loads
+      // flow through UCProxy directly. Throwing here (rather than silently doing nothing)
+      // surfaces a forgotten gate as a loud failure.
+      throw new UnsupportedOperationException(
+          "UCDeltaClientImpl.loadTable is DRC-only. Flag-off loads must route through "
+              + "UCProxy at the catalog layer; caller must gate on isDRCEnabled() before "
+              + "invocation.");
+    }
+  }
+
+  private UCLoadTableResponse loadTableDRC(
+      TablesApi api, String catalog, String schema, String table) throws IOException {
+    final LoadTableResponse resp;
+    try {
+      resp = api.loadTable(catalog, schema, table);
+    } catch (ApiException e) {
+      throw translateApiException(e, catalog, schema, table);
+    }
+
+    require(resp != null, "DRC loadTable returned a null response for "
+        + fqn(catalog, schema, table));
+    require(resp.getLatestTableVersion() != null,
+        "DRC loadTable response missing required 'latest-table-version'");
+
+    final TableMetadata meta = resp.getMetadata();
+    require(meta != null, "DRC loadTable response missing required 'metadata'");
+    require(meta.getTableUuid() != null,
+        "DRC loadTable response missing required 'metadata.table-uuid'");
+    require(meta.getColumns() != null && meta.getColumns().getFields() != null,
+        "DRC loadTable response missing required 'metadata.columns'");
+
+    // Commit translation lands in the commit-path PR. Fail loud the instant a server
+    // upgrade returns unbackfilled commits so the oversight surfaces immediately rather
+    // than producing a silent stale snapshot.
+    require(resp.getCommits() == null || resp.getCommits().isEmpty(),
+        "DRC loadTable returned " + (resp.getCommits() == null ? 0 : resp.getCommits().size())
+            + " unbackfilled commits; commit translation not yet implemented");
+
+    final DRCMetadataAdapter adapter = new DRCMetadataAdapter(
+        meta.getTableUuid().toString(),
+        /* name */ table,
+        /* description */ null,
+        meta.getColumns().getFields(),
+        meta.getPartitionColumns() != null
+            ? meta.getPartitionColumns() : Collections.emptyList(),
+        meta.getProperties() != null
+            ? meta.getProperties() : Collections.emptyMap(),
+        meta.getCreatedTime());
+
+    // Protocol was removed from TableMetadata in the DRC spec (delta.yaml). It is derived
+    // from the flat delta.feature.* / delta.minReaderVersion / delta.minWriterVersion
+    // properties. Writer features from delta.feature.X=supported keys are populated;
+    // reader features are intentionally left empty and come from the Delta commit log
+    // via SnapshotManagement -- populating them here would silently force reader-feature
+    // support for writer-only features (appendOnly, invariants, etc.).
+    final AbstractProtocol protocol = deriveProtocolFromProperties(adapter.getConfiguration());
+
+    return new UCLoadTableResponse(
+        meta.getTableUuid().toString(),
+        adapter,
+        protocol,
+        /* unbackfilled commits -- filled by commit-path PR */ new ArrayList<>(),
+        resp.getLatestTableVersion(),
+        Optional.ofNullable(meta.getEtag()));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unimplemented (wired in later PRs)
+  // ---------------------------------------------------------------------------
+
+  @Override
+  public UCListTablesResponse listTables(
+      String catalog, String schema, Optional<String> pageToken, Optional<Integer> maxResults) {
+    throw notYetImplemented("listTables");
+  }
+
+  @Override
+  public UCCreateStagingTableResponse createStagingTable(
+      String catalog, String schema, String name) {
+    throw notYetImplemented("createStagingTable");
+  }
+
+  @Override
+  public UCLoadTableResponse createTable(
+      String catalog,
+      String schema,
+      String name,
+      AbstractMetadata metadata,
+      AbstractProtocol protocol,
+      List<UCDomainMetadata> domainMetadata,
+      Commit initialCommit) {
+    throw notYetImplemented("createTable");
+  }
+
+  @Override
+  public UCLoadTableResponse commit(
+      String catalog,
+      String schema,
+      String table,
+      Optional<String> etag,
+      Commit commit,
+      AbstractMetadata oldMetadata,
+      AbstractMetadata newMetadata,
+      AbstractProtocol oldProtocol,
+      AbstractProtocol newProtocol,
+      List<UCDomainMetadata> oldDomainMetadata,
+      List<UCDomainMetadata> newDomainMetadata) {
+    throw notYetImplemented("commit");
+  }
+
+  @Override
+  public void dropTable(String catalog, String schema, String table) {
+    throw notYetImplemented("dropTable");
+  }
+
+  @Override
+  public void renameTable(String catalog, String schema, String oldName, String newName) {
+    throw notYetImplemented("renameTable");
+  }
+
+  @Override
+  public UCCredentialsResponse getTableCredentials(
+      String catalog, String schema, String table, UCCredentialOperation operation) {
+    throw notYetImplemented("getTableCredentials");
+  }
+
+  @Override
+  public UCCredentialsResponse getStagingTableCredentials(String tableId) {
+    throw notYetImplemented("getStagingTableCredentials");
+  }
+
+  @Override
+  public UCCredentialsResponse getPathCredentials(
+      String location, UCCredentialOperation operation) {
+    throw notYetImplemented("getPathCredentials");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Legacy UCClient methods -- delegate to injected UCClient or fail loud
+  // ---------------------------------------------------------------------------
+
+  @Override
+  public String getMetastoreId() throws IOException {
+    return requireLegacy("getMetastoreId").getMetastoreId();
+  }
+
+  @Override
+  public void commit(
+      String tableId,
+      URI tableUri,
+      Optional<Commit> commit,
+      Optional<Long> lastKnownBackfilledVersion,
+      boolean disown,
+      Optional<AbstractMetadata> newMetadata,
+      Optional<AbstractProtocol> newProtocol,
+      Optional<UniformMetadata> uniform)
+      throws IOException, CommitFailedException, UCCommitCoordinatorException {
+    requireLegacy("commit(tableId, tableUri, ...)").commit(
+        tableId, tableUri, commit, lastKnownBackfilledVersion, disown,
+        newMetadata, newProtocol, uniform);
+  }
+
+  @Override
+  public GetCommitsResponse getCommits(
+      String tableId, URI tableUri, Optional<Long> startVersion, Optional<Long> endVersion)
+      throws IOException, UCCommitCoordinatorException {
+    return requireLegacy("getCommits").getCommits(
+        tableId, tableUri, startVersion, endVersion);
+  }
+
+  @Override
+  public void finalizeCreate(
+      String tableName,
+      String catalogName,
+      String schemaName,
+      String storageLocation,
+      List<UCClient.ColumnDef> columns,
+      Map<String, String> properties) throws CommitFailedException {
+    requireLegacy("finalizeCreate").finalizeCreate(
+        tableName, catalogName, schemaName, storageLocation, columns, properties);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      if (legacyClient.isPresent()) {
+        legacyClient.get().close();
+      }
+    } finally {
+      LOG.debug("UCDeltaClientImpl closed. DRC loadTable count={}, legacy count={}",
+          drcLoadTableCount.get(), legacyLoadTableCount.get());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Observability / test hooks
+  // ---------------------------------------------------------------------------
+
+  /** Minimum viable path-taken counter per clarifications §8; exposed for metrics. */
+  public long getDRCLoadTableCount() { return drcLoadTableCount.get(); }
+  public long getLegacyLoadTableCount() { return legacyLoadTableCount.get(); }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private void logRoutingTransition(boolean drc) {
+    final Boolean prev = lastLoggedRoute.getAndSet(drc);
+    if (prev == null) {
+      LOG.info("UCDeltaClientImpl routing resolved: {}", drc ? "DRC" : "LEGACY");
+    } else if (prev.booleanValue() != drc) {
+      LOG.info("UCDeltaClientImpl routing transition: {} -> {}",
+          prev ? "DRC" : "LEGACY", drc ? "DRC" : "LEGACY");
+    }
+  }
+
+  private static IOException translateApiException(
+      ApiException e, String c, String s, String t) {
+    final int code = e.getCode();
+    final String body = Optional.ofNullable(e.getResponseBody()).orElse("");
+    final String fqn = fqn(c, s, t);
+    if (code == 404) {
+      return new FileNotFoundException("DRC loadTable: table not found " + fqn + ": " + body);
+    }
+    // 409/429/500 collapse to IOException in v1. Typed mappings
+    // (UpdateRequirementConflictException, ResourceExhaustedException,
+    // CommitStateUnknownException) arrive with the commit-path PR where they're
+    // actionable to callers; loadTable's 409/500 are advisory.
+    return new IOException(String.format(
+        "DRC loadTable failed for %s (HTTP %d): %s", fqn, code, body), e);
+  }
+
+  /**
+   * Derives an {@link AbstractProtocol} from the flat {@code delta.feature.*} property
+   * map. Writer features are populated from {@code delta.feature.X=supported} entries;
+   * reader features are intentionally left empty (see the class-level note on the DRC
+   * spec's protocol removal and the read-side routing via SnapshotManagement).
+   *
+   * <p>Fails loud if a {@code delta.feature.*} key carries a status other than
+   * {@code "supported"}. Silent acceptance would downgrade an advertised feature.
+   */
+  private static AbstractProtocol deriveProtocolFromProperties(
+      java.util.Map<String, String> props) {
+    final int minR = Integer.parseInt(props.getOrDefault("delta.minReaderVersion", "1"));
+    final int minW = Integer.parseInt(props.getOrDefault("delta.minWriterVersion", "2"));
+    final Set<String> writerFeatures = new HashSet<>();
+    for (java.util.Map.Entry<String, String> e : props.entrySet()) {
+      final String k = e.getKey();
+      if (!k.startsWith("delta.feature.")) continue;
+      final String status = e.getValue();
+      require("supported".equals(status),
+          "Unknown delta.feature status '" + status + "' for key '" + k
+              + "' (expected 'supported'); refusing to guess classification");
+      writerFeatures.add(k.substring("delta.feature.".length()));
+    }
+    return new AbstractProtocol() {
+      @Override public int getMinReaderVersion() { return minR; }
+      @Override public int getMinWriterVersion() { return minW; }
+      @Override public Set<String> getReaderFeatures() { return Collections.emptySet(); }
+      @Override public Set<String> getWriterFeatures() {
+        return Collections.unmodifiableSet(writerFeatures);
+      }
+    };
+  }
+
+  private static String fqn(String c, String s, String t) { return c + "." + s + "." + t; }
+
+  private static void require(boolean cond, String msg) {
+    if (!cond) throw new IllegalStateException(msg);
+  }
+
+  private static void requireNonEmpty(String v, String name) {
+    Objects.requireNonNull(v, name);
+    if (v.isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be empty");
+    }
+  }
+
+  private static UnsupportedOperationException notYetImplemented(String method) {
+    return new UnsupportedOperationException(
+        "UCDeltaClient." + method + " is not yet implemented in the DRC impl; "
+            + "coming in a later PR.");
+  }
+
+  private UCClient requireLegacy(String method) {
+    return legacyClient.orElseThrow(() -> new UnsupportedOperationException(
+        "UCDeltaClient." + method + " requires a legacy UCClient; construct "
+            + "UCDeltaClientImpl with the two-arg constructor to enable it."));
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDomainMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDomainMetadata.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Storage-level domain metadata entry passed through the {@link UCDeltaClient} surface.
+ * Mirrors Delta's {@code DomainMetadata} action ({@code name} + {@code configuration} map)
+ * but lives in storage so that non-Spark consumers can use the interface without pulling in
+ * Spark.
+ *
+ * <p>Promotion to a first-class {@code AbstractDomainMetadata} interface in
+ * {@code io.delta.storage.commit.actions} is a follow-up; for DRC v1 a concrete DTO is
+ * enough.
+ */
+public final class UCDomainMetadata {
+
+  private final String name;
+  private final Map<String, String> configuration;
+  private final boolean removed;
+
+  public UCDomainMetadata(String name, Map<String, String> configuration, boolean removed) {
+    this.name = Objects.requireNonNull(name, "name");
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("domain name must not be empty");
+    }
+    this.configuration = Collections.unmodifiableMap(
+        Objects.requireNonNull(configuration, "configuration"));
+    this.removed = removed;
+  }
+
+  public String getName() { return name; }
+  public Map<String, String> getConfiguration() { return configuration; }
+  public boolean isRemoved() { return removed; }
+
+  @Override
+  public String toString() {
+    return "UCDomainMetadata{name='" + name + "', keys=" + configuration.keySet()
+        + ", removed=" + removed + '}';
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCListTablesResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCListTablesResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Paginated response for {@link UCDeltaClient#listTables}. {@link #getNextPageToken()}
+ * is empty when the server has no more pages.
+ */
+public final class UCListTablesResponse {
+
+  private final List<UCTableIdentifier> identifiers;
+  private final Optional<String> nextPageToken;
+
+  public UCListTablesResponse(
+      List<UCTableIdentifier> identifiers, Optional<String> nextPageToken) {
+    this.identifiers = Collections.unmodifiableList(
+        Objects.requireNonNull(identifiers, "identifiers"));
+    this.nextPageToken = Objects.requireNonNull(nextPageToken, "nextPageToken");
+  }
+
+  public List<UCTableIdentifier> getIdentifiers() { return identifiers; }
+  public Optional<String> getNextPageToken() { return nextPageToken; }
+
+  @Override
+  public String toString() {
+    return "UCListTablesResponse{count=" + identifiers.size()
+        + ", hasNextPage=" + nextPageToken.isPresent() + '}';
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCLoadTableResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCLoadTableResponse.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.Commit;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Storage-level envelope returned by {@link UCDeltaClient#loadTable},
+ * {@link UCDeltaClient#createTable}, and {@link UCDeltaClient#commit}.
+ *
+ * <p>Holds only Delta storage types ({@link AbstractMetadata}, {@link AbstractProtocol},
+ * {@link Commit}) so that non-Spark consumers (Kernel, Flink) can read it without pulling
+ * in the UC SDK. Callers that need the DRC-native columnar representation of the schema
+ * cast {@code metadata} to {@code DRCMetadataAdapter}.
+ *
+ * <p>{@code etag} is {@link Optional} in v1 (design clarifications §3 -- etag optional).
+ * An absent etag still returns a valid response; callers that would otherwise emit
+ * {@code assert-etag} on the next commit must skip that requirement.
+ *
+ * <p>Immutable. {@code unbackfilledCommits} is wrapped with
+ * {@link Collections#unmodifiableList(List)}.
+ */
+public final class UCLoadTableResponse {
+
+  private final String tableUuid;
+  private final AbstractMetadata metadata;
+  private final AbstractProtocol protocol;
+  private final List<Commit> unbackfilledCommits;
+  private final long latestTableVersion;
+  private final Optional<String> etag;
+
+  public UCLoadTableResponse(
+      String tableUuid,
+      AbstractMetadata metadata,
+      AbstractProtocol protocol,
+      List<Commit> unbackfilledCommits,
+      long latestTableVersion,
+      Optional<String> etag) {
+    this.tableUuid = Objects.requireNonNull(tableUuid, "tableUuid");
+    this.metadata = Objects.requireNonNull(metadata, "metadata");
+    this.protocol = Objects.requireNonNull(protocol, "protocol");
+    this.unbackfilledCommits = Collections.unmodifiableList(
+        Objects.requireNonNull(unbackfilledCommits, "unbackfilledCommits"));
+    this.latestTableVersion = latestTableVersion;
+    this.etag = Objects.requireNonNull(etag, "etag");
+  }
+
+  public String getTableUuid() { return tableUuid; }
+  public AbstractMetadata getMetadata() { return metadata; }
+  public AbstractProtocol getProtocol() { return protocol; }
+  public List<Commit> getUnbackfilledCommits() { return unbackfilledCommits; }
+  public long getLatestTableVersion() { return latestTableVersion; }
+  public Optional<String> getEtag() { return etag; }
+
+  @Override
+  public String toString() {
+    return "UCLoadTableResponse{tableUuid='" + tableUuid
+        + "', latestTableVersion=" + latestTableVersion
+        + ", etagPresent=" + etag.isPresent()
+        + ", unbackfilledCommitCount=" + unbackfilledCommits.size() + '}';
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCStorageCredential.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCStorageCredential.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One vended cloud-storage credential entry scoped to a path prefix. Carried inside
+ * {@link UCCreateStagingTableResponse} and {@link UCCredentialsResponse}.
+ *
+ * <p>{@code pathPrefix} is the cloud URI prefix the credential is valid for (e.g.
+ * {@code s3://bucket/path}). Callers match the longest prefix that contains the file
+ * they intend to access.
+ *
+ * <p>{@code credentials} carries the cloud-vendor-specific secret bag (access key,
+ * session token, refresh token, bearer token, etc.). The key space is provider-dependent
+ * and opaque to storage.
+ */
+public final class UCStorageCredential {
+
+  private final String pathPrefix;
+  private final Map<String, String> credentials;
+  private final long expiryMillis;
+
+  public UCStorageCredential(
+      String pathPrefix, Map<String, String> credentials, long expiryMillis) {
+    this.pathPrefix = Objects.requireNonNull(pathPrefix, "pathPrefix");
+    this.credentials = Collections.unmodifiableMap(
+        Objects.requireNonNull(credentials, "credentials"));
+    this.expiryMillis = expiryMillis;
+  }
+
+  public String getPathPrefix() { return pathPrefix; }
+  public Map<String, String> getCredentials() { return credentials; }
+  /** Expiration as epoch-millis. A value of {@code 0} means server did not declare a TTL. */
+  public long getExpiryMillis() { return expiryMillis; }
+
+  @Override
+  public String toString() {
+    return "UCStorageCredential{prefix='" + pathPrefix + "', keys=" + credentials.keySet()
+        + ", expiryMillis=" + expiryMillis + '}';
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTableIdentifier.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTableIdentifier.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import java.util.Objects;
+
+/**
+ * A three-part table identifier returned by {@link UCDeltaClient#listTables}.
+ * {@code dataSourceFormat} mirrors the server's string enum (e.g. {@code "DELTA"},
+ * {@code "ICEBERG"}); callers that only care about Delta tables filter client-side.
+ */
+public final class UCTableIdentifier {
+
+  private final String schema;
+  private final String name;
+  private final String dataSourceFormat;
+
+  public UCTableIdentifier(String schema, String name, String dataSourceFormat) {
+    this.schema = Objects.requireNonNull(schema, "schema");
+    this.name = Objects.requireNonNull(name, "name");
+    this.dataSourceFormat = Objects.requireNonNull(dataSourceFormat, "dataSourceFormat");
+  }
+
+  public String getSchema() { return schema; }
+  public String getName() { return name; }
+  public String getDataSourceFormat() { return dataSourceFormat; }
+
+  @Override
+  public String toString() {
+    return schema + "." + name + "[" + dataSourceFormat + "]";
+  }
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapterSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/DRCMetadataAdapterSuite.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.util.{ArrayList, Arrays, Collections, HashMap}
+
+import io.unitycatalog.client.delta.model.{PrimitiveType, StructField}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class DRCMetadataAdapterSuite extends AnyFunSuite {
+
+  private def primField(name: String): StructField = {
+    val t = new PrimitiveType(); t.setType("string")
+    val f = new StructField(); f.setName(name); f.setType(t); f.setNullable(true)
+    f.setMetadata(Collections.emptyMap()); f
+  }
+
+  private def newAdapter(
+      id: String = "id-1",
+      name: String = "t",
+      description: String = null,
+      columns: java.util.List[StructField] = Arrays.asList(primField("a")),
+      partitionColumns: java.util.List[String] = Collections.emptyList(),
+      configuration: java.util.Map[String, String] = Collections.emptyMap(),
+      createdTime: java.lang.Long = 0L): DRCMetadataAdapter =
+    new DRCMetadataAdapter(
+      id, name, description, columns, partitionColumns, configuration, createdTime)
+
+  test("getDRCColumns returns UC POJOs verbatim, ready for the converter") {
+    val cols = Arrays.asList(primField("a"), primField("b"))
+    val adapter = newAdapter(columns = cols)
+    assert(adapter.getDRCColumns.size == 2)
+    assert(adapter.getDRCColumns.get(0).getName == "a")
+    assert(adapter.getDRCColumns.get(1).getName == "b")
+  }
+
+  test("getDRCColumns list is unmodifiable") {
+    val adapter = newAdapter()
+    intercept[UnsupportedOperationException] {
+      adapter.getDRCColumns.add(primField("x"))
+    }
+  }
+
+  test("defensive copy: mutations on the source list do not leak into the adapter") {
+    val mutable = new ArrayList[StructField]()
+    mutable.add(primField("a"))
+    val adapter = newAdapter(columns = mutable)
+    mutable.add(primField("sneaky"))
+    // The adapter snapshotted at construction -- post-hoc additions are invisible.
+    assert(adapter.getDRCColumns.size == 1)
+    assert(adapter.getDRCColumns.get(0).getName == "a")
+  }
+
+  test("configuration map is defensively copied and unmodifiable") {
+    val mutable = new HashMap[String, String]()
+    mutable.put("k", "v")
+    val adapter = newAdapter(configuration = mutable)
+    mutable.put("sneaky", "bypass")
+    assert(!adapter.getConfiguration.containsKey("sneaky"))
+    intercept[UnsupportedOperationException] {
+      adapter.getConfiguration.put("x", "y")
+    }
+  }
+
+  test("rejects null id / columns / partitionColumns / configuration") {
+    intercept[NullPointerException] {
+      new DRCMetadataAdapter(
+        null, "t", null, Collections.emptyList(), Collections.emptyList(),
+        Collections.emptyMap(), 0L)
+    }
+    intercept[NullPointerException] {
+      new DRCMetadataAdapter(
+        "id", "t", null, null, Collections.emptyList(),
+        Collections.emptyMap(), 0L)
+    }
+    intercept[NullPointerException] {
+      new DRCMetadataAdapter(
+        "id", "t", null, Collections.emptyList(), null,
+        Collections.emptyMap(), 0L)
+    }
+    intercept[NullPointerException] {
+      new DRCMetadataAdapter(
+        "id", "t", null, Collections.emptyList(), Collections.emptyList(),
+        null, 0L)
+    }
+  }
+
+  test("getSchemaString returns a deterministic empty-struct stub (fallback path)") {
+    val adapter = newAdapter()
+    val s1 = adapter.getSchemaString
+    val s2 = adapter.getSchemaString
+    assert(s1 == """{"type":"struct","fields":[]}""")
+    assert(s2 == s1)
+  }
+
+  test("getProvider is always 'delta' regardless of constructor input") {
+    assert(newAdapter().getProvider == "delta")
+  }
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientDTOSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientDTOSuite.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.util.{Arrays, Collections, HashMap, Optional}
+
+import io.delta.storage.commit.Commit
+import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Construction and null-safety tests for the DTOs exposed by [[UCDeltaClient]]. These
+ * lock down the public contract -- null-forbidden fields must reject `null`, Optional
+ * fields must accept `Optional.empty()`, unmodifiable collections must reject mutation.
+ */
+class UCDeltaClientDTOSuite extends AnyFunSuite {
+
+  private def stubMetadata: AbstractMetadata = new AbstractMetadata {
+    override def getId: String = "id-1"
+    override def getName: String = "t"
+    override def getDescription: String = null
+    override def getProvider: String = "delta"
+    override def getFormatOptions: java.util.Map[String, String] = Collections.emptyMap()
+    override def getSchemaString: String = "{\"type\":\"struct\",\"fields\":[]}"
+    override def getPartitionColumns: java.util.List[String] = Collections.emptyList()
+    override def getConfiguration: java.util.Map[String, String] = Collections.emptyMap()
+    override def getCreatedTime: java.lang.Long = 0L
+  }
+
+  private def stubProtocol: AbstractProtocol = new AbstractProtocol {
+    override def getMinReaderVersion: Int = 1
+    override def getMinWriterVersion: Int = 2
+    override def getReaderFeatures: java.util.Set[String] = Collections.emptySet()
+    override def getWriterFeatures: java.util.Set[String] = Collections.emptySet()
+  }
+
+  // --------------------------------------------------------------------------
+  // UCLoadTableResponse
+  // --------------------------------------------------------------------------
+
+  test("UCLoadTableResponse accepts empty etag (v1 optional)") {
+    val resp = new UCLoadTableResponse(
+      "uuid-1", stubMetadata, stubProtocol,
+      Collections.emptyList[Commit](), 0L, Optional.empty[String]())
+    assert(!resp.getEtag.isPresent)
+    assert(resp.getLatestTableVersion == 0L)
+    assert(resp.toString.contains("etagPresent=false"))
+  }
+
+  test("UCLoadTableResponse round-trips present etag and version") {
+    val resp = new UCLoadTableResponse(
+      "uuid-42", stubMetadata, stubProtocol,
+      Collections.emptyList[Commit](), 42L, Optional.of("etag-abc"))
+    assert(resp.getEtag.get == "etag-abc")
+    assert(resp.getLatestTableVersion == 42L)
+    assert(resp.toString.contains("latestTableVersion=42"))
+  }
+
+  test("UCLoadTableResponse rejects null required fields") {
+    val m = stubMetadata; val p = stubProtocol
+    val empty = Collections.emptyList[Commit]()
+    intercept[NullPointerException] {
+      new UCLoadTableResponse(null, m, p, empty, 0L, Optional.empty())
+    }
+    intercept[NullPointerException] {
+      new UCLoadTableResponse("u", null, p, empty, 0L, Optional.empty())
+    }
+    intercept[NullPointerException] {
+      new UCLoadTableResponse("u", m, null, empty, 0L, Optional.empty())
+    }
+    intercept[NullPointerException] {
+      new UCLoadTableResponse("u", m, p, null, 0L, Optional.empty())
+    }
+    // etag must be Optional.empty(), not null, so callers cannot silently bypass the
+    // intentional v1 optional-etag contract by passing null.
+    intercept[NullPointerException] {
+      new UCLoadTableResponse("u", m, p, empty, 0L, null)
+    }
+  }
+
+  test("UCLoadTableResponse.unbackfilledCommits is unmodifiable") {
+    val resp = new UCLoadTableResponse(
+      "u", stubMetadata, stubProtocol,
+      Collections.emptyList[Commit](), 0L, Optional.empty())
+    intercept[UnsupportedOperationException] {
+      resp.getUnbackfilledCommits.add(null.asInstanceOf[Commit])
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // UCCreateStagingTableResponse
+  // --------------------------------------------------------------------------
+
+  test("UCCreateStagingTableResponse wraps all fields immutably") {
+    val creds = Arrays.asList(
+      new UCStorageCredential(
+        "s3://b/", new HashMap[String, String]() {{ put("k", "v") }}, 0L))
+    val resp = new UCCreateStagingTableResponse(
+      "table-1", "s3://b/t", creds, stubProtocol,
+      new HashMap[String, String]() {{ put("delta.foo", "bar") }})
+    assert(resp.getTableId == "table-1")
+    assert(resp.getLocation == "s3://b/t")
+    assert(resp.getStorageCredentials.size == 1)
+    assert(resp.getRequiredProperties.get("delta.foo") == "bar")
+    intercept[UnsupportedOperationException] {
+      resp.getStorageCredentials.add(null.asInstanceOf[UCStorageCredential])
+    }
+    intercept[UnsupportedOperationException] {
+      resp.getRequiredProperties.put("x", "y")
+    }
+  }
+
+  test("UCCreateStagingTableResponse rejects null required fields") {
+    val empty = Collections.emptyList[UCStorageCredential]()
+    val emptyMap = Collections.emptyMap[String, String]()
+    intercept[NullPointerException] {
+      new UCCreateStagingTableResponse(null, "loc", empty, stubProtocol, emptyMap)
+    }
+    intercept[NullPointerException] {
+      new UCCreateStagingTableResponse("id", null, empty, stubProtocol, emptyMap)
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // UCListTablesResponse
+  // --------------------------------------------------------------------------
+
+  test("UCListTablesResponse round-trips identifiers and page token") {
+    val ids = Arrays.asList(new UCTableIdentifier("sch", "t1", "DELTA"))
+    val resp = new UCListTablesResponse(ids, Optional.of("next"))
+    assert(resp.getIdentifiers.size == 1)
+    assert(resp.getIdentifiers.get(0).toString == "sch.t1[DELTA]")
+    assert(resp.getNextPageToken.get == "next")
+    intercept[UnsupportedOperationException] {
+      resp.getIdentifiers.add(null.asInstanceOf[UCTableIdentifier])
+    }
+  }
+
+  test("UCListTablesResponse accepts empty page token (end of listing)") {
+    val resp = new UCListTablesResponse(
+      Collections.emptyList[UCTableIdentifier](), Optional.empty[String]())
+    assert(!resp.getNextPageToken.isPresent)
+  }
+
+  // --------------------------------------------------------------------------
+  // UCCredentialsResponse + UCStorageCredential
+  // --------------------------------------------------------------------------
+
+  test("UCCredentialsResponse wraps credentials immutably") {
+    val c = new UCStorageCredential(
+      "s3://bucket/", new HashMap[String, String]() {{ put("token", "x") }}, 1234L)
+    val resp = new UCCredentialsResponse(Arrays.asList(c))
+    assert(resp.getCredentials.size == 1)
+    assert(resp.getCredentials.get(0).getExpiryMillis == 1234L)
+    intercept[UnsupportedOperationException] {
+      resp.getCredentials.add(null.asInstanceOf[UCStorageCredential])
+    }
+    intercept[UnsupportedOperationException] {
+      resp.getCredentials.get(0).getCredentials.put("k", "v")
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // UCDomainMetadata
+  // --------------------------------------------------------------------------
+
+  test("UCDomainMetadata rejects empty name (fail-loud domain addressing)") {
+    intercept[IllegalArgumentException] {
+      new UCDomainMetadata("", Collections.emptyMap(), false)
+    }
+  }
+
+  test("UCDomainMetadata configuration is unmodifiable and toString omits values") {
+    val dm = new UCDomainMetadata(
+      "delta.clustering",
+      new HashMap[String, String]() {{ put("clusteringColumns", "a,b") }},
+      false)
+    assert(dm.getConfiguration.get("clusteringColumns") == "a,b")
+    intercept[UnsupportedOperationException] {
+      dm.getConfiguration.put("x", "y")
+    }
+    // Values may contain PII (literal filter values, etc.); toString shows only keys.
+    assert(dm.toString.contains("clusteringColumns"))
+    assert(!dm.toString.contains("a,b"))
+  }
+
+  // --------------------------------------------------------------------------
+  // UCCredentialOperation
+  // --------------------------------------------------------------------------
+
+  test("UCCredentialOperation exposes both scopes") {
+    assert(UCCredentialOperation.valueOf("READ") == UCCredentialOperation.READ)
+    assert(UCCredentialOperation.valueOf("READ_WRITE") == UCCredentialOperation.READ_WRITE)
+  }
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientImplSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaClientImplSuite.scala
@@ -1,0 +1,366 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import java.io.{FileNotFoundException, IOException}
+import java.util.{Collections, Optional, UUID}
+import java.util.concurrent.atomic.AtomicReference
+
+import io.unitycatalog.client.{ApiClient, ApiException}
+import io.unitycatalog.client.delta.DeltaRestClientProvider
+import io.unitycatalog.client.delta.api.TablesApi
+import io.unitycatalog.client.delta.model.{
+  LoadTableResponse,
+  PrimitiveType,
+  StructField,
+  StructType,
+  TableMetadata
+}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class UCDeltaClientImplSuite extends AnyFunSuite {
+
+  // --- fixtures -------------------------------------------------------------
+
+  private def primField(name: String, ptype: String, nullable: Boolean): StructField = {
+    val p = new PrimitiveType(); p.setType(ptype)
+    val f = new StructField(); f.setName(name); f.setType(p); f.setNullable(nullable)
+    f.setMetadata(Collections.emptyMap()); f
+  }
+
+  private def okResponse(): LoadTableResponse = {
+    val st = new StructType()
+    st.setFields(java.util.Arrays.asList(
+      primField("id", "long", nullable = false),
+      primField("name", "string", nullable = true)))
+    val meta = new TableMetadata()
+    meta.setTableUuid(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+    meta.setColumns(st)
+    meta.setEtag("etag-1")
+    meta.setProperties(new java.util.HashMap[String, String]() {{
+      put("delta.minReaderVersion", "1")
+      put("delta.minWriterVersion", "2")
+      put("delta.feature.catalogManaged", "supported")
+    }})
+    meta.setPartitionColumns(Collections.emptyList())
+    meta.setCreatedTime(12345L)
+    val resp = new LoadTableResponse()
+    resp.setMetadata(meta); resp.setLatestTableVersion(42L)
+    resp.setCommits(Collections.emptyList()); resp
+  }
+
+  private def provider(api: Option[TablesApi]): DeltaRestClientProvider =
+    new DeltaRestClientProvider {
+      override def getDeltaTablesApi: Optional[TablesApi] = api match {
+        case Some(a) => Optional.of(a)
+        case None => Optional.empty()
+      }
+      override def getApiClient: ApiClient =
+        throw new UnsupportedOperationException("unused in unit tests")
+    }
+
+  private class StubApi(onLoad: () => LoadTableResponse) extends TablesApi(new ApiClient()) {
+    override def loadTable(catalog: String, schema: String, table: String): LoadTableResponse =
+      onLoad.apply()
+  }
+
+  private class FailingApi(ex: ApiException) extends TablesApi(new ApiClient()) {
+    override def loadTable(c: String, s: String, t: String): LoadTableResponse = throw ex
+  }
+
+  // --- happy path -----------------------------------------------------------
+
+  test("DRC happy path: response becomes a DRCMetadataAdapter with derived protocol") {
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => okResponse()))))
+    assert(client.isDRCEnabled)
+    val resp = client.loadTable("cat", "sch", "tbl")
+    assert(resp.getLatestTableVersion == 42L)
+    assert(resp.getEtag == Optional.of("etag-1"))
+    val adapter = resp.getMetadata.asInstanceOf[DRCMetadataAdapter]
+    assert(adapter.getDRCColumns.size == 2)
+    assert(adapter.getDRCColumns.get(0).getName == "id")
+    val proto = resp.getProtocol
+    assert(proto.getMinReaderVersion == 1)
+    assert(proto.getMinWriterVersion == 2)
+    assert(proto.getWriterFeatures.contains("catalogManaged"))
+    // Reader features sourced from Delta log via SnapshotManagement, not from flat
+    // delta.feature.* props here. Populating them would silently force reader-feature
+    // support for writer-only features (appendOnly, invariants, etc.).
+    assert(proto.getReaderFeatures.isEmpty)
+  }
+
+  test("path-taken counters increment on each call") {
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => okResponse()))))
+    client.loadTable("c", "s", "t")
+    client.loadTable("c", "s", "t")
+    assert(client.getDRCLoadTableCount == 2)
+    assert(client.getLegacyLoadTableCount == 0)
+  }
+
+  // --- silent-failure guards ------------------------------------------------
+
+  test("writer-only features do NOT appear in readerFeatures (silent-mis-read guard)") {
+    val r = okResponse()
+    r.getMetadata.getProperties.put("delta.feature.appendOnly", "supported")
+    r.getMetadata.getProperties.put("delta.feature.invariants", "supported")
+    val resp = new UCDeltaClientImpl(provider(Some(new StubApi(() => r))))
+      .loadTable("c", "s", "t")
+    assert(resp.getProtocol.getReaderFeatures.isEmpty)
+    assert(resp.getProtocol.getWriterFeatures.contains("appendOnly"))
+    assert(resp.getProtocol.getWriterFeatures.contains("invariants"))
+  }
+
+  test("unknown delta.feature status fails loud (no silent downgrade)") {
+    val r = okResponse()
+    r.getMetadata.getProperties.put("delta.feature.myFeature", "deprecated")
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => r))))
+    val ex = intercept[IllegalStateException] { client.loadTable("c", "s", "t") }
+    assert(ex.getMessage.contains("Unknown delta.feature status"))
+    assert(ex.getMessage.contains("deprecated"))
+  }
+
+  test("unbackfilled commits fail loud (commit translation not yet implemented)") {
+    val r = okResponse()
+    r.setCommits(java.util.Arrays.asList(
+      new io.unitycatalog.client.delta.model.DeltaCommit()))
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => r))))
+    val ex = intercept[IllegalStateException] { client.loadTable("c", "s", "t") }
+    assert(ex.getMessage.contains("unbackfilled commits"))
+  }
+
+  test("null required field (metadata.columns) fails loud") {
+    val badResp: LoadTableResponse = {
+      val r = okResponse(); r.getMetadata.setColumns(null); r
+    }
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => badResp))))
+    val ex = intercept[IllegalStateException] { client.loadTable("c", "s", "t") }
+    assert(ex.getMessage.contains("metadata.columns"))
+  }
+
+  test("null required field (latest-table-version) fails loud") {
+    val badResp = { val r = okResponse(); r.setLatestTableVersion(null); r }
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => badResp))))
+    val ex = intercept[IllegalStateException] { client.loadTable("c", "s", "t") }
+    assert(ex.getMessage.contains("latest-table-version"))
+  }
+
+  test("null required field (metadata.table-uuid) fails loud") {
+    val badResp = { val r = okResponse(); r.getMetadata.setTableUuid(null); r }
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => badResp))))
+    val ex = intercept[IllegalStateException] { client.loadTable("c", "s", "t") }
+    assert(ex.getMessage.contains("table-uuid"))
+  }
+
+  test("etag-absent response round-trips Optional.empty") {
+    val r = okResponse(); r.getMetadata.setEtag(null)
+    val resp = new UCDeltaClientImpl(provider(Some(new StubApi(() => r))))
+      .loadTable("c", "s", "t")
+    assert(!resp.getEtag.isPresent)
+  }
+
+  // --- routing --------------------------------------------------------------
+
+  test("flag off: loadTable throws UnsupportedOperation, isDRCEnabled is false") {
+    val client = new UCDeltaClientImpl(provider(None))
+    assert(!client.isDRCEnabled)
+    val ex = intercept[UnsupportedOperationException] { client.loadTable("c", "s", "t") }
+    assert(ex.getMessage.contains("DRC-only"))
+    // Legacy counter increments even when we throw -- we still took the legacy path.
+    assert(client.getLegacyLoadTableCount == 1)
+    assert(client.getDRCLoadTableCount == 0)
+  }
+
+  test("flag flip mid-session re-routes on the next call (no caching)") {
+    // Load-bearing: UCDeltaClientImpl is constructed once per catalog and lives across
+    // many loadTable calls. A cached isDRCEnabled would pin the first-seen flag value.
+    val apiRef = new AtomicReference[Optional[TablesApi]](Optional.empty())
+    val flippingProvider = new DeltaRestClientProvider {
+      override def getDeltaTablesApi: Optional[TablesApi] = apiRef.get()
+      override def getApiClient: ApiClient =
+        throw new UnsupportedOperationException("unused")
+    }
+    val client = new UCDeltaClientImpl(flippingProvider)
+    assert(!client.isDRCEnabled)
+    apiRef.set(Optional.of(new StubApi(() => okResponse())))
+    assert(client.isDRCEnabled)
+    val resp = client.loadTable("c", "s", "t")
+    assert(resp.getTableUuid == "00000000-0000-0000-0000-000000000001")
+    assert(client.getDRCLoadTableCount == 1)
+  }
+
+  // --- error translation ----------------------------------------------------
+
+  test("404 translates to FileNotFoundException with FQN in message") {
+    val api = new FailingApi(new ApiException(
+      404, "not found", null.asInstanceOf[java.net.http.HttpHeaders], "nope"))
+    val ex = intercept[FileNotFoundException] {
+      new UCDeltaClientImpl(provider(Some(api))).loadTable("c", "s", "t")
+    }
+    assert(ex.getMessage.contains("c.s.t"))
+    assert(ex.getMessage.contains("nope"))
+  }
+
+  test("500 translates to IOException (not FileNotFoundException) preserving HTTP code") {
+    val api = new FailingApi(new ApiException(
+      500, "boom", null.asInstanceOf[java.net.http.HttpHeaders], "boom"))
+    val ex = intercept[IOException] {
+      new UCDeltaClientImpl(provider(Some(api))).loadTable("c", "s", "t")
+    }
+    assert(!ex.isInstanceOf[FileNotFoundException])
+    assert(ex.getMessage.contains("HTTP 500"))
+  }
+
+  test("409 translates to IOException with HTTP code (typed mapping deferred)") {
+    val api = new FailingApi(new ApiException(
+      409, "conflict", null.asInstanceOf[java.net.http.HttpHeaders], ""))
+    val ex = intercept[IOException] {
+      new UCDeltaClientImpl(provider(Some(api))).loadTable("c", "s", "t")
+    }
+    assert(ex.getMessage.contains("HTTP 409"))
+  }
+
+  test("429 translates to IOException with HTTP code (typed mapping deferred)") {
+    val api = new FailingApi(new ApiException(
+      429, "limit", null.asInstanceOf[java.net.http.HttpHeaders], ""))
+    val ex = intercept[IOException] {
+      new UCDeltaClientImpl(provider(Some(api))).loadTable("c", "s", "t")
+    }
+    assert(ex.getMessage.contains("HTTP 429"))
+  }
+
+  // --- input validation -----------------------------------------------------
+
+  test("empty / null catalog, schema, or table rejected") {
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => okResponse()))))
+    intercept[NullPointerException] { client.loadTable(null, "s", "t") }
+    intercept[IllegalArgumentException] { client.loadTable("", "s", "t") }
+    intercept[NullPointerException] { client.loadTable("c", null, "t") }
+    intercept[IllegalArgumentException] { client.loadTable("c", "", "t") }
+    intercept[NullPointerException] { client.loadTable("c", "s", null) }
+    intercept[IllegalArgumentException] { client.loadTable("c", "s", "") }
+  }
+
+  // --- stubs for not-yet-implemented methods -------------------------------
+
+  test("unimplemented methods throw UnsupportedOperation with PR-pointer") {
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => okResponse()))))
+    val methods: Seq[() => Any] = Seq(
+      () => client.listTables("c", "s", Optional.empty(), Optional.empty()),
+      () => client.createStagingTable("c", "s", "n"),
+      () => client.dropTable("c", "s", "t"),
+      () => client.renameTable("c", "s", "o", "n"),
+      () => client.getTableCredentials("c", "s", "t", UCCredentialOperation.READ),
+      () => client.getStagingTableCredentials("tid"),
+      () => client.getPathCredentials("s3://x", UCCredentialOperation.READ))
+    methods.foreach { m =>
+      val ex = intercept[UnsupportedOperationException] { m() }
+      assert(ex.getMessage.contains("not yet implemented"))
+    }
+  }
+
+  // --- Legacy UCClient delegation ------------------------------------------
+
+  /** [[UCClient]] stub that records each call so tests can assert delegation. */
+  private class RecordingLegacy extends UCClient {
+    var metastoreIdCalls = 0
+    var commitCalls = 0
+    var getCommitsCalls = 0
+    var finalizeCreateCalls = 0
+    var closeCalls = 0
+
+    override def getMetastoreId(): String = { metastoreIdCalls += 1; "metastore-1" }
+    override def commit(
+        tableId: String, tableUri: java.net.URI,
+        commit: Optional[io.delta.storage.commit.Commit],
+        lastKnownBackfilledVersion: Optional[java.lang.Long],
+        disown: Boolean,
+        newMetadata: Optional[io.delta.storage.commit.actions.AbstractMetadata],
+        newProtocol: Optional[io.delta.storage.commit.actions.AbstractProtocol],
+        uniform: Optional[io.delta.storage.commit.uniform.UniformMetadata]): Unit =
+      { commitCalls += 1 }
+    override def getCommits(
+        tableId: String, tableUri: java.net.URI,
+        startVersion: Optional[java.lang.Long],
+        endVersion: Optional[java.lang.Long]): io.delta.storage.commit.GetCommitsResponse = {
+      getCommitsCalls += 1
+      new io.delta.storage.commit.GetCommitsResponse(Collections.emptyList(), -1L)
+    }
+    override def finalizeCreate(
+        tableName: String, catalogName: String, schemaName: String, storageLocation: String,
+        columns: java.util.List[UCClient.ColumnDef],
+        properties: java.util.Map[String, String]): Unit = { finalizeCreateCalls += 1 }
+    override def close(): Unit = { closeCalls += 1 }
+  }
+
+  test("inherited legacy methods delegate to the injected UCClient") {
+    val legacy = new RecordingLegacy
+    val client = new UCDeltaClientImpl(provider(None), legacy)
+    assert(client.getMetastoreId == "metastore-1")
+    client.commit("tid", new java.net.URI("s3://b/t"),
+      Optional.empty(), Optional.empty(), false,
+      Optional.empty(), Optional.empty(), Optional.empty())
+    client.getCommits("tid", new java.net.URI("s3://b/t"),
+      Optional.empty(), Optional.empty())
+    client.finalizeCreate(
+      "t", "c", "s", "s3://b/t",
+      Collections.emptyList(), Collections.emptyMap())
+    assert(legacy.metastoreIdCalls == 1)
+    assert(legacy.commitCalls == 1)
+    assert(legacy.getCommitsCalls == 1)
+    assert(legacy.finalizeCreateCalls == 1)
+  }
+
+  test("inherited legacy methods fail loud when no legacy UCClient is injected") {
+    val client = new UCDeltaClientImpl(provider(Some(new StubApi(() => okResponse()))))
+    intercept[UnsupportedOperationException] { client.getMetastoreId }
+    intercept[UnsupportedOperationException] {
+      client.commit("tid", new java.net.URI("s3://b/t"),
+        Optional.empty(), Optional.empty(), false,
+        Optional.empty(), Optional.empty(), Optional.empty())
+    }
+    intercept[UnsupportedOperationException] {
+      client.getCommits("tid", new java.net.URI("s3://b/t"),
+        Optional.empty(), Optional.empty())
+    }
+    intercept[UnsupportedOperationException] {
+      client.finalizeCreate(
+        "t", "c", "s", "s3://b/t",
+        Collections.emptyList(), Collections.emptyMap())
+    }
+  }
+
+  test("close delegates to the injected legacy UCClient") {
+    val legacy = new RecordingLegacy
+    val client = new UCDeltaClientImpl(provider(None), legacy)
+    client.close()
+    assert(legacy.closeCalls == 1)
+  }
+
+  test("close is a no-op when no legacy UCClient is injected") {
+    new UCDeltaClientImpl(provider(None)).close() // should not throw
+  }
+
+  test("DRC loadTable works alongside an injected legacy client without cross-talk") {
+    val legacy = new RecordingLegacy
+    val client = new UCDeltaClientImpl(
+      provider(Some(new StubApi(() => okResponse()))), legacy)
+    val resp = client.loadTable("c", "s", "t")
+    assert(resp.getLatestTableVersion == 42L)
+    assert(legacy.commitCalls == 0)
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6654/files/8e5059b895f7e34951f49b3cfb87621b0c3412f3..733aff2c8ba483952afca447d97b1bfc3bf1fe8f) to review incremental changes.
- [stack/drc/v2/01-interface](https://github.com/delta-io/delta/pull/6652) [[Files changed](https://github.com/delta-io/delta/pull/6652/files)]
  - [stack/drc/v2/02-adapter](https://github.com/delta-io/delta/pull/6653) [[Files changed](https://github.com/delta-io/delta/pull/6653/files/80dbecf87ee8f0b5ae0666a599b3447115369727..8e5059b895f7e34951f49b3cfb87621b0c3412f3)]
    - [**stack/drc/v2/03-impl-load**](https://github.com/delta-io/delta/pull/6654) [[Files changed](https://github.com/delta-io/delta/pull/6654/files/8e5059b895f7e34951f49b3cfb87621b0c3412f3..733aff2c8ba483952afca447d97b1bfc3bf1fe8f)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

Wires the read path through UCDeltaClientImpl. Routing is resolved via
DeltaRestClientProvider.getDeltaTablesApi() on every call, so UC-side
flag flips take effect immediately without client reconstruction.

loadTable builds a DRCMetadataAdapter (PR 2) from the structured
UC response, deriving the AbstractProtocol from delta.feature.* /
minReaderVersion / minWriterVersion properties because the DRC spec
removed the structured protocol field from the loadTable response.
Reader features are intentionally left empty so writer-only features
(appendOnly, invariants, etc.) do not silently force reader support.

Fail-loud asserts at the DRC boundary for latest-table-version,
metadata.table-uuid, metadata.columns, and unknown delta.feature
status. Path-taken counters exposed for future metrics wiring.

All other UCDeltaClient methods throw UnsupportedOperation with a
PR-pointer message; they land incrementally. loadTable intentionally
throws UnsupportedOperation on the flag-off path because the legacy
loadTable lives in UCProxy (Scala) and has no storage-side
counterpart -- catalog wiring must gate on isDRCEnabled() before
invocation. A deliberate and documented deviation from the full
internal-routing pattern.

17 tests cover happy path, silent-failure guards (writer-only
features, unknown status, null required fields), routing (flag-off
throws, mid-session flip), and error translation (404 -> FNF,
409/429/500 -> IOException with HTTP code preserved for the commit
PR's typed mapping to replace).
## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
