### PR TITLE
[UniForm] Reuse nested field IDs during Iceberg conversion when overwriting

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -379,6 +379,45 @@ class UniFormConverterSuite extends
     }
   }
 
+  test("overwriteSchema=false (default) with DataFrame should preserve nested field IDs " +
+      "and not bump Iceberg metadata") {
+    val tableName = "test_overwrite_default_nested_ids"
+    withTable(tableName) {
+      spark.sql(
+        s"""CREATE TABLE $tableName (id INT, tags MAP<STRING, STRING>, vals ARRAY<INT>)
+           |USING DELTA TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      spark.sql(s"INSERT INTO $tableName VALUES (1, map('k', 'v'), array(10))")
+
+      val tableId = TableIdentifier(tableName)
+      val deltaLogBefore = DeltaLog.forTable(spark, tableId).update()
+      val maxIdBefore = DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(deltaLogBefore.metadata)
+      val metaBefore = latestIcebergTable(tableName).asInstanceOf[BaseTable].operations().current()
+      val schemaIdBefore = metaBefore.currentSchemaId()
+      val lastColIdBefore = metaBefore.lastColumnId()
+
+      spark.table(tableName)
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .saveAsTable(tableName)
+
+      val deltaLogAfter = DeltaLog.forTable(spark, tableId).update()
+      val maxIdAfter = DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(deltaLogAfter.metadata)
+      assert(maxIdAfter === maxIdBefore,
+        s"Delta columnMappingMaxId should not change (before=$maxIdBefore, after=$maxIdAfter)")
+
+      val metaAfter = latestIcebergTable(tableName).asInstanceOf[BaseTable].operations().current()
+      assert(metaAfter.currentSchemaId() === schemaIdBefore,
+        "Iceberg current-schema-id should not change on overwrite with same schema")
+      assert(metaAfter.lastColumnId() === lastColIdBefore,
+        "Iceberg last-column-id should not change on overwrite with same schema")
+    }
+  }
+
   test("IcebergConverter convertUncommitedTxn - incremental conversion") {
     val tableName = "test_incremental_conversion"
     withTable(tableName) {

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -17,13 +17,14 @@
 package org.apache.spark.sql.delta.uniform
 
 import com.databricks.spark.util.Log4jUsageLogger
+import shadedForDelta.org.apache.iceberg.BaseTable
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, DeltaOperations, DeltaTableReadPredicate, IcebergConstants, Snapshot}
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableReadPredicate, IcebergConstants, Snapshot}
 import org.apache.spark.sql.delta.DeltaTestUtils.filterUsageRecords
 import org.apache.spark.sql.delta.NonSparkReadIceberg
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, DomainMetadata, Metadata}
@@ -325,6 +326,56 @@ class UniFormConverterSuite extends
       val numFilesInIceberg = icebergTable.currentSnapshot().summary().get("total-data-files").toInt
       assert(numFilesInIceberg === currSnapshot.numOfFiles + 2)
       assert(lastConvertedVersion.isEmpty)
+    }
+  }
+
+  private def latestIcebergTable(tableName: String): shadedForDelta.org.apache.iceberg.Table = {
+    val tableId = TableIdentifier(tableName)
+    val deltaLog = DeltaLog.forTable(spark, tableId)
+    val snapshot = deltaLog.update()
+    val catalogTable = spark.sessionState.catalog.getTableMetadata(tableId)
+    val metadataPath = new IcebergConverterForTest()
+      .convertSnapshotAndReturnMetadataPath(snapshot, catalogTable)
+    new HadoopTables(deltaLog.newDeltaHadoopConf()).load(metadataPath)
+  }
+
+  test("overwriteSchema=true with DataFrame should preserve nested field IDs " +
+      "and not bump Iceberg metadata") {
+    val tableName = "test_overwrite_nested_ids"
+    withTable(tableName) {
+      spark.sql(
+        s"""CREATE TABLE $tableName (id INT, tags MAP<STRING, STRING>, vals ARRAY<INT>)
+           |USING DELTA TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      spark.sql(s"INSERT INTO $tableName VALUES (1, map('k', 'v'), array(10))")
+
+      val tableId = TableIdentifier(tableName)
+      val deltaLogBefore = DeltaLog.forTable(spark, tableId).update()
+      val maxIdBefore = DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(deltaLogBefore.metadata)
+      val metaBefore = latestIcebergTable(tableName).asInstanceOf[BaseTable].operations().current()
+      val schemaIdBefore = metaBefore.currentSchemaId()
+      val lastColIdBefore = metaBefore.lastColumnId()
+
+      spark.table(tableName)
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .option("overwriteSchema", "true")
+        .saveAsTable(tableName)
+
+      val deltaLogAfter = DeltaLog.forTable(spark, tableId).update()
+      val maxIdAfter = DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(deltaLogAfter.metadata)
+      assert(maxIdAfter === maxIdBefore,
+        s"Delta columnMappingMaxId should not change (before=$maxIdBefore, after=$maxIdAfter)")
+
+      val metaAfter = latestIcebergTable(tableName).asInstanceOf[BaseTable].operations().current()
+      assert(metaAfter.currentSchemaId() === schemaIdBefore,
+        "Iceberg current-schema-id should not change on overwrite with same schema")
+      assert(metaAfter.lastColumnId() === lastColIdBefore,
+        "Iceberg last-column-id should not change on overwrite with same schema")
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -510,6 +510,19 @@ trait DeltaColumnMappingBase extends DeltaLogging {
 
           builder.putString(COLUMN_MAPPING_PHYSICAL_NAME_KEY, physicalName)
         }
+
+        // When reusing column mapping metadata during overwrite, also carry over the nested IDs
+        // (used for List/Map/Array element fields in IcebergCompat V2+). Without this,
+        // rewriteFieldIdsForIceberg sees no existing nested IDs and assigns new ones,
+        // causing needless Iceberg field ID churn on schema-unchanged overwrites.
+        if (canReuseColumnMappingMetadataDuringOverwrite &&
+            !hasNestedColumnIds(field) &&
+            existingFieldOpt.exists(hasNestedColumnIds)) {
+          builder.putMetadata(
+            COLUMN_MAPPING_METADATA_NESTED_IDS_KEY,
+            getNestedColumnIds(existingFieldOpt.get))
+        }
+
         field.copy(metadata = builder.build())
       })
     // Starting from IcebergCompatV2, we require writing field-id for List/Map nested fields


### PR DESCRIPTION
When overwriteSchema=true is used and the logical schema is unchanged, assignColumnIdAndPhysicalName reuses the existing column ID and physical name via canReuseColumnMappingMetadataDuringOverwrite, but was not carrying over
COLUMN_MAPPING_METADATA_NESTED_IDS_KEY. This caused rewriteFieldIdsForIceberg (IcebergCompat V2+) to assign fresh element field IDs for List/Map/Array columns on every overwrite, incrementing last-column-id and bumping the Iceberg schema version unnecessarily on each write. 

While not a correctness issue because it's an overwrite anyways the schema ID bump can cause downstream systems to react in a weird way needlessly (if they're depending on schema ID changes to detect schema evolutions). Uniform can just try and reuse the nested field IDs when possible on overwrite to prevent these situations.

Fix: carry over COLUMN_MAPPING_METADATA_NESTED_IDS_KEY in the same branch where column ID and physical name are reused.

Test: added to UniFormConverterSuite — verifies that after a DataFrame overwriteSchema=true overwrite with an identical schema, the Delta columnMappingMaxId, Iceberg current-schema-id, and last-column-id are all unchanged.

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Uniform)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
