### PR TITLE
[Spark] Use CatalogManaged commits in UniForm UC tests

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -16,40 +16,34 @@
 
 package org.apache.spark.sql.delta.uniform
 
-import java.util.{Collections, Optional, UUID}
-
-import scala.collection.JavaConverters._
+import java.util.{Collections, UUID}
 
 import io.delta.storage.commit.{CommitCoordinatorClient => JCommitCoordinatorClient}
-import io.delta.storage.commit.{TableIdentifier => UCTableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkSessionSwitch}
-import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
-import org.apache.spark.sql.delta.{DeltaLog, IcebergConstants}
-import org.apache.spark.sql.delta.DeltaConfigs.{
-  COORDINATED_COMMITS_COORDINATOR_CONF,
-  COORDINATED_COMMITS_COORDINATOR_NAME
-}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaLog, DeltaOperations, IcebergConstants}
 import org.apache.spark.sql.delta.NonSparkReadIceberg
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.coordinatedcommits.{
   CatalogOwnedCommitCoordinatorBuilder,
-  CommitCoordinatorProvider,
+  CatalogOwnedCommitCoordinatorProvider,
+  CatalogOwnedTableUtils,
   InMemoryUCClient,
   InMemoryUCCommitCoordinator,
+  TrackingInMemoryCommitCoordinatorBuilder,
   UCCommitCoordinatorBuilder
 }
 import org.apache.spark.sql.delta.icebergShaded.IcebergConverter
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.uniform.hms.HMSTest
-import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -106,7 +100,7 @@ class UCBackedDeltaCatalog extends DeltaCatalog {
   override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table = {
     val enriched = UCBackedDeltaCatalog.currentCoordinator.flatMap { coordinator =>
       val deltaLog = DeltaLog.forTable(spark, new Path(catalogTable.location))
-      val tableConf = deltaLog.update().metadata.coordinatedCommitsTableConf
+      val tableConf = deltaLog.update().metadata.configuration
       tableConf.get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY).flatMap { tableId =>
         coordinator.getUniformMetadata(tableId)
           .filter(_.getIcebergMetadata.isPresent)
@@ -133,96 +127,115 @@ object UCBackedDeltaCatalog {
  *
  * Mix this into a concrete suite that already extends [[UniFormE2EIcebergSuiteBase]] (or any
  * other [[UniFormE2ETest]] subclass) to redirect every [[readAndVerify]] call through the
- * native Iceberg reader backed by the in-memory UC coordinator
+ * native Iceberg reader backed by the in-memory UC coordinator.
  *
  * Concrete suites must call [[requiredTableProperties]] inside their
- * [[UniFormE2EIcebergSuiteBase.extraTableProperties]] override to inject the coordinator
- * name and conf into every `CREATE TABLE` statement.
+ * [[UniFormE2EIcebergSuiteBase.extraTableProperties]] override to enable
+ * [[CatalogOwnedTableFeature]] in every `CREATE TABLE` statement.
  */
 trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
   with DeltaSQLCommandTest
   with NonSparkReadIceberg {
+  this: UniFormE2EIcebergSuiteBase =>
 
   /**
-   * Use customized catalog so that uniform property is injected into catalogTable
+   * Use customized catalog so that uniform property is injected into catalogTable.
    */
   override protected def sparkConf: SparkConf =
     super.sparkConf.set(
       SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
       classOf[UCBackedDeltaCatalog].getName)
 
-  /**
-   * A [[UCCommitCoordinatorClient]] subclass that overrides [[registerTable]] to auto-assign
-   * a UC table ID, simulating what the UC catalog does during CREATE TABLE.
-   */
-  private class TestUCBackedCommitCoordinator(ucClient: InMemoryUCClient)
-    extends UCCommitCoordinatorClient(Collections.emptyMap(), ucClient) {
-
-    @volatile var lastRegisteredTableId: String = _
-
-    /**
-     * Delta blocks setting `COORDINATED_COMMITS_TABLE_CONF` in TBLPROPERTIES, so this trait
-     * simulates what the real UC catalog does: a [[CatalogOwnedCommitCoordinatorBuilder]] returns
-     * a single [[TestUCBackedCommitCoordinator]] instance whose [[registerTable]] auto-assigns a
-     * UUID.  Returning the same instance from every [[build]]/[[buildForCatalog]] call ensures
-     * that [[UCCommitCoordinatorClient.semanticEquals]] (which uses reference equality on `conf`)
-     * returns true and Delta does not reject intra-test metadata updates.
-     */
-    override def registerTable(
-        logPath: Path,
-        tableIdentifier: Optional[UCTableIdentifier],
-        currentVersion: Long,
-        currentMetadata: AbstractMetadata,
-        currentProtocol: AbstractProtocol): java.util.Map[String, String] = {
-      val tableId = UUID.randomUUID().toString
-      lastRegisteredTableId = tableId
-      Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableId).asJava
-    }
-  }
-
   protected var ucCommitCoordinator: InMemoryUCCommitCoordinator = _
-  private var testCoordinator: TestUCBackedCommitCoordinator = _
+  private var testCoordinator: UCCommitCoordinatorClient = _
+  private var currentTableId: String = _
 
   abstract override def beforeEach(): Unit = {
     super.beforeEach()
     DeltaLog.clearCache()
-    CommitCoordinatorProvider.clearAllBuilders()
     ucCommitCoordinator = new InMemoryUCCommitCoordinator()
     UCBackedDeltaCatalog.currentCoordinator = Some(ucCommitCoordinator)
     val ucClient = new InMemoryUCClient("test-metastore", ucCommitCoordinator)
-    testCoordinator = new TestUCBackedCommitCoordinator(ucClient)
-    CommitCoordinatorProvider.registerBuilder(new CatalogOwnedCommitCoordinatorBuilder {
-      override def getName: String = UCCommitCoordinatorBuilder.getName
-      override def build(
-          spark: SparkSession, conf: Map[String, String]): JCommitCoordinatorClient =
-        testCoordinator
-      override def buildForCatalog(
-          spark: SparkSession, catalogName: String): JCommitCoordinatorClient =
-        testCoordinator
-    })
+    testCoordinator = new UCCommitCoordinatorClient(Collections.emptyMap(), ucClient)
+    registerBootstrapCatalogOwnedProvider()
+  }
+
+  private def registerBootstrapCatalogOwnedProvider(): Unit = {
+    CatalogOwnedCommitCoordinatorProvider.clearBuilders()
+    CatalogOwnedCommitCoordinatorProvider.registerBuilder(
+      catalogName = CatalogOwnedTableUtils.DEFAULT_CATALOG_NAME_FOR_TESTING,
+      commitCoordinatorBuilder = TrackingInMemoryCommitCoordinatorBuilder(batchSize = 1))
+  }
+
+  private def registerUCBackedCatalogOwnedProvider(): Unit = {
+    CatalogOwnedCommitCoordinatorProvider.clearBuilders()
+    CatalogOwnedCommitCoordinatorProvider.registerBuilder(
+      catalogName = CatalogOwnedTableUtils.DEFAULT_CATALOG_NAME_FOR_TESTING,
+      commitCoordinatorBuilder = new CatalogOwnedCommitCoordinatorBuilder {
+        override def getName: String = UCCommitCoordinatorBuilder.getName
+        override def build(
+            spark: SparkSession, conf: Map[String, String]): JCommitCoordinatorClient =
+          testCoordinator
+        override def buildForCatalog(
+            spark: SparkSession, catalogName: String): JCommitCoordinatorClient =
+          testCoordinator
+      })
+  }
+
+  private def assignUCTableIdIfNeeded(tableName: String): Unit = {
+    val tableIdentifier = TableIdentifier(tableName)
+    if (!spark.sessionState.catalog.tableExists(tableIdentifier)) {
+      return
+    }
+    val catalogTable = spark.sessionState.catalog.getTableMetadata(tableIdentifier)
+    val deltaLog = DeltaLog.forTable(spark, catalogTable)
+    val snapshot = deltaLog.update(catalogTableOpt = Some(catalogTable))
+    if (!snapshot.isCatalogOwned) {
+      return
+    }
+    snapshot.metadata.configuration.get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY) match {
+      case Some(tableId) =>
+        currentTableId = tableId
+        registerUCBackedCatalogOwnedProvider()
+      case None =>
+        val tableId = UUID.randomUUID().toString
+        val newMetadata = snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration +
+            (UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableId))
+        deltaLog.startTransaction(Some(catalogTable))
+          .commit(Seq(newMetadata), DeltaOperations.ManualUpdate)
+        currentTableId = tableId
+        DeltaLog.clearCache()
+        registerUCBackedCatalogOwnedProvider()
+    }
   }
 
   abstract override def afterEach(): Unit = {
     UCBackedDeltaCatalog.currentCoordinator = None
-    CommitCoordinatorProvider.clearAllBuilders()
+    CatalogOwnedCommitCoordinatorProvider.clearBuilders()
     DeltaLog.clearCache()
     super.afterEach()
   }
 
   /**
-   * Returns the TBLPROPERTIES SQL fragment required to enable the UC commit coordinator.
+   * Returns the TBLPROPERTIES SQL fragment required to enable CatalogOwned commits.
    * Concrete suites should append this to their [[extraTableProperties]] override.
    */
   def requiredTableProperties: String =
-    s", '${COORDINATED_COMMITS_COORDINATOR_NAME.key}' = '${UCCommitCoordinatorBuilder.getName}'" +
-      s", '${COORDINATED_COMMITS_COORDINATOR_CONF.key}' = " +
-      s"'${JsonUtils.toJson(Map.empty[String, String])}'"
+    s", '${TableFeatureProtocolUtils.propertyKey(CatalogOwnedTableFeature)}' = " +
+      s"'${TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED}'"
+
+  override protected def write(sqlText: String): DataFrame = {
+    val result = super.write(sqlText)
+    assignUCTableIdIfNeeded(testTableName)
+    result
+  }
 
   override protected def readAndVerify(
       table: String, fields: String, orderBy: String, expect: Seq[Row]): Unit = {
-    val tableId = testCoordinator.lastRegisteredTableId
+    val tableId = currentTableId
     assert(tableId != null,
-      s"No table UUID assigned for '$table' - table was not created with CC properties")
+      s"No table UUID assigned for '$table' - table was not created with CatalogOwned commits")
     val schema = DeltaLog.forTable(spark, TableIdentifier(table)).update().schema
     val uniformMetadata = ucCommitCoordinator.getUniformMetadata(tableId)
     assert(uniformMetadata.isDefined,
@@ -240,7 +253,10 @@ trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
  */
 class UniFormE2EIcebergUCSuite extends UniFormE2EIcebergSuiteBase
     with WriteDeltaUCCCReadIceberg {
-  // No test should go here. Please add tests in [[UniFormE2EIcebergSuiteBase]]
+  // No test should go here. Please add tests in [[UniFormE2EIcebergSuiteBase]].
+  // CatalogManaged tables block REORG in production.
+  override protected def supportsReorgFromV1ToV2: Boolean = false
+
   override def extraTableProperties(compatVersion: Int): String =
     super.extraTableProperties(compatVersion) + requiredTableProperties
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuiteBase.scala
@@ -32,6 +32,9 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
   def isAtomicConversionEnabled: Boolean =
     true
 
+  protected def supportsReorgFromV1ToV2: Boolean =
+    true
+
   val testTableName = "delta_table"
 
   var compatVersions: Seq[Int] = Seq(1, 2)
@@ -195,27 +198,29 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
     }
   }
 
-  test("reorg from v1 to v2") {
-    withTable(testTableName) {
-      write(
-        s"""CREATE TABLE $testTableName (col1 INT) USING DELTA
-           |TBLPROPERTIES (
-           |  'delta.columnMapping.mode' = 'name',
-           |  'delta.enableIcebergCompatV1' = 'true',
-           |  'delta.universalFormat.enabledFormats' = 'iceberg'
-           |  ${extraTableProperties(1)}
-           |)""".stripMargin)
-      write(s"INSERT INTO $testTableName VALUES (1)")
-      readAndVerify(testTableName, "col1", "col1", Seq(Row(1)))
+  if (supportsReorgFromV1ToV2) {
+    test("reorg from v1 to v2") {
+      withTable(testTableName) {
+        write(
+          s"""CREATE TABLE $testTableName (col1 INT) USING DELTA
+             |TBLPROPERTIES (
+             |  'delta.columnMapping.mode' = 'name',
+             |  'delta.enableIcebergCompatV1' = 'true',
+             |  'delta.universalFormat.enabledFormats' = 'iceberg'
+             |  ${extraTableProperties(1)}
+             |)""".stripMargin)
+        write(s"INSERT INTO $testTableName VALUES (1)")
+        readAndVerify(testTableName, "col1", "col1", Seq(Row(1)))
 
-      write(s"ALTER TABLE `$testTableName` UNSET TBLPROPERTIES " +
-        s"('delta.universalFormat.enabledFormats')")
-      write(s"""
-               | REORG TABLE $testTableName APPLY
-               | (UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION = 2))
-               |""".stripMargin)
-      write(s"INSERT INTO $testTableName VALUES (2)")
-      readAndVerify(testTableName, "col1", "col1", Seq(Row(1), Row(2)))
+        write(s"ALTER TABLE `$testTableName` UNSET TBLPROPERTIES " +
+          s"('delta.universalFormat.enabledFormats')")
+        write(s"""
+                 | REORG TABLE $testTableName APPLY
+                 | (UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION = 2))
+                 |""".stripMargin)
+        write(s"INSERT INTO $testTableName VALUES (2)")
+        readAndVerify(testTableName, "col1", "col1", Seq(Row(1), Row(2)))
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR updates `UniFormE2EIcebergUCSuite` so the UC-backed UniForm E2E tests use the current CatalogManaged table setup instead of injecting legacy coordinated commits coordinator table properties. The suite now enables `CatalogOwnedTableFeature` through the table feature property, bootstraps CatalogManaged commits with the in-memory coordinator used by existing tests, assigns the UC table id through a metadata update that simulates catalog integration, and then switches subsequent commits to the in-memory `UCCommitCoordinatorClient`. `UCBackedDeltaCatalog` now reads the table id from metadata configuration directly, which matches where the CatalogManaged path stores the catalog table id.

The shared UniForm E2E base keeps the REORG upgrade test enabled by default, but the UC-backed CatalogManaged suite opts out of that specific positive REORG path because CatalogManaged tables intentionally block REORG in production. The rest of the UC-backed UniForm E2E coverage still runs through CREATE, INSERT, UPDATE, DELETE, CREATE OR REPLACE SHALLOW CLONE, partitions, and nested schemas with the native Iceberg reader.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Ran locally with Java 17 and Spark 4.0.1:

```
./build/sbt -DsparkVersion=4.0.1 "iceberg/testOnly org.apache.spark.sql.delta.uniform.UniFormE2EIcebergUCSuite"
```

Result: 10 tests passed.
