### PR TITLE
[PROTOCOL] Reword `active` to `enabled` in icebergCompatV3

### DIFF
--- a/protocol_rfcs/iceberg-compat-v3.md
+++ b/protocol_rfcs/iceberg-compat-v3.md
@@ -32,7 +32,7 @@ When this feature is supported and enabled, writers must:
   - Materialized Row ID column must use field ID 2147483540
   - Materialized Row Commit Version column must use field ID 2147483539
 - Require that the nested `element` field of ArrayTypes and the nested `key` and `value` fields of MapTypes be assigned 32 bit integer identifiers. The requirement to ID allocation is the same as that in IcebergCompatV2.
-- Require that IcebergCompatV1 and IcebergCompatV2 are not active on the table
+- Require that IcebergCompatV1 and IcebergCompatV2 are not enabled on the table
 - Require that partition column values be materialized when writing Parquet data files
 - Require that all new `AddFile`s committed to the table have the `numRecords` statistic populated in their `stats` field
 - Require writing timestamp columns as int64


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (protocol)

## Description
In icebergCompatV3, the protocol specified:
```
Require that IcebergCompatV1 and IcebergCompatV2 are not active on the table
```
The word active means `enabled`, this PR changes the wording to be more accurate.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
N/A
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
N/A
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
