### PR TITLE
[Iceberg] Avoid duplicate Delta column mapping IDs when converting Iceberg identity partitions with renamed spec fields

### DIFF
--- a/iceberg/src/main/scala/org/apache/iceberg/transforms/IcebergPartitionUtil.scala
+++ b/iceberg/src/main/scala/org/apache/iceberg/transforms/IcebergPartitionUtil.scala
@@ -118,7 +118,10 @@ object IcebergPartitionUtil {
   }
 
   def getPartitionFields(
-      partSpec: PartitionSpec, schema: Schema, castTimeType: Boolean): Seq[StructField] = {
+      partSpec: PartitionSpec,
+      schema: Schema,
+      castTimeType: Boolean,
+      caseSensitive: Boolean = true): Seq[StructField] = {
     // Skip removed partition fields due to partition evolution.
     partSpec.fields.asScala.toSeq.collect {
       case partField if !partField.transform().isInstanceOf[VoidTransform[_]] &&
@@ -135,9 +138,25 @@ object IcebergPartitionUtil {
           // table has a binary type partition column
           case _: Identity[_] if sourceType.typeId() != TypeID.BINARY =>
             // copy id only for identity transform because source id will be the converted column id
-            // ids for other columns will be assigned later automatically during schema evolution
-            metadataBuilder
-              .putLong(DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY, sourceField.fieldId())
+            // ids for other columns will be assigned later automatically during schema evolution.
+            // When Iceberg uses a distinct partition field name (e.g. identity("org_id",
+            // "org_id_identity")), Delta must use the Iceberg partition field id instead,
+            // which Iceberg assigns uniquely in the partition spec.
+            val partitionNameMatchesSourceColumn =
+              if (caseSensitive) {
+                partField.name() == sourceColumnName
+              } else {
+                partField.name().equalsIgnoreCase(sourceColumnName)
+              }
+            val deltaColumnMappingId =
+              if (partitionNameMatchesSourceColumn) {
+                sourceField.fieldId()
+              } else {
+                partField.fieldId()
+              }
+            metadataBuilder.putLong(
+              DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY,
+              deltaColumnMappingId.toLong)
             ("", TypeUtil.visit(sourceType, new TypeToSparkTypeWithCustomCast(castTimeType)))
 
           case Timestamps.MICROS_TO_YEAR | Dates.YEAR =>

--- a/iceberg/src/main/scala/org/apache/iceberg/transforms/IcebergPartitionUtil.scala
+++ b/iceberg/src/main/scala/org/apache/iceberg/transforms/IcebergPartitionUtil.scala
@@ -18,7 +18,6 @@ package shadedForDelta.org.apache.iceberg.transforms
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.commands.convert.TypeToSparkTypeWithCustomCast
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.util.{DateFormatter, TimestampFormatter}
@@ -118,10 +117,7 @@ object IcebergPartitionUtil {
   }
 
   def getPartitionFields(
-      partSpec: PartitionSpec,
-      schema: Schema,
-      castTimeType: Boolean,
-      caseSensitive: Boolean = true): Seq[StructField] = {
+      partSpec: PartitionSpec, schema: Schema, castTimeType: Boolean): Seq[StructField] = {
     // Skip removed partition fields due to partition evolution.
     partSpec.fields.asScala.toSeq.collect {
       case partField if !partField.transform().isInstanceOf[VoidTransform[_]] &&
@@ -137,26 +133,6 @@ object IcebergPartitionUtil {
           // binary partition values are problematic in Delta, so we block converting if the iceberg
           // table has a binary type partition column
           case _: Identity[_] if sourceType.typeId() != TypeID.BINARY =>
-            // copy id only for identity transform because source id will be the converted column id
-            // ids for other columns will be assigned later automatically during schema evolution.
-            // When Iceberg uses a distinct partition field name (e.g. identity("org_id",
-            // "org_id_identity")), Delta must use the Iceberg partition field id instead,
-            // which Iceberg assigns uniquely in the partition spec.
-            val partitionNameMatchesSourceColumn =
-              if (caseSensitive) {
-                partField.name() == sourceColumnName
-              } else {
-                partField.name().equalsIgnoreCase(sourceColumnName)
-              }
-            val deltaColumnMappingId =
-              if (partitionNameMatchesSourceColumn) {
-                sourceField.fieldId()
-              } else {
-                partField.fieldId()
-              }
-            metadataBuilder.putLong(
-              DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY,
-              deltaColumnMappingId.toLong)
             ("", TypeUtil.visit(sourceType, new TypeToSparkTypeWithCustomCast(castTimeType)))
 
           case Timestamps.MICROS_TO_YEAR | Dates.YEAR =>

--- a/iceberg/src/main/scala/org/apache/iceberg/transforms/IcebergPartitionUtil.scala
+++ b/iceberg/src/main/scala/org/apache/iceberg/transforms/IcebergPartitionUtil.scala
@@ -18,6 +18,7 @@ package shadedForDelta.org.apache.iceberg.transforms
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.commands.convert.TypeToSparkTypeWithCustomCast
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.util.{DateFormatter, TimestampFormatter}
@@ -133,6 +134,15 @@ object IcebergPartitionUtil {
           // binary partition values are problematic in Delta, so we block converting if the iceberg
           // table has a binary type partition column
           case _: Identity[_] if sourceType.typeId() != TypeID.BINARY =>
+            // Same-name identity partition columns replace the data column during schema merge,
+            // so they must keep the source Iceberg field id. Renamed identity partition columns
+            // or nested columns (use dotted paths) are extra Delta columns, so leave their
+            // ids unset to avoid collisions.
+            if (partField.name() == sourceColumnName && !sourceColumnName.contains(".")) {
+              metadataBuilder.putLong(
+                DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY,
+                sourceField.fieldId())
+            }
             ("", TypeUtil.visit(sourceType, new TypeToSparkTypeWithCustomCast(castTimeType)))
 
           case Timestamps.MICROS_TO_YEAR | Dates.YEAR =>

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -179,7 +179,10 @@ class IcebergTable(
     val mergedPartitionSchema = DeltaColumnMapping.setPhysicalNames(
       StructType(
         IcebergPartitionUtil.getPartitionFields(
-          tablePartitionSpec, icebergTable.schema(), castTimeType
+          tablePartitionSpec,
+          icebergTable.schema(),
+          castTimeType,
+          spark.sessionState.conf.caseSensitiveAnalysis
         )
       ),
       fieldPathToPhysicalName)

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -179,11 +179,7 @@ class IcebergTable(
     val mergedPartitionSchema = DeltaColumnMapping.setPhysicalNames(
       StructType(
         IcebergPartitionUtil.getPartitionFields(
-          tablePartitionSpec,
-          icebergTable.schema(),
-          castTimeType,
-          spark.sessionState.conf.caseSensitiveAnalysis
-        )
+          tablePartitionSpec, icebergTable.schema(), castTimeType)
       ),
       fieldPathToPhysicalName)
 

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -179,7 +179,8 @@ class IcebergTable(
     val mergedPartitionSchema = DeltaColumnMapping.setPhysicalNames(
       StructType(
         IcebergPartitionUtil.getPartitionFields(
-          tablePartitionSpec, icebergTable.schema(), castTimeType)
+          tablePartitionSpec, icebergTable.schema(), castTimeType
+        )
       ),
       fieldPathToPhysicalName)
 

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -1049,6 +1049,8 @@ trait ConvertIcebergToDeltaSuiteBase
       assert(icebergTable.schema().findField("id").fieldId() === 1)
       assert(icebergTable.schema().findField("org_id").fieldId() === 2)
       assert(icebergTable.schema().findField("other_id").fieldId() === 3)
+      assert(icebergTable.spec().fields().get(0).fieldId() === 1000)
+      assert(icebergTable.spec().fields().get(0).sourceId() === 2)
 
       withTempDir { deltaDir =>
         ConvertToDeltaCommand(

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -34,8 +34,10 @@ import io.delta.sql.DeltaSparkSessionExtension
 import org.apache.hadoop.fs.Path
 import org.apache.avro.file.{DataFileReader, DataFileWriter, SeekableByteArrayInput}
 import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord}
-import org.apache.iceberg.{Table, TableProperties}
+import org.apache.iceberg.{PartitionSpec, Schema, Table, TableProperties}
 import org.apache.iceberg.hadoop.HadoopTables
+import org.apache.iceberg.types.Types
+import org.apache.iceberg.types.Types.NestedField
 import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
 
 import org.apache.spark.SparkConf
@@ -1008,6 +1010,51 @@ trait ConvertIcebergToDeltaSuiteBase
         convert(s"iceberg.`$tablePath`")
       }
       assert(e.getMessage.contains("Unsupported partition transform expression"))
+    }
+  }
+
+  test("convert Iceberg renamed identity partition with high source field id") {
+    withTempDir { icebergDir =>
+      val icebergUri = "file://" + icebergDir.getCanonicalPath
+      val icebergSchema = new Schema(
+        Seq(
+          NestedField.required(1, "id", Types.LongType.get()),
+          NestedField.required(1000, "org_id", Types.StringType.get())
+        ).asJava)
+      val partSpec = PartitionSpec
+        .builderFor(icebergSchema)
+        .identity("org_id", "org_id_identity")
+        .build()
+      val tables = new HadoopTables(spark.sessionState.newHadoopConf)
+      tables.create(icebergSchema, partSpec, icebergUri)
+
+      val tbl = "local.db.iceberg_renamed_high_id_conv"
+      spark.sql(
+        s"CALL local.system.register_table('db', 'iceberg_renamed_high_id_conv', '$icebergUri')")
+      try {
+        spark.sql(s"INSERT INTO $tbl VALUES (1, 'acme')")
+
+        withTempDir { deltaDir =>
+          ConvertToDeltaCommand(
+            TableIdentifier(icebergUri, Some("iceberg")),
+            None,
+            collectStats = true,
+            Some(deltaDir.getCanonicalPath)).run(spark)
+
+          val deltaLog = DeltaLog.forTable(spark, new Path(deltaDir.getCanonicalPath))
+          val schema = deltaLog.update().schema
+          val columnIds =
+            SchemaMergingUtils.explode(schema).map(_._2).map(DeltaColumnMapping.getColumnId)
+          assert(columnIds.size == columnIds.distinct.size)
+
+          checkAnswer(
+            spark.read.format("delta").load(deltaDir.getCanonicalPath)
+              .select("id", "org_id", "org_id_identity"),
+            Row(1L, "acme", "acme") :: Nil)
+        }
+      } finally {
+        spark.sql(s"DROP TABLE IF EXISTS $tbl")
+      }
     }
   }
 }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -1019,41 +1019,69 @@ trait ConvertIcebergToDeltaSuiteBase
       val icebergSchema = new Schema(
         Seq(
           NestedField.required(1, "id", Types.LongType.get()),
-          NestedField.required(1000, "org_id", Types.StringType.get())
+          NestedField.required(1000, "org_id", Types.StringType.get()),
+          NestedField.required(1001, "other_id", Types.LongType.get())
         ).asJava)
       val partSpec = PartitionSpec
         .builderFor(icebergSchema)
         .identity("org_id", "org_id_identity")
         .build()
-      val tables = new HadoopTables(spark.sessionState.newHadoopConf)
+      // scalastyle:off deltahadoopconfiguration
+      val tables = new HadoopTables(spark.sessionState.newHadoopConf())
+      // scalastyle:on deltahadoopconfiguration
       tables.create(icebergSchema, partSpec, icebergUri)
 
-      val tbl = "local.db.iceberg_renamed_high_id_conv"
-      spark.sql(
-        s"CALL local.system.register_table('db', 'iceberg_renamed_high_id_conv', '$icebergUri')")
-      try {
-        spark.sql(s"INSERT INTO $tbl VALUES (1, 'acme')")
+      spark
+        .createDataFrame(
+          Seq(Row(1L, "acme", 42L)).asJava,
+          StructType(
+            Seq(
+              StructField("id", LongType, nullable = false),
+              StructField("org_id", StringType, nullable = false),
+              StructField("other_id", LongType, nullable = false))))
+        .write
+        .format("iceberg")
+        .mode("append")
+        .save(icebergUri)
 
-        withTempDir { deltaDir =>
-          ConvertToDeltaCommand(
-            TableIdentifier(icebergUri, Some("iceberg")),
-            None,
-            collectStats = true,
-            Some(deltaDir.getCanonicalPath)).run(spark)
+      // Iceberg re-assigns IDs
+      val icebergTable = readIcebergHadoopTable(icebergDir.getCanonicalPath)
+      assert(icebergTable.schema().findField("id").fieldId() === 1)
+      assert(icebergTable.schema().findField("org_id").fieldId() === 2)
+      assert(icebergTable.schema().findField("other_id").fieldId() === 3)
 
-          val deltaLog = DeltaLog.forTable(spark, new Path(deltaDir.getCanonicalPath))
-          val schema = deltaLog.update().schema
-          val columnIds =
-            SchemaMergingUtils.explode(schema).map(_._2).map(DeltaColumnMapping.getColumnId)
-          assert(columnIds.size == columnIds.distinct.size)
+      withTempDir { deltaDir =>
+        ConvertToDeltaCommand(
+          TableIdentifier(icebergUri, Some("iceberg")),
+          None,
+          collectStats = true,
+          Some(deltaDir.getCanonicalPath)).run(spark)
 
-          checkAnswer(
-            spark.read.format("delta").load(deltaDir.getCanonicalPath)
-              .select("id", "org_id", "org_id_identity"),
-            Row(1L, "acme", "acme") :: Nil)
-        }
-      } finally {
-        spark.sql(s"DROP TABLE IF EXISTS $tbl")
+        val deltaLog = DeltaLog.forTable(spark, new Path(deltaDir.getCanonicalPath))
+        val snapshot = deltaLog.update()
+        val schema = snapshot.schema
+        val fields = schema.fields
+        assert(fields.length == 4)
+        val idsByName = fields.map(f => f.name -> DeltaColumnMapping.getColumnId(f)).toMap
+        assert(idsByName.keySet == Set("id", "org_id", "other_id", "org_id_identity"))
+        assert(idsByName.values.toSet.size == 4)
+        // Delta column mapping ids observed after convert
+        assert(idsByName("id") === 1L)
+        assert(idsByName("org_id") === 2L)
+        assert(idsByName("other_id") === 3L)
+        assert(idsByName("org_id_identity") === 4L)
+
+        checkAnswer(
+          spark.read.format("delta").load(deltaDir.getCanonicalPath)
+            .select("id", "org_id", "other_id", "org_id_identity"),
+          Row(1L, "acme", 42L, "acme") :: Nil)
+
+        // Spark Iceberg scan may not expose the identity partition column as a top-level field
+        // here; still verify the table on disk and data columns.
+        assert(icebergTable.spec().fields.asScala.exists(_.name == "org_id_identity"))
+        checkAnswer(
+          spark.read.format("iceberg").load(icebergUri).select("id", "org_id", "other_id"),
+          Row(1L, "acme", 42L) :: Nil)
       }
     }
   }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
@@ -217,9 +217,9 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
 
     val partitionField = partSpec.fields().get(0)
     assert(icebergSchema.findField("org_id").fieldId() == 1000)
-    // Partition spec field ids are assigned independently from data column ids and may overlap
-    // (e.g. both 1000), which previously caused duplicate Delta column mapping ids.
-    assert(partitionField.fieldId() >= 1000)
+    assert(partitionField.name() == "org_id_identity")
+    assert(partitionField.sourceId() == 1000)
+    assert(partitionField.fieldId() == 1000)
 
     val partitionFields =
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
@@ -22,6 +22,7 @@ import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.delta.DeltaColumnMapping
 import shadedForDelta.org.apache.iceberg.{PartitionData, PartitionSpec, Schema}
 import shadedForDelta.org.apache.iceberg.transforms._
 import shadedForDelta.org.apache.iceberg.types.Conversions
@@ -112,5 +113,46 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     assertResult("Map(pname1 -> 2005-01-17, " +
       "pname2 -> 2026-09-21 18:26:54.9, pname3 -> 2026-09-21 18:26:54.9)")(
       partitionConverter.toDelta(partData).toString)
+  }
+
+  test("identity partition with distinct field name uses partition field id") {
+    val icebergSchema = new Schema(
+      1,
+      Seq(
+        NestedField.required(1, "id", LongType.get),
+        NestedField.required(4, "org_id", StringType.get)
+      ).asJava)
+
+    val partSpec = PartitionSpec
+      .builderFor(icebergSchema)
+      .identity("org_id", "org_id_identity")
+      .build()
+
+    val partitionField = partSpec.fields().get(0)
+    assert(partitionField.name() == "org_id_identity")
+    assert(partitionField.sourceId() == 4)
+    assert(partitionField.fieldId() != 4)
+
+    val fields =
+      IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
+    assert(fields.length == 1)
+    assert(fields.head.name == "org_id_identity")
+    assert(DeltaColumnMapping.getColumnId(fields.head) == partitionField.fieldId())
+  }
+
+  test("identity partition field name matches source column uses source field id") {
+    val icebergSchema = new Schema(
+      1,
+      Seq(
+        NestedField.required(1, "id", LongType.get),
+        NestedField.required(4, "org_id", StringType.get)
+      ).asJava)
+
+    val partSpec = PartitionSpec.builderFor(icebergSchema).identity("org_id").build()
+    val fields =
+      IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
+    assert(fields.length == 1)
+    assert(fields.head.name == "org_id")
+    assert(DeltaColumnMapping.getColumnId(fields.head) == 4)
   }
 }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
@@ -148,7 +148,7 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     val partitionField = partSpec.fields().get(0)
     assert(partitionField.name() == "org_id_identity")
     assert(partitionField.sourceId() == 4)
-    assert(partitionField.fieldId() != 4)
+    assert(partitionField.fieldId() == 1000)
 
     val partitionFields =
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
@@ -21,8 +21,14 @@ import java.math.BigDecimal
 import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
-import org.apache.spark.sql.delta.DeltaColumnMapping
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaConfigs}
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.types.{
+  StructField => SparkStructField,
+  StructType => SparkStructType
+}
 import shadedForDelta.org.apache.iceberg.{PartitionData, PartitionSpec, Schema}
 import shadedForDelta.org.apache.iceberg.transforms._
 import shadedForDelta.org.apache.iceberg.types.Conversions
@@ -31,6 +37,25 @@ import shadedForDelta.org.apache.iceberg.types.Types._
 import org.apache.spark.SparkFunSuite
 
 class IcebergPartitionConverterSuite extends SparkFunSuite {
+  private def assertColumnMappingValidationPasses(fields: Seq[SparkStructField]): Unit = {
+    val schemaWithPhysicalNames =
+      DeltaColumnMapping.assignPhysicalNames(
+        SparkStructType(fields.toArray),
+        reuseLogicalName = true)
+    val metadata = Metadata(
+      schemaString = schemaWithPhysicalNames.json,
+      configuration = Map(
+        DeltaConfigs.COLUMN_MAPPING_MODE.key -> "id",
+        DeltaConfigs.COLUMN_MAPPING_MAX_ID.key ->
+          DeltaColumnMapping.findMaxColumnId(schemaWithPhysicalNames).toString))
+    val validationFailure =
+      Try(DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)).failed.toOption
+    assert(
+      validationFailure.isEmpty,
+      s"Expected checkColumnIdAndPhysicalNameAssignments to succeed, but got: " +
+        s"${validationFailure.map(_.getMessage).getOrElse("<no error message>")}"
+    )
+  }
 
   test("convert partition simple case, including empty and null") {
     val icebergSchema = new Schema(10, Seq[NestedField](
@@ -133,11 +158,18 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     assert(partitionField.sourceId() == 4)
     assert(partitionField.fieldId() != 4)
 
-    val fields =
+    val partitionFields =
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
-    assert(fields.length == 1)
-    assert(fields.head.name == "org_id_identity")
-    assert(DeltaColumnMapping.getColumnId(fields.head) == partitionField.fieldId())
+    assert(partitionFields.length == 1)
+    assert(partitionFields.head.name == "org_id_identity")
+    assert(DeltaColumnMapping.getColumnId(partitionFields.head) == 1000)
+    assert(DeltaColumnMapping.getColumnId(partitionFields.head) == partitionField.fieldId())
+
+    val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
+
+    // With the fix, the partition column gets a unique ID and validation succeeds
+    val mergedFields = sourceFields ++ partitionFields
+    assertColumnMappingValidationPasses(mergedFields)
   }
 
   test("identity partition field name matches source column uses source field id") {
@@ -149,10 +181,13 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
       ).asJava)
 
     val partSpec = PartitionSpec.builderFor(icebergSchema).identity("org_id").build()
-    val fields =
+    val partitionFields =
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
-    assert(fields.length == 1)
-    assert(fields.head.name == "org_id")
-    assert(DeltaColumnMapping.getColumnId(fields.head) == 4)
+    assert(partitionFields.length == 1)
+    assert(partitionFields.head.name == "org_id")
+    assert(DeltaColumnMapping.getColumnId(partitionFields.head) == 4)
+
+    val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
+    assertColumnMappingValidationPasses(sourceFields)
   }
 }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
