### PR TITLE
[kernel-spark] Support CDC + schema tracking log in v2

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSchemaEvolutionSuite.scala
@@ -137,14 +137,11 @@ class DeltaV2SourceSchemaEvolutionIdColumnMappingSuite
     with DeltaV2SourceSchemaEvolutionSuiteBase
 
 // CDC suites
-// TODO(#5319): Support CDC non-additive schema evolution
 trait DeltaV2SourceSchemaEvolutionCDCSuiteBase extends DeltaV2SourceSchemaEvolutionSuiteBase {
   self: StreamingSchemaEvolutionSuiteBase =>
 
-  override protected def shouldPassTests: Set[String] = Set.empty[String]
-
-  override protected def shouldFailTests: Set[String] =
-    super.shouldPassTests ++ super.shouldFailTests ++ Set(
+  override protected def shouldPassTests: Set[String] =
+    super.shouldPassTests ++ Set(
       // Additional tests from CDCStreamingSchemaEvolutionSuiteBase
       "CDC streaming with schema evolution",
       "protocol and configuration evolution"

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -75,9 +75,8 @@ import scala.collection.immutable.Seq;
 import scala.collection.immutable.Seq$;
 
 /**
- * TODO(#5319): Support CDC V2 port of V1's {@code DeltaSourceMetadataEvolutionSupport} trait.
- * Handles metadata evolution (schema, table configuration, or protocol changes) for the v2 Delta
- * streaming source.
+ * V2 port of V1's {@code DeltaSourceMetadataEvolutionSupport} trait. Handles metadata evolution
+ * (schema, table configuration, or protocol changes) for the v2 Delta streaming source.
  *
  * <p>To safely evolve schema mid-stream, this class intercepts streaming at several stages to:
  *
@@ -531,7 +530,6 @@ public class MetadataEvolutionHandler {
             options,
             snapshotManager,
             engine,
-            SparkMicroBatchStream.ACTION_SET,
             /* sourceMetadataPathOpt= */ Option.empty(),
             mergeConsecutiveSchemaChanges);
     if (trackingLog.isEmpty()) {
@@ -670,7 +668,6 @@ public class MetadataEvolutionHandler {
       Map<String, String> options,
       DeltaSnapshotManager snapshotManager,
       Engine engine,
-      Set<DeltaLogActionUtils.DeltaAction> mergeActionSet,
       Option<String> sourceMetadataPathOpt,
       boolean mergeConsecutiveSchemaChanges) {
     Option<String> locationOpt =
@@ -702,7 +699,7 @@ public class MetadataEvolutionHandler {
             /* consecutiveSchemaChangesMerger= */ Option.apply(
                 currentMetadata ->
                     getMergedConsecutiveMetadataChanges(
-                        currentMetadata, snapshotManager, engine, tablePath, mergeActionSet)),
+                        currentMetadata, snapshotManager, engine, tablePath)),
             /* initMetadataLogEagerly= */ true));
   }
 
