### PR TITLE
[Spark] Onboard more tests to InMemorySparkTable, support saveAsTable

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -148,8 +148,8 @@ object SuiteGeneratorConfig {
     val DELETE_SCALA = DimensionMixin("DeleteScala", alias = Some("Scala"))
     val DELETE_SQL = DimensionMixin("DeleteSQL", alias = Some("SQL"))
     val DELETE_WITH_DVS = DimensionMixin("DeleteSQLWithDeletionVectors", alias = Some("DV"))
-    val V2_IN_MEMORY_TABLE_MERGE =
-      DimensionMixin("MergeIntoSuiteInMemoryTestTable", alias = Some("InMemoryTable"))
+    val V2_IN_MEMORY_TABLE =
+      DimensionMixin("DeltaDMLInMemoryTestUtils", suffix = "", alias = Some("InMemoryTable"))
   }
 
   private object Tests {
@@ -234,9 +234,11 @@ object SuiteGeneratorConfig {
             "MergeIntoAnalysisExceptionTests",
             "MergeIntoNotMatchedBySourceSuite",
             "MergeIntoUnlimitedMergeClausesTests",
+            "MergeIntoExtendedSyntaxTests",
             "MergeIntoSchemaEvolutionCoreTests",
-            "MergeIntoSchemaEvolutionNotMatchedBySourceTests"),
-          List(List(Dims.MERGE_SQL, Dims.V2_IN_MEMORY_TABLE_MERGE, Dims.NAME_BASED))
+            "MergeIntoSchemaEvolutionNotMatchedBySourceTests"
+          ),
+          List(List(Dims.MERGE_SQL, Dims.V2_IN_MEMORY_TABLE, Dims.NAME_BASED))
         ),
         TestConfig(
           "MergeCDCTests" :: "MergeIntoDVsTests" :: Tests.MERGE_SQL ::: Tests.MERGE_BASE,
@@ -345,6 +347,12 @@ object SuiteGeneratorConfig {
             List(Dims.DELETE_SQL, Dims.PATH_BASED, Dims.COLUMN_MAPPING.asOptional),
             List(Dims.DELETE_SQL, Dims.PATH_BASED, Dims.DELETE_WITH_DVS, Dims.PREDPUSH),
             List(Dims.DELETE_SQL, Dims.PATH_BASED, Dims.CDC)
+          )
+        ),
+        TestConfig(
+          List("DeleteSubqueryExistsTests"),
+          List(
+            List(Dims.DELETE_SQL, Dims.NAME_BASED, Dims.V2_IN_MEMORY_TABLE)
           )
         ),
         TestConfig(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -859,6 +859,14 @@ trait DeltaDMLInMemoryTestUtils
     extends DeltaDMLTestUtils
     with DeltaSQLInMemoryTestUtils {
 
+  protected def v2ErrorConditionMapping: Map[String, String] = Map(
+    "DELTA_AGGREGATION_NOT_SUPPORTED" -> "UNSUPPORTED_MERGE_CONDITION.AGGREGATE",
+    "DELTA_NON_DETERMINISTIC_FUNCTION_NOT_SUPPORTED" ->
+      "UNSUPPORTED_MERGE_CONDITION.NON_DETERMINISTIC",
+    "DELTA_MULTIPLE_SOURCE_ROW_MATCHING_TARGET_ROW_IN_MERGE" -> "MERGE_CARDINALITY_VIOLATION",
+    "DELTA_MERGE_UNRESOLVED_EXPRESSION" -> "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+    "DELTA_SUBQUERY_NOT_SUPPORTED" -> "UNSUPPORTED_MERGE_CONDITION.SUBQUERY")
+
   /**
    * Appends [[df]] into the test table.
    */
@@ -874,6 +882,29 @@ trait DeltaDMLInMemoryTestUtils
     }
     df.writeTo(tableSQLIdentifier).append()
     assertNoV1Writes(tableSQLIdentifier)
+  }
+
+  override def checkError(
+      exception: SparkThrowable,
+      condition: String,
+      sqlState: Option[String] = None,
+      parameters: Map[String, String] = Map.empty,
+      matchPVals: Boolean = false,
+      queryContext: Array[ExpectedContext] = Array.empty): Unit = {
+    v2ErrorConditionMapping.get(condition) match {
+      case Some(v2Condition) =>
+        assert(exception.getCondition == v2Condition,
+          s"Expected V2 condition '$v2Condition' (mapped from '$condition'), " +
+            s"got '${exception.getCondition}'")
+      case None =>
+        super.checkError(
+          exception = exception,
+          condition = condition,
+          sqlState = sqlState,
+          parameters = parameters,
+          matchPVals = matchPVals,
+          queryContext = queryContext)
+    }
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -16,14 +16,11 @@
 
 package org.apache.spark.sql.delta
 
-import java.io.File
 import java.lang.{Integer => JInt}
-import java.net.URI
 
 import scala.language.implicitConversions
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
-import org.apache.spark.sql.delta.catalog.InMemoryDeltaCatalog
 import org.apache.spark.sql.delta.commands.MergeIntoCommand
 import org.apache.spark.sql.delta.commands.merge.MergeStats
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -32,9 +29,9 @@ import org.apache.spark.sql.delta.test.ScanReportHelper
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.QueryContext
+import org.apache.spark.{QueryContext, SparkThrowable}
 import org.apache.spark.sql.{functions, AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.catalyst.plans.logical.{SubqueryAlias, View}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
@@ -2014,18 +2011,19 @@ trait MergeIntoExtendedSyntaxTests extends MergeIntoSuiteBaseMixin {
 
   private def testMergeErrorOnMultipleMatches(
       name: String,
-      confs: Seq[(String, String)] = Seq.empty)(
+      confs: Seq[(String, String)] = Seq.empty,
+      testTags: Seq[org.scalatest.Tag] = Seq.empty)(
       source: Seq[(Int, Int)],
       target: Seq[(Int, Int)],
       mergeOn: String,
       mergeClauses: MergeClause*): Unit = {
-    test(s"extended syntax - $name") {
+    test(s"extended syntax - $name", testTags: _*) {
       withSQLConf(confs: _*) {
         withKeyValueData(source, target) { case (sourceName, targetName) =>
           val docURL = "/delta-update.html#upsert-into-a-table-using-merge"
 
           checkError(
-            exception = intercept[DeltaUnsupportedOperationException] {
+            exception = intercept[SparkThrowable] {
               executeMerge(s"$targetName t", s"$sourceName s", mergeOn, mergeClauses: _*)
             },
             "DELTA_MULTIPLE_SOURCE_ROW_MATCHING_TARGET_ROW_IN_MERGE",
@@ -2379,7 +2377,10 @@ trait MergeIntoExtendedSyntaxTests extends MergeIntoSuiteBaseMixin {
 
   testMergeErrorOnMultipleMatches(
     "unconditional insert only merge - multiple matches when feature flag off",
-    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"))(
+    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"),
+    testTags = Seq(DSv2Incompatible(
+      "This covers legacy behavior where Delta was too strict. Existing and V2 behavior both " +
+        "are able to detect that the multiple matches aren't problematic and succeed")))(
     source = (1, 10) :: (1, 100) :: (2, 20) :: Nil,
     target = (1, 1) :: Nil,
     mergeOn = "s.key = t.key",
@@ -2387,7 +2388,10 @@ trait MergeIntoExtendedSyntaxTests extends MergeIntoSuiteBaseMixin {
 
   testMergeErrorOnMultipleMatches(
     "conditional insert only merge - multiple matches when feature flag off",
-    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"))(
+    confs = Seq(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "false"),
+    testTags = Seq(DSv2Incompatible(
+      "V2 in-memory MERGE does not raise cardinality violations for insert-only MERGE " +
+        "even when MERGE_INSERT_ONLY_ENABLED=false")))(
     source = (1, 10) :: (1, 100) :: (2, 20) :: (2, 200) :: Nil,
     target = (1, 1) :: Nil,
     mergeOn = "s.key = t.key",
@@ -3465,51 +3469,6 @@ trait MergeIntoSuiteBaseMiscTests extends MergeIntoSuiteBaseMixin {
           Row(-1, part3) :: Row(-1, part3) :: Row(-1, part3) ::
           Row(0, part4) ::
           Nil)
-    }
-  }
-}
-
-/**
- * Merge-specific V2-DML mixin.
- * Remaps known error conditions between V1 and V2.
- */
-trait MergeIntoSuiteInMemoryTestTableMixin
-    extends DeltaDMLInMemoryTestUtils {
-
-  /**
-   * Override that checks for known-different [[condition]]s between V1 and V2.
-   * When a matching [[condition]] is found, the [[exception]] is only asserted to match the mapped
-   * condition.
-   */
-  override def checkError(
-      exception: org.apache.spark.SparkThrowable,
-      condition: String,
-      sqlState: Option[String] = None,
-      parameters: Map[String, String] = Map.empty,
-      matchPVals: Boolean = false,
-      queryContext: Array[ExpectedContext] = Array.empty): Unit = {
-    def assertV2(v2Condition: String): Unit = {
-      assert(exception.getCondition == v2Condition,
-        s"Expected V2 condition '$v2Condition' (mapped from '$condition'), " +
-        s"got '${exception.getCondition}'")
-    }
-    condition match {
-      case "DELTA_AGGREGATION_NOT_SUPPORTED" =>
-        assertV2("UNSUPPORTED_MERGE_CONDITION.AGGREGATE")
-      case "DELTA_NON_DETERMINISTIC_FUNCTION_NOT_SUPPORTED" =>
-        assertV2("UNSUPPORTED_MERGE_CONDITION.NON_DETERMINISTIC")
-      case "DELTA_MERGE_UNRESOLVED_EXPRESSION" =>
-        assertV2("UNRESOLVED_COLUMN.WITH_SUGGESTION")
-      case "DELTA_SUBQUERY_NOT_SUPPORTED" =>
-        assertV2("UNSUPPORTED_MERGE_CONDITION.SUBQUERY")
-      case _ =>
-        super.checkError(
-          exception = exception,
-          condition = condition,
-          sqlState = sqlState,
-          parameters = parameters,
-          matchPVals = matchPVals,
-          queryContext = queryContext)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -16,15 +16,9 @@
 
 package org.apache.spark.sql.delta
 
-import java.io.File
-import java.net.URI
-import java.nio.file.{Files, Path}
-
 import org.apache.spark.sql.delta.catalog.InMemorySparkTable
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -76,6 +70,35 @@ class V2DmlInMemoryTableSuite
       QueryTest.checkAnswer(
         sql(s"SELECT id, value FROM $tableName ORDER BY id"),
         Seq(Row(3L, "c")))
+    }
+  }
+
+  test("saveAsTable writes data into DSv2 InMemoryTable") {
+    import testImplicits._
+
+    val tableName = "v2_dml_test_save_as_table"
+    withTable(tableName) {
+      Seq((1L, "a"), (2L, "b")).toDF("id", "value").write.format("delta").saveAsTable(tableName)
+
+      QueryTest.checkAnswer(
+        sql(s"SELECT id, value FROM $tableName ORDER BY id"),
+        Seq(Row(1L, "a"), Row(2L, "b")))
+    }
+  }
+
+  test("createOrReplace writes data into DSv2 InMemoryTable") {
+    import testImplicits._
+
+    val tableName = "v2_dml_test_create_or_replace"
+    withTable(tableName) {
+      Seq((1L, "a"), (2L, "b")).toDF("id", "value")
+        .writeTo(tableName)
+        .using("delta")
+        .createOrReplace()
+
+      QueryTest.checkAnswer(
+        sql(s"SELECT id, value FROM $tableName ORDER BY id"),
+        Seq(Row(1L, "a"), Row(2L, "b")))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -16,16 +16,33 @@
 
 package org.apache.spark.sql.delta.catalog
 
+import java.util
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableChange}
+import org.apache.spark.sql.catalyst.util.QuotingUtils
+import org.apache.spark.sql.connector.catalog.{
+  CatalogV2Util,
+  Identifier,
+  StagedTable,
+  SupportsWrite,
+  Table,
+  TableCapability,
+  TableChange}
 import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.metric.CustomTaskMetric
+import org.apache.spark.sql.connector.write.{
+  LogicalWriteInfo,
+  SupportsTruncate,
+  V1Write,
+  WriteBuilder}
+import org.apache.spark.sql.sources.InsertableRelation
+import org.apache.spark.sql.types.StructType
 
 /**
  * Test-only catalog that extends [[DeltaCatalog]] and overrides [[loadCatalogTable]]
@@ -40,6 +57,73 @@ class InMemoryDeltaCatalog extends DeltaCatalog {
 
   override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table =
     InMemoryDeltaCatalog.getOrCreateTable(ident, catalogTable, spark)
+
+  override def stageCreate(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    new InMemoryStagedTable(ident, super.stageCreate(ident, schema, partitions, properties))
+  }
+
+  override def stageReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    new InMemoryStagedTable(ident, super.stageReplace(ident, schema, partitions, properties))
+  }
+
+  override def stageCreateOrReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    new InMemoryStagedTable(
+      ident,
+      super.stageCreateOrReplace(ident, schema, partitions, properties))
+  }
+
+  private class InMemoryStagedTable(ident: Identifier, stagedTable: StagedTable)
+      extends StagedTable with SupportsWrite {
+    private var asSelectQuery: Option[DataFrame] = None
+
+    override def name(): String = stagedTable.name()
+
+    override def schema(): StructType = stagedTable.schema()
+
+    override def partitioning(): Array[Transform] = stagedTable.partitioning()
+
+    override def properties(): util.Map[String, String] = stagedTable.properties()
+
+    override def capabilities(): util.Set[TableCapability] = stagedTable.capabilities()
+
+    override def commitStagedChanges(): Unit = {
+      stagedTable.commitStagedChanges()
+      asSelectQuery.foreach(_.writeTo(QuotingUtils.fullyQuoted(ident)).append())
+    }
+
+    override def abortStagedChanges(): Unit = stagedTable.abortStagedChanges()
+
+    override def reportDriverMetrics(): Array[CustomTaskMetric] = stagedTable.reportDriverMetrics()
+
+    override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+      stagedTable.asInstanceOf[SupportsWrite].newWriteBuilder(info)
+      new WriteBuilder with SupportsTruncate {
+        override def truncate(): WriteBuilder = this
+
+        override def build(): V1Write = new V1Write {
+          override def toInsertableRelation(): InsertableRelation = {
+            new InsertableRelation {
+              override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+                asSelectQuery = Option(data)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
     loadTable(ident) match {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/delete/DeleteSubqueryExistsTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/delete/DeleteSubqueryExistsTests.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
 import org.apache.spark.sql.delta.rowid._
 
+class DeleteSubqueryExistsSQLNameBasedInMemoryTableSuite
+  extends DeleteSubqueryExistsTests
+  with DeleteSQLMixin
+  with DeltaDMLTestUtilsNameBased
+  with DeltaDMLInMemoryTestUtils
+
 class DeleteSubqueryExistsSQLNameBasedSuite
   extends DeleteSubqueryExistsTests
   with DeleteSQLMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoAnalysisExceptionTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoAnalysisExceptionTests.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.rowid._
 class MergeIntoAnalysisExceptionSQLInMemoryTableNameBasedSuite
   extends MergeIntoAnalysisExceptionTests
   with MergeIntoSQLMixin
-  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLInMemoryTestUtils
   with DeltaDMLTestUtilsNameBased
 
 class MergeIntoAnalysisExceptionSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoBasicTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoBasicTests.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.rowid._
 class MergeIntoBasicSQLInMemoryTableNameBasedSuite
   extends MergeIntoBasicTests
   with MergeIntoSQLMixin
-  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLInMemoryTestUtils
   with DeltaDMLTestUtilsNameBased
 
 class MergeIntoBasicSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoExtendedSyntaxTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoExtendedSyntaxTests.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
 import org.apache.spark.sql.delta.rowid._
 
+class MergeIntoExtendedSyntaxSQLInMemoryTableNameBasedSuite
+  extends MergeIntoExtendedSyntaxTests
+  with MergeIntoSQLMixin
+  with DeltaDMLInMemoryTestUtils
+  with DeltaDMLTestUtilsNameBased
+
 class MergeIntoExtendedSyntaxSQLNameBasedSuite
   extends MergeIntoExtendedSyntaxTests
   with MergeIntoSQLMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoNotMatchedBySourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoNotMatchedBySourceSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.rowid._
 class MergeIntoNotMatchedBySourceSQLInMemoryTableNameBasedSuite
   extends MergeIntoNotMatchedBySourceSuite
   with MergeIntoSQLMixin
-  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLInMemoryTestUtils
   with DeltaDMLTestUtilsNameBased
 
 class MergeIntoNotMatchedBySourceSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoSchemaEvolutionCoreTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoSchemaEvolutionCoreTests.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.rowid._
 class MergeIntoSchemaEvolutionCoreSQLInMemoryTableNameBasedSuite
   extends MergeIntoSchemaEvolutionCoreTests
   with MergeIntoSQLMixin
-  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLInMemoryTestUtils
   with DeltaDMLTestUtilsNameBased
 
 class MergeIntoSchemaEvolutionCoreSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoSchemaEvolutionNotMatchedBySourceTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoSchemaEvolutionNotMatchedBySourceTests.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.rowid._
 class MergeIntoSchemaEvolutionNotMatchedBySourceSQLInMemoryTableNameBasedSuite
   extends MergeIntoSchemaEvolutionNotMatchedBySourceTests
   with MergeIntoSQLMixin
-  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLInMemoryTestUtils
   with DeltaDMLTestUtilsNameBased
 
 class MergeIntoSchemaEvolutionNotMatchedBySourceSQLNameBasedSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoUnlimitedMergeClausesTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/merge/MergeIntoUnlimitedMergeClausesTests.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.rowid._
 class MergeIntoUnlimitedMergeClausesSQLInMemoryTableNameBasedSuite
   extends MergeIntoUnlimitedMergeClausesTests
   with MergeIntoSQLMixin
-  with MergeIntoSuiteInMemoryTestTableMixin
+  with DeltaDMLInMemoryTestUtils
   with DeltaDMLTestUtilsNameBased
 
 class MergeIntoUnlimitedMergeClausesSQLNameBasedSuite


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding support for `saveAsTable` through the `InMemorySparkTable`, onboarding more generated suites that use it.

## How was this patch tested?

This patch onboards a couple more generated tests.