### PR TITLE
[Build] Use GCS Maven Central mirror for Unity Catalog CI setup to avoid HTTP 429s

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -159,6 +159,25 @@ fi
 # coordinate. Applied as a persistent setting so it sticks across the two sbt invocations below.
 SET_VERSION_CMD="set ThisBuild / version := \"$UC_VERSION\""
 
+# Inject GCS Maven Central mirror to avoid HTTP 429 rate-limiting from repo1.maven.org.
+# UC's build/sbt respects SBT_OPTS when MAVEN_PROXY_URL and JENKINS_URL are both unset.
+# DEFAULT_ARTIFACT_REPOSITORY is used by sbt-launch-lib.bash for downloading sbt-launch.jar.
+UC_SBT_REPOS_CONFIG=$(mktemp)
+cat > "$UC_SBT_REPOS_CONFIG" <<'REPOS'
+[repositories]
+  local
+  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
+  gcs-maven-central-mirror: https://maven-central.storage-download.googleapis.com/maven2/
+  maven-central
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-releases: https://repo.typesafe.com/typesafe/releases/
+REPOS
+export SBT_OPTS="${SBT_OPTS:-} -Dsbt.override.build.repos=true -Dsbt.repository.config=$UC_SBT_REPOS_CONFIG"
+export DEFAULT_ARTIFACT_REPOSITORY="https://maven-central.storage-download.googleapis.com/maven2"
+
 echo ">>> Building and publishing UC client + server to local Maven repo"
 ./build/sbt \
   "$SET_VERSION_CMD" \


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Build / CI infrastructure)

## Description

CI's "Set up pinned Unity Catalog" step clones UC from source and builds it with UC's own `./build/sbt`. That script goes directly to `repo1.maven.org`, which rate-limits GitHub Actions runners with HTTP 429 responses, causing frequent build failures across all workflows that use this step.

This change injects a `repositories` config (with the GCS Maven Central mirror listed before `maven-central`) into the UC build via `SBT_OPTS`, and sets `DEFAULT_ARTIFACT_REPOSITORY` so the `sbt-launch.jar` download itself also uses the mirror.

This is safe because UC's `build/sbt` leaves `SBT_OPTS` untouched when neither `MAVEN_PROXY_URL` nor `JENKINS_URL` is set (the normal case on GitHub Actions).

## How was this patch tested?

- Verified locally that the script correctly constructs the sbt-launch.jar download URL via the mirror (`https://maven-central.storage-download.googleapis.com/maven2/org/scala-sbt/sbt-launch/1.9.9/sbt-launch-1.9.9.jar`)
- Verified that UC's `build/sbt` does not override `SBT_OPTS` when `MAVEN_PROXY_URL` and `JENKINS_URL` are unset
- CI on this PR will serve as the real validation (the "Build Test" job that was failing with 429s)

## Does this PR introduce _any_ user-facing changes?

No. This only affects CI infrastructure — specifically how the Unity Catalog dependency is built from source during CI runs.