### PR TITLE
[kernel-spark] Implement consecutiveSchemaChangesMerger

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
@@ -113,20 +113,16 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
 
     // ========== Schema evolution scenarios ==========
     "consecutive schema evolutions without schema merging",
+    "consecutive schema evolutions",
     "upgrade and downgrade",
     "multiple sources with schema evolution",
     "schema evolution with Delta sink",
     "latestOffset should not progress before schema evolved",
-    "schema tracking interacting with unsafe escape flag",
-    "partition evolution"
-  )
-
-  // TODO(#5319): Move to PASS after consecutive schema merger is supported
-  override protected def shouldFailTests: Set[String] = Set(
-    // ========== Schema log core ==========
-    "consecutive schema evolutions",
     "unblock with sql conf",
-    "streaming with a column mapping upgrade"
+    "unblock with sql conf - nested struct",
+    "schema tracking interacting with unsafe escape flag",
+    "streaming with a column mapping upgrade",
+    "partition evolution"
   )
 }
 

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/typewidening/TypeWideningStreamingV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/typewidening/TypeWideningStreamingV2SourceSuite.scala
@@ -86,11 +86,5 @@ class TypeWideningStreamingV2SourceSchemaTrackingSuite
       "unblocking stream with reader option after type change - unblock version",
       "overwrite schema with type change and dropped column",
       "disable schema tracking log using internal conf"
-    ) -- shouldFailTests
-
-  // TODO(#5319): Move to PASS after consecutive schema merger is supported
-  override  protected def shouldFailTests: Set[String] =
-    super.shouldFailTests ++ Set(
-      "type change in delta source writing to a delta sink"
     )
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataTrackingLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataTrackingLog.scala
@@ -107,7 +107,8 @@ object PersistedMetadata {
   def fromJson(json: String): PersistedMetadata = JsonUtils.fromJson[PersistedMetadata](json)
 
   /**
-   * Builds a [[PersistedMetadata]] from V2 interop abstractions.
+   * Serializes an [[AbstractProtocol]] to the Spark [[Protocol]] JSON format used in
+   * [[PersistedMetadata.protocolJson]].
    *
    * Contract on [[AbstractProtocol]]: `readerFeatures` / `writerFeatures` must be consistent
    * with the min protocol versions: `readerFeatures` may only be defined when
@@ -116,26 +117,32 @@ object PersistedMetadata {
    * relies on this invariant; [[Protocol]] will throw a `require` failure if an implementation
    * gets it wrong.
    */
+  def toProtocolJson(abstractProtocol: AbstractProtocol): String = {
+    Protocol(
+      abstractProtocol.minReaderVersion,
+      abstractProtocol.minWriterVersion
+    ).copy(
+      readerFeatures = abstractProtocol.readerFeatures,
+      writerFeatures = abstractProtocol.writerFeatures
+    ).json
+  }
+
+  /**
+   * Builds a [[PersistedMetadata]] from V2 interop abstractions.
+   */
   def apply(
       tableId: String,
       deltaCommitVersion: Long,
       abstractMetadata: AbstractMetadata,
       abstractProtocol: AbstractProtocol,
       sourceMetadataPath: String): PersistedMetadata = {
-    val protocol = Protocol(
-      abstractProtocol.minReaderVersion,
-      abstractProtocol.minWriterVersion
-    ).copy(
-      readerFeatures = abstractProtocol.readerFeatures,
-      writerFeatures = abstractProtocol.writerFeatures
-    )
     PersistedMetadata(tableId, deltaCommitVersion,
       abstractMetadata.schema.json, abstractMetadata.partitionSchema.json,
       // The schema is bound to the specific source
       sourceMetadataPath,
       // Table configurations come from the Metadata action
       Some(abstractMetadata.configuration),
-      Some(protocol.json)
+      Some(toProtocolJson(abstractProtocol))
     )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -190,6 +190,22 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
     }
   }
 
