### PR TITLE
[V2 Streaming] Add SerializableReadOnlySnapshot, ScanFileRDD, and DataFrameSnapshotCache

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DataFrameSnapshotCache.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DataFrameSnapshotCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DataFrameSnapshotCache.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DataFrameSnapshotCache.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+/** Cached sorted AddFile DataFrame, keyed by version. Callers synchronize externally. */
+public class DataFrameSnapshotCache implements AutoCloseable {
+
+  private final long version;
+  private Dataset<Row> sortedAddFiles;
+
+  public DataFrameSnapshotCache(long version, Dataset<Row> sortedAddFiles) {
+    this.version = version;
+    this.sortedAddFiles = sortedAddFiles;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public Dataset<Row> getSortedAddFiles() {
+    return sortedAddFiles;
+  }
+
+  @Override
+  public void close() {
+    Dataset<Row> df = sortedAddFiles;
+    if (df != null) {
+      df.unpersist();
+      sortedAddFiles = null;
+    }
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import io.delta.kernel.Scan;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.spark.internal.v2.utils.KernelRowToSparkRow;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import io.delta.spark.internal.v2.utils.SerializableReadOnlySnapshot;
+import io.delta.spark.internal.v2.utils.StreamingHelper;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.apache.spark.Partition;
+import org.apache.spark.SparkContext;
+import org.apache.spark.TaskContext;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
+import scala.reflect.ClassTag$;
+
+/**
+ * A single-partition Spark RDD that reconstructs a Kernel {@link Scan} on the executor from a
+ * {@link SerializableReadOnlySnapshot} and lazily streams {@link AddFile} records as Spark {@link
+ * Row}s. The RDD output schema matches {@link AddFile#SCHEMA_WITHOUT_STATS}.
+ *
+ * <p>Single partition is an intentional limitation; a future version will use Kernel's plan API for
+ * multi-partition replay. The downstream sort is still distributed.
+ */
+public class ScanFileRDD extends RDD<Row> {
+
+  public static final StructType SPARK_SCHEMA =
+      SchemaUtils.convertKernelSchemaToSparkSchema(AddFile.SCHEMA_WITHOUT_STATS);
+
+  private final SerializableReadOnlySnapshot serializableSnapshot;
+
+  public ScanFileRDD(SparkContext sc, SerializableReadOnlySnapshot serializableSnapshot) {
+    super(
+        sc,
+        scala.collection.immutable.Seq$.MODULE$.<org.apache.spark.Dependency<?>>empty(),
+        ClassTag$.MODULE$.apply(Row.class));
+    this.serializableSnapshot = serializableSnapshot;
+  }
+
+  private static final class SinglePartition implements Partition, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public int index() {
+      return 0;
+    }
+  }
+
+  @Override
+  public Partition[] getPartitions() {
+    return new Partition[] {new SinglePartition()};
+  }
+
+  @Override
+  public scala.collection.Iterator<Row> compute(Partition split, TaskContext context) {
+    Engine engine = DefaultEngine.create(serializableSnapshot.getHadoopConf());
+    Scan scan = serializableSnapshot.toScan();
+
+    CloseableIterator<FilteredColumnarBatch> batchIter;
+    try {
+      batchIter = scan.getScanFiles(engine);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to open scan files on executor", e);
+    }
+
+    AddFileLazyIterator lazyIter = new AddFileLazyIterator(batchIter);
+
+    if (context != null) {
+      context.addTaskCompletionListener(
+          ctx -> {
+            try {
+              batchIter.close();
+            } catch (IOException e) {
+              // best effort cleanup
+            }
+          });
+    }
+
+    return lazyIter;
+  }
+
+  /**
+   * Lazy Scala iterator that streams AddFile rows one at a time from the underlying Kernel batch
+   * iterator. No eager materialization into a list.
+   */
+  private static final class AddFileLazyIterator implements scala.collection.Iterator<Row> {
+
+    private final CloseableIterator<FilteredColumnarBatch> batchIter;
+
+    private FilteredColumnarBatch currentBatch;
+    private int currentRowId;
+    private int currentBatchSize;
+    private Row nextRow;
+
+    AddFileLazyIterator(CloseableIterator<FilteredColumnarBatch> batchIter) {
+      this.batchIter = batchIter;
+      this.currentBatch = null;
+      this.currentRowId = 0;
+      this.currentBatchSize = 0;
+      this.nextRow = null;
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (nextRow != null) {
+        return true;
+      }
+      nextRow = advance();
+      return nextRow != null;
+    }
+
+    @Override
+    public Row next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      Row result = nextRow;
+      nextRow = null;
+      return result;
+    }
+
+    private Row advance() {
+      while (true) {
+        while (currentRowId < currentBatchSize) {
+          int rowId = currentRowId++;
+          Optional<AddFile> addOpt = StreamingHelper.getAddFile(currentBatch, rowId);
+          if (addOpt.isPresent()) {
+            return new KernelRowToSparkRow(addOpt.get().toRow(), SPARK_SCHEMA);
+          }
+        }
+        if (!batchIter.hasNext()) {
+          return null;
+        }
+        currentBatch = batchIter.next();
+        currentRowId = 0;
+        currentBatchSize = currentBatch.getData().getSize();
+      }
+    }
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
@@ -87,6 +87,8 @@ public class ScanFileRDD extends RDD<Row> {
     CloseableIterator<FilteredColumnarBatch> batchIter;
     try {
       batchIter = scan.getScanFiles(engine);
+    } catch (KernelEngineException e) {
+      throw e;
     } catch (Exception e) {
       throw new KernelEngineException("open scan files on executor", e);
     }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
@@ -101,8 +101,7 @@ public class ScanFileRDD extends RDD<Row> {
             try {
               batchIter.close();
             } catch (IOException e) {
-              LOG.warn(
-                  "Failed to close scan file iterator for distributed initial snapshot", e);
+              LOG.warn("Failed to close scan file iterator for distributed initial snapshot", e);
             }
           });
     }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
@@ -19,6 +19,7 @@ import io.delta.kernel.Scan;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.KernelEngineException;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.utils.KernelRowToSparkRow;
@@ -35,6 +36,8 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.reflect.ClassTag$;
 
 /**
@@ -46,6 +49,8 @@ import scala.reflect.ClassTag$;
  * multi-partition replay. The downstream sort is still distributed.
  */
 public class ScanFileRDD extends RDD<Row> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ScanFileRDD.class);
 
   public static final StructType SPARK_SCHEMA =
       SchemaUtils.convertKernelSchemaToSparkSchema(AddFile.SCHEMA_WITHOUT_STATS);
@@ -83,7 +88,7 @@ public class ScanFileRDD extends RDD<Row> {
     try {
       batchIter = scan.getScanFiles(engine);
     } catch (Exception e) {
-      throw new RuntimeException("Failed to open scan files on executor", e);
+      throw new KernelEngineException("open scan files on executor", e);
     }
 
     AddFileLazyIterator lazyIter = new AddFileLazyIterator(batchIter);
@@ -94,7 +99,8 @@ public class ScanFileRDD extends RDD<Row> {
             try {
               batchIter.close();
             } catch (IOException e) {
-              // best effort cleanup
+              LOG.warn(
+                  "Failed to close scan file iterator for distributed initial snapshot", e);
             }
           });
     }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import io.delta.kernel.Scan;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.ScanImpl;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.checksum.CRCInfo;
