### PR TITLE
Narrow Snapshot usage to SnapshotDescriptor if possible

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
@@ -75,7 +75,7 @@ object DeltaToIcebergConvert
           builder: FileMetadata.Builder,
           fileAction: FileAction,
           partitionSpec: PartitionSpec,
-          snapshot: Snapshot,
+          snapshot: SnapshotDescriptor,
           logicalToPhysicalPartitionNames: Map[String, String]): Unit = {
         if (partitionSpec.isPartitioned) {
             builder.withPartition(
@@ -357,7 +357,7 @@ object DeltaToIcebergConvert
   object Partition {
 
     private[delta] def convertPartitionValues(
-        snapshot: Snapshot,
+        snapshot: SnapshotDescriptor,
         partitionSpec: PartitionSpec,
         partitionValues: Map[String, String],
         logicalToPhysicalPartitionNames: Map[String, String]): StructLike = {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaErrors, Snapshot}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaErrors, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.PartitionUtils.{timestampPartitionPattern, utcFormatter}
@@ -130,7 +130,7 @@ object IcebergTransactionUtils
       tablePath: Path,
       partitionSpec: PartitionSpec,
       logicalToPhysicalPartitionNames: Map[String, String],
-      snapshot: Snapshot): DataFile = {
+      snapshot: SnapshotDescriptor): DataFile = {
     convertFileAction(
       remove, tablePath, partitionSpec, logicalToPhysicalPartitionNames, snapshot)
       .withRecordCount(remove.numLogicalRecords.getOrElse(0L))
@@ -142,7 +142,7 @@ object IcebergTransactionUtils
       tablePath: Path,
       partitionSpec: PartitionSpec,
       logicalToPhysicalPartitionNames: Map[String, String],
-      snapshot: Snapshot): DataFiles.Builder = {
+      snapshot: SnapshotDescriptor): DataFiles.Builder = {
     val absPath = canonicalizeFilePath(f, tablePath)
     var builder = DataFiles
       .builder(partitionSpec)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -628,7 +628,7 @@ object Checkpoints
    */
   def getV2CheckpointFormatOpt(
       spark: SparkSession,
-      snapshot: Snapshot): Option[V2Checkpoint.Format] = {
+      snapshot: SnapshotDescriptor): Option[V2Checkpoint.Format] = {
     val policy = DeltaConfigs.CHECKPOINT_POLICY.fromMetaData(snapshot.metadata)
     if (policy.needsV2CheckpointSupport) {
       assert(CheckpointProvider.isV2CheckpointEnabled(snapshot))
@@ -1222,12 +1222,12 @@ object Checkpoints
     )
   }
 
-  def shouldWriteStatsAsStruct(conf: SQLConf, snapshot: Snapshot): Boolean = {
+  def shouldWriteStatsAsStruct(conf: SQLConf, snapshot: SnapshotDescriptor): Boolean = {
     DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.fromMetaData(snapshot.metadata) &&
       !conf.getConf(DeltaSQLConf.STATS_AS_STRUCT_IN_CHECKPOINT_FORCE_DISABLED).getOrElse(false)
   }
 
-  def shouldWriteStatsAsJson(snapshot: Snapshot): Boolean = {
+  def shouldWriteStatsAsJson(snapshot: SnapshotDescriptor): Boolean = {
     DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON.fromMetaData(snapshot.metadata)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DefaultRowCommitVersion.scala
@@ -28,7 +28,7 @@ object DefaultRowCommitVersion {
   def assignIfMissing(
       spark: SparkSession,
       protocol: Protocol,
-      snapshot: Snapshot,
+      snapshot: SnapshotDescriptor,
       actions: Iterator[Action],
       version: Long): Iterator[Action] = {
     if (!RowTracking.isSupported(protocol)) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -1229,7 +1229,7 @@ object DeltaLog extends DeltaLogging {
    * Checks whether this table only accepts appends. If so it will throw an error in operations that
    * can remove data such as DELETE/UPDATE/MERGE.
    */
-  def assertRemovable(snapshot: Snapshot): Unit = {
+  def assertRemovable(snapshot: SnapshotDescriptor): Unit = {
     val metadata = snapshot.metadata
     if (DeltaConfigs.IS_APPEND_ONLY.fromMetaData(metadata)) {
       throw DeltaErrors.modifyAppendOnlyTableException(metadata.name)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
@@ -374,7 +374,7 @@ object IdentityColumn extends DeltaLogging {
   }
 
   def logTableWrite(
-      snapshot: Snapshot,
+      snapshot: SnapshotDescriptor,
       generatedIdentityColumns: Set[String],
       numInsertedRowsOpt: Option[Long]): Unit = {
     val identityColumns = getIdentityColumns(snapshot.schema)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
@@ -117,7 +117,7 @@ abstract class MaterializedRowTrackingColumn {
    * in 'dataFrame' if one is available. Otherwise returns None.
    */
   private[delta] def getAttribute(
-      snapshot: Snapshot, dataFrame: DataFrame): Option[Attribute] = {
+      snapshot: SnapshotDescriptor, dataFrame: DataFrame): Option[Attribute] = {
     if (!RowTracking.isEnabled(snapshot.protocol, snapshot.metadata)) {
       return None
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -199,7 +199,7 @@ trait MetadataCleanup extends DeltaLogging {
    * protocol we skip the cleanup.
    */
   private def metadataCleanupAllowed(
-      snapshot: Snapshot,
+      snapshot: SnapshotDescriptor,
       fileCutOffTime: Long): Boolean = {
     def expandVersionRange(currentRange: VersionRange, versionToCover: Long): VersionRange =
       versionRange(currentRange.start.min(versionToCover), currentRange.end.max(versionToCover))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -1359,7 +1359,7 @@ object CheckpointProtectionTableFeature
    * Gets the version requiring checkpoint protection from `snapshot`. If the table property is
    * not set, return the default value 0.
    */
-  def getCheckpointProtectionVersion(snapshot: Snapshot): Long = {
+  def getCheckpointProtectionVersion(snapshot: SnapshotDescriptor): Long = {
     getCheckpointProtectionVersionOption(snapshot.protocol, snapshot.metadata).getOrElse(0)
   }
 
@@ -1386,7 +1386,7 @@ object CheckpointProtectionTableFeature
   }
 
   def historyPriorToCheckpointProtectionVersionIsTruncated(
-      snapshot: Snapshot,
+      snapshot: SnapshotDescriptor,
       catalogTableOpt: Option[CatalogTable]): Boolean = {
     val checkpointProtectionVersion = getCheckpointProtectionVersion(snapshot)
     if (checkpointProtectionVersion <= 0) return true

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaErrors, Snapshot}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaErrors, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.AddFile
 
 import org.apache.spark.sql.{Row, SparkSession}
@@ -100,7 +100,10 @@ sealed trait DeltaReorgOperation {
    * Collects files that need to be processed by the reorg operation from the list of candidate
    * files.
    */
-  def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile]
+  def filterFilesToReorg(
+      spark: SparkSession,
+      snapshot: SnapshotDescriptor,
+      files: Seq[AddFile]): Seq[AddFile]
 }
 
 /**
@@ -109,8 +112,10 @@ sealed trait DeltaReorgOperation {
  * if ever exists such column that does not present in the current table schema.
  */
 class DeltaPurgeOperation extends DeltaReorgOperation with ReorgTableHelper {
-  override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
-    : Seq[AddFile] = {
+  override def filterFilesToReorg(
+      spark: SparkSession,
+      snapshot: SnapshotDescriptor,
+      files: Seq[AddFile]): Seq[AddFile] = {
     val physicalSchema = DeltaColumnMapping.renameColumns(snapshot.schema)
     val protocol = snapshot.protocol
     val metadata = snapshot.metadata
@@ -130,8 +135,10 @@ class DeltaPurgeOperation extends DeltaReorgOperation with ReorgTableHelper {
  * Reorg operation to upgrade the iceberg compatibility version of a table.
  */
 class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorgOperation {
-  override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
-    : Seq[AddFile] = {
+  override def filterFilesToReorg(
+      spark: SparkSession,
+      snapshot: SnapshotDescriptor,
+      files: Seq[AddFile]): Seq[AddFile] = {
     def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
       if (file.tags == null) return true
       val fileIcebergCompatVersion =
@@ -147,8 +154,10 @@ class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorg
  * the type widening table feature.
  */
 class DeltaRewriteTypeWideningOperation extends DeltaReorgOperation with ReorgTableHelper {
-  override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
-    : Seq[AddFile] = {
+  override def filterFilesToReorg(
+      spark: SparkSession,
+      snapshot: SnapshotDescriptor,
+      files: Seq[AddFile]): Seq[AddFile] = {
     val physicalSchema = DeltaColumnMapping.renameColumns(snapshot.schema)
     filterParquetFilesOnExecutors(spark, files, snapshot, ignoreCorruptFiles = false) {
       schema => fileHasDifferentTypes(schema, physicalSchema)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{MaterializedRowCommitVersion, MaterializedRowId, Snapshot}
+import org.apache.spark.sql.delta.{MaterializedRowCommitVersion, MaterializedRowId, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
 import org.apache.spark.sql.delta.commands.VacuumCommand.generateCandidateFileMap
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
@@ -103,7 +103,7 @@ trait ReorgTableHelper extends Serializable {
   protected def filterParquetFilesOnExecutors(
       spark: SparkSession,
       files: Seq[AddFile],
-      snapshot: Snapshot,
+      snapshot: SnapshotDescriptor,
       ignoreCorruptFiles: Boolean)(
       filterFileFn: StructType => Boolean): Seq[AddFile] = {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -16,11 +16,11 @@
 
 package org.apache.spark.sql.delta.commands
 
-// scalastyle:off import.ordering.noEmptyLine
 import java.util.concurrent.TimeUnit
 
 import scala.util.control.NonFatal
 
+// scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.ClassicColumnConversions._
@@ -611,7 +611,7 @@ object UpdateCommand {
    */
   def preserveRowTrackingColumns(
       targetDfWithoutRowTrackingColumns: DataFrame,
-      snapshot: Snapshot,
+      snapshot: SnapshotDescriptor,
       targetOutput: Seq[Attribute] = Seq.empty,
       updateExpressions: Seq[Expression] = Seq.empty):
     (DataFrame, Seq[Attribute], Seq[Expression]) = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.delta.{
   DeltaOperations,
   RedirectReaderWriterFeature,
   RedirectWriterOnlyFeature,
-  Snapshot
+  Snapshot,
+  SnapshotDescriptor
 }
 import org.apache.spark.sql.delta.DeltaLog.logPathFor
 import org.apache.spark.sql.delta.actions.Metadata
@@ -419,24 +420,24 @@ class TableRedirect(val config: DeltaConfig[Option[String]]) {
 
 object RedirectReaderWriter extends TableRedirect(config = DeltaConfigs.REDIRECT_READER_WRITER) {
   /** True if `snapshot` enables redirect-reader-writer feature. */
-  def isFeatureSupported(snapshot: Snapshot): Boolean = {
+  def isFeatureSupported(snapshot: SnapshotDescriptor): Boolean = {
     snapshot.protocol.isFeatureSupported(RedirectReaderWriterFeature)
   }
 
   /** True if the update property command tries to set/unset redirect-reader-writer feature. */
-  def isUpdateProperty(snapshot: Snapshot, propKeys: Seq[String]): Boolean = {
+  def isUpdateProperty(snapshot: SnapshotDescriptor, propKeys: Seq[String]): Boolean = {
     propKeys.contains(DeltaConfigs.REDIRECT_READER_WRITER.key) && isFeatureSupported(snapshot)
   }
 }
 
 object RedirectWriterOnly extends TableRedirect(config = DeltaConfigs.REDIRECT_WRITER_ONLY) {
   /** True if `snapshot` enables redirect-writer-only feature. */
-  def isFeatureSupported(snapshot: Snapshot): Boolean = {
+  def isFeatureSupported(snapshot: SnapshotDescriptor): Boolean = {
     snapshot.protocol.isFeatureSupported(RedirectWriterOnlyFeature)
   }
 
   /** True if the update property command tries to set/unset redirect-writer-only feature. */
-  def isUpdateProperty(snapshot: Snapshot, propKeys: Seq[String]): Boolean = {
+  def isUpdateProperty(snapshot: SnapshotDescriptor, propKeys: Seq[String]): Boolean = {
     propKeys.contains(DeltaConfigs.REDIRECT_WRITER_ONLY.key) && isFeatureSupported(snapshot)
   }
 }
@@ -445,7 +446,7 @@ object RedirectFeature {
   /**
    * Determine whether the redirect-reader-writer or the redirect-writer-only feature is supported.
    */
-  def isFeatureSupported(snapshot: Snapshot): Boolean = {
+  def isFeatureSupported(snapshot: SnapshotDescriptor): Boolean = {
     RedirectReaderWriter.isFeatureSupported(snapshot) ||
     RedirectWriterOnly.isFeatureSupported(snapshot)
   }
@@ -505,7 +506,7 @@ object RedirectFeature {
    * Determine whether the operation `op` updates the existing redirect-reader-writer or
    * redirect-writer-only table property of a table with `snapshot`.
    */
-  def isUpdateProperty(snapshot: Snapshot, op: DeltaOperations.Operation): Boolean = {
+  def isUpdateProperty(snapshot: SnapshotDescriptor, op: DeltaOperations.Operation): Boolean = {
     op match {
       case _ @ DeltaOperations.SetTableProperties(properties) =>
         val propertyKeys = properties.keySet.toSeq
@@ -536,7 +537,7 @@ object RedirectFeature {
    * Get the current `TableRedirectConfiguration` object from the snapshot.
    * Note that the redirect-reader-writer takes precedence over redirect-writer-only.
    */
-  def getRedirectConfiguration(snapshot: Snapshot): Option[TableRedirectConfiguration] = {
+  def getRedirectConfiguration(snapshot: SnapshotDescriptor): Option[TableRedirectConfiguration] = {
     getRedirectConfiguration(snapshot.metadata.configuration)
   }
 
@@ -598,7 +599,7 @@ object RedirectFeature {
   }
 
   def validateTableRedirect(
-      snapshot: Snapshot,
+      snapshot: SnapshotDescriptor,
       catalogTable: Option[CatalogTable],
       configs: Map[String, String]
   ): Unit = {


### PR DESCRIPTION
## Description

Narrows APIs from `Snapshot` to `SnapshotDescriptor` where the implementation only needs descriptor-level state such as `deltaLog`, `version`, `metadata`, `protocol`, or `schema`.

This is purely a parameter-type narrowing for cleaner abstraction. Callers that genuinely need full `Snapshot` state (e.g., `allFiles`, `withStats`, checkpoint state, derived counters, domain metadata, file-action streams) are unchanged.

Affected APIs include:
- `DeltaToIcebergConvert.convertPartitionValues`, related helpers in `IcebergTransactionUtils`
- `Checkpoints.getV2CheckpointFormatOpt`, `shouldWriteStatsAsStruct`, `shouldWriteStatsAsJson`
- `DefaultRowCommitVersion.assignIfMissing`
- `DeltaLog.assertRemovable`
- `IdentityColumn.logTableWrite`
- `MaterializedRowTrackingColumn.getAttribute`
- `MetadataCleanup.metadataCleanupAllowed`
- `CheckpointProtectionTableFeature.getCheckpointProtectionVersion`, `historyPriorToCheckpointProtectionVersionIsTruncated`
- `DeltaReorgOperation.filterFilesToReorg` (and `DeltaPurgeOperation`, `DeltaUpgradeUniformOperation`, `DeltaRewriteTypeWideningOperation`)
- `ReorgTableHelper.filterParquetFilesOnExecutors`
- `UpdateCommand.preserveRowTrackingColumns`
- `RedirectReaderWriter.isFeatureSupported`/`isUpdateProperty`, `RedirectWriterOnly.isFeatureSupported`/`isUpdateProperty`, `RedirectFeature.*`

## How was this patch tested?

Existing unit tests cover all callers; this is a type-narrowing-only change.
