### PR TITLE
[Spark] Fix type name from 'int' to 'integer' in TypeWideningTableFeatureSuite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
@@ -435,7 +435,7 @@ trait TypeWideningTableFeatureAdvancedTests extends QueryTest
       .putMetadataArray("delta.typeChanges", Array(
         new MetadataBuilder()
           .putString("toType", "string")
-          .putString("fromType", "int")
+          .putString("fromType", "integer")
           .putLong("tableVersion", 2)
           .putString("fieldPath", "element")
           .build()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`int` is not standard: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types, For example, it is not supported by Kernel.

Fix type name from 'int' to 'integer' in TypeWideningTableFeatureSuite

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
No