### PR TITLE
Bump Delta to 4.3.0-SNAPSHOT

### DIFF
--- a/python/delta/version.py
+++ b/python/delta/version.py
@@ -18,4 +18,4 @@
 # Do not edit manually - edit version.sbt instead and run:
 #   build/sbt sparkV1/generatePythonVersion
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.2.0-SNAPSHOT"
+ThisBuild / version := "4.3.0-SNAPSHOT"


### PR DESCRIPTION
## Summary
- bump the repo-wide Delta version from `4.2.0-SNAPSHOT` to `4.3.0-SNAPSHOT`
- regenerate the checked-in Python version file so package metadata stays aligned with `version.sbt`

## Test plan
- [x] `build/sbt sparkV1/generatePythonVersion`
- [x] `build/sbt \"show version\"`
- [x] Ran `python/delta/tests/test_version.py` under `python3.11` with lightweight local `pyspark` stubs because the host default `python3` is 3.6 and does not have `pyspark`