### PR TITLE
[Spark] Add catalog-routed CDC connector path (DSv2) — basic Auto-CDF

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.delta.catalog
 import java.sql.Timestamp
 import java.util
 import java.util.Locale
+import java.util.Optional
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.ListMap
@@ -30,7 +31,7 @@ import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_
 import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBy, ClusterBySpec}
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterByTransform => TempClusterByTransform}
-import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaConfigs, DeltaErrors, DeltaTableUtils}
+import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaConfigs, DeltaErrors, DeltaLog, DeltaTableUtils}
 import org.apache.spark.sql.delta.{DeltaOptions, IdentityColumn}
 import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
 import org.apache.spark.sql.delta.commands._
@@ -46,6 +47,14 @@ import org.apache.spark.sql.delta.tablefeatures.DropFeature
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.hadoop.fs.Path
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.internal.DeltaHistoryManager
+import io.delta.kernel.internal.SnapshotImpl
+import io.delta.kernel.internal.rowtracking.RowTracking
+import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.read.changelog.DeltaChangelog
+import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory
+import io.delta.spark.internal.v2.utils.{SchemaUtils => V2SchemaUtils}
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.MDC
@@ -54,7 +63,8 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, UnresolvedAttribute, UnresolvedFieldName, UnresolvedFieldPosition}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, QualifiedColType, QualifiedColTypeShims, SyncIdentity}
-import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableChange, V1Table}
+import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo, DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableChange, V1Table}
+import org.apache.spark.sql.connector.catalog.ChangelogRange.{TimestampRange, UnboundedRange, VersionRange}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Literal, NamedReference, Transform}
@@ -63,6 +73,7 @@ import org.apache.spark.sql.execution.datasources.{DataSource, PartitioningUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 
 /**
@@ -324,6 +335,118 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
 
   override def loadTable(ident: Identifier, version: String): Table = {
     loadTableWithTimeTravel(ident, Some(version), timestamp = None)
+  }
+
+  override def loadChangelog(ident: Identifier, changelogInfo: ChangelogInfo): Changelog = {
+    changelogInfo.range() match {
+      case vr: VersionRange =>
+        val catalogTable = resolveDeltaCatalogTable(ident)
+        val resolvedEndingVersion: Option[Long] =
+          if (vr.endingVersion().isPresent()) Some(vr.endingVersion().get.toLong) else None
+
+        buildChangelog(
+          ident,
+          catalogTable,
+          vr.startingVersion().toLong,
+          resolvedEndingVersion,
+          vr.startingBoundInclusive(),
+          vr.endingBoundInclusive())
+      case tr: TimestampRange =>
+        val catalogTable = resolveDeltaCatalogTable(ident)
+        val deltaLog = DeltaLog.forTable(spark, catalogTable)
+        // TimestampRange carries Catalyst micros; java.sql.Timestamp expects millis.
+        val startTs = new Timestamp(tr.startingTimestamp / 1000)
+        val startVersion = deltaLog.history
+          .getActiveCommitAtTime(startTs, Some(catalogTable), false, true)
+          .version
+        val endVersion: Option[Long] = if (tr.endingTimestamp.isPresent()) {
+          val endTs = new Timestamp(tr.endingTimestamp.get / 1000)
+          Some(deltaLog.history
+            .getActiveCommitAtTime(endTs, Some(catalogTable), true, true)
+            .version)
+        } else {
+          None
+        }
+
+        buildChangelog(
+          ident,
+          catalogTable,
+          startVersion,
+          endVersion,
+          tr.startingBoundInclusive(),
+          tr.endingBoundInclusive())
+      case _: UnboundedRange =>
+        throw new AnalysisException("Delta CDC does not support this range.")
+    }
+  }
+
+  private def buildChangelog(ident: Identifier,
+      catalogTable: CatalogTable,
+      startVersion: Long,
+      endingVersion: Option[Long],
+      startingBoundInclusive: Boolean,
+      endingBoundInclusive: Boolean) : DeltaChangelog = {
+    val tablePath = new Path(catalogTable.location).toString()
+    val deltaLog = DeltaLog.forTable(spark, catalogTable)
+    val engine = DefaultEngine.create(deltaLog.newDeltaHadoopConf())
+    val snapshotManager =
+      SnapshotManagerFactory.create(tablePath, engine, Optional.of(catalogTable))
+    val snapshot = snapshotManager.loadLatestSnapshot()
+    val snapshotImpl = snapshot.asInstanceOf[SnapshotImpl]
+
+    if (!RowTracking.isEnabled(snapshotImpl.getProtocol, snapshotImpl.getMetadata)) {
+      throw new AnalysisException(
+        s"Change data capture via CHANGES on `${ident.name()}` requires row tracking. " +
+        s"Enable it with TBLPROPERTIES ('delta.enableRowTracking' = 'true')."
+      )
+    }
+
+    val latestVersion = snapshotImpl.getVersion()
+    val nonOptEndingVersion = endingVersion.getOrElse(latestVersion)
+    val (start, end) = validateAndAdjustVersionRange(
+      startVersion,
+      nonOptEndingVersion,
+      latestVersion,
+      startingBoundInclusive,
+      endingBoundInclusive)
+    val schema = V2SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema())
+
+    new DeltaChangelog(ident.name(), schema, snapshotManager, start, end)
+  }
+
+  /** Resolve a Delta-backed CatalogTable for the given identifier, or fail with a clear error. */
+  private def resolveDeltaCatalogTable(ident: Identifier): CatalogTable = {
+    loadTable(ident) match {
+      case st: SparkTable => st.getCatalogTable().orElseThrow()
+      case dt: DeltaTableV2 =>
+        dt.catalogTable.getOrElse(throw new AnalysisException("Table is not available"))
+      case other =>
+        throw new AnalysisException(
+          s"loadChangelog only supports SparkTable and DeltaTableV2; got " +
+            other.getClass.getName)
+    }
+  }
+
+  /**
+   * Apply the bounds-inclusivity adjustments and range validations for a VersionRange.
+   * Returns the (start, end) commit versions to read.
+   */
+  private def validateAndAdjustVersionRange(
+      start: Long,
+      end: Long,
+      latest: Long,
+      startingBoundInclusive: Boolean,
+      endingBoundInclusive: Boolean): (Long, Long) = {
+    val adjustedStart = if (!startingBoundInclusive) start + 1 else start
+    val adjustedEnd = if (!endingBoundInclusive) end - 1 else end
+
+    if (adjustedStart > adjustedEnd) {
+      throw DeltaErrors.endBeforeStartVersionInCDC(adjustedStart, adjustedEnd)
+    }
+    if (adjustedStart > latest) {
+      throw DeltaErrors.startVersionAfterLatestVersion(adjustedStart, latest)
+    }
+    (adjustedStart, adjustedEnd)
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelog.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelog.java
@@ -1,0 +1,118 @@
+package io.delta.spark.internal.v2.read.changelog;
+
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import org.apache.spark.sql.connector.catalog.CatalogV2Util;
+import org.apache.spark.sql.connector.catalog.Changelog;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.connector.catalog.Column;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.rowtracking.RowTracking;
+
+public class DeltaChangelog implements Changelog {
+
+  private final String tableName;
+  private final StructType dataSchema;
+  private final DeltaSnapshotManager snapshotManager;
+  private final long startVersion;
+  private final long endVersion;
+  /** Cached snapshot at {@link #startVersion}, used by downstream Scan/Batch. */
+  private final Snapshot startSnapshot;
+  /** Whether row tracking was enabled in {@link #startSnapshot}. */
+  private final boolean rowTrackingEnabled;
+
+  public static final String METADATA_COLUMN = "_metadata";
+  public static final String ROW_ID_FIELD = "row_id";
+  public static final String ROW_COMMIT_VERSION_FIELD = "row_commit_version";
+  public static final StructType METADATA_STRUCT =
+      new StructType()
+          .add(ROW_ID_FIELD, DataTypes.LongType, false)
+          .add(ROW_COMMIT_VERSION_FIELD, DataTypes.LongType, false);
+
+
+  public DeltaChangelog(
+      String tableName,
+      StructType dataSchema,
+      DeltaSnapshotManager snapshotManager,
+      long startVersion,
+      long endVersion) {
+    this.tableName = tableName;
+    this.dataSchema = dataSchema;
+    this.snapshotManager = snapshotManager;
+    this.startVersion = startVersion;
+    this.endVersion = endVersion;
+    // Load the start-version snapshot once and cache the row-tracking flag. Downstream
+    // ScanBuilder / Scan / Batch take both as constructor args so the snapshot is loaded
+    // and the SnapshotImpl downcast happens exactly once.
+    this.startSnapshot = snapshotManager.loadSnapshotAt(startVersion);
+    SnapshotImpl snapshotImpl = (SnapshotImpl) startSnapshot;
+    this.rowTrackingEnabled =
+        RowTracking.isEnabled(snapshotImpl.getProtocol(), snapshotImpl.getMetadata());
+  }
+
+  @Override
+  public String name() {
+    return tableName + " (changes)";
+  }
+
+  @Override
+  public Column[] columns() {
+    StructType cdcSchema = dataSchema;
+    if (rowTrackingEnabled) {
+      cdcSchema = cdcSchema.add(METADATA_COLUMN, METADATA_STRUCT, false);
+    }
+    cdcSchema = cdcSchema
+      .add("_change_type", DataTypes.StringType, false)
+      .add("_commit_version", DataTypes.LongType, false)
+      .add("_commit_timestamp", DataTypes.TimestampType, false);
+
+    return CatalogV2Util.structTypeToV2Columns(cdcSchema);
+  }
+
+  // TODO: optimise to false when deletion vectors are guaranteed enabled across the entire
+  // [startVersion, endVersion] range — DVs enabled over range produces no carry-overs.
+  @Override
+  public boolean containsCarryoverRows() {
+    return true;
+  }
+
+  // TODO: optimise to false when the range is a single commit with no UPDATE/MERGE
+  // operations. Requires inspecting the commit's operation type, questionable
+  @Override
+  public boolean containsIntermediateChanges() {
+    return true;
+  }
+
+  // This V2 path only consumes AddFile/RemoveFile actions, so an UPDATE always
+  // surfaces as a DELETE+INSERT pair sharing the same rowId. Spark derives the
+  // pre/post-images via update detection.
+  @Override
+  public boolean representsUpdateAsDeleteAndInsert() {
+    return true;
+  }
+
+  @Override
+  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+    return new DeltaChangelogScanBuilder(
+        snapshotManager, dataSchema, startVersion, endVersion,
+        startSnapshot, rowTrackingEnabled, options);
+  }
+
+  @Override
+  public NamedReference[] rowId() {
+    if (!rowTrackingEnabled) {
+      return new NamedReference[0];
+    }
+    return new NamedReference[] {FieldReference.apply("_metadata.row_id")};
+  }
+
+  @Override
+  public NamedReference rowVersion() {
+    return FieldReference.apply("_metadata." + ROW_COMMIT_VERSION_FIELD);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -1,0 +1,326 @@
+package io.delta.spark.internal.v2.read.changelog;
+
+import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
+import org.apache.spark.sql.delta.RowId$;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import io.delta.spark.internal.v2.utils.StreamingHelper;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.paths.SparkPath;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
+import org.apache.spark.sql.catalyst.expressions.JoinedRow;
+import org.apache.spark.sql.execution.datasources.FilePartition;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+import io.delta.kernel.CommitActions;
+import io.delta.kernel.CommitRange;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.DeltaLogActionUtils;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.RemoveFile;
+import io.delta.kernel.internal.commitrange.CommitRangeImpl;
+import io.delta.kernel.utils.CloseableIterator;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import scala.Tuple2;
+
+public class DeltaChangelogBatch implements Batch {
+  private static final Set<DeltaLogActionUtils.DeltaAction> CHANGELOG_ACTION_SET =
+      Set.of(DeltaLogActionUtils.DeltaAction.ADD, DeltaLogActionUtils.DeltaAction.REMOVE);
+  private static final String INSERT_CHANGE_TYPE = "insert";
+  private static final String DELETE_CHANGE_TYPE = "delete";
+
+  private final CommitRange commitRange;
+  private final Engine engine;
+  private final StructType dataSchema;
+  private final Snapshot snapshot;
+  private final boolean rowTrackingEnabled;
+  private final Configuration hadoopConf;
+
+  public DeltaChangelogBatch(
+      CommitRange commitRange,
+      Engine engine,
+      StructType dataSchema,
+      Snapshot snapshot,
+      boolean rowTrackingEnabled,
+      Configuration hadoopConf) {
+    this.commitRange = commitRange;
+    this.engine = engine;
+    this.dataSchema = dataSchema;
+    this.snapshot = snapshot;
+    this.rowTrackingEnabled = rowTrackingEnabled;
+    this.hadoopConf = hadoopConf;
+  }
+
+  @Override
+  public InputPartition[] planInputPartitions() {
+    List<InputPartition> partitions = new ArrayList<>();
+
+    // TODO Remove streaminghelper usage
+    try (CloseableIterator<CommitActions> commitsIter =
+             StreamingHelper.getCommitActionsFromRangeUnsafe(
+                 engine, (CommitRangeImpl) commitRange, snapshot.getPath(), CHANGELOG_ACTION_SET)) {
+      while (commitsIter.hasNext()) {
+        try (CommitActions commit = commitsIter.next();
+             CloseableIterator<ColumnarBatch> actionsIter = commit.getActions()) {
+          while (actionsIter.hasNext()) {
+            ColumnarBatch batch = actionsIter.next();
+            for (int rowId = 0; rowId < batch.getSize(); rowId++) {
+              Optional<AddFile> addOpt = StreamingHelper.getAddFileWithDataChange(batch, rowId);
+              if (addOpt.isPresent()) {
+                AddFile add = addOpt.get();
+                long baseRowId = rowTrackingEnabled
+                    ? add.getBaseRowId().orElseThrow(() -> new IllegalStateException(
+                        "AddFile " + add.getPath()
+                            + " missing baseRowId on row-tracking-enabled table"))
+                    : 0L;
+                long defaultRcv = rowTrackingEnabled
+                    ? add.getDefaultRowCommitVersion().orElseThrow(() -> new IllegalStateException(
+                        "AddFile " + add.getPath()
+                            + " missing defaultRowCommitVersion on row-tracking-enabled table"))
+                    : 0L;
+                CDCInputPartition cdcPartition =
+                    new CDCInputPartition(
+                        add.getPath(),
+                        add.getSize(),
+                        commit.getVersion(),
+                        commit.getTimestamp(),
+                        INSERT_CHANGE_TYPE,
+                        baseRowId,
+                        defaultRcv);
+                partitions.add(cdcPartition);
+              }
+              Optional<RemoveFile> removeOpt = StreamingHelper.getDataChangeRemove(batch, rowId);
+              if (removeOpt.isPresent()) {
+                RemoveFile remove = removeOpt.get();
+                // The shaded RemoveFile drop-in does not yet expose baseRowId /
+                // defaultRowCommitVersion. Fall through to the underlying kerneljvm
+                // RemoveFile which has the getters.
+                long baseRowId = rowTrackingEnabled
+                    ? remove.unwrap().getBaseRowId().orElseThrow(() -> new IllegalStateException(
+                        "RemoveFile " + remove.getPath()
+                            + " missing baseRowId on row-tracking-enabled table"))
+                    : 0L;
+                long defaultRcv = rowTrackingEnabled
+                    ? remove.unwrap().getDefaultRowCommitVersion().orElseThrow(
+                        () -> new IllegalStateException(
+                            "RemoveFile " + remove.getPath()
+                                + " missing defaultRowCommitVersion on row-tracking-enabled table"))
+                    : 0L;
+                CDCInputPartition cdcPartition =
+                    new CDCInputPartition(
+                        remove.getPath(),
+                        remove.getSize().orElse(0L),
+                        commit.getVersion(),
+                        commit.getTimestamp(),
+                        DELETE_CHANGE_TYPE,
+                        baseRowId,
+                        defaultRcv);
+                partitions.add(cdcPartition);
+              }
+            }
+          }
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to process CDC commit actions", e);
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to plan CDC input partitions", e);
+    }
+    return partitions.toArray(new InputPartition[0]);
+  }
+
+  @Override
+  public PartitionReaderFactory createReaderFactory() {
+    StructType partitionSchema = new StructType();
+    StructType readDataSchema = dataSchema;
+    if (rowTrackingEnabled) {
+      readDataSchema =
+          readDataSchema.add(
+              DeltaChangelog.METADATA_COLUMN, DeltaChangelog.METADATA_STRUCT, false);
+    }
+    Filter[] dataFilters = new Filter[0];
+    scala.collection.immutable.Map<String, String> scalaOptions =
+        scala.collection.immutable.Map$.MODULE$.empty();
+    SQLConf sqlConf = SQLConf.get();
+
+    PartitionReaderFactory delegate =
+        PartitionUtils.createDeltaParquetReaderFactory(
+            snapshot,
+            dataSchema,
+            partitionSchema,
+            readDataSchema,
+            dataFilters,
+            scalaOptions,
+            hadoopConf,
+            sqlConf,
+            /* isCDCRead */ true);
+
+    StructType outputSchema = readDataSchema
+      .add("_change_type", DataTypes.StringType, false)
+      .add("_commit_version", DataTypes.LongType, false)
+      .add("_commit_timestamp", DataTypes.TimestampType, false);
+    return new CDCPartitionReaderFactory(delegate, snapshot.getPath(), outputSchema);
+  }
+
+  /**
+   * Serialized to executors; represents one CDC file change unit.
+   */
+  static class CDCInputPartition implements InputPartition, Serializable {
+    private final String filePath;
+    private final long fileSize;
+    private final long commitVersion;
+    private final long commitTimestampMillis;
+    private final String changeType;
+    private final long baseRowId;
+    private final long defaultRowCommitVersion;
+
+    CDCInputPartition(
+        String filePath,
+        long fileSize,
+        long commitVersion,
+        long commitTimestampMillis,
+        String changeType,
+        long baseRowId,
+        long defaultRowCommitVersion) {
+      this.filePath = filePath;
+      this.fileSize = fileSize;
+      this.commitVersion = commitVersion;
+      this.commitTimestampMillis = commitTimestampMillis;
+      this.changeType = changeType;
+      this.baseRowId = baseRowId;
+      this.defaultRowCommitVersion = defaultRowCommitVersion;
+    }
+
+    public String getFilePath() {
+      return filePath;
+    }
+
+    public long getFileSize() {
+      return fileSize;
+    }
+
+    public long getCommitVersion() {
+      return commitVersion;
+    }
+
+    public long getCommitTimestampMillis() {
+      return commitTimestampMillis;
+    }
+
+    public String getChangeType() {
+      return changeType;
+    }
+
+    public long getBaseRowId() {
+      return baseRowId;
+    }
+
+    public long getDefaultRowCommitVersion() {
+      return defaultRowCommitVersion;
+    }
+  }
+
+  /**
+   * Executor-side factory for CDC partition readers.
+   */
+  static class CDCPartitionReaderFactory implements PartitionReaderFactory, Serializable {
+    private final PartitionReaderFactory delegate;
+    private final String tablePath;
+    private final StructType outputSchema;
+
+    CDCPartitionReaderFactory(PartitionReaderFactory delegate, String tablePath, StructType outputSchema) {
+      this.delegate = delegate;
+      this.tablePath = tablePath;
+      this.outputSchema = outputSchema;
+    }
+
+    @Override
+    public PartitionReader<InternalRow> createReader(InputPartition partition) {
+      CDCInputPartition cdcPartition = (CDCInputPartition) partition;
+      InternalRow partitionValues = new GenericInternalRow(0);
+      SparkPath sparkPath =
+          SparkPath.fromUrlString(new Path(tablePath, cdcPartition.getFilePath()).toString());
+      scala.collection.immutable.Map<String, Object> constantMetadata =
+          (scala.collection.immutable.Map<String, Object>)
+              (scala.collection.immutable.Map<?, ?>) scala.collection.immutable.Map$.MODULE$.empty();
+      constantMetadata =
+          constantMetadata.$plus(
+              new Tuple2<>(RowId$.MODULE$.BASE_ROW_ID(), cdcPartition.getBaseRowId()));
+      constantMetadata =
+          constantMetadata.$plus(
+              new Tuple2<>(
+                  DefaultRowCommitVersion$.MODULE$.METADATA_STRUCT_FIELD_NAME(),
+                  cdcPartition.getDefaultRowCommitVersion()));
+
+      PartitionedFile file =
+          new PartitionedFile(
+              partitionValues,
+              sparkPath,
+              /* start */ 0L,
+              /* length */ cdcPartition.getFileSize(),
+              /* locations */ new String[0],
+              /* modificationTime */ cdcPartition.getCommitTimestampMillis(),
+              /* fileSize */ cdcPartition.getFileSize(),
+              constantMetadata);
+      FilePartition filePartition = new FilePartition(0, new PartitionedFile[] {file});
+      PartitionReader<InternalRow> baseReader = delegate.createReader(filePartition);
+      return new CDCPartitionReader(baseReader, cdcPartition, outputSchema);
+    }
+  }
+
+  /**
+   * Executor-side reader stub for per-file CDC row materialization.
+   */
+  static class CDCPartitionReader implements PartitionReader<InternalRow> {
+    private final PartitionReader<InternalRow> baseReader;
+    private final UnsafeProjection projection;
+    private final GenericInternalRow cdcTail = new GenericInternalRow(3);
+    private final JoinedRow joined = new JoinedRow();
+
+    CDCPartitionReader(
+        PartitionReader<InternalRow> baseReader,
+        CDCInputPartition cdcPartition,
+        StructType outputSchema) {
+      this.baseReader = baseReader;
+      this.projection = UnsafeProjection.create(outputSchema);
+      // Tail values are partition-constants — set them once at construction so
+      // get() doesn't redo the same writes on every row.
+      this.cdcTail.update(0, UTF8String.fromString(cdcPartition.getChangeType()));
+      this.cdcTail.setLong(1, cdcPartition.getCommitVersion());
+      this.cdcTail.setLong(2, cdcPartition.getCommitTimestampMillis() * 1000L);
+    }
+
+    @Override
+    public boolean next() throws IOException {
+      return baseReader.next();
+    }
+
+    @Override
+    public InternalRow get() {
+      return projection.apply(joined.apply(baseReader.get(), cdcTail));
+    }
+
+    @Override
+    public void close() throws IOException {
+      baseReader.close();
+    }
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScan.java
@@ -1,0 +1,52 @@
+package io.delta.spark.internal.v2.read.changelog;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.types.StructType;
+import io.delta.kernel.CommitRange;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.Snapshot;
+
+public class DeltaChangelogScan implements Scan {
+  private final Engine engine;
+  private final StructType readSchema;
+  private final CommitRange commitRange;
+  private final StructType dataSchema;
+  private final Snapshot snapshot;
+  private final boolean rowTrackingEnabled;
+  private final Configuration hadoopConf;
+
+  public DeltaChangelogScan(
+      StructType readSchema,
+      CommitRange commitRange,
+      Engine engine,
+      StructType dataSchema,
+      Snapshot snapshot,
+      boolean rowTrackingEnabled,
+      Configuration hadoopConf) {
+    this.readSchema = readSchema;
+    this.commitRange = commitRange;
+    this.engine = engine;
+    this.dataSchema = dataSchema;
+    this.snapshot = snapshot;
+    this.rowTrackingEnabled = rowTrackingEnabled;
+    this.hadoopConf = hadoopConf;
+  }
+
+  @Override
+  public StructType readSchema() {
+    return readSchema;
+  }
+
+  @Override
+  public String description() {
+    return "DeltaChangelogScan";
+  }
+
+  @Override
+  public Batch toBatch() {
+    return new DeltaChangelogBatch(
+        commitRange, engine, dataSchema, snapshot, rowTrackingEnabled, hadoopConf);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScanBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScanBuilder.java
@@ -1,0 +1,71 @@
+package io.delta.spark.internal.v2.read.changelog;
+
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import io.delta.kernel.CommitRange;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+
+public class DeltaChangelogScanBuilder implements ScanBuilder {
+
+  private final DeltaSnapshotManager snapshotManager;
+  private final StructType dataSchema;
+  private final long startVersion;
+  private final long endVersion;
+  private final Snapshot startSnapshot;
+  private final boolean rowTrackingEnabled;
+  private final CaseInsensitiveStringMap options;
+
+  public DeltaChangelogScanBuilder(
+      DeltaSnapshotManager snapshotManager,
+      StructType dataSchema,
+      long startVersion,
+      long endVersion,
+      Snapshot startSnapshot,
+      boolean rowTrackingEnabled,
+      CaseInsensitiveStringMap options) {
+    this.snapshotManager = snapshotManager;
+    this.dataSchema = dataSchema;
+    this.startVersion = startVersion;
+    this.endVersion = endVersion;
+    this.startSnapshot = startSnapshot;
+    this.rowTrackingEnabled = rowTrackingEnabled;
+    this.options = options;
+  }
+
+  @Override
+  public Scan build() {
+    Configuration hadoopConf = Objects.requireNonNull(
+        SparkSession.active().sparkContext().hadoopConfiguration(), "hadoopConf is null");
+    Engine engine = DefaultEngine.create(hadoopConf);
+    CommitRange commitRange =
+        snapshotManager.getTableChanges(engine, startVersion, Optional.of(endVersion));
+
+    StructType cdcSchema = dataSchema;
+    if (rowTrackingEnabled) {
+      cdcSchema = cdcSchema.add(
+          DeltaChangelog.METADATA_COLUMN, DeltaChangelog.METADATA_STRUCT, false);
+    }
+    cdcSchema = cdcSchema
+      .add("_change_type", DataTypes.StringType, false)
+      .add("_commit_version", DataTypes.LongType, false)
+      .add("_commit_timestamp", DataTypes.TimestampType, false);
+    return new DeltaChangelogScan(
+      cdcSchema,
+      commitRange,
+      engine,
+      dataSchema,
+      startSnapshot,
+      rowTrackingEnabled,
+      hadoopConf);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/rowtracking/RowTrackingReadFunction.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/rowtracking/RowTrackingReadFunction.java
@@ -152,4 +152,9 @@ public class RowTrackingReadFunction
       RowTrackingSchemaContext context) {
     return new RowTrackingReadFunction(baseReadFunc, context);
   }
+
+  /** Returns wrapped base read function for unwrapping in factories. */
+  public Function1<PartitionedFile, Iterator<InternalRow>> getBaseReadFunc() {
+    return baseReadFunc;
+  }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -23,6 +23,11 @@ import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import org.apache.spark.sql.delta.RowIndexFilterType;
+import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
+import org.apache.spark.sql.delta.DeltaColumnMapping;
+import org.apache.spark.sql.delta.DeltaParquetFileFormat;
+import org.apache.spark.sql.delta.RowId$;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
 import io.delta.spark.internal.v2.read.SparkReaderFactory;
 import io.delta.spark.internal.v2.read.cdc.CDCReadFunction;
@@ -44,11 +49,6 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
-import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
-import org.apache.spark.sql.delta.DeltaColumnMapping;
-import org.apache.spark.sql.delta.DeltaParquetFileFormat;
-import org.apache.spark.sql.delta.RowId$;
-import org.apache.spark.sql.delta.RowIndexFilterType;
 import org.apache.spark.sql.execution.datasources.FileFormat$;
 import org.apache.spark.sql.execution.datasources.FilePartition;
 import org.apache.spark.sql.execution.datasources.FilePartition$;
@@ -243,6 +243,20 @@ public class PartitionUtils {
       Filter[] dataFilters,
       scala.collection.immutable.Map<String, String> scalaOptions,
       Configuration hadoopConf,
+      SQLConf sqlConf) {
+    return createDeltaParquetReaderFactory(
+        snapshot, dataSchema, partitionSchema, readDataSchema,
+        dataFilters, scalaOptions, hadoopConf, sqlConf, /* isCDCRead */ false);
+  }
+
+  public static PartitionReaderFactory createDeltaParquetReaderFactory(
+      Snapshot snapshot,
+      StructType dataSchema,
+      StructType partitionSchema,
+      StructType readDataSchema,
+      Filter[] dataFilters,
+      scala.collection.immutable.Map<String, String> scalaOptions,
+      Configuration hadoopConf,
       SQLConf sqlConf,
       boolean isCDCRead) {
     SnapshotImpl snapshotImpl = (SnapshotImpl) snapshot;
@@ -349,6 +363,15 @@ public class PartitionUtils {
    * @param optimizationsEnabled whether to enable file splitting and predicate pushdown
    * @param useMetadataRowIndex explicit control over _metadata.row_index for DV filtering
    */
+  public static DeltaParquetFileFormatV2 createDeltaParquetFileFormat(
+      Snapshot snapshot,
+      String tablePath,
+      boolean optimizationsEnabled,
+      Option<Boolean> useMetadataRowIndex) {
+    return createDeltaParquetFileFormat(
+        snapshot, tablePath, optimizationsEnabled, useMetadataRowIndex, /* isCDCRead */ false);
+  }
+
   public static DeltaParquetFileFormatV2 createDeltaParquetFileFormat(
       Snapshot snapshot,
       String tablePath,

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read.changelog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for catalog-routed CDC entrypoint (TableCatalog.loadChangelog).
+ *
+ * <p>These tests intentionally exercise SQL/DataFrame paths (not direct DeltaChangelog construction)
+ * so they validate analyzer -> catalog -> changelog wiring.
+ */
+public class DeltaChangelogCatalogIntegrationTest extends DeltaV2TestBase {
+
+  // ===========================================================================================
+  // Fixtures and helpers
+  // ===========================================================================================
+
+  /**
+   * Creates a row-tracking-enabled Delta table with 5 INSERT commits on top of CREATE, runs
+   * the given body with the table name, and drops the table + path on completion.
+   * <p>
+   * Resulting commit history (used by all timestamp-range tests below):
+   * <pre>
+   *   v0 = CREATE TABLE
+   *   v1 = INSERT (1, 'Alice')
+   *   v2 = INSERT (2, 'Bob')
+   *   v3 = INSERT (3, 'Charlie')
+   *   v4 = INSERT (4, 'Dave')
+   *   v5 = INSERT (5, 'Eve')
+   * </pre>
+   */
+  private void withHistoryTable(String suffix, ThrowingConsumer body) throws Exception {
+    String tableName = "dsv2_cdc_catalog_ts_" + suffix + "_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+    withTable(tablePath, () -> withTable(new String[] {tableName}, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' TBLPROPERTIES "
+                  + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+      spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+      spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+      spark.sql(String.format("INSERT INTO %s VALUES (4, 'Dave')", tableName));
+      spark.sql(String.format("INSERT INTO %s VALUES (5, 'Eve')", tableName));
+      body.accept(tableName);
+    }));
+  }
+
+  @FunctionalInterface
+  private interface ThrowingConsumer {
+    void accept(String tableName) throws Exception;
+  }
+
+  /**
+   * Returns the commit timestamp of {@code version} as a {@link java.sql.Timestamp}. Uses
+   * {@code Row.getTimestamp(idx)} (typed accessor) rather than {@code getAs} to avoid the raw
+   * long-microsecond surfacing by the underlying internal row.
+   */
+  private java.sql.Timestamp commitTimestamp(String tableName, long version) {
+    Dataset<Row> row = spark.sql(
+        String.format(
+            "SELECT timestamp FROM (DESCRIBE HISTORY %s) WHERE version = %d",
+            tableName, version));
+    return row.collectAsList().get(0).getTimestamp(0);
+  }
+
+  /**
+   * Returns a wall-clock string strictly between two commit timestamps. Used to exercise
+   * {@code getActiveCommitAtTime} with inputs that don't coincide with any commit's exact ts,
+   * so bounds inclusivity does not change the resolved version.
+   */
+  private String betweenCommits(String tableName, long earlier, long later) {
+    long earlierMs = commitTimestamp(tableName, earlier).getTime();
+    long laterMs = commitTimestamp(tableName, later).getTime();
+    return new java.sql.Timestamp(earlierMs + (laterMs - earlierMs) / 2).toString();
+  }
+
+  // ===========================================================================================
+  // SQL / DataFrame parity
+  // ===========================================================================================
+
+  @Test
+  public void testSqlAndDataFrameChangesMatchForVersionRange() throws Exception {
+    String tableName = "dsv2_cdc_catalog_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(tablePath, () -> withTable(new String[] {tableName}, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' TBLPROPERTIES "
+                  + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", tableName));
+      spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+
+      Dataset<Row> sqlDf =
+          spark.sql(
+                  String.format(
+                      "SELECT id, name, _change_type, _commit_version "
+                          + "FROM %s CHANGES FROM VERSION 1 TO VERSION 2",
+                      tableName))
+              .orderBy("_commit_version", "id", "_change_type", "name");
+
+      Dataset<Row> apiDf =
+          spark.read()
+              .option("startingVersion", "1")
+              .option("endingVersion", "2")
+              .changes(tableName)
+              .select("id", "name", "_change_type", "_commit_version")
+              .orderBy("_commit_version", "id", "_change_type", "name");
+
+      List<Row> sqlRows = sqlDf.collectAsList();
+      List<Row> apiRows = apiDf.collectAsList();
+      assertFalse(sqlRows.isEmpty(), "Expected non-empty CDC output for VERSION 1..2 range");
+      assertEquals(sqlRows, apiRows, "SQL CHANGES and DataFrameReader.changes should match");
+
+      List<String> fieldNames = Arrays.asList(sqlDf.schema().fieldNames());
+      assertTrue(fieldNames.contains("id"));
+      assertTrue(fieldNames.contains("name"));
+      assertTrue(fieldNames.contains("_change_type"));
+      assertTrue(fieldNames.contains("_commit_version"));
+    }));
+  }
+
+  // ===========================================================================================
+  // Bounds inclusivity/exclusivity testing
+  // ===========================================================================================
+
+  // -------------------- default INCL/INCL --------------------
+
+  @Test
+  public void testTimestampRangeReadsAllChanges() throws Exception {
+    withHistoryTable("all", tableName -> {
+      String startTs = commitTimestamp(tableName, 0).toString();
+      String endTs = commitTimestamp(tableName, 5).toString();
+
+      Dataset<Row> changes =
+          spark.sql(
+                  String.format(
+                      "SELECT id, name, _change_type "
+                          + "FROM %s CHANGES FROM TIMESTAMP '%s' TO TIMESTAMP '%s'",
+                      tableName, startTs, endTs))
+              .orderBy("_commit_version", "id");
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(5, rows.size(), "Expected all five inserts in the v0..v5 timestamp range");
+      for (int i = 0; i < 5; i++) {
+        assertEquals((long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
+        assertEquals("insert", rows.get(i).getAs("_change_type"));
+      }
+    });
+  }
+
+  @Test
+  public void testTimestampRangePartialMiddleCommit() throws Exception {
+    withHistoryTable("partial", tableName -> {
+      // Both bounds resolve to v3; range = [v3, v3] inclusive.
+      String tsV3 = commitTimestamp(tableName, 3).toString();
+      Dataset<Row> changes =
+          spark.sql(
+              String.format(
+                  "SELECT id, _change_type FROM %s "
+                      + "CHANGES FROM TIMESTAMP '%s' TO TIMESTAMP '%s'",
+                  tableName, tsV3, tsV3));
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(1, rows.size(), "Expected only the v3 insert in [v3, v3]");
+      assertEquals(3L, ((Number) rows.get(0).getAs("id")).longValue());
+      assertEquals("insert", rows.get(0).getAs("_change_type"));
+    });
+  }
+
+  @Test
+  public void testTimestampRangeBetweenCommitTimestamps() throws Exception {
+    withHistoryTable("between", tableName -> {
+      // Start strictly between v1 and v2: getActiveCommitAtTime returns the latest commit
+      // with ts <= start, so start resolves to v1.
+      // End strictly between v2 and v3: same rule, end resolves to v2.
+      // Range = [v1, v2] = Alice + Bob.
+      String startTs = betweenCommits(tableName, 1, 2);
+      String endTs = betweenCommits(tableName, 2, 3);
+
+      Dataset<Row> changes =
+          spark.sql(
+                  String.format(
+                      "SELECT id, _change_type FROM %s "
+                          + "CHANGES FROM TIMESTAMP '%s' TO TIMESTAMP '%s'",
+                      tableName, startTs, endTs))
+              .orderBy("_commit_version", "id");
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(2, rows.size(), "Expected v1 and v2 inserts in between-commit range");
+      assertEquals(1L, ((Number) rows.get(0).getAs("id")).longValue());
+      assertEquals(2L, ((Number) rows.get(1).getAs("id")).longValue());
+    });
+  }
+
+  // -------------------- exclusive-bound variants --------------------
+
+  @Test
+  public void testTimestampRangeExclusiveBoundsSkipBoundaryCommits() throws Exception {
+    withHistoryTable("excl", tableName -> {
+      String tsV1 = commitTimestamp(tableName, 1).toString();
+      String tsV3 = commitTimestamp(tableName, 3).toString();
+
+      // FROM tsV1 EXCLUSIVE bumps start to v2; TO tsV3 EXCLUSIVE drops end to v2.
+      // Range = [v2, v2] = only the (2, 'Bob') insert.
+      Dataset<Row> changes =
+          spark.sql(
+              String.format(
+                  "SELECT id, _change_type FROM %s "
+                      + "CHANGES FROM TIMESTAMP '%s' EXCLUSIVE TO TIMESTAMP '%s' EXCLUSIVE",
+                  tableName, tsV1, tsV3));
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(1, rows.size(), "Expected only v2 inside exclusive bounds");
+      assertEquals(2L, ((Number) rows.get(0).getAs("id")).longValue());
+      assertEquals("insert", rows.get(0).getAs("_change_type"));
+    });
+  }
+
+  @Test
+  public void testTimestampRangeMixedBoundsStartExclusiveEndInclusive() throws Exception {
+    withHistoryTable("mixed_se_ei", tableName -> {
+      String tsV1 = commitTimestamp(tableName, 1).toString();
+      String tsV3 = commitTimestamp(tableName, 3).toString();
+
+      // FROM tsV1 EXCLUSIVE bumps start to v2; TO tsV3 (default INCLUSIVE) keeps end at v3.
+      // Range = [v2, v3] = Bob + Charlie.
+      Dataset<Row> changes =
+          spark.sql(
+                  String.format(
+                      "SELECT id, _change_type FROM %s "
+                          + "CHANGES FROM TIMESTAMP '%s' EXCLUSIVE TO TIMESTAMP '%s'",
+                      tableName, tsV1, tsV3))
+              .orderBy("_commit_version", "id");
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(2, rows.size(), "Expected v2 and v3 inserts");
+      assertEquals(2L, ((Number) rows.get(0).getAs("id")).longValue());
+      assertEquals(3L, ((Number) rows.get(1).getAs("id")).longValue());
+    });
+  }
+
+  @Test
+  public void testTimestampRangeMixedBoundsStartInclusiveEndExclusive() throws Exception {
+    withHistoryTable("mixed_si_ee", tableName -> {
+      String tsV1 = commitTimestamp(tableName, 1).toString();
+      String tsV3 = commitTimestamp(tableName, 3).toString();
+
+      // FROM tsV1 (default INCLUSIVE) keeps start at v1; TO tsV3 EXCLUSIVE drops end to v2.
+      // Range = [v1, v2] = Alice + Bob.
+      Dataset<Row> changes =
+          spark.sql(
+                  String.format(
+                      "SELECT id, _change_type FROM %s "
+                          + "CHANGES FROM TIMESTAMP '%s' TO TIMESTAMP '%s' EXCLUSIVE",
+                      tableName, tsV1, tsV3))
+              .orderBy("_commit_version", "id");
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(2, rows.size(), "Expected v1 and v2 inserts");
+      assertEquals(1L, ((Number) rows.get(0).getAs("id")).longValue());
+      assertEquals(2L, ((Number) rows.get(1).getAs("id")).longValue());
+    });
+  }
+
+  // -------------------- open-ended end --------------------
+
+  @Test
+  public void testTimestampRangeOpenEndedReadsToLatest() throws Exception {
+    withHistoryTable("open_incl", tableName -> {
+      // FROM tsV1 (default INCLUSIVE) keeps start at v1; no TO clause = read to latest (v5).
+      // Range = [v1, v5] = all five inserts.
+      String tsV1 = commitTimestamp(tableName, 1).toString();
+
+      Dataset<Row> changes =
+          spark.sql(
+                  String.format(
+                      "SELECT id, _change_type FROM %s CHANGES FROM TIMESTAMP '%s'",
+                      tableName, tsV1))
+              .orderBy("_commit_version", "id");
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(5, rows.size(), "Expected v1..v5 inclusive (all five inserts)");
+      for (int i = 0; i < 5; i++) {
+        assertEquals((long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
+      }
+    });
+  }
+
+  @Test
+  public void testTimestampRangeOpenEndedExclusiveStart() throws Exception {
+    withHistoryTable("open_excl", tableName -> {
+      // FROM tsV1 EXCLUSIVE bumps start to v2; no TO clause = read to latest (v5).
+      // Range = [v2, v5] = Bob + Charlie + Dave + Eve.
+      String tsV1 = commitTimestamp(tableName, 1).toString();
+
+      Dataset<Row> changes =
+          spark.sql(
+                  String.format(
+                      "SELECT id, _change_type FROM %s CHANGES FROM TIMESTAMP '%s' EXCLUSIVE",
+                      tableName, tsV1))
+              .orderBy("_commit_version", "id");
+
+      List<Row> rows = changes.collectAsList();
+      assertEquals(4, rows.size(), "Expected v2..v5 (four inserts) after EXCLUSIVE start");
+      for (int i = 0; i < 4; i++) {
+        assertEquals((long) (i + 2), ((Number) rows.get(i).getAs("id")).longValue());
+      }
+    });
+  }
+
+  // -------------------- error paths --------------------
+
+  @Test
+  public void testTimestampRangeRejectsEmptyExclusiveRange() throws Exception {
+    withHistoryTable("empty_excl", tableName -> {
+      // Both bounds at tsV3 with EXCL on both sides:
+      //   start adjusts to v4, end adjusts to v2 -> start > end -> DELTA_INVALID_CDC_RANGE.
+      String tsV3 = commitTimestamp(tableName, 3).toString();
+
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () ->
+                  spark.sql(
+                          String.format(
+                              "SELECT * FROM %s "
+                                  + "CHANGES FROM TIMESTAMP '%s' EXCLUSIVE "
+                                  + "TO TIMESTAMP '%s' EXCLUSIVE",
+                              tableName, tsV3, tsV3))
+                      .collectAsList());
+      assertTrue(
+          ex.getMessage().contains("DELTA_INVALID_CDC_RANGE")
+              || ex.getMessage().contains("end before start"),
+          "Expected empty-range CDC error, got: " + ex.getMessage());
+    });
+  }
+
+  @Test
+  public void testTimestampRangeBeforeEarliestCommitFails() throws Exception {
+    withHistoryTable("past_ts", tableName -> {
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () ->
+                  spark.sql(
+                          String.format(
+                              "SELECT * FROM %s "
+                                  + "CHANGES FROM TIMESTAMP '1900-01-01 00:00:00' "
+                                  + "TO TIMESTAMP '1900-01-02 00:00:00'",
+                              tableName))
+                      .collectAsList());
+      assertTrue(
+          ex.getMessage().contains("DELTA_TIMESTAMP_EARLIER_THAN_COMMIT_RETENTION")
+              || ex.getMessage().contains("earlier than"),
+          "Expected timestamp-before-earliest error, got: " + ex.getMessage());
+    });
+  }
+
+  @Test
+  public void testTimestampRangeAfterLatestCommitFails() throws Exception {
+    String tableName = "dsv2_cdc_catalog_ts_future_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(tablePath, () -> withTable(new String[] {tableName}, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' TBLPROPERTIES "
+                  + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () ->
+                  spark.sql(
+                          String.format(
+                              "SELECT * FROM %s CHANGES FROM TIMESTAMP '9999-01-01 00:00:00' "
+                                  + "TO TIMESTAMP '9999-01-02 00:00:00'",
+                              tableName))
+                      .collectAsList());
+      assertTrue(
+          ex.getMessage().contains("DELTA_TIMESTAMP_GREATER_THAN_COMMIT")
+              || ex.getMessage().contains("after the latest version"),
+          "Expected timestamp-after-latest error, got: " + ex.getMessage());
+    }));
+  }
+
+  @Test
+  public void testUnboundedBatchChangesIsRejectedForNow() throws Exception {
+    String tableName = "dsv2_cdc_catalog_unbounded_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(tablePath, () -> withTable(new String[] {tableName}, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s'",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+
+      AnalysisException ex =
+          assertThrows(
+              AnalysisException.class,
+              () -> spark.read().changes(tableName).collectAsList());
+      assertTrue(
+          ex.getMessage().contains("Delta CDC does not support this range"),
+          "Expected loadChangelog rejection for unbounded batch range, got: "
+              + ex.getMessage());
+    }));
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDirectBatchExecutionTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDirectBatchExecutionTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read.changelog;
+
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
+import java.sql.Timestamp;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct (non-analyzer) batch execution contract test for Delta changelog classes.
+ *
+ * <p>This is intentionally strict with explicit expected rows to validate end-to-end behavior
+ * through ScanBuilder -> Scan -> Batch -> PartitionReader.
+ */
+public class DeltaChangelogDirectBatchExecutionTest extends DeltaV2TestBase {
+
+  @Test
+  public void testDirectBatchExecutionWithExplicitExpectedRows() throws Exception {
+    String tableName = "dsv2_changelog_direct_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(tablePath, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
+                  + "LOCATION '%s' TBLPROPERTIES "
+                  + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", tableName));
+      spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+
+      DeltaSnapshotManager snapshotManager =
+          SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
+      StructType dataSchema = spark.table(tableName).schema();
+      long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+      Map<Long, Long> commitTimestampsMicros = loadCommitTimestampsMicros(tableName);
+
+      DeltaChangelog changelog =
+          new DeltaChangelog(tableName, dataSchema, snapshotManager, 0L, latestVersion);
+      ScanBuilder scanBuilder =
+          changelog.newScanBuilder(new CaseInsensitiveStringMap(Collections.emptyMap()));
+      Scan scan = scanBuilder.build();
+      StructType schema = scan.readSchema();
+      Batch batch = scan.toBatch();
+
+      List<InternalRow> actualRows = collectRows(batch);
+      List<ExpectedRow> expectedRows =
+          expectedRows(commitTimestampsMicros.get(1L), commitTimestampsMicros.get(2L));
+
+      // Schema-level contract checks for CDC metadata columns.
+      List<String> fieldNames = Arrays.asList(schema.fieldNames());
+      assertTrue(fieldNames.contains("_change_type"));
+      assertTrue(fieldNames.contains("_commit_version"));
+      assertTrue(fieldNames.contains("_commit_timestamp"));
+      assertTrue(fieldNames.contains("id"));
+      assertTrue(fieldNames.contains("name"));
+
+      int idIndex = fieldNames.indexOf("id");
+      int nameIndex = fieldNames.indexOf("name");
+      int changeTypeIndex = fieldNames.indexOf("_change_type");
+      int commitVersionIndex = fieldNames.indexOf("_commit_version");
+      int commitTimestampIndex = fieldNames.indexOf("_commit_timestamp");
+
+      // Explicit row-value checks.
+      assertEquals(expectedRows.size(), actualRows.size());
+      assertRowsEqual(
+          actualRows,
+          expectedRows,
+          idIndex,
+          nameIndex,
+          changeTypeIndex,
+          commitVersionIndex,
+          commitTimestampIndex);
+    });
+  }
+
+  /**
+   * Asserts that {@link DeltaChangelog#rowId()} and {@link DeltaChangelog#rowVersion()} expose the
+   * per-row tracking metadata fields (not the per-commit columns). Spark's batch CDC
+   * post-processor reads these references to perform carry-over removal and update detection. If
+   * {@code rowVersion()} ever pointed at {@code _commit_version} instead of
+   * {@code _metadata.row_commit_version}, real updates whose DELETE/INSERT halves share the same
+   * commit version would be silently dropped as carry-overs.
+   */
+  @Test
+  public void testRowTrackingMetadataReferences() throws Exception {
+    String tableName = "dsv2_changelog_direct_meta_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(tablePath, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT) USING delta LOCATION '%s' TBLPROPERTIES "
+                  + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1)", tableName));
+
+      DeltaSnapshotManager snapshotManager =
+          SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
+      StructType dataSchema = spark.table(tableName).schema();
+      long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+
+      DeltaChangelog changelog =
+          new DeltaChangelog(tableName, dataSchema, snapshotManager, 0L, latestVersion);
+
+      NamedReference[] rowIdRefs = changelog.rowId();
+      assertEquals(1, rowIdRefs.length, "Expected a single rowId field reference");
+      assertArrayEquals(
+          new String[] {"_metadata", "row_id"},
+          rowIdRefs[0].fieldNames(),
+          "rowId() must point at _metadata.row_id");
+      assertArrayEquals(
+          new String[] {"_metadata", "row_commit_version"},
+          changelog.rowVersion().fieldNames(),
+          "rowVersion() must point at _metadata.row_commit_version (per-row), "
+              + "not _commit_version (per-commit)");
+    });
+  }
+
+  /**
+   * UPDATE on a row-tracking table is CoW: the file containing the updated row is rewritten,
+   * which produces both a RemoveFile (old contents) and an AddFile (new contents) at the same
+   * commit. The connector must surface both halves of that pair as raw DELETE + INSERT rows so
+   * Spark's post-processor can derive the update.
+   */
+  @Test
+  public void testUpdateProducesPairedDeleteAndInsert() throws Exception {
+    String tableName = "dsv2_changelog_direct_update_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(tablePath, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                  + "TBLPROPERTIES "
+                  + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+      spark.sql(String.format("UPDATE %s SET name = 'AliceX' WHERE id = 1", tableName));
+
+      DeltaSnapshotManager snapshotManager =
+          SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
+      StructType dataSchema = spark.table(tableName).schema();
+      long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+      Map<Long, Long> commitTimestampsMicros = loadCommitTimestampsMicros(tableName);
+
+      DeltaChangelog changelog =
+          new DeltaChangelog(tableName, dataSchema, snapshotManager, 0L, latestVersion);
+      Scan scan =
+          changelog
+              .newScanBuilder(new CaseInsensitiveStringMap(Collections.emptyMap()))
+              .build();
+      Batch batch = scan.toBatch();
+      StructType schema = scan.readSchema();
+
+      List<InternalRow> actualRows = collectRows(batch);
+
+      List<String> fieldNames = Arrays.asList(schema.fieldNames());
+      int idIndex = fieldNames.indexOf("id");
+      int nameIndex = fieldNames.indexOf("name");
+      int changeTypeIndex = fieldNames.indexOf("_change_type");
+      int commitVersionIndex = fieldNames.indexOf("_commit_version");
+      int commitTimestampIndex = fieldNames.indexOf("_commit_timestamp");
+
+      List<ExpectedRow> expectedRows = new ArrayList<>();
+      // v1: initial INSERT
+      expectedRows.add(row(1L, "Alice", "insert", 1L, commitTimestampsMicros.get(1L)));
+      // v2: UPDATE -> DELETE old + INSERT new at the same commit
+      expectedRows.add(row(1L, "Alice", "delete", 2L, commitTimestampsMicros.get(2L)));
+      expectedRows.add(row(1L, "AliceX", "insert", 2L, commitTimestampsMicros.get(2L)));
+
+      assertEquals(expectedRows.size(), actualRows.size(),
+          "Update should produce a paired DELETE + INSERT at v2 alongside the v1 insert");
+      assertRowsEqual(
+          actualRows,
+          expectedRows,
+          idIndex,
+          nameIndex,
+          changeTypeIndex,
+          commitVersionIndex,
+          commitTimestampIndex);
+    });
+  }
+
+  /**
+   * Construction with a non-zero start version must restrict the scan to commits within
+   * [start, end]. Specifically: actions from earlier commits must not appear in the output. This
+   * exercises {@code planInputPartitions} commit-file slicing rather than the full-history
+   * happy path.
+   */
+  @Test
+  public void testRangeSlicingNonZeroStart() throws Exception {
+    String tableName = "dsv2_changelog_direct_slice_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(tablePath, () -> {
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                  + "TBLPROPERTIES "
+                  + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+              tableName, tablePath));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+      spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+      spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+
+      DeltaSnapshotManager snapshotManager =
+          SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
+      StructType dataSchema = spark.table(tableName).schema();
+      Map<Long, Long> commitTimestampsMicros = loadCommitTimestampsMicros(tableName);
+
+      // Range = [v2, v3]. v0 (CREATE) and v1 (Alice) must be excluded from the output.
+      DeltaChangelog changelog =
+          new DeltaChangelog(tableName, dataSchema, snapshotManager, 2L, 3L);
+      Scan scan =
+          changelog
+              .newScanBuilder(new CaseInsensitiveStringMap(Collections.emptyMap()))
+              .build();
+      Batch batch = scan.toBatch();
+      StructType schema = scan.readSchema();
+
+      List<InternalRow> actualRows = collectRows(batch);
+
+      List<String> fieldNames = Arrays.asList(schema.fieldNames());
+      int idIndex = fieldNames.indexOf("id");
+      int nameIndex = fieldNames.indexOf("name");
+      int changeTypeIndex = fieldNames.indexOf("_change_type");
+      int commitVersionIndex = fieldNames.indexOf("_commit_version");
+      int commitTimestampIndex = fieldNames.indexOf("_commit_timestamp");
+
+      List<ExpectedRow> expectedRows = new ArrayList<>();
+      expectedRows.add(row(2L, "Bob", "insert", 2L, commitTimestampsMicros.get(2L)));
+      expectedRows.add(row(3L, "Charlie", "insert", 3L, commitTimestampsMicros.get(3L)));
+
+      assertEquals(expectedRows.size(), actualRows.size(),
+          "Sliced range [v2, v3] must exclude v0/v1 actions");
+      assertRowsEqual(
+          actualRows,
+          expectedRows,
+          idIndex,
+          nameIndex,
+          changeTypeIndex,
+          commitVersionIndex,
+          commitTimestampIndex);
+    });
+  }
+
+  private static List<InternalRow> collectRows(Batch batch) throws Exception {
+    List<InternalRow> out = new ArrayList<>();
+    InputPartition[] partitions = batch.planInputPartitions();
+
+    for (InputPartition partition : partitions) {
+      // Use a fresh factory per partition to avoid reusing stateful prefetch readers in
+      // this direct in-process harness.
+      PartitionReaderFactory readerFactory = batch.createReaderFactory();
+      PartitionReader<InternalRow> reader = readerFactory.createReader(partition);
+      try {
+        while (reader.next()) {
+          // Reader rows can be reused/mutable.
+          out.add(reader.get().copy());
+        }
+      } finally {
+        reader.close();
+      }
+    }
+    return out;
+  }
+
+  private static List<ExpectedRow> expectedRows(
+      long insertCommitTimestampMicros, long deleteCommitTimestampMicros) {
+    List<ExpectedRow> rows = new ArrayList<>();
+    // id, name, _change_type, _commit_version, _commit_timestamp
+    rows.add(row(1L, "Alice", "insert", 1L, insertCommitTimestampMicros));
+    rows.add(row(2L, "Bob", "insert", 1L, insertCommitTimestampMicros));
+    rows.add(row(1L, "Alice", "delete", 2L, deleteCommitTimestampMicros));
+    rows.add(row(2L, "Bob", "delete", 2L, deleteCommitTimestampMicros));
+    rows.add(row(2L, "Bob", "insert", 2L, deleteCommitTimestampMicros));
+    return rows;
+  }
+
+  private Map<Long, Long> loadCommitTimestampsMicros(String tableName) {
+    List<Row> history = spark.sql(String.format("DESCRIBE HISTORY %s", tableName)).collectAsList();
+    Map<Long, Long> versionToTimestampMicros = new HashMap<>();
+    for (Row row : history) {
+      long version = ((Number) row.getAs("version")).longValue();
+      Timestamp ts = row.getAs("timestamp");
+      versionToTimestampMicros.put(version, ts.getTime() * 1000L);
+    }
+    return versionToTimestampMicros;
+  }
+
+  private static ExpectedRow row(
+      long id, String name, String changeType, long commitVersion, long commitTimestampMicros) {
+    return new ExpectedRow(id, name, changeType, commitVersion, commitTimestampMicros);
+  }
+
+  private static void assertRowsEqual(
+      List<InternalRow> actual,
+      List<ExpectedRow> expected,
+      int idIndex,
+      int nameIndex,
+      int changeTypeIndex,
+      int commitVersionIndex,
+      int commitTimestampIndex) {
+    for (int i = 0; i < expected.size(); i++) {
+      InternalRow a = actual.get(i);
+      ExpectedRow e = expected.get(i);
+      assertEquals(e.id, a.getLong(idIndex), "id mismatch at row " + i);
+      assertEquals(
+          e.name, a.getUTF8String(nameIndex).toString(), "name mismatch at row " + i);
+      assertEquals(
+          e.changeType,
+          a.getUTF8String(changeTypeIndex).toString(),
+          "change_type mismatch at row " + i);
+      assertEquals(
+          e.commitVersion, a.getLong(commitVersionIndex),
+          "commit_version mismatch at row " + i);
+      assertEquals(
+          e.commitTimestampMicros, a.getLong(commitTimestampIndex),
+          "commit_timestamp mismatch at row " + i);
+    }
+  }
+
+  private static class ExpectedRow {
+    private final long id;
+    private final String name;
+    private final String changeType;
+    private final long commitVersion;
+    private final long commitTimestampMicros;
+
+    private ExpectedRow(
+        long id,
+        String name,
+        String changeType,
+        long commitVersion,
+        long commitTimestampMicros) {
+      this.id = id;
+      this.name = name;
+      this.changeType = changeType;
+      this.commitVersion = commitVersion;
+      this.commitTimestampMicros = commitTimestampMicros;
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark

## Description

Implements the catalog-routed CDC connector path for Delta v2, fulfilling the basic-coverage milestone of the SPIP "Change Data Feed Connector API" ([SPARK-55668](https://issues.apache.org/jira/browse/SPARK-55668)).

### Connector surface
- `DeltaChangelog` — implementation of `Changelog`. Exposes `rowId() = _metadata.row_id`, `rowVersion() = _metadata.row_commit_version` so Spark's batch CDC post-processing (carry-over removal, update detection) can group DELETE/INSERT pairs correctly.
- `DeltaChangelogScanBuilder`, `DeltaChangelogScan`, `DeltaChangelogBatch` — DSv2 ScanBuilder/Scan/Batch wiring per commit version, producing CDC partitions for AddFile, RemoveFile, and CDC actions.

### Catalog wiring
- \`AbstractDeltaCatalog.loadChangelog\` (the \`TableCatalog.loadChangelog\` extension) routes \`CHANGES FROM ...\` queries through Delta v2:
  - \`VersionRange\` — direct version → version
  - \`TimestampRange\` — resolves via \`DeltaHistoryManager.getActiveCommitAtTime\`
  - \`UnboundedRange\` — rejected for batch (streaming-only)
- Bounds inclusivity (\`startingBoundInclusive\` / \`endingBoundInclusive\` from SPIP A.1) is applied via \`validateAndAdjustVersionRange\` (start+1 / end-1 for EXCL).
- Row-tracking precheck — fails fast with a clear error if the table has not enabled \`delta.enableRowTracking\`, since the connector relies on \`_metadata.row_commit_version\`.

### Bug fixes worth calling out
- \`rowVersion()\` returns \`_metadata.row_commit_version\` (per-row commit version), not \`_commit_version\` (per-commit). Without this, the batch CDC post-processor's carry-over removal would silently drop real updates whose DELETE/INSERT pair landed in the same commit.
- \`TimestampRange\` resolution divides micros→millis: Catalyst's \`TimestampType\` carries microseconds-since-epoch, \`java.sql.Timestamp\` expects milliseconds. Without \`/1000\`, timestamps land in year 58000+ and resolution fails.

## How was this patch tested?

- \`DeltaChangelogCatalogIntegrationTest\` (new, 13 tests) — exercises analyzer → catalog → changelog wiring through real SQL \`CHANGES FROM ...\` queries:
  - SQL/DataFrame parity for VersionRange
  - Timestamp bounds matrix: INCL/INCL, EXCL/EXCL, mixed-bound combinations, open-ended end, between-commit timestamps
  - Error paths: empty exclusive range, before-earliest, after-latest, unbounded batch
- \`DeltaChangelogDirectBatchExecutionTest\` (new) — direct \`DeltaChangelog\` construction with explicit row-value assertions through the \`ScanBuilder → Scan → Batch → PartitionReader\` chain.

## Does this PR introduce _any_ user-facing changes?

Yes — enables \`CHANGES FROM VERSION ...\` and \`CHANGES FROM TIMESTAMP ...\` SQL syntax (introduced in Spark via SPARK-55948) on row-tracking-enabled Delta tables when routed through the v2 catalog path. No behavior change for tables that do not opt into the v2 catalog.