### PR TITLE
[Spark] Fix metadata columns in V2 streaming reads

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -124,7 +124,9 @@ class DeltaDataSource
     val deltaV2Mode = new DeltaV2Mode(sqlContext.sparkSession.sessionState.conf)
     if (schema.isDefined &&
         deltaV2Mode.shouldBypassSchemaValidationForStreaming(parameters.asJava)) {
-      require(!CDCReader.isCDCRead(options), "CDC read is not supported for schema bypass.")
+      require(!CDCReader.isCDCRead(options),
+        "The 'readChangeFeed' (Change Data Feed) streaming option is not supported for " +
+          "Unity Catalog managed Delta tables.")
       return (shortName(), schema.get)
     }
     val path = parameters.getOrElse("path", {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -352,6 +352,45 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
         });
   }
 
+  @TestAllTableTypes
+  public void testStreamingReadChangeFeedFalseDoesNotError(TableType tableType) throws Exception {
+    if (tableType != TableType.MANAGED) return;
+    assertManagedStreamingOptionDoesNotError(
+        "streaming_read_cdf_false_test", "readChangeFeed", "false");
+  }
+
+  @TestAllTableTypes
+  public void testStreamingAllowSourceColumnDropFalseDoesNotError(TableType tableType)
+      throws Exception {
+    if (tableType != TableType.MANAGED) return;
+    assertManagedStreamingOptionDoesNotError(
+        "streaming_allow_drop_false_test", "allowSourceColumnDrop", "false");
+  }
+
+  private void assertManagedStreamingOptionDoesNotError(
+      String tableName, String optionName, String optionValue) throws Exception {
+    withNewTable(
+        tableName,
+        "id INT",
+        TableType.MANAGED,
+        fullTableName -> {
+          sql("INSERT INTO %s VALUES (1)", fullTableName);
+          List<Integer> result = new ArrayList<>();
+          spark()
+              .readStream()
+              .format("delta")
+              .option(optionName, optionValue)
+              .table(fullTableName)
+              .writeStream()
+              .trigger(Trigger.AvailableNow())
+              .option("checkpointLocation", checkpoint())
+              .foreachBatch((VoidFunction2<Dataset<Row>, Long>) (df, id) -> result.addAll(ids(df)))
+              .start()
+              .awaitTermination();
+          assertThat(result).containsExactly(1);
+        });
+  }
+
   /**
    * Starts a streaming read with options applied by {@code configure}, then asserts the stream
    * fails with a message containing all {@code fragments} (case-insensitive).

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -367,6 +367,38 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
         "streaming_allow_drop_false_test", "allowSourceColumnDrop", "false");
   }
 
+  @TestAllTableTypes
+  public void testStreamingMetadataColumns(TableType tableType) throws Exception {
+    if (tableType != TableType.MANAGED) return;
+    withNewTable(
+        "streaming_metadata_columns_test",
+        "id INT",
+        null,
+        tableType,
+        "'delta.enableRowTracking'='true'",
+        tableName -> {
+          sql("INSERT INTO %s VALUES (1)", tableName);
+          List<Row> result = new ArrayList<>();
+          spark()
+              .readStream()
+              .format("delta")
+              .table(tableName)
+              .selectExpr("id", "_metadata.file_path AS file_path", "_metadata.row_id AS row_id")
+              .writeStream()
+              .trigger(Trigger.AvailableNow())
+              .option("checkpointLocation", checkpoint())
+              .foreachBatch(
+                  (VoidFunction2<Dataset<Row>, Long>) (df, id) -> result.addAll(df.collectAsList()))
+              .start()
+              .awaitTermination();
+
+          assertThat(result).hasSize(1);
+          assertThat(result.get(0).getInt(0)).isEqualTo(1);
+          assertThat(result.get(0).getString(1)).endsWith(".parquet");
+          assertThat(result.get(0).isNullAt(2)).isFalse();
+        });
+  }
+
   private void assertManagedStreamingOptionDoesNotError(
       String tableName, String optionName, String optionValue) throws Exception {
     withNewTable(

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -243,7 +243,8 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
    * CDF streaming reads work for EXTERNAL tables but fail for MANAGED tables.
    *
    * <p>For EXTERNAL: verifies that inserts and a delete produce the expected typed change events.
-   * For MANAGED: verifies the stream fails with an error containing "not supported" and "CDC".
+   * For MANAGED: verifies the stream fails with an error that names the user-facing option and
+   * table type.
    */
   @TestAllTableTypes
   public void testStreamingCDFRead(TableType tableType) throws Exception {
@@ -286,7 +287,8 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
                 tableName,
                 r -> r.option("readChangeFeed", "true").option("startingVersion", insertVersion),
                 "not supported",
-                "CDC");
+                "readChangeFeed",
+                "Unity Catalog managed");
           }
         });
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/SparkTable.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/SparkTable.java
@@ -25,6 +25,7 @@ import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.spark.internal.v2.read.SparkScanBuilder;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
@@ -54,6 +55,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import scala.collection.JavaConverters;
 
 /** DataSource V2 Table implementation for Delta Lake using the Delta Kernel API. */
 public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsMetadataColumns {
@@ -253,21 +255,22 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
   }
 
   /**
-   * Exposes row-tracking metadata via a single DSv2 metadata struct column.
+   * Exposes metadata via a single DSv2 metadata struct column.
    *
    * <p>This always returns one metadata column named {@code _metadata}. When row tracking is
-   * enabled, the struct contains fields {@code row_id} and {@code row_commit_version}. When row
-   * tracking is disabled, those fields are omitted from the struct.
+   * enabled, the struct contains fields {@code row_id} and {@code row_commit_version}. For
+   * catalog-managed tables, it also contains Spark's standard file metadata fields.
    */
   @Override
   public MetadataColumn[] metadataColumns() {
     SnapshotImpl snapshotImpl = (SnapshotImpl) initialSnapshot;
     boolean rowTrackingEnabled =
         RowTracking.isEnabled(snapshotImpl.getProtocol(), snapshotImpl.getMetadata());
+    boolean catalogManaged = TableFeatures.isCatalogManagedSupported(snapshotImpl.getProtocol());
 
     final StructType metadataType =
         rowTrackingEnabled
-            ? new StructType()
+            ? baseMetadataSchema(catalogManaged)
                 .add(ROW_ID_METADATA_FIELD_NAME, DataTypes.LongType, false)
                 .add(ROW_COMMIT_VERSION_METADATA_FIELD_NAME, DataTypes.LongType, false)
             : new StructType();
@@ -292,6 +295,15 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
         };
 
     return columns;
