### PR TITLE
[SPARK] Add support for Parquet compression codec configuration in Delta tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
@@ -89,7 +89,11 @@ trait CheckpointProvider extends UninitializedCheckpointProvider {
    * checkpoint (i.e. V2 checkpoints) implement this; the default throws.
    */
   def createCompatibilityCheckpoint(
-      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit =
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      logPath: Path,
+      hadoopConf: Configuration,
+      tableProperties: Map[String, String]): Unit =
     throw new IllegalStateException(
       s"createCompatibilityCheckpoint is not supported for ${this.getClass.getName}.")
 
@@ -557,8 +561,13 @@ abstract class LazyCompleteCheckpointProvider(
     underlyingCheckpointProvider.checkpointPolicyForLogging
 
   override def createCompatibilityCheckpoint(
-      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit =
-    underlyingCheckpointProvider.createCompatibilityCheckpoint(spark, deltaLog, logPath, hadoopConf)
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      logPath: Path,
+      hadoopConf: Configuration,
+      tableProperties: Map[String, String]): Unit =
+    underlyingCheckpointProvider.createCompatibilityCheckpoint(
+      spark, deltaLog, logPath, hadoopConf, tableProperties)
 
   override def allActionsFileIndexesAndSchemas(
       spark: SparkSession, deltaLog: DeltaLog): Seq[(DeltaLogFileIndex, StructType)] = {
@@ -614,7 +623,11 @@ case class V2CheckpointProvider(
     Some(CheckpointPolicy.V2)
 
   override def createCompatibilityCheckpoint(
-      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit = {
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      logPath: Path,
+      hadoopConf: Configuration,
+      tableProperties: Map[String, String]): Unit = {
     // topLevelFileIndex is non-empty for V2CheckpointProvider and
     // represents the v2 manifest file
     val shallowCopyDf = deltaLog.loadIndex(topLevelFileIndex.get, Action.logSchema)
@@ -624,7 +637,8 @@ case class V2CheckpointProvider(
       shallowCopyDf,
       finalPath,
       hadoopConf,
-      useRename = false)
+      useRename = false,
+      tableProperties = tableProperties)
   }
 
   private val v2SchemaWithCaching = new LazyCheckpointSchemaGetter {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
@@ -89,7 +89,11 @@ trait CheckpointProvider extends UninitializedCheckpointProvider {
    * checkpoint (i.e. V2 checkpoints) implement this; the default throws.
    */
   def createCompatibilityCheckpoint(
-      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit =
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      logPath: Path,
+      hadoopConf: Configuration,
+      tableProperties: Map[String, String]): Unit =
     throw new IllegalStateException(
       s"createCompatibilityCheckpoint is not supported for ${this.getClass.getName}.")
 
@@ -604,8 +608,13 @@ abstract class LazyCompleteCheckpointProvider(
     underlyingCheckpointProvider.checkpointPolicyForLogging
 
   override def createCompatibilityCheckpoint(
-      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit =
-    underlyingCheckpointProvider.createCompatibilityCheckpoint(spark, deltaLog, logPath, hadoopConf)
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      logPath: Path,
+      hadoopConf: Configuration,
+      tableProperties: Map[String, String]): Unit =
+    underlyingCheckpointProvider.createCompatibilityCheckpoint(
+      spark, deltaLog, logPath, hadoopConf, tableProperties)
 
   override def allActionsFileIndexesAndSchemas(
       spark: SparkSession, deltaLog: DeltaLog): Seq[(DeltaLogFileIndex, StructType)] = {
@@ -661,7 +670,11 @@ case class V2CheckpointProvider(
     Some(CheckpointPolicy.V2)
 
   override def createCompatibilityCheckpoint(
-      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit = {
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      logPath: Path,
+      hadoopConf: Configuration,
+      tableProperties: Map[String, String]): Unit = {
     // topLevelFileIndex is non-empty for V2CheckpointProvider and
     // represents the v2 manifest file
     val shallowCopyDf = deltaLog.loadIndex(topLevelFileIndex.get, Action.logSchema)
@@ -671,7 +684,8 @@ case class V2CheckpointProvider(
       shallowCopyDf,
       finalPath,
       hadoopConf,
-      useRename = false)
+      useRename = false,
+      tableProperties = tableProperties)
   }
 
   private val v2SchemaWithCaching = new LazyCheckpointSchemaGetter {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
-import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, DeltaFileOperations, DeltaLogGroupingIterator, FileNames}
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, DeltaFileOperations, DeltaLogGroupingIterator, FileNames, TableParquetCompressionCodecOption}
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.spark.sql.delta.util.JsonUtils
@@ -1030,7 +1030,10 @@ object Checkpoints
       val format = new ParquetFileFormat()
       val job = Job.getInstance(hadoopConf)
       // Right now, we don't shred variant stats in checkpoints.
-      val writeOptions = VariantShreddingShims.getVariantInferShreddingSchemaOptions(false)
+      val writeOptions = VariantShreddingShims.getVariantInferShreddingSchemaOptions(false) ++
+        TableParquetCompressionCodecOption.getWriterOptions(
+          writerOptions = Map.empty,
+          tableProperties = snapshot.metadata.configuration)
       (format.prepareWrite(spark, job, Map.empty ++ writeOptions, schema),
         new SerializableConfiguration(job.getConfiguration))
     }
@@ -1243,7 +1246,8 @@ object Checkpoints
         val dfToWrite = nonFileActionsToWrite.map(_.wrap).toDF()
         val v2CheckpointPath = newV2CheckpointParquetFile(deltaLog.logPath, snapshot.version)
         val schemaOfDfWritten = createCheckpointV2ParquetFile(
-          spark, dfToWrite, v2CheckpointPath, hadoopConf, useRename)
+          spark, dfToWrite, v2CheckpointPath, hadoopConf, useRename,
+          tableProperties = snapshot.metadata.configuration)
         (v2CheckpointPath, Some(schemaOfDfWritten))
       } else {
         throw DeltaErrors.assertionFailedError(
@@ -1273,17 +1277,24 @@ object Checkpoints
    * that they don't have the capability to read table for which they were created.
    * This is needed in cases where commit 0 has been cleaned up and the reader needs to
    * read a checkpoint to read the [[Protocol]].
+   *
+   * @param tableProperties The configuration map from the table's [[Metadata]]. This is used to
+   *                        honor table properties that affect checkpoint Parquet files such as
+   *                        `delta.parquet.compression.codec`. Pass [[Map.empty]] if the table
+   *                        properties are not known (e.g., from synthetic test setups).
    */
   def createCheckpointV2ParquetFile(
       spark: SparkSession,
       ds: Dataset[Row],
       finalPath: Path,
       hadoopConf: Configuration,
-      useRename: Boolean): StructType = {
+      useRename: Boolean,
+      tableProperties: Map[String, String]): StructType = {
     val df = ds.select(
       "txn", "add", "remove", "metaData", "protocol", "domainMetadata",
       "checkpointMetadata", "sidecar")
-    writeAtomicCheckpointParquetFile(spark, df, finalPath, hadoopConf, useRename)
+    writeAtomicCheckpointParquetFile(
+      spark, df, finalPath, hadoopConf, useRename, tableProperties = tableProperties)
   }
 
   /**
@@ -1318,6 +1329,10 @@ object Checkpoints
    *                  ids (carried on `outputSchema` via `parquet.field.nested.ids`, which the stock
    *                  `ParquetWriteSupport` omits) and int64 `TIMESTAMP(MICROS)` timestamps. Needed
    *                  for the AMT manifest schema. Default false uses the standard parquet write.
+   * @param tableProperties The table's [[Metadata]] configuration map, used to honor table
+   *                  properties that affect the written Parquet file such as
+   *                  `delta.parquet.compression.codec`. Defaults to [[Map.empty]] when the
+   *                  table properties are not known (e.g., from synthetic test setups).
    * @return The schema actually written.
    */
   def writeAtomicCheckpointParquetFile(
@@ -1327,13 +1342,17 @@ object Checkpoints
       hadoopConf: Configuration,
       useRename: Boolean,
       outputSchema: Option[StructType] = None,
-      writeAsIcebergManifest: Boolean = false): StructType =
+      writeAsIcebergManifest: Boolean = false,
+      tableProperties: Map[String, String] = Map.empty): StructType =
       recordFrameProfile(
         "Checkpoints", "writeAtomicCheckpointParquetFile") {
     val schema = outputSchema.getOrElse(df.schema.asNullable)
     val format = new ParquetFileFormat()
     val job = Job.getInstance(hadoopConf)
-    val factory = format.prepareWrite(spark, job, Map.empty, schema)
+    val writeOptions = TableParquetCompressionCodecOption.getWriterOptions(
+      writerOptions = Map.empty,
+      tableProperties = tableProperties)
+    val factory = format.prepareWrite(spark, job, writeOptions, schema)
     if (writeAsIcebergManifest) {
       // Write as an Iceberg-V4 manifest (nested field ids + int64 micros timestamps). Applied after
       // prepareWrite so it overrides what prepareWrite put on the job.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
-import org.apache.spark.sql.delta.util.{DeltaFileOperations, DeltaLogGroupingIterator, FileNames}
+import org.apache.spark.sql.delta.util.{DeltaFileOperations, DeltaLogGroupingIterator, FileNames, TableParquetCompressionCodecOption}
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.spark.sql.delta.util.JsonUtils
@@ -768,7 +768,10 @@ object Checkpoints
       val format = new ParquetFileFormat()
       val job = Job.getInstance(hadoopConf)
       // Right now, we don't shred variant stats in checkpoints.
-      val writeOptions = VariantShreddingShims.getVariantInferShreddingSchemaOptions(false)
+      val writeOptions = VariantShreddingShims.getVariantInferShreddingSchemaOptions(false) ++
+        TableParquetCompressionCodecOption.getWriterOptions(
+          writerOptions = Map.empty,
+          tableProperties = snapshot.metadata.configuration)
       (format.prepareWrite(spark, job, Map.empty ++ writeOptions, schema),
         new SerializableConfiguration(job.getConfiguration))
     }
@@ -981,7 +984,8 @@ object Checkpoints
         val dfToWrite = nonFileActionsToWrite.map(_.wrap).toDF()
         val v2CheckpointPath = newV2CheckpointParquetFile(deltaLog.logPath, snapshot.version)
         val schemaOfDfWritten = createCheckpointV2ParquetFile(
-          spark, dfToWrite, v2CheckpointPath, hadoopConf, useRename)
+          spark, dfToWrite, v2CheckpointPath, hadoopConf, useRename,
+          tableProperties = snapshot.metadata.configuration)
         (v2CheckpointPath, Some(schemaOfDfWritten))
       } else {
         throw DeltaErrors.assertionFailedError(
@@ -1011,17 +1015,23 @@ object Checkpoints
    * that they don't have the capability to read table for which they were created.
    * This is needed in cases where commit 0 has been cleaned up and the reader needs to
    * read a checkpoint to read the [[Protocol]].
+   *
+   * @param tableProperties The configuration map from the table's [[Metadata]]. This is used to
+   *                        honor table properties that affect checkpoint Parquet files such as
+   *                        `delta.parquet.compression.codec`. Pass [[Map.empty]] if the table
+   *                        properties are not known (e.g., from synthetic test setups).
    */
   def createCheckpointV2ParquetFile(
       spark: SparkSession,
       ds: Dataset[Row],
       finalPath: Path,
       hadoopConf: Configuration,
-      useRename: Boolean): StructType = {
+      useRename: Boolean,
+      tableProperties: Map[String, String]): StructType = {
     val df = ds.select(
       "txn", "add", "remove", "metaData", "protocol", "domainMetadata",
       "checkpointMetadata", "sidecar")
-    writeAtomicCheckpointParquetFile(spark, df, finalPath, hadoopConf, useRename)
+    writeAtomicCheckpointParquetFile(spark, df, finalPath, hadoopConf, useRename, tableProperties)
   }
 
   /**
@@ -1056,6 +1066,10 @@ object Checkpoints
    *                  carried on `outputSchema` via `parquet.field.nested.ids` are emitted to the
    *                  file's Parquet schema (the stock `ParquetWriteSupport` does not). Needed for
    *                  the AMT Iceberg-V4 manifest schema. Default false uses the standard support.
+   * @param tableProperties The table's [[Metadata]] configuration map, used to honor table
+   *                  properties that affect the written Parquet file such as
+   *                  `delta.parquet.compression.codec`. Defaults to [[Map.empty]] when the
+   *                  table properties are not known (e.g., from synthetic test setups).
    * @return The schema actually written.
    */
   def writeAtomicCheckpointParquetFile(
@@ -1065,13 +1079,17 @@ object Checkpoints
       hadoopConf: Configuration,
       useRename: Boolean,
       outputSchema: Option[StructType] = None,
-      useDeltaParquetWriteSupport: Boolean = false): StructType =
+      useDeltaParquetWriteSupport: Boolean = false,
+      tableProperties: Map[String, String] = Map.empty): StructType =
       recordFrameProfile(
         "Checkpoints", "writeAtomicCheckpointParquetFile") {
     val schema = outputSchema.getOrElse(df.schema.asNullable)
     val format = new ParquetFileFormat()
     val job = Job.getInstance(hadoopConf)
-    val factory = format.prepareWrite(spark, job, Map.empty, schema)
+    val writeOptions = TableParquetCompressionCodecOption.getWriterOptions(
+      writerOptions = Map.empty,
+      tableProperties = tableProperties)
+    val factory = format.prepareWrite(spark, job, writeOptions, schema)
     if (useDeltaParquetWriteSupport) {
       // Emit nested (list-element / map key-value) field ids, which the stock ParquetWriteSupport
       // does not. Set after prepareWrite so it overrides the write-support class prepareWrite set.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -644,6 +644,38 @@ trait DeltaConfigsBase extends DeltaLogging {
       s"(${ParquetFormatVersion.values().map(_.getVersion).mkString(", ")})"
     )
 
+  /**
+   * The set of compression codecs recognized by `delta.parquet.compression.codec`.
+   *
+   * The set is intentionally limited to the values listed in the Delta protocol:
+   * https://github.com/delta-io/delta/blob/master/PROTOCOL.md#table-properties
+   *
+   * Other codecs that Parquet may technically support are not allowed here so that tables
+   * written via Delta remain portable across writers.
+   */
+  private[delta] val VALID_PARQUET_COMPRESSION_CODECS: Set[String] =
+    Set("uncompressed", "none", "snappy", "gzip", "lz4", "lz4_raw", "zstd")
+
+  /**
+   * Compression codec that writers should use for new Parquet data files and checkpoint files.
+   *
+   * Changing this property does not affect existing files; a table may contain files written with
+   * different codecs which is a normal and expected state.
+   *
+   * Values are matched case-insensitively. When unset, writers fall back to Spark's existing
+   * default behavior (configured via `spark.sql.parquet.compression.codec`).
+   */
+  val PARQUET_COMPRESSION_CODEC: DeltaConfig[Option[String]] =
+    buildConfig[Option[String]](
+      "parquet.compression.codec",
+      null,
+      fromString = v => Option(v).map(_.toLowerCase(Locale.ROOT)),
+      validationFunction = _.forall(VALID_PARQUET_COMPRESSION_CODECS.contains),
+      helpMessage = "needs to be one of: " +
+        VALID_PARQUET_COMPRESSION_CODECS.toSeq.sorted.map(s => s"'$s'").mkString(", ") +
+        " (case-insensitive)."
+    )
+
   val ENABLE_VARIANT_SHREDDING = buildConfig[Boolean](
     key = "enableVariantShredding",
     defaultValue = "false",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -360,7 +360,8 @@ trait MetadataCleanup extends DeltaLogging {
     }
 
     checkpointProvider.createCompatibilityCheckpoint(
-      spark, self, snapshotToCleanup.logPath, hadoopConf)
+      spark, self, snapshotToCleanup.logPath, hadoopConf,
+      tableProperties = snapshotToCleanup.metadata.configuration)
     metrics.v2CheckpointCompatLogicTimeTakenMs = System.currentTimeMillis() - startTimeMs
     metrics.checkpointVersion = checkpointVersion
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -373,7 +373,8 @@ trait MetadataCleanup extends DeltaLogging {
     }
 
     checkpointProvider.createCompatibilityCheckpoint(
-      spark, self, snapshotToCleanup.logPath, hadoopConf)
+      spark, self, snapshotToCleanup.logPath, hadoopConf,
+      tableProperties = snapshotToCleanup.metadata.configuration)
     metrics.v2CheckpointCompatLogicTimeTakenMs = System.currentTimeMillis() - startTimeMs
     metrics.checkpointVersion = checkpointVersion
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.delta.stats.{
   StatisticsCollection,
   StatsCollectionUtils
 }
-import org.apache.spark.sql.delta.util.TableParquetVersionOption
+import org.apache.spark.sql.delta.util.{TableParquetCompressionCodecOption, TableParquetVersionOption}
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.Path
 
@@ -495,6 +495,9 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
           DeltaConfigs.ENABLE_VARIANT_SHREDDING.fromMetaData(metadata)) ++
         TableParquetVersionOption.getWriterOptions(
           spark = spark,
+          writerOptions = filteredOptions,
+          tableProperties = metadata.configuration) ++
+        TableParquetCompressionCodecOption.getWriterOptions(
           writerOptions = filteredOptions,
           tableProperties = metadata.configuration)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TableParquetCompressionCodecOption.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TableParquetCompressionCodecOption.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaOptions}
+
+/**
+ * Helper for resolving the Parquet compression codec to use for a Delta write, based on the
+ * `delta.parquet.compression.codec` table property defined in the Delta protocol.
+ *
+ * See: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#table-properties
+ */
+object TableParquetCompressionCodecOption {
+  private val tablePropKey = DeltaConfigs.PARQUET_COMPRESSION_CODEC.key
+  private val writerOptionKey = DeltaOptions.COMPRESSION
+
+  /**
+   * Determines the writer options to add to indicate the Parquet compression codec of the files
+   * being written. The precedence order is:
+   * 1. The `compression` DataFrame writer option (case-insensitive). If specified, no extra
+   *    options are added; the user-provided value is respected by the Parquet writer.
+   * 2. A raw `compression` entry in the table properties (which can be set via
+   *    CREATE TABLE ... OPTIONS ('compression' = ...)). This mirrors the behavior of
+   *    [[TableParquetVersionOption]].
+   * 3. The [[DeltaConfigs.PARQUET_COMPRESSION_CODEC]] (`delta.parquet.compression.codec`) table
+   *    property.
+   * 4. Spark's default Parquet compression behavior (no override added).
+   */
+  def getWriterOptions(
+      writerOptions: Map[String, String],
+      tableProperties: Map[String, String]
+  ): Map[String, String] = {
+    if (writerOptions.keysIterator.exists(_.equalsIgnoreCase(writerOptionKey))) {
+      Map.empty[String, String]
+    } else if (tableProperties.contains(writerOptionKey)) {
+      Map(writerOptionKey -> tableProperties(writerOptionKey))
+    } else {
+      DeltaConfigs.PARQUET_COMPRESSION_CODEC
+        .fromMap(tableProperties)
+        .map(codec => Map(writerOptionKey -> codec))
+        .getOrElse(Map.empty[String, String])
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -1122,7 +1122,8 @@ class CheckpointsSuite
             dfToWrite,
             v2CheckpointPath,
             deltaLog.newDeltaHadoopConf(),
-            false)
+            false,
+            tableProperties = snapshot.metadata.configuration)
         (v2CheckpointPath, Some(schemaOfDfWritten))
       } else {
         throw DeltaErrors.assertionFailedError(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -1130,7 +1130,8 @@ class CheckpointsSuite
             dfToWrite,
             v2CheckpointPath,
             deltaLog.newDeltaHadoopConf(),
-            false)
+            false,
+            tableProperties = snapshot.metadata.configuration)
         (v2CheckpointPath, Some(schemaOfDfWritten))
       } else {
         throw DeltaErrors.assertionFailedError(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetCompressionCodecSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetCompressionCodecSuite.scala
@@ -1,0 +1,291 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import org.apache.parquet.hadoop.util.HadoopInputFile
+
+import org.apache.spark.sql.{DataFrameWriter, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
+import org.apache.spark.sql.functions.current_timestamp
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests for the `delta.parquet.compression.codec` table property defined in the Delta protocol:
+ * https://github.com/delta-io/delta/blob/master/PROTOCOL.md#table-properties
+ */
+class DeltaParquetCompressionCodecSuite
+    extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest {
+  import testImplicits._
+
+  private val tablePropertyKey: String = DeltaConfigs.PARQUET_COMPRESSION_CODEC.key
+  private val writerOptionKey: String = DeltaOptions.COMPRESSION
+
+  /**
+   * Reads the compression codecs from all data Parquet files of the given Delta table.
+   */
+  private def collectCodecsOfDataFiles(table: String): Set[CompressionCodecName] = {
+    val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(table))
+    val files = DeltaLog
+      .forTable(spark, catalogTable)
+      .update()
+      .allFiles
+      .collect()
+    assert(files.nonEmpty, "Expected at least one data file in the table")
+
+    files.flatMap { addFile =>
+      val pathStr = ExternalCatalogUtils.unescapePathName(
+        s"${catalogTable.location}/${addFile.path}")
+      readParquetFileCodecs(new Path(pathStr))
+    }.toSet
+  }
+
+  /**
+   * Reads the compression codecs from a single Parquet file (any column-chunk in any row-group).
+   */
+  private def readParquetFileCodecs(path: Path): Set[CompressionCodecName] = {
+    val file = HadoopInputFile.fromPath(path, new Configuration())
+    val reader = ParquetFileReader.open(file)
+    try {
+      reader.getFooter.getBlocks.asScala.flatMap { block =>
+        block.getColumns.asScala.map(_.getCodec)
+      }.toSet
+    } finally {
+      reader.close()
+    }
+  }
+
+  private def writeDF: DataFrameWriter[Row] = {
+    (1 to 100)
+      .map(i => (i, i.toString))
+      .toDF("c0", "c1")
+      .withColumn("c2", current_timestamp())
+      .repartition(2)
+      .write
+      .format("delta")
+  }
+
+  private def getProperties(tableName: String): Map[String, String] =
+    sql(s"describe detail $tableName")
+      .collect()
+      .head
+      .getAs[Map[String, String]]("properties")
+
+  /** Maps a codec name (as accepted by the Delta property) to the expected ParquetCodec name. */
+  private def expectedCodec(name: String): CompressionCodecName =
+    name.toLowerCase(Locale.ROOT) match {
+    case "uncompressed" | "none" => CompressionCodecName.UNCOMPRESSED
+    case "snappy" => CompressionCodecName.SNAPPY
+    case "gzip" => CompressionCodecName.GZIP
+    case "lz4" => CompressionCodecName.LZ4
+    case "lz4_raw" => CompressionCodecName.LZ4_RAW
+    case "zstd" => CompressionCodecName.ZSTD
+    case other => fail(s"Unexpected codec name: $other")
+  }
+
+  test("DeltaConfig: accepts every protocol-defined codec, case-insensitively") {
+    for {
+      codec <- Seq("uncompressed", "none", "snappy", "gzip", "lz4", "lz4_raw", "zstd")
+      casing <- Seq[String => String](identity, _.toUpperCase(Locale.ROOT), _.capitalize)
+    } {
+      val pair = DeltaConfigs.PARQUET_COMPRESSION_CODEC(casing(codec))
+      assert(pair._1 == tablePropertyKey)
+      assert(pair._2 == casing(codec))
+    }
+  }
+
+  test("DeltaConfig: rejects invalid codecs") {
+    val ex = intercept[IllegalArgumentException] {
+      DeltaConfigs.PARQUET_COMPRESSION_CODEC("invalid")
+    }
+    assert(ex.getMessage.contains(tablePropertyKey))
+  }
+
+  test("DeltaConfig: fromMetaData returns lowercase regardless of stored case") {
+    val metadata = actions.Metadata(configuration = Map(tablePropertyKey -> "GZIP"))
+    val result = DeltaConfigs.PARQUET_COMPRESSION_CODEC.fromMetaData(metadata)
+    assert(result.contains("gzip"))
+  }
+
+  test("DeltaConfig: fromMetaData returns None when property is absent") {
+    val metadata = actions.Metadata(configuration = Map.empty)
+    val result = DeltaConfigs.PARQUET_COMPRESSION_CODEC.fromMetaData(metadata)
+    assert(result.isEmpty)
+  }
+
+  for (codec <- Seq("snappy", "gzip", "zstd", "uncompressed", "none", "lz4", "lz4_raw")) {
+    test(s"CREATE TABLE TBLPROPERTIES with codec '$codec' is respected for data files") {
+      withTable("t") {
+        sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+               |TBLPROPERTIES ('$tablePropertyKey' = '$codec')""".stripMargin)
+        writeDF.mode("append").saveAsTable("t")
+        assert(getProperties("t").get(tablePropertyKey).contains(codec))
+        val codecs = collectCodecsOfDataFiles("t")
+        assert(codecs == Set(expectedCodec(codec)),
+          s"Expected only codec ${expectedCodec(codec)} but got: $codecs")
+      }
+    }
+  }
+
+  test("Mixed-case codec is normalized to lowercase when written") {
+    withTable("t") {
+      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+             |TBLPROPERTIES ('$tablePropertyKey' = 'GzIp')""".stripMargin)
+      writeDF.mode("append").saveAsTable("t")
+      val codecs = collectCodecsOfDataFiles("t")
+      assert(codecs == Set(CompressionCodecName.GZIP))
+    }
+  }
+
+  test("DataFrame .option('compression', ...) overrides the table property") {
+    withTable("t") {
+      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+             |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
+      writeDF.option(writerOptionKey, "snappy").mode("append").saveAsTable("t")
+      val codecs = collectCodecsOfDataFiles("t")
+      assert(codecs == Set(CompressionCodecName.SNAPPY))
+    }
+  }
+
+  test("Mixed-case DataFrame compression option overrides the table property") {
+    withTable("t") {
+      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+             |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
+      // Spark normalizes the option key case-insensitively; ensure Delta does too.
+      writeDF.option("Compression", "snappy").mode("append").saveAsTable("t")
+      val codecs = collectCodecsOfDataFiles("t")
+      assert(codecs == Set(CompressionCodecName.SNAPPY))
+    }
+  }
+
+  test("ALTER TABLE can change codec; existing files keep their original codec") {
+    withTable("t") {
+      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
+             |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
+      writeDF.mode("append").saveAsTable("t")
+      sql(s"ALTER TABLE t SET TBLPROPERTIES ('$tablePropertyKey' = 'snappy')")
+      assert(getProperties("t").get(tablePropertyKey).contains("snappy"))
+      writeDF.mode("append").saveAsTable("t")
+      val codecs = collectCodecsOfDataFiles("t")
+      assert(codecs == Set(CompressionCodecName.GZIP, CompressionCodecName.SNAPPY),
+        s"Expected both GZIP and SNAPPY files but got: $codecs")
+    }
+  }
+
+  test("Unset table property falls back to Spark's default behavior") {
+    withTable("t") {
+      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA""".stripMargin)
+      assert(!getProperties("t").contains(tablePropertyKey))
+      writeDF.mode("append").saveAsTable("t")
+      val codecs = collectCodecsOfDataFiles("t")
+      // Spark's default Parquet codec is SNAPPY. We don't hard-code it - just assert that we
+      // don't accidentally write something exotic, and that we get one consistent codec.
+      assert(codecs.size == 1, s"Expected exactly one codec but got: $codecs")
+    }
+  }
+
+  test("Unset table property falls back to spark.sql.parquet.compression.codec override") {
+    // When the Delta table property is unset, writes should honor the session-level
+    // `spark.sql.parquet.compression.codec` config, including non-default values.
+    withSQLConf("spark.sql.parquet.compression.codec" -> "gzip") {
+      withTable("t") {
+        sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA""".stripMargin)
+        assert(!getProperties("t").contains(tablePropertyKey))
+        writeDF.mode("append").saveAsTable("t")
+        val codecs = collectCodecsOfDataFiles("t")
+        assert(codecs == Set(CompressionCodecName.GZIP),
+          s"Expected GZIP from session conf override but got: $codecs")
+      }
+    }
+  }
+
+  /** Recursively lists all parquet files in the given _delta_log directory (incl. _sidecars/). */
+  private def listAllCheckpointParquetFiles(
+      logPath: Path,
+      hadoopConf: Configuration): Seq[Path] = {
+    val fs = logPath.getFileSystem(hadoopConf)
+    if (!fs.exists(logPath)) return Seq.empty
+    val result = scala.collection.mutable.ArrayBuffer.empty[Path]
+    val recursive = true
+    val it = fs.listFiles(logPath, recursive)
+    while (it.hasNext) {
+      val st = it.next()
+      val name = st.getPath.getName
+      if (name.endsWith(".parquet") && name.contains(".checkpoint.")) {
+        result += st.getPath
+      }
+    }
+    result.toSeq
+  }
+
+  test("V2 checkpoint files honor the codec") {
+    withSQLConf(
+      DeltaConfigs.CHECKPOINT_POLICY.defaultTablePropertyKey -> CheckpointPolicy.V2.name,
+      DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> V2Checkpoint.Format.PARQUET.name) {
+      withTempDir { dir =>
+        val path = dir.getCanonicalPath
+        sql(s"""CREATE TABLE delta.`$path` (c0 BIGINT) USING delta
+               |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
+        // Generate some commits so the snapshot has content to checkpoint.
+        (1 to 5).foreach { i =>
+          spark.range(i, i + 1).toDF("c0").write.format("delta").mode("append").save(path)
+        }
+        val log = DeltaLog.forTable(spark, path)
+        log.checkpoint(log.update())
+        val checkpointFiles = listAllCheckpointParquetFiles(log.logPath, log.newDeltaHadoopConf())
+        assert(checkpointFiles.nonEmpty, "Expected at least one V2 checkpoint parquet file")
+        checkpointFiles.foreach { p =>
+          val codecs = readParquetFileCodecs(p)
+          assert(codecs.nonEmpty && codecs.subsetOf(Set(CompressionCodecName.GZIP)),
+            s"Expected GZIP codec in checkpoint $p but got: $codecs")
+        }
+      }
+    }
+  }
+
+  test("Classic checkpoint files honor the codec") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      sql(s"""CREATE TABLE delta.`$path` (c0 BIGINT) USING delta
+             |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
+      (1 to 5).foreach { i =>
+        spark.range(i, i + 1).toDF("c0").write.format("delta").mode("append").save(path)
+      }
+      val log = DeltaLog.forTable(spark, path)
+      log.checkpoint(log.update())
+      val checkpointFiles = listAllCheckpointParquetFiles(log.logPath, log.newDeltaHadoopConf())
+      assert(checkpointFiles.nonEmpty, "Expected at least one classic checkpoint parquet file")
+      checkpointFiles.foreach { p =>
+        val codecs = readParquetFileCodecs(p)
+        assert(codecs == Set(CompressionCodecName.GZIP),
+          s"Expected GZIP codec in checkpoint $p but got: $codecs")
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetCompressionCodecSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetCompressionCodecSuite.scala
@@ -46,6 +46,7 @@ class DeltaParquetCompressionCodecSuite
 
   private val tablePropertyKey: String = DeltaConfigs.PARQUET_COMPRESSION_CODEC.key
   private val writerOptionKey: String = DeltaOptions.COMPRESSION
+  private val sessionCodecKey: String = "spark.sql.parquet.compression.codec"
 
   /**
    * Reads the compression codecs from all data Parquet files of the given Delta table.
@@ -127,60 +128,103 @@ class DeltaParquetCompressionCodecSuite
     assert(ex.getMessage.contains(tablePropertyKey))
   }
 
-  test("DeltaConfig: fromMetaData returns lowercase regardless of stored case") {
-    val metadata = actions.Metadata(configuration = Map(tablePropertyKey -> "GZIP"))
-    val result = DeltaConfigs.PARQUET_COMPRESSION_CODEC.fromMetaData(metadata)
-    assert(result.contains("gzip"))
+  for {
+    (desc, config, expected) <- Seq(
+      ("returns lowercase regardless of stored case",
+        Map(tablePropertyKey -> "GZIP"), Some("gzip")),
+      ("returns None when the property is absent",
+        Map.empty[String, String], Option.empty[String]))
+  } {
+    test(s"DeltaConfig: fromMetaData $desc") {
+      val metadata = actions.Metadata(configuration = config)
+      assert(DeltaConfigs.PARQUET_COMPRESSION_CODEC.fromMetaData(metadata) == expected)
+    }
   }
 
-  test("DeltaConfig: fromMetaData returns None when property is absent") {
-    val metadata = actions.Metadata(configuration = Map.empty)
-    val result = DeltaConfigs.PARQUET_COMPRESSION_CODEC.fromMetaData(metadata)
-    assert(result.isEmpty)
-  }
+  /**
+   * A single-write data-file compression scenario: configure the table property, session conf,
+   * and/or writer option as specified, append data, then assert the codec(s) of the resulting
+   * data files. These cases are effectively the same test with different parameters, so they are
+   * expressed as data rather than written out one by one.
+   *
+   * @param tableProperty        codec to set via `TBLPROPERTIES` at CREATE time, if any.
+   * @param sessionCodec         value for `spark.sql.parquet.compression.codec`, if any.
+   * @param writerOption         `(key, value)` DataFrame writer option to set, if any.
+   * @param expectedStoredCodec  when set, assert the stored table property equals this value.
+   * @param verifyCodecs         assertion on the set of codecs found across the data files.
+   */
+  private case class DataFileCodecCase(
+      name: String,
+      tableProperty: Option[String] = None,
+      sessionCodec: Option[String] = None,
+      writerOption: Option[(String, String)] = None,
+      expectedStoredCodec: Option[String] = None,
+      verifyCodecs: Set[CompressionCodecName] => Unit)
 
-  for (codec <- Seq("snappy", "gzip", "zstd", "uncompressed", "none", "lz4", "lz4_raw")) {
-    test(s"CREATE TABLE TBLPROPERTIES with codec '$codec' is respected for data files") {
-      withTable("t") {
-        sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
-               |TBLPROPERTIES ('$tablePropertyKey' = '$codec')""".stripMargin)
-        writeDF.mode("append").saveAsTable("t")
-        assert(getProperties("t").get(tablePropertyKey).contains(codec))
-        val codecs = collectCodecsOfDataFiles("t")
-        assert(codecs == Set(expectedCodec(codec)),
-          s"Expected only codec ${expectedCodec(codec)} but got: $codecs")
+  private val dataFileCodecCases: Seq[DataFileCodecCase] = {
+    // Every protocol-defined codec set via the table property is honored for data files.
+    val perProtocolCodec =
+      Seq("snappy", "gzip", "zstd", "uncompressed", "none", "lz4", "lz4_raw").map { codec =>
+        DataFileCodecCase(
+          name = s"table property '$codec' is respected",
+          tableProperty = Some(codec),
+          expectedStoredCodec = Some(codec),
+          verifyCodecs = codecs => assert(codecs == Set(expectedCodec(codec)),
+            s"Expected only codec ${expectedCodec(codec)} but got: $codecs"))
       }
-    }
+    perProtocolCodec ++ Seq(
+      DataFileCodecCase(
+        name = "mixed-case table property is normalized to lowercase when written",
+        tableProperty = Some("GzIp"),
+        verifyCodecs = codecs => assert(codecs == Set(CompressionCodecName.GZIP))),
+      DataFileCodecCase(
+        name = "DataFrame .option('compression', ...) overrides the table property",
+        tableProperty = Some("gzip"),
+        writerOption = Some(writerOptionKey -> "snappy"),
+        verifyCodecs = codecs => assert(codecs == Set(CompressionCodecName.SNAPPY))),
+      DataFileCodecCase(
+        name = "mixed-case DataFrame compression option overrides the table property",
+        tableProperty = Some("gzip"),
+        // Spark normalizes the option key case-insensitively; ensure Delta does too.
+        writerOption = Some("Compression" -> "snappy"),
+        verifyCodecs = codecs => assert(codecs == Set(CompressionCodecName.SNAPPY))),
+      DataFileCodecCase(
+        name = "unset table property falls back to Spark's default behavior",
+        // Spark's default Parquet codec is SNAPPY. We don't hard-code it - just assert that we
+        // don't accidentally write something exotic, and that we get one consistent codec.
+        verifyCodecs = codecs => assert(codecs.size == 1,
+          s"Expected exactly one codec but got: $codecs")),
+      DataFileCodecCase(
+        name = "unset table property honors spark.sql.parquet.compression.codec override",
+        sessionCodec = Some("gzip"),
+        verifyCodecs = codecs => assert(codecs == Set(CompressionCodecName.GZIP),
+          s"Expected GZIP from session conf override but got: $codecs")))
   }
 
-  test("Mixed-case codec is normalized to lowercase when written") {
-    withTable("t") {
-      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
-             |TBLPROPERTIES ('$tablePropertyKey' = 'GzIp')""".stripMargin)
-      writeDF.mode("append").saveAsTable("t")
-      val codecs = collectCodecsOfDataFiles("t")
-      assert(codecs == Set(CompressionCodecName.GZIP))
-    }
-  }
-
-  test("DataFrame .option('compression', ...) overrides the table property") {
-    withTable("t") {
-      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
-             |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
-      writeDF.option(writerOptionKey, "snappy").mode("append").saveAsTable("t")
-      val codecs = collectCodecsOfDataFiles("t")
-      assert(codecs == Set(CompressionCodecName.SNAPPY))
-    }
-  }
-
-  test("Mixed-case DataFrame compression option overrides the table property") {
-    withTable("t") {
-      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA
-             |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
-      // Spark normalizes the option key case-insensitively; ensure Delta does too.
-      writeDF.option("Compression", "snappy").mode("append").saveAsTable("t")
-      val codecs = collectCodecsOfDataFiles("t")
-      assert(codecs == Set(CompressionCodecName.SNAPPY))
+  for (testCase <- dataFileCodecCases) {
+    test(s"data files: ${testCase.name}") {
+      def runScenario(): Unit = withTable("t") {
+        val tblProperties = testCase.tableProperty
+          .map(codec => s" TBLPROPERTIES ('$tablePropertyKey' = '$codec')")
+          .getOrElse("")
+        sql(s"CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA$tblProperties")
+        if (testCase.tableProperty.isEmpty) {
+          assert(!getProperties("t").contains(tablePropertyKey))
+        }
+        val writer = testCase.writerOption match {
+          case Some((key, value)) => writeDF.option(key, value)
+          case None => writeDF
+        }
+        writer.mode("append").saveAsTable("t")
+        testCase.expectedStoredCodec.foreach { stored =>
+          assert(getProperties("t").get(tablePropertyKey).contains(stored))
+        }
+        testCase.verifyCodecs(collectCodecsOfDataFiles("t"))
+      }
+      testCase.sessionCodec match {
+        case Some(codec) => withSQLConf(sessionCodecKey -> codec)(runScenario())
+        case None => runScenario()
+      }
     }
   }
 
@@ -195,33 +239,6 @@ class DeltaParquetCompressionCodecSuite
       val codecs = collectCodecsOfDataFiles("t")
       assert(codecs == Set(CompressionCodecName.GZIP, CompressionCodecName.SNAPPY),
         s"Expected both GZIP and SNAPPY files but got: $codecs")
-    }
-  }
-
-  test("Unset table property falls back to Spark's default behavior") {
-    withTable("t") {
-      sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA""".stripMargin)
-      assert(!getProperties("t").contains(tablePropertyKey))
-      writeDF.mode("append").saveAsTable("t")
-      val codecs = collectCodecsOfDataFiles("t")
-      // Spark's default Parquet codec is SNAPPY. We don't hard-code it - just assert that we
-      // don't accidentally write something exotic, and that we get one consistent codec.
-      assert(codecs.size == 1, s"Expected exactly one codec but got: $codecs")
-    }
-  }
-
-  test("Unset table property falls back to spark.sql.parquet.compression.codec override") {
-    // When the Delta table property is unset, writes should honor the session-level
-    // `spark.sql.parquet.compression.codec` config, including non-default values.
-    withSQLConf("spark.sql.parquet.compression.codec" -> "gzip") {
-      withTable("t") {
-        sql(s"""CREATE TABLE t (c0 INT, c1 STRING, c2 TIMESTAMP) USING DELTA""".stripMargin)
-        assert(!getProperties("t").contains(tablePropertyKey))
-        writeDF.mode("append").saveAsTable("t")
-        val codecs = collectCodecsOfDataFiles("t")
-        assert(codecs == Set(CompressionCodecName.GZIP),
-          s"Expected GZIP from session conf override but got: $codecs")
-      }
     }
   }
 
@@ -244,47 +261,38 @@ class DeltaParquetCompressionCodecSuite
     result.toSeq
   }
 
-  test("V2 checkpoint files honor the codec") {
-    withSQLConf(
-      DeltaConfigs.CHECKPOINT_POLICY.defaultTablePropertyKey -> CheckpointPolicy.V2.name,
-      DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> V2Checkpoint.Format.PARQUET.name) {
-      withTempDir { dir =>
-        val path = dir.getCanonicalPath
-        sql(s"""CREATE TABLE delta.`$path` (c0 BIGINT) USING delta
-               |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
-        // Generate some commits so the snapshot has content to checkpoint.
-        (1 to 5).foreach { i =>
-          spark.range(i, i + 1).toDF("c0").write.format("delta").mode("append").save(path)
+  // Both classic and V2 Parquet checkpoints must write their Parquet files (top-level manifest
+  // and sidecars) using the table's configured compression codec. The only difference between
+  // the two cases is the checkpoint policy, so they are parameterized over the session confs.
+  for {
+    (checkpointPolicy, extraConfs) <- Seq(
+      "V2" -> Seq(
+        DeltaConfigs.CHECKPOINT_POLICY.defaultTablePropertyKey -> CheckpointPolicy.V2.name,
+        DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> V2Checkpoint.Format.PARQUET.name),
+      "Classic" -> Seq.empty[(String, String)])
+  } {
+    test(s"$checkpointPolicy checkpoint files honor the codec") {
+      withSQLConf(extraConfs: _*) {
+        withTempDir { dir =>
+          val path = dir.getCanonicalPath
+          sql(s"""CREATE TABLE delta.`$path` (c0 BIGINT) USING delta
+                 |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
+          // Generate some commits so the snapshot has content to checkpoint.
+          (1 to 5).foreach { i =>
+            spark.range(i, i + 1).toDF("c0").write.format("delta").mode("append").save(path)
+          }
+          val log = DeltaLog.forTable(spark, path)
+          log.checkpoint(log.update())
+          val checkpointFiles =
+            listAllCheckpointParquetFiles(log.logPath, log.newDeltaHadoopConf())
+          assert(checkpointFiles.nonEmpty,
+            s"Expected at least one $checkpointPolicy checkpoint parquet file")
+          checkpointFiles.foreach { p =>
+            val codecs = readParquetFileCodecs(p)
+            assert(codecs == Set(CompressionCodecName.GZIP),
+              s"Expected GZIP codec in checkpoint $p but got: $codecs")
+          }
         }
-        val log = DeltaLog.forTable(spark, path)
-        log.checkpoint(log.update())
-        val checkpointFiles = listAllCheckpointParquetFiles(log.logPath, log.newDeltaHadoopConf())
-        assert(checkpointFiles.nonEmpty, "Expected at least one V2 checkpoint parquet file")
-        checkpointFiles.foreach { p =>
-          val codecs = readParquetFileCodecs(p)
-          assert(codecs.nonEmpty && codecs.subsetOf(Set(CompressionCodecName.GZIP)),
-            s"Expected GZIP codec in checkpoint $p but got: $codecs")
-        }
-      }
-    }
-  }
-
-  test("Classic checkpoint files honor the codec") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      sql(s"""CREATE TABLE delta.`$path` (c0 BIGINT) USING delta
-             |TBLPROPERTIES ('$tablePropertyKey' = 'gzip')""".stripMargin)
-      (1 to 5).foreach { i =>
-        spark.range(i, i + 1).toDF("c0").write.format("delta").mode("append").save(path)
-      }
-      val log = DeltaLog.forTable(spark, path)
-      log.checkpoint(log.update())
-      val checkpointFiles = listAllCheckpointParquetFiles(log.logPath, log.newDeltaHadoopConf())
-      assert(checkpointFiles.nonEmpty, "Expected at least one classic checkpoint parquet file")
-      checkpointFiles.foreach { p =>
-        val codecs = readParquetFileCodecs(p)
-        assert(codecs == Set(CompressionCodecName.GZIP),
-          s"Expected GZIP codec in checkpoint $p but got: $codecs")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -277,7 +277,8 @@ trait DeltaRetentionSuiteBase extends QueryTest
           dfToWrite,
           parquetFile,
           hadoopConf,
-          useRename = false)
+          useRename = false,
+          tableProperties = snapshot.metadata.configuration)
       case _ =>
         assert(false, "Invalid v2 checkpoint format")
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -292,15 +292,16 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
   }
 
   test("createStagingTable: suggested property unknown to Delta Spark is silently dropped") {
-    // UC may suggest Kernel-only properties (e.g. `delta.parquet.compression.codec`) that
-    // this Delta Spark build doesn't recognize. The suggested-properties path drops them
-    // instead of letting `DeltaConfigs.validateConfigurations` throw downstream.
+    // UC may suggest properties that this Delta Spark build doesn't recognize. The
+    // suggested-properties path drops them instead of letting
+    // `DeltaConfigs.validateConfigurations` throw downstream.
+    val unknownProperty = "delta.someFutureUnknownProperty"
     val (client, _) = newRecordingClient(
-      suggestedProperties = javaMap("delta.parquet.compression.codec" -> "snappy"))
+      suggestedProperties = javaMap(unknownProperty -> "someValue"))
     val out = client.createStagingTable(
       Identifier.of(Array("sch"), "tbl"),
       stageProps("delta.catalogManaged" -> "supported"))
-    assert(!out.containsKey("delta.parquet.compression.codec"),
+    assert(!out.containsKey(unknownProperty),
       "unknown delta.* suggested keys must not flow through")
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -852,6 +852,10 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
               .put("delta.lastUpdateVersion", expectedLastUpdateVersion)
               .put("delta.minReaderVersion", "3")
               .put("delta.minWriterVersion", "7")
+              // UC suggests `zstd` as the managed-table Parquet compression codec. Delta now
+              // recognizes `delta.parquet.compression.codec` as a valid config, so the suggestion
+              // passes validation and is persisted (before, it was dropped as an unknown key).
+              .put("delta.parquet.compression.codec", "zstd")
               .put("delta.randomizeFilePrefixes", "true")
               .put(UC_TABLE_ID_KEY, tableInfo.getTableId())
               // User specified custom table property is also sent.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add support for Parquet compression codec configuration in Delta tables

I haven't changed the default to ZSTD yet, I plan to do in a separate PR as I expect that changing the default might raise concerns.

Fix #6803

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
Exposes a new config, no behavior changes by default
