### PR TITLE
[BUILD] Plumb kernelVersion through Python test runners

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,10 @@ val protoVersion = "3.25.1"
 val grpcVersion = "1.62.2"
 val flinkVersion = "2.0.1"
 
+// Optional kernel version override. See `project/KernelVersion.scala` for the
+// resolution rule and `-DkernelVersion=<v>` semantics.
+val kernelVersionOpt: Option[String] = KernelVersion.kernelVersionOpt
+
 // Define the ecosystem support flags.
 val supportIceberg = CrossSparkVersions.getSparkVersionSpec().supportIceberg
 val supportHudi = CrossSparkVersions.getSparkVersionSpec().supportHudi
@@ -450,49 +454,79 @@ lazy val sparkV1Filtered = (project in file("spark-v1-filtered"))
 // ============================================================
 // Spark Module 3: sparkV2 (Kernel-based DSv2 connector, depends on v1-filtered)
 // ============================================================
-lazy val sparkV2 = (project in file("spark/v2"))
-  .dependsOn(sparkV1Filtered)
-  .dependsOn(kernelDefaults)
-  .dependsOn(kernelUnityCatalog % "compile->compile;test->test")
-  .dependsOn(goldenTables % "test")
-  .settings(
-    name := "delta-spark-v2",
-    commonSettings,
-    javafmtCheckSettings,
-    skipReleaseSettings, // Internal module - not published to Maven
-    CrossSparkVersions.sparkDependentSettings(sparkVersion),
-    exportJars := true,  // Export as JAR to avoid classpath conflicts
+lazy val sparkV2 = {
+  // When kernelVersionOpt is set, consume the kernel from Maven instead of the
+  // local source projects: drop the project dependsOn / kernelApi unmanagedJars
+  // wiring and add the matching Maven artifacts at that version.
+  val kernelSourceDeps: Project => Project = kernelVersionOpt match {
+    case None => p => p
+      .dependsOn(kernelDefaults)
+      .dependsOn(kernelUnityCatalog % "compile->compile;test->test")
+    case Some(_) => p => p
+  }
+  val kernelDepSettings: Seq[Setting[_]] = kernelVersionOpt match {
+    case None => Seq(
+      // make sure shaded kernel-api jar exists before compiling/testing
+      Compile / compile := (Compile / compile)
+        .dependsOn(kernelApi / Compile / packageBin).value,
+      Test / test := (Test / test)
+        .dependsOn(kernelApi / Compile / packageBin).value,
+      Test / unmanagedJars += (kernelApi / Test / packageBin).value,
+      Compile / unmanagedJars ++= Seq(
+        (kernelApi / Compile / packageBin).value
+      )
+    )
+    case Some(v) => Seq(
+      libraryDependencies ++= Seq(
+        "io.delta" % "delta-kernel-api" % v,
+        "io.delta" % "delta-kernel-defaults" % v,
+        "io.delta" % "delta-kernel-unitycatalog" % v
+      ),
+      // Kernel main classes are pulled from Maven at version `v`, but several
+      // sparkV2 tests depend on test-only helpers (e.g. InMemoryUCClient,
+      // UCCatalogManagedTestUtils) that are not published. Build those test
+      // jars from the in-tree kernel sources and add them to the test classpath.
+      Test / unmanagedJars ++= Seq(
+        (kernelApi / Test / packageBin).value,
+        (kernelDefaults / Test / packageBin).value,
+        (kernelUnityCatalog / Test / packageBin).value
+      )
+    )
+  }
 
-    Test / javaOptions ++= Seq("-ea"),
-    // make sure shaded kernel-api jar exists before compiling/testing
-    Compile / compile := (Compile / compile)
-      .dependsOn(kernelApi / Compile / packageBin).value,
-    Test / test := (Test / test)
-      .dependsOn(kernelApi / Compile / packageBin).value,
-    Test / unmanagedJars += (kernelApi / Test / packageBin).value,
-    Compile / unmanagedJars ++= Seq(
-      (kernelApi / Compile / packageBin).value
-    ),
-    libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",
-      "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided",
-      "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided",
+  kernelSourceDeps(Project("sparkV2", file("spark/v2")).dependsOn(sparkV1Filtered))
+    .dependsOn(goldenTables % "test")
+    .settings(
+      name := "delta-spark-v2",
+      commonSettings,
+      javafmtCheckSettings,
+      skipReleaseSettings, // Internal module - not published to Maven
+      CrossSparkVersions.sparkDependentSettings(sparkVersion),
+      exportJars := true,  // Export as JAR to avoid classpath conflicts
 
-      // Test dependencies
-      "org.junit.jupiter" % "junit-jupiter-api" % "5.11.4" % "test",
-      "org.junit.jupiter" % "junit-jupiter-engine" % "5.11.4" % "test",
-      "org.junit.jupiter" % "junit-jupiter-params" % "5.11.4" % "test",
-      "com.github.sbt.junit" % "jupiter-interface" % "0.17.0" % "test",
-      // Spark test classes for Scala/Java test utilities
-      "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
-      "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
-      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests",
-      // ScalaTest for test utilities (needed by Spark test classes)
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
-    ),
-    Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-    TestParallelization.settings
-  )
+      Test / javaOptions ++= Seq("-ea"),
+      libraryDependencies ++= Seq(
+        "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",
+        "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided",
+        "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided",
+
+        // Test dependencies
+        "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test",
+        "org.junit.jupiter" % "junit-jupiter-engine" % "5.8.2" % "test",
+        "org.junit.jupiter" % "junit-jupiter-params" % "5.8.2" % "test",
+        "net.aichler" % "jupiter-interface" % "0.11.1" % "test",
+        // Spark test classes for Scala/Java test utilities
+        "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
+        "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
+        "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests",
+        // ScalaTest for test utilities (needed by Spark test classes)
+        "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      ),
+      Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
+      TestParallelization.settings
+    )
+    .settings(kernelDepSettings: _*)
+}
 
 
 // ============================================================

