### PR TITLE
Update delta-sharing-client version to 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -919,7 +919,7 @@ lazy val sharing = (project in file("sharing"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",
 
-      "io.delta" %% "delta-sharing-client" % "1.3.11",
+      "io.delta" %% "delta-sharing-client" % "1.4.0",
 
       // Test deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (sharing)

## Description

- Upgrade delta-sharing-client version to 1.4.0
  https://github.com/delta-io/delta-sharing/releases/tag/v1.4.0

## How was this patch tested?

CI

## Does this PR introduce _any_ user-facing changes?

No