@@ -16,13 +16,9 @@
 
 package org.apache.spark.sql.delta.commands.convert
 
-import java.lang.{Integer => JInt, Long => JLong}
-import java.math.BigDecimal
-import java.util.{List => JList}
-
 import scala.collection.JavaConverters._
-import scala.util.Try
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaConfigs}
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.types.{
@@ -31,30 +27,25 @@ import org.apache.spark.sql.types.{
 }
 import shadedForDelta.org.apache.iceberg.{PartitionData, PartitionSpec, Schema}
 import shadedForDelta.org.apache.iceberg.transforms._
-import shadedForDelta.org.apache.iceberg.types.Conversions
 import shadedForDelta.org.apache.iceberg.types.Types._
 
-import org.apache.spark.SparkFunSuite
-
 class IcebergPartitionConverterSuite extends SparkFunSuite {
-  private def assertColumnMappingValidationPasses(fields: Seq[SparkStructField]): Unit = {
+  private def assignColumnIdAndPhysicalName(fields: Seq[SparkStructField]): Metadata = {
     val schemaWithPhysicalNames =
       DeltaColumnMapping.assignPhysicalNames(
         SparkStructType(fields.toArray),
         reuseLogicalName = true)
-    val metadata = Metadata(
+    val maxFromFields = DeltaColumnMapping.findMaxColumnId(schemaWithPhysicalNames)
+    val provisionalMetadata = Metadata(
       schemaString = schemaWithPhysicalNames.json,
       configuration = Map(
         DeltaConfigs.COLUMN_MAPPING_MODE.key -> "id",
-        DeltaConfigs.COLUMN_MAPPING_MAX_ID.key ->
-          DeltaColumnMapping.findMaxColumnId(schemaWithPhysicalNames).toString))
-    val validationFailure =
-      Try(DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)).failed.toOption
-    assert(
-      validationFailure.isEmpty,
-      s"Expected checkColumnIdAndPhysicalNameAssignments to succeed, but got: " +
-        s"${validationFailure.map(_.getMessage).getOrElse("<no error message>")}"
-    )
+        DeltaConfigs.COLUMN_MAPPING_MAX_ID.key -> maxFromFields.toString))
+    DeltaColumnMapping.assignColumnIdAndPhysicalName(
+      provisionalMetadata,
+      Metadata(),
+      isChangingModeOnExistingTable = false,
+      isOverwritingSchema = false)
   }
 
   test("convert partition simple case, including empty and null") {
@@ -140,12 +131,13 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
       partitionConverter.toDelta(partData).toString)
   }
 
