### PR TITLE
[Flink][Upsert Step 1] Add upsert sink interfaces and base strategy

### DIFF
--- a/flink/skills.md
+++ b/flink/skills.md
@@ -1,0 +1,29 @@
+# Flink Connector Development Skills
+
+## Pull Request Requirements
+
+### Repository
+- All newly created PRs must target the repository:
+  - `github.com/delta-io/delta`
+
+### Pre-push Validation
+Before pushing any PR, always run the following sbt tasks successfully:
+
+```bash
+build/sbt "flink / javafmt"
+build/sbt "flink / Test / javafmt"
+build/sbt "flink / test"
+build/sbt "flink / Compile / doc"
+```
+
+### PR Tracking
+For every newly created PR:
+- Add the PR link to the tracking issue:
+  - https://github.com/delta-io/delta/issues/5901
+
+## Development Expectations
+
+- Ensure formatting is clean before push.
+- Ensure all Flink tests pass locally before opening or updating a PR.
+- Ensure generated documentation compiles successfully.
+- Keep PR descriptions clear and scoped to a single logical change whenever possible.

--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
@@ -20,6 +20,7 @@ import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -114,6 +115,18 @@ public class DeltaSinkConf implements Serializable {
               "Schema evolution policy: 'no' disallows any change; 'newcolumn' allows adding new "
                   + "columns only.");
 
+  /**
+   * Internal carrier for primary-key column ordinals (0-based field indices into the sink schema).
+   *
+   * <p>Format: comma-separated, decimal, non-negative integers. Example: {@code "0,3"} declares a
+   * composite PK on field ordinals 0 and 3.
+   */
+  public static final ConfigOption<String> PRIMARY_KEY =
+      ConfigOptions.key("primary_key")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Comma-separated primary key column ordinals.");
+
   // ----------------------------------------------------------------------
   // State
   // ----------------------------------------------------------------------