+  /** Like `addData`, but also fills nested struct fields recursively. */
+  protected def addNestedData(data: Seq[Int])(implicit log: DeltaLog): Unit = {
+    val schema = log.update().schema
+    def buildRow(s: StructType, value: String): Row = Row.fromSeq(s.fields.map { f =>
+      f.dataType match {
+        case sub: StructType => buildRow(sub, value)
+        case _ => value
+      }
+    })
+    data.foreach { i =>
+      val row = buildRow(schema, i.toString)
+      spark.createDataFrame(Seq(row).asJava, schema)
+        .write.format("delta").mode("append").save(log.dataPath.toString)
+    }
+  }
+
   protected def readStream(
       schemaLocation: Option[String] = None,
       sourceTrackingId: Option[String] = None,
@@ -1928,6 +1944,43 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
     }
   }
 
+  /**
+   * Same as `withSimpleStreamingDf` but with a nested struct column, so tests can exercise
+   * drop / rename of fields inside a struct: schema is `a STRING, s STRUCT<x STRING, y STRING>`.
+   */
+  protected def withNestedStructStreamingDf(f: (() => DataFrame, DeltaLog) => Unit): Unit = {
+    withTempDir { dir =>
+      val tablePath = dir.getCanonicalPath
+      val schema = StructType.fromDDL("a STRING, s STRUCT<x: STRING, y: STRING>")
+      val initialRow = Seq(Row("0", Row("0", "0")))
+      spark.createDataFrame(initialRow.asJava, schema)
+        .write.mode("append").format("delta").save(tablePath)
+      implicit val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val s0 = log.update()
+      val schemaLog = getDefaultSchemaLog()
+      schemaLog.writeNewMetadata(
+        PersistedMetadata(log.unsafeVolatileTableId, s0.version, s0.metadata, s0.protocol,
+          sourceMetadataPath = "")
+      )
+
+      def read(): DataFrame =
+        readStream(
+          Some(getDefaultSchemaLocation.toString),
+          startingVersion = Some(s0.version))
+
+      withSQLConf(
+        DeltaSQLConf.DELTA_STREAMING_SCHEMA_TRACKING_METADATA_PATH_CHECK_ENABLED.key -> "false") {
+        testStream(read())(
+          StartStream(checkpointLocation = getDefaultCheckpoint.toString),
+          ProcessAllAvailable(),
+          CheckAnswer(Row("0", Row("0", "0"))),
+          StopStream
+        )
+        f(read, log)
+      }
+    }
+  }
+
   testWithoutAllowStreamRestart("unblock with sql conf") {
     def testStreamFlow(
         changeSchema: DeltaLog => Unit,
@@ -2030,6 +2083,105 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
           columnChangeDetails =
             s"""Columns renamed:
                |'b' -> 'c'
+               |""".stripMargin,
+          getConfKV
+        )
+      }
+    }
+  }
+
+  testWithoutAllowStreamRestart("unblock with sql conf - nested struct") {
+    def testStreamFlow(
+        changeSchema: DeltaLog => Unit,
+        schemaChangeType: String,
+        columnChangeDetails: String,
+        getConfKV: (Int, Long) => (String, String)): Unit = {
+      withNestedStructStreamingDf { (readDf, log) =>
+        val ckptHash = (getDefaultCheckpoint(log).toString + "/sources/0").hashCode
+        changeSchema(log)
+        val v1 = log.update().version
+        addNestedData(Seq(1))(log)
+        // Encounter schema evolution exception
+        testStream(readDf())(
+          StartStream(checkpointLocation = getDefaultCheckpoint(log).toString),
+          ProcessAllAvailableIgnoreError,
+          CheckAnswer(Nil: _*),
+          ExpectMetadataEvolutionException
+        )
+        // Restart fails on SQL conf validation
+        testStream(readDf())(
+          StartStream(checkpointLocation = getDefaultCheckpoint(log).toString),
+          ProcessAllAvailableIgnoreError,
+          CheckAnswer(Nil: _*),
+          expectSqlConfException(schemaChangeType, v1, columnChangeDetails, ckptHash)
+        )
+        // With SQL Conf set we can move on
+        val (k, v) = getConfKV(ckptHash, v1)
+        withSQLConf(k -> v) {
+          testStream(readDf())(
+            StartStream(checkpointLocation = getDefaultCheckpoint(log).toString),
+            ProcessAllAvailable()
+          )
+        }
+      }
+    }
+
+    // Test drop column inside a nested struct (s.x)
+    Seq("allowSourceColumnRenameAndDrop", "allowSourceColumnDrop").foreach { allow =>
+      Seq(
+        (
+          (log: DeltaLog) => {
+            dropColumn("s.x")(log)
+            // Revert via add to ensure consecutive schema changes don't affect sql conf validation
+            addColumn("s.x")(log)
+          },
+          (ckptHash: Int, _: Long) =>
+            (s"${DeltaSQLConf.SQL_CONF_PREFIX}.streaming.$allow.ckpt_$ckptHash", "always")
+        ),
+        (
+          (log: DeltaLog) => {
+            dropColumn("s.x")(log)
+            addColumn("s.x")(log)
+          },
+          (ckptHash: Int, ver: Long) =>
+            (s"${DeltaSQLConf.SQL_CONF_PREFIX}.streaming.$allow.ckpt_$ckptHash", ver.toString)
+        )
+      ).foreach { case (changeSchema, getConfKV) =>
+        testStreamFlow(
+          changeSchema,
+          schemaChangeType = "DROP COLUMN",
+          columnChangeDetails =
+            s"""Columns dropped:
+               |'s.x'
+               |""".stripMargin,
+          getConfKV)
+      }
+    }
+
+    // Test rename column inside a nested struct (s.x -> s.z)
+    Seq("allowSourceColumnRenameAndDrop", "allowSourceColumnRename").foreach { allow =>
+      Seq(
+        (
+          (log: DeltaLog) => {
+            renameColumn("s.x", "z")(log)
+          },
+          (ckptHash: Int, _: Long) =>
+            (s"${DeltaSQLConf.SQL_CONF_PREFIX}.streaming.$allow.ckpt_$ckptHash", "always")
+        ),
+        (
+          (log: DeltaLog) => {
+            renameColumn("s.x", "z")(log)
+          },
+          (ckptHash: Int, ver: Long) =>
+            (s"${DeltaSQLConf.SQL_CONF_PREFIX}.streaming.$allow.ckpt_$ckptHash", ver.toString)
+        )
+      ).foreach { case (changeSchema, getConfKV) =>
+        testStreamFlow(
+          changeSchema,
+          schemaChangeType = "RENAME COLUMN",
+          columnChangeDetails =
+            s"""Columns renamed:
+               |'s.x' -> 's.z'
                |""".stripMargin,
           getConfKV
         )

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -15,16 +15,21 @@
  */
 package io.delta.spark.internal.v2.read;
 
+import io.delta.kernel.CommitActions;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.checksum.CRCInfo;
+import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.internal.lang.Lazy;
 import io.delta.kernel.internal.metrics.SnapshotQueryContext;
 import io.delta.kernel.internal.replay.LogReplay;
 import io.delta.kernel.internal.snapshot.LogSegment;
+import io.delta.kernel.internal.util.Preconditions;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.StringType;
@@ -36,6 +41,7 @@ import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.utils.StreamingHelper;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -692,9 +698,140 @@ public class MetadataEvolutionHandler {
             tablePath,
             ScalaUtils.toScalaMap(options),
             sourceMetadataPathOpt,
-            // TODO(#5319): Implement v2 consecutiveSchema schema changes merger
-            /* mergeConsecutiveSchemaChanges= */ false,
-            /* consecutiveSchemaChangesMerger= */ Option.empty(),
+            /* mergeConsecutiveSchemaChanges= */ mergeConsecutiveSchemaChanges,
+            /* consecutiveSchemaChangesMerger= */ Option.apply(
+                currentMetadata ->
+                    getMergedConsecutiveMetadataChanges(
+                        currentMetadata, snapshotManager, engine, tablePath, mergeActionSet)),
             /* initMetadataLogEagerly= */ true));
+  }
+
+  /** V2 port of {@code DeltaSourceMetadataEvolutionSupport.getMergedConsecutiveMetadataChanges}. */
+  public static Option<PersistedMetadata> getMergedConsecutiveMetadataChanges(
+      PersistedMetadata currentMetadata,
+      DeltaSnapshotManager snapshotManager,
+      Engine engine,
+      String tablePath,
+      Set<DeltaLogActionUtils.DeltaAction> mergeActionSet) {
+    final long currentMetadataVersion = currentMetadata.deltaCommitVersion();
+    // We start from the currentSchemaVersion so that we can stop early in case the current
+    // version still has file actions that potentially needs to be processed.
+    long mergedVersion = currentMetadataVersion;
+    Metadata mergedMetadata = null;
+    Protocol mergedProtocol = null;
+
+    CommitRangeImpl commitRange =
+        (CommitRangeImpl)
+            snapshotManager.getTableChanges(engine, currentMetadataVersion, Optional.empty());
+
+    try (CloseableIterator<CommitActions> commitsIter =
+        StreamingHelper.getCommitActionsFromRangeUnsafe(
+            engine, commitRange, tablePath, mergeActionSet)) {
+      while (commitsIter.hasNext()) {
+        try (CommitActions commit = commitsIter.next()) {
+          long version = commit.getVersion();
+          Metadata metadataAction = null;
+          Protocol protocolAction = null;
+          boolean hasFileAction = false;
+
+          try (CloseableIterator<ColumnarBatch> actionsIter = commit.getActions()) {
+            outer:
+            while (actionsIter.hasNext()) {
+              ColumnarBatch batch = actionsIter.next();
+              int numRows = batch.getSize();
+              int addIdx = batch.getSchema().indexOf(DeltaLogActionUtils.DeltaAction.ADD.colName);
+              int removeIdx =
+                  batch.getSchema().indexOf(DeltaLogActionUtils.DeltaAction.REMOVE.colName);
+              ColumnVector addVec = addIdx >= 0 ? batch.getColumnVector(addIdx) : null;
+              ColumnVector removeVec = removeIdx >= 0 ? batch.getColumnVector(removeIdx) : null;
+
+              // TODO(#5319): handle AddCDCFile as well
+              for (int rowId = 0; rowId < numRows; rowId++) {
+                Optional<Metadata> m = StreamingHelper.getMetadata(batch, rowId);
+                if (m.isPresent()) {
+                  Preconditions.checkArgument(
+                      metadataAction == null,
+                      "Should not encounter two metadata actions in the same commit of version %d",
+                      version);
+                  metadataAction = m.get();
+                }
+                Optional<Protocol> p = StreamingHelper.getProtocol(batch, rowId);
+                if (p.isPresent()) {
+                  Preconditions.checkArgument(
+                      protocolAction == null,
+                      "Should not encounter two protocol actions in the same commit of version %d",
+                      version);
+                  protocolAction = p.get();
+                }
+                if ((addVec != null && !addVec.isNullAt(rowId))
+                    || (removeVec != null && !removeVec.isNullAt(rowId))) {
+                  hasFileAction = true;
+                  break outer;
+                }
+              }
+            }
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to process commit at version " + version, e);
+          }
+
+          // Mirror v1's takeWhile predicate:
+          //   continue while !hasFileAction && (metadata.isDefined || protocol.isDefined)
+          if (hasFileAction) break;
+          if (metadataAction == null && protocolAction == null) break;
+
+          mergedVersion = version;
+          if (metadataAction != null) mergedMetadata = metadataAction;
+          if (protocolAction != null) mergedProtocol = protocolAction;
+        }
+      }
+    } catch (RuntimeException e) {
+      throw e; // Rethrow runtime exceptions directly
+    } catch (Exception e) {
+      // CommitActions.close() throws Exception
+      throw new RuntimeException("Failed to merge consecutive metadata changes", e);
+    }
+
+    if (mergedVersion == currentMetadataVersion) {
+      return Option.empty();
+    }
+
+    logger.info(
+        "Looked ahead from version {} and will use metadata at version {} to read Delta stream.",
+        currentMetadataVersion,
+        mergedVersion);
+
+    return Option.apply(
+        buildMergedPersistedMetadata(
+            currentMetadata, mergedVersion, mergedMetadata, mergedProtocol));
+  }
+
+  private static PersistedMetadata buildMergedPersistedMetadata(
+      PersistedMetadata current, long newVersion, Metadata newMetadata, Protocol newProtocol) {
+    String dataSchemaJson = current.dataSchemaJson();
+    String partitionSchemaJson = current.partitionSchemaJson();
+    Option<scala.collection.immutable.Map<String, String>> tableConfigurations =
+        current.tableConfigurations();
+    Option<String> protocolJson = current.protocolJson();
+
+    if (newMetadata != null) {
+      KernelMetadataAdapter mAdapter = new KernelMetadataAdapter(newMetadata);
+      dataSchemaJson = mAdapter.schema().json();
+      partitionSchemaJson = mAdapter.partitionSchema().json();
+      tableConfigurations = Option.apply(mAdapter.configuration());
+    }
+    if (newProtocol != null) {
+      protocolJson =
+          Option.apply(PersistedMetadata.toProtocolJson(new KernelProtocolAdapter(newProtocol)));
+    }
+
+    return new PersistedMetadata(
+        current.tableId(),
+        newVersion,
+        dataSchemaJson,
+        partitionSchemaJson,
+        current.sourceMetadataPath(),
+        tableConfigurations,
+        protocolJson,
+        current.previousMetadataSeqNum());
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -264,7 +264,7 @@ public class SparkMicroBatchStream
     // tracking has a persisted entry, layer it onto the freshly loaded snapshotAtSourceInit so
     // the read schema/protocol/config reflect the evolved state. The merged entry has already
     // been written to the durable schema log during analysis (by SparkTable's call to
-    // getMetadataTrackingLogForMicroBatchStream with mergeConsecutiveSchemaChanges=true), so
+    // getPersistedMetadataForMicroBatchStream with mergeConsecutiveSchemaChanges=true), so
     // reading it back from the log here yields the same value V1 obtains.
     Option<PersistedMetadata> persistedMetadataAtSourceInit =
         metadataTrackingLog.isDefined()
@@ -1340,6 +1340,10 @@ public class SparkMicroBatchStream
           // Track Protocol for schema evolution barrier detection.
           Optional<Protocol> protocolOpt = StreamingHelper.getProtocol(batch, rowId);
           if (protocolOpt.isPresent()) {
+            Preconditions.checkArgument(
+                protocolAction == null,
+                "Should not encounter two protocol actions in the same commit of version %d",
+                version);
             protocolAction = protocolOpt.get();
           }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/SparkTableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/SparkTableTest.java
@@ -649,11 +649,15 @@ public class SparkTableTest extends DeltaV2TestBase {
             tablePath + "/_delta_log/_streaming_metadata");
     trackingLog.writeNewMetadata(seededEntry, false);
 
-    // Evolve the table — version 1 has an extra non-partition column.
+    // INSERT at v1 acts as a file-action barrier so the consecutive-schema-change merger (on by
+    // default) cannot fast-forward the seeded v0 entry past the upcoming v2 ALTER TABLE.
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'a')", tableName));
+
+    // Evolve the table — version 2 has an extra non-partition column.
     spark.sql(String.format("ALTER TABLE %s ADD COLUMNS (value DOUBLE)", tableName));
 
     // Construct SparkTable with the schema-tracking option pointing at the seeded log. The
-    // snapshot is at v1 (3 columns) but the persisted entry is at v0 (2 columns). Default to
+    // snapshot is at v2 (3 columns) but the persisted entry is at v0 (2 columns). Default to
     // the catalog-table constructor since that's how production code typically loads the table.
     Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
     Map<String, String> options = new HashMap<>();
@@ -672,7 +676,7 @@ public class SparkTableTest extends DeltaV2TestBase {
       table = new SparkTable(identifier, catalogTable, options);
     }
 
-    // Persisted metadata wins: schema reflects v0 (2 columns), not v1 (3 columns).
+    // Persisted metadata wins: schema reflects v0 (2 columns), not v2 (3 columns).
     // Public schema layout is data fields followed by partition fields, so [id, name].
     StructType schema = table.schema();
     assertEquals(2, schema.fields().length, "Persisted entry should override snapshot schema");

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
@@ -1153,7 +1153,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
 
   /** Schema-tracking set and the log has a seeded entry → returns that entry. */
   @Test
-  public void testGetPersistedMetadata_returnsSeededEntry(@TempDir File tempDir) {
+  public void testGetPersistedMetadata_returnsSeededEntry(@TempDir File tempDir) throws Exception {
     String tablePath = new File(tempDir, "table").getAbsolutePath();
     String tableName = "t_" + UUID.randomUUID().toString().replace('-', '_');
     createEmptyTestTable(tablePath, tableName);
@@ -1165,34 +1165,42 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     Map<String, String> options = new HashMap<>();
     options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
 
-    // Open the log through the same code path the util uses, then seed an entry.
-    DeltaSourceMetadataTrackingLog trackingLog =
-        MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
-                spark,
-                snapshot,
-                options,
-                snapshotManager,
-                defaultEngine,
-                SparkMicroBatchStream.ACTION_SET,
-                Option.empty(),
-                /* mergeConsecutiveSchemaChanges= */ false)
-            .get();
-    // Use a non-zero version so it's distinct from a default-init entry.
-    long seededVersion = 42L;
-    PersistedMetadata seeded =
-        PersistedMetadata.apply(
-            snapshot.getMetadata().getId(),
-            seededVersion,
-            new KernelMetadataAdapter(snapshot.getMetadata()),
-            new KernelProtocolAdapter(snapshot.getProtocol()),
-            tablePath + "/_delta_log/_streaming_metadata");
-    trackingLog.writeNewMetadata(seeded, false);
+    // Disable consecutive-schema-change merging: this test only verifies that a seeded entry is
+    // returned. With merging enabled, the merger looks ahead from the seeded version, and the
+    // artificial seededVersion (below) doesn't exist as a real commit on the table.
+    withSQLConf(
+        DeltaSQLConf.DELTA_STREAMING_ENABLE_SCHEMA_TRACKING_MERGE_CONSECUTIVE_CHANGES().key(),
+        "false",
+        () -> {
+          // Open the log through the same code path the util uses, then seed an entry.
+          DeltaSourceMetadataTrackingLog trackingLog =
+              MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
+                      spark,
+                      snapshot,
+                      options,
+                      snapshotManager,
+                      defaultEngine,
+                      SparkMicroBatchStream.ACTION_SET,
+                      Option.empty(),
+                      /* mergeConsecutiveSchemaChanges= */ false)
+                  .get();
+          // Use a non-zero version so it's distinct from a default-init entry.
+          long seededVersion = 42L;
+          PersistedMetadata seeded =
+              PersistedMetadata.apply(
+                  snapshot.getMetadata().getId(),
+                  seededVersion,
+                  new KernelMetadataAdapter(snapshot.getMetadata()),
+                  new KernelProtocolAdapter(snapshot.getProtocol()),
+                  tablePath + "/_delta_log/_streaming_metadata");
+          trackingLog.writeNewMetadata(seeded, false);
 
-    Optional<PersistedMetadata> result =
-        MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
-            spark, snapshot, options, snapshotManager, defaultEngine);
-    assertTrue(result.isPresent());
-    assertEquals(seededVersion, result.get().deltaCommitVersion());
+          Optional<PersistedMetadata> result =
+              MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
+                  spark, snapshot, options, snapshotManager, defaultEngine);
+          assertTrue(result.isPresent());
+          assertEquals(seededVersion, result.get().deltaCommitVersion());
+        });
   }
 
   // ---------------------------------------------------------------------------
