### PR TITLE
Add isFeatureSupportedInTableConfigs for targeted feature lookup

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -464,6 +464,25 @@ object TableFeatureProtocolUtils {
   def propertyKey(featureName: String): String =
     s"$FEATURE_PROP_PREFIX$featureName"
 
+  /**
+   * Checks whether `configs` marks `feature` as supported.
+   *
+   * This inspects only the requested feature key, so callers that receive protocol-derived
+   * catalog properties can avoid failing on unrelated feature names newer than this runtime.
+   */
+  def isFeatureSupportedInTableConfigs(
+      configs: Map[String, String],
+      feature: TableFeature): Boolean = {
+    val featureKey = propertyKey(feature).toLowerCase(Locale.ROOT)
+    configs.exists { case (key, status) =>
+      // Snapshot.getProperties generates protocol-derived catalog feature properties.
+      // Those properties always use `supported`.
+      // Do not accept the deprecated `enabled` table property status here.
+      key.toLowerCase(Locale.ROOT) == featureKey &&
+        status.toLowerCase(Locale.ROOT) == FEATURE_PROP_SUPPORTED
+    }
+  }
+
   /** Get the session default config key for the `feature`. */
   def defaultPropertyKey(feature: TableFeature): String = defaultPropertyKey(feature.name)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
+import java.util.Locale
 
 import scala.collection.mutable
 
@@ -146,6 +147,19 @@ class DeltaTableFeatureSuite
           TestWriterFeatureWithTransitiveDependency.name,
           TestFeatureWithDependency.name,
           TestReaderWriterFeature.name))
+  }
+
+  test("isFeatureSupportedInTableConfigs checks only the requested feature") {
+    val lowerCaseFeatureKey = propertyKey(TestReaderWriterFeature).toLowerCase(Locale.ROOT)
+    val configs = Map(
+      lowerCaseFeatureKey -> "Supported",
+      propertyKey("unknownFeatureForTargetedLookupTest") -> FEATURE_PROP_SUPPORTED)
+
+    assert(isFeatureSupportedInTableConfigs(configs, TestReaderWriterFeature))
+    assert(!isFeatureSupportedInTableConfigs(configs, TestWriterFeature))
+    assert(!isFeatureSupportedInTableConfigs(
+      Map(propertyKey(TestReaderWriterFeature) -> FEATURE_PROP_ENABLED),
+      TestReaderWriterFeature))
   }
 
   test("implicitly-enabled features") {


### PR DESCRIPTION
## Description

Adds `TableFeatureProtocolUtils.isFeatureSupportedInTableConfigs(configs, feature)`, a targeted helper that checks whether a specific table feature is marked as `supported` in a given config map.

The helper differs from a full scan of feature-prefixed keys in two ways:

- It inspects only the requested feature key (case-insensitive match), so callers that receive protocol-derived catalog properties do not fail when the configs include unrelated feature names newer than the current runtime.
- It accepts only the `supported` status value. The deprecated `enabled` value used in some legacy table properties is intentionally rejected, matching how protocol-derived catalog feature properties are generated.

## How was this patch tested?

Adds `DeltaTableFeatureSuite."isFeatureSupportedInTableConfigs checks only the requested feature"`, which covers:

- A configs map mixing a known supported feature (with a mixed-case `Supported` status to exercise the case-insensitive comparison) and an unknown feature name. The known feature returns `true`; an unrelated feature returns `false`.
- A configs map where the feature is marked with the deprecated `enabled` status, which returns `false`.

## Does this PR introduce _any_ user-facing changes?

No.
