### PR TITLE
[PROTOCOL] Add `commitInfo.incremental` spec

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -788,10 +788,11 @@ When [In-Commit Timestamps](#in-commit-timestamps) are enabled, writers are requ
 
 The `commitInfo` action may include an optional boolean field `isIncrementalSafe`. When `true`, the writer asserts that this commit is incrementally safe: its effect on any aggregate derived from the log (e.g. those recorded in a [Version Checksum](#version-checksum-file)) can be computed from this commit's own `add` and `remove` actions alone. For example, given the Version Checksum at version `N`, a reader can derive `numFiles`, `tableSizeBytes`, and `fileSizeHistogram` at any later version by iteratively applying each subsequent commit's `add.size` and `remove.size`, provided every such commit asserts `isIncrementalSafe=true`. Specifically, the writer guarantees:
 
-1. If this commit emits an `add` whose `path` is already live in the immediately preceding snapshot, it also contains a `remove` for the existing [`(path, deletionVector.uniqueId)`](#add-file-and-remove-file) pair (e.g. a Deletion Vector update).
-2. Every `remove` action in this commit includes the `size` field (which is otherwise [optional](#add-file-and-remove-file)).
+1. **No double adds.** No [logical file](#add-file-and-remove-file) added by this commit was present in the previous snapshot.
+2. **No double removes.** Every logical file removed by this commit was present in the previous snapshot.
+3. Every `remove` action in this commit includes the `size` field (which is otherwise [optional](#add-file-and-remove-file)).
 
-In practice, ordinary DML and table-maintenance operations (e.g. `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) naturally satisfy both guarantees. The canonical counter-example is a `COMPUTE STATISTICS`-style operation that recomputes file-level statistics by emitting `add` actions for files already live in the table without paired `remove` actions; such an operation violates guarantee (1).
+In practice, ordinary DML and table-maintenance operations (e.g. `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) naturally satisfy these guarantees. The canonical counter-example is a `COMPUTE STATISTICS`-style operation that recomputes file-level statistics by re-adding logical files already present in the table; such an operation violates guarantee (1).
 
 An example of storing provenance information related to an `INSERT` operation:
 ```json

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -782,9 +782,16 @@ A delta file can optionally contain additional provenance information about what
 When the `catalogManaged` table feature is enabled, the `commitInfo` action must have a field
 `txnId` that stores a unique transaction identifier string.
 
-Implementations are free to store any valid JSON-formatted data via the `commitInfo` action.
+The `commitInfo` action must be a JSON object. Implementations are free to store any fields within that object; table features may require additional fields or impose semantics on specific fields.
 
 When [In-Commit Timestamps](#in-commit-timestamps) are enabled, writers are required to include a `commitInfo` action with every commit, which must include the `inCommitTimestamp` field. Also, the `commitInfo` action must be first action in the commit.
+
+The `commitInfo` action may include an optional boolean field `isIncrementalSafe`. When `true`, the writer asserts that this commit is incrementally safe: its effect on any aggregate derived from the log (e.g. those recorded in a [Version Checksum](#version-checksum-file)) can be computed from this commit's own `add` and `remove` actions alone. For example, given the Version Checksum at version `N`, a reader can derive `numFiles`, `tableSizeBytes`, and `fileSizeHistogram` at any later version by iteratively applying each subsequent commit's `add.size` and `remove.size`, provided every such commit asserts `isIncrementalSafe=true`. Specifically, the writer guarantees:
+
+1. If this commit emits an `add` whose `path` is already live in the immediately preceding snapshot, it also contains a `remove` for the existing [`(path, deletionVector.uniqueId)`](#add-file-and-remove-file) pair (e.g. a Deletion Vector update).
+2. Every `remove` action in this commit includes the `size` field (which is otherwise [optional](#add-file-and-remove-file)).
+
+In practice, ordinary DML and table-maintenance operations (e.g. `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) naturally satisfy both guarantees. The canonical counter-example is a `COMPUTE STATISTICS`-style operation that recomputes file-level statistics by emitting `add` actions for files already live in the table without paired `remove` actions; such an operation violates guarantee (1).
 
 An example of storing provenance information related to an `INSERT` operation:
 ```json
@@ -795,6 +802,7 @@ An example of storing provenance information related to an `INSERT` operation:
     "userName":"michael@databricks.com",
     "operation":"INSERT",
     "operationParameters":{"mode":"Append","partitionBy":"[]"},
+    "isIncrementalSafe":true,
     "notebook":{
       "notebookId":"4443029",
       "notebookPath":"Users/michael@databricks.com/actions"},

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -786,13 +786,14 @@ The `commitInfo` action must be a JSON object. Implementations are free to store
 
 When [In-Commit Timestamps](#in-commit-timestamps) are enabled, writers are required to include a `commitInfo` action with every commit, which must include the `inCommitTimestamp` field. Also, the `commitInfo` action must be first action in the commit.
 
-The `commitInfo` action may include an optional boolean field `isIncrementalSafe`. When `true`, the writer asserts that this commit is incrementally safe: its effect on any aggregate derived from the log (e.g. those recorded in a [Version Checksum](#version-checksum-file)) can be computed from this commit's own `add` and `remove` actions alone. For example, given the Version Checksum at version `N`, a reader can derive `numFiles`, `tableSizeBytes`, and `fileSizeHistogram` at any later version by iteratively applying each subsequent commit's `add.size` and `remove.size`, provided every such commit asserts `isIncrementalSafe=true`. Specifically, the writer guarantees:
+The `commitInfo` action may include an optional `incremental` object describing how this commit affects aggregates derived from the log, such as the `numFiles`, `tableSizeBytes`, and `fileSizeHistogram` recorded in a [Version Checksum](#version-checksum-file). When present, a reader can update such aggregates from a baseline using this commit's own `add` and `remove` actions alone, without reconstructing table state. It has two required fields, each set to `apply` or `ignore`:
 
-1. **No double adds.** No [logical file](#add-file-and-remove-file) added by this commit was present in the previous snapshot.
-2. **No double removes.** Every logical file removed by this commit was present in the previous snapshot.
-3. Every `remove` action in this commit includes the `size` field (which is otherwise [optional](#add-file-and-remove-file)).
+- `adds`: `apply` asserts every [logical file](#add-file-and-remove-file) added by this commit is new (absent from the previous snapshot), so each `add` is counted. `ignore` asserts every `add` re-adds a logical file already present, contributing nothing.
+- `removes`: `apply` asserts every logical file removed by this commit was present in the previous snapshot and that every `remove` includes the (otherwise [optional](#add-file-and-remove-file)) `size` field, so each `remove` is subtracted. `ignore` asserts the `remove` actions are not reflected in the aggregates and are skipped.
 
-In practice, ordinary DML and table-maintenance operations (e.g. `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) naturally satisfy these guarantees. The canonical counter-example is a `COMPUTE STATISTICS`-style operation that recomputes file-level statistics by re-adding logical files already present in the table; such an operation violates guarantee (1).
+Each field applies uniformly to every action of its type in the commit, so a commit whose `add` (or `remove`) actions are not all alike cannot use the corresponding declaration. When `incremental` is absent, a reader makes no such assumption.
+
+In practice, ordinary DML and table-maintenance operations (e.g. `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) set both fields to `apply`. An operation that re-adds existing files (e.g. recomputing file statistics) sets `adds` to `ignore`; an operation that writes `remove` tombstones for files absent from the live set (e.g. protecting deletion-vector files from vacuum) sets `removes` to `ignore`.
 
 An example of storing provenance information related to an `INSERT` operation:
 ```json
@@ -803,7 +804,7 @@ An example of storing provenance information related to an `INSERT` operation:
     "userName":"michael@databricks.com",
     "operation":"INSERT",
     "operationParameters":{"mode":"Append","partitionBy":"[]"},
-    "isIncrementalSafe":true,
+    "incremental":{"adds":"apply","removes":"apply"},
     "notebook":{
       "notebookId":"4443029",
       "notebookPath":"Users/michael@databricks.com/actions"},

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -793,7 +793,9 @@ The `commitInfo` action may include an optional `incremental` object describing 
 
 Each field applies uniformly to every action of its type in the commit, so a commit whose `add` (or `remove`) actions are not all alike cannot use the corresponding declaration. When `incremental` is absent, a reader makes no such assumption.
 
-In practice, ordinary DML and table-maintenance operations (e.g. `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) set both fields to `apply`. An operation that re-adds existing files (e.g. recomputing file statistics) sets `adds` to `ignore`; an operation that writes `remove` tombstones for files absent from the live set (e.g. protecting deletion-vector files from vacuum) sets `removes` to `ignore`.
+The `incremental` object may also include optional pre-computed totals for this commit's own actions. `numFilesAdded` and `numBytesAdded` give the count of, and sum of the `size` field over, the commit's `add` actions, and may be present only when `adds` is `apply`. `numFilesRemoved` and `numBytesRemoved` give the same over its `remove` actions, and may be present only when `removes` is `apply`. When present, they let a reader maintain file-count and byte-size aggregates (such as `numFiles` and `tableSizeBytes`) without reading the commit's `add` and `remove` actions. Deriving per-file aggregates such as `fileSizeHistogram` still requires the individual file sizes.
+
+In practice, ordinary DML and table-maintenance operations (e.g. `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) set both fields to `apply`. An operation that re-adds files already present (e.g. recomputing file statistics) sets `adds` to `ignore`. An operation may set `removes` to `ignore` when its `remove` actions do not correspond to counted files leaving the table, so subtracting them would be wrong. The case today is dropping the `deletionVectors` feature, whose `remove` actions pin deletion-vector side files (referenced by [`add.deletionVector`](#deletion-vectors), never themselves an `add`) rather than record data files leaving: the `remove` marks each deletion-vector file so that [VACUUM](#vacuum-protocol-check) retains it, protecting older versions that still reference it.
 
 An example of storing provenance information related to an `INSERT` operation:
 ```json
@@ -804,7 +806,7 @@ An example of storing provenance information related to an `INSERT` operation:
     "userName":"michael@databricks.com",
     "operation":"INSERT",
     "operationParameters":{"mode":"Append","partitionBy":"[]"},
-    "incremental":{"adds":"apply","removes":"apply"},
+    "incremental":{"adds":"apply","removes":"apply","numFilesAdded":3,"numBytesAdded":1048576,"numFilesRemoved":0,"numBytesRemoved":0},
     "notebook":{
       "notebookId":"4443029",
       "notebookPath":"Users/michael@databricks.com/actions"},


### PR DESCRIPTION
Adds an optional `commitInfo.incremental` object that declares how a commit affects aggregates derived from the log (e.g. `numFiles`, `tableSizeBytes`, `fileSizeHistogram` in a Version Checksum).

It has two required fields: `adds` and `removes`. Each can have value `apply` or `ignore`, which let a reader update those aggregates from the commit's own `add`/`remove` actions without reconstructing table state.

The two fields are independent because real operations need each direction separately:
- `adds: "ignore"`: the commit re-adds files already present (e.g. recomputing file statistics, row-tracking backfill, dropping a feature).
- `removes: "ignore"`: the commit writes `remove` tombstones for files absent from the live set (e.g. protecting deletion-vector files from vacuum).

Ordinary DML and maintenance (`INSERT`, `UPDATE`, `DELETE`, `MERGE`, `OPTIMIZE`) set both fields to `apply`.

This is a new optional field; no known Delta writer (trino, duckdb, delta-rs, flink, spark) emits it today, so I don't expect conflicts. While here, I also clarify that `commitInfo` must be a JSON object, not arbitrary JSON such as an array; a small oversight in the existing spec.

The spec also introduces _optional_ fields `numFilesAdded, numBytesAdded, numFilesRemoved, numBytesRemoved`.

Once merged, existing writers that already deduce per-commit incremental behavior should be updated to emit this object.
