### PR TITLE
[Spark] Fix streaming schema merger dropping metadata change when chain ends with a protocol-only commit

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
@@ -114,6 +114,7 @@ trait DeltaV2SourceSchemaEvolutionSuiteBase extends V2ForceTest {
     // ========== Schema evolution scenarios ==========
     "consecutive schema evolutions without schema merging",
     "consecutive schema evolutions",
+    "consecutive schema evolutions with protocol-only tail",
     "upgrade and downgrade",
     "multiple sources with schema evolution",
     "schema evolution with Delta sink",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -765,28 +765,44 @@ object DeltaSourceMetadataEvolutionSupport extends Logging {
         (!hasFileAction && (metadataAction.isDefined || protocolAction.isDefined),
           version, metadataAction, protocolAction)
       }.takeWhile(_._1)
-    DeltaSource.iteratorLast(untilMetadataChange.toClosable)
-      .flatMap { case (_, version, metadataOpt, protocolOpt) =>
-        if (version == currentMetadataVersion) {
-          None
-        } else {
-          log.info(s"Looked ahead from version $currentMetadataVersion and " +
-            s"will use metadata at version $version to read Delta stream.")
-          Some(
-            currentMetadata.copy(
-              deltaCommitVersion = version,
-              dataSchemaJson =
-                metadataOpt.map(_.schema.json).getOrElse(currentMetadata.dataSchemaJson),
-              partitionSchemaJson =
-                metadataOpt.map(_.partitionSchema.json)
-                  .getOrElse(currentMetadata.partitionSchemaJson),
-              tableConfigurations = metadataOpt.map(_.configuration)
-                .orElse(currentMetadata.tableConfigurations),
-              protocolJson = protocolOpt.map(_.json).orElse(currentMetadata.protocolJson)
-            )
-          )
-        }
+    // Fold the chain so the merged entry tracks the latest Metadata and Protocol seen
+    // anywhere in the run, not just the last commit's actions -- otherwise a (Metadata,
+    // Protocol-only) tail would advance deltaCommitVersion while losing the schema change.
+    var lastVersion: Option[Long] = None
+    var latestMetadata: Option[Metadata] = None
+    var latestProtocol: Option[Protocol] = None
+    val chainIter = untilMetadataChange.toClosable
+    try {
+      while (chainIter.hasNext) {
+        val (_, version, metadataOpt, protocolOpt) = chainIter.next()
+        lastVersion = Some(version)
+        metadataOpt.foreach(m => latestMetadata = Some(m))
+        protocolOpt.foreach(p => latestProtocol = Some(p))
       }
+    } finally {
+      chainIter.close()
+    }
+    lastVersion.flatMap { version =>
+      if (version == currentMetadataVersion) {
+        None
+      } else {
+        log.info(s"Looked ahead from version $currentMetadataVersion and " +
+          s"will use metadata at version $version to read Delta stream.")
+        Some(
+          currentMetadata.copy(
+            deltaCommitVersion = version,
+            dataSchemaJson =
+              latestMetadata.map(_.schema.json).getOrElse(currentMetadata.dataSchemaJson),
+            partitionSchemaJson =
+              latestMetadata.map(_.partitionSchema.json)
+                .getOrElse(currentMetadata.partitionSchemaJson),
+            tableConfigurations = latestMetadata.map(_.configuration)
+              .orElse(currentMetadata.tableConfigurations),
+            protocolJson = latestProtocol.map(_.json).orElse(currentMetadata.protocolJson)
+          )
+        )
+      }
+    }
   }
 
   // scalastyle:off

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -1545,25 +1545,25 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
 
   testSchemaEvolution("consecutive schema evolutions with protocol-only tail") {
     implicit log =>
-    // The merger chain here ends with a Protocol-only commit (no Metadata action). The schema
-    // changes are chosen so that the start schema, the post-first-change schema (currentMetadata
-    // when the merger runs), and the final snapshot schema are all distinct -- otherwise a faulty
-    // merger could land on a coincidentally-equal schema and still appear to pass.
-    val v5 = log.update().version // file action; starting schema <a, b>
-    renameColumn("b", "c") // v6 -> <a, c>  (this becomes currentMetadata at merger time)
-    addColumn("d") // v7 -> <a, c, d>
-    dropColumn("c") // v8/v9 -> <a, d>      (this is the final snapshot schema)
+    // Chain ends with a Protocol-only commit; start, currentMetadata, and final schemas
+    // are chosen pairwise distinct so a coincidence can't mask a faulty merger.
+    val v5 = log.update().version // <a, b>
+    renameColumn("b", "c") // <a, c> -- becomes currentMetadata at merger time
+    addColumn("d") // <a, c, d>
+    dropColumn("c") // <a, d> -- the final snapshot schema
+    // Writer-only feature keeps the tail protocol-only without adding reader-writer
+    // features Kernel can't read (which would break the V2 read path).
     val newProtocol = log.update().protocol.merge(
-      Action.supportedProtocolVersion(featuresToExclude = Seq(CatalogOwnedTableFeature)))
+      Action.supportedProtocolVersion(withAllFeatures = false)
+        .withFeature(DomainMetadataTableFeature))
     log.upgradeProtocol(newProtocol) // protocol-only tail commit
     val vTail = log.update().version
-    // File action bounds the merger chain.
-    addData(5 until 6)
+    addData(5 until 6) // file action bounds the merger chain
 
     def df: DataFrame = readStream(
       schemaLocation = Some(getDefaultSchemaLocation.toString), startingVersion = Some(v5))
 
-    // Initialize the schema log @ v5 with <a, b>.
+    // Init schema log @ v5 with <a, b>.
     testStream(df)(
       StartStream(checkpointLocation = getDefaultCheckpoint.toString),
       ProcessAllAvailableIgnoreError,
@@ -1573,7 +1573,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
     assert(getDefaultSchemaLog().getLatestMetadata.get.dataSchema.fieldNames
       .sameElements(Array("a", "b")))
 
-    // Encounter the first schema change at v6, persists (v6, <a, c>), fails the stream.
+    // First schema change at v6 -> persists (v6, <a, c>), fails the stream.
     testStream(df)(
       StartStream(checkpointLocation = getDefaultCheckpoint.toString),
       ProcessAllAvailableIgnoreError,
@@ -1584,17 +1584,11 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
     assert(getDefaultSchemaLog().getLatestMetadata.get.dataSchema.fieldNames
       .sameElements(Array("a", "c")))
 
-    // Next restart runs the consecutive-merger, scanning v6..vTail and stopping at the file
-    // action. The merged entry must reflect the post-dropColumn schema <a, d> and the upgraded
-    // protocol, with deltaCommitVersion == vTail. With the protocol-only-tail bug, the merger
-    // would instead leave dataSchema = <a, c> (the pre-chain currentMetadata) -- which is
-    // distinguishable from both the start schema <a, b> and the correct schema <a, d>.
+    // Next restart runs the merger; entry should advance to vTail with schema <a, d>.
     val latestDf = df
-    assert(getDefaultSchemaLog().getLatestMetadata.get.deltaCommitVersion == vTail,
-      s"merger should advance deltaCommitVersion to the protocol-only tail at $vTail")
+    assert(getDefaultSchemaLog().getLatestMetadata.get.deltaCommitVersion == vTail)
     assert(latestDf.schema.fieldNames.sameElements(Array("a", "d")),
-      "merger should fold the metadata changes through dropColumn; got " +
-        latestDf.schema.fieldNames.toSeq)
+      s"got ${latestDf.schema.fieldNames.toSeq}")
   }
 
   testSchemaEvolution("upgrade and downgrade") { implicit log =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -22,9 +22,10 @@ import java.nio.charset.Charset
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
 import org.apache.spark.sql.delta.sources._
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -49,6 +50,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
     "trigger.Once with deferred commit should work",
     "trigger.AvailableNow should work",
     "consecutive schema evolutions",
+    "consecutive schema evolutions with protocol-only tail",
     "latestOffset should not progress before schema evolved"
   )
 
@@ -1539,6 +1541,60 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       ProcessAllAvailable(),
       CheckAnswer((5 until 6).map(i => (i.toString, i.toString)): _*)
     )