-  test("identity partition with distinct field name uses partition field id") {
+  test("identity partition with custom spec field: merged schema has unique column ids") {
     val icebergSchema = new Schema(
       1,
       Seq(
         NestedField.required(1, "id", LongType.get),
-        NestedField.required(4, "org_id", StringType.get)
+        NestedField.required(4, "org_id", StringType.get),
+        NestedField.required(5, "other_id", StringType.get)
       ).asJava)
 
     val partSpec = PartitionSpec
@@ -162,22 +154,31 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
     assert(partitionFields.length == 1)
     assert(partitionFields.head.name == "org_id_identity")
-    assert(DeltaColumnMapping.getColumnId(partitionFields.head) == 1000)
-    assert(DeltaColumnMapping.getColumnId(partitionFields.head) == partitionField.fieldId())
+    assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
 
     val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
+    val metadata = assignColumnIdAndPhysicalName(sourceFields ++ partitionFields)
+    DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)
 
-    // With the fix, the partition column gets a unique ID and validation succeeds
-    val mergedFields = sourceFields ++ partitionFields
-    assertColumnMappingValidationPasses(mergedFields)
+    val fields = metadata.schema.fields
+    assert(fields.length == 4)
+    assert(fields(0).name == "id")
+    assert(DeltaColumnMapping.getColumnId(fields(0)) == 1)
+    assert(fields(1).name == "org_id")
+    assert(DeltaColumnMapping.getColumnId(fields(1)) == 4)
+    assert(fields(2).name == "other_id")
+    assert(DeltaColumnMapping.getColumnId(fields(2)) == 5)
+    assert(fields(3).name == "org_id_identity")
+    assert(DeltaColumnMapping.getColumnId(fields(3)) == 6)
   }
 
