### PR TITLE
[Kernel] Auto-enable variantShredding-preview instead variantShredding from delta.enableVariantShredding

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -256,14 +256,13 @@ public class TableFeatures {
 
   /* ---- Start: variantShredding ---- */
   // Base class for variantShredding and variantShredding-preview features. Both features have
-  // identical behavior. Now that variantShredding has graduated to GA:
+  // identical behavior.
   //
-  // - When `delta.enableVariantShredding` is set to true, the GA feature (`variantShredding`)
-  //   is automatically enabled unless the table already has `variantShredding-preview` in its
-  //   protocol (to avoid breaking clients that only understand the preview feature).
-  // - The preview feature (`variantShredding-preview`) is never auto-enabled. To use it on a
-  //   new table, a user must explicitly set `delta.feature.variantShredding-preview=supported`
-  //   in the table properties.
+  // - When `delta.enableVariantShredding` is set to true, the preview feature
+  //   (`variantShredding-preview`) is automatically enabled unless the table already has
+  //   `variantShredding` in its protocol.
+  // - The GA feature (`variantShredding`) is never auto-enabled via metadata. To use it on a
+  //   new table, users must explicitly set `delta.feature.variantShredding=supported`.
   private static class VariantShreddingTableFeatureBase extends TableFeature.ReaderWriterFeature {
     VariantShreddingTableFeatureBase(String featureName) {
       super(featureName, /* minReaderVersion = */ 3, /* minWriterVersion = */ 7);
@@ -275,27 +274,32 @@ public class TableFeatures {
     }
   }
 
-  private static class VariantShreddingTableFeature extends VariantShreddingTableFeatureBase
-      implements FeatureAutoEnabledByMetadata {
+  private static class VariantShreddingTableFeature extends VariantShreddingTableFeatureBase {
     VariantShreddingTableFeature() {
       super("variantShredding");
+    }
+  }
+
+  private static class VariantShreddingPreviewTableFeature extends VariantShreddingTableFeatureBase
+      implements FeatureAutoEnabledByMetadata {
+    VariantShreddingPreviewTableFeature() {
+      super("variantShredding-preview");
     }
 
     @Override
     public boolean metadataRequiresFeatureToBeEnabled(Protocol protocol, Metadata metadata) {
       return TableConfig.VARIANT_SHREDDING_ENABLED.fromMetadata(metadata)
           &&
-          // Don't automatically enable the stable feature if the preview feature is
-          // already supported, to avoid possibly breaking old clients that only
-          // support the preview feature.
-          !protocol.supportsFeature(VARIANT_SHREDDING_PREVIEW_RW_FEATURE);
+          // Don't automatically enable the preview feature if the GA feature is already
+          // supported, so the protocol of a table that opted into GA is left unchanged.
+          !protocol.supportsFeature(VARIANT_SHREDDING_RW_FEATURE);
     }
   }
 
   public static final TableFeature VARIANT_SHREDDING_RW_FEATURE =
       new VariantShreddingTableFeature();
   public static final TableFeature VARIANT_SHREDDING_PREVIEW_RW_FEATURE =
-      new VariantShreddingTableFeatureBase("variantShredding-preview");
+      new VariantShreddingPreviewTableFeature();
   /* ---- End: variantShredding ---- */
 
   public static final TableFeature DOMAIN_METADATA_W_FEATURE = new DomainMetadataFeature();

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/tablefeatures/TableFeaturesSuite.scala
@@ -136,11 +136,11 @@ class TableFeaturesSuite extends AnyFunSuite {
     ("rowTracking", testMetadata(tblProps = Map("delta.enableRowTracking" -> "true")), true),
     ("rowTracking", testMetadata(tblProps = Map("delta.enableRowTracking" -> "false")), false),
     (
-      "variantShredding",
+      "variantShredding-preview",
       testMetadata(tblProps = Map("delta.enableVariantShredding" -> "true")),
       true),
     (
-      "variantShredding",
+      "variantShredding-preview",
       testMetadata(tblProps = Map("delta.enableVariantShredding" -> "false")),
       false),
     (
@@ -215,7 +215,7 @@ class TableFeaturesSuite extends AnyFunSuite {
     "clustering",
     "catalogManaged",
     "allowColumnDefaults",
-    "variantShredding-preview",
+    "variantShredding",
     "collations-preview").foreach {
     feature =>
       test(s"doesn't support auto enable by metadata: $feature") {
@@ -227,9 +227,6 @@ class TableFeaturesSuite extends AnyFunSuite {
   Seq(
     ("variantType", testMetadata(includeVariantTypeCol = true)),
     ("typeWidening", testMetadata(tblProps = Map("delta.enableTypeWidening" -> "true"))),
-    (
-      "variantShredding",
-      testMetadata(tblProps = Map("delta.enableVariantShredding" -> "true"))),
     ("collations", testMetadata(includeCollatedStringTypeCol = true))).foreach {
     case (feature, metadataEnablingFeature) =>
       test("special handling of tables containing preview features: " + feature) {
@@ -243,6 +240,20 @@ class TableFeaturesSuite extends AnyFunSuite {
             metadataEnablingFeature)
         assert(!enable, "shouldn't enable non-preview feature")
       }
+  }
+
+  // variantShredding has the inverted relationship: only the preview feature is auto-enabled,
+  // so we verify that the preview is NOT auto-enabled when the GA feature is already in protocol.
+  test("special handling of tables containing variantShredding GA feature") {
+    val protocolWithGaFeature = new Protocol(3, 7)
+      .withFeature(TableFeatures.VARIANT_SHREDDING_RW_FEATURE)
+
+    val enable = TableFeatures.VARIANT_SHREDDING_PREVIEW_RW_FEATURE
+      .asInstanceOf[FeatureAutoEnabledByMetadata]
+      .metadataRequiresFeatureToBeEnabled(
+        protocolWithGaFeature,
+        testMetadata(tblProps = Map("delta.enableVariantShredding" -> "true")))
+    assert(!enable, "shouldn't enable preview feature when GA feature is already supported")
   }
 
   test("hasKernelReadSupport expected to be true") {
@@ -1081,9 +1092,9 @@ class TableFeaturesSuite extends AnyFunSuite {
         set(
           "columnMapping",
           "deletionVectors",
-          "variantShredding",
+          "variantShredding-preview",
           "variantType")),
-      set("variantType", "variantShredding")),
+      set("variantType", "variantShredding-preview")),
     (
       testMetadata(includeGeometryTypeCol = true),
       new Protocol(1, 1),
@@ -1203,8 +1214,8 @@ class TableFeaturesSuite extends AnyFunSuite {
         set("columnMapping", "deletionVectors"),
         set("columnMapping", "deletionVectors", "icebergCompatV2"))),
     (
-      // Enable the variantShredding GA feature when the preview feature is already enabled.
-      // The GA feature should not be auto-enabled.
+      // Setting delta.enableVariantShredding=true is a no-op when the preview feature is
+      // already supported (the preview feature is what auto-enable would otherwise add).
       testMetadata(
         tblProps = Map("delta.enableVariantShredding" -> "true"),
         includeVariantTypeCol = true),
@@ -1212,7 +1223,18 @@ class TableFeaturesSuite extends AnyFunSuite {
         3,
         7,
         set("variantType", "variantShredding-preview"),
-        set("variantType", "variantShredding-preview")))).foreach {
+        set("variantType", "variantShredding-preview"))),
+    (
+      // Setting delta.enableVariantShredding=true is a no-op when the GA feature is already
+      // supported. We must not auto-add the preview feature in this case.
+      testMetadata(
+        tblProps = Map("delta.enableVariantShredding" -> "true"),
+        includeVariantTypeCol = true),
+      new Protocol(
+        3,
+        7,
+        set("variantType", "variantShredding"),
+        set("variantType", "variantShredding")))).foreach {
     case (newMetadata, currentProtocol) =>
       test(s"autoUpgradeProtocolBasedOnMetadata: no-op upgrade: $currentProtocol") {
         val newProtocolAndNewFeaturesEnabled =

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableFeaturesSuite.scala
@@ -409,7 +409,7 @@ trait DeltaTableFeaturesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
   /* ---- End: type widening tests ---- */
 
   /* ---- Start: variant shredding tests ---- */
-  test("only variantShredding feature is enabled when metadata supports it: new table") {
+  test("only variantShredding-preview is enabled when metadata supports it: new table") {
     withTempDirAndEngine { (tablePath, engine) =>
       createEmptyTable(
         engine,
@@ -418,8 +418,8 @@ trait DeltaTableFeaturesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
         tableProperties = Map("delta.enableVariantShredding" -> "true"))
 
       val protocolV0 = getProtocol(engine, tablePath)
-      assert(!protocolV0.supportsFeature(TableFeatures.VARIANT_SHREDDING_PREVIEW_RW_FEATURE))
-      assert(protocolV0.supportsFeature(TableFeatures.VARIANT_SHREDDING_RW_FEATURE))
+      assert(protocolV0.supportsFeature(TableFeatures.VARIANT_SHREDDING_PREVIEW_RW_FEATURE))
+      assert(!protocolV0.supportsFeature(TableFeatures.VARIANT_SHREDDING_RW_FEATURE))
       assert(protocolV0.supportsFeature(TableFeatures.VARIANT_RW_FEATURE))
 
       updateTableMetadata(
@@ -431,7 +431,7 @@ trait DeltaTableFeaturesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
     }
   }
 
-  test("only variantShredding feature is enabled when new metadata supports it: existing table") {
+  test("only variantShredding-preview is enabled when new metadata supports it: existing table") {
     withTempDirAndEngine { (tablePath, engine) =>
       createEmptyTable(engine, tablePath = tablePath, schema = testSchema)
       val protocolV0 = getProtocol(engine, tablePath)
@@ -444,8 +444,32 @@ trait DeltaTableFeaturesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
         tablePath = tablePath,
         tableProperties = Map("delta.enableVariantShredding" -> "true"))
       val protocolV1 = getProtocol(engine, tablePath)
-      assert(!protocolV1.supportsFeature(TableFeatures.VARIANT_SHREDDING_PREVIEW_RW_FEATURE))
+      assert(protocolV1.supportsFeature(TableFeatures.VARIANT_SHREDDING_PREVIEW_RW_FEATURE))
+      assert(!protocolV1.supportsFeature(TableFeatures.VARIANT_SHREDDING_RW_FEATURE))
+      assert(protocolV1.supportsFeature(TableFeatures.VARIANT_RW_FEATURE))
+    }
+  }
+
+  test("variantShredding GA in existing table is respected") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createEmptyTable(
+        engine,
+        tablePath = tablePath,
+        schema = testSchema,
+        tableProperties = Map("delta.feature.variantShredding" -> "supported"))
+
+      val protocolV0 = getProtocol(engine, tablePath)
+      require(protocolV0.supportsFeature(TableFeatures.VARIANT_SHREDDING_RW_FEATURE))
+      require(!protocolV0.supportsFeature(TableFeatures.VARIANT_SHREDDING_PREVIEW_RW_FEATURE))
+      require(protocolV0.supportsFeature(TableFeatures.VARIANT_RW_FEATURE))
+
+      updateTableMetadata(
+        engine = engine,
+        tablePath = tablePath,
+        tableProperties = Map("delta.enableVariantShredding" -> "true"))
+      val protocolV1 = getProtocol(engine, tablePath)
       assert(protocolV1.supportsFeature(TableFeatures.VARIANT_SHREDDING_RW_FEATURE))
+      assert(!protocolV1.supportsFeature(TableFeatures.VARIANT_SHREDDING_PREVIEW_RW_FEATURE))
       assert(protocolV1.supportsFeature(TableFeatures.VARIANT_RW_FEATURE))
     }
   }
@@ -480,7 +504,7 @@ trait DeltaTableFeaturesSuiteBase extends AnyFunSuite with AbstractWriteUtils {
         tablePath = tablePath,
         schema = testSchema,
         tableProperties = Map(
-          "delta.enableVariantShredding" -> "true",
+          "delta.feature.variantShredding" -> "supported",
           "delta.feature.variantShredding-preview" -> "supported"))
 
       val protocol = getProtocol(engine, tablePath)


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Reverts the auto-enable behavior introduced in #6322 so that the preview feature (variantShredding-preview) is what gets auto-added to a table's protocol when delta.enableVariantShredding=true. The GA feature (variantShredding) remains registered and is still recognized when explicitly set via delta.feature.variantShredding=supported.

The rust delta-kernel does not yet implement variantShredding GA, so writing GA into a protocol via auto-enable would make tables unreadable from the rust kernel. This change also keeps kernel-java aligned with the Delta Spark default, which likewise auto-enables the preview feature only.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, `variantShredding-preview` remains the auto-enabled feature instead of `variantShredding`