### PR TITLE
[Build] Remove -DuseDefaultUnityCatalogReleaseVersion=true from unidoc workflow

### DIFF
--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -20,4 +20,4 @@
             java-version: "17"
         - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         - name: generate unidoc
-          run: build/sbt -DuseDefaultUnityCatalogReleaseVersion=true "++ ${{ matrix.scala }}" unidoc
+          run: build/sbt "++ ${{ matrix.scala }}" unidoc


### PR DESCRIPTION
## Description

Remove `-DuseDefaultUnityCatalogReleaseVersion=true` from the unidoc GitHub workflow.

The unidoc build compiles the entire Delta project. As we introduce new classes that depend on the latest Unity Catalog Delta REST Catalog API (e.g., `UCDeltaClient` and `UCDeltaTokenBasedRestClient` in #6780), the build must resolve against the latest OSS Unity Catalog SDK. With `-DuseDefaultUnityCatalogReleaseVersion=true`, the build pins to an older released UC version that does not contain the newly generated API classes (such as `io.unitycatalog.client.delta.api.TablesApi`), causing compilation failures like [this CI failure](https://github.com/delta-io/delta/actions/runs/25843381938/job/75933149764?pr=6780).

Removing this flag allows the unidoc workflow to always build against the latest OSS Unity Catalog dependency, avoiding these compilation breakages going forward.

## How was this patch tested?

CI — the unidoc build should pass by resolving the UC dependency from Maven Central directly without version override.