### PR TITLE
[Storage] Add tableIdentifier to UCClient getCommits

### DIFF
--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
@@ -429,6 +429,7 @@ public class UCCatalogManagedClient {
               try {
                 return ucClient.getCommits(
                     ucTableId,
+                    null /* tableIdentifier */,
                     new Path(tablePath).toUri(),
                     Optional.empty() /* startVersion */,
                     versionOpt /* endVersion */);

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -205,6 +205,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
 
   override def getCommits(
       tableId: String,
+      tableIdentifier: TableIdentifier,
       tableUri: URI,
       startVersion: Optional[JLong],
       endVersion: Optional[JLong]): GetCommitsResponse = {

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClientSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClientSuite.scala
@@ -37,7 +37,12 @@ class InMemoryUCClientSuite extends AnyFunSuite with UCCatalogManagedTestUtils {
       endVersionOpt: Optional[JLong],
       expectedVersions: Seq[Long]): Unit = {
     val client = getInMemoryUCClientWithCommitsForTableId("tableId", allVersions)
-    val response = client.getCommits("tableId", fakeURI, startVersionOpt, endVersionOpt)
+    val response = client.getCommits(
+      "tableId",
+      null,
+      fakeURI,
+      startVersionOpt,
+      endVersionOpt)
     val actualVersions = response.getCommits.asScala.map(_.getVersion)
 
     assert(actualVersions == expectedVersions)
@@ -82,7 +87,12 @@ class InMemoryUCClientSuite extends AnyFunSuite with UCCatalogManagedTestUtils {
   test("getCommits throws InvalidTargetTableException for non-existent table") {
     val client = new InMemoryUCClient("ucMetastoreId")
     val exception = intercept[InvalidTargetTableException] {
-      client.getCommits("abcd", new URI("s3://bucket/table"), Optional.empty(), Optional.empty())
+      client.getCommits(
+        "abcd",
+        null,
+        new URI("s3://bucket/table"),
+        Optional.empty(),
+        Optional.empty())
     }
     assert(exception.getMessage.contains(s"Table not found: abcd"))
   }

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedTestUtils.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedTestUtils.scala
@@ -38,7 +38,7 @@ import io.delta.kernel.internal.util.Utils.singletonCloseableIterator
 import io.delta.kernel.metrics.MetricsReport
 import io.delta.kernel.test.{ActionUtils, TestFixtures}
 import io.delta.kernel.utils.CloseableIterator
-import io.delta.storage.commit.{Commit, GetCommitsResponse}
+import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier}
 
 import InMemoryUCClient.TableData
 import org.apache.hadoop.conf.Configuration
@@ -207,11 +207,12 @@ trait UCCatalogManagedTestUtils
 
     override def getCommits(
         tableId: String,
+        tableIdentifier: TableIdentifier,
         tableUri: URI,
         startVersion: Optional[JLong],
         endVersion: Optional[JLong]): GetCommitsResponse = {
       numGetCommitsCalls += 1
-      super.getCommits(tableId, tableUri, startVersion, endVersion)
+      super.getCommits(tableId, tableIdentifier, tableUri, startVersion, endVersion)
     }
 
     def getNumGetCommitCalls: Long = numGetCommitsCalls

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
@@ -29,7 +29,7 @@ import io.delta.kernel.internal.SnapshotImpl
 import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.unitycatalog.UCCatalogManagedCommitter
 import io.delta.kernel.utils.CloseableIterable
-import io.delta.storage.commit.{Commit, GetCommitsResponse}
+import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier}
 
 import InMemoryUCClient.TableData
 import org.scalatest.funsuite.AnyFunSuite
@@ -445,10 +445,11 @@ object UCE2ESuite {
 
     override def getCommits(
         tableId: String,
+        tableIdentifier: TableIdentifier,
         tableUri: java.net.URI,
         startVersion: Optional[java.lang.Long],
         endVersion: Optional[java.lang.Long]): GetCommitsResponse = {
-      val response = super.getCommits(tableId, tableUri, startVersion, endVersion)
+      val response = super.getCommits(tableId, tableIdentifier, tableUri, startVersion, endVersion)
       maxVersionLimit match {
         case Some(limit) =>
           // Filter commits and limit maxRatifiedVersion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -43,6 +43,7 @@ import io.delta.storage.commit.uniform.UniformMetadata
  * // Use the client for testing
  * val getCommitsResponse = client.getCommits(
  *     "tableId",
+ *     null,
  *     new URI("tableUri"),
  *     Optional.empty(),
  *     Optional.empty())
@@ -86,6 +87,7 @@ class InMemoryUCClient(
 
   override def getCommits(
       tableId: String,
+      tableIdentifier: TableIdentifier,
       tableUri: URI,
       startVersion: Optional[JLong],
       endVersion: Optional[JLong]): JGetCommitsResponse = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.coordinatedcommits
 
 import java.io.IOException
 import java.lang.{Long => JLong}
-import java.util.{List => JList, Optional}
+import java.util.{Collections, List => JList, Optional}
 
 import scala.collection.JavaConverters._
 import scala.jdk.OptionConverters._
@@ -42,7 +42,9 @@ import io.delta.storage.commit.{
   Commit => JCommit,
   CommitFailedException => JCommitFailedException,
   CoordinatedCommitsUtils => JCoordinatedCommitsUtils,
+  GetCommitsResponse => JGetCommitsResponse,
   TableDescriptor,
+  TableIdentifier => JTableIdentifier,
   UpdatedActions
 }
 import io.delta.storage.commit.uccommitcoordinator.{
@@ -87,6 +89,35 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     assert(usageLogs.exists { record =>
       record.tags.get("opType").contains(opType)
     })
+  }
+
+  test("getCommits forwards table identifier to UCClient") {
+    withTempTableDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.toString)
+      var capturedTableIdentifier: JTableIdentifier = null
+      val capturingUCClient = new InMemoryUCClient(metastoreId.toString, ucCommitCoordinator) {
+        override def getCommits(
+            tableId: String,
+            tableIdentifier: JTableIdentifier,
+            tableUri: java.net.URI,
+            startVersion: Optional[JLong],
+            endVersion: Optional[JLong]): JGetCommitsResponse = {
+          capturedTableIdentifier = tableIdentifier
+          new JGetCommitsResponse(Collections.emptyList(), -1L)
+        }
+      }
+      val tableCommitCoordinatorClient = TableCommitCoordinatorClient(
+        new UCCommitCoordinatorClient(Map.empty[String, String].asJava, capturingUCClient),
+        log,
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString))
+      val tableIdentifier = TableIdentifier("tbl", Some("default"), Some("main"))
+
+      tableCommitCoordinatorClient.getCommits(Some(tableIdentifier))
+
+      assert(capturedTableIdentifier != null)
+      assert(capturedTableIdentifier.getNamespace.toSeq == Seq("main", "default"))
+      assert(capturedTableIdentifier.getName == "tbl")
+    }
   }
 
   test("incorrect last known backfilled version") {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -110,6 +110,8 @@ public interface UCClient extends AutoCloseable {
    *                 (and not s3://bucket/path/to/table/_delta_log).
    *                 If the tableId exists but the tableUri is different from the one previously
    *                 registered (e.g., if the table as moved), the request will fail.
+   * @param tableIdentifier The three-part table identifier (catalog, schema, table name)
+   *                        for the table in Unity Catalog, or null if unavailable.
    * @param startVersion An Optional containing the start version of the range of commits to
    *                     retrieve.
    * @param endVersion An Optional containing the end version of the range of commits to retrieve.
@@ -123,6 +125,7 @@ public interface UCClient extends AutoCloseable {
    */
   GetCommitsResponse getCommits(
       String tableId,
+      TableIdentifier tableIdentifier,
       URI tableUri,
       Optional<Long> startVersion,
       Optional<Long> endVersion) throws IOException, UCCommitCoordinatorException;

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -852,6 +852,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
     try {
       return ucClient.getCommits(
         extractUCTableId(tableDesc),
+        tableDesc.getTableIdentifier().orElse(null),
         CoordinatedCommitsUtils.getTablePath(tableDesc.getLogPath()).toUri(),
         startVersion,
         endVersion);

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -198,6 +198,7 @@ public class UCTokenBasedRestClient implements UCClient {
   @Override
   public GetCommitsResponse getCommits(
       String tableId,
+      TableIdentifier tableIdentifier,
       URI tableUri,
       Optional<Long> startVersion,
       Optional<Long> endVersion) throws IOException, UCCommitCoordinatorException {
@@ -205,7 +206,8 @@ public class UCTokenBasedRestClient implements UCClient {
     Objects.requireNonNull(tableId, "tableId must not be null.");
     Objects.requireNonNull(tableUri, "tableUri must not be null.");
 
-    // Build the DeltaGetCommits request using SDK models
+    // Build the DeltaGetCommits request using SDK models. The legacy API does not accept
+    // tableIdentifier, but UC Delta Rest Catalog clients need it in this shared interface.
     DeltaGetCommits request = new DeltaGetCommits()
         .tableId(tableId)
         .tableUri(tableUri.toString())

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -22,7 +22,7 @@ import java.util.{Collections, Optional}
 
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
-import io.delta.storage.commit.{Commit, CommitFailedException}
+import io.delta.storage.commit.{Commit, CommitFailedException, TableIdentifier}
 import io.delta.storage.commit.actions.AbstractMetadata
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 import io.unitycatalog.client.auth.TokenProvider
@@ -228,20 +228,39 @@ class UCTokenBasedRestClientSuite
     commitsHandler = exchange => sendJson(exchange, HttpStatus.SC_OK, responseJson)
     withClient { client =>
       val response = client.getCommits(
-        testTableId, testTableUri, Optional.empty(), Optional.empty())
+        testTableId, null, testTableUri, Optional.empty(), Optional.empty())
       assert(response.getCommits.size() === 1)
       assert(response.getCommits.get(0).getVersion === 1L)
       assert(response.getLatestTableVersion === 1L)
     }
   }
 
+  test("getCommits accepts table identifier without changing legacy request") {
+    var capturedBody: String = null
+    commitsHandler = exchange => {
+      capturedBody = readRequestBody(exchange)
+      sendJson(exchange, HttpStatus.SC_OK, """{"commits":[],"latest_table_version":1}""")
+    }
+    val tableIdentifier = new TableIdentifier(Array("main", "default"), "tbl")
+
+    withClient { client =>
+      client.getCommits(
+        testTableId, tableIdentifier, testTableUri, Optional.of(2L), Optional.empty())
+    }
+
+    val requestJson = objectMapper.readTree(capturedBody)
+    assert(requestJson.get("table_id").asText() === testTableId)
+    assert(requestJson.get("table_uri").asText() === testTableUri.toString)
+    assert(requestJson.get("start_version").asLong() === 2L)
+  }
+
   test("getCommits validates required parameters") {
     withClient { client =>
       intercept[NullPointerException] {
-        client.getCommits(null, testTableUri, Optional.empty(), Optional.empty())
+        client.getCommits(null, null, testTableUri, Optional.empty(), Optional.empty())
       }
       intercept[NullPointerException] {
-        client.getCommits(testTableId, null, Optional.empty(), Optional.empty())
+        client.getCommits(testTableId, null, null, Optional.empty(), Optional.empty())
       }
     }
   }
@@ -250,7 +269,7 @@ class UCTokenBasedRestClientSuite
     commitsHandler = exchange => sendJson(exchange, HttpStatus.SC_NOT_FOUND, "{}")
     withClient { client =>
       intercept[InvalidTargetTableException] {
-        client.getCommits(testTableId, testTableUri, Optional.empty(), Optional.empty())
+        client.getCommits(testTableId, null, testTableUri, Optional.empty(), Optional.empty())
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?


## How was this patch tested?

- `build/sbt javafmtAll scalafmtAll`
- `build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClientSuite"`
- `build/sbt "spark/testOnly org.apache.spark.sql.delta.coordinatedcommits.UCCommitCoordinatorClientSuite"`
- `build/sbt "kernelUnityCatalog/testOnly io.delta.kernel.unitycatalog.InMemoryUCClientSuite"`
