### PR TITLE
Minor formatting: TableCommitCoordinatorClient.apply and callers

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2138,7 +2138,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
           TableCommitCoordinatorClient(
             commitCoordinatorClient = new FileSystemBasedCommitCoordinatorClient(deltaLog),
             deltaLog = deltaLog,
-            coordinatedCommitsTableConf = snapshot.metadata.coordinatedCommitsTableConf)
+            coordinatedCommitsTableConf = snapshot.metadata.coordinatedCommitsTableConf
+          )
         }
       val updatedActions = new UpdatedActions(
         commitInfo, metadata, protocol, snapshot.metadata, snapshot.protocol)
@@ -2916,7 +2917,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       TableCommitCoordinatorClient(
         new FileSystemBasedCommitCoordinatorClient(deltaLog),
         deltaLog,
-        snapshot.metadata.coordinatedCommitsTableConf)
+        snapshot.metadata.coordinatedCommitsTableConf
+      )
     }
     val commitFile = writeCommitFileImpl(
       attemptVersion, jsonActions, commitCoordinatorClient, currentTransactionInfo)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -123,8 +123,8 @@ object CatalogOwnedTableUtils extends DeltaLogging {
               logPath = snapshot.deltaLog.logPath,
               tableConf = snapshot.metadata.configuration,
               hadoopConf = snapshot.deltaLog.newDeltaHadoopConf(),
-              logStore = snapshot.deltaLog.store)
-            )
+              logStore = snapshot.deltaLog.store
+            ))
           }
       }
       // This table is catalog owned table but catalogTableOpt is not defined. This means

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/TableCommitCoordinatorClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/TableCommitCoordinatorClient.scala
@@ -51,7 +51,8 @@ case class TableCommitCoordinatorClient(
     logPath: Path,
     tableConf: Map[String, String],
     hadoopConf: Configuration,
-    logStore: LogStore) {
+    logStore: LogStore
+  ) {
 
   private def makeTableDesc(
       tableIdentifierOpt: Option[CatalystTableIdentifier]): TableDescriptor = {
@@ -130,13 +131,15 @@ object TableCommitCoordinatorClient {
     def apply(
       commitCoordinatorClient: JCommitCoordinatorClient,
       deltaLog: DeltaLog,
-      coordinatedCommitsTableConf: Map[String, String]): TableCommitCoordinatorClient = {
+      coordinatedCommitsTableConf: Map[String, String]
+    ): TableCommitCoordinatorClient = {
     val hadoopConf = deltaLog.newDeltaHadoopConf()
     new TableCommitCoordinatorClient(
       commitCoordinatorClient,
       deltaLog.logPath,
       coordinatedCommitsTableConf,
       hadoopConf,
-      deltaLog.store)
+      deltaLog.store
+    )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/DynamoDBCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/DynamoDBCommitCoordinatorClientSuite.scala
@@ -162,7 +162,11 @@ abstract class DynamoDBCommitCoordinatorClientSuite(batchSize: Long)
     val cs = TestDynamoDBCommitCoordinatorBuilder(batchSize = batchSize).build(spark, Map.empty)
     val tableConf = cs.registerTable(
       deltaLog.logPath, Optional.empty(), -1L, Metadata(), Protocol(1, 1))
-    TableCommitCoordinatorClient(cs, deltaLog, tableConf.asScala.toMap)
+    TableCommitCoordinatorClient(
+      cs,
+      deltaLog,
+      tableConf.asScala.toMap
+    )
   }
 
   override protected def registerBackfillOp(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinatorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinatorSuite.scala
@@ -34,7 +34,11 @@ abstract class InMemoryCommitCoordinatorSuite(batchSize: Int)
     val cs = InMemoryCommitCoordinatorBuilder(batchSize).build(spark, Map.empty)
     val conf = cs.registerTable(
       deltaLog.logPath, Optional.empty(), -1L, initMetadata, Protocol(1, 1))
-    TableCommitCoordinatorClient(cs, deltaLog, conf.asScala.toMap)
+    TableCommitCoordinatorClient(
+      cs,
+      deltaLog,
+      conf.asScala.toMap
+    )
   }
 
   override protected def registerBackfillOp(


### PR DESCRIPTION
## Description

Minor formatting tweaks in the coordinated-commits path:

- Move the closing parenthesis onto its own line for the `TableCommitCoordinatorClient` case class and its secondary `apply` overload.
- Update two `FileSystemBasedCommitCoordinatorClient` construction sites in `OptimisticTransaction` and two test suites (`DynamoDBCommitCoordinatorClientSuite`, `InMemoryCommitCoordinatorSuite`) to match.
- Adjust closing parens in one branch of `CoordinatedCommitsUtils.CatalogOwnedTableUtils`.

No behavior change.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.
