### PR TITLE
[Storage] Add UC Delta Rest Catalog API loadTable client APIs

### DIFF
--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedApiClientProvider.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedApiClientProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.unitycatalog.client.ApiClient;
+import io.unitycatalog.client.ApiClientBuilder;
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.retry.JitterDelayRetryPolicy;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+abstract class UCTokenBasedApiClientProvider {
+  private ApiClient apiClient;
+
+  protected UCTokenBasedApiClientProvider(
+      String baseUri,
+      TokenProvider tokenProvider,
+      Map<String, String> appVersions) {
+    this.apiClient = buildApiClient(baseUri, tokenProvider, appVersions);
+  }
+
+  protected UCTokenBasedApiClientProvider(
+      String baseUri,
+      TokenProvider tokenProvider,
+      Map<String, String> appVersions,
+      String catalog) {
+    // The catalog is consumed by subclasses that probe catalog-scoped Delta API support.
+    this(baseUri, tokenProvider, appVersions);
+  }
+
+  private static ApiClient buildApiClient(
+      String baseUri,
+      TokenProvider tokenProvider,
+      Map<String, String> appVersions) {
+    Objects.requireNonNull(baseUri, "baseUri must not be null");
+    Objects.requireNonNull(tokenProvider, "tokenProvider must not be null");
+    Objects.requireNonNull(appVersions, "appVersions must not be null");
+
+    ApiClientBuilder builder = ApiClientBuilder.create()
+        .uri(baseUri)
+        .tokenProvider(tokenProvider)
+        .retryPolicy(JitterDelayRetryPolicy.builder().build());
+
+    appVersions.forEach((name, version) -> {
+      if (version != null) {
+        builder.addAppVersion(name, version);
+      }
+    });
+
+    return builder.build();
+  }
+
+  protected ApiClient getApiClient() {
+    return apiClient;
+  }
+
+  public void close() throws IOException {
+    apiClient = null;
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -26,7 +26,6 @@ import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.IcebergMetadata;
 import io.delta.storage.commit.uniform.UniformMetadata;
 import io.unitycatalog.client.ApiClient;
-import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.DeltaCommitsApi;
 import io.unitycatalog.client.api.MetastoresApi;
@@ -83,7 +82,7 @@ import java.util.*;
  * @see GetCommitsResponse
  * @see TokenProvider
  */
-public class UCTokenBasedRestClient implements UCClient {
+public class UCTokenBasedRestClient extends UCTokenBasedApiClientProvider implements UCClient {
 
   private DeltaCommitsApi deltaCommitsApi;
   private MetastoresApi metastoresApi;
@@ -109,21 +108,20 @@ public class UCTokenBasedRestClient implements UCClient {
       String baseUri,
       TokenProvider tokenProvider,
       Map<String, String> appVersions) {
-    Objects.requireNonNull(baseUri, "baseUri must not be null");
-    Objects.requireNonNull(tokenProvider, "tokenProvider must not be null");
-    Objects.requireNonNull(appVersions, "appVersions must not be null");
+    super(baseUri, tokenProvider, appVersions);
+    ApiClient apiClient = getApiClient();
+    this.deltaCommitsApi = new DeltaCommitsApi(apiClient);
+    this.metastoresApi = new MetastoresApi(apiClient);
+    this.tablesApi = new TablesApi(apiClient);
+  }
 
-    ApiClientBuilder builder = ApiClientBuilder.create()
-        .uri(baseUri)
-        .tokenProvider(tokenProvider);
-
-    appVersions.forEach((name, version) -> {
-      if (version != null) {
-        builder.addAppVersion(name, version);
-      }
-    });
-
-    ApiClient apiClient = builder.build();
+  public UCTokenBasedRestClient(
+      String baseUri,
+      TokenProvider tokenProvider,
+      Map<String, String> appVersions,
+      String catalog) {
+    super(baseUri, tokenProvider, appVersions, catalog);
+    ApiClient apiClient = getApiClient();
     this.deltaCommitsApi = new DeltaCommitsApi(apiClient);
     this.metastoresApi = new MetastoresApi(apiClient);
     this.tablesApi = new TablesApi(apiClient);
@@ -233,6 +231,7 @@ public class UCTokenBasedRestClient implements UCClient {
 
   @Override
   public void close() throws IOException {
+    super.close();
     // Nulling out the API instances makes them eligible for GC. Once garbage collected,
     // the underlying connection pool is freed and destroyed.
     this.deltaCommitsApi = null;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6659/files) to review incremental changes.
- [**stack/drc-loadtable-storage**](https://github.com/delta-io/delta/pull/6659) [[Files changed](https://github.com/delta-io/delta/pull/6659/files)]
  - [stack/drc-loadtable-catalog](https://github.com/delta-io/delta/pull/6660) [[Files changed](https://github.com/delta-io/delta/pull/6660/files/5a06eff7e950bb03c85022c29d7d4981c575d298..466d2eb1adeb23510b7fa4b2552cdab0ba378fb8)]
    - [stack/drc-path-credentials](https://github.com/delta-io/delta/pull/6682) [[Files changed](https://github.com/delta-io/delta/pull/6682/files/466d2eb1adeb23510b7fa4b2552cdab0ba378fb8..4b796b90cceeef08daadd479b35f7ebf11e2f46e)]
      - [stack/drc-createtable-storage](https://github.com/delta-io/delta/pull/6672) [[Files changed](https://github.com/delta-io/delta/pull/6672/files/4b796b90cceeef08daadd479b35f7ebf11e2f46e..123be47236f97f29dda8b67f960799aad7ddb5dc)]
        - [stack/drc-createtable-catalog](https://github.com/delta-io/delta/pull/6673) [[Files changed](https://github.com/delta-io/delta/pull/6673/files/123be47236f97f29dda8b67f960799aad7ddb5dc..36f1da44772667928ced30d6595e599a27107395)]
          - [stack/drc-external-createtable](https://github.com/delta-io/delta/pull/6675) [[Files changed](https://github.com/delta-io/delta/pull/6675/files/36f1da44772667928ced30d6595e599a27107395..95cc75eb259af4e67e78c4d570e83a960018755e)]
            - [stack/drc-updatetable-storage](https://github.com/delta-io/delta/pull/6766) [[Files changed](https://github.com/delta-io/delta/pull/6766/files/95cc75eb259af4e67e78c4d570e83a960018755e..7fff3e164f7151abf16276d6bd0297d8bcdd57b2)]
              - [stack/drc-updatetable-catalog](https://github.com/delta-io/delta/pull/6767) [[Files changed](https://github.com/delta-io/delta/pull/6767/files/7fff3e164f7151abf16276d6bd0297d8bcdd57b2..110fa6cc40457dc7b0adc2fedab41e85aef4c47b)]

---------
#### Which Delta project/connector is this regarding?

Storage / Unity Catalog

## Description

This PR adds the storage-layer client support needed for named-table `loadTable` through the UC Delta Rest Catalog API.

Without this change, Delta has no common storage-level client API for UC Delta Rest Catalog API named-table metadata and credentials. The Spark catalog wiring is added in the next PR.

This PR adds:

- `UCClient.supportsUCDeltaRestCatalogApi()`, `loadTable(...)`, and `getTableCredentials(...)`.
- `UCDeltaClient` and `UCDeltaTokenBasedRestClient` as the UC Delta Rest Catalog API surface below the existing UC client.
- `UCTokenBasedRestClient` probing of the UC Delta Rest Catalog API config endpoint.
- Named table metadata and table credential calls when the UC server advertises the required endpoints.
- Loud default failures for legacy-only UC clients, so UC Delta Rest Catalog API operations cannot silently route through unsupported clients.
- UC SDK schema conversion inside the token-based client, so UC SDK schema types do not leak past the storage client boundary.
- `UC_DELTA_REST_CATALOG_API_ENABLED` for Spark UC integration tests; unset means enabled by default, and `false` runs the legacy UC Spark catalog path.

## How was this patch tested?

Covered by `UCTokenBasedRestClientSuite` for supported endpoints, missing endpoints, config probe failures, default unsupported client behavior, metadata conversion, and table credential handling.

Covered by `UnityCatalogSupportTest` for the integration-test environment variable behavior.

Local verification:

```bash
./build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClientSuite"
```

## Does this PR introduce _any_ user-facing changes?

No. This adds internal client APIs and an integration-test toggle.
