### PR TITLE
[Storage] Expose Kernel schema in metadata API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1163,6 +1163,37 @@ lazy val storage = (project in file("storage"))
     commonSettings,
     exportJars := true,
     javaOnlyReleaseSettings,
+
+    // Use the shaded kernel-api jar. A direct project dependency puts kernel-api's unshaded
+    // class directory on downstream classpaths, which conflicts with Kernel's shaded Jackson API.
+    Compile / unmanagedJars += (kernelApi / Compile / packageBin).value,
+    Test / unmanagedJars += (kernelApi / Compile / packageBin).value,
+    Compile / compile := (Compile / compile).dependsOn(kernelApi / Compile / packageBin).value,
+    Test / test := (Test / test).dependsOn(kernelApi / Compile / packageBin).value,
+
+    // delta-storage exposes Kernel types in its public API, so the published POM must still
+    // declare delta-kernel-api even though local compilation uses the shaded jar above.
+    pomPostProcess := { node =>
+      val ver = version.value
+      import scala.xml._
+      import scala.xml.transform._
+
+      val kernelApiDependency =
+        <dependency>
+          <groupId>io.delta</groupId>
+          <artifactId>delta-kernel-api</artifactId>
+          <version>{ver}</version>
+        </dependency>
+
+      new RuleTransformer(new RewriteRule {
+        override def transform(n: Node): Seq[Node] = n match {
+          case e: Elem if e.label == "dependencies" =>
+            Seq(e.copy(child = e.child ++ kernelApiDependency))
+          case _ => Seq(n)
+        }
+      }).transform(node).head
+    },
+
     libraryDependencies ++= Seq(
       // User can provide any 2.x or 3.x version. We don't use any new fancy APIs. Watch out for
       // versions with known vulnerabilities.

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/MetadataAdapter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/MetadataAdapter.java
@@ -18,6 +18,7 @@ package io.delta.kernel.unitycatalog.adapters;
 
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.types.StructType;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import java.util.*;
 
@@ -56,6 +57,11 @@ public class MetadataAdapter implements AbstractMetadata {
   @Override
   public Map<String, String> getFormatOptions() {
     return Collections.unmodifiableMap(kernelMetadata.getFormat().getOptions());
+  }
+
+  @Override
+  public StructType getSchema() {
+    return kernelMetadata.getSchema();
   }
 
   @Override

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/adapters/ActionAdaptersSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/adapters/ActionAdaptersSuite.scala
@@ -74,6 +74,7 @@ class ActionAdaptersSuite extends AnyFunSuite {
     assert(adapter.getDescription === "description")
     assert(adapter.getProvider === "parquet")
     assert(adapter.getFormatOptions.asScala == Map("foo" -> "bar"))
+    assert(adapter.getSchema === kernelMetadata.getSchema)
     assert(adapter.getSchemaString === "schemaStringJson")
     assert(adapter.getPartitionColumns.asScala == Seq("part1"))
     assert(adapter.getConfiguration.asScala == Map("zip" -> "zap"))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1251,6 +1251,12 @@ case class Metadata(
     .map(DataType.fromJson(_).asInstanceOf[StructType])
     .getOrElse(StructType.apply(Nil))
 
+  /** Returns the schema as a Kernel [[io.delta.kernel.types.StructType]] */
+  @JsonIgnore
+  private lazy val kernelSchema: io.delta.kernel.types.StructType = Option(schemaString)
+    .map(io.delta.kernel.internal.types.DataTypeJsonSerDe.deserializeStructType)
+    .orNull
+
   /** Returns the partitionSchema as a [[StructType]] */
   @JsonIgnore
   lazy val partitionSchema: StructType =
@@ -1311,6 +1317,9 @@ case class Metadata(
 
   @JsonIgnore
   override def getFormatOptions: java.util.Map[String, String] = format.options.asJava
+
+  @JsonIgnore
+  override def getSchema: io.delta.kernel.types.StructType = kernelSchema
 
   override def getSchemaString: String = schemaString
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -134,6 +134,19 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       new StructType().json,
       Seq("a")))
 
+  test("Metadata getSchema parses schemaString as Kernel schema") {
+    val schemaString = new StructType()
+      .add("id", "long")
+      .add("nested", new StructType().add("name", "string"))
+      .json
+    val metadata = Metadata(schemaString = schemaString)
+    val expected =
+      io.delta.kernel.internal.types.DataTypeJsonSerDe.deserializeStructType(schemaString)
+
+    assert(metadata.getSchema === expected)
+    assert(Metadata().getSchema === null)
+  }
+
   test("extra fields") {
     // TODO reading from checkpoint
     Action.fromJson("""{"txn": {"test": 1}}""")

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractMetadata.java
@@ -16,8 +16,11 @@
 
 package io.delta.storage.commit.actions;
 
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
+
+import io.delta.kernel.internal.types.DataTypeJsonSerDe;
+import io.delta.kernel.types.StructType;
 
 /**
  * Interface for metadata actions in Delta. The metadata defines the metadata
@@ -45,6 +48,17 @@ public interface AbstractMetadata {
 
   /** The format options */
   Map<String, String> getFormatOptions();
+
+  /**
+   * The table schema as a Delta Kernel type.
+   *
+   * <p>The default implementation parses {@link #getSchemaString()}; if {@code getSchemaString()}
+   * returns {@code null}, this method returns {@code null}.
+   */
+  default StructType getSchema() {
+    String schemaString = getSchemaString();
+    return schemaString == null ? null : DataTypeJsonSerDe.deserializeStructType(schemaString);
+  }
 
   /**
    * The table schema in string representation.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6716/files) to review incremental changes.
- [**stack/drc-storage-kernel-schema**](https://github.com/delta-io/delta/pull/6716) [[Files changed](https://github.com/delta-io/delta/pull/6716/files)]
  - [stack/drc-loadtable-storage](https://github.com/delta-io/delta/pull/6659) [[Files changed](https://github.com/delta-io/delta/pull/6659/files/968410144c066f40a91f83038e3701015cc3a757..38a0fc67d23e65d10154595a771eeefe48e6e6bd)]
    - [stack/drc-loadtable-catalog](https://github.com/delta-io/delta/pull/6660) [[Files changed](https://github.com/delta-io/delta/pull/6660/files/38a0fc67d23e65d10154595a771eeefe48e6e6bd..d88afebb70e13d55fd528e1844517d05c7b6e1c2)]
      - [stack/drc-path-credentials](https://github.com/delta-io/delta/pull/6682) [[Files changed](https://github.com/delta-io/delta/pull/6682/files/d88afebb70e13d55fd528e1844517d05c7b6e1c2..bb0bcad93fb71c739f2a4386666df13a84b7b84d)]
        - [stack/drc-createtable-storage](https://github.com/delta-io/delta/pull/6672) [[Files changed](https://github.com/delta-io/delta/pull/6672/files/bb0bcad93fb71c739f2a4386666df13a84b7b84d..ea2a073d98161f4b417d2e298e9b8466d4c613fb)]
          - [stack/drc-createtable-catalog](https://github.com/delta-io/delta/pull/6673) [[Files changed](https://github.com/delta-io/delta/pull/6673/files/ea2a073d98161f4b417d2e298e9b8466d4c613fb..8956ad5a383c5d2b6e7d51125b9c5dc1d2a22849)]
            - [stack/drc-external-createtable](https://github.com/delta-io/delta/pull/6675) [[Files changed](https://github.com/delta-io/delta/pull/6675/files/8956ad5a383c5d2b6e7d51125b9c5dc1d2a22849..ff9be5f3178638b79a373ca8e668f76036254bb3)]

---------
#### Which Delta project/connector is this regarding?

Storage / Kernel

## Description

This PR extends the storage metadata abstraction so Delta code can access table schema as a Kernel `StructType`, not only as schema JSON.

Without this, each caller that needs typed schema has to parse `getSchemaString()` itself. That makes UC Delta Rest Catalog API integration harder because the typed schema would be converted in multiple places.

This PR adds:

- `storage` access to Kernel API types.
- A default `AbstractMetadata.getSchema()` method returning Kernel `StructType`.
- Implementations for Spark metadata and Kernel metadata adapters.
- A Spark-side test that verifies `Metadata.getSchema` parses schema JSON through Kernel serde.

`AbstractMetadata.getSchemaString()` remains for existing callers.

## How was this patch tested?

Local verification:

```bash
./build/sbt "storage/compile" "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClientSuite" "spark/testOnly org.apache.spark.sql.delta.ActionSerializerSuite"
./build/sbt scalafmtAll javafmtAll
git diff --check
```

Downstream stack verification:

```bash
./build/sbt "storage/compile" "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClientSuite"
./build/sbt "spark/testOnly org.apache.spark.sql.delta.catalog.UCDeltaRestCatalogApiSchemaConverterSuite org.apache.spark.sql.delta.catalog.DeltaCatalogClientSuite"
./build/sbt "sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableReadTest"
```

## Does this PR introduce _any_ user-facing changes?

No.