@@ -711,8 +708,7 @@ public class MetadataEvolutionHandler {
       PersistedMetadata currentMetadata,
       DeltaSnapshotManager snapshotManager,
       Engine engine,
-      String tablePath,
-      Set<DeltaLogActionUtils.DeltaAction> mergeActionSet) {
+      String tablePath) {
     final long currentMetadataVersion = currentMetadata.deltaCommitVersion();
     // We start from the currentSchemaVersion so that we can stop early in case the current
     // version still has file actions that potentially needs to be processed.
@@ -725,8 +721,9 @@ public class MetadataEvolutionHandler {
             snapshotManager.getTableChanges(engine, currentMetadataVersion, Optional.empty());
 
     try (CloseableIterator<CommitActions> commitsIter =
+        // Always include CDC: the merger must stop on any file action
         StreamingHelper.getCommitActionsFromRangeUnsafe(
-            engine, commitRange, tablePath, mergeActionSet)) {
+            engine, commitRange, tablePath, SparkMicroBatchStream.CDC_ACTION_SET)) {
       while (commitsIter.hasNext()) {
         try (CommitActions commit = commitsIter.next()) {
           long version = commit.getVersion();
@@ -742,10 +739,11 @@ public class MetadataEvolutionHandler {
               int addIdx = batch.getSchema().indexOf(DeltaLogActionUtils.DeltaAction.ADD.colName);
               int removeIdx =
                   batch.getSchema().indexOf(DeltaLogActionUtils.DeltaAction.REMOVE.colName);
+              int cdcIdx = batch.getSchema().indexOf(DeltaLogActionUtils.DeltaAction.CDC.colName);
               ColumnVector addVec = addIdx >= 0 ? batch.getColumnVector(addIdx) : null;
               ColumnVector removeVec = removeIdx >= 0 ? batch.getColumnVector(removeIdx) : null;
+              ColumnVector cdcVec = cdcIdx >= 0 ? batch.getColumnVector(cdcIdx) : null;
 
-              // TODO(#5319): handle AddCDCFile as well
               for (int rowId = 0; rowId < numRows; rowId++) {
                 Optional<Metadata> m = StreamingHelper.getMetadata(batch, rowId);
                 if (m.isPresent()) {
@@ -764,7 +762,8 @@ public class MetadataEvolutionHandler {
                   protocolAction = p.get();
                 }
                 if ((addVec != null && !addVec.isNullAt(rowId))
-                    || (removeVec != null && !removeVec.isNullAt(rowId))) {
+                    || (removeVec != null && !removeVec.isNullAt(rowId))
+                    || (cdcVec != null && !cdcVec.isNullAt(rowId))) {
                   hasFileAction = true;
                   break outer;
                 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -19,6 +19,7 @@ import static io.delta.kernel.internal.tablefeatures.TableFeatures.TYPE_WIDENING
 import static io.delta.kernel.internal.tablefeatures.TableFeatures.TYPE_WIDENING_RW_PREVIEW_FEATURE;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import io.delta.kernel.CommitActions;
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Scan;
@@ -103,26 +104,16 @@ public class SparkMicroBatchStream
   private static final Logger logger = LoggerFactory.getLogger(SparkMicroBatchStream.class);
 
   public static final Set<DeltaAction> ACTION_SET =
-      Collections.unmodifiableSet(
-          new HashSet<>(
-              Arrays.asList(
-                  DeltaAction.ADD,
-                  DeltaAction.REMOVE,
-                  DeltaAction.METADATA,
-                  DeltaAction.PROTOCOL,
-                  DeltaAction.COMMITINFO)));
+      ImmutableSet.of(
+          DeltaAction.ADD,
+          DeltaAction.REMOVE,
+          DeltaAction.METADATA,
+          DeltaAction.PROTOCOL,
+          DeltaAction.COMMITINFO);
 
-  /** Action set for CDC reads. */
-  private static final Set<DeltaAction> CDC_ACTION_SET =
-      Collections.unmodifiableSet(
-          new HashSet<>(
-              Arrays.asList(
-                  DeltaAction.ADD,
-                  DeltaAction.REMOVE,
-                  DeltaAction.METADATA,
-                  DeltaAction.PROTOCOL,
-                  DeltaAction.CDC,
-                  DeltaAction.COMMITINFO)));
+  /** Action set for CDC reads: {@link #ACTION_SET} plus {@link DeltaAction#CDC}. */
+  public static final Set<DeltaAction> CDC_ACTION_SET =
+      ImmutableSet.<DeltaAction>builder().addAll(ACTION_SET).add(DeltaAction.CDC).build();
 
   /**
    * Max attempts to resolve the start version when failOnDataLoss=false. Attempt 1 is the initial
@@ -934,7 +925,13 @@ public class SparkMicroBatchStream
     }
 
     // Start boundary already applied above (before admission). Only apply end boundary here.
-    return applyEndBoundaryFiltering(result, endOffset);
+    result = applyEndBoundaryFiltering(result, endOffset);
+
+    // Stop before any schema change barrier if detected. V1's wrap is in
+    // DeltaSource.getFileChangesWithRateLimit, shared by CDC and non-CDC; V2 applies it inside
+    // this CDC-specific method because both planInputPartitions and the outer
+    // getFileChangesWithRateLimit reach the CDC iterator through here.
+    return metadataEvolutionHandler.stopIndexedFileIteratorAtSchemaChangeBarrier(result);
   }
 
   /**
@@ -1845,6 +1842,11 @@ public class SparkMicroBatchStream
   /**
    * Scans a commit's actions in a single pass: validates metadata, checks CDF is enabled, detects
    * no-op MERGEs, and collects CDC/Add/Remove files into IndexedFiles.
+   *
+   * <p>If schema tracking is on and this commit's metadata or protocol differs from source-init,
+   * returns a single barrier sentinel instead of BASE + files + END. V1 splits this across
+   * DeltaSourceCDCSupport.filterAndIndexDeltaLogs (barrier injection) and
+   * IndexedChangeFileSeq.filterFiles (short-circuit); V2 collapses both here.
    */
   private List<IndexedFile> collectAndBuildCDCIndexedFiles(
       CommitActions commit,
@@ -1853,6 +1855,8 @@ public class SparkMicroBatchStream
       long startVersion,
       Optional<DeltaSourceOffset> endOffsetOpt)
       throws IOException {
+    boolean trackingMetadataChange = metadataEvolutionHandler.shouldTrackMetadataChange();
+
     // Phase 1: scan actions to validate metadata and collect CDC/Add/Remove files.
     List<CDCDataFile> cdcFiles = new ArrayList<>();
     // Single ordered list for inferred CDC files, preserving delta-log action ordering.
@@ -1860,12 +1864,14 @@ public class SparkMicroBatchStream
     List<CDCDataFile> inferredCdcFiles = new ArrayList<>();
     boolean shouldSkip = false;
     Metadata metadataAction = null;
+    Protocol protocolAction = null;
 
     try (CloseableIterator<ColumnarBatch> actionsIter = commit.getActions()) {
       while (actionsIter.hasNext()) {
         ColumnarBatch batch = actionsIter.next();
         for (int rowId = 0; rowId < batch.getSize(); rowId++) {
-          // Metadata: check schema changes + CDF still enabled
+          // Metadata: check schema changes + CDF still enabled. Skip the read-compat check when
+          // tracking — the barrier protocol below handles divergence.
           Optional<Metadata> metadataOpt = StreamingHelper.getMetadata(batch, rowId);
           if (metadataOpt.isPresent()) {
             metadataAction =
@@ -1875,7 +1881,7 @@ public class SparkMicroBatchStream
                     version,
                     startVersion,
                     endOffsetOpt,
-                    /* verifyMetadataAction= */ true);
+                    /* verifyMetadataAction= */ !trackingMetadataChange);
             if (!isCDFEnabled(metadataAction)) {
               throw new RuntimeException(
                   DeltaErrors.changeDataNotRecordedException(
@@ -1883,6 +1889,16 @@ public class SparkMicroBatchStream
                       startVersion,
                       endOffsetOpt.map(DeltaSourceOffset::reservoirVersion).orElse(version)));
             }
+          }
+
+          // Protocol: captured so the barrier fires on protocol-only changes.
+          Optional<Protocol> protocolOpt = StreamingHelper.getProtocol(batch, rowId);
+          if (protocolOpt.isPresent()) {
+            Preconditions.checkArgument(
+                protocolAction == null,
+                "Should not encounter two protocol actions in the same commit of version %d",
+                version);
+            protocolAction = protocolOpt.get();
           }
 
           // CommitInfo: detect no-op MERGEs where the operation rewrites files without
@@ -1913,6 +1929,19 @@ public class SparkMicroBatchStream
             inferredCdcFiles.add(CDCDataFile.fromAddFile(addOpt.get(), timestamp));
           }
         }
+      }
+    }
+
+    // Schema-change barrier: emit only the barrier when this commit diverges from source-init.
+    // V1 injects in DeltaSourceCDCSupport.filterAndIndexDeltaLogs and short-circuits in
+    // IndexedChangeFileSeq.filterFiles; V2 does both here.
+    try (CloseableIterator<IndexedFile> barrierIter =
+        metadataEvolutionHandler.getMetadataOrProtocolChangeIndexedFileIterator(
+            metadataAction, protocolAction, version)) {
+      if (barrierIter.hasNext()) {
+        List<IndexedFile> result = new ArrayList<>();
+        result.add(barrierIter.next());
+        return result;
       }
     }
 
@@ -1957,15 +1986,22 @@ public class SparkMicroBatchStream
   /**
    * Per-commit CDC admission control. Mirrors DSv1's IndexedChangeFileSeq.filterFiles.
    *
-   * <p>Input is a single commit's IndexedFiles: an optional BASE sentinel (absent on resume when
-   * the sentinel was already processed) followed by data files. Applies batch or per-file admission
-   * and appends an END sentinel only when all data files are admitted. Returns empty list on
-   * batch-reject so the offset doesn't advance.
+   * <p>Input is a single commit's IndexedFiles: either a schema-change barrier (passed through
+   * unchanged), or an optional BASE sentinel followed by data files. Applies batch or per-file
+   * admission and appends an END sentinel only when all data files are admitted. Returns empty list
+   * on batch-reject so the offset doesn't advance.
    */
   private List<IndexedFile> applyPerCommitCDCAdmission(
       List<IndexedFile> commitFiles,
       DeltaSource.AdmissionLimits admissionLimits,
       long commitVersion) {
+    // Schema-change barrier: pass through. collectAndBuildCDCIndexedFiles returns the barrier as a
+    // singleton, so it can only appear as element 0.
+    if (!commitFiles.isEmpty()
+        && commitFiles.get(0).getIndex() == DeltaSourceOffset.METADATA_CHANGE_INDEX()) {
+      return new ArrayList<>(commitFiles);
+    }
+
     // Split out the optional BASE sentinel from data files.
     Optional<IndexedFile> baseSentinel = Optional.empty();
     List<IndexedFile> dataFiles = new ArrayList<>();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -265,7 +265,6 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
             options,
             snapshotManager,
             DefaultEngine.create(hadoopConf),
-            SparkMicroBatchStream.ACTION_SET,
             Option.apply(checkpointLocation),
             /* mergeConsecutiveSchemaChanges= */ false);
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
@@ -1003,7 +1003,6 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
         options,
         snapshotManager,
         defaultEngine,
-        SparkMicroBatchStream.ACTION_SET,
         Option.empty(),
         /* mergeConsecutiveSchemaChanges= */ false);
   }
@@ -1180,7 +1179,6 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
                       options,
                       snapshotManager,
                       defaultEngine,
-                      SparkMicroBatchStream.ACTION_SET,
                       Option.empty(),
                       /* mergeConsecutiveSchemaChanges= */ false)
                   .get();
@@ -1430,7 +1428,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
 
     Option<PersistedMetadata> result =
         MetadataEvolutionHandler.getMergedConsecutiveMetadataChanges(
-            current, snapshotManager, defaultEngine, tablePath, SparkMicroBatchStream.ACTION_SET);
+            current, snapshotManager, defaultEngine, tablePath);
 
     if (expectedMergedVersion == EXPECTED_NO_MERGE) {
       assertTrue(result.isEmpty());
@@ -1454,5 +1452,53 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     assertEquals(expected.dataSchemaJson(), result.get().dataSchemaJson());
     assertEquals(expected.partitionSchemaJson(), result.get().partitionSchemaJson());
     assertEquals(expected.protocolJson(), result.get().protocolJson());
+  }
+
+  /**
+   * On a CDF-enabled table, the merger must stop at a commit that contains AddCDCFile actions —
+   * UPDATE on a CDF table writes Add + Remove + AddCDCFile, and the merger should recognize the
+   * AddCDCFile as a file action and not merge past it.
+   *
+   * <p>Setup: v0=CREATE CDF, v1=INSERT seed, v2=ALTER ADD c3, v3=ALTER RENAME, v4=UPDATE(CDC).
+   * Walking from current=v2, the merger should advance through v3 (metadata-only) and stop at v4.
+   */
+  @Test
+  public void testGetMergedConsecutive_stopsAtCdfUpdateCommit(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "t_" + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s' "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name', "
+                + "'delta.enableChangeDataFeed' = 'true')",
+            tableName, tablePath)); // v0
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'a')", tableName)); // v1
+    spark.sql(String.format("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName)); // v2
+    spark.sql(String.format("ALTER TABLE %s RENAME COLUMN name TO display_name", tableName)); // v3
+    spark.sql(String.format("UPDATE %s SET c3 = 10 WHERE id = 1", tableName)); // v4
+
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
+
+    // current = v2 (the ALTER ADD COLUMN). Merger walks forward from here.
+    SnapshotImpl v2Snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(2L);
+    PersistedMetadata current =
+        PersistedMetadata.apply(
+            "test-table-id",
+            2L,
+            new KernelMetadataAdapter(v2Snapshot.getMetadata()),
+            new KernelProtocolAdapter(v2Snapshot.getProtocol()),
+            tablePath + "/_delta_log/_streaming_metadata");
+
+    Option<PersistedMetadata> result =
+        MetadataEvolutionHandler.getMergedConsecutiveMetadataChanges(
+            current, snapshotManager, defaultEngine, tablePath);
+
+    // v3 is metadata-only → merge advances to v3. v4 has file actions → stop.
+    assertTrue(result.isDefined());
+    assertEquals(3L, result.get().deltaCommitVersion());
+
+    SnapshotImpl v3Snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(3L);
+    assertEquals(v3Snapshot.getMetadata().getSchemaString(), result.get().dataSchemaJson());
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkMicroBatchStreamCDCTest.java
@@ -496,6 +496,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
           DeltaAction.ADD,
           DeltaAction.REMOVE,
           DeltaAction.METADATA,
+          DeltaAction.PROTOCOL,
           DeltaAction.CDC,
           DeltaAction.COMMITINFO);
 
@@ -807,6 +808,274 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     assertCDCFileChangesMatch(dsv1Call2, dsv2Call2);
     long dsv2DataCount2 = dsv2Call2.stream().filter(IndexedFile::hasFileAction).count();
     assertTrue(dsv2DataCount2 > 0, "Call 2 should return new data files (not stall)");
+  }
+
+  /**
+   * Per-commit barrier emission: a metadata-only commit on a CDC stream with schema tracking must
+   * produce a barrier sentinel (METADATA_CHANGE_INDEX) as element [0], followed by an END sentinel
+   * (limits=empty branch appends END after the barrier).
+   *
+   * <p>Setup: v0=CREATE, v1=ALTER ENABLE CDF, v2=INSERT, v3=ALTER ADD COLUMNS (metadata-only).
+   * Tracking log is seeded at v2, so v3 diverges from source-init.
+   */
+  @Test
+  public void testProcessCommit_emitsBarrierAtSchemaChange(@TempDir File tempDir) throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_process_barrier_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName); // v0=CREATE, v1=ALTER ENABLE CDF
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName); // v2 data
+    sql("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName); // v3 metadata-only
+
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    SparkMicroBatchStream stream =
+        createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
+
+    long commitVersion = 3L;
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+    List<IndexedFile> files;
+    // lastProcessedVersion = commitVersion - 1: fresh process, the start-boundary filter
+    // doesn't run, so the barrier (which has index < BASE_INDEX) is preserved.
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit,
+            /* startVersion= */ commitVersion,
+            /* limits= */ Optional.empty(),
+            /* endOffsetOpt= */ Optional.empty(),
+            /* lastProcessedVersion= */ commitVersion - 1,
+            /* lastProcessedIndex= */ DeltaSourceOffset.BASE_INDEX())) {
+      files = collectAll(iter);
+    }
+
+    // limits=empty branch appends an END sentinel after the barrier.
+    assertEquals(2, files.size(), "Expected [barrier, END], got " + files.size());
+    IndexedFile barrier = files.get(0);
+    assertEquals(commitVersion, barrier.getVersion(), "Barrier must be at v3");
+    assertEquals(
+        DeltaSourceOffset.METADATA_CHANGE_INDEX(),
+        barrier.getIndex(),
+        "First entry must be the schema-change barrier sentinel");
+    assertFalse(barrier.hasFileAction(), "Barrier must not carry a file action");
+
+    IndexedFile end = files.get(1);
+    assertEquals(DeltaSourceOffset.END_INDEX(), end.getIndex(), "Second entry must be END");
+  }
+
+  /**
+   * On a CDC stream with schema tracking, a metadata-change commit must emit a barrier sentinel
+   * (METADATA_CHANGE_INDEX) and the iterator must truncate after it — no files from later commits
+   * appear in the same batch. Exercises four pieces of the CDC schema-tracking wiring at once:
+   *
+   * <ol>
+   *   <li>Metadata/protocol capture in {@code collectAndBuildCDCIndexedFiles}.
+   *   <li>Barrier emission via {@code getMetadataOrProtocolChangeIndexedFileIterator}.
+   *   <li>Barrier passthrough in {@code applyPerCommitCDCAdmission}.
+   *   <li>{@code stopIndexedFileIteratorAtSchemaChangeBarrier} truncating across commits.
+   * </ol>
+   *
+   * <p>Setup: v0=CREATE, v1=ALTER ENABLE CDF, v2=INSERT, v3=ALTER ADD COLUMNS (metadata-only),
+   * v4=INSERT. Tracking log is seeded at v2 (pre-ALTER schema), so v3 diverges from source-init.
+   */
+  @Test
+  public void testGetFileChangesForCDC_emitsBarrierAtSchemaChange(@TempDir File tempDir)
+      throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_barrier_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName); // v0=CREATE, v1=ALTER ENABLE CDF
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName); // v2 data
+    sql("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName); // v3 metadata-only
+    sql("INSERT INTO %s VALUES (2, 'b', 99)", tableName); // v4 post-barrier
+
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    SparkMicroBatchStream stream =
+        createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
+
+    // Drive the stream from v2 (inclusive). Expected output structure:
+    //   v2: BASE + CDC data + END  (pre-barrier commit, fully emitted)
+    //   v3: barrier at METADATA_CHANGE_INDEX
+    //   v4: nothing — truncated.
+    List<IndexedFile> result;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.getFileChangesWithRateLimitForCDC(
+            /* fromVersion= */ 2L,
+            /* fromIndex= */ DeltaSourceOffset.BASE_INDEX(),
+            /* isInitialSnapshot= */ false,
+            /* limits= */ Optional.empty(),
+            /* endOffset= */ Optional.empty())) {
+      result = collectAll(iter);
+    }
+
+    assertFalse(result.isEmpty(), "Expected at least the barrier in the output");
+    IndexedFile last = result.get(result.size() - 1);
+    assertEquals(
+        DeltaSourceOffset.METADATA_CHANGE_INDEX(),
+        last.getIndex(),
+        "Last entry must be the schema-change barrier sentinel");
+    assertEquals(3L, last.getVersion(), "Barrier must be at v3 (the ALTER commit)");
+
+    for (IndexedFile f : result) {
+      assertNotEquals(
+          4L, f.getVersion(), "v4 must not appear — stopIterator truncates at the barrier");
+    }
+  }
+
+  /**
+   * Same as {@link #testProcessCommit_emitsBarrierAtSchemaChange} but the divergence is a
+   * protocol-only ALTER (minReaderVersion/minWriterVersion bump). Targets the protocol-capture
+   * branch in {@code collectAndBuildCDCIndexedFiles} — without it, protocol-only commits would not
+   * fire the barrier.
+   *
+   * <p>Setup: v0=CREATE, v1=ALTER ENABLE CDF, v2=INSERT, v3=ALTER reader/writer protocol versions.
+   */
+  @Test
+  public void testProcessCommit_emitsBarrierAtProtocolChange(@TempDir File tempDir)
+      throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_process_protocol_barrier_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName); // v0, v1
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName); // v2 data
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES "
+            + "('delta.minReaderVersion' = '2', 'delta.minWriterVersion' = '5')",
+        tableName); // v3 protocol-only
+
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    SparkMicroBatchStream stream =
+        createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
+
+    long commitVersion = 3L;
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+    List<IndexedFile> files;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit,
+            /* startVersion= */ commitVersion,
+            /* limits= */ Optional.empty(),
+            /* endOffsetOpt= */ Optional.empty(),
+            /* lastProcessedVersion= */ commitVersion - 1,
+            /* lastProcessedIndex= */ DeltaSourceOffset.BASE_INDEX())) {
+      files = collectAll(iter);
+    }
+
+    assertEquals(2, files.size(), "Expected [barrier, END], got " + files.size());
+    IndexedFile barrier = files.get(0);
+    assertEquals(commitVersion, barrier.getVersion());
+    assertEquals(
+        DeltaSourceOffset.METADATA_CHANGE_INDEX(),
+        barrier.getIndex(),
+        "First entry must be the schema-change barrier sentinel (fired by protocol change)");
+  }
+
+  /**
+   * The barrier sentinel must survive {@code applyPerCommitCDCAdmission} when limits are set —
+   * admission is bypassed for barrier-only commits. Without that bypass, admission would treat the
+   * barrier as a normal file action and either lose it or count it against the budget.
+   *
+   * <p>Setup: v0=CREATE, v1=ALTER ENABLE CDF, v2=INSERT, v3=ALTER ADD COLUMNS (metadata-only).
+   */
+  @Test
+  public void testProcessCommit_barrierSurvivesAdmissionLimit(@TempDir File tempDir)
+      throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+    String tableName = "test_cdc_barrier_admission_" + System.nanoTime();
+    createCDFEnabledTable(tablePath, tableName); // v0, v1
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName); // v2 data
+    sql("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName); // v3 metadata-only
+
+    String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
+    SparkMicroBatchStream stream =
+        createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
+
+    long commitVersion = 3L;
+    CommitActions commit = getCommitActions(tablePath, commitVersion);
+    Optional<DeltaSource.AdmissionLimits> limits =
+        createAdmissionLimits(/* maxFiles= */ Optional.of(1), /* maxBytes= */ Optional.empty());
+
+    List<IndexedFile> files;
+    try (CloseableIterator<IndexedFile> iter =
+        stream.processCommitToIndexedFilesForCDC(
+            commit,
+            /* startVersion= */ commitVersion,
+            /* limits= */ limits,
+            /* endOffsetOpt= */ Optional.empty(),
+            /* lastProcessedVersion= */ commitVersion - 1,
+            /* lastProcessedIndex= */ DeltaSourceOffset.BASE_INDEX())) {
+      files = collectAll(iter);
+    }
+
+    // With limits set, applyPerCommitCDCAdmission returns the barrier list unchanged (no END
+    // appended — END is only added in the no-limits branch).
+    assertEquals(
+        1, files.size(), "Barrier must pass through admission unchanged (1 entry expected)");
+    IndexedFile barrier = files.get(0);
+    assertEquals(commitVersion, barrier.getVersion());
+    assertEquals(
+        DeltaSourceOffset.METADATA_CHANGE_INDEX(),
+        barrier.getIndex(),
+        "Barrier sentinel must survive admission");
+  }
+
+  /**
+   * Builds a stream where the schema-tracking log has been seeded with the table's metadata at
+   * {@code seededVersion}. {@code mergeConsecutiveSchemaChanges=false} so the merger doesn't fold
+   * later metadata into the seeded entry — useful when the test wants a specific divergence point.
+   */
+  private SparkMicroBatchStream createStreamWithSeededTrackingLog(
+      String tablePath, String schemaLogPath, long seededVersion) {
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
+    Engine engine = DefaultEngine.create(hadoopConf);
+
+    Map<String, String> javaOptions = new HashMap<>();
+    javaOptions.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
+    javaOptions.put("readChangeFeed", "true");
+    scala.collection.immutable.Map<String, String> scalaOptions =
+        ScalaUtils.toScalaMap(javaOptions);
+    DeltaOptions deltaOptions = new DeltaOptions(scalaOptions, spark.sessionState().conf());
+
+    io.delta.kernel.internal.SnapshotImpl latestSnapshot =
+        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    io.delta.kernel.internal.SnapshotImpl seededSnapshot =
+        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadSnapshotAt(seededVersion);
+
+    org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog trackingLog =
+        MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
+                spark,
+                latestSnapshot,
+                javaOptions,
+                snapshotManager,
+                engine,
+                Option.empty(),
+                /* mergeConsecutiveSchemaChanges= */ false)
+            .get();
+    org.apache.spark.sql.delta.sources.PersistedMetadata seeded =
+        org.apache.spark.sql.delta.sources.PersistedMetadata.apply(
+            seededSnapshot.getMetadata().getId(),
+            seededVersion,
+            new io.delta.spark.internal.v2.adapters.KernelMetadataAdapter(
+                seededSnapshot.getMetadata()),
+            new io.delta.spark.internal.v2.adapters.KernelProtocolAdapter(
+                seededSnapshot.getProtocol()),
+            tablePath + "/_delta_log/_streaming_metadata");
+    trackingLog.writeNewMetadata(seeded, /* replaceCurrent= */ false);
+
+    StructType tableSchema =
+        io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
+            seededSnapshot.getSchema());
+    return new SparkMicroBatchStream(
+        snapshotManager,
+        latestSnapshot,
+        hadoopConf,
+        spark,
+        deltaOptions,
+        tablePath,
+        tableSchema,
+        /* partitionSchema= */ new StructType(),
+        /* readDataSchema= */ tableSchema,
+        /* ddlOrderedReadOutputSchema= */ tableSchema,
+        /* dataFilters= */ new org.apache.spark.sql.sources.Filter[0],
+        scalaOptions,
+        Option.apply(trackingLog),
+        tablePath + "/_checkpoint");
   }
 
   /**


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6801/files) to review incremental changes.
- [stack/SparkMetadataAdapter](https://github.com/delta-io/delta/pull/6546) [[Files changed](https://github.com/delta-io/delta/pull/6546/files)] [MERGED]
  - [stack/RefactorMetadataTrackingLog](https://github.com/delta-io/delta/pull/6550) [[Files changed](https://github.com/delta-io/delta/pull/6550/files)] [MERGED]
    - [stack/RefactorDeltaSourceMetadataEvolutionSupport](https://github.com/delta-io/delta/pull/6562) [[Files changed](https://github.com/delta-io/delta/pull/6562/files)] [MERGED]
      - [stack/MetadataEvolutionHandler2](https://github.com/delta-io/delta/pull/6563) [[Files changed](https://github.com/delta-io/delta/pull/6563/files)] [MERGED]
        - [stack/NonAdditiveSchemaEvolution2](https://github.com/delta-io/delta/pull/6570) [[Files changed](https://github.com/delta-io/delta/pull/6570/files)] [MERGED]
          - [stack/NonAdditiveSchemaEvolution3](https://github.com/delta-io/delta/pull/6697) [[Files changed](https://github.com/delta-io/delta/pull/6697/files)] [MERGED]
            - [stack/consecutiveSchemaChangesMerger](https://github.com/delta-io/delta/pull/6698) [[Files changed](https://github.com/delta-io/delta/pull/6698/files)] [MERGED]
              - [**stack/SchemaTrackingWithCDC**](https://github.com/delta-io/delta/pull/6801) [[Files changed](https://github.com/delta-io/delta/pull/6801/files)]
              - [stack/V1V2MixTest](https://github.com/delta-io/delta/pull/6759) [[Files changed](https://github.com/delta-io/delta/pull/6759/files)]

---------
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Follow-up to the non-additive schema evolution stack: extend V2 streaming schema tracking to CDC reads so a CDC stream stops at metadata- or protocol-change commits with a barrier sentinel instead of either silently reading across the change or failing the read-compat check.

- `SparkMicroBatchStream.collectAndBuildCDCIndexedFiles`: capture `Protocol` alongside `Metadata` while scanning a commit's actions, then call `MetadataEvolutionHandler.getMetadataOrProtocolChangeIndexedFileIterator` once the scan is done; when the commit diverges from source-init, return a singleton barrier (`METADATA_CHANGE_INDEX`) in place of BASE + files + END. Skip the on-commit `verifyMetadataAction` read-compat check when schema tracking is active — the barrier covers divergence. V1 splits this between `DeltaSourceCDCSupport.filterAndIndexDeltaLogs` (barrier injection) and `IndexedChangeFileSeq.filterFiles` (short-circuit); V2 collapses both into this single method.
- `SparkMicroBatchStream.applyPerCommitCDCAdmission`: pass barrier sentinels through admission unchanged (they can only appear as element 0 of the per-commit list).
- `SparkMicroBatchStream.getFileChangesForCDC`: apply `metadataEvolutionHandler.stopIndexedFileIteratorAtSchemaChangeBarrier` after end-boundary filtering so post-barrier commits in the same batch are truncated. V1's wrap lives in the shared `DeltaSource.getFileChangesWithRateLimit`; V2 places it inside the CDC-specific method because both `planInputPartitions` and the outer `getFileChangesWithRateLimit` reach the CDC iterator through here.
- `MetadataEvolutionHandler.getMergedConsecutiveMetadataChanges`: include `AddCDCFile` in the action set the merger walks and treat any non-null CDC column as a file action that stops the merger walk. Drops the `mergeActionSet` parameter (always `CDC_ACTION_SET` now) so non-CDC and CDC analysis share the same stop semantics. Resolves the TODO(#5319) placeholder left by PR 7/7.
- `SparkMicroBatchStream.CDC_ACTION_SET`: promote to `public` so `MetadataEvolutionHandler` can reuse it.

## How was this patch tested?

`SparkMicroBatchStreamCDCTest` adds barrier-emission cases:
- `testProcessCommit_emitsBarrierAtSchemaChange`: a metadata-only commit on a CDC stream with seeded tracking emits `[barrier, END]` from `processCommitToIndexedFilesForCDC`.
- `testGetFileChangesForCDC_emitsBarrierAtSchemaChange`: end-to-end check that the barrier fires and the iterator truncates across commits — exercises metadata/protocol capture, barrier emission, admission passthrough, and cross-commit truncation in one path.

`MetadataEvolutionHandlerTest` extends the merger walk tests to cover CDC file actions stopping the walk. The unified `DeltaV2SourceSchemaEvolutionCDCSuiteBase` moves all evolution scenarios out of `shouldFailTests` into `shouldPassTests` so the CDC variants of the streaming schema-evolution suite now run alongside non-CDC.

## Does this PR introduce _any_ user-facing changes?

No.