### PR TITLE
[V2 Streaming] Add generic Kernel Row <-> Spark Row zero-copy wrappers

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import io.delta.kernel.data.ArrayValue;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.internal.data.StructRow;
+import io.delta.kernel.types.*;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+
+/**
+ * Adapts a Kernel Row to the Spark Row interface. Designed and tested for AddFile schema; other
+ * schemas may work but are not validated.
+ */
+public class KernelRowToSparkRow implements Row {
+
+  private final io.delta.kernel.data.Row kernelRow;
+  private final StructType kernelSchema;
+  private final org.apache.spark.sql.types.StructType sparkSchema;
+  private final FieldAccessor rowFieldAccessor;
+
+  public KernelRowToSparkRow(io.delta.kernel.data.Row kernelRow) {
+    this(kernelRow, SchemaUtils.convertKernelSchemaToSparkSchema(kernelRow.getSchema()));
+  }
+
+  /**
+   * Constructor that accepts a pre-computed Spark schema to avoid redundant schema conversion when
+   * wrapping many rows that share the same schema.
+   */
+  public KernelRowToSparkRow(
+      io.delta.kernel.data.Row kernelRow, org.apache.spark.sql.types.StructType sparkSchema) {
+    this.kernelRow = kernelRow;
+    this.kernelSchema = kernelRow.getSchema();
+    this.sparkSchema = sparkSchema;
+    this.rowFieldAccessor = rowAccessor(kernelRow);
+  }
+
+  @Override
+  public int length() {
+    return kernelSchema.length();
+  }
+
+  @Override
+  public org.apache.spark.sql.types.StructType schema() {
+    return sparkSchema;
+  }
+
+  @Override
+  public Object get(int i) {
+    return toSparkValue(rowFieldAccessor, i, kernelSchema.at(i).getDataType());
+  }
+
+  @Override
+  public Row copy() {
+    Object[] values = new Object[length()];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = get(i);
+    }
+    return RowFactory.create(values);
+  }
+
+  interface FieldAccessor {
+    boolean isNullAt(int i);
+
+    boolean getBoolean(int i);
+
+    byte getByte(int i);
+
+    short getShort(int i);
+
+    int getInt(int i);
+
+    long getLong(int i);
+
+    float getFloat(int i);
+
+    double getDouble(int i);
+
+    String getString(int i);
+
+    BigDecimal getDecimal(int i);
+
+    byte[] getBinary(int i);
+
+    io.delta.kernel.data.Row getStruct(int i);
+
+    MapValue getMap(int i);
+
+    ArrayValue getArray(int i);
+  }
+
+  private static FieldAccessor rowAccessor(io.delta.kernel.data.Row row) {
+    return new FieldAccessor() {
+      @Override
+      public boolean isNullAt(int i) {
+        return row.isNullAt(i);
+      }
+
+      @Override
+      public boolean getBoolean(int i) {
+        return row.getBoolean(i);
+      }
+
+      @Override
+      public byte getByte(int i) {
+        return row.getByte(i);
+      }
+
+      @Override
+      public short getShort(int i) {
+        return row.getShort(i);
+      }
+
+      @Override
+      public int getInt(int i) {
+        return row.getInt(i);
+      }
+
+      @Override
+      public long getLong(int i) {
+        return row.getLong(i);
+      }
+
+      @Override
+      public float getFloat(int i) {
+        return row.getFloat(i);
+      }
+
+      @Override
+      public double getDouble(int i) {
+        return row.getDouble(i);
+      }
+
+      @Override
+      public String getString(int i) {
+        return row.getString(i);
+      }
+
+      @Override
+      public BigDecimal getDecimal(int i) {
+        return row.getDecimal(i);
+      }
+
+      @Override
+      public byte[] getBinary(int i) {
+        return row.getBinary(i);
+      }
+
+      @Override
+      public io.delta.kernel.data.Row getStruct(int i) {
+        return row.getStruct(i);
+      }
+
+      @Override
+      public MapValue getMap(int i) {
+        return row.getMap(i);
+      }
+
+      @Override
+      public ArrayValue getArray(int i) {
+        return row.getArray(i);
+      }
+    };
+  }
+
+  static FieldAccessor vectorAccessor(ColumnVector cv) {
+    return new FieldAccessor() {
+      @Override
+      public boolean isNullAt(int i) {
+        return cv.isNullAt(i);
+      }
+
+      @Override
+      public boolean getBoolean(int i) {
+        return cv.getBoolean(i);
+      }
+
+      @Override
+      public byte getByte(int i) {
+        return cv.getByte(i);
+      }
+
+      @Override
+      public short getShort(int i) {
+        return cv.getShort(i);
+      }
+
+      @Override
+      public int getInt(int i) {
+        return cv.getInt(i);
+      }
+
+      @Override
+      public long getLong(int i) {
+        return cv.getLong(i);
+      }
+
+      @Override
+      public float getFloat(int i) {
+        return cv.getFloat(i);
+      }
+
+      @Override
+      public double getDouble(int i) {
+        return cv.getDouble(i);
+      }
+
+      @Override
+      public String getString(int i) {
+        return cv.getString(i);
+      }
+
+      @Override
+      public BigDecimal getDecimal(int i) {
+        return cv.getDecimal(i);
+      }
+
+      @Override
+      public byte[] getBinary(int i) {
+        return cv.getBinary(i);
+      }
+
+      @Override
+      public io.delta.kernel.data.Row getStruct(int i) {
+        return StructRow.fromStructVector(cv, i);
+      }
+
+      @Override
+      public MapValue getMap(int i) {
+        return cv.getMap(i);
+      }
+
+      @Override
+      public ArrayValue getArray(int i) {
+        return cv.getArray(i);
+      }
+    };
+  }
+
+  static Object toSparkValue(FieldAccessor accessor, int ordinal, DataType dt) {
+    if (accessor.isNullAt(ordinal)) {
+      return null;
+    }
+    if (dt instanceof BooleanType) {
+      return accessor.getBoolean(ordinal);
+    } else if (dt instanceof ByteType) {
+      return accessor.getByte(ordinal);
+    } else if (dt instanceof ShortType) {
+      return accessor.getShort(ordinal);
+    } else if (dt instanceof IntegerType || dt instanceof DateType) {
+      return accessor.getInt(ordinal);
+    } else if (dt instanceof LongType
+        || dt instanceof TimestampType
+        || dt instanceof TimestampNTZType) {
+      return accessor.getLong(ordinal);
+    } else if (dt instanceof FloatType) {
+      return accessor.getFloat(ordinal);
+    } else if (dt instanceof DoubleType) {
+      return accessor.getDouble(ordinal);
+    } else if (dt instanceof StringType) {
+      return accessor.getString(ordinal);
+    } else if (dt instanceof DecimalType) {
+      return accessor.getDecimal(ordinal);
+    } else if (dt instanceof BinaryType) {
+      return accessor.getBinary(ordinal);
+    } else if (dt instanceof StructType) {
+      return new KernelRowToSparkRow(
+          accessor.getStruct(ordinal),
+          SchemaUtils.convertKernelSchemaToSparkSchema((StructType) dt));
+    } else if (dt instanceof MapType) {
+      return mapValueToScalaMap(accessor.getMap(ordinal), (MapType) dt);
+    } else if (dt instanceof ArrayType) {
+      return arrayValueToScalaSeq(accessor.getArray(ordinal), (ArrayType) dt);
+    }
+    throw new UnsupportedOperationException("Unsupported Kernel DataType: " + dt);
+  }
+
+  static scala.collection.Map<Object, Object> mapValueToScalaMap(MapValue mv, MapType mt) {
+    ColumnVector keys = mv.getKeys();
+    ColumnVector values = mv.getValues();
+    FieldAccessor keyAccessor = vectorAccessor(keys);
+    FieldAccessor valueAccessor = vectorAccessor(values);
+    Map<Object, Object> javaMap = new HashMap<>();
+    for (int i = 0; i < mv.getSize(); i++) {
+      Object key = toSparkValue(keyAccessor, i, mt.getKeyType());
+      Object value = toSparkValue(valueAccessor, i, mt.getValueType());
+      javaMap.put(key, value);
+    }
+    return scala.jdk.javaapi.CollectionConverters.asScala(javaMap);
+  }
+
+  static scala.collection.Seq<Object> arrayValueToScalaSeq(ArrayValue av, ArrayType at) {
+    ColumnVector elements = av.getElements();
+    FieldAccessor elemAccessor = vectorAccessor(elements);
+    List<Object> javaList = new ArrayList<>();
+    for (int i = 0; i < av.getSize(); i++) {
+      javaList.add(toSparkValue(elemAccessor, i, at.getElementType()));
+    }
+    return scala.jdk.javaapi.CollectionConverters.asScala(javaList).toList();
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
@@ -120,8 +120,8 @@ public class KernelRowToSparkRow implements Row {
     for (int i = 0; i < values.length; i++) {
       Object v = get(i);
       // Recursively copy nested struct wrappers that still reference the live kernel row.
-      // Note: structs nested inside maps/arrays are already materialized by toSparkValue()
-      // as Scala collections of plain objects, so they don't hold kernel row references.
+      // Structs nested inside maps/arrays are materialized when those collections are built
+      // by mapValueToScalaMap() and arrayValueToScalaSeq(), so only top-level fields need this.
       if (v instanceof KernelRowToSparkRow) {
         v = ((KernelRowToSparkRow) v).copy();
       }
@@ -376,7 +376,13 @@ public class KernelRowToSparkRow implements Row {
     Map<Object, Object> javaMap = new HashMap<>();
     for (int i = 0; i < mv.getSize(); i++) {
       Object key = toSparkValue(keyAccessor, i, mt.getKeyType(), sparkMt.keyType());
+      if (key instanceof KernelRowToSparkRow) {
+        key = ((KernelRowToSparkRow) key).copy();
+      }
       Object value = toSparkValue(valueAccessor, i, mt.getValueType(), sparkMt.valueType());
+      if (value instanceof KernelRowToSparkRow) {
+        value = ((KernelRowToSparkRow) value).copy();
+      }
       javaMap.put(key, value);
     }
     return scala.jdk.javaapi.CollectionConverters.asScala(javaMap);
@@ -388,7 +394,11 @@ public class KernelRowToSparkRow implements Row {
     FieldAccessor elemAccessor = vectorAccessor(elements);
     List<Object> javaList = new ArrayList<>();
     for (int i = 0; i < av.getSize(); i++) {
-      javaList.add(toSparkValue(elemAccessor, i, at.getElementType(), sparkAt.elementType()));
+      Object elem = toSparkValue(elemAccessor, i, at.getElementType(), sparkAt.elementType());
+      if (elem instanceof KernelRowToSparkRow) {
+        elem = ((KernelRowToSparkRow) elem).copy();
+      }
+      javaList.add(elem);
     }
     return scala.jdk.javaapi.CollectionConverters.asScala(javaList).toList();
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 
 /**
  * Adapts a Kernel Row to the Spark Row interface. Designed and tested for AddFile schema; other
@@ -74,7 +75,11 @@ public class KernelRowToSparkRow implements Row {
   public Row copy() {
     Object[] values = new Object[length()];
     for (int i = 0; i < values.length; i++) {
-      values[i] = get(i);
+      Object v = get(i);
+      if (v instanceof KernelRowToSparkRow) {
+        v = ((KernelRowToSparkRow) v).copy();
+      }
+      values[i] = v;
     }
     return RowFactory.create(values);
   }
@@ -267,12 +272,14 @@ public class KernelRowToSparkRow implements Row {
       return accessor.getByte(ordinal);
     } else if (dt instanceof ShortType) {
       return accessor.getShort(ordinal);
-    } else if (dt instanceof IntegerType || dt instanceof DateType) {
+    } else if (dt instanceof IntegerType) {
       return accessor.getInt(ordinal);
-    } else if (dt instanceof LongType
-        || dt instanceof TimestampType
-        || dt instanceof TimestampNTZType) {
+    } else if (dt instanceof DateType) {
+      return DateTimeUtils.toJavaDate(accessor.getInt(ordinal));
+    } else if (dt instanceof LongType) {
       return accessor.getLong(ordinal);
+    } else if (dt instanceof TimestampType || dt instanceof TimestampNTZType) {
+      return DateTimeUtils.toJavaTimestamp(accessor.getLong(ordinal));
     } else if (dt instanceof FloatType) {
       return accessor.getFloat(ordinal);
     } else if (dt instanceof DoubleType) {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
@@ -72,6 +72,48 @@ public class KernelRowToSparkRow implements Row {
         rowFieldAccessor, i, kernelSchema.at(i).getDataType(), sparkSchema.fields()[i].dataType());
   }
 
+  /**
+   * Field-by-field equality matching Spark's Row.equals semantics. Required because Java classes
+   * implementing Scala traits get Object.equals (reference equality) -- the JVM does not inherit
+   * default methods from interfaces for Object methods.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Row)) return false;
+    Row other = (Row) o;
+    if (length() != other.length()) return false;
+    for (int i = 0; i < length(); i++) {
+      if (isNullAt(i) != other.isNullAt(i)) return false;
+      if (!isNullAt(i)) {
+        Object thisVal = get(i);
+        Object otherVal = other.get(i);
+        if (thisVal instanceof byte[] && otherVal instanceof byte[]) {
+          if (!java.util.Arrays.equals((byte[]) thisVal, (byte[]) otherVal)) return false;
+        } else if (!thisVal.equals(otherVal)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 37;
+    for (int i = 0; i < length(); i++) {
+      Object val = isNullAt(i) ? null : get(i);
+      if (val == null) {
+        result = 37 * result;
+      } else if (val instanceof byte[]) {
+        result = 37 * result + java.util.Arrays.hashCode((byte[]) val);
+      } else {
+        result = 37 * result + val.hashCode();
+      }
+    }
+    return result;
+  }
+
   @Override
   public Row copy() {
     Object[] values = new Object[length()];
@@ -287,12 +329,18 @@ public class KernelRowToSparkRow implements Row {
     } else if (dt instanceof IntegerType) {
       return accessor.getInt(ordinal);
     } else if (dt instanceof DateType) {
+      // Kernel stores DateType internally as int (epoch days since 1970-01-01).
+      // Spark's public Row.getDate() expects java.sql.Date objects.
       return DateTimeUtils.toJavaDate(accessor.getInt(ordinal));
     } else if (dt instanceof LongType) {
       return accessor.getLong(ordinal);
     } else if (dt instanceof TimestampType) {
+      // Kernel stores TimestampType as long (microseconds since epoch, UTC).
+      // Spark's public Row expects java.sql.Timestamp objects.
       return DateTimeUtils.toJavaTimestamp(accessor.getLong(ordinal));
     } else if (dt instanceof TimestampNTZType) {
+      // Kernel stores TimestampNTZType as long (microseconds, wall-clock / no timezone).
+      // Spark's public Row expects java.time.LocalDateTime objects.
       return DateTimeUtils.microsToLocalDateTime(accessor.getLong(ordinal));
     } else if (dt instanceof FloatType) {
       return accessor.getFloat(ordinal);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
@@ -68,7 +68,8 @@ public class KernelRowToSparkRow implements Row {
 
   @Override
   public Object get(int i) {
-    return toSparkValue(rowFieldAccessor, i, kernelSchema.at(i).getDataType());
+    return toSparkValue(
+        rowFieldAccessor, i, kernelSchema.at(i).getDataType(), sparkSchema.fields()[i].dataType());
   }
 
   @Override
@@ -265,7 +266,15 @@ public class KernelRowToSparkRow implements Row {
     };
   }
 
-  static Object toSparkValue(FieldAccessor accessor, int ordinal, DataType dt) {
+  /**
+   * Converts a Kernel field value to its Spark equivalent. Accepts a pre-computed Spark DataType to
+   * avoid redundant schema conversion on every row for nested types (structs, maps, arrays).
+   */
+  static Object toSparkValue(
+      FieldAccessor accessor,
+      int ordinal,
+      DataType dt,
+      org.apache.spark.sql.types.DataType sparkDt) {
     if (accessor.isNullAt(ordinal)) {
       return null;
     }
@@ -297,36 +306,41 @@ public class KernelRowToSparkRow implements Row {
       return accessor.getBinary(ordinal);
     } else if (dt instanceof StructType) {
       return new KernelRowToSparkRow(
-          accessor.getStruct(ordinal),
-          SchemaUtils.convertKernelSchemaToSparkSchema((StructType) dt));
+          accessor.getStruct(ordinal), (org.apache.spark.sql.types.StructType) sparkDt);
     } else if (dt instanceof MapType) {
-      return mapValueToScalaMap(accessor.getMap(ordinal), (MapType) dt);
+      org.apache.spark.sql.types.MapType sparkMapType =
+          (org.apache.spark.sql.types.MapType) sparkDt;
+      return mapValueToScalaMap(accessor.getMap(ordinal), (MapType) dt, sparkMapType);
     } else if (dt instanceof ArrayType) {
-      return arrayValueToScalaSeq(accessor.getArray(ordinal), (ArrayType) dt);
+      org.apache.spark.sql.types.ArrayType sparkArrayType =
+          (org.apache.spark.sql.types.ArrayType) sparkDt;
+      return arrayValueToScalaSeq(accessor.getArray(ordinal), (ArrayType) dt, sparkArrayType);
     }
     throw new UnsupportedOperationException("Unsupported Kernel DataType: " + dt);
   }
 
-  static scala.collection.Map<Object, Object> mapValueToScalaMap(MapValue mv, MapType mt) {
+  static scala.collection.Map<Object, Object> mapValueToScalaMap(
+      MapValue mv, MapType mt, org.apache.spark.sql.types.MapType sparkMt) {
     ColumnVector keys = mv.getKeys();
     ColumnVector values = mv.getValues();
     FieldAccessor keyAccessor = vectorAccessor(keys);
     FieldAccessor valueAccessor = vectorAccessor(values);
     Map<Object, Object> javaMap = new HashMap<>();
     for (int i = 0; i < mv.getSize(); i++) {
-      Object key = toSparkValue(keyAccessor, i, mt.getKeyType());
-      Object value = toSparkValue(valueAccessor, i, mt.getValueType());
+      Object key = toSparkValue(keyAccessor, i, mt.getKeyType(), sparkMt.keyType());
+      Object value = toSparkValue(valueAccessor, i, mt.getValueType(), sparkMt.valueType());
       javaMap.put(key, value);
     }
     return scala.jdk.javaapi.CollectionConverters.asScala(javaMap);
   }
 
-  static scala.collection.Seq<Object> arrayValueToScalaSeq(ArrayValue av, ArrayType at) {
+  static scala.collection.Seq<Object> arrayValueToScalaSeq(
+      ArrayValue av, ArrayType at, org.apache.spark.sql.types.ArrayType sparkAt) {
     ColumnVector elements = av.getElements();
     FieldAccessor elemAccessor = vectorAccessor(elements);
     List<Object> javaList = new ArrayList<>();
     for (int i = 0; i < av.getSize(); i++) {
-      javaList.add(toSparkValue(elemAccessor, i, at.getElementType()));
+      javaList.add(toSparkValue(elemAccessor, i, at.getElementType(), sparkAt.elementType()));
     }
     return scala.jdk.javaapi.CollectionConverters.asScala(javaList).toList();
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRow.java
@@ -76,6 +76,9 @@ public class KernelRowToSparkRow implements Row {
     Object[] values = new Object[length()];
     for (int i = 0; i < values.length; i++) {
       Object v = get(i);
+      // Recursively copy nested struct wrappers that still reference the live kernel row.
+      // Note: structs nested inside maps/arrays are already materialized by toSparkValue()
+      // as Scala collections of plain objects, so they don't hold kernel row references.
       if (v instanceof KernelRowToSparkRow) {
         v = ((KernelRowToSparkRow) v).copy();
       }
@@ -278,8 +281,10 @@ public class KernelRowToSparkRow implements Row {
       return DateTimeUtils.toJavaDate(accessor.getInt(ordinal));
     } else if (dt instanceof LongType) {
       return accessor.getLong(ordinal);
-    } else if (dt instanceof TimestampType || dt instanceof TimestampNTZType) {
+    } else if (dt instanceof TimestampType) {
       return DateTimeUtils.toJavaTimestamp(accessor.getLong(ordinal));
+    } else if (dt instanceof TimestampNTZType) {
+      return DateTimeUtils.microsToLocalDateTime(accessor.getLong(ordinal));
     } else if (dt instanceof FloatType) {
       return accessor.getFloat(ordinal);
     } else if (dt instanceof DoubleType) {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import io.delta.kernel.data.ArrayValue;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.types.*;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adapts a Spark Row to the Kernel Row interface. Designed and tested for AddFile schema; other
+ * schemas may work but are not validated.
+ */
+public class SparkRowToKernelRow implements Row {
+
+  private static final Set<Class<? extends DataType>> PASSTHROUGH_TYPES =
+      Set.of(
+          BooleanType.class,
+          ByteType.class,
+          ShortType.class,
+          IntegerType.class,
+          DateType.class,
+          LongType.class,
+          TimestampType.class,
+          TimestampNTZType.class,
+          FloatType.class,
+          DoubleType.class,
+          StringType.class,
+          BinaryType.class,
+          DecimalType.class);
+
+  private final org.apache.spark.sql.Row sparkRow;
+  private final StructType kernelSchema;
+
+  public SparkRowToKernelRow(org.apache.spark.sql.Row sparkRow, StructType kernelSchema) {
+    this.sparkRow = sparkRow;
+    this.kernelSchema = kernelSchema;
+  }
+
+  @Override
+  public StructType getSchema() {
+    return kernelSchema;
+  }
+
+  @Override
+  public boolean isNullAt(int ordinal) {
+    return sparkRow.isNullAt(ordinal);
+  }
+
+  @Override
+  public boolean getBoolean(int ordinal) {
+    return sparkRow.getBoolean(ordinal);
+  }
+
+  @Override
+  public byte getByte(int ordinal) {
+    return sparkRow.getByte(ordinal);
+  }
+
+  @Override
+  public short getShort(int ordinal) {
+    return sparkRow.getShort(ordinal);
+  }
+
+  @Override
+  public int getInt(int ordinal) {
+    return sparkRow.getInt(ordinal);
+  }
+
+  @Override
+  public long getLong(int ordinal) {
+    return sparkRow.getLong(ordinal);
+  }
+
+  @Override
+  public float getFloat(int ordinal) {
+    return sparkRow.getFloat(ordinal);
+  }
+
+  @Override
+  public double getDouble(int ordinal) {
+    return sparkRow.getDouble(ordinal);
+  }
+
+  @Override
+  public String getString(int ordinal) {
+    return sparkRow.getString(ordinal);
+  }
+
+  @Override
+  public BigDecimal getDecimal(int ordinal) {
+    return sparkRow.getDecimal(ordinal);
+  }
+
+  @Override
+  public byte[] getBinary(int ordinal) {
+    return (byte[]) sparkRow.get(ordinal);
+  }
+
+  @Override
+  public Row getStruct(int ordinal) {
+    org.apache.spark.sql.Row nested = sparkRow.getStruct(ordinal);
+    StructType nestedSchema = (StructType) kernelSchema.at(ordinal).getDataType();
+    return new SparkRowToKernelRow(nested, nestedSchema);
+  }
+
+  @Override
+  public MapValue getMap(int ordinal) {
+    Map<?, ?> javaMap = sparkRow.getJavaMap(ordinal);
+    MapType mt = (MapType) kernelSchema.at(ordinal).getDataType();
+    return javaMapToKernelMapValue(javaMap, mt);
+  }
+
+  @Override
+  public ArrayValue getArray(int ordinal) {
+    List<?> javaList = sparkRow.getList(ordinal);
+    ArrayType at = (ArrayType) kernelSchema.at(ordinal).getDataType();
+    return javaListToKernelArrayValue(javaList, at);
+  }
+
+  static MapValue javaMapToKernelMapValue(Map<?, ?> javaMap, MapType mt) {
+    List<Object> keys = new ArrayList<>(javaMap.size());
+    List<Object> values = new ArrayList<>(javaMap.size());
+    for (Map.Entry<?, ?> entry : javaMap.entrySet()) {
+      keys.add(sparkValueToKernel(entry.getKey(), mt.getKeyType()));
+      values.add(sparkValueToKernel(entry.getValue(), mt.getValueType()));
+    }
+    int size = javaMap.size();
+    ColumnVector keyVector = VectorUtils.buildColumnVector(keys, mt.getKeyType());
+    ColumnVector valueVector = VectorUtils.buildColumnVector(values, mt.getValueType());
+    return new MapValue() {
+      @Override
+      public int getSize() {
+        return size;
+      }
+
+      @Override
+      public ColumnVector getKeys() {
+        return keyVector;
+      }
+
+      @Override
+      public ColumnVector getValues() {
+        return valueVector;
+      }
+    };
+  }
+
+  static ArrayValue javaListToKernelArrayValue(List<?> javaList, ArrayType at) {
+    List<Object> kernelValues = new ArrayList<>(javaList.size());
+    for (Object element : javaList) {
+      kernelValues.add(sparkValueToKernel(element, at.getElementType()));
+    }
+    return VectorUtils.buildArrayValue(kernelValues, at.getElementType());
+  }
+
+  @SuppressWarnings("unchecked")
+  static Object sparkValueToKernel(Object sparkValue, DataType dt) {
+    if (sparkValue == null) {
+      return null;
+    }
+    if (PASSTHROUGH_TYPES.contains(dt.getClass())) {
+      return sparkValue;
+    }
+    if (dt instanceof StructType) {
+      return new SparkRowToKernelRow((org.apache.spark.sql.Row) sparkValue, (StructType) dt);
+    }
+    if (dt instanceof MapType) {
+      Map<?, ?> javaMap;
+      if (sparkValue instanceof scala.collection.Map) {
+        javaMap =
+            scala.jdk.javaapi.CollectionConverters.asJava((scala.collection.Map<?, ?>) sparkValue);
+      } else {
+        javaMap = (Map<?, ?>) sparkValue;
+      }
+      return javaMapToKernelMapValue(javaMap, (MapType) dt);
+    }
+    if (dt instanceof ArrayType) {
+      List<?> javaList;
+      if (sparkValue instanceof scala.collection.Seq) {
+        javaList =
+            scala.jdk.javaapi.CollectionConverters.asJava((scala.collection.Seq<?>) sparkValue);
+      } else {
+        javaList = (List<?>) sparkValue;
+      }
+      return javaListToKernelArrayValue(javaList, (ArrayType) dt);
+    }
+    throw new UnsupportedOperationException("Unsupported Kernel DataType: " + dt);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 
 /**
  * Adapts a Spark Row to the Kernel Row interface. Designed and tested for AddFile schema; other
@@ -44,10 +45,7 @@ public class SparkRowToKernelRow implements Row {
           ByteType.class,
           ShortType.class,
           IntegerType.class,
-          DateType.class,
           LongType.class,
-          TimestampType.class,
-          TimestampNTZType.class,
           FloatType.class,
           DoubleType.class,
           StringType.class,
@@ -238,6 +236,37 @@ public class SparkRowToKernelRow implements Row {
     }
     if (PASSTHROUGH_TYPES.contains(dt.getClass())) {
       return sparkValue;
+    }
+    if (dt instanceof DateType) {
+      if (sparkValue instanceof Integer) {
+        return sparkValue;
+      } else if (sparkValue instanceof java.sql.Date) {
+        return DateTimeUtils.fromJavaDate((java.sql.Date) sparkValue);
+      } else if (sparkValue instanceof java.time.LocalDate) {
+        return DateTimeUtils.localDateToDays((java.time.LocalDate) sparkValue);
+      }
+      throw new UnsupportedOperationException(
+          "Cannot convert " + sparkValue.getClass() + " to DateType");
+    }
+    if (dt instanceof TimestampType) {
+      if (sparkValue instanceof Long) {
+        return sparkValue;
+      } else if (sparkValue instanceof java.sql.Timestamp) {
+        return DateTimeUtils.fromJavaTimestamp((java.sql.Timestamp) sparkValue);
+      } else if (sparkValue instanceof java.time.Instant) {
+        return DateTimeUtils.instantToMicros((java.time.Instant) sparkValue);
+      }
+      throw new UnsupportedOperationException(
+          "Cannot convert " + sparkValue.getClass() + " to TimestampType");
+    }
+    if (dt instanceof TimestampNTZType) {
+      if (sparkValue instanceof Long) {
+        return sparkValue;
+      } else if (sparkValue instanceof java.time.LocalDateTime) {
+        return DateTimeUtils.localDateTimeToMicros((java.time.LocalDateTime) sparkValue);
+      }
+      throw new UnsupportedOperationException(
+          "Cannot convert " + sparkValue.getClass() + " to TimestampNTZType");
     }
     if (dt instanceof StructType) {
       return new SparkRowToKernelRow((org.apache.spark.sql.Row) sparkValue, (StructType) dt);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -129,16 +129,22 @@ public class SparkRowToKernelRow implements Row {
         String.format("Cannot read a null value as LONG at ordinal %d", ordinal));
     DataType dt = kernelSchema.at(ordinal).getDataType();
     if (dt instanceof TimestampType || dt instanceof TimestampNTZType) {
-      // Kernel's Row.getLong() contract for TimestampType: return microseconds since epoch (UTC).
-      // For TimestampNTZType: return microseconds (wall-clock, no timezone).
-      // Same evidence pattern as getInt()/DateType above -- production vector-backed rows store
-      // timestamps as raw longs, and Kernel consumers (ActionsIterator, LogReplay, etc.) call
-      // getLong() to read them.
+      // Kernel's Row.getLong() contract: return microseconds for timestamp types.
+      // TimestampType = UTC micros, TimestampNTZType = wall-clock micros.
+      // (Evidence: VectorUtils groups LongType||TimestampType -> getLong(),
+      // GenericColumnVector does the same, StructRow delegates to ColumnVector.getLong().)
       //
-      // Spark's public Row stores TimestampType as java.sql.Timestamp (or java.time.Instant)
-      // and TimestampNTZType as java.time.LocalDateTime -- not raw long.
-      // We must convert to the microsecond representation Kernel expects.
+      // Spark's public Row stores TimestampType as java.sql.Timestamp (or Instant) and
+      // TimestampNTZType as java.time.LocalDateTime — not raw long. We must convert.
+      //
+      // Note: unlike sparkValueToKernel() which rejects Long for TimestampNTZType (to
+      // prevent UTC/wall-clock ambiguity in recursive map/array values), getLong() accepts
+      // Long directly because it fulfills Kernel's Row.getLong() contract — the schema
+      // already establishes the timestamp semantics at this level.
       Object raw = sparkRow.get(ordinal);
+      if (raw instanceof Long) {
+        return (long) raw;
+      }
       return (long) sparkValueToKernel(raw, dt);
     }
     return sparkRow.getLong(ordinal);
@@ -319,20 +325,21 @@ public class SparkRowToKernelRow implements Row {
           "Cannot convert " + sparkValue.getClass() + " to TimestampType");
     }
     if (dt instanceof TimestampNTZType) {
-      if (sparkValue instanceof Long) {
-        // Already wall-clock microseconds (from InternalRow or pre-converted value).
-        // Kernel stores both TimestampType and TimestampNTZType as long micros with no
-        // runtime distinction — the semantic difference (UTC vs wall-clock) is carried
-        // solely by the schema DataType, not the value representation. Callers are
-        // responsible for ensuring the long value has the correct semantics for the
-        // declared type.
-        return sparkValue;
-      } else if (sparkValue instanceof java.time.LocalDateTime) {
-        // Convert wall-clock LocalDateTime -> epoch-microseconds long (no timezone).
+      // Unlike TimestampType, we do NOT accept raw Long here. A Long is ambiguous for
+      // TimestampNTZType: it could be UTC micros (from a TimestampType context) silently
+      // misinterpreted as wall-clock micros. KernelRowToSparkRow.toSparkValue() converts
+      // TimestampNTZType to LocalDateTime (via DateTimeUtils.microsToLocalDateTime), so
+      // the reverse path must require LocalDateTime to preserve the round-trip contract.
+      // Callers with a raw long must explicitly wrap it:
+      //   DateTimeUtils.microsToLocalDateTime(longVal)
+      if (sparkValue instanceof java.time.LocalDateTime) {
         return DateTimeUtils.localDateTimeToMicros((java.time.LocalDateTime) sparkValue);
       }
       throw new UnsupportedOperationException(
-          "Cannot convert " + sparkValue.getClass() + " to TimestampNTZType");
+          "Cannot convert "
+              + sparkValue.getClass()
+              + " to TimestampNTZType. Use java.time.LocalDateTime"
+              + " (raw Long is rejected to prevent UTC/wall-clock ambiguity).");
     }
     if (dt instanceof StructType) {
       return new SparkRowToKernelRow((org.apache.spark.sql.Row) sparkValue, (StructType) dt);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -15,6 +15,8 @@
  */
 package io.delta.spark.internal.v2.utils;
 
+import static io.delta.kernel.internal.util.Preconditions.checkState;
+
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
@@ -72,57 +74,57 @@ public class SparkRowToKernelRow implements Row {
 
   @Override
   public boolean getBoolean(int ordinal) {
-    if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException("Cannot read a null value as BOOLEAN at ordinal " + ordinal);
-    }
+    checkState(
+        !sparkRow.isNullAt(ordinal),
+        String.format("Cannot read a null value as BOOLEAN at ordinal %d", ordinal));
     return sparkRow.getBoolean(ordinal);
   }
 
   @Override
   public byte getByte(int ordinal) {
-    if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException("Cannot read a null value as BYTE at ordinal " + ordinal);
-    }
+    checkState(
+        !sparkRow.isNullAt(ordinal),
+        String.format("Cannot read a null value as BYTE at ordinal %d", ordinal));
     return sparkRow.getByte(ordinal);
   }
 
   @Override
   public short getShort(int ordinal) {
-    if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException("Cannot read a null value as SHORT at ordinal " + ordinal);
-    }
+    checkState(
+        !sparkRow.isNullAt(ordinal),
+        String.format("Cannot read a null value as SHORT at ordinal %d", ordinal));
     return sparkRow.getShort(ordinal);
   }
 
   @Override
   public int getInt(int ordinal) {
-    if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException("Cannot read a null value as INT at ordinal " + ordinal);
-    }
+    checkState(
+        !sparkRow.isNullAt(ordinal),
+        String.format("Cannot read a null value as INT at ordinal %d", ordinal));
     return sparkRow.getInt(ordinal);
   }
 
   @Override
   public long getLong(int ordinal) {
-    if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException("Cannot read a null value as LONG at ordinal " + ordinal);
-    }
+    checkState(
+        !sparkRow.isNullAt(ordinal),
+        String.format("Cannot read a null value as LONG at ordinal %d", ordinal));
     return sparkRow.getLong(ordinal);
   }
 
   @Override
   public float getFloat(int ordinal) {
-    if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException("Cannot read a null value as FLOAT at ordinal " + ordinal);
-    }
+    checkState(
+        !sparkRow.isNullAt(ordinal),
+        String.format("Cannot read a null value as FLOAT at ordinal %d", ordinal));
     return sparkRow.getFloat(ordinal);
   }
 
   @Override
   public double getDouble(int ordinal) {
-    if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException("Cannot read a null value as DOUBLE at ordinal " + ordinal);
-    }
+    checkState(
+        !sparkRow.isNullAt(ordinal),
+        String.format("Cannot read a null value as DOUBLE at ordinal %d", ordinal));
     return sparkRow.getDouble(ordinal);
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -30,6 +30,11 @@ import java.util.Set;
 /**
  * Adapts a Spark Row to the Kernel Row interface. Designed and tested for AddFile schema; other
  * schemas may work but are not validated.
+ *
+ * <p>Null contract: primitive getters ({@code getBoolean}, {@code getInt}, etc.) throw
+ * {@link IllegalStateException} if the field is null (callers must check {@code isNullAt} first).
+ * Reference-type getters ({@code getString}, {@code getStruct}, {@code getMap}, {@code getArray})
+ * return {@code null} for null fields.
  */
 public class SparkRowToKernelRow implements Row {
 
@@ -156,6 +161,9 @@ public class SparkRowToKernelRow implements Row {
 
   @Override
   public Row getStruct(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      return null;
+    }
     org.apache.spark.sql.Row nested = sparkRow.getStruct(ordinal);
     StructType nestedSchema = (StructType) kernelSchema.at(ordinal).getDataType();
     return new SparkRowToKernelRow(nested, nestedSchema);
@@ -179,6 +187,9 @@ public class SparkRowToKernelRow implements Row {
 
   @Override
   public ArrayValue getArray(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      return null;
+    }
     List<?> javaList = sparkRow.getList(ordinal);
     ArrayType at = (ArrayType) kernelSchema.at(ordinal).getDataType();
     return javaListToKernelArrayValue(javaList, at);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -101,6 +101,24 @@ public class SparkRowToKernelRow implements Row {
     checkState(
         !sparkRow.isNullAt(ordinal),
         String.format("Cannot read a null value as INT at ordinal %d", ordinal));
+    if (kernelSchema.at(ordinal).getDataType() instanceof DateType) {
+      // Kernel's Row.getInt() contract for DateType: return epoch days since 1970-01-01.
+      // (Evidence: VectorUtils.java groups IntegerType||DateType -> getInt(),
+      // GenericColumnVector does the same, StructRow delegates to ColumnVector.getInt()
+      // which natively stores dates as epoch-day ints.)
+      //
+      // Spark's public Row stores DateType as java.sql.Date (or java.time.LocalDate
+      // depending on spark.sql.datetime.java8API.enabled), NOT as raw int.
+      // Row.getInt() on Spark's side is just a raw cast -- it would ClassCastException.
+      // We must convert the java.sql/java.time object to the int Kernel expects.
+      //
+      // We handle multiple input types because the wrapped Spark Row could be:
+      // - GenericRowWithSchema from RowFactory.create() -> stores java.sql.Date
+      // - InternalRow wrapper -> may already store as int (epoch days)
+      // - Any other Row implementation
+      Object raw = sparkRow.get(ordinal);
+      return (int) sparkValueToKernel(raw, DateType.DATE);
+    }
     return sparkRow.getInt(ordinal);
   }
 
@@ -109,6 +127,20 @@ public class SparkRowToKernelRow implements Row {
     checkState(
         !sparkRow.isNullAt(ordinal),
         String.format("Cannot read a null value as LONG at ordinal %d", ordinal));
+    DataType dt = kernelSchema.at(ordinal).getDataType();
+    if (dt instanceof TimestampType || dt instanceof TimestampNTZType) {
+      // Kernel's Row.getLong() contract for TimestampType: return microseconds since epoch (UTC).
+      // For TimestampNTZType: return microseconds (wall-clock, no timezone).
+      // Same evidence pattern as getInt()/DateType above -- production vector-backed rows store
+      // timestamps as raw longs, and Kernel consumers (ActionsIterator, LogReplay, etc.) call
+      // getLong() to read them.
+      //
+      // Spark's public Row stores TimestampType as java.sql.Timestamp (or java.time.Instant)
+      // and TimestampNTZType as java.time.LocalDateTime -- not raw long.
+      // We must convert to the microsecond representation Kernel expects.
+      Object raw = sparkRow.get(ordinal);
+      return (long) sparkValueToKernel(raw, dt);
+    }
     return sparkRow.getLong(ordinal);
   }
 
@@ -232,12 +264,33 @@ public class SparkRowToKernelRow implements Row {
     if (PASSTHROUGH_TYPES.contains(dt.getClass())) {
       return sparkValue;
     }
+    // --- Date/Timestamp conversion (Spark -> Kernel) ---
+    //
+    // Kernel expects dates and timestamps as raw primitives:
+    //   DateType        -> int  (epoch days since 1970-01-01)
+    //   TimestampType   -> long (microseconds since epoch, UTC)
+    //   TimestampNTZType -> long (microseconds since epoch, wall-clock / no timezone)
+    //
+    // However, the incoming sparkValue can arrive in MULTIPLE forms depending on the
+    // call site:
+    //   1. Already a raw int/long — happens when the value originated from Spark's
+    //      InternalRow (e.g., a GenericInternalRow or UnsafeRow), where dates/timestamps
+    //      are stored as primitives matching Kernel's representation.
+    //   2. A java.sql.Date / java.sql.Timestamp / java.time.* object — happens when the
+    //      value comes through Spark's public Row interface (Row.get(i)), which returns
+    //      the user-facing Java types.
+    //
+    // We handle both forms for each type so this converter works regardless of whether
+    // the caller supplies internal or external row values.
     if (dt instanceof DateType) {
       if (sparkValue instanceof Integer) {
+        // Already epoch-days (from InternalRow); matches Kernel's DateType representation.
         return sparkValue;
       } else if (sparkValue instanceof java.sql.Date) {
+        // Convert java.sql.Date -> epoch-days int.
         return DateTimeUtils.fromJavaDate((java.sql.Date) sparkValue);
       } else if (sparkValue instanceof java.time.LocalDate) {
+        // Convert java.time.LocalDate -> epoch-days int.
         return DateTimeUtils.localDateToDays((java.time.LocalDate) sparkValue);
       }
       throw new UnsupportedOperationException(
@@ -245,10 +298,13 @@ public class SparkRowToKernelRow implements Row {
     }
     if (dt instanceof TimestampType) {
       if (sparkValue instanceof Long) {
+        // Already epoch-microseconds (from InternalRow); matches Kernel's TimestampType.
         return sparkValue;
       } else if (sparkValue instanceof java.sql.Timestamp) {
+        // Convert java.sql.Timestamp -> epoch-microseconds long (UTC).
         return DateTimeUtils.fromJavaTimestamp((java.sql.Timestamp) sparkValue);
       } else if (sparkValue instanceof java.time.Instant) {
+        // Convert java.time.Instant -> epoch-microseconds long (UTC).
         return DateTimeUtils.instantToMicros((java.time.Instant) sparkValue);
       }
       throw new UnsupportedOperationException(
@@ -256,8 +312,10 @@ public class SparkRowToKernelRow implements Row {
     }
     if (dt instanceof TimestampNTZType) {
       if (sparkValue instanceof Long) {
+        // Already epoch-microseconds (from InternalRow); matches Kernel's TimestampNTZType.
         return sparkValue;
       } else if (sparkValue instanceof java.time.LocalDateTime) {
+        // Convert wall-clock LocalDateTime -> epoch-microseconds long (no timezone).
         return DateTimeUtils.localDateTimeToMicros((java.time.LocalDateTime) sparkValue);
       }
       throw new UnsupportedOperationException(

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -69,51 +69,88 @@ public class SparkRowToKernelRow implements Row {
 
   @Override
   public boolean getBoolean(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      throw new IllegalStateException(
+          "Cannot read a null value as BOOLEAN at ordinal " + ordinal);
+    }
     return sparkRow.getBoolean(ordinal);
   }
 
   @Override
   public byte getByte(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      throw new IllegalStateException(
+          "Cannot read a null value as BYTE at ordinal " + ordinal);
+    }
     return sparkRow.getByte(ordinal);
   }
 
   @Override
   public short getShort(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      throw new IllegalStateException(
+          "Cannot read a null value as SHORT at ordinal " + ordinal);
+    }
     return sparkRow.getShort(ordinal);
   }
 
   @Override
   public int getInt(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      throw new IllegalStateException(
+          "Cannot read a null value as INT at ordinal " + ordinal);
+    }
     return sparkRow.getInt(ordinal);
   }
 
   @Override
   public long getLong(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      throw new IllegalStateException(
+          "Cannot read a null value as LONG at ordinal " + ordinal);
+    }
     return sparkRow.getLong(ordinal);
   }
 
   @Override
   public float getFloat(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      throw new IllegalStateException(
+          "Cannot read a null value as FLOAT at ordinal " + ordinal);
+    }
     return sparkRow.getFloat(ordinal);
   }
 
   @Override
   public double getDouble(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      throw new IllegalStateException(
+          "Cannot read a null value as DOUBLE at ordinal " + ordinal);
+    }
     return sparkRow.getDouble(ordinal);
   }
 
   @Override
   public String getString(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      return null;
+    }
     return sparkRow.getString(ordinal);
   }
 
   @Override
   public BigDecimal getDecimal(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      return null;
+    }
     return sparkRow.getDecimal(ordinal);
   }
 
   @Override
   public byte[] getBinary(int ordinal) {
+    if (sparkRow.isNullAt(ordinal)) {
+      return null;
+    }
     return (byte[]) sparkRow.get(ordinal);
   }
 
@@ -126,7 +163,16 @@ public class SparkRowToKernelRow implements Row {
 
   @Override
   public MapValue getMap(int ordinal) {
-    Map<?, ?> javaMap = sparkRow.getJavaMap(ordinal);
+    if (sparkRow.isNullAt(ordinal)) {
+      return null;
+    }
+    Object raw = sparkRow.get(ordinal);
+    Map<?, ?> javaMap;
+    if (raw instanceof scala.collection.Map) {
+      javaMap = scala.jdk.javaapi.CollectionConverters.asJava((scala.collection.Map<?, ?>) raw);
+    } else {
+      javaMap = (Map<?, ?>) raw;
+    }
     MapType mt = (MapType) kernelSchema.at(ordinal).getDataType();
     return javaMapToKernelMapValue(javaMap, mt);
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -215,7 +215,13 @@ public class SparkRowToKernelRow implements Row {
     if (sparkRow.isNullAt(ordinal)) {
       return null;
     }
-    List<?> javaList = sparkRow.getList(ordinal);
+    Object raw = sparkRow.get(ordinal);
+    List<?> javaList;
+    if (raw instanceof scala.collection.Seq) {
+      javaList = scala.jdk.javaapi.CollectionConverters.asJava((scala.collection.Seq<?>) raw);
+    } else {
+      javaList = (List<?>) raw;
+    }
     ArrayType at = (ArrayType) kernelSchema.at(ordinal).getDataType();
     return javaListToKernelArrayValue(javaList, at);
   }
@@ -298,7 +304,9 @@ public class SparkRowToKernelRow implements Row {
     }
     if (dt instanceof TimestampType) {
       if (sparkValue instanceof Long) {
-        // Already epoch-microseconds (from InternalRow); matches Kernel's TimestampType.
+        // Already UTC epoch-microseconds (from InternalRow or pre-converted value).
+        // Kernel stores TimestampType as long micros. Callers are responsible for
+        // ensuring the long value represents UTC microseconds.
         return sparkValue;
       } else if (sparkValue instanceof java.sql.Timestamp) {
         // Convert java.sql.Timestamp -> epoch-microseconds long (UTC).
@@ -312,7 +320,12 @@ public class SparkRowToKernelRow implements Row {
     }
     if (dt instanceof TimestampNTZType) {
       if (sparkValue instanceof Long) {
-        // Already epoch-microseconds (from InternalRow); matches Kernel's TimestampNTZType.
+        // Already wall-clock microseconds (from InternalRow or pre-converted value).
+        // Kernel stores both TimestampType and TimestampNTZType as long micros with no
+        // runtime distinction — the semantic difference (UTC vs wall-clock) is carried
+        // solely by the schema DataType, not the value representation. Callers are
+        // responsible for ensuring the long value has the correct semantics for the
+        // declared type.
         return sparkValue;
       } else if (sparkValue instanceof java.time.LocalDateTime) {
         // Convert wall-clock LocalDateTime -> epoch-microseconds long (no timezone).

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRow.java
@@ -32,8 +32,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils;
  * Adapts a Spark Row to the Kernel Row interface. Designed and tested for AddFile schema; other
  * schemas may work but are not validated.
  *
- * <p>Null contract: primitive getters ({@code getBoolean}, {@code getInt}, etc.) throw
- * {@link IllegalStateException} if the field is null (callers must check {@code isNullAt} first).
+ * <p>Null contract: primitive getters ({@code getBoolean}, {@code getInt}, etc.) throw {@link
+ * IllegalStateException} if the field is null (callers must check {@code isNullAt} first).
  * Reference-type getters ({@code getString}, {@code getStruct}, {@code getMap}, {@code getArray})
  * return {@code null} for null fields.
  */
@@ -73,8 +73,7 @@ public class SparkRowToKernelRow implements Row {
   @Override
   public boolean getBoolean(int ordinal) {
     if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException(
-          "Cannot read a null value as BOOLEAN at ordinal " + ordinal);
+      throw new IllegalStateException("Cannot read a null value as BOOLEAN at ordinal " + ordinal);
     }
     return sparkRow.getBoolean(ordinal);
   }
@@ -82,8 +81,7 @@ public class SparkRowToKernelRow implements Row {
   @Override
   public byte getByte(int ordinal) {
     if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException(
-          "Cannot read a null value as BYTE at ordinal " + ordinal);
+      throw new IllegalStateException("Cannot read a null value as BYTE at ordinal " + ordinal);
     }
     return sparkRow.getByte(ordinal);
   }
@@ -91,8 +89,7 @@ public class SparkRowToKernelRow implements Row {
   @Override
   public short getShort(int ordinal) {
     if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException(
-          "Cannot read a null value as SHORT at ordinal " + ordinal);
+      throw new IllegalStateException("Cannot read a null value as SHORT at ordinal " + ordinal);
     }
     return sparkRow.getShort(ordinal);
   }
@@ -100,8 +97,7 @@ public class SparkRowToKernelRow implements Row {
   @Override
   public int getInt(int ordinal) {
     if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException(
-          "Cannot read a null value as INT at ordinal " + ordinal);
+      throw new IllegalStateException("Cannot read a null value as INT at ordinal " + ordinal);
     }
     return sparkRow.getInt(ordinal);
   }
@@ -109,8 +105,7 @@ public class SparkRowToKernelRow implements Row {
   @Override
   public long getLong(int ordinal) {
     if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException(
-          "Cannot read a null value as LONG at ordinal " + ordinal);
+      throw new IllegalStateException("Cannot read a null value as LONG at ordinal " + ordinal);
     }
     return sparkRow.getLong(ordinal);
   }
@@ -118,8 +113,7 @@ public class SparkRowToKernelRow implements Row {
   @Override
   public float getFloat(int ordinal) {
     if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException(
-          "Cannot read a null value as FLOAT at ordinal " + ordinal);
+      throw new IllegalStateException("Cannot read a null value as FLOAT at ordinal " + ordinal);
     }
     return sparkRow.getFloat(ordinal);
   }
@@ -127,8 +121,7 @@ public class SparkRowToKernelRow implements Row {
   @Override
   public double getDouble(int ordinal) {
     if (sparkRow.isNullAt(ordinal)) {
-      throw new IllegalStateException(
-          "Cannot read a null value as DOUBLE at ordinal " + ordinal);
+      throw new IllegalStateException("Cannot read a null value as DOUBLE at ordinal " + ordinal);
     }
     return sparkRow.getDouble(ordinal);
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.data.GenericRow;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.types.*;
+import java.math.BigDecimal;
+import java.util.*;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+public class KernelRowToSparkRowTest {
+
+  @Test
+  public void testPrimitiveTypes() {
+    StructType schema =
+        new StructType()
+            .add("boolField", BooleanType.BOOLEAN)
+            .add("byteField", ByteType.BYTE)
+            .add("shortField", ShortType.SHORT)
+            .add("intField", IntegerType.INTEGER)
+            .add("longField", LongType.LONG)
+            .add("floatField", FloatType.FLOAT)
+            .add("doubleField", DoubleType.DOUBLE)
+            .add("stringField", StringType.STRING)
+            .add("decimalField", new DecimalType(10, 2));
+
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(0, true);
+    fieldMap.put(1, (byte) 42);
+    fieldMap.put(2, (short) 1000);
+    fieldMap.put(3, 123456);
+    fieldMap.put(4, 9876543210L);
+    fieldMap.put(5, 3.14f);
+    fieldMap.put(6, 2.71828);
+    fieldMap.put(7, "hello");
+    fieldMap.put(8, new BigDecimal("12345.67"));
+
+    io.delta.kernel.data.Row kernelRow = new GenericRow(schema, fieldMap);
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    assertEquals(9, sparkRow.length());
+    assertEquals(true, sparkRow.get(0));
+    assertEquals((byte) 42, sparkRow.get(1));
+    assertEquals((short) 1000, sparkRow.get(2));
+    assertEquals(123456, sparkRow.get(3));
+    assertEquals(9876543210L, sparkRow.get(4));
+    assertEquals(3.14f, sparkRow.get(5));
+    assertEquals(2.71828, sparkRow.get(6));
+    assertEquals("hello", sparkRow.get(7));
+    assertEquals(new BigDecimal("12345.67"), sparkRow.get(8));
+  }
+
+  @Test
+  public void testNullableFields() {
+    StructType schema =
+        new StructType()
+            .add("a", StringType.STRING, true)
+            .add("b", LongType.LONG, true)
+            .add("c", StringType.STRING, true);
+
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(0, "present");
+    // b and c are null (not in fieldMap)
+
+    io.delta.kernel.data.Row kernelRow = new GenericRow(schema, fieldMap);
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    assertFalse(sparkRow.isNullAt(0));
+    assertEquals("present", sparkRow.get(0));
+    assertTrue(sparkRow.isNullAt(1));
+    assertNull(sparkRow.get(1));
+    assertTrue(sparkRow.isNullAt(2));
+    assertNull(sparkRow.get(2));
+  }
+
+  @Test
+  public void testMapField() {
+    StructType schema =
+        new StructType()
+            .add("tags", new MapType(StringType.STRING, StringType.STRING, true), false);
+
+    Map<String, String> tags = new HashMap<>();
+    tags.put("key1", "val1");
+    tags.put("key2", "val2");
+
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(0, VectorUtils.stringStringMapValue(tags));
+
+    io.delta.kernel.data.Row kernelRow = new GenericRow(schema, fieldMap);
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    Object mapObj = sparkRow.get(0);
+    assertTrue(mapObj instanceof scala.collection.Map);
+    @SuppressWarnings("unchecked")
+    scala.collection.Map<String, String> scalaMap = (scala.collection.Map<String, String>) mapObj;
+    assertEquals("val1", scalaMap.apply("key1"));
+    assertEquals("val2", scalaMap.apply("key2"));
+  }
+
+  @Test
+  public void testNestedStruct() {
+    StructType innerSchema =
+        new StructType().add("x", IntegerType.INTEGER).add("y", StringType.STRING);
+
+    StructType outerSchema = new StructType().add("nested", innerSchema);
+
+    Map<Integer, Object> innerFieldMap = new HashMap<>();
+    innerFieldMap.put(0, 99);
+    innerFieldMap.put(1, "inner");
+    io.delta.kernel.data.Row innerRow = new GenericRow(innerSchema, innerFieldMap);
+
+    Map<Integer, Object> outerFieldMap = new HashMap<>();
+    outerFieldMap.put(0, innerRow);
+    io.delta.kernel.data.Row outerRow = new GenericRow(outerSchema, outerFieldMap);
+
+    Row sparkRow = new KernelRowToSparkRow(outerRow);
+    Row nested = sparkRow.getStruct(0);
+    assertNotNull(nested);
+    assertEquals(99, nested.get(0));
+    assertEquals("inner", nested.get(1));
+  }
+
+  @Test
+  public void testArrayField() {
+    StructType schema = new StructType().add("arr", new ArrayType(StringType.STRING, true));
+
+    List<String> elements = Arrays.asList("a", "b", "c");
+
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(0, VectorUtils.buildArrayValue(elements, StringType.STRING));
+
+    io.delta.kernel.data.Row kernelRow = new GenericRow(schema, fieldMap);
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    Object seqObj = sparkRow.get(0);
+    assertTrue(seqObj instanceof scala.collection.Seq);
+    @SuppressWarnings("unchecked")
+    scala.collection.Seq<String> seq = (scala.collection.Seq<String>) seqObj;
+    assertEquals(3, seq.length());
+    assertEquals("a", seq.apply(0));
+    assertEquals("b", seq.apply(1));
+    assertEquals("c", seq.apply(2));
+  }
+
+  /** Integration test: verifies AddFile survives Kernel Row -> Spark Row -> Kernel Row. */
+  @Tag("integration")
+  @Test
+  public void testAddFileRoundTrip() {
+    Map<String, String> partVals = Collections.singletonMap("date", "2025-01-01");
+    Map<String, String> tags = new HashMap<>();
+    tags.put("ZCUBE_ID", "abc123");
+
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(AddFile.SCHEMA_WITHOUT_STATS.indexOf("path"), "file.parquet");
+    fieldMap.put(
+        AddFile.SCHEMA_WITHOUT_STATS.indexOf("partitionValues"),
+        VectorUtils.stringStringMapValue(partVals));
+    fieldMap.put(AddFile.SCHEMA_WITHOUT_STATS.indexOf("size"), 2048L);
+    fieldMap.put(AddFile.SCHEMA_WITHOUT_STATS.indexOf("modificationTime"), 1000L);
+    fieldMap.put(AddFile.SCHEMA_WITHOUT_STATS.indexOf("dataChange"), true);
+    fieldMap.put(
+        AddFile.SCHEMA_WITHOUT_STATS.indexOf("deletionVector"),
+        new DeletionVectorDescriptor("u", "ab^-aqEH.-t@S}", Optional.of(4), 40, 3).toRow());
+    fieldMap.put(
+        AddFile.SCHEMA_WITHOUT_STATS.indexOf("tags"), VectorUtils.stringStringMapValue(tags));
+    fieldMap.put(AddFile.SCHEMA_WITHOUT_STATS.indexOf("baseRowId"), 42L);
+    fieldMap.put(AddFile.SCHEMA_WITHOUT_STATS.indexOf("defaultRowCommitVersion"), 7L);
+
+    AddFile original = new AddFile(new GenericRow(AddFile.SCHEMA_WITHOUT_STATS, fieldMap));
+
+    Row sparkRow = new KernelRowToSparkRow(original.toRow());
+    io.delta.kernel.data.Row kernelRow =
+        new SparkRowToKernelRow(sparkRow, AddFile.SCHEMA_WITHOUT_STATS);
+    AddFile roundTripped = new AddFile(kernelRow);
+
+    assertEquals(original.getPath(), roundTripped.getPath());
+    assertEquals(original.getSize(), roundTripped.getSize());
+    assertEquals(original.getModificationTime(), roundTripped.getModificationTime());
+    assertEquals(original.getDataChange(), roundTripped.getDataChange());
+
+    assertTrue(roundTripped.getDeletionVector().isPresent());
+    DeletionVectorDescriptor dv = roundTripped.getDeletionVector().get();
+    assertEquals("u", dv.getStorageType());
+    assertEquals("ab^-aqEH.-t@S}", dv.getPathOrInlineDv());
+    assertEquals(Optional.of(4), dv.getOffset());
+    assertEquals(40, dv.getSizeInBytes());
+    assertEquals(3, dv.getCardinality());
+
+    assertTrue(roundTripped.getTags().isPresent());
+    Map<?, ?> roundTrippedTags = VectorUtils.toJavaMap(roundTripped.getTags().get());
+    assertEquals("abc123", roundTrippedTags.get("ZCUBE_ID"));
+
+    assertEquals(Optional.of(42L), roundTripped.getBaseRowId());
+    assertEquals(Optional.of(7L), roundTripped.getDefaultRowCommitVersion());
+
+    Map<?, ?> roundTrippedPartVals = VectorUtils.toJavaMap(roundTripped.getPartitionValues());
+    assertEquals("2025-01-01", roundTrippedPartVals.get("date"));
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
@@ -250,6 +250,103 @@ public class KernelRowToSparkRowTest {
     assertEquals(DateTimeUtils.microsToLocalDateTime(ntzMicros), ntzVal);
   }
 
+  @Test
+  public void testDateEpochBoundary() {
+    StructType schema = new StructType().add("dateField", DateType.DATE);
+
+    ColumnVector dateVector = VectorUtils.buildColumnVector(List.of(0), DateType.DATE);
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, schema, new ColumnVector[] {dateVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+    assertEquals(java.sql.Date.valueOf(java.time.LocalDate.ofEpochDay(0)), sparkRow.get(0));
+  }
+
+  @Test
+  public void testPreEpochDate() {
+    StructType schema = new StructType().add("dateField", DateType.DATE);
+
+    ColumnVector dateVector = VectorUtils.buildColumnVector(List.of(-1), DateType.DATE);
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, schema, new ColumnVector[] {dateVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+    assertEquals(java.sql.Date.valueOf(java.time.LocalDate.ofEpochDay(-1)), sparkRow.get(0));
+  }
+
+  @Test
+  public void testTimestampZeroMicros() {
+    StructType schema = new StructType().add("tsField", TimestampType.TIMESTAMP);
+
+    ColumnVector tsVector = VectorUtils.buildColumnVector(List.of(0L), TimestampType.TIMESTAMP);
+    DefaultColumnarBatch batch = new DefaultColumnarBatch(1, schema, new ColumnVector[] {tsVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+    assertEquals(DateTimeUtils.toJavaTimestamp(0L), sparkRow.get(0));
+  }
+
+  @Test
+  public void testNullDateTimestampFields() {
+    StructType schema =
+        new StructType()
+            .add("dateField", DateType.DATE, true)
+            .add("tsField", TimestampType.TIMESTAMP, true)
+            .add("ntzField", TimestampNTZType.TIMESTAMP_NTZ, true);
+
+    ColumnVector dateVector =
+        VectorUtils.buildColumnVector(Collections.singletonList(null), DateType.DATE);
+    ColumnVector tsVector =
+        VectorUtils.buildColumnVector(Collections.singletonList(null), TimestampType.TIMESTAMP);
+    ColumnVector ntzVector =
+        VectorUtils.buildColumnVector(
+            Collections.singletonList(null), TimestampNTZType.TIMESTAMP_NTZ);
+
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, schema, new ColumnVector[] {dateVector, tsVector, ntzVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+    assertTrue(sparkRow.isNullAt(0));
+    assertTrue(sparkRow.isNullAt(1));
+    assertTrue(sparkRow.isNullAt(2));
+    assertNull(sparkRow.get(0));
+    assertNull(sparkRow.get(1));
+    assertNull(sparkRow.get(2));
+  }
+
+  @Test
+  public void testDateTimestampRoundTrip() {
+    StructType schema =
+        new StructType()
+            .add("dateField", DateType.DATE)
+            .add("tsField", TimestampType.TIMESTAMP)
+            .add("ntzField", TimestampNTZType.TIMESTAMP_NTZ);
+
+    int epochDays = 20254;
+    long tsMicros = 1750000000000000L;
+    long ntzMicros = 1750000000000000L;
+
+    ColumnVector dateVector = VectorUtils.buildColumnVector(List.of(epochDays), DateType.DATE);
+    ColumnVector tsVector =
+        VectorUtils.buildColumnVector(List.of(tsMicros), TimestampType.TIMESTAMP);
+    ColumnVector ntzVector =
+        VectorUtils.buildColumnVector(List.of(ntzMicros), TimestampNTZType.TIMESTAMP_NTZ);
+
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, schema, new ColumnVector[] {dateVector, tsVector, ntzVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+    io.delta.kernel.data.Row backToKernel = new SparkRowToKernelRow(sparkRow, schema);
+
+    assertEquals(epochDays, backToKernel.getInt(0));
+    assertEquals(tsMicros, backToKernel.getLong(1));
+    assertEquals(ntzMicros, backToKernel.getLong(2));
+  }
+
   /** Integration test: verifies AddFile survives Kernel Row -> Spark Row -> Kernel Row. */
   @Tag("integration")
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
@@ -27,6 +27,7 @@ import io.delta.kernel.types.*;
 import java.math.BigDecimal;
 import java.util.*;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -234,16 +235,19 @@ public class KernelRowToSparkRowTest {
     Object dateVal = sparkRow.get(0);
     assertTrue(
         dateVal instanceof java.sql.Date, "Expected java.sql.Date, got " + dateVal.getClass());
+    assertEquals(java.sql.Date.valueOf(java.time.LocalDate.ofEpochDay(epochDays)), dateVal);
 
     Object tsVal = sparkRow.get(1);
     assertTrue(
         tsVal instanceof java.sql.Timestamp,
         "Expected java.sql.Timestamp, got " + tsVal.getClass());
+    assertEquals(DateTimeUtils.toJavaTimestamp(tsMicros), tsVal);
 
     Object ntzVal = sparkRow.get(2);
     assertTrue(
         ntzVal instanceof java.time.LocalDateTime,
         "Expected java.time.LocalDateTime, got " + ntzVal.getClass());
+    assertEquals(DateTimeUtils.microsToLocalDateTime(ntzMicros), ntzVal);
   }
 
   /** Integration test: verifies AddFile survives Kernel Row -> Spark Row -> Kernel Row. */

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
@@ -17,8 +17,11 @@ package io.delta.spark.internal.v2.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.MapValue;
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
+import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.data.GenericRow;
@@ -400,5 +403,303 @@ public class KernelRowToSparkRowTest {
 
     Map<?, ?> roundTrippedPartVals = VectorUtils.toJavaMap(roundTripped.getPartitionValues());
     assertEquals("2025-01-01", roundTrippedPartVals.get("date"));
+  }
+
+  /**
+   * Verifies that struct values nested inside a map are materialized (deep-copied) when copy() is
+   * called on the outer KernelRowToSparkRow. Without the fix in mapValueToScalaMap(), these struct
+   * values would remain as live KernelRowToSparkRow wrappers holding references to the underlying
+   * kernel ColumnVector.
+   */
+  @Test
+  public void testCopyMaterializesStructsInsideMap() {
+    StructType innerSchema =
+        new StructType().add("innerInt", IntegerType.INTEGER).add("innerStr", StringType.STRING);
+    MapType mapType = new MapType(StringType.STRING, innerSchema, true);
+    StructType outerSchema = new StructType().add("mapField", mapType, false);
+
+    Map<Integer, Object> innerFieldMap1 = new HashMap<>();
+    innerFieldMap1.put(0, 10);
+    innerFieldMap1.put(1, "hello");
+    GenericRow innerRow1 = new GenericRow(innerSchema, innerFieldMap1);
+
+    Map<Integer, Object> innerFieldMap2 = new HashMap<>();
+    innerFieldMap2.put(0, 20);
+    innerFieldMap2.put(1, "world");
+    GenericRow innerRow2 = new GenericRow(innerSchema, innerFieldMap2);
+
+    MapValue mv =
+        new MapValue() {
+          @Override
+          public int getSize() {
+            return 2;
+          }
+
+          @Override
+          public ColumnVector getKeys() {
+            return VectorUtils.buildColumnVector(List.of("key1", "key2"), StringType.STRING);
+          }
+
+          @Override
+          public ColumnVector getValues() {
+            return VectorUtils.buildColumnVector(List.of(innerRow1, innerRow2), innerSchema);
+          }
+        };
+
+    ColumnVector mapVector = VectorUtils.buildColumnVector(List.of(mv), mapType);
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, outerSchema, new ColumnVector[] {mapVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    KernelRowToSparkRow sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    // Struct values are materialized at collection-build time (in mapValueToScalaMap),
+    // so even before copy(), the map values are already GenericRow, not KernelRowToSparkRow.
+    @SuppressWarnings("unchecked")
+    scala.collection.Map<Object, Object> preCopyMap =
+        (scala.collection.Map<Object, Object>) sparkRow.get(0);
+    Row preCopyVal1 = (Row) preCopyMap.apply("key1");
+    assertFalse(
+        preCopyVal1 instanceof KernelRowToSparkRow,
+        "Struct inside map should be materialized at collection-build time");
+
+    Row copied = sparkRow.copy();
+
+    @SuppressWarnings("unchecked")
+    scala.collection.Map<Object, Object> scalaMap =
+        (scala.collection.Map<Object, Object>) copied.get(0);
+
+    Row val1 = (Row) scalaMap.apply("key1");
+    assertFalse(
+        val1 instanceof KernelRowToSparkRow,
+        "Struct inside map should be materialized, not a live KernelRowToSparkRow");
+    assertNotSame(preCopyVal1, val1, "Copied struct should be a different reference");
+    assertEquals(preCopyVal1, val1, "Copied struct should have the same content");
+    assertEquals(10, val1.get(0));
+    assertEquals("hello", val1.get(1));
+
+    Row val2 = (Row) scalaMap.apply("key2");
+    assertFalse(
+        val2 instanceof KernelRowToSparkRow,
+        "Struct inside map should be materialized, not a live KernelRowToSparkRow");
+    assertEquals(20, val2.get(0));
+    assertEquals("world", val2.get(1));
+  }
+
+  /**
+   * Verifies that struct elements nested inside an array are materialized (deep-copied) when copy()
+   * is called on the outer KernelRowToSparkRow. Without the fix in arrayValueToScalaSeq(), these
+   * struct elements would remain as live KernelRowToSparkRow wrappers.
+   */
+  @Test
+  public void testCopyMaterializesStructsInsideArray() {
+    StructType innerSchema =
+        new StructType().add("innerInt", IntegerType.INTEGER).add("innerStr", StringType.STRING);
+    ArrayType arrayType = new ArrayType(innerSchema, true);
+    StructType outerSchema = new StructType().add("arrayField", arrayType, false);
+
+    Map<Integer, Object> innerFieldMap1 = new HashMap<>();
+    innerFieldMap1.put(0, 100);
+    innerFieldMap1.put(1, "alpha");
+    GenericRow innerRow1 = new GenericRow(innerSchema, innerFieldMap1);
+
+    Map<Integer, Object> innerFieldMap2 = new HashMap<>();
+    innerFieldMap2.put(0, 200);
+    innerFieldMap2.put(1, "beta");
+    GenericRow innerRow2 = new GenericRow(innerSchema, innerFieldMap2);
+
+    ArrayValue av = VectorUtils.buildArrayValue(List.of(innerRow1, innerRow2), innerSchema);
+
+    ColumnVector arrayVector = VectorUtils.buildColumnVector(List.of(av), arrayType);
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, outerSchema, new ColumnVector[] {arrayVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    KernelRowToSparkRow sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    // Struct elements are materialized at collection-build time (in arrayValueToScalaSeq),
+    // so even before copy(), the array elements are already GenericRow.
+    @SuppressWarnings("unchecked")
+    scala.collection.Seq<Object> preCopySeq = (scala.collection.Seq<Object>) sparkRow.get(0);
+    Row preCopyElem0 = (Row) preCopySeq.apply(0);
+    assertFalse(
+        preCopyElem0 instanceof KernelRowToSparkRow,
+        "Struct inside array should be materialized at collection-build time");
+
+    Row copied = sparkRow.copy();
+
+    @SuppressWarnings("unchecked")
+    scala.collection.Seq<Object> seq = (scala.collection.Seq<Object>) copied.get(0);
+    assertEquals(2, seq.length());
+
+    Row elem0 = (Row) seq.apply(0);
+    assertFalse(
+        elem0 instanceof KernelRowToSparkRow,
+        "Struct inside array should be materialized, not a live KernelRowToSparkRow");
+    assertNotSame(preCopyElem0, elem0, "Copied struct should be a different reference");
+    assertEquals(preCopyElem0, elem0, "Copied struct should have the same content");
+    assertEquals(100, elem0.get(0));
+    assertEquals("alpha", elem0.get(1));
+
+    Row elem1 = (Row) seq.apply(1);
+    assertFalse(
+        elem1 instanceof KernelRowToSparkRow,
+        "Struct inside array should be materialized, not a live KernelRowToSparkRow");
+    assertEquals(200, elem1.get(0));
+    assertEquals("beta", elem1.get(1));
+  }
+
+  /**
+   * Verifies that the basic read path (without copy()) returns correct values for struct fields
+   * nested inside both maps and arrays in a single row.
+   */
+  @Test
+  public void testMapAndArrayStructValuesAreCorrect() {
+    StructType innerSchema =
+        new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+    MapType mapType = new MapType(StringType.STRING, innerSchema, true);
+    ArrayType arrayType = new ArrayType(innerSchema, true);
+    StructType outerSchema =
+        new StructType().add("mapField", mapType, false).add("arrayField", arrayType, false);
+
+    Map<Integer, Object> mapStructFields = new HashMap<>();
+    mapStructFields.put(0, 1);
+    mapStructFields.put(1, "one");
+    GenericRow mapStructRow = new GenericRow(innerSchema, mapStructFields);
+
+    Map<Integer, Object> arrayStructFields = new HashMap<>();
+    arrayStructFields.put(0, 2);
+    arrayStructFields.put(1, "two");
+    GenericRow arrayStructRow = new GenericRow(innerSchema, arrayStructFields);
+
+    MapValue mv =
+        new MapValue() {
+          @Override
+          public int getSize() {
+            return 1;
+          }
+
+          @Override
+          public ColumnVector getKeys() {
+            return VectorUtils.buildColumnVector(List.of("entry"), StringType.STRING);
+          }
+
+          @Override
+          public ColumnVector getValues() {
+            return VectorUtils.buildColumnVector(List.of(mapStructRow), innerSchema);
+          }
+        };
+
+    ArrayValue av = VectorUtils.buildArrayValue(List.of(arrayStructRow), innerSchema);
+
+    ColumnVector mapVector = VectorUtils.buildColumnVector(List.of(mv), mapType);
+    ColumnVector arrayVector = VectorUtils.buildColumnVector(List.of(av), arrayType);
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, outerSchema, new ColumnVector[] {mapVector, arrayVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    @SuppressWarnings("unchecked")
+    scala.collection.Map<Object, Object> map =
+        (scala.collection.Map<Object, Object>) sparkRow.get(0);
+    Row mapStruct = (Row) map.apply("entry");
+    assertEquals(1, mapStruct.get(0));
+    assertEquals("one", mapStruct.get(1));
+
+    @SuppressWarnings("unchecked")
+    scala.collection.Seq<Object> seq = (scala.collection.Seq<Object>) sparkRow.get(1);
+    assertEquals(1, seq.length());
+    Row arrayStruct = (Row) seq.apply(0);
+    assertEquals(2, arrayStruct.get(0));
+    assertEquals("two", arrayStruct.get(1));
+  }
+
+  /**
+   * Verifies that null struct values inside maps and arrays are handled correctly -- they should
+   * come through as null rather than throwing.
+   *
+   * <p>Uses {@link DefaultGenericVector} instead of {@link VectorUtils#buildColumnVector} for
+   * struct-typed vectors because GenericColumnVector.getChild() eagerly iterates all entries via
+   * extractChildValues(), which crashes on null elements. DefaultGenericVector.getChild() creates a
+   * DefaultSubFieldVector that lazily accesses rows per-index and properly handles nulls.
+   */
+  @Test
+  public void testNullStructValuesInsideMapAndArray() {
+    StructType innerSchema =
+        new StructType().add("innerInt", IntegerType.INTEGER).add("innerStr", StringType.STRING);
+    MapType mapType = new MapType(StringType.STRING, innerSchema, true);
+    ArrayType arrayType = new ArrayType(innerSchema, true);
+    StructType outerSchema =
+        new StructType().add("mapField", mapType, false).add("arrayField", arrayType, false);
+
+    Map<Integer, Object> innerFieldMap = new HashMap<>();
+    innerFieldMap.put(0, 10);
+    innerFieldMap.put(1, "hello");
+    GenericRow innerRow1 = new GenericRow(innerSchema, innerFieldMap);
+
+    List<Object> mapStructValues = new ArrayList<>();
+    mapStructValues.add(innerRow1);
+    mapStructValues.add(null);
+
+    MapValue mv =
+        new MapValue() {
+          @Override
+          public int getSize() {
+            return 2;
+          }
+
+          @Override
+          public ColumnVector getKeys() {
+            return VectorUtils.buildColumnVector(List.of("key1", "key2"), StringType.STRING);
+          }
+
+          @Override
+          public ColumnVector getValues() {
+            return DefaultGenericVector.fromList(innerSchema, mapStructValues);
+          }
+        };
+
+    List<Object> arrayStructValues = new ArrayList<>();
+    arrayStructValues.add(innerRow1);
+    arrayStructValues.add(null);
+    ArrayValue av =
+        new ArrayValue() {
+          @Override
+          public int getSize() {
+            return 2;
+          }
+
+          @Override
+          public ColumnVector getElements() {
+            return DefaultGenericVector.fromList(innerSchema, arrayStructValues);
+          }
+        };
+
+    ColumnVector mapVector = VectorUtils.buildColumnVector(List.of(mv), mapType);
+    ColumnVector arrayVector = VectorUtils.buildColumnVector(List.of(av), arrayType);
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, outerSchema, new ColumnVector[] {mapVector, arrayVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
+    KernelRowToSparkRow sparkRow = new KernelRowToSparkRow(kernelRow);
+    Row copied = sparkRow.copy();
+
+    @SuppressWarnings("unchecked")
+    scala.collection.Map<Object, Object> map = (scala.collection.Map<Object, Object>) copied.get(0);
+    Row mapVal1 = (Row) map.apply("key1");
+    assertNotNull(mapVal1);
+    assertEquals(10, mapVal1.get(0));
+    assertEquals("hello", mapVal1.get(1));
+    assertNull(map.apply("key2"));
+
+    @SuppressWarnings("unchecked")
+    scala.collection.Seq<Object> seq = (scala.collection.Seq<Object>) copied.get(1);
+    assertEquals(2, seq.length());
+    Row arrayElem0 = (Row) seq.apply(0);
+    assertNotNull(arrayElem0);
+    assertEquals(10, arrayElem0.get(0));
+    assertEquals("hello", arrayElem0.get(1));
+    assertNull(seq.apply(1));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
@@ -162,6 +162,73 @@ public class KernelRowToSparkRowTest {
     assertEquals("c", seq.apply(2));
   }
 
+  @Test
+  public void testEqualsAndHashCode() {
+    StructType schema =
+        new StructType()
+            .add("name", StringType.STRING)
+            .add("value", IntegerType.INTEGER)
+            .add("flag", BooleanType.BOOLEAN);
+
+    Map<Integer, Object> fieldMap1 = new HashMap<>();
+    fieldMap1.put(0, "alpha");
+    fieldMap1.put(1, 42);
+    fieldMap1.put(2, true);
+
+    Map<Integer, Object> fieldMap2 = new HashMap<>();
+    fieldMap2.put(0, "alpha");
+    fieldMap2.put(1, 42);
+    fieldMap2.put(2, true);
+
+    Map<Integer, Object> fieldMap3 = new HashMap<>();
+    fieldMap3.put(0, "beta");
+    fieldMap3.put(1, 42);
+    fieldMap3.put(2, true);
+
+    Row row1 = new KernelRowToSparkRow(new GenericRow(schema, fieldMap1));
+    Row row2 = new KernelRowToSparkRow(new GenericRow(schema, fieldMap2));
+    Row row3 = new KernelRowToSparkRow(new GenericRow(schema, fieldMap3));
+
+    assertEquals(row1, row2);
+    assertEquals(row1.hashCode(), row2.hashCode());
+    assertNotEquals(row1, row3);
+  }
+
+  @Test
+  public void testDateAndTimestampConversion() {
+    StructType schema =
+        new StructType()
+            .add("dateField", DateType.DATE)
+            .add("tsField", TimestampType.TIMESTAMP)
+            .add("tsNtzField", TimestampNTZType.TIMESTAMP_NTZ);
+
+    int epochDays = 20254; // ~2025-06-15
+    long tsMicros = 1750000000000000L;
+    long ntzMicros = 1750000000000000L;
+
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(0, epochDays);
+    fieldMap.put(1, tsMicros);
+    fieldMap.put(2, ntzMicros);
+
+    io.delta.kernel.data.Row kernelRow = new GenericRow(schema, fieldMap);
+    Row sparkRow = new KernelRowToSparkRow(kernelRow);
+
+    Object dateVal = sparkRow.get(0);
+    assertTrue(
+        dateVal instanceof java.sql.Date, "Expected java.sql.Date, got " + dateVal.getClass());
+
+    Object tsVal = sparkRow.get(1);
+    assertTrue(
+        tsVal instanceof java.sql.Timestamp,
+        "Expected java.sql.Timestamp, got " + tsVal.getClass());
+
+    Object ntzVal = sparkRow.get(2);
+    assertTrue(
+        ntzVal instanceof java.time.LocalDateTime,
+        "Expected java.time.LocalDateTime, got " + ntzVal.getClass());
+  }
+
   /** Integration test: verifies AddFile survives Kernel Row -> Spark Row -> Kernel Row. */
   @Tag("integration")
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/KernelRowToSparkRowTest.java
@@ -17,6 +17,8 @@ package io.delta.spark.internal.v2.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.data.GenericRow;
@@ -194,6 +196,17 @@ public class KernelRowToSparkRowTest {
     assertNotEquals(row1, row3);
   }
 
+  /**
+   * Uses vector-backed rows (via DefaultColumnarBatch) instead of GenericRow because GenericRow's
+   * throwIfUnsafeAccess rejects getInt() for DateType and getLong() for
+   * TimestampType/TimestampNTZType. In production, KernelRowToSparkRow wraps ColumnarBatchRow or
+   * StructRow (both extend ChildVectorBasedRow), where getInt()/getLong() delegate to
+   * ColumnVector.getInt()/getLong() which correctly handle date/timestamp types.
+   *
+   * <p>This test exercises the exact production code path: ColumnarBatchRow ->
+   * ChildVectorBasedRow.getInt()/getLong() -> GenericColumnVector.getInt()/getLong() ->
+   * KernelRowToSparkRow.toSparkValue() -> DateTimeUtils conversion
+   */
   @Test
   public void testDateAndTimestampConversion() {
     StructType schema =
@@ -206,12 +219,16 @@ public class KernelRowToSparkRowTest {
     long tsMicros = 1750000000000000L;
     long ntzMicros = 1750000000000000L;
 
-    Map<Integer, Object> fieldMap = new HashMap<>();
-    fieldMap.put(0, epochDays);
-    fieldMap.put(1, tsMicros);
-    fieldMap.put(2, ntzMicros);
+    ColumnVector dateVector = VectorUtils.buildColumnVector(List.of(epochDays), DateType.DATE);
+    ColumnVector tsVector =
+        VectorUtils.buildColumnVector(List.of(tsMicros), TimestampType.TIMESTAMP);
+    ColumnVector ntzVector =
+        VectorUtils.buildColumnVector(List.of(ntzMicros), TimestampNTZType.TIMESTAMP_NTZ);
 
-    io.delta.kernel.data.Row kernelRow = new GenericRow(schema, fieldMap);
+    DefaultColumnarBatch batch =
+        new DefaultColumnarBatch(1, schema, new ColumnVector[] {dateVector, tsVector, ntzVector});
+    io.delta.kernel.data.Row kernelRow = batch.getRows().next();
+
     Row sparkRow = new KernelRowToSparkRow(kernelRow);
 
     Object dateVal = sparkRow.get(0);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.types.*;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.RowFactory;
+import org.junit.jupiter.api.Test;
+
+public class SparkRowToKernelRowTest {
+
+  @Test
+  public void testPrimitiveTypes() {
+    StructType kernelSchema =
+        new StructType()
+            .add("boolField", BooleanType.BOOLEAN)
+            .add("intField", IntegerType.INTEGER)
+            .add("longField", LongType.LONG)
+            .add("stringField", StringType.STRING)
+            .add("doubleField", DoubleType.DOUBLE);
+
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(true, 42, 9876543210L, "hello", 2.71828);
+
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, kernelSchema);
+
+    assertEquals(true, kernelRow.getBoolean(0));
+    assertEquals(42, kernelRow.getInt(1));
+    assertEquals(9876543210L, kernelRow.getLong(2));
+    assertEquals("hello", kernelRow.getString(3));
+    assertEquals(2.71828, kernelRow.getDouble(4));
+  }
+
+  @Test
+  public void testNullableFields() {
+    StructType kernelSchema =
+        new StructType().add("a", StringType.STRING, true).add("b", LongType.LONG, true);
+
+    org.apache.spark.sql.Row sparkRow = RowFactory.create("present", null);
+
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, kernelSchema);
+
+    assertFalse(kernelRow.isNullAt(0));
+    assertEquals("present", kernelRow.getString(0));
+    assertTrue(kernelRow.isNullAt(1));
+  }
+
+  @Test
+  public void testMapField() {
+    StructType kernelSchema =
+        new StructType().add("tags", new MapType(StringType.STRING, StringType.STRING, true));
+
+    Map<String, String> tags = new HashMap<>();
+    tags.put("key1", "val1");
+    tags.put("key2", "val2");
+    scala.collection.Map<String, String> scalaMap =
+        scala.jdk.javaapi.CollectionConverters.asScala(tags);
+
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(scalaMap);
+
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, kernelSchema);
+
+    MapValue mv = kernelRow.getMap(0);
+    assertNotNull(mv);
+    assertEquals(2, mv.getSize());
+    Map<?, ?> roundTripped = VectorUtils.toJavaMap(mv);
+    assertEquals("val1", roundTripped.get("key1"));
+    assertEquals("val2", roundTripped.get("key2"));
+  }
+
+  @Test
+  public void testNestedStruct() {
+    StructType innerKernelSchema =
+        new StructType().add("x", IntegerType.INTEGER).add("y", StringType.STRING);
+
+    StructType outerKernelSchema = new StructType().add("nested", innerKernelSchema);
+
+    org.apache.spark.sql.Row innerSparkRow = RowFactory.create(99, "inner");
+    org.apache.spark.sql.Row outerSparkRow = RowFactory.create(innerSparkRow);
+
+    Row kernelRow = new SparkRowToKernelRow(outerSparkRow, outerKernelSchema);
+
+    Row nested = kernelRow.getStruct(0);
+    assertNotNull(nested);
+    assertEquals(99, nested.getInt(0));
+    assertEquals("inner", nested.getString(1));
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
@@ -189,6 +189,143 @@ public class SparkRowToKernelRowTest {
   }
 
   @Test
+  public void testDateFieldWithLocalDate() {
+    StructType schema = new StructType().add("dateField", DateType.DATE);
+
+    LocalDate ld = LocalDate.of(1970, 1, 1);
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(Date.valueOf(ld));
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    assertEquals(0, kernelRow.getInt(0));
+  }
+
+  @Test
+  public void testDateFieldEpochBoundary() {
+    StructType schema = new StructType().add("dateField", DateType.DATE);
+
+    Date preEpoch = Date.valueOf(LocalDate.of(1969, 12, 31));
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(preEpoch);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    int epochDays = kernelRow.getInt(0);
+    assertEquals(-1, epochDays);
+  }
+
+  @Test
+  public void testTimestampFieldWithInstant() {
+    StructType schema = new StructType().add("tsField", TimestampType.TIMESTAMP);
+
+    java.time.Instant instant = java.time.Instant.parse("2025-06-15T10:30:00Z");
+    Timestamp sqlTs = Timestamp.from(instant);
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(sqlTs);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    long micros = kernelRow.getLong(0);
+    assertEquals(DateTimeUtils.fromJavaTimestamp(sqlTs), micros);
+  }
+
+  @Test
+  public void testTimestampNTZFieldRoundTrip() {
+    StructType schema = new StructType().add("ntzField", TimestampNTZType.TIMESTAMP_NTZ);
+
+    LocalDateTime ldt = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(ldt);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    long micros = kernelRow.getLong(0);
+    assertEquals(ldt, DateTimeUtils.microsToLocalDateTime(micros));
+  }
+
+  @Test
+  public void testGetLongPassesThroughRawLongForTimestampNTZ() {
+    StructType ntzStruct = new StructType().add("ntz", TimestampNTZType.TIMESTAMP_NTZ);
+    StructType schema = new StructType().add("nested", ntzStruct);
+
+    // Inner Row holds a raw Long (simulates InternalRow-backed path).
+    // getLong() on the Kernel Row interface should still work — it fulfills the
+    // Row.getLong() contract directly without going through sparkValueToKernel().
+    org.apache.spark.sql.Row inner = RowFactory.create(1750000000000000L);
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(inner);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    Row nested = kernelRow.getStruct(0);
+    assertEquals(1750000000000000L, nested.getLong(0));
+  }
+
+  @Test
+  public void testSparkValueToKernelRejectsRawLongForTimestampNTZ() {
+    // sparkValueToKernel (used in map/array/struct recursion) should reject Long for
+    // TimestampNTZType because a raw Long is ambiguous — it could be UTC micros from a
+    // TimestampType context silently misinterpreted as wall-clock micros.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            SparkRowToKernelRow.sparkValueToKernel(
+                1750000000000000L, TimestampNTZType.TIMESTAMP_NTZ));
+  }
+
+  @Test
+  public void testSparkValueToKernelAcceptsLocalDateTimeForTimestampNTZ() {
+    LocalDateTime ldt = LocalDateTime.of(2025, 6, 15, 10, 30, 0);
+    Object result = SparkRowToKernelRow.sparkValueToKernel(ldt, TimestampNTZType.TIMESTAMP_NTZ);
+    assertEquals(DateTimeUtils.localDateTimeToMicros(ldt), result);
+  }
+
+  @Test
+  public void testSparkValueToKernelAcceptsLongForTimestampType() {
+    // For TimestampType (UTC), raw Long IS accepted — UTC micros is unambiguous.
+    long utcMicros = 1750000000000000L;
+    Object result = SparkRowToKernelRow.sparkValueToKernel(utcMicros, TimestampType.TIMESTAMP);
+    assertEquals(utcMicros, result);
+  }
+
+  @Test
+  public void testSparkValueToKernelAcceptsTimestampForTimestampType() {
+    Timestamp ts = Timestamp.valueOf("2025-06-15 10:30:00");
+    Object result = SparkRowToKernelRow.sparkValueToKernel(ts, TimestampType.TIMESTAMP);
+    assertEquals(DateTimeUtils.fromJavaTimestamp(ts), result);
+  }
+
+  @Test
+  public void testSparkValueToKernelAcceptsInstantForTimestampType() {
+    java.time.Instant instant = java.time.Instant.parse("2025-06-15T10:30:00Z");
+    Object result = SparkRowToKernelRow.sparkValueToKernel(instant, TimestampType.TIMESTAMP);
+    assertEquals(DateTimeUtils.instantToMicros(instant), result);
+  }
+
+  @Test
+  public void testSparkValueToKernelDateConversions() {
+    LocalDate ld = LocalDate.of(2025, 6, 15);
+    Date sqlDate = Date.valueOf(ld);
+
+    Object fromSqlDate = SparkRowToKernelRow.sparkValueToKernel(sqlDate, DateType.DATE);
+    Object fromLocalDate = SparkRowToKernelRow.sparkValueToKernel(ld, DateType.DATE);
+    Object fromInt = SparkRowToKernelRow.sparkValueToKernel(20254, DateType.DATE);
+
+    assertEquals(fromSqlDate, fromLocalDate);
+    assertEquals(DateTimeUtils.fromJavaDate(sqlDate), fromInt);
+  }
+
+  @Test
+  public void testNullDateAndTimestampFields() {
+    StructType schema =
+        new StructType()
+            .add("dateField", DateType.DATE, true)
+            .add("tsField", TimestampType.TIMESTAMP, true)
+            .add("ntzField", TimestampNTZType.TIMESTAMP_NTZ, true);
+
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(null, null, null);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    assertTrue(kernelRow.isNullAt(0));
+    assertTrue(kernelRow.isNullAt(1));
+    assertTrue(kernelRow.isNullAt(2));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getInt(0));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getLong(1));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getLong(2));
+  }
+
+  @Test
   public void testJavaUtilListArrayInput() {
     StructType schema = new StructType().add("items", new ArrayType(StringType.STRING, true));
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
@@ -337,7 +337,7 @@ public class SparkRowToKernelRowTest {
     ArrayValue av = kernelRow.getArray(0);
     assertNotNull(av);
     // Verify round-trip
-    List<?> roundTripped = VectorUtils.toJavaList(av, StringType.STRING);
+    List<?> roundTripped = VectorUtils.toJavaList(av);
     assertEquals(3, roundTripped.size());
     assertEquals("alpha", roundTripped.get(0));
     assertEquals("beta", roundTripped.get(1));

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
@@ -17,6 +17,7 @@ package io.delta.spark.internal.v2.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.util.VectorUtils;
@@ -26,6 +27,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
@@ -184,5 +186,24 @@ public class SparkRowToKernelRowTest {
     Map<?, ?> roundTripped = VectorUtils.toJavaMap(mv);
     assertEquals("spark", roundTripped.get("engine"));
     assertEquals("4.0", roundTripped.get("version"));
+  }
+
+  @Test
+  public void testJavaUtilListArrayInput() {
+    StructType schema = new StructType().add("items", new ArrayType(StringType.STRING, true));
+
+    List<String> javaList = List.of("alpha", "beta", "gamma");
+
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(javaList);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    ArrayValue av = kernelRow.getArray(0);
+    assertNotNull(av);
+    // Verify round-trip
+    List<?> roundTripped = VectorUtils.toJavaList(av, StringType.STRING);
+    assertEquals(3, roundTripped.size());
+    assertEquals("alpha", roundTripped.get(0));
+    assertEquals("beta", roundTripped.get(1));
+    assertEquals("gamma", roundTripped.get(2));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SparkRowToKernelRowTest.java
@@ -21,9 +21,14 @@ import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.*;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.junit.jupiter.api.Test;
 
 public class SparkRowToKernelRowTest {
@@ -102,5 +107,82 @@ public class SparkRowToKernelRowTest {
     assertNotNull(nested);
     assertEquals(99, nested.getInt(0));
     assertEquals("inner", nested.getString(1));
+  }
+
+  @Test
+  public void testDateField() {
+    StructType schema = new StructType().add("dateField", DateType.DATE);
+
+    Date sqlDate = Date.valueOf(LocalDate.of(2025, 6, 15));
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(sqlDate);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    int epochDays = kernelRow.getInt(0);
+    assertEquals(DateTimeUtils.fromJavaDate(sqlDate), epochDays);
+  }
+
+  @Test
+  public void testTimestampField() {
+    StructType schema = new StructType().add("tsField", TimestampType.TIMESTAMP);
+
+    Timestamp sqlTs = Timestamp.valueOf("2025-06-15 10:30:00");
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(sqlTs);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    long micros = kernelRow.getLong(0);
+    assertEquals(DateTimeUtils.fromJavaTimestamp(sqlTs), micros);
+  }
+
+  @Test
+  public void testTimestampNTZField() {
+    StructType schema = new StructType().add("tsNtzField", TimestampNTZType.TIMESTAMP_NTZ);
+
+    LocalDateTime ldt = LocalDateTime.of(2025, 6, 15, 10, 30, 0);
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(ldt);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    long micros = kernelRow.getLong(0);
+    assertEquals(DateTimeUtils.localDateTimeToMicros(ldt), micros);
+  }
+
+  @Test
+  public void testNullGuardsOnPrimitiveGetters() {
+    StructType schema =
+        new StructType()
+            .add("boolField", BooleanType.BOOLEAN, true)
+            .add("intField", IntegerType.INTEGER, true)
+            .add("longField", LongType.LONG, true)
+            .add("floatField", FloatType.FLOAT, true)
+            .add("doubleField", DoubleType.DOUBLE, true);
+
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(null, null, null, null, null);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    assertTrue(kernelRow.isNullAt(0));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getBoolean(0));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getInt(1));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getLong(2));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getFloat(3));
+    assertThrows(IllegalStateException.class, () -> kernelRow.getDouble(4));
+  }
+
+  @Test
+  public void testJavaUtilMapInput() {
+    StructType schema =
+        new StructType().add("tags", new MapType(StringType.STRING, StringType.STRING, true));
+
+    Map<String, String> javaMap = new HashMap<>();
+    javaMap.put("engine", "spark");
+    javaMap.put("version", "4.0");
+
+    org.apache.spark.sql.Row sparkRow = RowFactory.create(javaMap);
+    Row kernelRow = new SparkRowToKernelRow(sparkRow, schema);
+
+    MapValue mv = kernelRow.getMap(0);
+    assertNotNull(mv);
+    assertEquals(2, mv.getSize());
+    Map<?, ?> roundTripped = VectorUtils.toJavaMap(mv);
+    assertEquals("spark", roundTripped.get("engine"));
+    assertEquals("4.0", roundTripped.get("version"));
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6701/files) to review incremental changes.
- [stack/streaming_phase0_pr1](https://github.com/delta-io/delta/pull/6700) [[Files changed](https://github.com/delta-io/delta/pull/6700/files)] [MERGED]
  - [**stack/streaming_phase0_pr2**](https://github.com/delta-io/delta/pull/6701) [[Files changed](https://github.com/delta-io/delta/pull/6701/files)]
    - [stack/streaming_phase0_pr3](https://github.com/delta-io/delta/pull/6702) [[Files changed](https://github.com/delta-io/delta/pull/6702/files/e3a7e2ae94fd8e7a6c342131faefc5d32b6240d5..6e056dcbcbf9d6868556d9ec628a1018794b849b)]
      - [stack/streaming_phase0_pr4](https://github.com/delta-io/delta/pull/6703) [[Files changed](https://github.com/delta-io/delta/pull/6703/files/6e056dcbcbf9d6868556d9ec628a1018794b849b..64188d2e77e0c9303a13670e0fbe7da7a029841b)]
        - [stack/streaming_phase0_pr5](https://github.com/delta-io/delta/pull/6706) [[Files changed](https://github.com/delta-io/delta/pull/6706/files/64188d2e77e0c9303a13670e0fbe7da7a029841b..9bf5431f800ae5cd6742ca25359931bf806819a8)]

---------
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

### Overall Scope (stacked PRs #6700-#6706)

This PR stack fixes a **driver OOM** in Delta V2 Structured Streaming when processing tables with very long commit histories during the initial snapshot. The existing implementation materializes the entire file listing on the driver, which exhausts memory when the commit history is large (100K+ files). The fix introduces a **distributed initial snapshot** approach that offloads the file listing and sorting to Spark executors via a DataFrame, keeping only metadata on the driver.

The stack is organized as:
- **PR1** (#6700, merged): `SerializableFileStatus` — make kernel `FileStatus` serializable for cross-executor shipping
- **PR2** (this PR): `KernelRowToSparkRow` / `SparkRowToKernelRow` — zero-copy row wrappers for Kernel<->Spark interop
- **PR3** (#6702): `SerializableReadOnlySnapshot`, `ScanFileRDD`, `DataFrameSnapshotCache` — the distributed data plane
- **PR4** (#6703): Integration into `SparkMicroBatchStream` and `SparkScan` behind a feature flag
- **PR5** (#6706): End-to-end integration tests

### This PR

Adds two generic utility classes for converting between Delta Kernel `Row` objects and Spark `Row` objects:

- **`KernelRowToSparkRow`**: Wraps a Kernel `Row` as a Spark `GenericRowWithSchema`, performing a deep copy of all field values at construction time. This ensures the Spark row remains valid after the underlying Kernel `ColumnarBatch` is closed. Handles all Kernel types including nested structs (recursive copy), arrays, maps, and date/timestamp conversions.

- **`SparkRowToKernelRow`**: Wraps a Spark `Row` as a Kernel `Row` (zero-copy, live view). Provides type-safe accessors with null guards (`Preconditions.checkState`) on all primitive getters to fail fast on null fields rather than throwing opaque NPEs. Handles `scala.collection.Map` vs `java.util.Map` polymorphism via `instanceof` checks.

Both classes are designed as general-purpose utilities reusable beyond the streaming use case.

## How was this patch tested?

- `KernelRowToSparkRowTest`: Tests round-trip conversion of all supported types (primitives, strings, binary, arrays, maps, nested structs), null handling, schema preservation, and deep-copy independence from the source row.
- `SparkRowToKernelRowTest`: Tests all typed getters, null guard behavior (throws on null primitive access), and correct handling of Spark-to-Kernel type mappings.

Run with: `build/sbt 'sparkV2/testOnly *KernelRowToSparkRowTest *SparkRowToKernelRowTest'`

## Does this PR introduce _any_ user-facing changes?

No. These are internal utility classes with no public API surface.