### PR TITLE
[Spark] Make partition-like skipping respect skipping stats disablement

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -763,7 +763,8 @@ trait DataSkippingReaderBase
       //    rough heuristic, require the table to no longer be considered a "small delta table."
       // 3. At least 1 data filter was not already used for data skipping.
       val shouldRewriteDataFiltersAsPartitionLike =
-        spark.conf.get(DeltaSQLConf.DELTA_DATASKIPPING_PARTITION_LIKE_FILTERS_ENABLED) &&
+        useStats &&
+          spark.conf.get(DeltaSQLConf.DELTA_DATASKIPPING_PARTITION_LIKE_FILTERS_ENABLED) &&
           ClusteredTableUtils.isSupported(snapshotToScan.protocol) &&
           snapshotToScan.numOfFilesIfKnown.exists(_ >=
             spark.conf.get(DeltaSQLConf.DELTA_DATASKIPPING_PARTITION_LIKE_FILTERS_THRESHOLD)) &&

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/PartitionLikeDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/PartitionLikeDataSkippingSuite.scala
@@ -448,6 +448,28 @@ trait PartitionLikeDataSkippingSuiteBase
         minNumFilesToApply = 1L)
     }
   }
+
+  test("partition-like skipping disabled when data skipping stats use is disabled") {
+    withSQLConf(
+        DeltaSQLConf.DELTA_STATS_SKIPPING.key -> "false",
+        DeltaSQLConf.DELTA_DATASKIPPING_PARTITION_LIKE_FILTERS_ENABLED.key -> "true",
+        DeltaSQLConf.DELTA_DATASKIPPING_PARTITION_LIKE_FILTERS_THRESHOLD.key -> "0") {
+      // We can't test this E2E via a read (as `PrepareDeltaScan` will avoid file skipping when
+      // stats collection is disabled), so we have to test this directly by invoking `filesForScan`
+      // to simulate file skipping that might occur by another caller.
+      val df = sql(
+        s"SELECT * FROM $testTableName " +
+          "WHERE LOWER(CONCAT('AAA', s.b)) = 'aaa1971-01-31 17:01:01.001'")
+      val predicates = df.queryExecution.optimizedPlan.collect {
+        case Filter(condition, _) => condition
+      }.flatMap(splitConjunctivePredicates)
+      val scanResult = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+        .update().filesForScan(predicates)
+      assert(scanResult.files.length == 22)
+      assert(scanResult.unusedFilters.nonEmpty)
+      assert(scanResult.partitionLikeDataFilters.size == 0)
+    }
+  }
 }
 
 class PartitionLikeDataSkippingSuite extends PartitionLikeDataSkippingSuiteBase


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Today, partition-like skipping doesn't respect skipping stats disablement, and would use stats for skipping even when this conf is off. This PR fixes it to respect the conf.

## How was this patch tested?
See test change.

## Does this PR introduce _any_ user-facing changes?
No.