@@ -1328,5 +1336,123 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     assertTrue(
         segEx.getMessage().contains("log segment is not available"),
         "Unexpected message: " + segEx.getMessage());
+  }
+
+  // ---------------------------------------------------------------------------
+  // getMergedConsecutiveMetadataChanges
+  //
+  // Walks forward from currentMetadata.deltaCommitVersion looking for consecutive
+  // commits that contain only metadata/protocol changes (no file actions). Returns
+  // a merged PersistedMetadata at the last such version, or Option.empty if no
+  // forward progress beyond the current version was possible.
+  // ---------------------------------------------------------------------------
+
+  /** Builds a {@link PersistedMetadata} snapshot of the table state at v0. */
+  private PersistedMetadata buildCurrentMetadataAtV0(
+      String tablePath, PathBasedSnapshotManager snapshotManager) {
+    SnapshotImpl v0 = (SnapshotImpl) snapshotManager.loadSnapshotAt(0L);
+    return PersistedMetadata.apply(
+        "test-table-id",
+        0L,
+        new KernelMetadataAdapter(v0.getMetadata()),
+        new KernelProtocolAdapter(v0.getProtocol()),
+        tablePath + "/_delta_log/_streaming_metadata");
+  }
+
+  /**
+   * -1 sentinel means {@code Option.empty} (no merge). Other values are expected merged version.
+   */
+  private static final long EXPECTED_NO_MERGE = -1L;
+
+  /**
+   * Creates a v0 table partitioned by {@code id} with column mapping (name) enabled. Partitioning
+   * exercises {@code partitionSchemaJson} verification; column mapping makes RENAME / DROP COLUMN
+   * (including renaming the partition column) valid.
+   */
+  private void createPartitionedColumnMappingTable(String tablePath, String tableName) {
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta "
+                + "PARTITIONED BY (id) LOCATION '%s' "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            tableName, tablePath));
+  }
+
+  private static Stream<Arguments> mergerTestCases() {
+    String alterAddC3 = "ALTER TABLE %s ADD COLUMNS (c3 INT)";
+    String alterRenamePartitionId = "ALTER TABLE %s RENAME COLUMN id TO id_renamed";
+    String alterDropNonPartitionName = "ALTER TABLE %s DROP COLUMN name";
+    String alterBumpProtocol =
+        "ALTER TABLE %s SET TBLPROPERTIES "
+            + "('delta.minReaderVersion' = '3', 'delta.minWriterVersion' = '7')";
+    String insert2col = "INSERT INTO %s VALUES (1, 'Alice')";
+    String insert3col = "INSERT INTO %s VALUES (1, 'Alice', 10)";
+    return Stream.of(
+        // scenario, postV0Commits, expectedMergedVersion
+        Arguments.of("noLaterCommits", List.of(), EXPECTED_NO_MERGE),
+        Arguments.of("nextCommitHasFileAction", List.of(insert2col), EXPECTED_NO_MERGE),
+        // Renaming the PARTITION column changes both dataSchemaJson and partitionSchemaJson.
+        Arguments.of("renamePartitionColumn", List.of(alterRenamePartitionId), 1L),
+        // Dropping a NON-partition column changes dataSchemaJson but not partitionSchemaJson.
+        Arguments.of("dropNonPartitionColumn", List.of(alterDropNonPartitionName), 1L),
+        // Schema change (v1) followed by protocol change (v2) — both must merge.
+        Arguments.of("schemaChangeThenProtocolUpgrade", List.of(alterAddC3, alterBumpProtocol), 2L),
+        // All three change kinds in one consecutive run: data schema (ADD c3),
+        // partition schema (RENAME id), and protocol (TBLPROPERTIES bump).
+        Arguments.of(
+            "mergesDataSchemaPartitionAndProtocol",
+            List.of(alterAddC3, alterRenamePartitionId, alterBumpProtocol),
+            3L),
+        // v1=ADD c3, v2=INSERT, v3=DROP name → must stop at v1 (NOT skip to v3)
+        Arguments.of(
+            "stopsAtFileActionDoesNotSkipAhead",
+            List.of(alterAddC3, insert3col, alterDropNonPartitionName),
+            1L));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("mergerTestCases")
+  public void testGetMergedConsecutive(
+      String scenario,
+      List<String> postV0Commits,
+      long expectedMergedVersion,
+      @TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "t_" + UUID.randomUUID().toString().replace('-', '_');
+    createPartitionedColumnMappingTable(tablePath, tableName); // v0
+    for (String sqlTemplate : postV0Commits) {
+      spark.sql(String.format(sqlTemplate, tableName));
+    }
+
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
+    PersistedMetadata current = buildCurrentMetadataAtV0(tablePath, snapshotManager);
+
+    Option<PersistedMetadata> result =
+        MetadataEvolutionHandler.getMergedConsecutiveMetadataChanges(
+            current, snapshotManager, defaultEngine, tablePath, SparkMicroBatchStream.ACTION_SET);
+
+    if (expectedMergedVersion == EXPECTED_NO_MERGE) {
+      assertTrue(result.isEmpty());
+      return;
+    }
+
+    // Verify the merger's result against the table's actual schema and protocol at the merged
+    // version. We build the "expected" PersistedMetadata directly from the snapshot at that
+    // version — if the merger captured the right metadata/protocol actions, the JSONs will match.
+    assertTrue(result.isDefined());
+    SnapshotImpl mergedSnapshot =
+        (SnapshotImpl) snapshotManager.loadSnapshotAt(expectedMergedVersion);
+    PersistedMetadata expected =
+        PersistedMetadata.apply(
+            "test-table-id",
+            expectedMergedVersion,
+            new KernelMetadataAdapter(mergedSnapshot.getMetadata()),
+            new KernelProtocolAdapter(mergedSnapshot.getProtocol()),
+            tablePath + "/_delta_log/_streaming_metadata");
+
+    assertEquals(expected.dataSchemaJson(), result.get().dataSchemaJson());
+    assertEquals(expected.partitionSchemaJson(), result.get().partitionSchemaJson());
+    assertEquals(expected.protocolJson(), result.get().protocolJson());
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6698/files) to review incremental changes.
- [stack/SparkMetadataAdapter](https://github.com/delta-io/delta/pull/6546) [[Files changed](https://github.com/delta-io/delta/pull/6546/files)] [MERGED]
  - [stack/RefactorMetadataTrackingLog](https://github.com/delta-io/delta/pull/6550) [[Files changed](https://github.com/delta-io/delta/pull/6550/files)] [MERGED]
    - [stack/RefactorDeltaSourceMetadataEvolutionSupport](https://github.com/delta-io/delta/pull/6562) [[Files changed](https://github.com/delta-io/delta/pull/6562/files)] [MERGED]
      - [stack/MetadataEvolutionHandler2](https://github.com/delta-io/delta/pull/6563) [[Files changed](https://github.com/delta-io/delta/pull/6563/files)] [MERGED]
        - [stack/NonAdditiveSchemaEvolution2](https://github.com/delta-io/delta/pull/6570) [[Files changed](https://github.com/delta-io/delta/pull/6570/files)] [MERGED]
          - [stack/NonAdditiveSchemaEvolution3](https://github.com/delta-io/delta/pull/6697) [[Files changed](https://github.com/delta-io/delta/pull/6697/files)] [MERGED]
            - [**stack/consecutiveSchemaChangesMerger**](https://github.com/delta-io/delta/pull/6698) [[Files changed](https://github.com/delta-io/delta/pull/6698/files)]
              - [stack/SchemaTrackingWithCDC](https://github.com/delta-io/delta/pull/6801) [[Files changed](https://github.com/delta-io/delta/pull/6801/files/e230b46c3acb772d6599662b7c5aaf17e3625498..1ed4903f1b06fd49533dad3a1cf25c9206aef2f3)]
              - [stack/V1V2MixTest](https://github.com/delta-io/delta/pull/6759) [[Files changed](https://github.com/delta-io/delta/pull/6759/files/e230b46c3acb772d6599662b7c5aaf17e3625498..e3c0d530a63150797b7b882fab2dad2070452683)]

---------
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

PR 7/7 in the non-additive schema evolution for V2 streaming connector stack.

Implement V2's consecutive-schema-changes merger so analysis-time evolution matches V1: runs of consecutive metadata-only commits collapse to a single tracked entry at the latest version. Without the merger, each metadata-only commit produces its own pending schema offset.

- `MetadataEvolutionHandler.getMergedConsecutiveMetadataChanges`: V2 port of V1's `DeltaSourceMetadataEvolutionSupport.getMergedConsecutiveMetadataChanges`. Walks Kernel commits forward via `CommitRangeImpl` + `StreamingHelper.getCommitActionsFromRangeUnsafe`; for each commit detects file actions (ADD/REMOVE) and metadata/protocol actions; stops on the first commit with a file action or with neither metadata nor protocol; emits a merged `PersistedMetadata` at the latest metadata-only version.
- `MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream`: pass the merger lambda into `DeltaSourceMetadataTrackingLog.create` (was a `null` placeholder).
- `DeltaSourceMetadataTrackingLog` (V1): extract `PersistedMetadata.toProtocolJson` helper so V2's merger can reuse the same protocol-JSON encoding.

## How was this patch tested?

`MetadataEvolutionHandlerTest` covers merger walk semantics — stop-on-file-action, stop-on-no-metadata-or-protocol, multiple folded changes, protocol-only and combined updates. `DeltaSourceSchemaEvolutionSuite` adds parallel V1 tests for the same scenarios. Unified `DeltaV2SourceSchemaEvolutionSuite` moves the remaining merger-dependent scenarios (`consecutive schema evolutions`, `unblock with sql conf`, `streaming with a column mapping upgrade`) from `shouldFailTests` to `shouldPassTests`.

## Does this PR introduce _any_ user-facing changes?

No.