-  test("identity partition field name matches source column uses source field id") {
+  test("identity partition field name matches source column: validate merged schema") {
     val icebergSchema = new Schema(
       1,
       Seq(
         NestedField.required(1, "id", LongType.get),
-        NestedField.required(4, "org_id", StringType.get)
+        NestedField.required(4, "org_id", StringType.get),
+        NestedField.required(5, "other_id", StringType.get)
       ).asJava)
 
     val partSpec = PartitionSpec.builderFor(icebergSchema).identity("org_id").build()
@@ -185,9 +186,58 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
     assert(partitionFields.length == 1)
     assert(partitionFields.head.name == "org_id")
-    assert(DeltaColumnMapping.getColumnId(partitionFields.head) == 4)
+    assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
 
     val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
-    assertColumnMappingValidationPasses(sourceFields)
+    val metadata = assignColumnIdAndPhysicalName(sourceFields)
+    DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)
+
+    val fields = metadata.schema.fields
+    assert(fields.length == 3)
+    assert(fields(0).name == "id")
+    assert(DeltaColumnMapping.getColumnId(fields(0)) == 1)
+    assert(fields(1).name == "org_id")
+    assert(DeltaColumnMapping.getColumnId(fields(1)) == 4)
+    assert(fields(2).name == "other_id")
+    assert(DeltaColumnMapping.getColumnId(fields(2)) == 5)
+  }
+
+  test("renamed identity partition with source field id 1000: no id collision after Delta assign") {
+    val icebergSchema = new Schema(
+      1,
+      Seq(
+        NestedField.required(1, "id", LongType.get),
+        NestedField.required(1000, "org_id", StringType.get)
+      ).asJava)
+
+    val partSpec = PartitionSpec
+      .builderFor(icebergSchema)
+      .identity("org_id", "org_id_identity")
+      .build()
+
+    val partitionField = partSpec.fields().get(0)
+    assert(icebergSchema.findField("org_id").fieldId() == 1000)
+    // Partition spec field ids are assigned independently from data column ids and may overlap
+    // (e.g. both 1000), which previously caused duplicate Delta column mapping ids.
+    assert(partitionField.fieldId() >= 1000)
+
+    val partitionFields =
+      IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
+    assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
+
+    val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
+    assert(DeltaColumnMapping.getColumnId(sourceFields.find(_.name == "org_id").get) == 1000)
+
+    val metadata = assignColumnIdAndPhysicalName(sourceFields ++ partitionFields)
+    DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)
+
+    val fields = metadata.schema.fields
+    assert(fields.length == 3)
+    assert(fields(0).name == "id")
+    assert(DeltaColumnMapping.getColumnId(fields(0)) == 1)
+    assert(fields(1).name == "org_id")
+    assert(DeltaColumnMapping.getColumnId(fields(1)) == 1000)
+    assert(fields(2).name == "org_id_identity")
+    assert(DeltaColumnMapping.getColumnId(fields(2)) == 1001)
   }
 }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
