### PR TITLE
[Spark] Prefer post-prune numRows in SparkScan, with catalog stats as fallback

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -111,10 +111,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
   // Planned input files and stats
   private List<PartitionedFile> partitionedFiles = new ArrayList<>();
+  // Per-file row counts, parallel to partitionedFiles. Populated only while rowCountKnown is
+  // true; cleared if any AddFile lacks numRecords. Retained so totalRows can be recomputed
+  // after runtime partition filtering prunes files, instead of invalidating the count.
+  private List<Long> perFileRowCounts = new ArrayList<>();
   private long totalBytes = 0L;
   private long totalRows = 0L;
-  // true iff every AddFile in the scan had numRecords in its stats JSON AND no runtime
-  // partition filter has been applied (runtime filtering invalidates the cached totalRows).
+  // true iff every AddFile in the scan had numRecords in its stats JSON.
   private boolean rowCountKnown = false;
   // Estimated size in bytes accounting for column projection, used for query optimizer cost
   // estimation
@@ -283,7 +286,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
         @Override
         public OptionalLong numRows() {
-          return rowCountKnownSnapshot ? OptionalLong.of(totalRowsSnapshot) : OptionalLong.empty();
+          // Prefer per-file (post-prune) numRows when known. Fall back to catalog numRows
+          // when per-file is unavailable (e.g. some AddFile lacks numRecords). The catalog
+          // value is table-level and may be stale, but it's better than reporting unknown.
+          if (rowCountKnownSnapshot) {
+            return OptionalLong.of(totalRowsSnapshot);
+          }
+          return stats.numRows();
         }
 
         @Override
@@ -458,11 +467,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
             Optional<Long> numRecords = addFile.getNumRecords();
             if (numRecords.isPresent()) {
               totalRows += numRecords.get();
+              perFileRowCounts.add(numRecords.get());
             } else {
               // This file has no numRecords — row count is unknowable for the whole scan.
               // Clear partial state and stop accumulating for all subsequent files.
               rowCountKnown = false;
               totalRows = 0;
+              perFileRowCounts.clear();
             }
           }
         }
@@ -494,13 +505,22 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
       }
 
       List<PartitionedFile> runtimeFilteredPartitionedFiles = new ArrayList<>();
-      for (PartitionedFile pf : this.partitionedFiles) {
+      // Parallel to runtimeFilteredPartitionedFiles; only used when rowCountKnown is true.
+      List<Long> filteredRowCounts = rowCountKnown ? new ArrayList<>() : null;
+      long newTotalRows = 0L;
+      for (int i = 0; i < this.partitionedFiles.size(); i++) {
+        PartitionedFile pf = this.partitionedFiles.get(i);
         InternalRow partitionValues = pf.partitionValues();
         boolean allMatch =
             runtimePredicates.stream()
                 .allMatch(predicate -> predicate.evaluator.eval(partitionValues));
         if (allMatch) {
           runtimeFilteredPartitionedFiles.add(pf);
+          if (rowCountKnown) {
+            long rc = this.perFileRowCounts.get(i);
+            filteredRowCounts.add(rc);
+            newTotalRows += rc;
+          }
         }
       }
 
@@ -511,13 +531,12 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
         this.totalBytes =
             runtimeFilteredPartitionedFiles.stream().mapToLong(PartitionedFile::fileSize).sum();
         this.estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(this.totalBytes);
-        // Per-file row counts are not retained, so we cannot recompute totalRows over the
-        // filtered subset. Invalidate rowCountKnown so numRows() returns OptionalLong.empty()
-        // rather than a stale pre-filter count. Retaining per-file counts just for this case
-        // would cost O(n) memory on every scan; the trade-off is losing numRows after runtime
-        // partition filtering fires.
-        rowCountKnown = false;
-        totalRows = 0L;
+        if (rowCountKnown) {
+          // Recompute totalRows from per-file counts of files that survived pruning so
+          // numRows() reports the post-prune count rather than a stale pre-filter value.
+          this.perFileRowCounts = filteredRowCounts;
+          this.totalRows = newTotalRows;
+        }
       }
     }
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -283,12 +283,6 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
         @Override
         public OptionalLong numRows() {
-          // Prefer catalog stats when available: ANALYZE TABLE counts are typically fresh
-          // enough for the optimizer, and using them lets us skip per-file stats JSON parsing
-          // during planning. Fall back to per-file row count only when the catalog lacks it.
-          if (stats.numRows().isPresent()) {
-            return stats.numRows();
-          }
           return rowCountKnownSnapshot ? OptionalLong.of(totalRowsSnapshot) : OptionalLong.empty();
         }
 
@@ -428,14 +422,11 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     // avoid coupling to the kernel-internal ScanImpl class. Until that API is available, this
     // instanceof check is the only way to request per-file statistics from the kernel.
     //
