### PR TITLE
[UC] Improve readChangeFeed error for managed streaming

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -124,7 +124,9 @@ class DeltaDataSource
     val deltaV2Mode = new DeltaV2Mode(sqlContext.sparkSession.sessionState.conf)
     if (schema.isDefined &&
         deltaV2Mode.shouldBypassSchemaValidationForStreaming(parameters.asJava)) {
-      require(!CDCReader.isCDCRead(options), "CDC read is not supported for schema bypass.")
+      require(!CDCReader.isCDCRead(options),
+        "The 'readChangeFeed' (Change Data Feed) streaming option is not supported for " +
+          "Unity Catalog managed Delta tables.")
       return (shortName(), schema.get)
     }
     val path = parameters.getOrElse("path", {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -243,7 +243,8 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
    * CDF streaming reads work for EXTERNAL tables but fail for MANAGED tables.
    *
    * <p>For EXTERNAL: verifies that inserts and a delete produce the expected typed change events.
-   * For MANAGED: verifies the stream fails with an error containing "not supported" and "CDC".
+   * For MANAGED: verifies the stream fails with an error that names the user-facing option and
+   * table type.
    */
   @TestAllTableTypes
   public void testStreamingCDFRead(TableType tableType) throws Exception {
@@ -286,7 +287,8 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
                 tableName,
                 r -> r.option("readChangeFeed", "true").option("startingVersion", insertVersion),
                 "not supported",
-                "CDC");
+                "readChangeFeed",
+                "Unity Catalog managed");
           }
         });
   }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6724/files) to review incremental changes.
- [**stack/dsv2-cdf-schema-bypass-message**](https://github.com/delta-io/delta/pull/6724) [[Files changed](https://github.com/delta-io/delta/pull/6724/files)]
  - [stack/dsv2-value-aware-streaming-options](https://github.com/delta-io/delta/pull/6725) [[Files changed](https://github.com/delta-io/delta/pull/6725/files/52c0d4bd462441ce06d4b20a35490270a154d1c4..6969bb1654212a1831653c58cd90585d3aa9f59a)]
    - [stack/dsv2-streaming-file-metadata](https://github.com/delta-io/delta/pull/6726) [[Files changed](https://github.com/delta-io/delta/pull/6726/files/6969bb1654212a1831653c58cd90585d3aa9f59a..ef1bab7f557f74801b5f48fd5c904f2d4f912509)]

---------

#### Which Delta project/connector is this regarding?

Spark / Unity Catalog managed Delta streaming reads.

## Description

### CUJ

A user tries to read Change Data Feed from a Unity Catalog managed Delta table in streaming:

```java
spark.readStream()
    .format("delta")
    .option("readChangeFeed", "true")
    .table("unity.default.t")
    .writeStream()
    .trigger(Trigger.AvailableNow())
    .option("checkpointLocation", checkpoint)
    .foreachBatch(...)
    .start();
```

This is a valid CUJ because `readChangeFeed` is a public Delta option, and users will try it when they want CDC rows from a streaming source.

### Problem

Unity Catalog managed Delta tables do not support this CDF streaming path today, so the query should fail.

Before this PR, it failed with this message:

```text
CDC read is not supported for schema bypass.
```

That message is hard to act on. `schema bypass` is internal wording. The message also does not mention the user option `readChangeFeed`.

### Solution

This PR keeps the same behavior: `readChangeFeed=true` is still rejected for Unity Catalog managed Delta tables.

It only changes the error message so it names:

- the option: `readChangeFeed`
- the feature: Change Data Feed
- the table type: Unity Catalog managed Delta tables

## How was this patch tested?

Verified as part of the stack with:

```text
build/sbt 'sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableDataFrameStreamingTest'
```

## Does this PR introduce _any_ user-facing changes?

Yes. The failure message for `readChangeFeed=true` on Unity Catalog managed Delta streaming reads is clearer.
