### PR TITLE
[UniForm] Support Incremental Conversion: Part1

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -66,12 +66,6 @@ object IcebergConverter {
    */
   val BASE_DELTA_VERSION_PROPERTY = "base-delta-version"
 
-  /** CatalogTable property key for the last converted Iceberg metadata location. */
-  val CATALOG_TABLE_ICEBERG_METADATA_LOCATION = "deltaUniformIceberg.metadataLocation"
-
-  /** CatalogTable property key for the last converted Delta version. */
-  val CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION = "deltaUniformIceberg.convertedDeltaVersion"
-
   def getLastConvertedDeltaVersion(table: Option[IcebergTable]): Option[Long] =
     table.flatMap(_.properties().asScala.get(DELTA_VERSION_PROPERTY)).map(_.toLong)
 
@@ -241,10 +235,10 @@ class IcebergConverter
       deltaLog: DeltaLog,
       enablingUniForm: Boolean): LastConvertedIcebergInfo = {
     val baseMetadataLocation =
-      catalogTable.properties.get(IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION)
+      catalogTable.properties.get(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP)
     val lastDeltaVersionConverted =
       catalogTable.properties.get(
-        IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION).map(_.toLong)
+        IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP).map(_.toLong)
     val lastConvertedIcebergTable =
       baseMetadataLocation.map(new HadoopTables(deltaLog.newDeltaHadoopConf()).load(_))
     val lastConvertedIcebergSnapshotId =

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -302,8 +302,7 @@ class IcebergConverter
 
       val icebergTxn = new IcebergConversionTransaction(
         spark, catalogTable, log.newDeltaHadoopConf(), snapshotToConvert, tableOp,
-        lastConvertedIcebergSnapshotId, lastDeltaVersionConverted
-        , baseMetadataLocation
+        lastConvertedIcebergSnapshotId, lastDeltaVersionConverted, baseMetadataLocation
       )
 
       val convertedCommits: Seq[Option[CommitInfo]] = prevConvertedSnapshotOpt match {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -66,6 +66,12 @@ object IcebergConverter {
    */
   val BASE_DELTA_VERSION_PROPERTY = "base-delta-version"
 
+  /** CatalogTable property key for the last converted Iceberg metadata location. */
+  val CATALOG_TABLE_ICEBERG_METADATA_LOCATION = "deltaUniformIceberg.metadataLocation"
+
+  /** CatalogTable property key for the last converted Delta version. */
+  val CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION = "deltaUniformIceberg.convertedDeltaVersion"
+
   def getLastConvertedDeltaVersion(table: Option[IcebergTable]): Option[Long] =
     table.flatMap(_.properties().asScala.get(DELTA_VERSION_PROPERTY)).map(_.toLong)
 
@@ -196,13 +202,15 @@ class IcebergConverter
       val snapshotToConvert = getSnapshotForUncommitedTxn(
         deltaLog, txnInfo, deltaAttemptVersion, catalogTable
       )
-
+      val enablingUniForm =
+        UniversalFormat.icebergEnabled(txnInfo.metadata) &&
+          !UniversalFormat.icebergEnabled(txnInfo.readSnapshot.metadata)
+      val lastConvertedInfo =
+        fetchLastConvertedIcebergInfo(refreshedTable, deltaLog, enablingUniForm)
       val icebergTxn = convertSnapshotInternal(
         snapshotToConvert,
         readSnapshotOpt = Some(txnInfo.readSnapshot),
-        lastConvertedInfo = LastConvertedIcebergInfo(
-          None, None, None, None
-        ),
+        lastConvertedInfo = lastConvertedInfo,
         conversionContext = new ConversionContext(
           conversionMode = UNIFORM_CC_MODE,
           additionalDeltaActionsToCommit = Some(txnInfo.finalActionsToCommit),
@@ -212,7 +220,7 @@ class IcebergConverter
       )
 
       val (newMetadataPath, _) = icebergTxn.getConvertedIcebergMetadata
-      (newMetadataPath, None)
+      (newMetadataPath, lastConvertedInfo.deltaVersionConverted)
     }
 
   private def refreshCatalogTableIfNeeded(
@@ -220,6 +228,34 @@ class IcebergConverter
       deltaAttemptVersion: Long,
       catalogTable: CatalogTable): CatalogTable = {
     catalogTable
+  }
+
+
+  /**
+   * Reads the last converted Iceberg state from the catalogTable properties.
+   * The catalogTable does not have a deltaUniformIceberg field; instead the metadata location
+   * and last converted delta version are stored as plain table properties as a workaround
+   */
+  protected def fetchLastConvertedIcebergInfo(
+      catalogTable: CatalogTable,
+      deltaLog: DeltaLog,
+      enablingUniForm: Boolean): LastConvertedIcebergInfo = {
+    val baseMetadataLocation =
+      catalogTable.properties.get(IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION)
+    val lastDeltaVersionConverted =
+      catalogTable.properties.get(
+        IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION).map(_.toLong)
+    val lastConvertedIcebergTable =
+      baseMetadataLocation.map(new HadoopTables(deltaLog.newDeltaHadoopConf()).load(_))
+    val lastConvertedIcebergSnapshotId =
+      lastConvertedIcebergTable.flatMap(it => Option(it.currentSnapshot())).map(_.snapshotId())
+
+    LastConvertedIcebergInfo(
+      icebergTable = lastConvertedIcebergTable,
+      icebergSnapshotId = lastConvertedIcebergSnapshotId,
+      deltaVersionConverted = lastDeltaVersionConverted,
+      baseMetadataLocationOpt = baseMetadataLocation
+    )
   }
 
   /**
@@ -273,6 +309,7 @@ class IcebergConverter
       val icebergTxn = new IcebergConversionTransaction(
         spark, catalogTable, log.newDeltaHadoopConf(), snapshotToConvert, tableOp,
         lastConvertedIcebergSnapshotId, lastDeltaVersionConverted
+        , baseMetadataLocation
       )
 
       val convertedCommits: Seq[Option[CommitInfo]] = prevConvertedSnapshotOpt match {
@@ -280,6 +317,8 @@ class IcebergConverter
           // Read the actions directly from the delta json files.
           // TODO: Run this as a spark job on executors
           val endVersion = conversionMode match {
+            case UNIFORM_CC_MODE =>
+              snapshotToConvert.version - 1
             case _ => snapshotToConvert.version
           }
           val deltaFiles = DeltaFileProviderUtils.getDeltaFilesInVersionRange(

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -23,10 +23,12 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, DeltaOperations, DeltaTableReadPredicate, Snapshot}
+import org.apache.spark.sql.delta.DeltaTestUtils.filterUsageRecords
 import org.apache.spark.sql.delta.NonSparkReadIceberg
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, DomainMetadata, Metadata}
 import org.apache.spark.sql.delta.icebergShaded.{IcebergConverter, UNIFORM_CC_MODE, UNIFORM_POST_COMMIT_MODE}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.test.SharedSparkSession
 
 class IcebergConverterForTest extends IcebergConverter {
@@ -88,6 +90,28 @@ class UniFormConverterSuite extends
       domainMetadata = Seq.empty,
       op = DeltaOperations.Write(mode = org.apache.spark.sql.SaveMode.Append)
     )
+  }
+
+  def catalogTableWithDeltaUniformIceberg(
+      catalogTable: CatalogTable,
+      metadataPath: String,
+      convertedDeltaVersion: Long): CatalogTable =
+    catalogTable.copy(
+      properties = catalogTable.properties +
+        (IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION -> metadataPath) +
+        (IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION ->
+          convertedDeltaVersion.toString)
+    )
+
+  def assertDeltaCommitRangeEvent(
+      events: Seq[com.databricks.spark.util.UsageRecord],
+      expectedFromVersion: Long,
+      expectedToVersion: Long): Unit = {
+    val rangeEvents = filterUsageRecords(events, "delta.iceberg.conversion.deltaCommitRange")
+    assert(rangeEvents.nonEmpty, "Expected deltaCommitRange event for incremental conversion")
+    val eventData = JsonUtils.fromJson[Map[String, Any]](rangeEvents.head.blob)
+    assert(eventData("fromVersion") === expectedFromVersion)
+    assert(eventData("toVersion") === expectedToVersion)
   }
 
   test("Verify convertSnapshot writes Iceberg metadata") {
@@ -297,6 +321,122 @@ class UniFormConverterSuite extends
       val numFilesInIceberg = icebergTable.currentSnapshot().summary().get("total-data-files").toInt
       assert(numFilesInIceberg === currSnapshot.numOfFiles + 2)
       assert(lastConvertedVersion.isEmpty)
+    }
+  }
+
+  test("IcebergConverter convertUncommitedTxn - incremental conversion") {
+    val tableName = "test_incremental_conversion"
+    withTable(tableName) {
+      spark.sql(
+        s"""CREATE TABLE $tableName (id INT) USING DELTA
+           |TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      spark.sql(s"INSERT INTO $tableName VALUES (2)")
+      spark.sql(s"INSERT INTO $tableName VALUES (3)")
+      val tableId = TableIdentifier(tableName)
+      val deltaLog = DeltaLog.forTable(spark, tableId)
+      val snapshot = deltaLog.update()
+      val catalogTable = spark.sessionState.catalog.getTableMetadata(tableId)
+      assert(snapshot.numOfFiles == 3)
+
+      // Do a full conversion to get the initial Iceberg metadata
+      val converter = new IcebergConverterForTest()
+      val metadataPath = converter.convertSnapshotAndReturnMetadataPath(snapshot, catalogTable)
+
+      // Do incremental conversion
+      // Simulate the catalogTable having the deltaUniformIceberg properties set
+      val catalogTableWithIcebergInfo =
+        catalogTableWithDeltaUniformIceberg(catalogTable, metadataPath, snapshot.version)
+      val attemptDeltaVersion = snapshot.version + 1
+      val txnInfo = constructDummyTxnInfo(
+        version = attemptDeltaVersion,
+        readSnapshot = snapshot,
+        newActions = Seq(constructDummyAddFile()),
+        catalogTable = catalogTableWithIcebergInfo,
+        newMetadata = snapshot.metadata
+      )
+
+      var newMetadataPath: String = null
+      var lastConvertedVersion: Option[Long] = None
+      val events = Log4jUsageLogger.track {
+        val (path, version) =
+          converter.convertUncommitedTxn(
+            txnInfo, attemptDeltaVersion, deltaLog, catalogTableWithIcebergInfo)
+        newMetadataPath = path
+        lastConvertedVersion = version
+      }
+
+      // Verify incremental conversion
+      assert(lastConvertedVersion === Some(snapshot.version))
+      val icebergTable = new HadoopTables(deltaLog.newDeltaHadoopConf()).load(newMetadataPath)
+      val numFilesInIceberg =
+        icebergTable.currentSnapshot().summary().get("total-data-files").toInt
+      assert(numFilesInIceberg === snapshot.numOfFiles + 1)
+      assertDeltaCommitRangeEvent(events, snapshot.version + 1, attemptDeltaVersion)
+    }
+  }
+
+  test("IcebergConverter convertUncommitedTxn - incremental conversion with conflict resolution") {
+    val tableName = "test_incremental_conflict"
+    withTable(tableName) {
+      spark.sql(
+        s"""CREATE TABLE $tableName (id INT) USING DELTA
+           |TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      spark.sql(s"INSERT INTO $tableName VALUES (2)")
+      spark.sql(s"INSERT INTO $tableName VALUES (3)")
+      val tableId = TableIdentifier(tableName)
+      val deltaLog = DeltaLog.forTable(spark, tableId)
+      val catalogTable = spark.sessionState.catalog.getTableMetadata(tableId)
+
+      // Do Iceberg conversion for stale Snapshot
+      val staleSnapshot = deltaLog.getSnapshotAt(1)
+      val converter = new IcebergConverterForTest()
+      val staleMetadataPath =
+        converter.convertSnapshotAndReturnMetadataPath(staleSnapshot, catalogTable)
+      val staleIcebergTable =
+        new HadoopTables(deltaLog.newDeltaHadoopConf()).load(staleMetadataPath)
+      assert(
+        staleIcebergTable.currentSnapshot().summary().get("total-data-files").toInt === 1)
+
+      // Do incremental conversion
+      // Simulate the catalogTable having the deltaUniformIceberg properties set
+      val catalogTableWithIcebergInfo = catalogTableWithDeltaUniformIceberg(
+        catalogTable, staleMetadataPath, staleSnapshot.version)
+      val currSnapshot = deltaLog.update()
+      val attemptDeltaVersion = currSnapshot.version + 1
+      val txnInfo = constructDummyTxnInfo(
+        version = attemptDeltaVersion,
+        readSnapshot = staleSnapshot,
+        newActions = Seq(constructDummyAddFile()),
+        catalogTable = catalogTableWithIcebergInfo,
+        newMetadata = staleSnapshot.metadata
+      )
+      var newMetadataPath: String = null
+      var lastConvertedVersion: Option[Long] = None
+      val events = Log4jUsageLogger.track {
+        val (path, version) =
+          converter.convertUncommitedTxn(
+            txnInfo, attemptDeltaVersion, deltaLog, catalogTableWithIcebergInfo)
+        newMetadataPath = path
+        lastConvertedVersion = version
+      }
+
+      // Verify incremental conversion
+      assert(lastConvertedVersion === Some(staleSnapshot.version))
+      val icebergTable = new HadoopTables(deltaLog.newDeltaHadoopConf()).load(newMetadataPath)
+      val numFilesInIceberg =
+        icebergTable.currentSnapshot().summary().get("total-data-files").toInt
+      assert(numFilesInIceberg === currSnapshot.numOfFiles + 1)
+      assertDeltaCommitRangeEvent(events, staleSnapshot.version + 1, attemptDeltaVersion)
     }
   }
 }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.uniform
 
 import com.databricks.spark.util.Log4jUsageLogger
-
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
 
 import org.apache.spark.sql.QueryTest

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.uniform
 
+import com.databricks.spark.util.Log4jUsageLogger
+
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
 
 import org.apache.spark.sql.QueryTest

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, DeltaOperations, DeltaTableReadPredicate, Snapshot}
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, DeltaOperations, DeltaTableReadPredicate, IcebergConstants, Snapshot}
 import org.apache.spark.sql.delta.DeltaTestUtils.filterUsageRecords
 import org.apache.spark.sql.delta.NonSparkReadIceberg
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, DomainMetadata, Metadata}
@@ -100,8 +100,8 @@ class UniFormConverterSuite extends
       convertedDeltaVersion: Long): CatalogTable =
     catalogTable.copy(
       properties = catalogTable.properties +
-        (IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION -> metadataPath) +
-        (IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION ->
+        (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP -> metadataPath) +
+        (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
           convertedDeltaVersion.toString)
     )
 

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -31,11 +31,11 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.delta.{DeltaLog, IcebergConstants}
 import org.apache.spark.sql.delta.DeltaConfigs.{
   COORDINATED_COMMITS_COORDINATOR_CONF,
   COORDINATED_COMMITS_COORDINATOR_NAME
 }
-import org.apache.spark.sql.delta.{DeltaLog, IcebergConstants}
 import org.apache.spark.sql.delta.NonSparkReadIceberg
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.coordinatedcommits.{

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.DeltaConfigs.{
   COORDINATED_COMMITS_COORDINATOR_CONF,
   COORDINATED_COMMITS_COORDINATOR_NAME
 }
-import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.{DeltaLog, IcebergConstants}
 import org.apache.spark.sql.delta.NonSparkReadIceberg
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.coordinatedcommits.{
@@ -97,8 +97,9 @@ trait WriteDeltaHMSReadIceberg extends UniFormE2ETest
 /**
  * A [[DeltaCatalog]] subclass that enriches [[CatalogTable]] with the last converted Iceberg
  * metadata from [[InMemoryUCCommitCoordinator]] before loading the table. This simulates what
- * the real UC catalog does: returning [[IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION]]
- * and [[IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION]] as catalog table
+ * the real UC catalog does: returning
+ * [[IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP]]
+ * and [[IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP]] as catalog table
  * properties so that [[IcebergConverter]] can perform incremental conversion.
  */
 class UCBackedDeltaCatalog extends DeltaCatalog {
@@ -112,9 +113,9 @@ class UCBackedDeltaCatalog extends DeltaCatalog {
           .map { meta =>
             val icebergMeta = meta.getIcebergMetadata.get
             catalogTable.copy(properties = catalogTable.properties +
-              (IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION ->
+              (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP->
                 icebergMeta.getMetadataLocation) +
-              (IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION ->
+              (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
                 icebergMeta.getConvertedDeltaVersion.toString))
           }
       }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -29,12 +29,15 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.{SparkConf, SparkSessionSwitch}
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 import org.apache.spark.sql.delta.DeltaConfigs.{
   COORDINATED_COMMITS_COORDINATOR_CONF,
   COORDINATED_COMMITS_COORDINATOR_NAME
 }
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.NonSparkReadIceberg
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.coordinatedcommits.{
   CatalogOwnedCommitCoordinatorBuilder,
   CommitCoordinatorProvider,

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -42,10 +42,12 @@ import org.apache.spark.sql.delta.coordinatedcommits.{
   InMemoryUCCommitCoordinator,
   UCCommitCoordinatorBuilder
 }
+import org.apache.spark.sql.delta.icebergShaded.IcebergConverter
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.uniform.hms.HMSTest
 import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * This trait allows the tests to write with Delta
@@ -90,6 +92,39 @@ trait WriteDeltaHMSReadIceberg extends UniFormE2ETest
 }
 
 /**
+ * A [[DeltaCatalog]] subclass that enriches [[CatalogTable]] with the last converted Iceberg
+ * metadata from [[InMemoryUCCommitCoordinator]] before loading the table. This simulates what
+ * the real UC catalog does: returning [[IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION]]
+ * and [[IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION]] as catalog table
+ * properties so that [[IcebergConverter]] can perform incremental conversion.
+ */
+class UCBackedDeltaCatalog extends DeltaCatalog {
+  override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table = {
+    val enriched = UCBackedDeltaCatalog.currentCoordinator.flatMap { coordinator =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(catalogTable.location))
+      val tableConf = deltaLog.update().metadata.coordinatedCommitsTableConf
+      tableConf.get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY).flatMap { tableId =>
+        coordinator.getUniformMetadata(tableId)
+          .filter(_.getIcebergMetadata.isPresent)
+          .map { meta =>
+            val icebergMeta = meta.getIcebergMetadata.get
+            catalogTable.copy(properties = catalogTable.properties +
+              (IcebergConverter.CATALOG_TABLE_ICEBERG_METADATA_LOCATION ->
+                icebergMeta.getMetadataLocation) +
+              (IcebergConverter.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION ->
+                icebergMeta.getConvertedDeltaVersion.toString))
+          }
+      }
+    }.getOrElse(catalogTable)
+    super.loadCatalogTable(ident, enriched)
+  }
+}
+
+object UCBackedDeltaCatalog {
+  @volatile var currentCoordinator: Option[InMemoryUCCommitCoordinator] = None
+}
+
+/**
  * Trait that wires up an in-memory UC commit coordinator for UniForm E2E testing.
  *
  * Mix this into a concrete suite that already extends [[UniFormE2EIcebergSuiteBase]] (or any
@@ -103,6 +138,14 @@ trait WriteDeltaHMSReadIceberg extends UniFormE2ETest
 trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
   with DeltaSQLCommandTest
   with NonSparkReadIceberg {
+
+  /**
+   * Use customized catalog so that uniform property is injected into catalogTable
+   */
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(
+      SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
+      classOf[UCBackedDeltaCatalog].getName)
 
   /**
    * A [[UCCommitCoordinatorClient]] subclass that overrides [[registerTable]] to auto-assign
@@ -141,6 +184,7 @@ trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
     DeltaLog.clearCache()
     CommitCoordinatorProvider.clearAllBuilders()
     ucCommitCoordinator = new InMemoryUCCommitCoordinator()
+    UCBackedDeltaCatalog.currentCoordinator = Some(ucCommitCoordinator)
     val ucClient = new InMemoryUCClient("test-metastore", ucCommitCoordinator)
     testCoordinator = new TestUCBackedCommitCoordinator(ucClient)
     CommitCoordinatorProvider.registerBuilder(new CatalogOwnedCommitCoordinatorBuilder {
@@ -155,6 +199,7 @@ trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
   }
 
   abstract override def afterEach(): Unit = {
+    UCBackedDeltaCatalog.currentCoordinator = None
     CommitCoordinatorProvider.clearAllBuilders()
     DeltaLog.clearCache()
     super.afterEach()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -362,6 +362,18 @@ object IcebergConstants {
   val ICEBERG_PROVIDER = "iceberg"
   val ICEBERG_NAME_MAPPING_PROPERTY = "schema.name-mapping.default"
 
+  // UniForm metadata would be stored inside catalogTable's properties upon loading
+  // Those are kept in-memory only and won't be sent to catalog
+  /** CatalogTable property key for the last converted Iceberg metadata location. */
+  val CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP =
+    "deltaUniformIceberg.metadataLocation"
+  /** CatalogTable property key for the last converted Delta version. */
+  val CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP =
+    "deltaUniformIceberg.convertedDeltaVersion"
+  /** CatalogTable property key for the last converted Delta timestamp. */
+  val CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP =
+    "delta.uniform.iceberg.convertedDeltaTimestamp"
+
   // Reserved field ID for the `_row_id` column
   // Iceberg spec: https://iceberg.apache.org/spec/?h=row#reserved-field-ids
   val ICEBERG_ROW_TRACKING_ROW_ID_FIELD_ID = 2147483540L

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -372,7 +372,7 @@ object IcebergConstants {
     "deltaUniformIceberg.convertedDeltaVersion"
   /** CatalogTable property key for the last converted Delta timestamp. */
   val CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP =
-    "delta.uniform.iceberg.convertedDeltaTimestamp"
+    "deltaUniformIceberg.convertedDeltaTimestamp"
 
   // Reserved field ID for the `_row_id` column
   // Iceberg spec: https://iceberg.apache.org/spec/?h=row#reserved-field-ids

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
@@ -29,6 +29,8 @@ import org.apache.spark.sql.types._
  * perform verification.
  */
 abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
+  def isAtomicConversionEnabled: Boolean =
+    true
 
   val testTableName = "delta_table"
 
@@ -56,8 +58,18 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
              |  'delta.universalFormat.enabledFormats' = 'iceberg'
              |  ${extraTableProperties(compatVersion)}
              |)""".stripMargin)
-        write(s"INSERT INTO $testTableName VALUES (123)")
+        writeAndVerify(
+          s"INSERT INTO $testTableName VALUES (123)", isAtomicMode = isAtomicConversionEnabled
+        )
         readAndVerify(testTableName, "col1", "col1", Seq(Row(123)))
+        writeAndVerify(
+          s"INSERT INTO $testTableName VALUES (456)",
+          isAtomicMode = isAtomicConversionEnabled,
+          verifyFullOrIncrementalOpt = Some(
+            VerifyFullOrIncremental(testTableName, isIncremental = true)
+          )
+        )
+        readAndVerify(testTableName, "col1", "col1", Seq(Row(123), Row(456)))
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ETest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ETest.scala
@@ -16,7 +16,13 @@
 
 package org.apache.spark.sql.delta.uniform
 
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaTestUtils.filterUsageRecords
+import org.apache.spark.sql.delta.util.JsonUtils
+
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
@@ -30,6 +36,9 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Implementing classes need to correctly set up the reader and writer environments.
  * See [[UniFormE2EIcebergSuiteBase]] for existing examples.
  */
+
+case class VerifyFullOrIncremental(tableName: String, isIncremental: Boolean)
+
 trait UniFormE2ETest
   extends QueryTest
   with SharedSparkSession {
@@ -40,6 +49,20 @@ trait UniFormE2ETest
    * @param sqlText write query to the UniForm table
    */
   protected def write(sqlText: String): DataFrame = sql(sqlText)
+
+  protected def writeAndVerify(
+      sqlText: String,
+      isAtomicMode: Boolean,
+      verifyFullOrIncrementalOpt: Option[VerifyFullOrIncremental] = None): Unit = {
+    val events = Log4jUsageLogger.track { sql(sqlText) }
+    verifyConversionMode(events, isAtomicMode)
+    verifyFullOrIncrementalOpt.foreach {
+      case VerifyFullOrIncremental(tbl, true) =>
+        verifyIncrementalConversion(tbl, events)
+      case VerifyFullOrIncremental(tbl, false) =>
+        verifyFullConversion(tbl, events)
+    }
+  }
 
   /**
    * Verify the result by reading from the reader session and compare the result to the expected.
@@ -64,4 +87,37 @@ trait UniFormE2ETest
    * @return table name for reading, default is no translation
    */
   protected def tableNameForRead(tableName: String): String = tableName
+
+  protected def verifyIncrementalConversion(
+      tableName: String,
+      events: Seq[UsageRecord]): Unit = {
+    val toVersion = DeltaLog.forTable(spark, TableIdentifier(tableName)).update().version
+    val fromVersion = toVersion
+    val rangeEvents = filterUsageRecords(events, "delta.iceberg.conversion.deltaCommitRange")
+    assert(rangeEvents.nonEmpty, "Expected deltaCommitRange event proving incremental conversion")
+    val eventData = JsonUtils.fromJson[Map[String, Any]](rangeEvents.head.blob)
+    assert(eventData("fromVersion") === fromVersion, s"Expected fromVersion=$fromVersion")
+    assert(eventData("toVersion") === toVersion, s"Expected toVersion=$toVersion")
+  }
+
+  protected def verifyFullConversion(tableName: String, events: Seq[UsageRecord]): Unit = {
+    val snapshot = DeltaLog.forTable(spark, TableIdentifier(tableName)).update()
+    val batchEvents = filterUsageRecords(events, "delta.iceberg.conversion.batch")
+    assert(batchEvents.nonEmpty, "Expected batch event proving full conversion")
+    val eventData = JsonUtils.fromJson[Map[String, Any]](batchEvents.head.blob)
+    assert(eventData("version") === snapshot.version, s"Expected version=${snapshot.version}")
+  }
+
+  // Verify if post-commit-conversion or atomic-UniForm conversion is triggered
+  private def verifyConversionMode(events: Seq[UsageRecord], isAtomicMode: Boolean): Unit = {
+    val postCommitConversionExists =
+      filterUsageRecords(events, "delta.iceberg.conversion.convertSnapshot").nonEmpty
+    val preCommitConversionExists =
+      filterUsageRecords(events, "delta.iceberg.conversion.convertUncommitedTxn").nonEmpty
+    if (isAtomicMode) {
+      assert(preCommitConversionExists && !postCommitConversionExists)
+    } else {
+      assert(!preCommitConversionExists && postCommitConversionExists)
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Support incremental conversion for Delta UniForm when `catalogTable` has UniForm information. Follow-up PR would parse UniForm metadata fetched from UC into `catalogTable` to complete E2E incremental conversion support

## How was this patch tested?
Add UTs
```
build/sbt -DsparkVersion=4.0 -DunityCatalogVersion=0.5.0-SNAPSHOT \                                                                                                                                          
    "iceberg/testOnly org.apache.spark.sql.delta.uniform.UniFormConverterSuite org.apache.spark.sql.delta.uniform.UniFormE2EIcebergUCSuite" 
```
