### PR TITLE
DeltaDropColumnSuite: use def instead of val for sparkConf

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, 
 class DeltaDropColumnSuite extends QueryTest
   with DeltaArbitraryColumnNameSuiteBase {
 
-  override protected val sparkConf: SparkConf =
+  override protected def sparkConf: SparkConf =
     super.sparkConf.set(DeltaSQLConf.DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED.key, "true")
 
   protected def dropTest(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Change `sparkConf` definition in `DeltaDropColumnSuite` from `val` to `def` to make overriding easier.

## How was this patch tested?

This is a test-only change

## Does this PR introduce _any_ user-facing changes?

No.