### PR TITLE
[kernel-spark] Fix DSv2 double-decoding URL-encoded partition values

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -143,7 +143,8 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "streaming read returns correct data from table with partition column in middle",
     "streaming read with column pruning and partition column in middle",
     "streaming read with column mapping id and partition column in middle",
-    "streaming read after column rename with partition column in middle"
+    "streaming read after column rename with partition column in middle",
+    "streaming read preserves percent-literal string partition value"
   )
 
   override protected def shouldFailTests: Set[String] = Set(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -3396,6 +3396,37 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
+  test("streaming read preserves percent-literal string partition value") {
+    withTempDirs { (inputDir, _, checkpointDir) =>
+      val tablePath = inputDir.getCanonicalPath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG, p STRING) " +
+        "USING delta PARTITIONED BY (p)")
+      // Each value is chosen so that an erroneous second unescape would produce a result
+      // pairwise distinct from the input and from the other cases' bug results:
+      //   "%20"   -> bug result " "   (canonical space-collapse)
+      //   "%25"   -> bug result "%"   (self-encoding of `%`)
+      //   "a%2Fb" -> bug result "a/b" (embedded percent escape mid-string)
+      Seq((1L, "%20"), (2L, "%25"), (3L, "a%2Fb")).toDF("id", "p")
+        .write.format("delta").mode("append").save(tablePath)
+
+      val streamingDF = loadStreamWithOptions(tablePath, Map.empty)
+      val q = streamingDF
+        .writeStream
+        .format("memory")
+        .queryName("percentLiteralPartStreamTest")
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          sql("SELECT * FROM percentLiteralPartStreamTest ORDER BY id"),
+          Row(1L, "%20") :: Row(2L, "%25") :: Row(3L, "a%2Fb") :: Nil)
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
 }
 
 /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -61,8 +61,10 @@ import org.apache.spark.sql.execution.datasources.PartitioningUtils;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import scala.Function1;
 import scala.Option;
 import scala.Tuple2;
@@ -170,10 +172,14 @@ public class PartitionUtils {
       final Integer pos = physicalNameToIndex.get(key);
       if (pos != null) {
         final StructField field = partitionSchema.fields()[pos];
-        values[pos] =
-            (strVal == null)
-                ? null
-                : PartitioningUtils.castPartValueToDesiredType(field.dataType(), strVal, zoneId);
+        if (strVal == null) {
+          values[pos] = null;
+        } else if (field.dataType() instanceof StringType) {
+          values[pos] = UTF8String.fromString(strVal);
+        } else {
+          values[pos] =
+              PartitioningUtils.castPartValueToDesiredType(field.dataType(), strVal, zoneId);
+        }
       }
     }
     return new GenericInternalRow(values);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkBatchTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkBatchTest.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.catalog.SparkTable;
 import java.io.File;
+import java.util.List;
 import java.util.stream.Stream;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.sources.EqualTo;