@@ -21,7 +21,9 @@ import scala.collection.JavaConverters._
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaConfigs}
 import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.types.{
+  StringType => SparkStringType,
   StructField => SparkStructField,
   StructType => SparkStructType
 }
@@ -156,8 +158,12 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     assert(partitionFields.head.name == "org_id_identity")
     assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
 
-    val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
-    val metadata = assignColumnIdAndPhysicalName(sourceFields ++ partitionFields)
+    val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
+    val mergedSchema = PartitioningUtils.mergeDataAndPartitionSchema(
+      sourceSchema,
+      SparkStructType(partitionFields),
+      caseSensitive = true)._1
+    val metadata = assignColumnIdAndPhysicalName(mergedSchema.fields.toSeq)
     DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)
 
     val fields = metadata.schema.fields
@@ -186,10 +192,15 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
     assert(partitionFields.length == 1)
     assert(partitionFields.head.name == "org_id")
-    assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
+    assert(DeltaColumnMapping.hasColumnId(partitionFields.head))
+    assert(DeltaColumnMapping.getColumnId(partitionFields.head) == 4)
 
-    val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
-    val metadata = assignColumnIdAndPhysicalName(sourceFields)
+    val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
+    val mergedSchema = PartitioningUtils.mergeDataAndPartitionSchema(
+      sourceSchema,
+      SparkStructType(partitionFields),
+      caseSensitive = true)._1
+    val metadata = assignColumnIdAndPhysicalName(mergedSchema.fields.toSeq)
     DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)
 
     val fields = metadata.schema.fields
