### PR TITLE
[CCv1-dep] Migrate simple suites to CatalogOwnedTestBaseSuite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import scala.language.implicitConversions
 
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.MemoryStream
 
@@ -33,7 +33,7 @@ import org.apache.spark.util.Utils
 
 class DeltaSourceTableAPISuite extends StreamTest
   with DeltaSQLCommandTest
-  with CoordinatedCommitsBaseSuite {
+  with CatalogOwnedTestBaseSuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -254,10 +254,10 @@ class DeltaSourceTableAPISuite extends StreamTest
   }
 }
 
-class DeltaSourceTableAPIWithCoordinatedCommitsBatch1Suite extends DeltaSourceTableAPISuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
+class DeltaSourceTableAPIWithCatalogManagedBatch1Suite extends DeltaSourceTableAPISuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
 }
 
-class DeltaSourceTableAPIWithCoordinatedCommitsBatch100Suite extends DeltaSourceTableAPISuite {
-  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
+class DeltaSourceTableAPIWithCatalogManagedBatch100Suite extends DeltaSourceTableAPISuite {
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/FindLastCompleteCheckpointSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/FindLastCompleteCheckpointSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.CheckpointInstance.Format
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
-import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.storage.LocalLogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
@@ -34,7 +34,7 @@ class FindLastCompleteCheckpointSuite
   extends QueryTest
   with SharedSparkSession
   with DeltaSQLCommandTest
-  with CoordinatedCommitsBaseSuite {
+  with CatalogOwnedTestBaseSuite {
 
   protected override def sparkConf: SparkConf = {
     super.sparkConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR migrates two simple Delta test suites from `CoordinatedCommitsBaseSuite` to `CatalogOwnedTestBaseSuite`:

- `DeltaSourceTableAPISuite`
- `FindLastCompleteCheckpointSuite`

It also updates the backfill override name to `catalogOwnedCoordinatorBackfillBatchSize` where needed.

## How was this patch tested?

Existing tests cover the migrated suites; this is a mechanical rename of the base trait and the override method.

## Does this PR introduce _any_ user-facing changes?

No.