### PR TITLE
Fix Iceberg DataFile record count to use physical rows instead of logical

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -109,7 +109,13 @@ object IcebergTransactionUtils
         // string is null/empty or not because this metric is required by Iceberg. If the number
         // of records is both unavailable here and unavailable in the Delta stats, Iceberg will
         // throw an exception when building the data file.
-        .withRecordCount(add.numLogicalRecords.getOrElse(-1L))
+        // Here, numPhysicalRecords is used as Iceberg's record count is position-oriented:
+        // it must reflect the total number of physical rows in the Parquet file,
+        // including rows masked by deletion vectors.
+        // This aligns with Delta's baseRowId assignment which reserves row ID space using
+        // numPhysicalRecords, and with Iceberg's row lineage where first_row_id + position
+        // must address every row in the file.
+        .withRecordCount(add.numPhysicalRecords.getOrElse(-1L))
 
     try {
       if (add.stats != null && add.stats.nonEmpty) {
@@ -133,7 +139,7 @@ object IcebergTransactionUtils
       snapshot: SnapshotDescriptor): DataFile = {
     convertFileAction(
       remove, tablePath, partitionSpec, logicalToPhysicalPartitionNames, snapshot)
-      .withRecordCount(remove.numLogicalRecords.getOrElse(0L))
+      .withRecordCount(remove.numPhysicalRecords.getOrElse(0L))
       .build()
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Fix issues raised in https://github.com/RussellSpitzer/delta/commit/63e4dd3cb72fb3c0a2a4bf6358bf0b246624e3a7 
> The UniForm conversion was using numLogicalRecords (which excludes rows
masked by deletion vectors) when setting the Iceberg DataFile record count.
Iceberg's record count is position-oriented per the spec and must reflect
the total number of physical rows in the Parquet file. This mismatch caused
Iceberg's row lineage (first_row_id / nextRowId) to under-count relative
to Delta's baseRowId assignment which correctly uses numPhysicalRecords.

