### PR TITLE
[Spark] Fix case-insensitive duplicate column detection in MERGE INSERT

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -147,7 +147,18 @@ case class PreprocessTableMerge(override val conf: SQLConf)
         m.resolvedActions.map(_.targetColNameParts))
 
       val targetColNames = m.resolvedActions.map(_.targetColNameParts.head)
-      if (targetColNames.distinct.size < targetColNames.size) {
+      // Without this, case-variant INSERT duplicates would crash `resolveImplicitColumns`
+      // with an internal assertion on tables with generated or identity columns.
+      val hasGeneratedOrIdentityColumns = generatedColumns.nonEmpty || identityColumns.nonEmpty
+      val shouldNormalizeColumnCase =
+        conf.getConf(DeltaSQLConf.DELTA_MERGE_INSERT_FIX_CASE_SENSITIVE_DUPLICATE_COLUMNS) &&
+          hasGeneratedOrIdentityColumns &&
+          !conf.caseSensitiveAnalysis
+      // scalastyle:off caselocale
+      val normalizedColNames =
+        if (shouldNormalizeColumnCase) targetColNames.map(_.toLowerCase) else targetColNames
+      // scalastyle:on caselocale
+      if (normalizedColNames.distinct.size < targetColNames.size) {
         throw DeltaErrors.duplicateColumnOnInsert()
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -154,10 +154,9 @@ case class PreprocessTableMerge(override val conf: SQLConf)
         conf.getConf(DeltaSQLConf.DELTA_MERGE_INSERT_FIX_CASE_SENSITIVE_DUPLICATE_COLUMNS) &&
           hasGeneratedOrIdentityColumns &&
           !conf.caseSensitiveAnalysis
-      // scalastyle:off caselocale
       val normalizedColNames =
-        if (shouldNormalizeColumnCase) targetColNames.map(_.toLowerCase) else targetColNames
-      // scalastyle:on caselocale
+        if (shouldNormalizeColumnCase) targetColNames.map(_.toLowerCase(Locale.ROOT))
+        else targetColNames
       if (normalizedColNames.distinct.size < targetColNames.size) {
         throw DeltaErrors.duplicateColumnOnInsert()
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -729,6 +729,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_MERGE_INSERT_FIX_CASE_SENSITIVE_DUPLICATE_COLUMNS =
+    buildConf("merge.insert.fixCaseSensitiveDuplicateColumns")
+      .internal()
+      .doc("Internal flag controlling a fix for case-variant duplicate columns in MERGE INSERT " +
+        "clauses (e.g., `colUtc` and `colUTC`). On tables with generated or identity columns, " +
+        "such duplicates would otherwise trigger an internal AssertionError in " +
+        "`resolveImplicitColumns` instead of a user-facing error. Disabling this fix restores " +
+        "the prior behavior.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_MERGE_SCHEMA_EVOLUTION_FIX_NESTED_STRUCT_ALIGNMENT =
     buildConf("schemaEvolution.merge.fixNestedStructAlignment")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.MemoryStream
 import org.apache.spark.sql.delta.util.FileNames
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.quietly
@@ -1878,6 +1879,124 @@ trait GeneratedColumnSuiteBase
           sql(s"SELECT * FROM ${tgt}"),
           Seq(Row(1, 2, null), Row(2, 3, 4))
         )
+      }
+    }
+  }
+
+  test("MERGE INSERT with duplicate columns differing only in case") {
+    // Regression test: when the INSERT clause contains columns that differ only in case
+    // (e.g., "c2" and "C2"), the duplicate check should catch them and throw a proper
+    // user-facing error instead of hitting an internal AssertionError in
+    // resolveImplicitColumns.
+    withTableName("source") { src =>
+      withTableName("target") { tgt =>
+        createTable(
+          tableName = src,
+          path = None,
+          schemaString = "c1 INT, c2 INT",
+          generatedColumns = Map.empty,
+          partitionColumns = Seq.empty
+        )
+        sql(s"INSERT INTO ${src} VALUES (2, 4)")
+        createTable(
+          tableName = tgt,
+          path = None,
+          schemaString = "c1 INT, c2 INT, c3 INT",
+          generatedColumns = Map("c3" -> "c1 + c2"),
+          partitionColumns = Seq.empty
+        )
+        sql(s"INSERT INTO ${tgt} VALUES (1, 2, 3)")
+
+        val e = intercept[AnalysisException] {
+          sql(s"""
+                 |MERGE INTO ${tgt}
+                 |USING ${src}
+                 |ON ${tgt}.c1 = ${src}.c1
+                 |WHEN NOT MATCHED THEN INSERT (c1, c2, C2)
+                 |VALUES (${src}.c1, ${src}.c2, ${src}.c2)
+                 |""".stripMargin)
+        }
+        assert(e.getMessage.contains("Duplicate column names in INSERT clause"))
+      }
+    }
+  }
+
+  test("MERGE INSERT with case-variant duplicate columns and fix disabled") {
+    // When the safer flag is disabled, case-variant duplicates bypass the duplicate check
+    // and instead trigger the internal AssertionError in resolveImplicitColumns on tables
+    // with generated columns. Kept as an A/B test pinning the prior failure mode.
+    withTableName("source") { src =>
+      withTableName("target") { tgt =>
+        createTable(
+          tableName = src,
+          path = None,
+          schemaString = "c1 INT, c2 INT",
+          generatedColumns = Map.empty,
+          partitionColumns = Seq.empty
+        )
+        sql(s"INSERT INTO ${src} VALUES (2, 4)")
+        createTable(
+          tableName = tgt,
+          path = None,
+          schemaString = "c1 INT, c2 INT, c3 INT",
+          generatedColumns = Map("c3" -> "c1 + c2"),
+          partitionColumns = Seq.empty
+        )
+        sql(s"INSERT INTO ${tgt} VALUES (1, 2, 3)")
+
+        withSQLConf(
+          DeltaSQLConf.DELTA_MERGE_INSERT_FIX_CASE_SENSITIVE_DUPLICATE_COLUMNS.key -> "false"
+        ) {
+          val e = intercept[SparkException] {
+            sql(s"""
+                   |MERGE INTO ${tgt}
+                   |USING ${src}
+                   |ON ${tgt}.c1 = ${src}.c1
+                   |WHEN NOT MATCHED THEN INSERT (c1, c2, C2)
+                   |VALUES (${src}.c1, ${src}.c2, ${src}.c2)
+                   |""".stripMargin)
+          }
+          assert(e.getCause.isInstanceOf[AssertionError])
+          assert(e.getCause.getMessage.contains(
+            "Invalid number of columns in INSERT clause"))
+        }
+      }
+    }
+  }
+
+  test("MERGE INSERT case-variant duplicates without generated or identity columns allowed") {
+    // Companion to the previous tests: when the target has no generated or identity columns,
+    // the case-insensitive duplicate check should NOT fire even with the fix enabled, to
+    // match existing behavior (see `MergeIntoSchemaEvolutionSuite: case-insensitive insert`).
+    // Without generated or identity columns `resolveImplicitColumns` early-returns, so the
+    // assertion path is unreachable and `alignedActions` silently absorbs the duplicate.
+    withTableName("source") { src =>
+      withTableName("target") { tgt =>
+        createTable(
+          tableName = src,
+          path = None,
+          schemaString = "c1 INT, c2 INT",
+          generatedColumns = Map.empty,
+          partitionColumns = Seq.empty
+        )
+        sql(s"INSERT INTO ${src} VALUES (2, 4)")
+        createTable(
+          tableName = tgt,
+          path = None,
+          schemaString = "c1 INT, c2 INT",
+          generatedColumns = Map.empty,
+          partitionColumns = Seq.empty
+        )
+        sql(s"INSERT INTO ${tgt} VALUES (1, 2)")
+
+        sql(s"""
+               |MERGE INTO ${tgt}
+               |USING ${src}
+               |ON ${tgt}.c1 = ${src}.c1
+               |WHEN NOT MATCHED THEN INSERT (c1, c2, C2)
+               |VALUES (${src}.c1, ${src}.c2, ${src}.c2)
+               |""".stripMargin)
+        checkAnswer(sql(s"SELECT * FROM ${tgt}"), Seq(Row(1, 2), Row(2, 4)))
       }
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The duplicate-column check in PreprocessTableMerge.scala used case-sensitive `.distinct`, allowing INSERT clauses such as `(colUtc, colUTC, ...)` to bypass detection. Downstream, `conf.resolver` (case-insensitive by default) collapsed both variants to the same target column. On tables with generated or identity columns, this inflated the action count and crashed the assertion `postEvolutionTargetSchema.size == allActions.size` in `resolveImplicitColumns` with an internal AssertionError instead of a user-facing error.

Lowercase the target column names before the duplicate check, but only when (a) the target has generated or identity columns and (b) analysis is case-insensitive — the only configuration where the assertion fires. Tables without generated or identity columns retain the existing behavior, where `resolveImplicitColumns` early-returns and `alignedActions` silently absorbs the duplicate (see existing test `MergeIntoSchemaEvolutionSuite: case-insensitive insert`).

Gated behind `spark.databricks.delta.merge.insert.fixCaseSensitiveDuplicateColumns` (default true) as a safety valve.

This supersedes #6234, which applied the lowercase normalization unconditionally and broke the existing case-insensitive insert test.

## How was this patch tested?
Tests in GeneratedColumnSuite cover:
- generated column + case-variant duplicates with fix on -> AnalysisException
- generated column + case-variant duplicates with fix off -> SparkException(AssertionError) (A/B pin of prior failure mode)
- no generated/identity columns + case-variant duplicates -> still tolerated, matches existing behavior

## Does this PR introduce _any_ user-facing changes?
No
