### PR TITLE
[Spark] Fix NoSuchElementException in getPrettyPartitionMessage for empty partitionValues

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1336,12 +1336,17 @@ private[delta] class ConflictChecker(
   /** A helper function for pretty printing a specific partition directory. */
   protected def getPrettyPartitionMessage(partitionValues: Map[String, String]): Option[String] = {
     val partitionColumns = currentTransactionInfo.partitionSchemaAtReadTime
-    if (partitionColumns.isEmpty || partitionValues == null) {
+    // Guard against null (e.g. RemoveFile written without extended metadata) and empty map
+    // (e.g. RemoveFile for a non-partitioned file or written by a client that omits partition
+    // values). Using getOrElse defensively also handles partially populated maps.
+    if (partitionColumns.isEmpty || partitionValues == null || partitionValues.isEmpty) {
       None
     } else {
       Some(
         partitionColumns.map { field =>
-          s"${field.name}=${partitionValues(DeltaColumnMapping.getPhysicalName(field))}"
+          val value =
+            partitionValues.getOrElse(DeltaColumnMapping.getPhysicalName(field), "null")
+          s"${field.name}=$value"
         }.mkString("[", ", ", "]")
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -369,6 +369,59 @@ trait OptimisticTransactionLegacyTests
     }
   }
 
+  // A RemoveFile with partitionValues = Map() (empty, non-null, as opposed to null) on a
+  // partitioned table previously caused NoSuchElementException in getPrettyPartitionMessage
+  // instead of the expected ConcurrentDeleteDeleteException.
+  test("block delete-delete conflict when winning RemoveFile has empty partitionValues") {
+    withLog(addB_1_2_nested :: Nil, partitionCols = "a" :: "b" :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      tx1.filterFiles(('a === 2).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // RemoveFile with extended metadata but empty partitionValues (non-null Map()).
+      // scalastyle:off
+      val removeWithEmptyPV = RemoveFile(
+        path = addB_1_2_nested.path,
+        deletionTimestamp = Some(System.currentTimeMillis()),
+        dataChange = true,
+        extendedFileMetadata = Some(true),
+        partitionValues = Map.empty)
+      // scalastyle:on
+      tx2.commit(removeWithEmptyPV :: Nil, ManualUpdate)
+
+      intercept[ConcurrentDeleteDeleteException] {
+        tx1.commit(addB_1_2_nested.remove :: Nil, ManualUpdate)
+      }
+    }
+  }
+
+  // A RemoveFile with partitionValues = Map() (empty, non-null, as opposed to null) on a
+  // partitioned table previously caused NoSuchElementException in getPrettyPartitionMessage
+  // instead of the expected ConcurrentDeleteReadException.
+  test("block delete-read conflict when winning RemoveFile has empty partitionValues") {
+    withLog(addB_1_2_nested :: Nil, partitionCols = "a" :: "b" :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      tx1.filterFiles()
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // scalastyle:off
+      val removeWithEmptyPV = RemoveFile(
+        path = addB_1_2_nested.path,
+        deletionTimestamp = Some(System.currentTimeMillis()),
+        dataChange = true,
+        extendedFileMetadata = Some(true),
+        partitionValues = Map.empty)
+      // scalastyle:on
+      tx2.commit(removeWithEmptyPV :: Nil, ManualUpdate)
+
+      intercept[ConcurrentDeleteReadException] {
+        tx1.commit(addA_1_1_nested :: Nil, ManualUpdate)
+      }
+    }
+  }
+
   test("block commit when full table read conflicts with add in any partition") {
     withLog(addA_P1 :: addC_P2 :: Nil) { log =>
       val tx1 = log.startTransaction()


### PR DESCRIPTION
## What changes were proposed in this pull request?

- `getPrettyPartitionMessage` in `ConflictChecker.scala` guarded against `null` `partitionValues` but not `Map()` (empty, non-null). When a winning commit has a `RemoveFile` with `partitionValues = Map()` on a partitioned table, `Map.apply(physicalName)` throws `NoSuchElementException`.
- Extended the guard to `partitionValues == null || partitionValues.isEmpty` so empty maps return `None` (the fallback path).
- Changed the map lookup from unsafe `.apply` to `.getOrElse(..., "null")` to also handle partially-populated maps robustly.
- Added two regression tests to `OptimisticTransactionLegacyTests` that verify the delete-delete and delete-read conflict paths correctly surface the expected `ConcurrentDeleteDeleteException` / `ConcurrentDeleteReadException` rather than crashing when the winning `RemoveFile` has empty partition values.

Empty `partitionValues` can arise from `OPTIMIZE` on NULL-predicate partitions, Delta clients that omit partition values, and liquid clustering table conversion. The `NoSuchElementException` propagates completely unhandled because `doCommitRetryIteratively` only catches `FileAlreadyExistsException` and `CommitFailedException`, so the commit fails with a hard exception and conflict-resolution paths are bypassed.

## How was this patch tested?

Two new regression tests in `OptimisticTransactionLegacyTests`:
- `block delete-delete conflict when winning RemoveFile has empty partitionValues` (covers `checkForDeletedFilesAgainstCurrentTxnDeletedFiles`)
- `block delete-read conflict when winning RemoveFile has empty partitionValues` (covers `checkForDeletedFilesAgainstCurrentTxnReadFiles`)

Both tests confirm that the appropriate `ConcurrentDelete*Exception` is raised rather than `NoSuchElementException`.
