### PR TITLE
[CI] Fix UC pin canary check to also verify ~/.m2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -809,13 +809,13 @@ Global / ensurePinnedUnityCatalog := {
     val home = file(sys.props("user.home"))
     // Check both layouts: a restored sbt cache can pre-populate ivy alone, leaving m2 empty -
     // checking only ivy would silently skip the slow publish and break mvn-based consumers.
-    val canary = home / ".ivy2" / "local" / "io.unitycatalog" /
+    val ivy2Canary = home / ".ivy2" / "local" / "io.unitycatalog" /
       "unitycatalog-client" / unityCatalogVersion / "ivys" / "ivy.xml"
     val m2Canary = home / ".m2" / "repository" / "io" / "unitycatalog" /
       "unitycatalog-client" / unityCatalogVersion /
       s"unitycatalog-client-$unityCatalogVersion.pom"
-    if (!canary.exists || !m2Canary.exists) {
-      publishPinnedUnityCatalog(log, canary)
+    if (!ivy2Canary.exists || !m2Canary.exists) {
+      publishPinnedUnityCatalog(log, ivy2Canary)
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -806,10 +806,15 @@ Global / ensurePinnedUnityCatalog := {
   val usingReleasedVersion = useDefaultUnityCatalogReleaseVersion ||
     sys.props.contains("unityCatalogVersion")
   if (unityCatalogReleaseVersion.isEmpty && !usingReleasedVersion) {
-    val canary =
-      file(sys.props("user.home")) / ".ivy2" / "local" / "io.unitycatalog" /
-        "unitycatalog-client" / unityCatalogVersion / "ivys" / "ivy.xml"
-    if (!canary.exists) {
+    val home = file(sys.props("user.home"))
+    // Check both layouts: a restored sbt cache can pre-populate ivy alone, leaving m2 empty -
+    // checking only ivy would silently skip the slow publish and break mvn-based consumers.
+    val canary = home / ".ivy2" / "local" / "io.unitycatalog" /
+      "unitycatalog-client" / unityCatalogVersion / "ivys" / "ivy.xml"
+    val m2Canary = home / ".m2" / "repository" / "io" / "unitycatalog" /
+      "unitycatalog-client" / unityCatalogVersion /
+      s"unitycatalog-client-$unityCatalogVersion.pom"
+    if (!canary.exists || !m2Canary.exists) {
       publishPinnedUnityCatalog(log, canary)
     }
   }

--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -89,13 +89,19 @@ if [[ "${1:-}" == "--print-version" ]]; then
   exit 0
 fi
 
-# Canonical Ivy artifact paths. Delta depends on all three UC modules; if any is missing
-# we must re-publish. If all exist, sbt can resolve every coordinate - no fetch, no publish.
+# Canonical Ivy + Maven artifact paths. Delta depends on all three UC modules; sbt resolves from
+# ~/.ivy2/local, mvn (kernel-examples integration tests) resolves from ~/.m2/repository. If any
+# is missing in either layout we must re-publish.
 IVY_LOCAL="$HOME/.ivy2/local/io.unitycatalog"
 IVY_CANARY_CLIENT="$IVY_LOCAL/unitycatalog-client/$UC_VERSION/ivys/ivy.xml"
 IVY_CANARY_SERVER="$IVY_LOCAL/unitycatalog-server/$UC_VERSION/ivys/ivy.xml"
 IVY_CANARY_SPARK="$IVY_LOCAL/unitycatalog-spark_2.13/$UC_VERSION/ivys/ivy.xml"
-ALL_CANARIES=("$IVY_CANARY_CLIENT" "$IVY_CANARY_SERVER" "$IVY_CANARY_SPARK")
+M2_LOCAL="$HOME/.m2/repository/io/unitycatalog"
+M2_CANARY_CLIENT="$M2_LOCAL/unitycatalog-client/$UC_VERSION/unitycatalog-client-$UC_VERSION.pom"
+M2_CANARY_SERVER="$M2_LOCAL/unitycatalog-server/$UC_VERSION/unitycatalog-server-$UC_VERSION.pom"
+M2_CANARY_SPARK="$M2_LOCAL/unitycatalog-spark_2.13/$UC_VERSION/unitycatalog-spark_2.13-$UC_VERSION.pom"
+ALL_CANARIES=("$IVY_CANARY_CLIENT" "$IVY_CANARY_SERVER" "$IVY_CANARY_SPARK"
+              "$M2_CANARY_CLIENT" "$M2_CANARY_SERVER" "$M2_CANARY_SPARK")
 
 all_canaries_present() {
   for c in "${ALL_CANARIES[@]}"; do


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (CI / Build)

## Description

Problem: `setup_unitycatalog_main.sh`'s canary check only looks at `~/.ivy2/local`. When the sbt cache pre-populates ivy, the script skips `publishM2` and the GHA cache saves with `~/.m2` empty. `kernel-examples` runs via `mvn`, can't find UC client in `~/.m2`, fails `DK: Integration`.

Fix: add the m2 `.pom` paths to `ALL_CANARIES` and to `ensurePinnedUnityCatalog`. Script edit bumps the cache key, discarding the bad cache.

## How was this patch tested?

`bash -n` passes, `--print-version` unchanged. CI on this PR exercises the slow-publish path; `DK: Integration` is the regression target.

## Does this PR introduce _any_ user-facing changes?

No.