### PR TITLE
[Spark] Return Some(0) instead of None for DELETE metrics

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -406,6 +406,15 @@ case class DeleteCommand(
     txn.registerSQLMetrics(sparkSession, metrics)
     sendDriverMetrics(sparkSession, metrics)
 
+    val alwaysReportSomeZero =
+      conf.getConf(DeltaSQLConf.METRICS_ALWAYS_REPORT_SOME_ZERO_METRICS)
+    def reportSomeZero(rowCount: Option[Long]): Option[Long] =
+      if (alwaysReportSomeZero) {
+        Some(rowCount.getOrElse(0L))
+      } else {
+        rowCount
+      }
+
     val numRecordsStats = NumRecordsStats.fromActions(deleteActions)
     val deleteMetric = DeleteMetric(
         condition = condition.map(_.sql).getOrElse("true"),
@@ -422,8 +431,8 @@ case class DeleteCommand(
         numPartitionsAfterSkipping,
         numPartitionsAddedTo,
         numPartitionsRemovedFrom,
-        numCopiedRows,
-        numDeletedRows,
+        reportSomeZero(numCopiedRows),
+        reportSomeZero(numDeletedRows),
         numAddedBytes,
         numRemovedBytes,
         changeFileBytes = changeFileBytes,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -656,6 +656,18 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val METRICS_ALWAYS_REPORT_SOME_ZERO_METRICS =
+    buildConf("metrics.alwaysReportSomeZeroMetrics")
+      .internal()
+      .doc(
+        """When enabled, DELETE operation metrics (numCopiedRows, numDeletedRows) always report
+          |Some(0) instead of None, even in cases where 0 rows are guaranteed to be copied or
+          |deleted. This aligns DELETE with UPDATE which already always reports Some(0). When
+          |disabled, reverts to the legacy behavior where DELETE returns None for these cases.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_VACUUM_RETENTION_WINDOW_IGNORE_ENABLED =
     buildConf("vacuum.retentionWindowIgnore.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
@@ -17,12 +17,13 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import com.databricks.spark.util.DatabricksLogging
+import com.databricks.spark.util.{DatabricksLogging, Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, RemoveFile}
 import org.apache.spark.sql.delta.commands.DeleteMetric
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.sql.{Dataset, QueryTest}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -199,8 +200,8 @@ class DeleteMetricsSuite extends QueryTest
     numPartitionsAfterSkipping = None,
     numPartitionsAddedTo = None,
     numPartitionsRemovedFrom = None,
-    numCopiedRows = None,
-    numDeletedRows = None,
+    numCopiedRows = Some(0),
+    numDeletedRows = Some(0),
     numBytesAdded = -1, // We don't want to assert equality on bytes
     numBytesRemoved = -1, // We don't want to assert equality on bytes
     changeFileBytes = -1, // We don't want to assert equality on bytes
@@ -421,6 +422,32 @@ class DeleteMetricsSuite extends QueryTest
       ),
     testConfig = testConfig
     )
+  }
+
+  for (alwaysReportSomeZero <- BOOLEAN_DOMAIN) {
+    test("DELETE with no matching rows reports numCopiedRows/numDeletedRows depending on flag " +
+      s"alwaysReportSomeZeroMetrics=$alwaysReportSomeZero") {
+      withSQLConf(
+        DeltaSQLConf.METRICS_ALWAYS_REPORT_SOME_ZERO_METRICS.key ->
+          alwaysReportSomeZero.toString
+      ) {
+        withTempDir { dir =>
+          spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+          val records = Log4jUsageLogger.track {
+            spark.sql("DELETE FROM delta.`" + dir.getAbsolutePath + "` WHERE id > 100")
+          }
+          val events = records.filter { r =>
+            r.metric == MetricDefinitions.EVENT_TAHOE.name &&
+              r.tags.get("opType").contains("delta.dml.delete.stats")
+          }
+          assert(events.size == 1)
+          val deleteMetric = JsonUtils.fromJson[DeleteMetric](events.head.blob)
+          val expected = if (alwaysReportSomeZero) Some(0L) else None
+          assert(deleteMetric.numCopiedRows === expected)
+          assert(deleteMetric.numDeletedRows === expected)
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
We align `DELETE` and `UPDATE` behavior regarding `Some(0)` and `None`. Before, `DELETE` returns `None` for metrics if it was guaranteed that we don't copy any rows, e.g. when using Deletion Vectors, while `UPDATE` was always returning `Some(0)` in this case. We are aligning the behavior of the statements by returning `Some(0)` in all cases now.

## How was this patch tested?
New unit test for testing the behavior with the flag enabled and disabled.


## Does this PR introduce _any_ user-facing changes?
Yes
Before this PR, `DELETE` would return `None` for metrics if it was guaranteed that we don't copy any rows, e.g. when using Deletion Vectors. Now, it also returns `Some(0)` as to align with the behavior of `UPDATE`.
This is not a breaking change as `Some(0)` was returned by `DELETE` in some cases before as well.