### PR TITLE
[Spark] Make REPLACE TABLE catalog-managed enablement a user-facing error

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2439,6 +2439,12 @@
     ],
     "sqlState" : "44000"
   },
+  "DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED" : {
+    "message" : [
+      "REPLACE TABLE cannot enable catalog-managed on the existing non-catalog-managed table <tableName>. Upgrade or recreate the table instead."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_REPLACE_WHERE_IN_OVERWRITE" : {
     "message" : [
       "You can't use replaceWhere in conjunction with an overwrite by filter"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -4001,6 +4001,12 @@ trait DeltaErrorsBase
     )
   }
 
+  def replaceTableWithCatalogManagedNotSupported(tableNameParts: Seq[String]): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED",
+      messageParameters = Array(toSQLId(tableNameParts)))
+  }
+
   def cannotResolveSourceColumnException(columnPath: Seq[String]): Throwable = {
     new DeltaIllegalArgumentException(
       errorClass = "DELTA_CANNOT_RESOLVE_SOURCE_COLUMN",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -147,6 +147,7 @@ case class CreateDeltaTableCommand(
       tableExists = deltaLog.tableExists,
       query = query,
       catalogTableProperties = tableWithLocation.properties,
+      catalogTable = tableWithLocation,
       existingTableSnapshotOpt =
         if (deltaLog.tableExists) Some(deltaLog.unsafeVolatileSnapshot) else None)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -310,6 +310,7 @@ object CatalogOwnedTableUtils extends DeltaLogging {
    * @param tableExists Whether the table already exists.
    * @param query The query to be executed (e.g., CloneTableCommand).
    * @param catalogTableProperties The table properties from the catalog table.
+   * @param catalogTable The catalog table, used to derive the table name in error messages.
    * @param existingTableSnapshotOpt The snapshot of the existing table, if it exists.
    */
   def validatePropertiesForCreateDeltaTableCommand(
@@ -317,6 +318,7 @@ object CatalogOwnedTableUtils extends DeltaLogging {
       tableExists: Boolean,
       query: Option[LogicalPlan],
       catalogTableProperties: Map[String, String],
+      catalogTable: CatalogTable,
       existingTableSnapshotOpt: Option[Snapshot] = None): Unit = {
     val (command, propertyOverrides) = query match {
       // For CLONE, we cannot use the properties from the catalog table, because they are already
@@ -352,10 +354,8 @@ object CatalogOwnedTableUtils extends DeltaLogging {
       // the CatalogManaged status during REPLACE (the table type won't change), there's no need
       // to block that case.
       if (isSpecifyingCatalogManaged && !existingTableIsCatalogManaged) {
-        throw new IllegalStateException(
-          "Specifying CatalogManaged in REPLACE TABLE command is not supported " +
-          "for tables that are not already CatalogManaged. " +
-          "Please either upgrade the existing table or create a fresh CatalogManaged table.")
+        throw DeltaErrors.replaceTableWithCatalogManagedNotSupported(
+          catalogTable.identifier.nameParts)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1786,6 +1786,14 @@ trait DeltaErrorsSuiteBase
         Map("path" -> path.toString))
     }
     {
+      val tableName = TableIdentifier("mytable")
+      val e = intercept[DeltaUnsupportedOperationException] {
+        throw DeltaErrors.replaceTableWithCatalogManagedNotSupported(tableName.nameParts)
+      }
+      checkError(e, "DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED", "0A000",
+        Map("tableName" -> "`mytable`"))
+    }
+    {
       val e = intercept[DeltaUnsupportedOperationException] {
         throw DeltaErrors.operationBlockedOnCatalogManagedTable("OPTIMIZE")
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
@@ -231,12 +231,16 @@ class CatalogOwnedPropertySuite extends QueryTest
       // Normal delta table.
       createTableAndValidateCatalogOwned(tableName = "t1", withCatalogOwned = false)
 
-      val error = intercept[IllegalStateException] {
+      val error = intercept[DeltaUnsupportedOperationException] {
         sql("REPLACE TABLE t1 (id LONG) USING delta TBLPROPERTIES " +
           s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
       }
-      assert(error.getMessage.contains(
-        "Specifying CatalogManaged in REPLACE TABLE command is not supported"))
+      checkError(
+        exception = error,
+        condition = "DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED",
+        sqlState = Some("0A000"),
+        parameters = Map("tableName" -> "(`[^`]+`\\.)*`t1`"),
+        matchPVals = true)
     }
   }
 
@@ -271,13 +275,17 @@ class CatalogOwnedPropertySuite extends QueryTest
       createTableAndValidateCatalogOwned(tableName = "t2", withCatalogOwned = false)
       sql("INSERT INTO t2 VALUES (1), (2)")
 
-      val error = intercept[IllegalStateException] {
+      val error = intercept[DeltaUnsupportedOperationException] {
         sql("REPLACE TABLE t1 USING delta TBLPROPERTIES " +
           s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported') " +
           s"AS SELECT * FROM t2")
       }
-      assert(error.getMessage.contains(
-        "Specifying CatalogManaged in REPLACE TABLE command is not supported"))
+      checkError(
+        exception = error,
+        condition = "DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED",
+        sqlState = Some("0A000"),
+        parameters = Map("tableName" -> "(`[^`]+`\\.)*`t1`"),
+        matchPVals = true)
     }
   }
 
@@ -449,12 +457,16 @@ class CatalogOwnedPropertySuite extends QueryTest
       sql("INSERT INTO t1 VALUES (1)")
 
       // CREATE OR REPLACE with CatalogManaged on existing non-CatalogManaged table should fail.
-      val error = intercept[IllegalStateException] {
+      val error = intercept[DeltaUnsupportedOperationException] {
         sql("CREATE OR REPLACE TABLE t1 (id LONG) USING delta TBLPROPERTIES " +
           s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
       }
-      assert(error.getMessage.contains(
-        "Specifying CatalogManaged in REPLACE TABLE command is not supported"))
+      checkError(
+        exception = error,
+        condition = "DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED",
+        sqlState = Some("0A000"),
+        parameters = Map("tableName" -> "(`[^`]+`\\.)*`t1`"),
+        matchPVals = true)
 
       // Original table should remain unchanged.
       validateCatalogOwnedAndUCTableId(tableName = "t1", expected = false)


### PR DESCRIPTION
## Description

`CatalogOwnedTableUtils.validatePropertiesForCreateDeltaTableCommand` previously threw a raw `IllegalStateException` when a user tried to enable CatalogManaged via `REPLACE TABLE` (or RTAS, REPLACE CLONE, CREATE OR REPLACE) on an existing non-CatalogManaged table. This PR replaces it with a structured user-facing `DeltaUnsupportedOperationException` (error class `DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED`, SQLSTATE `0A000`), so the failure surfaces a stable error condition that callers can match against.

The existing `CatalogTable` is threaded through `validatePropertiesForCreateDeltaTableCommand` so the offending table name can be included in the error.

## How was this patch tested?

Updated assertions in 4 existing tests in `CatalogOwnedPropertySuite` (`[REPLACE]`, `[RTAS]`, `[CREATE OR REPLACE]`, `[REPLACE SHALLOW/DEEP CLONE]`) to use `checkError` against the new error class and SQLSTATE.

## Does this PR introduce _any_ user-facing change?

Yes. Users who attempt to enable CatalogManaged on an existing non-CatalogManaged table via `REPLACE TABLE` (or related commands) will now see a structured `DeltaUnsupportedOperationException` with error condition `DELTA_REPLACE_TABLE_WITH_CATALOG_MANAGED_NOT_SUPPORTED` and SQLSTATE `0A000` instead of an `IllegalStateException`.
