### PR TITLE
Introduce semantic dsv2-related tags

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
@@ -35,7 +35,28 @@ case class DSv2Incompatible(reason: String) extends org.scalatest.Tag("DSv2Incom
  * Tests tagged with this are automatically skipped when [[InMemoryTestTableMixin]] is active.
  */
 case class DSv2TemporarilyIncompatible(reason: String)
-  extends org.scalatest.Tag("DSv2TemporariltyIncompatible")
+  extends org.scalatest.Tag("DSv2TemporarilyIncompatible")
+
+/**
+ * Tag for tests that assert the physical Delta execution plan shape.
+ * Tests tagged with this are automatically skipped when [[InMemoryTestTableMixin]] is active.
+ */
+case class ChecksPhysicalDeltaPlan(reason: String = "checks physical Delta plan")
+  extends org.scalatest.Tag("ChecksPhysicalDeltaPlan")
+
+/**
+ * Tag for tests that inspect or mutate Delta internals such as DeltaLog or file stats.
+ * Tests tagged with this are automatically skipped when [[InMemoryTestTableMixin]] is active.
+ */
+case class ChecksDeltaInternals(reason: String = "checks Delta internals")
+  extends org.scalatest.Tag("ChecksDeltaInternals")
+
+/**
+ * Tag for tests that inspect Delta metrics.
+ * Test tagged with this are automatically skipped when [[InMemoryTestTableMixin]] is active.
+ */
+case class ChecksDeltaMetrics(reason: String = "checks Delta metrics")
+  extends org.scalatest.Tag("ChecksDeltaMetrics")
 
 /**
  * Mixin trait that configures the session catalog to use [[InMemoryDeltaCatalog]],
@@ -49,16 +70,20 @@ trait InMemoryTestTableMixin extends SharedSparkSession {
       (testName: String, testTags: org.scalatest.Tag*)
       (testFun: => Any)
       (implicit pos: org.scalactic.source.Position): Unit = {
-    for (tag <- testTags) {
-      tag match {
-        case t: DSv2Incompatible =>
-          ignore(testName + s" (DSv2Incompatible: $t.reason)", testTags: _*)(testFun)
-          return
-        case t: DSv2TemporarilyIncompatible =>
-          ignore(testName + s" (DSv2TemporarilyIncompatible: $t.reason)", testTags: _*)(testFun)
-          return
-      }
+    testTags.collectFirst {
+      case t: DSv2Incompatible =>
+        "DSv2Incompatible" -> t.reason
+      case t: DSv2TemporarilyIncompatible =>
+        "DSv2TemporarilyIncompatible" -> t.reason
+      case t: ChecksPhysicalDeltaPlan =>
+        "ChecksPhysicalDeltaPlan" -> t.reason
+      case t: ChecksDeltaInternals =>
+        "ChecksDeltaInternals" -> t.reason
+    } match {
+      case Some((tagName, reason)) =>
+        ignore(testName + s" ($tagName: $reason)", testTags: _*)(testFun)
+      case None =>
+        super.test(testName, testTags: _*)(testFun)
     }
-    super.test(testName, testTags: _*)(testFun)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/V2DmlInMemoryTableSuite.scala
@@ -138,4 +138,12 @@ class V2DmlInMemoryTableSuite
       DSv2TemporarilyIncompatible("explicit skip")) {
     assert(false, "this test should have been skipped")
   }
+
+  test("should just throw, but checks physical Delta plan", ChecksPhysicalDeltaPlan()) {
+    assert(false, "this test should have been skipped")
+  }
+
+  test("should just throw, but checks Delta internals", ChecksDeltaInternals()) {
+    assert(false, "this test should have been skipped")
+  }
 }


### PR DESCRIPTION
## Description

Introduces additional ScalaTest tags for tests in the DSv2 in-memory test mixin so they can be selectively skipped when the in-memory catalog is active:

- `ChecksPhysicalDeltaPlan` — for tests that assert on the physical Delta execution plan shape.
- `ChecksDeltaInternals` — for tests that inspect or mutate Delta internals (e.g. `DeltaLog`, file stats).
- `ChecksDeltaMetrics` — for tests that inspect Delta metrics.

Also fixes a typo (`DSv2TemporariltyIncompatible` -> `DSv2TemporarilyIncompatible`) and refactors the `InMemoryTestTableMixin.test` override to use `collectFirst` instead of an early-return loop so the new tags can be added without further special-casing.

## How was this patch tested?

Simple smoke tests are included in `V2DmlInMemoryTableSuite` that assert the tagged tests are skipped. No real tests use these tags yet.
