### PR TITLE
[Spark] Add DSv2TemporarilyIncompatible test tag

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
@@ -28,6 +28,16 @@ import org.apache.spark.sql.test.SharedSparkSession
 case class DSv2Incompatible(reason: String) extends org.scalatest.Tag("DSv2Incompatible")
 
 /**
+ * Tag for tests that exercise some features that are _currently_ not implemented for DSv2, but
+ * should be implemented sometime in the future.
+ * Not [[DSv2Incompatible]] -- that one is for tests that are completely unsupported and would
+ * never pass with DSv2.
+ * Tests tagged with this are automatically skipped when [[InMemoryTestTableMixin]] is active.
+ */
+case class DSv2TemporarilyIncompatible(reason: String)
+  extends org.scalatest.Tag("DSv2TemporariltyIncompatible")
+
+/**
  * Mixin trait that configures the session catalog to use [[InMemoryDeltaCatalog]],
  * routing DML operations through Spark's V2 execution path via [[InMemorySparkTable]].
  */
@@ -39,11 +49,16 @@ trait InMemoryTestTableMixin extends SharedSparkSession {
       (testName: String, testTags: org.scalatest.Tag*)
       (testFun: => Any)
       (implicit pos: org.scalactic.source.Position): Unit = {
-    testTags.collectFirst { case t: DSv2Incompatible => t.reason } match {
-      case Some(reason) =>
-        ignore(testName + s" (DSv2Incompatible: $reason)", testTags: _*)(testFun)
-      case None =>
-        super.test(testName, testTags: _*)(testFun)
+    for (tag <- testTags) {
+      tag match {
+        case t: DSv2Incompatible =>
+          ignore(testName + s" (DSv2Incompatible: $t.reason)", testTags: _*)(testFun)
+          return
+        case t: DSv2TemporarilyIncompatible =>
+          ignore(testName + s" (DSv2TemporarilyIncompatible: $t.reason)", testTags: _*)(testFun)
+          return
+      }
     }
+    super.test(testName, testTags: _*)(testFun)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -133,4 +133,9 @@ class V2DmlInMemoryTableSuite
   test("should just throw, but is DSv2Incompatible", DSv2Incompatible("explicit skip")) {
     assert(false, "this test should have been skipped")
   }
+
+  test("should just throw, but is DSv2TemporarilyIncompatible",
+      DSv2TemporarilyIncompatible("explicit skip")) {
+    assert(false, "this test should have been skipped")
+  }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Introduce a new test tag -- `DSv2TemporarilyIncompatible`. It should be used to mark tests that should pass with DSv2 enabled _sometime in the future_, but not right now.

This is as opposed to `DSv2Incompatible`, which should only be used for tests that cover something that is completely unsupported when running under DSv2.

## How was this patch tested?

This patch includes a test that should always fail, but is skipped using the new test tag.

## Does this PR introduce _any_ user-facing changes?

No.
