### PR TITLE
[Spark] Make V2 streaming option validation value-aware

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -124,7 +124,9 @@ class DeltaDataSource
     val deltaV2Mode = new DeltaV2Mode(sqlContext.sparkSession.sessionState.conf)
     if (schema.isDefined &&
         deltaV2Mode.shouldBypassSchemaValidationForStreaming(parameters.asJava)) {
-      require(!CDCReader.isCDCRead(options), "CDC read is not supported for schema bypass.")
+      require(!CDCReader.isCDCRead(options),
+        "The 'readChangeFeed' (Change Data Feed) streaming option is not supported for " +
+          "Unity Catalog managed Delta tables.")
       return (shortName(), schema.get)
     }
     val path = parameters.getOrElse("path", {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -352,6 +352,45 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
         });
   }
 
+  @TestAllTableTypes
+  public void testStreamingReadChangeFeedFalseDoesNotError(TableType tableType) throws Exception {
+    if (tableType != TableType.MANAGED) return;
+    assertManagedStreamingOptionDoesNotError(
+        "streaming_read_cdf_false_test", "readChangeFeed", "false");
+  }
+
+  @TestAllTableTypes
+  public void testStreamingAllowSourceColumnDropFalseDoesNotError(TableType tableType)
+      throws Exception {
+    if (tableType != TableType.MANAGED) return;
+    assertManagedStreamingOptionDoesNotError(
+        "streaming_allow_drop_false_test", "allowSourceColumnDrop", "false");
+  }
+
+  private void assertManagedStreamingOptionDoesNotError(
+      String tableName, String optionName, String optionValue) throws Exception {
+    withNewTable(
+        tableName,
+        "id INT",
+        TableType.MANAGED,
+        fullTableName -> {
+          sql("INSERT INTO %s VALUES (1)", fullTableName);
+          List<Integer> result = new ArrayList<>();
+          spark()
+              .readStream()
+              .format("delta")
+              .option(optionName, optionValue)
+              .table(fullTableName)
+              .writeStream()
+              .trigger(Trigger.AvailableNow())
+              .option("checkpointLocation", checkpoint())
+              .foreachBatch((VoidFunction2<Dataset<Row>, Long>) (df, id) -> result.addAll(ids(df)))
+              .start()
+              .awaitTermination();
+          assertThat(result).containsExactly(1);
+        });
+  }
+
   /**
    * Starts a streaming read with options applied by {@code configure}, then asserts the stream
    * fails with a message containing all {@code fragments} (case-insensitive).

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -243,7 +243,8 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
    * CDF streaming reads work for EXTERNAL tables but fail for MANAGED tables.
    *
    * <p>For EXTERNAL: verifies that inserts and a delete produce the expected typed change events.
-   * For MANAGED: verifies the stream fails with an error containing "not supported" and "CDC".
+   * For MANAGED: verifies the stream fails with an error that names the user-facing option and
+   * table type.
    */
   @TestAllTableTypes
   public void testStreamingCDFRead(TableType tableType) throws Exception {
@@ -286,7 +287,8 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
                 tableName,
                 r -> r.option("readChangeFeed", "true").option("startingVersion", insertVersion),
                 "not supported",
-                "CDC");
+                "readChangeFeed",
+                "Unity Catalog managed");
           }
         });
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -642,6 +642,9 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
    * <p>Note: DeltaOptions internally uses CaseInsensitiveMap, which preserves the original key
    * casing but performs case-insensitive lookups.
    *
+   * <p>For boolean options that are unsupported only when enabled, only reject truthy values. For
+   * example, {@code readChangeFeed=false} explicitly opts out of CDF and should not be rejected.
+   *
    * @param deltaOptions the DeltaOptions to validate
    * @throws UnsupportedOperationException if unsupported options are found
    */
@@ -652,7 +655,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     while (keysIterator.hasNext()) {
       String key = keysIterator.next();
       // DeltaOptions uses CaseInsensitiveMap with keys already lowercased.
-      if (UNSUPPORTED_STREAMING_OPTIONS.contains(key)) {
+      if (isUnsupportedStreamingOptionEnabled(deltaOptions, key)) {
         unsupportedOptions.add(key);
       }
     }
@@ -665,6 +668,39 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
               String.join(", ", unsupportedOptions),
               String.join(", ", SUPPORTED_STREAMING_OPTIONS)));
     }