--- a/build.sbt
+++ b/build.sbt
@@ -511,10 +511,10 @@ lazy val sparkV2 = {
         "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided",
 
         // Test dependencies
-        "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test",
-        "org.junit.jupiter" % "junit-jupiter-engine" % "5.8.2" % "test",
-        "org.junit.jupiter" % "junit-jupiter-params" % "5.8.2" % "test",
-        "net.aichler" % "jupiter-interface" % "0.11.1" % "test",
+        "org.junit.jupiter" % "junit-jupiter-api" % "5.11.4" % "test",
+        "org.junit.jupiter" % "junit-jupiter-engine" % "5.11.4" % "test",
+        "org.junit.jupiter" % "junit-jupiter-params" % "5.11.4" % "test",
+        "com.github.sbt.junit" % "jupiter-interface" % "0.17.0" % "test",
         // Spark test classes for Scala/Java test utilities
         "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
         "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",

--- a/project/KernelVersion.scala
+++ b/project/KernelVersion.scala
@@ -1,0 +1,18 @@
+/**
+ * Kernel version override used by sparkV2.
+ *
+ * When `-DkernelVersion=<v>` is set on the SBT invocation, sparkV2 consumes
+ * `delta-kernel-{api,defaults,unitycatalog}` from Maven at version `v` instead
+ * of depending on the in-tree kernel source projects. When unset, sparkV2
+ * keeps using the in-tree kernel.
+ *
+ * Centralised here so the version-resolution rule lives in a single,
+ * easy-to-find file rather than inline in build.sbt.
+ */
+object KernelVersion {
+  /** SBT system property used to pin the kernel Maven version. */
+  val SystemProperty: String = "kernelVersion"
+
+  /** The resolved kernel version override, or None to use in-tree kernel sources. */
+  val kernelVersionOpt: Option[String] = sys.props.get(SystemProperty)
+}

--- a/project/KernelVersion.scala
+++ b/project/KernelVersion.scala
@@ -11,8 +11,8 @@
  */
 object KernelVersion {
   /** SBT system property used to pin the kernel Maven version. */
-  val SystemProperty: String = "kernelVersion"
+  val systemProperty: String = "kernelVersion"
 
   /** The resolved kernel version override, or None to use in-tree kernel sources. */
-  val kernelVersionOpt: Option[String] = sys.props.get(SystemProperty)
+  val kernelVersionOpt: Option[String] = sys.props.get(systemProperty)
 }

--- a/project/scripts/get_spark_version_info.py
+++ b/project/scripts/get_spark_version_info.py
@@ -24,6 +24,7 @@ Usage:
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -33,8 +34,13 @@ def generate_spark_versions_json(repo_root: Path) -> bool:
     """Generate the spark-versions.json file by running sbt exportSparkVersionsJson."""
     try:
         print("Generating spark-versions.json...", file=sys.stderr)
+        cmd = ["build/sbt"]
+        kernel_version = os.getenv("KERNEL_VERSION")
+        if kernel_version:
+            cmd.append(f"-DkernelVersion={kernel_version}")
+        cmd.append("exportSparkVersionsJson")
         subprocess.run(
-            ["build/sbt", "exportSparkVersionsJson"],
+            cmd,
             cwd=repo_root,
             check=True,
             stdout=subprocess.DEVNULL,

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -62,20 +62,31 @@ def delete_if_exists(path):
         print("Deleted %s " % path)
 
 
-def prepare(root_dir, spark_version):
+def prepare(root_dir, spark_version, kernel_version=None):
     print("##### Preparing python tests & building packages #####")
+    print(f"[python/run-tests.py] prepare: spark_version={spark_version!r}, "
+          f"kernel_version={kernel_version!r}")
     # Build package with python files in it
     sbt_path = path.join(root_dir, path.join("build", "sbt"))
-    ivy_caches_to_clear = [
-        filepath for filepath in os.listdir(os.path.expanduser("~"))
-        if filepath.startswith(".ivy")
-    ]
-    print(f"Clearing Ivy caches in: {ivy_caches_to_clear}")
-    for filepath in ivy_caches_to_clear:
-        delete_if_exists(os.path.expanduser(f"~/{filepath}/cache/io.delta"))
-    delete_if_exists(os.path.expanduser("~/.m2/repository/io/delta/"))
+    # When kernel_version is set we are consuming the kernel from Maven; wiping
+    # the io.delta caches would delete the very artifact we just resolved (or
+    # locally published as a snapshot), forcing an unnecessary re-resolve and
+    # potentially failing if the artifact is only available locally.
+    if kernel_version:
+        print(f"Skipping io.delta cache wipe because kernel_version={kernel_version!r}")
+    else:
+        ivy_caches_to_clear = [
+            filepath for filepath in os.listdir(os.path.expanduser("~"))
+            if filepath.startswith(".ivy")
+        ]
+        print(f"Clearing Ivy caches in: {ivy_caches_to_clear}")
+        for filepath in ivy_caches_to_clear:
+            delete_if_exists(os.path.expanduser(f"~/{filepath}/cache/io.delta"))
+        delete_if_exists(os.path.expanduser("~/.m2/repository/io/delta/"))
     sbt_command = [sbt_path]
     sbt_command = sbt_command + [f"-DsparkVersion={spark_version}"]
+    if kernel_version:
+        sbt_command = sbt_command + [f"-DkernelVersion={kernel_version}"]
     run_cmd(sbt_command + ["clean", "publishM2"], stream_output=True)
 
 
@@ -224,7 +235,8 @@ if __name__ == "__main__":
     print("##### Running python tests #####")
     root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     spark_version = os.getenv("SPARK_VERSION") or "default"
-    prepare(root_dir, spark_version)
+    kernel_version = os.getenv("KERNEL_VERSION")
+    prepare(root_dir, spark_version, kernel_version)
     delta_spark_package = get_local_package("delta-spark", spark_version, root_dir)
 
     run_python_style_checks(root_dir)

--- a/run-tests.py
+++ b/run-tests.py
@@ -53,19 +53,29 @@ def get_args():
         required=False,
         default=None,
         help="Spark version to use (passed as -DsparkVersion to SBT)")
+    parser.add_argument(
+        "--kernel-version",
+        required=False,
+        default=None,
+        help="Delta Kernel version to use (passed as -DkernelVersion to SBT)")
     return parser.parse_args()
 
 
-def run_sbt_tests(root_dir, test_group, coverage, scala_version=None, shard=None, spark_version=None):
+def run_sbt_tests(root_dir, test_group, coverage, scala_version=None, shard=None,
+                  spark_version=None, kernel_version=None):
     print("##### Running SBT tests #####")
+    print(f"[run-tests.py] run_sbt_tests: spark_version={spark_version!r}, "
+          f"kernel_version={kernel_version!r}")
 
     sbt_path = path.join(root_dir, path.join("build", "sbt"))
     cmd = [sbt_path]
-    
+
     # Pass Spark version as system property to SBT (must come before commands)
     if spark_version:
         cmd.append(f"-DsparkVersion={spark_version}")
-    
+    if kernel_version:
+        cmd.append(f"-DkernelVersion={kernel_version}")
+
     cmd.append("clean")
 
     test_cmd = "test"
@@ -98,11 +108,15 @@ def run_sbt_tests(root_dir, test_group, coverage, scala_version=None, shard=None
     run_cmd(cmd, stream_output=True)
 
 
-def run_python_tests(root_dir):
+def run_python_tests(root_dir, kernel_version=None):
     print("##### Running Python tests #####")
+    print(f"[run-tests.py] run_python_tests: kernel_version={kernel_version!r}")
     python_test_script = path.join(root_dir, path.join("python", "run-tests.py"))
     print("Calling script %s", python_test_script)
-    run_cmd(["python3", python_test_script], env={'DELTA_TESTING': '1'}, stream_output=True)
+    env = {'DELTA_TESTING': '1'}
+    if kernel_version:
+        env['KERNEL_VERSION'] = kernel_version
+    run_cmd(["python3", python_test_script], env=env, stream_output=True)
 
 
 def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):
@@ -202,7 +216,7 @@ def pull_or_build_docker_image(root_dir):
     return test_env_image_tag
 
 
-def run_tests_in_docker(image_tag, test_group):
+def run_tests_in_docker(image_tag, test_group, kernel_version=None):
     """
     Run the necessary tests in a docker container made from the given image.
     It starts the container with the delta repo mounted in it, and then
@@ -235,6 +249,10 @@ def run_tests_in_docker(image_tag, test_group):
     test_script_args = ""
     if test_group:
         test_script_args += " --group %s" % test_group
+    if kernel_version:
+        test_script_args += " --kernel-version %s" % kernel_version
+    print(f"[run-tests.py] run_tests_in_docker: forwarding to container: "
+          f"test_group={test_group!r}, kernel_version={kernel_version!r}")
 
     test_run_cmd = "docker run --rm  -v %s:%s -w %s %s %s ./%s %s" % (
         cwd, cwd, cwd, envs, image_tag, test_script, test_script_args
@@ -286,10 +304,14 @@ if __name__ == "__main__":
 
     if os.getenv("USE_DOCKER") is not None:
         test_env_image_tag = pull_or_build_docker_image(root_dir)
-        run_tests_in_docker(test_env_image_tag, args.group)
+        kernel_version = args.kernel_version or os.getenv("KERNEL_VERSION")
+        run_tests_in_docker(test_env_image_tag, args.group, kernel_version)
     elif args.group == "spark-python":
-        run_python_tests(root_dir)
+        kernel_version = args.kernel_version or os.getenv("KERNEL_VERSION")
+        run_python_tests(root_dir, kernel_version)
     else:
         scala_version = os.getenv("SCALA_VERSION")
         spark_version = args.spark_version or os.getenv("SPARK_VERSION")
-        run_sbt_tests(root_dir, args.group, args.coverage, scala_version, args.shard, spark_version)
+        kernel_version = args.kernel_version or os.getenv("KERNEL_VERSION")
+        run_sbt_tests(root_dir, args.group, args.coverage, scala_version, args.shard,
+                      spark_version, kernel_version)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other: build / test infrastructure

## Description

Allow callers to pass a Delta Kernel version through the Python test runners and into SBT as `-DkernelVersion=<value>`. This makes it possible to run the test suite against a specific kernel version (snapshot, locally-published artifact, etc.) without editing `build.sbt`.

Threading:

- `run-tests.py`
  - Adds a `--kernel-version` CLI flag (also picked up from `KERNEL_VERSION` env var).
  - `run_sbt_tests`, `run_tests_in_docker`, and `run_python_tests` all accept and forward it.
  - The Docker invocation re-emits `--kernel-version` in the inner script args so the value survives the container boundary.
- `python/run-tests.py`
  - `prepare()` reads `KERNEL_VERSION` from the environment and appends `-DkernelVersion=<value>` to its `build/sbt clean publishM2` call.
- `project/scripts/get_spark_version_info.py`
  - `generate_spark_versions_json()` reads `KERNEL_VERSION` and forwards it to `build/sbt exportSparkVersionsJson`, so the script keeps working in builds where `build.sbt` parsing requires `-DkernelVersion`.

When `KERNEL_VERSION` / `--kernel-version` is not set, behavior is unchanged.

## How was this patch tested?

- Locally ran `KERNEL_VERSION=<x> python3 project/scripts/get_spark_version_info.py --get-field default packageSuffix` and confirmed the SBT call includes `-DkernelVersion=<x>` and the script returns the expected suffix.
- Inspected the resulting `build/sbt` invocations in `python/run-tests.py:prepare` to confirm `-DkernelVersion` is appended only when set, preserving existing behavior otherwise.

## Does this PR introduce _any_ user-facing changes?

No. This adds an optional CLI flag / env var that defaults to the existing behavior.