-    // Only parse stats JSON when all of:
+    // Parse stats JSON when both of:
     //  - the optimizer will use numRows (CBO or planStats enabled), matching V1's behavior
     //    (LogicalRelation.computeStats())
-    //  - the catalog does not already provide numRows (otherwise catalog value is preferred in
-    //    estimateStatistics(), so per-file parsing would be wasted work)
     //  - the kernel scan is ScanImpl (the only path that supports includeStats)
-    final boolean includeStats =
-        kernelScan instanceof ScanImpl && arePlanStatsEnabled() && !catalogHasNumRows();
+    final boolean includeStats = kernelScan instanceof ScanImpl && arePlanStatsEnabled();
     final Iterator<FilteredColumnarBatch> scanFileBatches;
     if (includeStats) {
       scanFileBatches = ((ScanImpl) kernelScan).getScanFiles(tableEngine, true /* includeStats */);
@@ -600,19 +591,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
    *   <li>whether {@code numRows()} is reported in {@link #estimateStatistics()}
    *   <li>whether the catalog-stats branch is entered (which also governs {@code columnStats}
    *       propagation from the catalog)
-   *   <li>whether per-file stats JSON is parsed in {@link #planScanFiles()} (gated together with
-   *       {@code !catalogHasNumRows()} to avoid wasted parsing when the catalog already has it)
+   *   <li>whether per-file stats JSON is parsed in {@link #planScanFiles()}
    * </ul>
    *
    * Future readers touching any of these paths should treat this helper as load-bearing.
    */
   private boolean arePlanStatsEnabled() {
     return sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
-  }
-
-  /** Returns whether the catalog-provided statistics include a numRows value. */
-  private boolean catalogHasNumRows() {
-    return catalogStats.isPresent() && catalogStats.get().numRows().isPresent();
   }
 
   /**

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -604,9 +604,9 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testNumRowsAfterRuntimeFiltering() throws Exception {
-    // Runtime partition filtering invalidates the cached totalRows: per-file row counts are
-    // not retained (to avoid O(n) memory on every scan), so numRows() returns empty after
-    // filtering rather than a recomputed value.
+    // Runtime partition filtering recomputes totalRows from the per-file counts of files that
+    // survive pruning, so numRows() reflects the post-prune row count rather than the
+    // pre-filter total or empty.
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
         "true",
@@ -617,18 +617,23 @@ public class SparkScanTest extends DeltaV2TestBase {
           assertEquals(
               5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
 
+          // Two rows in the table have city=hz (Alice and Bob, in different date partitions).
           scan.filter(new Predicate[] {cityPredicate}); // city=hz
 
-          assertFalse(
+          assertTrue(
               scan.estimateStatistics().numRows().isPresent(),
-              "numRows should be empty after runtime filtering invalidates row count");
+              "numRows should remain known after runtime filtering");
+          assertEquals(
+              2L,
+              scan.estimateStatistics().numRows().getAsLong(),
+              "numRows should be recomputed to the post-prune count (2 city=hz rows)");
         });
   }
 
   @Test
-  public void testNumRowsEmptyAfterFilteringOutAllFiles() throws Exception {
-    // Same reasoning as testNumRowsAfterRuntimeFiltering: runtime filtering invalidates the
-    // cached totalRows regardless of how many files remain.
+  public void testNumRowsZeroAfterFilteringOutAllFiles() throws Exception {
+    // When runtime filtering prunes every file, totalRows recomputes to 0 (still a known
+    // value, not OptionalLong.empty()).
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
         "true",
@@ -638,9 +643,13 @@ public class SparkScanTest extends DeltaV2TestBase {
 
           scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
 
-          assertFalse(
+          assertTrue(
               scan.estimateStatistics().numRows().isPresent(),
-              "numRows should be empty after runtime filtering (even when all files filtered)");
+              "numRows should remain known after runtime filtering (even when all files filtered)");
+          assertEquals(
+              0L,
+              scan.estimateStatistics().numRows().getAsLong(),
+              "numRows should be 0 when all files are filtered out");
         });
   }
 
@@ -1221,6 +1230,61 @@ public class SparkScanTest extends DeltaV2TestBase {
               stats.numRows().getAsLong(),
               "numRows should come from per-file (2), not catalog (999)");
         });
+  }
+
+  @Test
+  public void testCatalogNumRowsFallbackWhenPerFileUnknown(@TempDir File tempDir) throws Exception {
+    // When per-file numRecords is unavailable for any AddFile (rowCountKnown=false), numRows()
+    // should fall back to the catalog value rather than return OptionalLong.empty().
+    String path = tempDir.getAbsolutePath();
+    String tblName = "stats_catalog_fallback";
+    try {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'a')", tblName));
+
+      // Disable stats collection so the next AddFile has no numRecords. With one file lacking
+      // numRecords, rowCountKnown is false for the whole scan.
+      spark.sql("SET spark.databricks.delta.stats.collect=false");
+      spark.sql(String.format("INSERT INTO %s VALUES (2, 'b')", tblName));
+
+      // Inject catalog stats with a distinguishable row count (777) so the fallback is observable.
+      CatalogStatistics catalogStats =
+          new CatalogStatistics(
+              scala.math.BigInt.apply(1024L),
+              scala.Option.apply(scala.math.BigInt.apply(777L)),
+              buildColStatsMap(new String[] {}, new CatalogColumnStat[] {}));
+      CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
+
+      withSQLConf(
+          "spark.sql.cbo.enabled",
+          "true",
+          () -> {
+            Identifier id = Identifier.of(new String[] {"default"}, tblName);
+            SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+            SparkScanBuilder builder =
+                (SparkScanBuilder)
+                    sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+            SparkScan scan = (SparkScan) builder.build();
+
+            assertFalse(
+                isRowCountKnown(scan),
+                "rowCountKnown should be false when an AddFile lacks numRecords");
+
+            Statistics stats = scan.estimateStatistics();
+            assertTrue(
+                stats.numRows().isPresent(),
+                "numRows should fall back to catalog when per-file unknown");
+            assertEquals(
+                777L,
+                stats.numRows().getAsLong(),
+                "numRows should come from catalog stats (777) when per-file is unknown");
+          });
+    } finally {
+      spark.sql("RESET spark.databricks.delta.stats.collect");
+      spark.sql("DROP TABLE IF EXISTS " + tblName);
+    }
   }
 
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -1157,7 +1157,7 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // numRows comes from catalog stats (per-file parsing is skipped when catalog has it)
+          // numRows comes from per-file (post-prune) stats
           assertTrue(stats.numRows().isPresent(), "numRows should be present with CBO enabled");
           assertEquals(2L, stats.numRows().getAsLong(), "numRows should be 2");
 
@@ -1183,13 +1183,12 @@ public class SparkScanTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testCatalogNumRowsPreferredOverPerFile(@TempDir File tempDir) throws Exception {
-    // Verifies that catalog numRows (from ANALYZE TABLE) is preferred over per-file numRows
-    // when both are available. This lets us skip per-file stats JSON parsing during planning,
-    // trading off freshness for planning cost. If the catalog value is stale, the user is
-    // expected to re-run ANALYZE TABLE.
+  public void testPerFileNumRowsPreferredOverCatalog(@TempDir File tempDir) throws Exception {
+    // Verifies that per-file (post-prune) numRows is used in preference to catalog numRows.
+    // numRows() reflects the row count for this scan after pruning, while catalog stats are
+    // table-level and unpruned.
     String path = tempDir.getAbsolutePath();
-    String tblName = "stats_catalog_wins";
+    String tblName = "stats_per_file_wins";
     spark.sql(
         String.format(
             "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
@@ -1215,12 +1214,12 @@ public class SparkScanTest extends DeltaV2TestBase {
           SparkScan scan = (SparkScan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
-          // Catalog numRows wins; per-file parsing is skipped entirely.
+          // Per-file numRows wins over catalog stats.
           assertTrue(stats.numRows().isPresent(), "numRows should be present");
           assertEquals(
-              999L,
+              2L,
               stats.numRows().getAsLong(),
-              "numRows should come from catalog (999), not per-file (2)");
+              "numRows should come from per-file (2), not catalog (999)");
         });
   }
 
@@ -1302,7 +1301,7 @@ public class SparkScanTest extends DeltaV2TestBase {
                 SparkScan scan = (SparkScan) builder.build();
                 Statistics stats = scan.estimateStatistics();
 
-                // With planStatsEnabled, numRows should come from catalog stats
+                // With planStatsEnabled, numRows should be present (from per-file stats)
                 assertTrue(
                     stats.numRows().isPresent(), "numRows should be present with planStatsEnabled");
                 assertEquals(2L, stats.numRows().getAsLong(), "numRows should be 2");


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`numRows()` should reflect the row count for this scan after pruning. Catalog stats (from ANALYZE TABLE) are table-level and unpruned, so preferring them produced an unpruned count from a pruned scan, which violated the contract.

This:

- Prefers the per-file (post-prune) row count in `numRows()`, and falls back to catalog `numRows` only when per-file is unavailable (e.g. some `AddFile` lacks `numRecords`).
- Removes the `!catalogHasNumRows()` gate on per-file stats parsing, which previously skipped JSON parsing whenever catalog had numRows (otherwise the new code path would now read empty).
- Retains per-file row counts across runtime partition filtering so `totalRows` is recomputed over the surviving files, instead of invalidating the count to empty after any partition pruning.
- Updates/renames the affected tests; adds a test for the catalog fallback when per-file `numRecords` is unknown.

## How was this patch tested?
unit test

## Does this PR introduce _any_ user-facing changes?

No