@@ -123,6 +136,7 @@ public class DeltaSinkConf implements Serializable {
   private final Map<String, String> conf;
   private final Configuration configuration;
   private final SchemaEvolutionPolicy schemaEvolutionPolicy;
+  private final int[] primaryKeyOrdinals;
 
   private transient StructType sinkSchema;
 
@@ -141,7 +155,7 @@ public class DeltaSinkConf implements Serializable {
     // Materialize the raw Map into Flink Configuration for ConfigOption access.
     this.configuration = Configuration.fromMap(conf);
 
-    String mode = configuration.get(SCHEMA_EVOLUTION_MODE).toLowerCase();
+    String mode = configuration.get(SCHEMA_EVOLUTION_MODE).toLowerCase(Locale.ROOT);
     switch (mode) {
       case "newcolumn":
         this.schemaEvolutionPolicy = new NewColumnEvolution();
@@ -152,6 +166,51 @@ public class DeltaSinkConf implements Serializable {
       default:
         throw new IllegalArgumentException("unknown evolution mode:" + mode);
     }
+
+    this.primaryKeyOrdinals = parsePrimaryKeyOrdinals(configuration.get(PRIMARY_KEY), sinkSchema);
+  }
+
+  private static int[] parsePrimaryKeyOrdinals(String raw, StructType schema) {
+    if (raw == null || raw.trim().isEmpty()) {
+      return new int[0];
+    }
+    int width = schema.length();
+    String[] segments = raw.split(",");
+    int[] ordinals = new int[segments.length];
+    int n = 0;
+    for (String segment : segments) {
+      String trimmed = segment.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      int ordinal;
+      try {
+        ordinal = Integer.parseInt(trimmed);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Invalid primary-key ordinal '"
+                + trimmed
+                + "' in '"
+                + PRIMARY_KEY.key()
+                + "'. Expected a non-negative integer.",
+            e);
+      }
+      if (ordinal < 0 || ordinal >= width) {
+        throw new IllegalArgumentException(
+            "Primary-key ordinal "
+                + ordinal
+                + " is out of range for sink schema of width "
+                + width
+                + ".");
+      }
+      ordinals[n++] = ordinal;
+    }
+    if (n == segments.length) {
+      return ordinals;
+    }
+    int[] result = new int[n];
+    System.arraycopy(ordinals, 0, result, 0, n);
+    return result;
   }
 
   /**
@@ -213,6 +272,15 @@ public class DeltaSinkConf implements Serializable {
    */
   public SchemaEvolutionPolicy getSchemaEvolutionPolicy() {
     return schemaEvolutionPolicy;
+  }
+
+  /**
+   * Returns the primary-key column ordinals (0-based indices into the sink schema).
+   *
+   * <p>The returned array is the live backing array; callers must not mutate it.
+   */
+  public int[] getPrimaryKeyOrdinals() {
+    return primaryKeyOrdinals;
   }
 
   /**

--- a/flink/src/main/java/io/delta/flink/sink/MergeStrategy.java
+++ b/flink/src/main/java/io/delta/flink/sink/MergeStrategy.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink;
+
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Performing the row-level merge that turns an incoming upsert/delete stream into Delta {@code
+ * Add}/{@code Remove} file actions.
+ *
+ * <p>A strategy owns the per-checkpoint bookkeeping it needs to do its job. {@link DeltaSinkWriter}
+ * pushes primary-key information into the strategy as rows arrive ({@link #recordUpsert} for {@code
+ * INSERT}/{@code UPDATE_AFTER}; {@link #recordDelete} for {@code DELETE}) and calls {@link #merge}
+ * once per checkpoint to materialize that bookkeeping into Delta actions and reset internal state.
+ *
+ * <p>Implementations are responsible for emitting:
+ *
+ * <ul>
+ *   <li>{@code RemoveFile} actions for any existing data file that contains rows whose PK matches
+ *       an upserted or deleted PK;
+ *   <li>{@code AddFile} actions for any rewritten (kept) rows from those files.
+ * </ul>
+ *
+ * <p>The newly-written upsert rows themselves are appended by the writer via the standard {@link
+ * DeltaTable#writeParquet} path and are <em>not</em> part of the strategy's responsibility.
+ *
+ * <p>Implementations must be {@link Serializable} so the writer can be shipped to TaskManagers.
+ * Implementations should keep their internal state empty between checkpoints (i.e. {@link #merge}
+ * must clear whatever {@link #recordUpsert} / {@link #recordDelete} accumulated).
+ */
+public interface MergeStrategy extends Serializable {
+
+  /**
+   * Records the primary key of an {@code INSERT} or {@code UPDATE_AFTER} row written during the
+   * current checkpoint, so the strategy can later remove any pre-existing row that shares this key.
+   * The new row itself has already been appended by the writer via {@link DeltaTable#writeParquet}.
+   *
+   * @param primaryKey the primary-key values, not null but individual elements may be null
+   * @param partitionValues the partition column values of the row; empty for unpartitioned tables
+   */
+  void recordUpsert(List<Literal> primaryKey, Map<String, Literal> partitionValues);
+
+  /**
+   * Records the primary key of a {@code DELETE} row observed during the current checkpoint. The
+   * {@code DELETE} row itself is <em>not</em> appended to the table — the strategy must remove the
+   * existing row with this key.
+   *
+   * @param primaryKey the primary-key values, not null but individual elements may be null
+   * @param partitionValues the partition column values of the row; empty for unpartitioned tables
+   */
+  void recordDelete(List<Literal> primaryKey, Map<String, Literal> partitionValues);
+
+  /**
+   * Resolves the recorded checkpoint work into Delta actions and clears internal state.
+   *
+   * <p>If no records were observed since the last call, returns an empty list.
+   *
+   * @param table the target Delta table; implementations may use it to read the current snapshot
+   *     and to write replacement data files via {@link DeltaTable#writeParquet}
+   * @param conf the sink configuration, providing the schema, primary-key columns, and rolling
+   *     strategy
+   * @return additional actions to include in the commit. Empty if no existing files need
+   *     modification.
+   * @throws IOException if reading existing files or writing replacement files fails
+   */
+  List<Row> merge(DeltaTable table, DeltaSinkConf conf) throws IOException;
+}

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/RowLocator.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/RowLocator.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.utils.CloseableIterator;
+import java.util.List;
+
+/**
+ * Pluggable strategy for finding Delta data files that may contain rows whose primary key matches a
+ * given set of PK tuples. The "where do I look" half of a merge — {@link Upsert} pairs a locator
+ * with a row-level filter that does the exact intersection.
+ *
+ * <p>Implementations must not return false negatives (would leave stale rows). False positives are
+ * fine — the row-level filter discards non-matches.
+ */
+public interface RowLocator {
+
+  /**
+   * Return scan-file rows for files that may contain at least one row whose PK is in {@code pks}.
+   *
+   * @param table the Delta table to search
+   * @param pkIndices ordinals of the PK columns in the table schema, in PK order
+   * @param pks PK tuples to locate; each inner list has the same arity as {@code pkIndices}. May be
+   *     empty, in which case implementations should return an empty iterator.
+   * @return iterator of scan-file rows in Kernel's {@code Scan.getScanFiles(...)} shape
+   */
+  CloseableIterator<Row> find(DeltaTable table, int[] pkIndices, List<List<Literal>> pks);
+}

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
@@ -1,0 +1,210 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import io.delta.flink.sink.DeltaSinkConf;
+import io.delta.flink.sink.MergeStrategy;
+import io.delta.flink.table.AbstractKernelTable;
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.ByteType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.DateType;
+import io.delta.kernel.types.DecimalType;
+import io.delta.kernel.types.DoubleType;
+import io.delta.kernel.types.FloatType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.ShortType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.TimestampNTZType;
+import io.delta.kernel.types.TimestampType;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract base for upsert merge strategies. Owns the per-checkpoint PK bookkeeping (upserted /
+ * deleted PKs, touched partitions, lookup index) and orchestrates {@link #merge}: ask the
+ * configured {@link RowLocator} for candidate files, hand each one to {@link #deleteRecords},
+ * flatten the resulting Delta actions, and clear internal state.
+ *
+ * <p>Subclasses choose how to materialize deletes, for example by rewriting matched files or by
+ * writing deletion vectors over them.
+ */
+public abstract class Upsert implements MergeStrategy {
+  /**
+   * Primary-key values (in {@link DeltaSinkConf#getPrimaryKeyOrdinals()} order) of every {@code
+   * INSERT}/{@code UPDATE_AFTER} row recorded during the current checkpoint.
+   */
+  private final List<List<Literal>> upsertedPrimaryKeys = new ArrayList<>();
+
+  /** Primary-key values of every {@code DELETE} row recorded during the current checkpoint. */
+  private final List<List<Literal>> deletedPrimaryKeys = new ArrayList<>();
+
+  /** Indices for quick search of pks. */
+  private final Set<List<String>> primaryKeyIndices = new HashSet<>();
+
+  /**
+   * Distinct partition value maps touched during the checkpoint. Keyed by a stringified form of the
+   * partition map so we deduplicate cheaply; the value is the original {@code Literal}-based map
+   * used to bound the scan in {@link #merge}.
+   */
+  private final Map<Map<String, String>, Map<String, Literal>> touchedPartitions =
+      new LinkedHashMap<>();
+
+  protected transient AbstractKernelTable table;
+
+  private final RowLocator rowLocator;
+
+  protected Upsert(RowLocator rowLocator) {
+    this.rowLocator = Objects.requireNonNull(rowLocator, "rowLocator");
+  }
+
+  @Override
+  public void recordUpsert(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
+    upsertedPrimaryKeys.add(primaryKey);
+    cachePrimaryKey(primaryKey);
+    cachePartition(partitionValues);
+  }
+
+  @Override
+  public void recordDelete(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
+    deletedPrimaryKeys.add(primaryKey);
+    cachePrimaryKey(primaryKey);
+    cachePartition(partitionValues);
+  }
+
+  @Override
+  public List<Row> merge(DeltaTable table, DeltaSinkConf conf) throws IOException {
+    this.table = (AbstractKernelTable) table;
+    boolean hasWork = !upsertedPrimaryKeys.isEmpty() || !deletedPrimaryKeys.isEmpty();
+    try {
+      if (!hasWork) {
+        return Collections.emptyList();
+      }
+
+      // 1. Locate all data files that pending scan.
+      List<List<Literal>> pkToDelete = new ArrayList<>();
+      pkToDelete.addAll(upsertedPrimaryKeys);
+      pkToDelete.addAll(deletedPrimaryKeys);
+      CloseableIterator<Row> addFiles =
+          rowLocator.find(table, conf.getPrimaryKeyOrdinals(), pkToDelete);
+
+      // 2. Delete rows from found data files.
+      BiPredicate<ColumnarBatch, Integer> filter =
+          (batch, rowId) ->
+              primaryKeyIndices.contains(
+                  extractPrimaryKey(conf.getPrimaryKeyOrdinals(), batch, rowId));
+      return addFiles.flatMap(addFile -> deleteRecords(addFile, filter)).toInMemoryList();
+    } finally {
+      upsertedPrimaryKeys.clear();
+      deletedPrimaryKeys.clear();
+      primaryKeyIndices.clear();
+      touchedPartitions.clear();
+    }
+  }
+
+  /**
+   * Emit the Delta actions needed to logically delete from {@code addFile} every row matched by
+   * {@code filter}. Called once per candidate file returned by {@link RowLocator#find}; the
+   * returned iterator is flattened into {@link #merge}'s overall result. Implementations may assume
+   * {@link #table} has been initialized by the surrounding {@code merge(...)} call.
+   *
+   * @param addFile scan-file row in Kernel's {@code Scan.getScanFiles(...)} shape
+   * @param filter row-level predicate; {@code true} to remove the row, {@code false} to keep it
+   * @return single-action rows already wrapped as {@code SingleAction}s
+   */
+  protected abstract CloseableIterator<Row> deleteRecords(
+      Row addFile, BiPredicate<ColumnarBatch, Integer> filter);
+
+  private void cachePrimaryKey(List<Literal> primaryKey) {
+    primaryKeyIndices.add(
+        primaryKey.stream()
+            .map(key -> Optional.ofNullable(key).map(Object::toString).orElse(""))
+            .collect(Collectors.toList()));
+  }
+
+  private void cachePartition(Map<String, Literal> partitionValues) {
+    Map<String, String> dedupKey =
+        partitionValues.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
+    touchedPartitions.putIfAbsent(dedupKey, partitionValues);
+  }
+
+  private List<String> extractPrimaryKey(int[] ordinals, ColumnarBatch data, Integer rowId) {
+    List<String> key = new ArrayList<>(ordinals.length);
+    for (int ord : ordinals) {
+      key.add(
+          Optional.ofNullable(columnVectorValue(data.getColumnVector(ord), rowId))
+              .map(Object::toString)
+              .orElse(""));
+    }
+    return key;
+  }
+
+  private Object columnVectorValue(ColumnVector input, int rowId) {
+    if (input.isNullAt(rowId)) {
+      return null;
+    }
+    DataType type = input.getDataType();
+    if (type.equivalent(BooleanType.BOOLEAN)) {
+      return input.getBoolean(rowId);
+    } else if (type.equivalent(ByteType.BYTE)) {
+      return input.getByte(rowId);
+    } else if (type.equivalent(ShortType.SHORT)) {
+      return input.getShort(rowId);
+    } else if (type.equivalent(IntegerType.INTEGER)) {
+      return input.getInt(rowId);
+    } else if (type.equivalent(LongType.LONG)) {
+      return input.getLong(rowId);
+    } else if (type.equivalent(FloatType.FLOAT)) {
+      return input.getFloat(rowId);
+    } else if (type.equivalent(DoubleType.DOUBLE)) {
+      return input.getDouble(rowId);
+    } else if (type.equivalent(StringType.STRING)) {
+      return input.getString(rowId);
+    } else if (type.equivalent(BinaryType.BINARY)) {
+      return input.getBinary(rowId);
+    } else if (type.equivalent(DateType.DATE)) {
+      return input.getInt(rowId);
+    } else if (type.equivalent(TimestampType.TIMESTAMP)) {
+      return input.getLong(rowId);
+    } else if (type.equivalent(TimestampNTZType.TIMESTAMP_NTZ)) {
+      return input.getLong(rowId);
+    } else if (type instanceof DecimalType) {
+      return input.getDecimal(rowId);
+    } else {
+      throw new UnsupportedOperationException("Unsupported column vector type: " + type);
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

Step 1 of the Flink upsert sink stack. This PR adds the public configuration and shared strategy contracts that the implementation PR builds on:

- `DeltaSinkConf` primary-key ordinal configuration.
- `MergeStrategy`, the sink-side contract for recording upserts/deletes and producing Delta actions.
- `RowLocator`, the pluggable contract for finding candidate files by primary key.
- `Upsert`, the abstract base class that owns per-checkpoint primary-key bookkeeping and delegates file lookup to a `RowLocator` plus row deletion materialization to concrete subclasses.

This PR intentionally does not add concrete locators or rewrite strategies. Those live in #6818.

## How was this patch tested?

- `build/sbt "flink / Compile / doc"`

## Does this PR introduce _any_ user-facing changes?

No.