+import io.delta.kernel.internal.lang.Lazy;
+import io.delta.kernel.internal.metrics.SnapshotQueryContext;
+import io.delta.kernel.internal.metrics.SnapshotReportImpl;
+import io.delta.kernel.internal.replay.LogReplay;
+import io.delta.kernel.internal.snapshot.LogSegment;
+import io.delta.kernel.metrics.SnapshotReport;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.util.SerializableConfiguration;
+
+/**
+ * Serializable carrier for a Delta snapshot's state. Created on the driver from an existing {@link
+ * SnapshotImpl} (zero I/O), and reconstructed on the executor as a read-only {@link Scan} via
+ * {@link #toScan(Configuration)}. The returned {@code Scan} interface exposes only read operations,
+ * preventing accidental misuse of write-path APIs (e.g. {@code Committer}).
+ */
+public class SerializableReadOnlySnapshot implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String dataPath;
+  private final String logPath;
+  private final long version;
+
+  private final ArrayList<SerializableFileStatus> deltas;
+  private final ArrayList<SerializableFileStatus> compactions;
+  private final ArrayList<SerializableFileStatus> checkpoints;
+  private final SerializableFileStatus deltaAtEndVersion;
+  private final SerializableFileStatus lastSeenChecksum; // nullable
+  private final Long maxPublishedDeltaVersion; // nullable
+
+  private final Protocol protocol;
+  private final Metadata metadata;
+  private final SerializableConfiguration hadoopConf;
+
+  private SerializableReadOnlySnapshot(
+      String dataPath,
+      String logPath,
+      long version,
+      ArrayList<SerializableFileStatus> deltas,
+      ArrayList<SerializableFileStatus> compactions,
+      ArrayList<SerializableFileStatus> checkpoints,
+      SerializableFileStatus deltaAtEndVersion,
+      SerializableFileStatus lastSeenChecksum,
+      Long maxPublishedDeltaVersion,
+      Protocol protocol,
+      Metadata metadata,
+      SerializableConfiguration hadoopConf) {
+    this.dataPath = dataPath;
+    this.logPath = logPath;
+    this.version = version;
+    this.deltas = deltas;
+    this.compactions = compactions;
+    this.checkpoints = checkpoints;
+    this.deltaAtEndVersion = deltaAtEndVersion;
+    this.lastSeenChecksum = lastSeenChecksum;
+    this.maxPublishedDeltaVersion = maxPublishedDeltaVersion;
+    this.protocol = protocol;
+    this.metadata = metadata;
+    this.hadoopConf = hadoopConf;
+  }
+
+  /**
+   * Driver-side: extract the snapshot state from an existing Kernel {@link SnapshotImpl}. This
+   * performs zero I/O — all data is already in memory on the driver.
+   */
+  public static SerializableReadOnlySnapshot fromSnapshot(
+      SnapshotImpl snapshot, Configuration hadoopConf) {
+    LogSegment logSegment = snapshot.getLogSegment();
+    return new SerializableReadOnlySnapshot(
+        snapshot.getDataPath().toString(),
+        logSegment.getLogPath().toString(),
+        snapshot.getVersion(),
+        new ArrayList<>(SerializableFileStatus.fromList(logSegment.getDeltas())),
+        new ArrayList<>(SerializableFileStatus.fromList(logSegment.getCompactions())),
+        new ArrayList<>(SerializableFileStatus.fromList(logSegment.getCheckpoints())),
+        SerializableFileStatus.from(logSegment.getDeltaFileAtEndVersion()),
+        logSegment.getLastSeenChecksum().map(SerializableFileStatus::from).orElse(null),
+        logSegment.getMaxPublishedDeltaVersion().orElse(null),
+        snapshot.getProtocol(),
+        snapshot.getMetadata(),
+        new SerializableConfiguration(hadoopConf));
+  }
+
+  /**
+   * Executor-side: reconstruct a read-only {@link Scan} from the serialized snapshot state. The
+   * returned {@code Scan} only exposes {@code getScanFiles()} — no write-path or commit APIs.
+   */
+  public Scan toScan(Configuration hadoopConfOverride) {
+    return buildScan(hadoopConfOverride);
+  }
+
+  /**
+   * Executor-side: reconstruct using the serialized Hadoop configuration. Convenience overload when
+   * no conf override is needed.
+   */
+  public Scan toScan() {
+    return buildScan(hadoopConf.value());
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  /** Returns the serialized Hadoop configuration for creating an Engine on the executor. */
+  public Configuration getHadoopConf() {
+    return hadoopConf.value();
+  }
+
+  // ---- internal reconstruction ----
+
+  private Scan buildScan(Configuration conf) {
+    Engine engine = DefaultEngine.create(conf);
+    io.delta.kernel.internal.fs.Path kernelDataPath =
+        new io.delta.kernel.internal.fs.Path(dataPath);
+    io.delta.kernel.internal.fs.Path kernelLogPath = new io.delta.kernel.internal.fs.Path(logPath);
+
+    LogSegment logSegment =
+        new LogSegment(
+            kernelLogPath,
+            version,
+            SerializableFileStatus.toFileStatusList(deltas),
+            SerializableFileStatus.toFileStatusList(compactions),
+            SerializableFileStatus.toFileStatusList(checkpoints),
+            deltaAtEndVersion.toFileStatus(),
+            Optional.ofNullable(lastSeenChecksum).map(SerializableFileStatus::toFileStatus),
+            Optional.ofNullable(maxPublishedDeltaVersion));
+
+    Lazy<LogSegment> lazyLogSegment = new Lazy<>(() -> logSegment);
+    Lazy<Optional<CRCInfo>> lazyCrcInfo = new Lazy<>(Optional::empty);
+
+    LogReplay logReplay = new LogReplay(engine, kernelDataPath, lazyLogSegment, lazyCrcInfo);
+
+    SnapshotQueryContext queryContext = SnapshotQueryContext.forVersionSnapshot(dataPath, version);
+    queryContext.setResolvedVersion(version);
+    SnapshotReport snapshotReport = SnapshotReportImpl.forSuccess(queryContext);
+
+    return new ScanImpl(
+        metadata.getSchema(),
+        metadata.getSchema(),
+        protocol,
+        metadata,
+        logReplay,
+        Optional.empty(),
+        kernelDataPath,
+        snapshotReport);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -44,8 +44,7 @@ import org.apache.spark.util.SerializableConfiguration;
  * <p>TODO: This class relies on 10 {@code io.delta.kernel.internal.*} packages which have no
  * stability guarantees. Any Kernel refactor (constructor signature changes, package moves, class
  * renames) will break this code without warning. This is temporary until Kernel exposes a public
- * serialization API (e.g. {@code Snapshot.toSerializableReadOnlyState()}). Track:
- * https://github.com/delta-io/delta/issues/XXXXX
+ * serialization API (e.g. {@code Snapshot.toSerializableReadOnlyState()}).
  */
 public class SerializableReadOnlySnapshot implements Serializable {
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -49,11 +49,11 @@ public class SerializableReadOnlySnapshot implements Serializable {
   private final String logPath;
   private final long version;
 
-  private final ArrayList<SerializableFileStatus> deltas;
-  private final ArrayList<SerializableFileStatus> compactions;
-  private final ArrayList<SerializableFileStatus> checkpoints;
-  private final SerializableFileStatus deltaAtEndVersion;
-  private final SerializableFileStatus lastSeenChecksum; // nullable
+  private final ArrayList<SerializableKernelFileStatus> deltas;
+  private final ArrayList<SerializableKernelFileStatus> compactions;
+  private final ArrayList<SerializableKernelFileStatus> checkpoints;
+  private final SerializableKernelFileStatus deltaAtEndVersion;
+  private final SerializableKernelFileStatus lastSeenChecksum; // nullable
   private final Long maxPublishedDeltaVersion; // nullable
 
   private final Protocol protocol;
@@ -64,11 +64,11 @@ public class SerializableReadOnlySnapshot implements Serializable {
       String dataPath,
       String logPath,
       long version,
-      ArrayList<SerializableFileStatus> deltas,
-      ArrayList<SerializableFileStatus> compactions,
-      ArrayList<SerializableFileStatus> checkpoints,
-      SerializableFileStatus deltaAtEndVersion,
-      SerializableFileStatus lastSeenChecksum,
+      ArrayList<SerializableKernelFileStatus> deltas,
+      ArrayList<SerializableKernelFileStatus> compactions,
+      ArrayList<SerializableKernelFileStatus> checkpoints,
+      SerializableKernelFileStatus deltaAtEndVersion,
+      SerializableKernelFileStatus lastSeenChecksum,
       Long maxPublishedDeltaVersion,
       Protocol protocol,
       Metadata metadata,
@@ -98,11 +98,11 @@ public class SerializableReadOnlySnapshot implements Serializable {
         snapshot.getDataPath().toString(),
         logSegment.getLogPath().toString(),
         snapshot.getVersion(),
-        new ArrayList<>(SerializableFileStatus.fromList(logSegment.getDeltas())),
-        new ArrayList<>(SerializableFileStatus.fromList(logSegment.getCompactions())),
-        new ArrayList<>(SerializableFileStatus.fromList(logSegment.getCheckpoints())),
-        SerializableFileStatus.from(logSegment.getDeltaFileAtEndVersion()),
-        logSegment.getLastSeenChecksum().map(SerializableFileStatus::from).orElse(null),
+        new ArrayList<>(SerializableKernelFileStatus.fromList(logSegment.getDeltas())),
+        new ArrayList<>(SerializableKernelFileStatus.fromList(logSegment.getCompactions())),
+        new ArrayList<>(SerializableKernelFileStatus.fromList(logSegment.getCheckpoints())),
+        SerializableKernelFileStatus.from(logSegment.getDeltaFileAtEndVersion()),
+        logSegment.getLastSeenChecksum().map(SerializableKernelFileStatus::from).orElse(null),
         logSegment.getMaxPublishedDeltaVersion().orElse(null),
         snapshot.getProtocol(),
         snapshot.getMetadata(),
@@ -146,11 +146,11 @@ public class SerializableReadOnlySnapshot implements Serializable {
         new LogSegment(
             kernelLogPath,
             version,
-            SerializableFileStatus.toFileStatusList(deltas),
-            SerializableFileStatus.toFileStatusList(compactions),
-            SerializableFileStatus.toFileStatusList(checkpoints),
+            SerializableKernelFileStatus.toFileStatusList(deltas),
+            SerializableKernelFileStatus.toFileStatusList(compactions),
+            SerializableKernelFileStatus.toFileStatusList(checkpoints),
             deltaAtEndVersion.toFileStatus(),
-            Optional.ofNullable(lastSeenChecksum).map(SerializableFileStatus::toFileStatus),
+            Optional.ofNullable(lastSeenChecksum).map(SerializableKernelFileStatus::toFileStatus),
             Optional.ofNullable(maxPublishedDeltaVersion));
 
     Lazy<LogSegment> lazyLogSegment = new Lazy<>(() -> logSegment);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -154,6 +154,10 @@ public class SerializableReadOnlySnapshot implements Serializable {
             Optional.ofNullable(maxPublishedDeltaVersion));
 
     Lazy<LogSegment> lazyLogSegment = new Lazy<>(() -> logSegment);
+    // CRC validation was already performed on the driver when snapshotAtSourceInit was
+    // constructed. CRC is an integrity check, not a correctness requirement for read-only
+    // log replay. Skipping it here avoids an unnecessary I/O round-trip to fetch the CRC
+    // file on each executor.
     Lazy<Optional<CRCInfo>> lazyCrcInfo = new Lazy<>(Optional::empty);
 
     LogReplay logReplay = new LogReplay(engine, kernelDataPath, lazyLogSegment, lazyCrcInfo);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -40,6 +40,12 @@ import org.apache.spark.util.SerializableConfiguration;
  * SnapshotImpl} (zero I/O), and reconstructed on the executor as a read-only {@link Scan} via
  * {@link #toScan(Configuration)}. The returned {@code Scan} interface exposes only read operations,
  * preventing accidental misuse of write-path APIs (e.g. {@code Committer}).
+ *
+ * <p>TODO: This class relies on 10 {@code io.delta.kernel.internal.*} packages which have no
+ * stability guarantees. Any Kernel refactor (constructor signature changes, package moves, class
+ * renames) will break this code without warning. This is temporary until Kernel exposes a public
+ * serialization API (e.g. {@code Snapshot.toSerializableReadOnlyState()}). Track:
+ * https://github.com/delta-io/delta/issues/XXXXX
  */
 public class SerializableReadOnlySnapshot implements Serializable {
 
@@ -154,10 +160,11 @@ public class SerializableReadOnlySnapshot implements Serializable {
             Optional.ofNullable(maxPublishedDeltaVersion));
 
     Lazy<LogSegment> lazyLogSegment = new Lazy<>(() -> logSegment);
-    // CRC validation was already performed on the driver when snapshotAtSourceInit was
-    // constructed. CRC is an integrity check, not a correctness requirement for read-only
-    // log replay. Skipping it here avoids an unnecessary I/O round-trip to fetch the CRC
-    // file on each executor.
+    // CRC is passed as empty because this Scan is only used for getScanFiles() which does not
+    // consult CRC. CRC validation was already performed on the driver when snapshotAtSourceInit
+    // was constructed. NOTE: if LogReplay.getActiveDomainMetadataMap() were ever called on this
+    // reconstructed snapshot, it would fall back to a full log scan (Case 1 in
+    // loadDomainMetadataMap) instead of the O(1) CRC shortcut — correct but expensive.
     Lazy<Optional<CRCInfo>> lazyCrcInfo = new Lazy<>(Optional::empty);
 
     LogReplay logReplay = new LogReplay(engine, kernelDataPath, lazyLogSegment, lazyCrcInfo);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import io.delta.spark.internal.v2.utils.SerializableReadOnlySnapshot;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ScanFileRDDTest extends DeltaV2TestBase {
+
+  @TempDir java.io.File tempDir;
+
+  @Test
+  public void testScanFileRDDProducesAddFileRows() {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.range(100).repartition(5).write().format("delta").save(tablePath);
+
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+
+    SerializableReadOnlySnapshot serializable =
+        SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
+
+    ScanFileRDD rdd = new ScanFileRDD(spark.sparkContext(), serializable);
+    Dataset<Row> df = spark.createDataFrame(rdd, ScanFileRDD.SPARK_SCHEMA);
+
+    List<Row> rows = df.collectAsList();
+    assertEquals(5, rows.size(), "Should have 5 parquet files from repartition(5)");
+
+    for (Row row : rows) {
+      String path = row.getAs("path");
+      assertNotNull(path, "path should not be null");
+      assertFalse(path.isEmpty(), "path should not be empty");
+    }
+  }
+
+  @Test
+  public void testScanFileRDDSortable() {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.range(50).repartition(3).write().format("delta").save(tablePath);
+
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+
+    SerializableReadOnlySnapshot serializable =
+        SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
+
+    ScanFileRDD rdd = new ScanFileRDD(spark.sparkContext(), serializable);
+    Dataset<Row> df = spark.createDataFrame(rdd, ScanFileRDD.SPARK_SCHEMA);
+
+    Dataset<Row> sorted = df.orderBy("modificationTime", "path");
+    List<Row> rows = sorted.collectAsList();
+    assertEquals(3, rows.size());
+
+    for (int i = 1; i < rows.size(); i++) {
+      long prevTime = rows.get(i - 1).getAs("modificationTime");
+      long currTime = rows.get(i).getAs("modificationTime");
+      String prevPath = rows.get(i - 1).getAs("path");
+      String currPath = rows.get(i).getAs("path");
+      assertTrue(
+          prevTime < currTime || (prevTime == currTime && prevPath.compareTo(currPath) <= 0),
+          "Rows should be sorted by modificationTime then path");
+    }
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.delta.kernel.Scan;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SerializableReadOnlySnapshotTest extends DeltaV2TestBase {
+
+  @TempDir java.io.File tempDir;
+
+  @Test
+  public void testSerializationRoundTrip() throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.range(10).write().format("delta").save(tablePath);
+
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+
+    SerializableReadOnlySnapshot original =
+        SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
+
+    byte[] bytes;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(original);
+      bytes = baos.toByteArray();
+    }
+
+    SerializableReadOnlySnapshot deserialized;
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(bais)) {
+      deserialized = (SerializableReadOnlySnapshot) ois.readObject();
+    }
+
+    assertEquals(original.getVersion(), deserialized.getVersion());
+
+    Scan scan = deserialized.toScan();
+    assertNotNull(scan);
+
+    Engine engine = DefaultEngine.create(deserialized.getHadoopConf());
+    List<FilteredColumnarBatch> batches = new ArrayList<>();
+    try (CloseableIterator<FilteredColumnarBatch> iter = scan.getScanFiles(engine)) {
+      while (iter.hasNext()) {
+        batches.add(iter.next());
+      }
+    }
+    assertFalse(batches.isEmpty(), "Deserialized scan should produce file batches");
+  }
+
+  @Test
+  public void testToScanReturnsReadOnlyScan() {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.range(5).write().format("delta").save(tablePath);
+
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+
+    SerializableReadOnlySnapshot serializable =
+        SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
+
+    Scan scan = serializable.toScan();
+    assertNotNull(scan);
+    assertNotNull(scan.getScanState(defaultEngine));
+    assertNotNull(scan.getRemainingFilter());
+  }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6702/files) to review incremental changes.
- [stack/streaming_phase0_pr1](https://github.com/delta-io/delta/pull/6700) [[Files changed](https://github.com/delta-io/delta/pull/6700/files)] [MERGED]
  - [stack/streaming_phase0_pr2](https://github.com/delta-io/delta/pull/6701) [[Files changed](https://github.com/delta-io/delta/pull/6701/files)] [MERGED]
    - [**stack/streaming_phase0_pr3**](https://github.com/delta-io/delta/pull/6702) [[Files changed](https://github.com/delta-io/delta/pull/6702/files)]
      - [stack/streaming_phase0_pr4](https://github.com/delta-io/delta/pull/6703) [[Files changed](https://github.com/delta-io/delta/pull/6703/files/aa42034e4900d5dc5c65a30596c890b4a007675e..43f4acce7ec9d6b1570cb84cc34f5f3c8f5d9728)]
        - [stack/streaming_phase0_pr5](https://github.com/delta-io/delta/pull/6706) [[Files changed](https://github.com/delta-io/delta/pull/6706/files/43f4acce7ec9d6b1570cb84cc34f5f3c8f5d9728..9657a1d282d9939cb5ce4987fcddb4280cb9e293)]
          - [stack/streaming_phase0_pr6](https://github.com/delta-io/delta/pull/6807) [[Files changed](https://github.com/delta-io/delta/pull/6807/files/9657a1d282d9939cb5ce4987fcddb4280cb9e293..464cadc7b21c4be4244792686edb4363977a8b73)]
            - [stack/streaming_phase0_pr7](https://github.com/delta-io/delta/pull/6808) [[Files changed](https://github.com/delta-io/delta/pull/6808/files/464cadc7b21c4be4244792686edb4363977a8b73..1456f0933854b563788118a83c8dc2c1a1960e2d)]

---------
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

### Overall Scope (stacked PRs #6700-#6706)

This PR stack fixes a **driver OOM** in Delta V2 Structured Streaming when processing tables with very long commit histories during the initial snapshot. The existing implementation materializes the entire file listing on the driver, which exhausts memory when the commit history is large (100K+ files). The fix introduces a **distributed initial snapshot** approach that offloads the file listing and sorting to Spark executors via a DataFrame, keeping only metadata on the driver.

The stack is organized as:
- **PR1** (#6700, merged): `SerializableFileStatus` — make kernel `FileStatus` serializable for cross-executor shipping
- **PR2** (#6701): `KernelRowToSparkRow` / `SparkRowToKernelRow` — zero-copy row wrappers for Kernel<->Spark interop
- **PR3** (this PR): `SerializableReadOnlySnapshot`, `ScanFileRDD`, `DataFrameSnapshotCache` — the distributed data plane
- **PR4** (#6703): Integration into `SparkMicroBatchStream` and `SparkScan` behind a feature flag
- **PR5** (#6706): End-to-end integration tests

### This PR

Adds the core infrastructure for distributing the initial snapshot file scan across Spark executors:

- **`SerializableReadOnlySnapshot`**: A serializable wrapper around Kernel's `SnapshotImpl` that reconstructs a read-only snapshot on executors. Captures the minimal state needed (table path, log segment, protocol/metadata, schema, version) and rebuilds the snapshot using Kernel internals. CRC validation is skipped on executors since it was already performed on the driver during `snapshotAtSourceInit`. Uses 8 `kernel.internal.*` packages — documented as temporary until Kernel exposes a public serialization API.

- **`ScanFileRDD`**: An `RDD[Row]` that replays the Delta log on each executor partition to produce `IndexedFile` rows. Each partition receives a `SerializableReadOnlySnapshot` and a partition range, performs log replay via `getScanFiles()`, and converts Kernel rows to Spark rows using `KernelRowToSparkRow` (from PR2). Exceptions are wrapped as `KernelEngineException` with typed error codes. Failed `close()` on the batch iterator is logged at WARN level.

- **`DataFrameSnapshotCache`**: Orchestrates the distributed scan — creates the `ScanFileRDD`, wraps it in a DataFrame, persists with `DISK_ONLY` storage level (to avoid executor OOM on large snapshots), and provides a `getFileChanges(fromIndex)` method that returns an iterator of `IndexedFile` rows starting from the given offset.

## How was this patch tested?

- `ScanFileRDDTest`: Verifies correct RDD partition creation, row emission from log replay, and proper cleanup of Kernel resources.
- `SerializableReadOnlySnapshotTest`: Tests serialization round-trip (Java serialization → deserialization → usable snapshot), list file emission correctness, and schema preservation.

Run with: `build/sbt 'sparkV2/testOnly *ScanFileRDDTest *SerializableReadOnlySnapshotTest'`

## Does this PR introduce _any_ user-facing changes?

No. These are internal implementation classes for the distributed initial snapshot feature, gated behind a feature flag (introduced in PR4).