@@ -199,6 +210,51 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     assert(fields(1).name == "org_id")
     assert(DeltaColumnMapping.getColumnId(fields(1)) == 4)
     assert(fields(2).name == "other_id")
+    assert(DeltaColumnMapping.getColumnId(fields(2)) == 5)
+  }
+
+  test("nested schema: identity on nested source omits partition column id") {
+    val addressStruct = StructType.of(
+      NestedField.required(3, "zip", StringType.get()),
+      NestedField.required(4, "city", StringType.get()))
+    val icebergSchema = new Schema(
+      1,
+      Seq(
+        NestedField.required(1, "id", LongType.get()),
+        NestedField.required(2, "address", addressStruct)
+      ).asJava)
+
+    val partSpec = PartitionSpec.builderFor(icebergSchema).identity("address.zip").build()
+    val icebergPartField = partSpec.fields().get(0)
+    assert(icebergPartField.sourceId() == 3)
+    assert(icebergSchema.findColumnName(3) == "address.zip")
+
+    val partitionFields =
+      IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
+    assert(partitionFields.length == 1)
+    assert(partitionFields.head.dataType == SparkStringType)
+    assert(partitionFields.head.name == icebergPartField.name())
+    // Nested dotted paths: partition column is extra after Spark merge vs data schema; do not
+    // reuse nested field id (see IcebergPartitionUtil identity branch).
+    assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
+
+    val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
+    val mergedSchema = PartitioningUtils.mergeDataAndPartitionSchema(
+      sourceSchema,
+      SparkStructType(partitionFields),
+      caseSensitive = true)._1
+    val metadata = assignColumnIdAndPhysicalName(mergedSchema.fields.toSeq)
+    DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)
+
+    val fields = metadata.schema.fields
+    assert(fields.length == 3)
+    assert(fields(0).name == "id")
+    assert(DeltaColumnMapping.getColumnId(fields(0)) == 1)
+    assert(fields(1).name == "address")
+    assert(DeltaColumnMapping.getColumnId(fields(1)) == 2)
+    val zipInStruct = fields(1).dataType.asInstanceOf[SparkStructType]("zip")
+    assert(DeltaColumnMapping.getColumnId(zipInStruct) == 3)
+    assert(fields(2).name == icebergPartField.name())
     assert(DeltaColumnMapping.getColumnId(fields(2)) == 5)
   }
 