+  }
+
+  private static StructType baseMetadataSchema(boolean includeFileMetadata) {
+    if (!includeFileMetadata) {
+      return new StructType();
+    }
+    return new StructType(
+        JavaConverters.seqAsJavaList(FileFormat$.MODULE$.BASE_METADATA_FIELDS())
+            .toArray(new StructField[0]));
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -24,8 +24,11 @@ import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.ScanImpl;
+import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.data.ScanStateRow;
+import io.delta.kernel.internal.rowtracking.RowTracking;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContext;
@@ -47,14 +50,18 @@ import org.apache.spark.sql.connector.read.*;
 import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.delta.DeltaOptions;
+import org.apache.spark.sql.delta.RowCommitVersion$;
+import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.execution.datasources.*;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import scala.collection.JavaConverters;
 
 /** Spark DSV2 Scan implementation backed by Delta Kernel. */
 public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
@@ -128,6 +135,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   // estimation
   private long estimatedSizeInBytes = 0L;
   private volatile boolean planned = false;
+  private boolean streamingScanNeedsMetadataColumn = false;
 
   // Runtime predicates applied after planning (using Set for order-independent comparison)
   private final Set<org.apache.spark.sql.connector.expressions.filter.Predicate>
@@ -201,7 +209,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     boolean metadataColumnRequested =
         Arrays.stream(readDataSchema.fields())
             .anyMatch(field -> FileFormat$.MODULE$.METADATA_NAME().equals(field.name()));
-    if (metadataColumnRequested) {
+    if (metadataColumnRequested || streamingScanNeedsMetadataColumn) {
       return Scan.ColumnarSupportMode.UNSUPPORTED;
     }
 
@@ -247,6 +255,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
     validateStreamingOptions(deltaOptions);
+    StructType streamingReadDataSchema = readDataSchema;
+    if (shouldAddMetadataColumnForStreaming()) {
+      streamingScanNeedsMetadataColumn = true;
+      streamingReadDataSchema =
+          readDataSchema.add(
+              FileFormat$.MODULE$.METADATA_NAME(), catalogManagedMetadataSchema(), false);
+    }
     return new SparkMicroBatchStream(
         snapshotManager,
         // Loads a fresh snapshot as the baseline for schema change detection and table identity
@@ -260,9 +275,27 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
         getTablePath(),
         dataSchema,
         partitionSchema,
-        readDataSchema,
+        streamingReadDataSchema,
         dataFilters != null ? dataFilters : new Filter[0],
         scalaOptions != null ? scalaOptions : scala.collection.immutable.Map$.MODULE$.empty());
+  }
+
+  private boolean shouldAddMetadataColumnForStreaming() {
+    SnapshotImpl snapshotImpl = (SnapshotImpl) initialSnapshot;
+    return !Arrays.stream(readDataSchema.fields())
+            .anyMatch(field -> FileFormat$.MODULE$.METADATA_NAME().equals(field.name()))
+        && TableFeatures.isCatalogManagedSupported(snapshotImpl.getProtocol())
+        && RowTracking.isEnabled(snapshotImpl.getProtocol(), snapshotImpl.getMetadata());
+  }
+
+  private static StructType catalogManagedMetadataSchema() {
+    StructType metadataSchema =
+        new StructType(
+            JavaConverters.seqAsJavaList(FileFormat$.MODULE$.BASE_METADATA_FIELDS())
+                .toArray(new StructField[0]));
+    return metadataSchema
+        .add(RowId$.MODULE$.ROW_ID(), DataTypes.LongType, false)
+        .add(RowCommitVersion$.MODULE$.METADATA_STRUCT_FIELD_NAME(), DataTypes.LongType, false);
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -642,6 +642,9 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
    * <p>Note: DeltaOptions internally uses CaseInsensitiveMap, which preserves the original key
    * casing but performs case-insensitive lookups.
    *
+   * <p>For boolean options that are unsupported only when enabled, only reject truthy values. For
+   * example, {@code readChangeFeed=false} explicitly opts out of CDF and should not be rejected.
+   *
    * @param deltaOptions the DeltaOptions to validate
    * @throws UnsupportedOperationException if unsupported options are found
    */
@@ -652,7 +655,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     while (keysIterator.hasNext()) {
       String key = keysIterator.next();
       // DeltaOptions uses CaseInsensitiveMap with keys already lowercased.
-      if (UNSUPPORTED_STREAMING_OPTIONS.contains(key)) {
+      if (isUnsupportedStreamingOptionEnabled(deltaOptions, key)) {
         unsupportedOptions.add(key);
       }
     }
@@ -665,6 +668,39 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
               String.join(", ", unsupportedOptions),
               String.join(", ", SUPPORTED_STREAMING_OPTIONS)));
     }
