### PR TITLE
[Cleanup] Pass Snapshot instead of DeltaLog to recordDeltaEvent in IcebergConverter

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -646,7 +646,7 @@ class IcebergConverter
             icebergTxn.getNullHelper
           case _ =>
             recordDeltaEvent(
-              targetSnapshot.deltaLog,
+              targetSnapshot,
               "delta.iceberg.conversion.unsupportedActions",
               data = Map(
                 "version" -> targetSnapshot.version,
@@ -670,7 +670,7 @@ class IcebergConverter
         }
     }
     recordDeltaEvent(
-      targetSnapshot.deltaLog,
+      targetSnapshot,
       "delta.iceberg.conversion.convertActions",
       data = Map(
         "version" -> targetSnapshot.version,


### PR DESCRIPTION
## Description

Pass `targetSnapshot` instead of `targetSnapshot.deltaLog` to `recordDeltaEvent` in two call sites within `IcebergConverter.convertActions`. `Snapshot` implements `DeltaLoggingProvider` (via `SnapshotDescriptor`) and carries richer metadata tags than the bare `DeltaLog`, so using it directly provides better logging context for these events.

## How was this patch tested?

Existing `IcebergConverterUTSuite` (9 tests, all pass).

## Does this PR introduce _any_ user-facing changes?

No.