@@ -225,10 +281,15 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
     assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
 
-    val sourceFields = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema).fields.toSeq
+    val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
+    val sourceFields = sourceSchema.fields.toSeq
     assert(DeltaColumnMapping.getColumnId(sourceFields.find(_.name == "org_id").get) == 1000)
 
-    val metadata = assignColumnIdAndPhysicalName(sourceFields ++ partitionFields)
+    val mergedSchema = PartitioningUtils.mergeDataAndPartitionSchema(
+      sourceSchema,
+      SparkStructType(partitionFields),
+      caseSensitive = true)._1
+    val metadata = assignColumnIdAndPhysicalName(mergedSchema.fields.toSeq)
     DeltaColumnMapping.checkColumnIdAndPhysicalNameAssignments(metadata)
 
     val fields = metadata.schema.fields

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergPartitionConverterSuite.scala
@@ -157,6 +157,14 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     assert(partitionFields.length == 1)
     assert(partitionFields.head.name == "org_id_identity")
     assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
+    val customPhysicalNameToField =
+      Map(DeltaColumnMapping.getPhysicalName(partitionFields.head) -> partitionField)
+    val customConverter = IcebergPartitionConverter(icebergSchema, customPhysicalNameToField)
+    val customPartData = new PartitionData(partSpec.partitionType())
+    customPartData.put(0, "tenant-a")
+    assertResult("Map(org_id_identity -> tenant-a)") {
+      customConverter.toDelta(customPartData).toString
+    }
 
     val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
     val mergedSchema = PartitioningUtils.mergeDataAndPartitionSchema(
@@ -188,12 +196,21 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
       ).asJava)
 
     val partSpec = PartitionSpec.builderFor(icebergSchema).identity("org_id").build()