+  }
+
+  private static boolean isUnsupportedStreamingOptionEnabled(
+      DeltaOptions deltaOptions, String key) {
+    if (!UNSUPPORTED_STREAMING_OPTIONS.contains(key)) {
+      return false;
+    }
+
+    if (key.equals(DeltaOptions.CDC_READ_OPTION().toLowerCase())
+        || key.equals(DeltaOptions.CDC_READ_OPTION_LEGACY().toLowerCase())
+        || key.equals(DeltaOptions.ALLOW_SOURCE_COLUMN_DROP().toLowerCase())
+        || key.equals(DeltaOptions.ALLOW_SOURCE_COLUMN_RENAME().toLowerCase())
+        || key.equals(DeltaOptions.ALLOW_SOURCE_COLUMN_TYPE_CHANGE().toLowerCase())) {
+      return optionValueIsTrue(deltaOptions, key);
+    }
+
+    if (key.equals(DeltaOptions.SCHEMA_TRACKING_LOCATION().toLowerCase())
+        || key.equals(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS().toLowerCase())
+        || key.equals(DeltaOptions.STREAMING_SOURCE_TRACKING_ID().toLowerCase())) {
+      return optionValueIsNonEmpty(deltaOptions, key);
+    }
+
+    return true;
+  }
+
+  private static boolean optionValueIsTrue(DeltaOptions deltaOptions, String key) {
+    scala.Option<String> raw = deltaOptions.options().get(key);
+    return raw.isDefined() && "true".equalsIgnoreCase(raw.get().trim());
+  }
+
+  private static boolean optionValueIsNonEmpty(DeltaOptions deltaOptions, String key) {
+    scala.Option<String> raw = deltaOptions.options().get(key);
+    return raw.isDefined() && !raw.get().trim().isEmpty();
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/rowtracking/RowTrackingReadFunction.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/rowtracking/RowTrackingReadFunction.java
@@ -21,20 +21,23 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.ProjectingInternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.JoinedRow;
+import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
+import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
+import org.apache.spark.sql.execution.datasources.FileFormat$;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.types.StructField;
 import scala.Function1;
 import scala.collection.Iterator;
 import scala.runtime.AbstractFunction1;
 
 /**
- * Read-function decorator that appends row-tracking values under the DSv2 {@code _metadata} struct.
+ * Read-function decorator that appends metadata values under the DSv2 {@code _metadata} struct.
  *
  * <p>This wrapper consumes rows that include internal helper columns introduced by {@link
- * RowTrackingSchemaContext}, computes requested row-tracking metadata fields using Delta
- * null-coalesce semantics, and returns rows in logical output order: {@code data columns +
- * _metadata + partition columns}.
+ * RowTrackingSchemaContext}, computes requested metadata fields, and returns rows in logical output
+ * order: {@code data columns + _metadata + partition columns}.
  */
 public class RowTrackingReadFunction
     extends AbstractFunction1<PartitionedFile, Iterator<InternalRow>> implements Serializable {
@@ -49,7 +52,8 @@ public class RowTrackingReadFunction
   }
 
   /**
-   * Produces rows with a single {@code _metadata} struct column that contains row-tracking values.
+   * Produces rows with a single {@code _metadata} struct column that contains requested metadata
+   * values.
    *
    * <p>For each row, computes {@code row_id} as {@code COALESCE(materialized_row_id, base_row_id +
    * physical_row_index)} and computes {@code row_commit_version} as {@code
@@ -77,15 +81,12 @@ public class RowTrackingReadFunction
       commitVersionId = 0L;
     }
 
-    int rowTrackingFieldsCount =
-        (rowTrackingSchemaContext.isRowIdRequested() ? 1 : 0)
-            + (rowTrackingSchemaContext.isRowCommitVersionRequested() ? 1 : 0);
-
     Iterator<InternalRow> baseIterator = baseReadFunc.apply(file);
 
     GenericInternalRow metadataStruct = new GenericInternalRow(1);
-    // The fields inside the metadata structs are ordered: row_id first / row_commit_version second
-    GenericInternalRow rowTrackingFields = new GenericInternalRow(rowTrackingFieldsCount);
+    GenericInternalRow metadataFields =
+        new GenericInternalRow(rowTrackingSchemaContext.getMetadataSchema().fields().length);
+    populateFileMetadataFields(file, metadataFields);
 
     ProjectingInternalRow dataProjection =
         ProjectingInternalRow.apply(
@@ -101,34 +102,10 @@ public class RowTrackingReadFunction
     return CloseableIterator.wrap(baseIterator)
         .mapCloseable(
             row -> {
-              int index = 0;
-              if (rowTrackingSchemaContext.isRowIdRequested()) {
-                int materializedRowIdIndex = rowTrackingSchemaContext.getMaterializedRowIdIndex();
-                int rowIndexColumnIndex = rowTrackingSchemaContext.getRowIndexColumnIndex();
-                long physicalRowIndex = row.getLong(rowIndexColumnIndex);
-                // When reading tables with f.e. mixed file history, the materialized RowIds can be
-                // absent so materializedRowIdIndex can be beyond the row's width. Treat this case
-                // like null and fall back to baseRowId + physicalRowIndex.
-                long rowId =
-                    (row.numFields() <= materializedRowIdIndex
-                            || row.isNullAt(materializedRowIdIndex))
-                        ? baseRowId + physicalRowIndex
-                        : row.getLong(materializedRowIdIndex);
-                rowTrackingFields.setLong(index++, rowId);
-              }
-
-              if (rowTrackingSchemaContext.isRowCommitVersionRequested()) {
-                int materializedCommitVersionIndex =
-                    rowTrackingSchemaContext.getMaterializedRowCommitVersionIndex();
-                long rowCommitVersion =
-                    row.isNullAt(materializedCommitVersionIndex)
-                        ? commitVersionId
-                        : row.getLong(materializedCommitVersionIndex);
-                rowTrackingFields.setLong(index, rowCommitVersion);
-              }
+              populateRowTrackingMetadataFields(row, metadataFields, baseRowId, commitVersionId);
               dataProjection.project(row);
               partitionProjection.project(row);
-              metadataStruct.update(0, rowTrackingFields.copy());
+              metadataStruct.update(0, metadataFields.copy());
 
               // Partition columns are appended after data columns in readSchema, so insert
               // `_metadata` between projected data columns and partition columns to preserve
@@ -144,6 +121,52 @@ public class RowTrackingReadFunction
               }
               return dataWithMetadata;
             });
+  }
+
+  private void populateRowTrackingMetadataFields(
+      InternalRow row, GenericInternalRow metadataFields, long baseRowId, long commitVersionId) {
+    StructField[] fields = rowTrackingSchemaContext.getMetadataSchema().fields();
+    for (int i = 0; i < fields.length; i++) {
+      String name = fields[i].name();
+      if (RowId$.MODULE$.ROW_ID().equals(name)) {
+        int materializedRowIdIndex = rowTrackingSchemaContext.getMaterializedRowIdIndex();
+        int rowIndexColumnIndex = rowTrackingSchemaContext.getRowIndexColumnIndex();
+        long physicalRowIndex = row.getLong(rowIndexColumnIndex);
+        // When reading tables with f.e. mixed file history, the materialized RowIds can be absent
+        // so materializedRowIdIndex can be beyond the row's width. Treat this case like null and
+        // fall back to baseRowId + physicalRowIndex.
+        long rowId =
+            (row.numFields() <= materializedRowIdIndex || row.isNullAt(materializedRowIdIndex))
+                ? baseRowId + physicalRowIndex
+                : row.getLong(materializedRowIdIndex);
+        metadataFields.setLong(i, rowId);
+      } else if (RowCommitVersion$.MODULE$.METADATA_STRUCT_FIELD_NAME().equals(name)) {
+        int materializedCommitVersionIndex =
+            rowTrackingSchemaContext.getMaterializedRowCommitVersionIndex();
+        long rowCommitVersion =
+            row.isNullAt(materializedCommitVersionIndex)
+                ? commitVersionId
+                : row.getLong(materializedCommitVersionIndex);
+        metadataFields.setLong(i, rowCommitVersion);
+      }
+    }
+  }
+
+  private void populateFileMetadataFields(PartitionedFile file, GenericInternalRow metadataFields) {
+    StructField[] fields = rowTrackingSchemaContext.getMetadataSchema().fields();
+    for (int i = 0; i < fields.length; i++) {
+      String name = fields[i].name();
+      if (FileFormat$.MODULE$.BASE_METADATA_EXTRACTORS().contains(name)) {
+        Literal literal =
+            FileFormat$.MODULE$.getFileConstantMetadataColumnValue(
+                name, file, FileFormat$.MODULE$.BASE_METADATA_EXTRACTORS());
+        if (literal.value() == null) {
+          metadataFields.setNullAt(i);
+        } else {
+          metadataFields.update(i, literal.value());
+        }
+      }
+    }
   }
 
   /** Creates a row-tracking read-function wrapper around a base Parquet read function. */

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/rowtracking/RowTrackingSchemaContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/rowtracking/RowTrackingSchemaContext.java
@@ -53,6 +53,7 @@ public class RowTrackingSchemaContext implements Serializable {
   private int materializedRowIdIndex = -1;
   private int materializedRowCommitVersionIndex = -1;
   private int rowIndexColumnIndex = -1;
+  private StructType metadataSchema;
   private StructType dataSchema;
   private Seq<Object> dataColumnsOrdinals;
   private StructType partitionSchema;
@@ -69,6 +70,7 @@ public class RowTrackingSchemaContext implements Serializable {
       return;
     }
     StructType metadataType = (StructType) metadataColumn.dataType();
+    this.metadataSchema = metadataType;
 
     StructType baseSchemaWithoutMetadata =
         new StructType(
@@ -148,6 +150,10 @@ public class RowTrackingSchemaContext implements Serializable {
 
   public boolean areRowTrackingMetadataFieldsRequested() {
     return isRowIdRequested() || isRowCommitVersionRequested();
+  }
+
+  public StructType getMetadataSchema() {
+    return metadataSchema;
   }
 
   private static Seq<Object> buildRangeOrdinals(int startInclusive, int endExclusive) {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6726/files/6969bb1654212a1831653c58cd90585d3aa9f59a..ef1bab7f557f74801b5f48fd5c904f2d4f912509) to review incremental changes.
- [stack/dsv2-cdf-schema-bypass-message](https://github.com/delta-io/delta/pull/6724) [[Files changed](https://github.com/delta-io/delta/pull/6724/files)]
  - [stack/dsv2-value-aware-streaming-options](https://github.com/delta-io/delta/pull/6725) [[Files changed](https://github.com/delta-io/delta/pull/6725/files/52c0d4bd462441ce06d4b20a35490270a154d1c4..6969bb1654212a1831653c58cd90585d3aa9f59a)]
    - [**stack/dsv2-streaming-file-metadata**](https://github.com/delta-io/delta/pull/6726) [[Files changed](https://github.com/delta-io/delta/pull/6726/files/6969bb1654212a1831653c58cd90585d3aa9f59a..ef1bab7f557f74801b5f48fd5c904f2d4f912509)]

---------

#### Which Delta project/connector is this regarding?

Spark / V2 streaming reads for Unity Catalog managed Delta tables.

## Description

### CUJ

A user wants the source file path for each row in a streaming query:

```java
spark.readStream()
    .format("delta")
    .table("unity.default.t")
    .selectExpr("id", "_metadata.file_path AS file_path")
    .writeStream()
    .trigger(Trigger.AvailableNow())
    .option("checkpointLocation", checkpoint)
    .foreachBatch(...)
    .start();
```

A user may also want Delta row tracking metadata:

```java
spark.readStream()
    .format("delta")
    .table("unity.default.t")
    .selectExpr("id", "_metadata.row_id AS row_id")
    .writeStream()
    .trigger(Trigger.AvailableNow())
    .option("checkpointLocation", checkpoint)
    .foreachBatch(...)
    .start();
```

This is a valid CUJ because `_metadata.file_path` is standard Spark file metadata, and `_metadata.row_id` is Delta row-tracking metadata.

### Problem

For Unity Catalog managed Delta tables, streaming uses the V2 read path.

Before this PR, `_metadata.file_path` failed during analysis:

```text
No such struct field `file_path` in `row_id`, `row_commit_version`
```

The connector only declared Delta row-tracking fields in `_metadata`. It did not declare Spark file metadata fields.

Also, `_metadata.row_id` could resolve, but streaming execution could crash because the streaming read schema did not carry `_metadata` down to the reader.

### Solution

This PR fixes the catalog-managed row-tracking V2 streaming path.

It does three things:

1. Declares Spark file metadata fields in `_metadata` for catalog-managed row-tracking tables.
2. Adds `_metadata` back to the streaming read schema when Spark does not push it down.
3. Populates the metadata struct in the existing row-tracking read function.

This keeps the existing non-managed row-tracking metadata behavior unchanged.

## How was this patch tested?

Verified with:

```text
build/sbt 'sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableDataFrameStreamingTest'
build/sbt 'sparkV2/testOnly io.delta.spark.internal.v2.V2RowTrackingReadTest'
```

## Does this PR introduce _any_ user-facing changes?

Yes. V2 streaming reads on Unity Catalog managed Delta tables can now project `_metadata.file_path` and `_metadata.row_id`.
