### PR TITLE
[Storage] Unwrap FilterFileSystem in S3LogStoreUtil before casting to S3AFileSystem

### DIFF
--- a/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
@@ -89,13 +89,29 @@ public final class S3LogStoreUtil {
             Path parentPath) throws IOException {
         S3AFileSystem s3afs;
         try {
-             s3afs = (S3AFileSystem) fs;
+             s3afs = (S3AFileSystem) unwrapFilterFileSystem(fs);
         } catch (ClassCastException e) {
             throw new UnsupportedOperationException(
                     "The Hadoop file system used for the S3LogStore must be castable to " +
-                            "org.apache.hadoop.fs.s3a.S3AFileSystem.", e);
+                            "org.apache.hadoop.fs.s3a.S3AFileSystem. The actual file system " +
+                            "class is " + fs.getClass().getName() + ".", e);
         }
         return iteratorToStatuses(S3LogStoreUtil.s3ListFrom(s3afs, resolvedPath, parentPath));
+    }
+
+    /**
+     * Unwraps any {@link FilterFileSystem} layers to get the underlying filesystem.
+     *
+     * This is necessary because credential-scoped filesystem wrappers (e.g. Unity Catalog's
+     * CredScopedFileSystem) wrap S3AFileSystem inside a FilterFileSystem. Without unwrapping,
+     * the cast to S3AFileSystem in {@link #s3ListFromArray} would fail.
+     */
+    static FileSystem unwrapFilterFileSystem(FileSystem fs) {
+        FileSystem current = fs;
+        while (current instanceof FilterFileSystem) {
+            current = ((FilterFileSystem) current).getRawFileSystem();
+        }
+        return current;
     }
 
     /**

--- a/storage/src/test/scala/io/delta/storage/internal/S3LogStoreUtilTest.scala
+++ b/storage/src/test/scala/io/delta/storage/internal/S3LogStoreUtilTest.scala
@@ -1,8 +1,37 @@
 package io.delta.storage.internal
 
+import java.net.URI
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FilterFileSystem, LocalFileSystem, RawLocalFileSystem}
 import org.scalatest.funsuite.AnyFunSuite
 
 class S3LogStoreUtilTest extends AnyFunSuite {
+
+  test("unwrapFilterFileSystem returns the same instance when not wrapped") {
+    val conf = new Configuration()
+    val rawFs = new RawLocalFileSystem()
+    rawFs.initialize(new URI("file:///"), conf)
+    assert(S3LogStoreUtil.unwrapFilterFileSystem(rawFs) eq rawFs)
+  }
+
+  test("unwrapFilterFileSystem unwraps a single layer of FilterFileSystem") {
+    val conf = new Configuration()
+    val rawFs = new RawLocalFileSystem()
+    rawFs.initialize(new URI("file:///"), conf)
+    val wrapped = new FilterFileSystem(rawFs) {}
+    assert(S3LogStoreUtil.unwrapFilterFileSystem(wrapped) eq rawFs)
+  }
+
+  test("unwrapFilterFileSystem unwraps multiple layers of FilterFileSystem") {
+    val conf = new Configuration()
+    val rawFs = new RawLocalFileSystem()
+    rawFs.initialize(new URI("file:///"), conf)
+    val inner = new FilterFileSystem(rawFs) {}
+    val outer = new FilterFileSystem(inner) {}
+    assert(S3LogStoreUtil.unwrapFilterFileSystem(outer) eq rawFs)
+  }
+
   test("keyBefore") {
     assert("a" == S3LogStoreUtil.keyBefore("b"))
     assert("aa/aa" == S3LogStoreUtil.keyBefore("aa/ab"))


### PR DESCRIPTION
## Description

When `delta.enableFastS3AListFrom=true`, `S3LogStoreUtil.s3ListFromArray` casts the Hadoop `FileSystem` to `S3AFileSystem` to use the optimized S3 listing API. This cast fails with an `UnsupportedOperationException` when the filesystem is wrapped in a `FilterFileSystem`.

This is a real-world issue encountered when using Unity Catalog's `CredScopedFileSystem` (from [unitycatalog-spark](https://github.com/unitycatalog/unitycatalog)), which wraps `S3AFileSystem` inside a `FilterFileSystem` to support per-table credential scoping. The wrapping is necessary because different tables backed by the same S3 bucket may require different temporary credentials simultaneously.

**Error before this fix:**
```
UnsupportedOperationException: The Hadoop file system used for the S3LogStore must be castable to org.apache.hadoop.fs.s3a.S3AFileSystem.
```

## Changes

- **`S3LogStoreUtil.s3ListFromArray`**: Call `unwrapFilterFileSystem(fs)` before casting to `S3AFileSystem`, so that filesystem wrappers (e.g. `CredScopedFileSystem`) are transparently handled.
- **`S3LogStoreUtil.unwrapFilterFileSystem`**: New package-private helper that iteratively peels off `FilterFileSystem` layers to reach the underlying concrete filesystem.
- **Improved error message**: When the cast still fails after unwrapping, the error now includes the actual filesystem class name for easier debugging.
- **Unit tests**: Three new tests covering no-wrap, single-wrap, and multi-wrap scenarios.

## How was this patch tested?

New unit tests in `S3LogStoreUtilTest`:
- `unwrapFilterFileSystem returns the same instance when not wrapped`
- `unwrapFilterFileSystem unwraps a single layer of FilterFileSystem`
- `unwrapFilterFileSystem unwraps multiple layers of FilterFileSystem`