### PR TITLE
[CI] Check Maven-side canaries too in the pinned UC setup script

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -89,13 +89,23 @@ if [[ "${1:-}" == "--print-version" ]]; then
   exit 0
 fi
 
-# Canonical Ivy artifact paths. Delta depends on all three UC modules; if any is missing
-# we must re-publish. If all exist, sbt can resolve every coordinate - no fetch, no publish.
+# Canonical artifact paths. Delta depends on all three UC modules, and consumes them via both
+# sbt (reads ~/.ivy2/local, written by publishLocal) and Maven (reads ~/.m2/repository, written
+# by publishM2). The kernel-examples integration test is a standalone Maven project; if only the
+# Ivy side is populated, that test fails with "unitycatalog-client (absent)" even though sbt
+# builds resolve fine. Check both sides so a half-populated cache triggers a republish.
 IVY_LOCAL="$HOME/.ivy2/local/io.unitycatalog"
 IVY_CANARY_CLIENT="$IVY_LOCAL/unitycatalog-client/$UC_VERSION/ivys/ivy.xml"
 IVY_CANARY_SERVER="$IVY_LOCAL/unitycatalog-server/$UC_VERSION/ivys/ivy.xml"
 IVY_CANARY_SPARK="$IVY_LOCAL/unitycatalog-spark_2.13/$UC_VERSION/ivys/ivy.xml"
-ALL_CANARIES=("$IVY_CANARY_CLIENT" "$IVY_CANARY_SERVER" "$IVY_CANARY_SPARK")
+M2_LOCAL="$HOME/.m2/repository/io/unitycatalog"
+M2_CANARY_CLIENT="$M2_LOCAL/unitycatalog-client/$UC_VERSION/unitycatalog-client-$UC_VERSION.pom"
+M2_CANARY_SERVER="$M2_LOCAL/unitycatalog-server/$UC_VERSION/unitycatalog-server-$UC_VERSION.pom"
+M2_CANARY_SPARK="$M2_LOCAL/unitycatalog-spark_2.13/$UC_VERSION/unitycatalog-spark_2.13-$UC_VERSION.pom"
+ALL_CANARIES=(
+  "$IVY_CANARY_CLIENT" "$IVY_CANARY_SERVER" "$IVY_CANARY_SPARK"
+  "$M2_CANARY_CLIENT" "$M2_CANARY_SERVER" "$M2_CANARY_SPARK"
+)
 
 all_canaries_present() {
   for c in "${ALL_CANARIES[@]}"; do
@@ -105,7 +115,7 @@ all_canaries_present() {
 }
 
 if [[ "$UC_FORCE" != "1" ]] && all_canaries_present; then
-  echo ">>> UC $UC_VERSION already published to ~/.ivy2/local; skipping."
+  echo ">>> UC $UC_VERSION already published to ~/.ivy2/local and ~/.m2/repository; skipping."
   echo ">>> (Set UC_FORCE=1 to rebuild anyway.)"
   exit 0
 fi


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[CI] Check Maven-side canaries too in the pinned UC setup script

The setup script's idempotency check only verified the Ivy-side canonical artifacts (~/.ivy2/local/io.unitycatalog/...). Maven-side artifacts (~/.m2/repository/io/unitycatalog/...) were published alongside but never checked. When a GHA cache saved with only the Ivy path populated (e.g. actions/cache/save silently skipping an absent path), subsequent runs restored the half-populated cache, hit the Ivy canary, and skipped the publish that would have filled ~/.m2/repository.

Downstream Maven consumers — specifically kernel-examples, the external-facing demo that the Delta Kernel integration workflow runs via `mvn package exec:java` — then failed with `unitycatalog-client:pom:<version> (absent)` even though sbt builds on the same runner resolved fine from ~/.ivy2/local.

Add the three Maven-side .pom files to ALL_CANARIES so a half-populated cache is treated as incomplete and triggers a republish. The post-publish assertion loop reuses the same array, so it now also verifies Maven-side files landed after publish — failing loudly instead of caching a partial state for future runs.

This change to the script shifts the hashFiles() input that forms the cache key, so the first run after this lands picks up a cache miss and writes a full cache covering both sides.

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
No.