### PR TITLE
Pass snapshotToScan to recordDeltaOperation for shadow tag injection

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -657,7 +657,7 @@ trait DataSkippingReaderBase
   override def filesForScan(filters: Seq[Expression], keepNumRecords: Boolean): DeltaScan = {
     val startTime = System.currentTimeMillis()
     if (filters == Seq(TrueLiteral) || filters.isEmpty || schema.isEmpty) {
-      recordDeltaOperation(deltaLog, "delta.skipping.none") {
+      recordDeltaOperation(snapshotToScan, "delta.skipping.none") {
         // When there are no filters we can just return allFiles with no extra processing
         val forceCollectRowCount =
           spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_ALWAYS_COLLECT_STATS)
@@ -730,7 +730,7 @@ trait DataSkippingReaderBase
         dataSkippingType =
           getCorrectDataSkippingType(DeltaDataSkippingType.partitionFilteringOnlyV1)
       )
-    } else recordDeltaOperation(deltaLog, "delta.skipping.data") {
+    } else recordDeltaOperation(snapshotToScan, "delta.skipping.data") {
       val finalPartitionFilters = constructPartitionFilters(partitionFilters)
 
       val dataSkippingType = if (partitionFilters.isEmpty) {
@@ -829,7 +829,7 @@ trait DataSkippingReaderBase
    * Statistics about the amount of data that will be read are gathered and returned.
    */
   override def filesForScan(limit: Long, partitionFilters: Seq[Expression]): DeltaScan =
-    recordDeltaOperation(deltaLog, "delta.skipping.filteredLimit") {
+    recordDeltaOperation(snapshotToScan, "delta.skipping.filteredLimit") {
       val startTime = System.currentTimeMillis()
       val finalPartitionFilters = constructPartitionFilters(partitionFilters)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `DataSkippingReaderBase`, changed three `recordDeltaOperation` calls to pass `snapshotToScan` instead of `deltaLog`:

- `delta.skipping.none`
- `delta.skipping.data`
- `delta.skipping.filteredLimit`

`recordDeltaOperation` calls `provider.getCommonTags` on its first argument to populate usage log tags. `snapshotToScan` carries snapshot-scoped tags (e.g., shadow-mode markers) that were not propagated when `deltaLog` was passed instead.

## How was this patch tested?

Existing unit tests in the data-skipping suites cover the affected code paths.

## Does this PR introduce _any_ user-facing changes?

No.