### PR TITLE
Decouple logging call sites from DeltaLog via DeltaLoggingProvider

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
@@ -204,7 +204,7 @@ object CheckpointProvider extends DeltaLogging {
       logPath: Path,
       exception: Option[Throwable]): Unit = {
     recordDeltaEvent(
-      deltaLog = null,
+      provider = null,
       opType = "delta.checkpointV2.readV2ActionsFromCheckpoint",
       data = Map(
         "timeTakenMs" -> (System.currentTimeMillis() - startTimeMs),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -333,7 +333,7 @@ private[delta] class ConflictChecker(
           // Sanity check.
           case m: Metadata if m != currentTransactionInfo.metadata =>
             recordDeltaEvent(
-              deltaLog = currentTransactionInfo.readSnapshot.deltaLog,
+              currentTransactionInfo.readSnapshot,
               opType = "dropFeature.conflictCheck.metadataMismatch",
               data = Map(
                 "transactionInfoMetadata" -> currentTransactionInfo.metadata,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
@@ -74,7 +74,7 @@ object DeltaFileProviderUtils extends DeltaLogging {
       // [[unsafeVolatileSnapshot]] maybe null, which needs to be explicitly filtered out.
       val snapshot = Some(deltaLog.unsafeVolatileSnapshot).filter(_ != null)
       recordDeltaEvent(
-        deltaLog = deltaLog,
+        provider = deltaLog,
         opType = "delta.exceptions.deltaVersionsNotContiguous",
         data = Map(
           // Remove the first element of the stack trace since this represents

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable
 import scala.util.Try
 import scala.util.control.NonFatal
 
+import com.databricks.spark.util.TagDefinition
 import com.databricks.spark.util.TagDefinitions._
 import org.apache.spark.sql.delta.v2.interop.DeltaV2TableManager
 import org.apache.spark.sql.delta.DataFrameUtils
@@ -35,7 +36,7 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.WriteIntoDelta
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeLogFileIndex}
-import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.redirect.RedirectFeature
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources._
@@ -90,10 +91,34 @@ class DeltaLog private(
   with DeltaFileFormat
   with ProvidesUniFormConverters
   with ReadChecksum
+  with DeltaLoggingProvider
   with DeltaV2TableManager {
 
   import org.apache.spark.sql.delta.files.TahoeFileIndex
   import org.apache.spark.sql.delta.util.FileNames._
+
+  /**
+   * Recording tags for this `DeltaLog`. Uses the latest volatile snapshot's metadata id, which may
+   * lag behind the snapshot a caller is operating on. Callers that hold a specific
+   * [[Snapshot]]/[[SnapshotDescriptor]] should prefer logging against that instead, so the tags
+   * reflect the exact snapshot version being observed.
+   */
+  override def getCommonTags: Map[TagDefinition, String] =
+    getCommonTags(Try(unsafeVolatileSnapshot.metadata.id).getOrElse(null))
+
+  /**
+   * Variant of [[getCommonTags]] where the caller supplies the tahoe id explicitly (typically a
+   * specific snapshot's `metadata.id`). Used by [[DeltaLoggingProvider]] implementations that
+   * refer to a specific snapshot version (e.g. [[Snapshot]], [[OptimisticTransaction]]).
+   */
+  def getCommonTags(tahoeId: String): Map[TagDefinition, String] = {
+    (
+      Map(
+        TAG_TAHOE_ID -> tahoeId,
+        TAG_TAHOE_PATH -> Try(dataPath.toString).getOrElse(null)
+      )
+    )
+  }
 
   /**
    * Path to sidecar directory.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/FileMetadataMaterializationTracker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/FileMetadataMaterializationTracker.scala
@@ -219,7 +219,7 @@ object FileMetadataMaterializationTracker extends DeltaLogging {
       logInfo(log"File metadata materialization metrics for the completed query: " +
         log"${MDC(DeltaLogKeys.METRICS, trackerMetrics)}")
       recordDeltaEvent(
-        deltaLog = origTxn.deltaLog,
+        provider = origTxn,
         opType = metricsOpType,
         data = trackerMetrics)
     } finally { tracker.releaseAllPermits()  }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -581,7 +581,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
     val executionId = Option(spark.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY))
       .getOrElse("unknown")
     recordDeltaEvent(
-      snapshot.deltaLog,
+      snapshot,
       "delta.generatedColumns.optimize",
       data = Map(
         "executionId" -> executionId,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
@@ -298,7 +298,7 @@ object IdentityColumn extends DeltaLogging {
             f, candidateHighWaterMark, allowLoweringHighWaterMarkForSyncIdentity = false)
           if (loggingSeq.nonEmpty) {
             recordDeltaEvent(
-              deltaLog = deltaLog,
+              provider = deltaLog,
               opType = opTypeHighWaterMarkUpdate,
               data = Map(
                 "columnName" -> f.name,
@@ -383,7 +383,7 @@ object IdentityColumn extends DeltaLogging {
         f => !generatedIdentityColumns.contains(f.name)
       }.map(_.name)
       recordDeltaEvent(
-        snapshot.deltaLog,
+        snapshot,
         opTypeWrite,
         data = Map(
           "numInsertedRows" -> numInsertedRowsOpt,
@@ -422,7 +422,7 @@ object IdentityColumn extends DeltaLogging {
         field, candidateHighWaterMark, allowLoweringHighWaterMarkForSyncIdentity)
       if (loggingSeq.nonEmpty) {
         recordDeltaEvent(
-          deltaLog = deltaLog,
+          provider = deltaLog,
           opType = opTypeHighWaterMarkUpdate,
           data = Map(
             "columnName" -> field.name,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -26,8 +26,10 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.jdk.OptionConverters._
+import scala.util.Try
 import scala.util.control.NonFatal
 
+import com.databricks.spark.util.TagDefinition
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
@@ -45,7 +47,7 @@ import org.apache.spark.sql.delta.hooks.metrics.UpdateMetricsHook
 import org.apache.spark.sql.delta.util.CatalogTableUtils
 import org.apache.spark.sql.delta.implicits.addFileEncoder
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
-import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.redirect.{RedirectFeature, TableRedirectConfiguration}
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
@@ -268,7 +270,16 @@ trait OptimisticTransactionImpl extends TransactionHelper
   with SQLMetricsReporting
   with DeltaScanGenerator
   with RecordChecksum
-  with DeltaLogging {
+  with DeltaLogging
+  with DeltaLoggingProvider {
+
+  /**
+   * Recording tags for this transaction, anchored to the read snapshot's `metadata.id`. Lets
+   * `recordDeltaEvent(txn, ...)` attribute events to the table being mutated without reaching
+   * through `txn.deltaLog`.
+   */
+  override def getCommonTags: Map[TagDefinition, String] =
+    deltaLog.getCommonTags(Try(snapshot.metadata.id).getOrElse(null))
 
   import org.apache.spark.sql.delta.util.FileNames._
 
@@ -1623,7 +1634,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
         if (illegalColChange) {
           recordDeltaEvent(
-            deltaLog = deltaLog,
+            provider = deltaLog,
             opType = "delta.metadataCheck.illegalPartitionColumnChange",
             data = Map(
               "operation" -> op.name,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -81,7 +81,7 @@ case class TestWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
     }
 
     if (DeltaUtils.isTesting) {
-      recordDeltaEvent(table.deltaLog, "delta.test.TestWriterFeaturePreDowngradeCommand")
+      recordDeltaEvent(table, "delta.test.TestWriterFeaturePreDowngradeCommand")
     }
 
     val properties = Seq(TestRemovableWriterFeature.TABLE_PROP_KEY)
@@ -132,7 +132,7 @@ case class TestReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
     }
 
     if (DeltaUtils.isTesting) {
-      recordDeltaEvent(table.deltaLog, "delta.test.TestReaderWriterFeaturePreDowngradeCommand")
+      recordDeltaEvent(table, "delta.test.TestReaderWriterFeaturePreDowngradeCommand")
     }
 
     val properties = Seq(TestRemovableReaderWriterFeature.TABLE_PROP_KEY)
@@ -332,7 +332,7 @@ case class DeletionVectorsPreDowngradeCommand(table: DeltaTableV2)
       TimeUnit.NANOSECONDS.toMillis(table.deltaLog.clock.nanoTime() - startTimeNs)
 
     recordDeltaEvent(
-      table.deltaLog,
+      table,
       opType = "delta.deletionVectorsFeatureRemovalMetrics",
       data = metrics)
     PreDowngradeStatus(performedChanges = tracesFound)
@@ -360,7 +360,7 @@ case class V2CheckpointPreDowngradeCommand(table: DeltaTableV2)
     AlterTableSetPropertiesDeltaCommand(table, properties).run(spark)
 
     recordDeltaEvent(
-      table.deltaLog,
+      table,
       opType = "delta.v2CheckpointFeatureRemovalMetrics",
       data =
         Map(("downgradeTimeMs", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs)))
@@ -414,7 +414,7 @@ case class InCommitTimestampsPreDowngradeCommand(table: DeltaTableV2)
       prop -> currentTableProperties.contains(prop).toString
     }
     recordDeltaEvent(
-      table.deltaLog,
+      table,
       opType = "delta.inCommitTimestampFeatureRemovalMetrics",
       data = Map(
           "downgradeTimeMs" -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs),
@@ -492,7 +492,7 @@ case class CoordinatedCommitsPreDowngradeCommand(table: DeltaTableV2)
       }
     }
     recordDeltaEvent(
-      table.deltaLog,
+      table,
       opType = "delta.coordinatedCommitsFeatureRemovalMetrics",
       data = Map(
           "downgradeTimeMs" -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs),
@@ -534,7 +534,7 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
     val metadataRemoved = removeMetadataIfNeeded()
 
     recordDeltaEvent(
-      table.deltaLog,
+      table,
       opType = "delta.typeWidening.featureRemoval",
       data = Map(
         "downgradeTimeMs" -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs),
@@ -612,7 +612,7 @@ case class ColumnMappingPreDowngradeCommand(table: DeltaTableV2)
     }
 
     recordDeltaOperation(
-      table.deltaLog,
+      table,
       opType = "delta.columnMappingFeatureRemoval") {
       RemoveColumnMappingCommand(table.deltaLog, table.catalogTable)
         .run(spark, removeColumnMappingTableProperty = true)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -21,14 +21,16 @@ import java.util.{Locale, TimeZone}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.Try
 
+import com.databricks.spark.util.TagDefinition
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.Action.logSchema
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CommitCoordinatorClient, CommitCoordinatorProvider, CoordinatedCommitsUsageLogs, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.expressions.EncodeNestedVariantAsZ85String
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
-import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DataSkippingReader
@@ -57,7 +59,7 @@ import org.apache.spark.util.Utils
  * A description of a Delta [[Snapshot]], including basic information such its [[DeltaLog]]
  * metadata, protocol, and version.
  */
-trait SnapshotDescriptor {
+trait SnapshotDescriptor extends DeltaLoggingProvider {
   def deltaLog: DeltaLog
   def version: Long
   def metadata: Metadata
@@ -73,6 +75,13 @@ trait SnapshotDescriptor {
     version >= 0 &&
       protocol.readerAndWriterFeatureNames.contains(CatalogOwnedTableFeature.name)
   }
+
+  /**
+   * Recording tags for this snapshot, anchored to the snapshot's own `metadata.id` (as opposed to
+   * the latest volatile metadata id that a bare [[DeltaLog]] would report).
+   */
+  override def getCommonTags: Map[TagDefinition, String] =
+    deltaLog.getCommonTags(Try(metadata.id).getOrElse(null))
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -278,7 +278,7 @@ trait SnapshotManagement { self: DeltaLog =>
           unbackfilledCommitsResponse.getCommits.asScala.map(commit => commit.getVersion),
         "latestCommitVersion" -> unbackfilledCommitsResponse.getLatestTableVersion)
       recordDeltaEvent(
-        deltaLog = this,
+        provider = this,
         opType = CoordinatedCommitsUsageLogs.FS_COMMIT_COORDINATOR_LISTING_UNEXPECTED_GAPS,
         data = eventData)
       if (DeltaUtils.isTesting) {
@@ -666,7 +666,7 @@ trait SnapshotManagement { self: DeltaLog =>
       "missingCommits" -> missingCommits
     )
     recordDeltaEvent(
-      deltaLog = this,
+      provider = this,
       opType = "delta.getLogSegmentForVersion.compactedDeltaValidationFailed",
       data = eventData)
     if (DeltaUtils.isTesting) {
@@ -1663,7 +1663,7 @@ object SnapshotManagement extends DeltaLogging {
         // in some cases, which needs to be explicitly filtered out.
         val snapshot = cachedSnapshot.filter(_ != null)
         recordDeltaEvent(
-          deltaLog = null,
+          provider = null,
           opType = "delta.exceptions.deltaVersionsNotContiguous",
           data = Map(
             // Remove the first element of the stack trace since this represents

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
@@ -162,7 +162,7 @@ private[delta] object TypeWideningMetadata extends DeltaLogging {
 
     if (changesToRecord.nonEmpty) {
       recordDeltaEvent(
-        deltaLog = txn.snapshot.deltaLog,
+        txn,
         opType = "delta.typeWidening.typeChanges",
         data = Map(
           "changes" -> changesToRecord.map { change =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -559,7 +559,7 @@ object DropTableFeatureUtils extends DeltaLogging {
       } catch {
         case NonFatal(e) =>
           recordDeltaEvent(
-            deltaLog = log,
+            provider = log,
             opType = "dropFeature.checkpointAndVerify.error",
             data = Map(
               "message" -> e.getMessage,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -31,7 +31,7 @@ import com.databricks.spark.util.TagDefinition
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
-import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{DeltaFileOperations, JsonUtils, Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.FileNames
@@ -76,12 +76,12 @@ object Action extends DeltaLogging {
   // We can't extend the [[Action]] class itself since it affects serialization.
   // Instead, we add a wrapper here as a helper method for logging.
   override def recordDeltaEvent(
-      deltaLog: DeltaLog,
+      provider: DeltaLoggingProvider,
       opType: String,
       tags: Map[TagDefinition, String] = Map.empty,
       data: AnyRef = null,
       path: Option[Path] = None): Unit = {
-    super.recordDeltaEvent(deltaLog, opType, tags, data, path)
+    super.recordDeltaEvent(provider, opType, tags, data, path)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -29,10 +29,11 @@ import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.WriteIntoDelta
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
-import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.ENABLE_TABLE_REDIRECT_FEATURE
+import com.databricks.spark.util.TagDefinition
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{DataFrame, Dataset, SaveMode, SparkSession}
@@ -70,7 +71,8 @@ class DeltaTableV2 private(
   extends Table
   with SupportsWrite
   with V2TableWithV1Fallback
-  with DeltaLogging {
+  with DeltaLogging
+  with DeltaLoggingProvider {
 
   case class PathInfo(
       rootPath: Path,
@@ -129,6 +131,9 @@ class DeltaTableV2 private(
         catalogTable)
     }
   }
+
+  override def getCommonTags: Map[TagDefinition, String] = deltaLog.getCommonTags
+
 
   /**
    * Updates the delta log for this table and returns a new snapshot

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
@@ -103,7 +103,7 @@ trait DeletionVectorUtils extends DeltaLogging {
     } catch {
       case e: Exception =>
         recordDeltaEvent(
-          deltaLog = null,
+          provider = null,
           opType = "delta.assertions.deletionVectorSerializationError",
           data = debugInfo ++ Map(
             "serializationFormat" -> serializationFormat,
@@ -128,7 +128,7 @@ trait DeletionVectorUtils extends DeltaLogging {
     } catch {
       case e: Exception =>
         recordDeltaEvent(
-          deltaLog = null,
+          provider = null,
           "delta.assertions.deletionVectorDeserializationError",
           data = debugInfo ++ Map(
             "errorMsg" -> e.getMessage,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaInsertReplaceOnOrUsingCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaInsertReplaceOnOrUsingCommand.scala
@@ -243,7 +243,7 @@ case class DeltaInsertReplaceOnOrUsingCommand(
     } finally {
       commandStats.totalExecutionTimeMs = System.currentTimeMillis() - commandStartTimeMs
       recordDeltaEvent(
-        deltaLog = deltaTable.deltaLog,
+        provider = deltaTable,
         opType = "delta.insertReplaceOnOrUsing.stats",
         data = commandStats)
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
@@ -208,7 +208,7 @@ trait ReorgTableForUpgradeUniformHelper extends DeltaLogging {
         log"${MDC(DeltaLogKeys.TABLE_NAME, target.tableIdentifier)} succeeded.")
     }
 
-    recordDeltaEvent(updatedSnapshot.deltaLog, "delta.upgradeUniform.success", data = Map(
+    recordDeltaEvent(updatedSnapshot, "delta.upgradeUniform.success", data = Map(
       "currIcebergCompatVersion" -> currIcebergCompatVersionOpt.toString,
       "targetIcebergCompatVersion" -> targetIcebergCompatVersion.toString,
       "metrics" -> metricsOpt.toString,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ShowDeltaTableColumnsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ShowDeltaTableColumnsCommand.scala
@@ -47,7 +47,7 @@ case class ShowDeltaTableColumnsCommand(child: LogicalPlan)
     // Return the schema from snapshot if it is an Delta table. Or raise
     // `DeltaErrors.notADeltaTableException` if it is a non-Delta table.
     val deltaTable = getDeltaTable(child, "SHOW COLUMNS")
-    recordDeltaOperation(deltaTable.deltaLog, "delta.ddl.showColumns") {
+    recordDeltaOperation(deltaTable, "delta.ddl.showColumns") {
       deltaTable.update().schema.fieldNames.map { x => Row(x) }.toSeq
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -387,7 +387,7 @@ case class AlterTableDropFeatureDeltaCommand(
       sparkSession: SparkSession,
       removableFeature: TableFeature with RemovableFeature): Seq[Row] = {
     val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.dropFeature") {
+    recordDeltaOperation(table, "delta.ddl.alter.dropFeature") {
       // The removableFeature.preDowngradeCommand needs to adhere to the following requirements:
       //
       // a) Bring the table to a state the validation passes.
@@ -467,7 +467,7 @@ case class AlterTableDropFeatureDeltaCommand(
       txn.updateMetadata(metadataWithNewConfiguration)
       txn.commit(commitActions, op)
       recordDeltaEvent(
-        deltaLog = deltaLog,
+        provider = table,
         opType = "dropFeatureCompleted.withHistoryTruncation",
         data = Map("droppedFeature" -> removableFeature.name))
       Nil
@@ -507,8 +507,7 @@ case class AlterTableDropFeatureDeltaCommand(
   private def executeDropFeatureWithCheckpointProtection(
       sparkSession: SparkSession,
       removableFeature: TableFeature with RemovableFeature): Seq[Row] = {
-    val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.dropFeatureWithCheckpointProtection") {
+    recordDeltaOperation(table, "delta.ddl.alter.dropFeatureWithCheckpointProtection") {
       var startTimeNs = System.nanoTime()
       val status = removableFeature
         .preDowngradeCommand(table)
@@ -570,7 +569,7 @@ case class AlterTableDropFeatureDeltaCommand(
       // This is a protected checkpoint.
       if (historyBarrierIsRequired) createCheckpointWithRetries(table, System.nanoTime())
       recordDeltaEvent(
-        deltaLog = deltaLog,
+        provider = table,
         opType = "dropFeatureCompleted.withCheckpointProtection",
         data = Map("droppedFeature" -> removableFeature.name))
       Nil
@@ -612,7 +611,7 @@ case class AlterTableAddColumnsDeltaCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.addColumns") {
+    recordDeltaOperation(table, "delta.ddl.alter.addColumns") {
       val txn = startTransaction()
 
       if (SchemaUtils.filterRecursively(
@@ -714,7 +713,7 @@ case class AlterTableDropColumnsDeltaCommand(
       throw DeltaErrors.dropColumnNotSupported(suggestUpgrade = false)
     }
     val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.dropColumns") {
+    recordDeltaOperation(table, "delta.ddl.alter.dropColumns") {
       val txn = startTransaction()
       val metadata = txn.metadata
       if (txn.metadata.columnMappingMode == NoMapping) {
@@ -783,7 +782,7 @@ case class AlterTableChangeColumnDeltaCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.changeColumns") {
+    recordDeltaOperation(table, "delta.ddl.alter.changeColumns") {
       val txn = startTransaction()
       val metadata = txn.metadata
       val bypassCharVarcharToStringFix =
@@ -1158,7 +1157,7 @@ case class AlterTableReplaceColumnsDeltaCommand(
   extends LeafRunnableCommand with AlterDeltaTableCommand with IgnoreCachedData {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    recordDeltaOperation(table.deltaLog, "delta.ddl.alter.replaceColumns") {
+    recordDeltaOperation(table, "delta.ddl.alter.replaceColumns") {
       val txn = startTransaction()
 
       val metadata = txn.metadata
@@ -1304,7 +1303,7 @@ case class AlterTableAddConstraintDeltaCommand(
     if (name == CharVarcharConstraint.INVARIANT_NAME) {
       throw DeltaErrors.invalidConstraintName(name)
     }
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.addConstraint") {
+    recordDeltaOperation(table, "delta.ddl.alter.addConstraint") {
       val txn = startTransaction()
 
       getConstraintWithName(table, name, txn.metadata, sparkSession).foreach { oldExpr =>
@@ -1340,7 +1339,7 @@ case class AlterTableAddConstraintDeltaCommand(
       logInfo(log"Checking that ${MDC(DeltaLogKeys.EXPR, exprText)} " +
         log"is satisfied for existing data. This will require a full table scan.")
       recordDeltaOperation(
-          txn.snapshot.deltaLog,
+          txn,
           "delta.ddl.alter.addConstraint.checkExisting") {
         val n = df.where(Column(Or(Not(unresolvedExpr), IsUnknown(unresolvedExpr)))).count()
 
@@ -1372,7 +1371,7 @@ case class AlterTableDropConstraintDeltaCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.dropConstraint") {
+    recordDeltaOperation(table, "delta.ddl.alter.dropConstraint") {
       val txn = startTransaction()
 
       val oldExprText = Constraints.getExprTextByName(name, txn.metadata, sparkSession)
@@ -1427,7 +1426,7 @@ case class AlterTableClusterByDeltaCommand(
           "newColumnsCount" -> 0))
       return Seq.empty
     }
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.clusterBy") {
+    recordDeltaOperation(table, "delta.ddl.alter.clusterBy") {
       val txn = startTransaction()
 
       val clusteringColsLogicalNames = ClusteringColumnInfo.extractLogicalNames(txn.snapshot)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -459,7 +459,7 @@ object CatalogOwnedTableUtils extends DeltaLogging {
     val allData = baseData ++ catalogData ++ coordinatorData ++ stackTraceData ++ diagnosticData
 
     recordDeltaEvent(
-      deltaLog = deltaLog,
+      provider = deltaLog,
       opType = opType,
       data = allData
     )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
@@ -83,7 +83,7 @@ case class DeletionVectorStoredBitmap(
     // Verify that the cardinality in the bitmap matches the DV descriptor.
     if (bitmap.cardinality != dvDescriptor.cardinality) {
       recordDeltaEvent(
-        deltaLog = null,
+        provider = null,
         opType = "delta.assertions.deletionVectorReadCardinalityMismatch",
         data = Map(
           "deletionVectorPath" -> onDiskPath,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
@@ -163,14 +163,14 @@ trait UpdateCatalogBase extends PostCommitHook with DeltaLogging {
           if (schemaHasChanged(snapshot, spark)) {
             updateSchema(spark, snapshot)
             recordDeltaEvent(
-              snapshot.deltaLog,
+              snapshot,
               "delta.catalog.update.schema",
               data = loggingData
             )
           } else if (propertiesHaveChanged(properties, snapshot.metadata, spark)) {
             updateProperties(spark, snapshot)
             recordDeltaEvent(
-              snapshot.deltaLog,
+              snapshot,
               "delta.catalog.update.properties",
               data = loggingData
             )
@@ -179,7 +179,7 @@ trait UpdateCatalogBase extends PostCommitHook with DeltaLogging {
             // table properties.
             updateProperties(spark, snapshot)
             recordDeltaEvent(
-              snapshot.deltaLog,
+              snapshot,
               "delta.catalog.update.clusteringColumns",
               data = loggingData
             )
@@ -187,7 +187,7 @@ trait UpdateCatalogBase extends PostCommitHook with DeltaLogging {
         } catch {
           case NonFatal(e) =>
             recordDeltaEvent(
-              snapshot.deltaLog,
+              snapshot,
               "delta.catalog.update.error",
               data = Map(
                 "exceptionMsg" -> ExceptionUtils.getMessage(e),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -29,6 +29,7 @@ import com.databricks.spark.util.TagDefinitions.{
   TAG_TAHOE_PATH
 }
 import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.SnapshotDescriptor
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
@@ -64,22 +65,27 @@ trait DeltaLogging
   extends DeltaProgressReporter
   with DatabricksLogging {
 
+
   /**
    * Used to record the occurrence of a single event or report detailed, operation specific
    * statistics.
    *
-   * @param path Used to log the path of the delta table when `deltaLog` is null.
+   * Takes a [[DeltaLoggingProvider]] so call sites don't need to reach through `xxx.deltaLog`
+   * purely for telemetry. A `DeltaLog` itself is a [[DeltaLoggingProvider]], so existing call
+   * sites like `recordDeltaEvent(deltaLog, ...)` continue to work via subtyping.
+   *
+   * @param path Used to log the path of the delta table when `provider` is null.
    */
   protected def recordDeltaEvent(
-      deltaLog: DeltaLog,
+      provider: DeltaLoggingProvider,
       opType: String,
       tags: Map[TagDefinition, String] = Map.empty,
       data: AnyRef = null,
       path: Option[Path] = None): Unit = recordFrameProfile("Delta", "recordDeltaEvent") {
     try {
       val json = if (data != null) JsonUtils.toJson(data) else ""
-      val tableTags = if (deltaLog != null) {
-        getCommonTags(deltaLog, Try(deltaLog.unsafeVolatileSnapshot.metadata.id).getOrElse(null))
+      val tableTags = if (provider != null) {
+        provider.getCommonTags
       } else if (path.isDefined) {
         Map(TAG_TAHOE_PATH -> path.get.toString)
       } else {
@@ -112,16 +118,14 @@ trait DeltaLogging
     recordDeltaOperationInternal(Map(TAG_TAHOE_PATH -> tablePath), opType, tags)(thunk)
   }
 
-  /**
-   * Used to report the duration as well as the success or failure of an operation on a `deltaLog`.
-   */
+  /** Used to report the duration as well as the success or failure of an operation. */
   protected def recordDeltaOperation[A](
-      deltaLog: DeltaLog,
+      provider: DeltaLoggingProvider,
       opType: String,
       tags: Map[TagDefinition, String] = Map.empty)(
       thunk: => A): A = {
-    val tableTags: Map[TagDefinition, String] = if (deltaLog != null) {
-      getCommonTags(deltaLog, Try(deltaLog.unsafeVolatileSnapshot.metadata.id).getOrElse(null))
+    val tableTags: Map[TagDefinition, String] = if (provider != null) {
+      provider.getCommonTags
     } else {
       Map.empty
     }
@@ -157,7 +161,7 @@ trait DeltaLogging
       assert(check, msg)
     } else if (!check) {
       recordDeltaEvent(
-        deltaLog = deltaLog,
+        provider = deltaLog,
         opType = s"delta.assertions.$name",
         data = data,
         path = path
@@ -175,15 +179,6 @@ trait DeltaLogging
     thunk
   }
 
-  // Extract common tags from the delta log and snapshot.
-  def getCommonTags(deltaLog: DeltaLog, tahoeId: String): Map[TagDefinition, String] = {
-    (
-      Map(
-        TAG_TAHOE_ID -> tahoeId,
-        TAG_TAHOE_PATH -> Try(deltaLog.dataPath.toString).getOrElse(null)
-      )
-    )
-  }
 
   /*
    * Returns error data suitable for logging.
@@ -204,6 +199,25 @@ trait DeltaLogging
     }
     data
   }
+}
+
+/**
+ * An object that can provide the table-attribution tags needed when emitting a Delta usage log
+ * event or operation. Implemented by anything that logically represents "a particular Delta table"
+ * for telemetry purposes (e.g. [[DeltaLog]], [[Snapshot]]/[[SnapshotDescriptor]],
+ * [[OptimisticTransaction]]).
+ *
+ * Prefer passing a `DeltaLoggingProvider` rather than a raw `DeltaLog` when invoking
+ * `recordDeltaEvent` / `recordDeltaOperation`. This decouples call sites from `DeltaLog` and
+ * lets future refactors (e.g. kernelization) evolve the tag source without touching every
+ * logging call site.
+ */
+trait DeltaLoggingProvider {
+  /**
+   * Returns the common table tags that should be attached to every usage log event/operation
+   * recorded on behalf of this provider.
+   */
+  def getCommonTags: Map[TagDefinition, String]
 }
 
 object DeltaLogging {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -370,7 +370,7 @@ def normalizeColumnNamesInDataType(
             s"Types without nesting should match but $sourceDataType != $tableDataType")
         } else if (sourceDataType != tableDataType) {
           recordDeltaEvent(
-            deltaLog = deltaLog,
+            provider = deltaLog,
             opType = "delta.assertions.schemaNormalization.nonNestedTypeMismatch",
             tags = Map.empty,
             data = Map(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -1407,14 +1407,14 @@ object DeltaSource extends DeltaLogging {
     } catch {
       case e: DeltaUnsupportedTableFeatureException =>
         recordDeltaEvent(
-          deltaLog = deltaLog,
+          provider = deltaLog,
           opType = "dropFeature.validateProtocolAt.unsupportedFeatureFound",
           data = Map("message" -> e.getMessage))
         throw e
       case NonFatal(e) => // Suppress rest errors.
         logWarning(log"Protocol validation failed with '${MDC(DeltaLogKeys.EXCEPTION, e)}'.")
         recordDeltaEvent(
-          deltaLog = deltaLog,
+          provider = deltaLog,
           opType = "dropFeature.validateProtocolAt.error",
           data = Map("message" -> e.getMessage))
     }


### PR DESCRIPTION
## Description

Decouples Delta logging call sites from a hard `DeltaLog` parameter by introducing a `DeltaLoggingProvider` trait that anything representing "a particular Delta table" can implement: `DeltaLog`, `Snapshot`/`SnapshotDescriptor`, `OptimisticTransaction`, and `DeltaTableV2`.

`DeltaLogging.recordDeltaEvent` and `recordDeltaOperation` now accept a `DeltaLoggingProvider` instead of a raw `DeltaLog`. A `DeltaLog` is still a `DeltaLoggingProvider`, so existing call sites continue to work via subtyping. New call sites can pass a snapshot or transaction directly, so the recorded `tahoe id` reflects the exact snapshot version being observed rather than the latest volatile snapshot.

### Why

Telemetry call sites previously had to reach through `xxx.deltaLog` purely for logging tags, which:
- coupled call sites to the concrete `DeltaLog` shape
- attributed events to whatever the latest volatile snapshot was, even when the caller held a specific older snapshot

`DeltaLoggingProvider` decouples logging tags from `DeltaLog`, lets snapshots/txns provide the right `metadata.id`, and is a pre-req for further refactoring (e.g. kernelization) that will evolve the tag source.

### Changes

- New `DeltaLoggingProvider` trait in `metering/DeltaLogging.scala` with `getCommonTags`.
- `DeltaLog`, `OptimisticTransactionImpl`, `SnapshotDescriptor`, and `DeltaTableV2` all extend `DeltaLoggingProvider`.
- `recordDeltaEvent` / `recordDeltaOperation` parameter renamed `deltaLog` → `provider` and typed as `DeltaLoggingProvider`.
- ~25 call sites updated to pass the most appropriate provider (often `txn` / `snapshot` / `table`) instead of `xxx.deltaLog`.
- `Action.recordDeltaEvent` wrapper signature updated to match.

## How was this patch tested?

Existing unit tests cover all of the affected logging call sites; this is a trait/parameter-type refactor with no behavioral changes to telemetry payloads.

cc @raveeram-db