+  }
+
+  testSchemaEvolution("consecutive schema evolutions with protocol-only tail") {
+    implicit log =>
+    // The merger chain here ends with a Protocol-only commit (no Metadata action). The schema
+    // changes are chosen so that the start schema, the post-first-change schema (currentMetadata
+    // when the merger runs), and the final snapshot schema are all distinct -- otherwise a faulty
+    // merger could land on a coincidentally-equal schema and still appear to pass.
+    val v5 = log.update().version // file action; starting schema <a, b>
+    renameColumn("b", "c") // v6 -> <a, c>  (this becomes currentMetadata at merger time)
+    addColumn("d") // v7 -> <a, c, d>
+    dropColumn("c") // v8/v9 -> <a, d>      (this is the final snapshot schema)
+    val newProtocol = log.update().protocol.merge(
+      Action.supportedProtocolVersion(featuresToExclude = Seq(CatalogOwnedTableFeature)))
+    log.upgradeProtocol(newProtocol) // protocol-only tail commit
+    val vTail = log.update().version
+    // File action bounds the merger chain.
+    addData(5 until 6)
+
+    def df: DataFrame = readStream(
+      schemaLocation = Some(getDefaultSchemaLocation.toString), startingVersion = Some(v5))
+
+    // Initialize the schema log @ v5 with <a, b>.
+    testStream(df)(
+      StartStream(checkpointLocation = getDefaultCheckpoint.toString),
+      ProcessAllAvailableIgnoreError,
+      ExpectMetadataEvolutionExceptionFromInitialization
+    )
+    assert(getDefaultSchemaLog().getLatestMetadata.get.deltaCommitVersion == v5)
+    assert(getDefaultSchemaLog().getLatestMetadata.get.dataSchema.fieldNames
+      .sameElements(Array("a", "b")))
+
+    // Encounter the first schema change at v6, persists (v6, <a, c>), fails the stream.
+    testStream(df)(
+      StartStream(checkpointLocation = getDefaultCheckpoint.toString),
+      ProcessAllAvailableIgnoreError,
+      CheckAnswer(Seq(4).map(_.toString).map(i => (i, i)): _*),
+      ExpectMetadataEvolutionException
+    )
+    assert(getDefaultSchemaLog().getLatestMetadata.get.deltaCommitVersion == v5 + 1)
+    assert(getDefaultSchemaLog().getLatestMetadata.get.dataSchema.fieldNames
+      .sameElements(Array("a", "c")))
+
+    // Next restart runs the consecutive-merger, scanning v6..vTail and stopping at the file
+    // action. The merged entry must reflect the post-dropColumn schema <a, d> and the upgraded
+    // protocol, with deltaCommitVersion == vTail. With the protocol-only-tail bug, the merger
+    // would instead leave dataSchema = <a, c> (the pre-chain currentMetadata) -- which is
+    // distinguishable from both the start schema <a, b> and the correct schema <a, d>.
+    val latestDf = df
+    assert(getDefaultSchemaLog().getLatestMetadata.get.deltaCommitVersion == vTail,
+      s"merger should advance deltaCommitVersion to the protocol-only tail at $vTail")
+    assert(latestDf.schema.fieldNames.sameElements(Array("a", "d")),
+      "merger should fold the metadata changes through dropColumn; got " +
+        latestDf.schema.fieldNames.toSeq)
   }
 
   testSchemaEvolution("upgrade and downgrade") { implicit log =>


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`DeltaSourceMetadataEvolutionSupport.getMergedConsecutiveMetadataChanges` looks ahead through the run of consecutive non-file commits after the current persisted schema entry and writes a single merged `PersistedMetadata` covering the whole run. It used `iteratorLast` to pick only the final commit's actions, then took its `Metadata`/`Protocol` (or fell back to the previously persisted entry).

That breaks for chains shaped like `(..., Metadata, Protocol-only)`: the final commit has no `Metadata` action, so `metadataOpt.getOrElse(currentMetadata.dataSchemaJson)` reverts to the pre-chain schema while `deltaCommitVersion` advances to the protocol-only tail. The persisted entry's `dataSchema` then disagrees with the snapshot at `deltaCommitVersion`, silently dropping the earlier metadata change.

This PR replaces the last-tuple logic with a fold across the chain, tracking the last `version`, the latest non-`None` `Metadata` action, and the latest non-`None` `Protocol` action separately. The merged entry now reflects the cumulative state at the end of the chain regardless of which commit each action lives in.

## How was this patch tested?

Added a regression test `consecutive schema evolutions with protocol-only tail` in `DeltaSourceSchemaEvolutionSuite`. The chain is constructed so the start schema, the post-first-change schema (which becomes `currentMetadata` for the merger), and the post-chain schema are pairwise distinct, so a coincidence can't mask the failure:
- `<a, b>` → `rename b→c` → `addColumn d` → `dropColumn c` → protocol-only upgrade → file action.
- Pre-fix: merged entry has `(vTail, <a, c>)` — schema reverts to pre-chain.
- Post-fix: merged entry has `(vTail, <a, d>)` — schema reflects the final metadata change.

The existing `consecutive schema evolutions` test (all-Metadata chain) still passes since the fold's "latest metadata in chain" coincides with `iteratorLast`'s result when every commit carries a `Metadata` action.

## Does this PR introduce _any_ user-facing changes?

No (bug fix to internal streaming schema-tracking behavior; no API changes).