### PR TITLE
[KERNEL] Accept case-insensitive algorithm in GeographyType

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeographyType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeographyType.java
@@ -16,10 +16,10 @@
 package io.delta.kernel.types;
 
 import io.delta.kernel.annotation.Evolving;
-import java.util.Locale;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeographyType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/GeographyType.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.types;
 
 import io.delta.kernel.annotation.Evolving;
+import java.util.Locale;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -82,7 +83,7 @@ public final class GeographyType extends DataType {
     if (algorithm == null || algorithm.isEmpty()) {
       throw new IllegalArgumentException("Algorithm cannot be null or empty");
     }
-    if (!VALID_ALGORITHMS.contains(algorithm)) {
+    if (!VALID_ALGORITHMS.contains(algorithm.toLowerCase(Locale.ROOT))) {
       throw new IllegalArgumentException(
           "Algorithm must be one of: spherical, vincenty, thomas, andoyer, karney, got: "
               + algorithm);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -187,10 +187,23 @@ class DataTypeJsonSerDeSuite extends AnyFunSuite {
     val expectedMsg = "Algorithm must be one of: spherical, vincenty, thomas, andoyer, karney"
     checkError[IllegalArgumentException](
       "\"geography(EPSG:4326, planar)\"",
-      expectedMsg)
+      expectedMsg + ", got: planar")
+    checkError[IllegalArgumentException](
+      "\"geography(OGC:CRS84, BoGuS)\"",
+      expectedMsg + ", got: BoGuS")
     checkError[IllegalArgumentException](
       "\"geography(haversine)\"",
-      expectedMsg)
+      expectedMsg + ", got: haversine")
+  }
+
+  test("parseDataType: geography accepts case-insensitive algorithm") {
+    // Uppercase algorithm input is accepted.
+    assert(parse("\"geography(OGC:CRS84, SPHERICAL)\"")
+      === new GeographyType("OGC:CRS84", "SPHERICAL"))
+    assert(parse("\"geography(ViNcEnTy)\"")
+      === new GeographyType("OGC:CRS84", "ViNcEnTy"))
+    assert(parse("\"geography(OGC:CRS84, Spherical)\"")
+      === new GeographyType("OGC:CRS84", "Spherical"))
   }
 
   /* ---------------  Complex types ----------------- */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -197,7 +197,7 @@ class DataTypeJsonSerDeSuite extends AnyFunSuite {
   }
 
   test("parseDataType: geography accepts case-insensitive algorithm") {
-    // Uppercase algorithm input is accepted.
+    // Uppercase algorithm input is accepted .
     assert(parse("\"geography(OGC:CRS84, SPHERICAL)\"")
       === new GeographyType("OGC:CRS84", "SPHERICAL"))
     assert(parse("\"geography(ViNcEnTy)\"")

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -197,7 +197,7 @@ class DataTypeJsonSerDeSuite extends AnyFunSuite {
   }
 
   test("parseDataType: geography accepts case-insensitive algorithm") {
-    // Uppercase algorithm input is accepted .
+    // Uppercase algorithm input is accepted.
     assert(parse("\"geography(OGC:CRS84, SPHERICAL)\"")
       === new GeographyType("OGC:CRS84", "SPHERICAL"))
     assert(parse("\"geography(ViNcEnTy)\"")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR is a `kernel-20250227` cherry-pick of: https://github.com/delta-io/delta/pull/6713.

Following up on https://github.com/delta-io/delta/pull/5885, this PR adds complete support for case-insensitive edge interpolation algorithm parsing for GEOGRAPHY. Although the `Geography` patterns in `DataTypeJsonSerDe` already allowed case-insensitive algorithms, the constructors in `GeographyType` were enforcing strict lowercase values.

## How was this patch tested?

Added appropriate unit tests for `GeographyType` parsing in `DataTypeJsonSerDeSuite`.

## Does this PR introduce _any_ user-facing changes?

Yes, `GeographyType` now allows case-insensitive edge interpolation algorithm values.
