### PR TITLE
Add SnapshotV1 type alias

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/package.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/package.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.delta.Snapshot
+
+package object delta {
+  /**
+   * Temporary non-load-bearing alias for the current concrete V1 DeltaLog-backed [[Snapshot]].
+   *
+   * The long-term goal is for `Snapshot` to become the common semantic snapshot abstraction used by
+   * Delta connectors. That common abstraction should cover table identity and metadata, constructed
+   * table state. Those APIs can eventually be backed by Kernel.
+   *
+   * Some existing call sites depend on physical DeltaLog implementation details instead:
+   * commit/checkpoint files exposed through `logSegment`. These APIs do not belong on the common
+   * snapshot abstraction because they will not line up with Kernel-backed snapshots and may not be
+   * extensible to future table formats such as Iceberg V4.
+   *
+   * Use this alias to pre-factor those V1-coupled call sites explicitly before renaming the current
+   * concrete [[Snapshot]] implementation to `SnapshotV1`.
+   */
+  type SnapshotV1 = Snapshot
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotV1Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotV1Suite.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.SparkFunSuite
+
+class SnapshotV1Suite extends SparkFunSuite {
+  test("SnapshotV1 is a non-load-bearing alias for Snapshot") {
+    implicitly[SnapshotV1 =:= Snapshot]
+    implicitly[Snapshot =:= SnapshotV1]
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a non-load-bearing `SnapshotV1` type alias for the current concrete `Snapshot` implementation:

```scala
type SnapshotV1 = Snapshot
```

This is the first prefactor step for reusing the current `Snapshot` abstraction. The design direction is to make `Snapshot` the common semantic interface with narrower interface.

## How was this patch tested?

Added a lightweight unit test (`SnapshotV1Suite`) to verify `SnapshotV1` remains a non-load-bearing alias for `Snapshot`.

## Does this PR introduce _any_ user-facing changes?

No.