+  }
+
+  private static boolean isUnsupportedStreamingOptionEnabled(
+      DeltaOptions deltaOptions, String key) {
+    if (!UNSUPPORTED_STREAMING_OPTIONS.contains(key)) {
+      return false;
+    }
+
+    if (key.equals(DeltaOptions.CDC_READ_OPTION().toLowerCase())
+        || key.equals(DeltaOptions.CDC_READ_OPTION_LEGACY().toLowerCase())
+        || key.equals(DeltaOptions.ALLOW_SOURCE_COLUMN_DROP().toLowerCase())
+        || key.equals(DeltaOptions.ALLOW_SOURCE_COLUMN_RENAME().toLowerCase())
+        || key.equals(DeltaOptions.ALLOW_SOURCE_COLUMN_TYPE_CHANGE().toLowerCase())) {
+      return optionValueIsTrue(deltaOptions, key);
+    }
+
+    if (key.equals(DeltaOptions.SCHEMA_TRACKING_LOCATION().toLowerCase())
+        || key.equals(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS().toLowerCase())
+        || key.equals(DeltaOptions.STREAMING_SOURCE_TRACKING_ID().toLowerCase())) {
+      return optionValueIsNonEmpty(deltaOptions, key);
+    }
+
+    return true;
+  }
+
+  private static boolean optionValueIsTrue(DeltaOptions deltaOptions, String key) {
+    scala.Option<String> raw = deltaOptions.options().get(key);
+    return raw.isDefined() && "true".equalsIgnoreCase(raw.get().trim());
+  }
+
+  private static boolean optionValueIsNonEmpty(DeltaOptions deltaOptions, String key) {
+    scala.Option<String> raw = deltaOptions.options().get(key);
+    return raw.isDefined() && !raw.get().trim().isEmpty();
   }
 
   @Override


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6725/files/52c0d4bd462441ce06d4b20a35490270a154d1c4..6969bb1654212a1831653c58cd90585d3aa9f59a) to review incremental changes.
- [stack/dsv2-cdf-schema-bypass-message](https://github.com/delta-io/delta/pull/6724) [[Files changed](https://github.com/delta-io/delta/pull/6724/files)]
  - [**stack/dsv2-value-aware-streaming-options**](https://github.com/delta-io/delta/pull/6725) [[Files changed](https://github.com/delta-io/delta/pull/6725/files/52c0d4bd462441ce06d4b20a35490270a154d1c4..6969bb1654212a1831653c58cd90585d3aa9f59a)]
    - [stack/dsv2-streaming-file-metadata](https://github.com/delta-io/delta/pull/6726) [[Files changed](https://github.com/delta-io/delta/pull/6726/files/6969bb1654212a1831653c58cd90585d3aa9f59a..ef1bab7f557f74801b5f48fd5c904f2d4f912509)]

---------

#### Which Delta project/connector is this regarding?

Spark / V2 streaming reads.

## Description

### CUJ

A user has a shared options map for streaming reads. For one query, they explicitly opt out of CDF:

```java
spark.readStream()
    .format("delta")
    .option("readChangeFeed", "false")
    .table("unity.default.t")
    .writeStream()
    .trigger(Trigger.AvailableNow())
    .option("checkpointLocation", checkpoint)
    .foreachBatch(...)
    .start();
```

Another similar case is opting out of unsafe schema-change handling:

```java
spark.readStream()
    .format("delta")
    .option("allowSourceColumnDrop", "false")
    .table("unity.default.t")
    .writeStream()
    .trigger(Trigger.AvailableNow())
    .option("checkpointLocation", checkpoint)
    .foreachBatch(...)
    .start();
```

This is a valid CUJ because option maps are often shared across pipelines. Setting an option to `false` means "do not enable this feature".

### Problem

V2 streaming validation checked only option keys.

So this failed:

```java
.option("readChangeFeed", "false")
```

because the key `readchangefeed` was present, even though the user did not request CDF.

This was different from V1 behavior, which checks the option value.

### Solution

This PR makes V2 streaming option validation value-aware.

- Boolean unsupported options are rejected only when enabled.
- `readChangeFeed=false` is allowed.
- `allowSourceColumnDrop=false` is allowed.
- String unsupported options are rejected only when the value is non-empty.

Real unsupported requests, like `readChangeFeed=true`, are still rejected.

## How was this patch tested?

Verified as part of the stack with:

```text
build/sbt 'sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableDataFrameStreamingTest'
```

## Does this PR introduce _any_ user-facing changes?

Yes. V2 streaming no longer rejects unsupported options when the user explicitly sets them to `false` or leaves a string option empty.