+    val icebergPartField = partSpec.fields().get(0)
     val partitionFields =
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
     assert(partitionFields.length == 1)
     assert(partitionFields.head.name == "org_id")
     assert(DeltaColumnMapping.hasColumnId(partitionFields.head))
     assert(DeltaColumnMapping.getColumnId(partitionFields.head) == 4)
+    val sameNamePhysicalNameToField =
+      Map(DeltaColumnMapping.getPhysicalName(partitionFields.head) -> icebergPartField)
+    val sameNameConverter = IcebergPartitionConverter(icebergSchema, sameNamePhysicalNameToField)
+    val sameNamePartData = new PartitionData(partSpec.partitionType())
+    sameNamePartData.put(0, "tenant-a")
+    assertResult("Map(org_id -> tenant-a)") {
+      sameNameConverter.toDelta(sameNamePartData).toString
+    }
 
     val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
     val mergedSchema = PartitioningUtils.mergeDataAndPartitionSchema(
@@ -237,6 +254,14 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     // Nested dotted paths: partition column is extra after Spark merge vs data schema; do not
     // reuse nested field id (see IcebergPartitionUtil identity branch).
     assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
+    val nestedPhysicalNameToField =
+      Map(DeltaColumnMapping.getPhysicalName(partitionFields.head) -> icebergPartField)
+    val nestedConverter = IcebergPartitionConverter(icebergSchema, nestedPhysicalNameToField)
+    val nestedPartData = new PartitionData(partSpec.partitionType())
+    nestedPartData.put(0, "94103")
+    assertResult("Map(address.zip -> 94103)") {
+      nestedConverter.toDelta(nestedPartData).toString
+    }
 
     val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
     val mergedSchema = PartitioningUtils.mergeDataAndPartitionSchema(
@@ -280,6 +305,14 @@ class IcebergPartitionConverterSuite extends SparkFunSuite {
     val partitionFields =
       IcebergPartitionUtil.getPartitionFields(partSpec, icebergSchema, castTimeType = false)
     assert(!DeltaColumnMapping.hasColumnId(partitionFields.head))
+    val physicalNameToField =
+      Map(DeltaColumnMapping.getPhysicalName(partitionFields.head) -> partitionField)
+    val converter = IcebergPartitionConverter(icebergSchema, physicalNameToField)
+    val partData = new PartitionData(partSpec.partitionType())
+    partData.put(0, "tenant-a")
+    assertResult("Map(org_id_identity -> tenant-a)") {
+      converter.toDelta(partData).toString
+    }
 
     val sourceSchema = IcebergSchemaUtils.convertIcebergSchemaToSpark(icebergSchema)
     val sourceFields = sourceSchema.fields.toSeq


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Iceberg)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Converting Iceberg tables whose partition spec uses identity transforms with a partition field name different from the source column (e.g. `identity("org_id", "org_id_identity")`) could produce duplicate `delta.columnMapping.id` values once the data schema (Iceberg schema field IDs) and partition columns were merged for Delta metadata. That breaks Delta’s column-mapping invariants and can fail validation or corrupt the table schema.

This change ensures partition columns produced for that case do not reuse Iceberg IDs in a way that collides with existing data-column IDs, and instead follows the same pattern as other partition transforms: leave mapping IDs unset on the partition StructFields where needed so Delta’s normal `assignColumnIdAndPhysicalName` flow assigns unique IDs.

## How was this patch tested?

added unit test that reproduces the original issue

## Does this PR introduce _any_ user-facing changes?

No