@@ -105,5 +107,35 @@ public class SparkBatchTest extends DeltaV2TestBase {
 
     assertNotEquals(batch1, batch2);
     assertNotEquals(batch1.hashCode(), batch2.hashCode());
+  }
+
+  @Test
+  public void testBatchReadPreservesPercentLiteralStringPartitionValue(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (id LONG, p STRING) USING delta PARTITIONED BY (p)", path));
+    // Each value is chosen so an erroneous second unescape would produce a result that's
+    // pairwise distinct from the input AND from the other cases' bug results, so a regression
+    // cannot coincidentally agree with the expected value:
+    //   "%20"   -> bug result " "   (canonical space-collapse)
+    //   "%25"   -> bug result "%"   (self-encoding of `%`)
+    //   "a%2Fb" -> bug result "a/b" (embedded percent escape mid-string)
+    spark.sql(
+        String.format(
+            "INSERT INTO delta.`%s` VALUES (1, '%%20'), (2, '%%25'), (3, 'a%%2Fb')", path));
+
+    List<Row> rows =
+        spark
+            .sql(String.format("SELECT id, p FROM dsv2.delta.`%s` ORDER BY id", path))
+            .collectAsList();
+
+    assertEquals(3, rows.size());
+    assertEquals(1L, rows.get(0).getLong(0));
+    assertEquals("%20", rows.get(0).getString(1));
+    assertEquals(2L, rows.get(1).getLong(0));
+    assertEquals("%25", rows.get(1).getString(1));
+    assertEquals(3L, rows.get(2).getLong(0));
+    assertEquals("a%2Fb", rows.get(2).getString(1));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Test;
 import scala.collection.immutable.Map$;
 
@@ -70,6 +71,37 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
     assertEquals(2024, row.getInt(0));
     assertEquals(11, row.getInt(1));
     assertEquals(25, row.getInt(2));
+  }
+
+  @Test
+  public void testGetPartitionRow_StringValueIsNotDoubleUrlDecoded() {
+    // Kernel's MapValue already holds the logical (decoded) string. Spark's
+    // castPartValueToDesiredType would unescapePathName again; each case below picks an input
+    // whose second-decode result is distinct from the input AND from the other cases' results,
+    // so a regression cannot coincidentally agree with the expected value.
+    //   "%20"   -> bug result " "   (canonical space-collapse)
+    //   "%25"   -> bug result "%"   (self-encoding of `%`)
+    //   "a%2Fb" -> bug result "a/b" (embedded percent escape mid-string)
+    StructType partitionSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("p_space", DataTypes.StringType, true),
+              DataTypes.createStructField("p_percent", DataTypes.StringType, true),
+              DataTypes.createStructField("p_embedded", DataTypes.StringType, true)
+            });
+
+    Map<String, String> partitionValues = new HashMap<>();
+    partitionValues.put("p_space", "%20");
+    partitionValues.put("p_percent", "%25");
+    partitionValues.put("p_embedded", "a%2Fb");
+
+    InternalRow row =
+        PartitionUtils.getPartitionRow(
+            stringStringMapValue(partitionValues), partitionSchema, ZoneId.of("UTC"));
+
+    assertEquals(UTF8String.fromString("%20"), row.getUTF8String(0));
+    assertEquals(UTF8String.fromString("%25"), row.getUTF8String(1));
+    assertEquals(UTF8String.fromString("a%2Fb"), row.getUTF8String(2));
   }
 
   @Test


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

Kernel hands DSv2 already-decoded partition values from the AddFile JSON, but `PartitionUtils.getPartitionRow` ran every value through Spark's `PartitioningUtils.castPartValueToDesiredType`, which calls `unescapePathName` for `StringType` — a second decode. A value of `"%20"` came back as `" "`; `"%25"` as `"%"`. Silent data corruption on DSv2 batch + streaming. DSv1's `TahoeFileIndex.getPartitionValuesRow` was unaffected (uses `Cast` with no unescape).

Fix: short-circuit `StringType` with `UTF8String.fromString(strVal)` in `PartitionUtils.java`; keep `castPartValueToDesiredType` for non-string types (where `unescapePathName` is a no-op for valid numeric/temporal literals).

## How was this patch tested?

- `PartitionUtilsTest.testGetPartitionRow_StringValueIsNotDoubleUrlDecoded` (new): unit-tests the fix at its logic layer over `%20`, `%25`, `a%2Fb` — three pairwise-distinct bug signatures (`" "`, `"%"`, `"a/b"`).
- `DeltaSourceSuite."streaming read preserves percent-literal string partition value"` (new): same three values, end-to-end streaming write/read. Registered in `DeltaV2SourceSuite.shouldPassTests` so it runs under both V1 and the V2-force connector (`V2_ENABLE_MODE=STRICT`).

## Does this PR introduce _any_ user-facing changes?

Yes — fixes silent data corruption in DSv2 reads. Partition string values containing `%XX` escape sequences (e.g. `%20`, `%25`) now round-trip correctly on DSv2 batch and streaming, matching DSv1.