### PR TITLE
[Storage] Implement getCommits in UC Delta token-based client

### DIFF
--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -236,7 +236,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
-    Objects.requireNonNull(tableIdentifier, "tableIdentifier must not be null");
+    ResolvedTableName name = resolveThreePartName(tableIdentifier);
 
     UpdateTableRequest request = new UpdateTableRequest();
     request.addRequirementsItem(new AssertTableUUID()
@@ -269,14 +269,10 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .protocol(toSDKDeltaProtocol(newProtocol.get())));
     }
 
-    String catalog = tableIdentifier.getNamespace()[0];
-    String schema = tableIdentifier.getNamespace()[1];
-    String table = tableIdentifier.getName();
-
     try {
-      deltaTablesApi.updateTable(catalog, schema, table, request);
+      deltaTablesApi.updateTable(name.catalog, name.schema, name.table, request);
     } catch (ApiException e) {
-      handleUpdateTableException(e, catalog, schema, table);
+      handleUpdateTableException(e, name.catalog, name.schema, name.table);
     }
   }
 
@@ -290,36 +286,26 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
     Objects.requireNonNull(tableUri, "tableUri must not be null");
-    Objects.requireNonNull(tableIdentifier, "tableIdentifier must not be null");
     Objects.requireNonNull(startVersion, "startVersion must not be null");
     Objects.requireNonNull(endVersion, "endVersion must not be null");
 
     UUID expectedTableUuid = UUID.fromString(tableId);
-    String[] namespace = Objects.requireNonNull(
-        tableIdentifier.getNamespace(), "tableIdentifier namespace must not be null");
-    if (namespace.length != 2) {
-      throw new IllegalArgumentException(
-          "tableIdentifier must be a three-part Unity Catalog table name");
-    }
-    String catalog = Objects.requireNonNull(namespace[0], "catalog name must not be null");
-    String schema = Objects.requireNonNull(namespace[1], "schema name must not be null");
-    String table = Objects.requireNonNull(tableIdentifier.getName(), "table name must not be null");
-    String fullName = catalog + "." + schema + "." + table;
+    ResolvedTableName name = resolveThreePartName(tableIdentifier);
 
     // The UC loadTable endpoint does not support server-side filtering by version range, so
     // we fetch the full unbackfilled commit window and filter client-side below. The server
     // bounds the window size, so this list is not unbounded in practice.
     LoadTableResponse response;
     try {
-      response = deltaTablesApi.loadTable(catalog, schema, table);
+      response = deltaTablesApi.loadTable(name.catalog, name.schema, name.table);
     } catch (ApiException e) {
       if (e.getCode() == HTTP_NOT_FOUND) {
-        throw new InvalidTargetTableException(
-            String.format("Table not found %s: %s", fullName, e.getResponseBody()));
+        throw new NoSuchTableException(
+            String.format("Table %s not found in Unity Catalog", name.fullName), e);
       }
       throw new IOException(
           String.format("Failed to load commits for table %s (HTTP %s): %s",
-              fullName, e.getCode(), e.getResponseBody()),
+              name.fullName, e.getCode(), e.getResponseBody()),
           e);
     }
 
@@ -329,7 +315,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       throw new InvalidTargetTableException(
           String.format(
               "Table UUID mismatch for %s: expected %s but got %s",
-              fullName,
+              name.fullName,
               expectedTableUuid,
               actualTableUuid));
     }
@@ -425,24 +411,16 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   @Override
   public TableInfo loadTable(TableIdentifier tableIdentifier) throws IOException {
     ensureOpen();
-    Objects.requireNonNull(tableIdentifier, "tableIdentifier must not be null");
-    String[] namespace = tableIdentifier.getNamespace();
-    if (namespace == null || namespace.length != 2) {
-      throw new IllegalArgumentException(
-          "UC tableIdentifier must have a 2-component namespace [catalog, schema]; got " +
-              (namespace == null ? "null" : java.util.Arrays.toString(namespace)));
-    }
-    String catalog = namespace[0];
-    String schema = namespace[1];
-    String table = tableIdentifier.getName();
+    ResolvedTableName name = resolveThreePartName(tableIdentifier);
 
     try {
       return toTableInfo(
-          deltaTablesApi.loadTable(catalog, schema, table), catalog, schema, table);
+          deltaTablesApi.loadTable(name.catalog, name.schema, name.table),
+          name.catalog, name.schema, name.table);
     } catch (ApiException e) {
       if (e.getCode() == HTTP_NOT_FOUND) {
         throw new NoSuchTableException(
-            String.format("Table %s.%s.%s not found in Unity Catalog", catalog, schema, table), e);
+            String.format("Table %s not found in Unity Catalog", name.fullName), e);
       }
       // UC encodes non-Delta-format errors as HTTP 400 with error.type =
       // "UnsupportedTableFormatException"; substring-match the body to avoid coupling to an
@@ -450,13 +428,13 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       String body = e.getResponseBody();
       if (body != null && body.contains("UnsupportedTableFormatException")) {
         throw new UnsupportedTableFormatException(
-            String.format("Table %s.%s.%s is not in Delta format; the Delta REST API cannot "
-                + "serve it. Body: %s", catalog, schema, table, body),
+            String.format("Table %s is not in Delta format; the Delta REST API cannot "
+                + "serve it. Body: %s", name.fullName, body),
             e);
       }
       throw new IOException(
-          String.format("Failed to load table %s.%s.%s (HTTP %s): %s",
-              catalog, schema, table, e.getCode(), e.getResponseBody()), e);
+          String.format("Failed to load table %s (HTTP %s): %s",
+              name.fullName, e.getCode(), e.getResponseBody()), e);
     }
   }
 
@@ -727,6 +705,25 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   }
 
   // ===========================
+  // Table Identifier Helpers
+  // ===========================
+
+  /**
+   * Validates that the given {@code tableIdentifier} is a Unity Catalog three-part
+   * (catalog.schema.table) name and returns its resolved parts.
+   */
+  private static ResolvedTableName resolveThreePartName(TableIdentifier tableIdentifier) {
+    Objects.requireNonNull(tableIdentifier, "tableIdentifier must not be null");
+    String[] namespace = tableIdentifier.getNamespace();
+    if (namespace == null || namespace.length != 2) {
+      throw new IllegalArgumentException(
+          "UC tableIdentifier must have a 2-component namespace [catalog, schema]; got " +
+              (namespace == null ? "null" : java.util.Arrays.toString(namespace)));
+    }
+    return new ResolvedTableName(namespace[0], namespace[1], tableIdentifier.getName());
+  }
+
+  // ===========================
   // Exception Handling
   // ===========================
 
@@ -758,6 +755,21 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   // ===========================
   // Inner Classes
   // ===========================
+
+  /** A Unity Catalog three-part table name resolved from a {@link TableIdentifier}. */
+  private static final class ResolvedTableName {
+    final String catalog;
+    final String schema;
+    final String table;
+    final String fullName;
+
+    ResolvedTableName(String catalog, String schema, String table) {
+      this.catalog = catalog;
+      this.schema = schema;
+      this.table = table;
+      this.fullName = catalog + "." + schema + "." + table;
+    }
+  }
 
   /**
    * Adapts a UC SDK {@link TableMetadata} to {@link AbstractMetadata}.

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -290,7 +290,6 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(startVersion, "startVersion must not be null");
     Objects.requireNonNull(endVersion, "endVersion must not be null");
 
-    UUID expectedTableUuid = UUID.fromString(tableId);
     ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     // The UC loadTable endpoint does not support server-side filtering by version range, so
@@ -311,14 +310,16 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     }
 
     TableMetadata metadata = response.getMetadata();
-    UUID actualTableUuid = metadata != null ? metadata.getTableUuid() : null;
-    if (!expectedTableUuid.equals(actualTableUuid)) {
+    String actualTableId = metadata != null && metadata.getTableUuid() != null
+        ? metadata.getTableUuid().toString()
+        : null;
+    if (!tableId.equals(actualTableId)) {
       throw new InvalidTargetTableException(
           String.format(
               "Table UUID mismatch for %s: expected %s but got %s",
               name.fullName,
-              expectedTableUuid,
-              actualTableUuid));
+              tableId,
+              actualTableId));
     }
 
     Path basePath = CoordinatedCommitsUtils.commitDirPath(

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -61,6 +61,7 @@ import io.unitycatalog.hadoop.UCCredentialHadoopConfs.TableOperation;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -236,7 +237,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
-    ResolvedTableName name = resolveThreePartName(tableIdentifier);
+    ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     UpdateTableRequest request = new UpdateTableRequest();
     request.addRequirementsItem(new AssertTableUUID()
@@ -290,7 +291,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(endVersion, "endVersion must not be null");
 
     UUID expectedTableUuid = UUID.fromString(tableId);
-    ResolvedTableName name = resolveThreePartName(tableIdentifier);
+    ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     // The UC loadTable endpoint does not support server-side filtering by version range, so
     // we fetch the full unbackfilled commit window and filter client-side below. The server
@@ -325,8 +326,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     List<Commit> commits = new ArrayList<>();
     if (response.getCommits() != null) {
       for (DeltaCommit deltaCommit : response.getCommits()) {
-        long version = Objects.requireNonNull(
-            deltaCommit.getVersion(), "commit version must not be null");
+        long version = deltaCommit.getVersion();
         if (startVersion.isPresent() && version < startVersion.get()) {
           continue;
         }
@@ -345,20 +345,13 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   /** Converts a UC SDK {@link DeltaCommit} to a Delta {@link Commit}. */
   private Commit fromDeltaCommit(DeltaCommit deltaCommit, Path basePath) {
     FileStatus fileStatus = new FileStatus(
-        Objects.requireNonNull(
-            deltaCommit.getFileSize(), "commit fileSize must not be null"),
+        deltaCommit.getFileSize(),
         false /* isdir */,
         0 /* block_replication */,
         0 /* blocksize */,
-        Objects.requireNonNull(
-            deltaCommit.getFileModificationTimestamp(),
-            "commit fileModificationTimestamp must not be null"),
-        new Path(basePath, Objects.requireNonNull(
-            deltaCommit.getFileName(), "commit fileName must not be null")));
-    return new Commit(
-        Objects.requireNonNull(deltaCommit.getVersion(), "commit version must not be null"),
-        fileStatus,
-        Objects.requireNonNull(deltaCommit.getTimestamp(), "commit timestamp must not be null"));
+        deltaCommit.getFileModificationTimestamp(),
+        new Path(basePath, deltaCommit.getFileName()));
+    return new Commit(deltaCommit.getVersion(), fileStatus, deltaCommit.getTimestamp());
   }
 
   @Override
@@ -411,7 +404,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   @Override
   public TableInfo loadTable(TableIdentifier tableIdentifier) throws IOException {
     ensureOpen();
-    ResolvedTableName name = resolveThreePartName(tableIdentifier);
+    ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     try {
       return toTableInfo(
@@ -712,13 +705,13 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
    * Validates that the given {@code tableIdentifier} is a Unity Catalog three-part
    * (catalog.schema.table) name and returns its resolved parts.
    */
-  private static ResolvedTableName resolveThreePartName(TableIdentifier tableIdentifier) {
+  private static ResolvedTableName requireThreePartName(TableIdentifier tableIdentifier) {
     Objects.requireNonNull(tableIdentifier, "tableIdentifier must not be null");
     String[] namespace = tableIdentifier.getNamespace();
     if (namespace == null || namespace.length != 2) {
       throw new IllegalArgumentException(
           "UC tableIdentifier must have a 2-component namespace [catalog, schema]; got " +
-              (namespace == null ? "null" : java.util.Arrays.toString(namespace)));
+              (namespace == null ? "null" : Arrays.toString(namespace)));
     }
     return new ResolvedTableName(namespace[0], namespace[1], tableIdentifier.getName());
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -294,6 +294,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(startVersion, "startVersion must not be null");
     Objects.requireNonNull(endVersion, "endVersion must not be null");
 
+    UUID expectedTableUuid = UUID.fromString(tableId);
     String[] namespace = Objects.requireNonNull(
         tableIdentifier.getNamespace(), "tableIdentifier namespace must not be null");
     if (namespace.length != 2) {
@@ -305,6 +306,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     String table = Objects.requireNonNull(tableIdentifier.getName(), "table name must not be null");
     String fullName = catalog + "." + schema + "." + table;
 
+    // The UC loadTable endpoint does not support server-side filtering by version range, so
+    // we fetch the full unbackfilled commit window and filter client-side below. The server
+    // bounds the window size, so this list is not unbounded in practice.
     LoadTableResponse response;
     try {
       response = deltaTablesApi.loadTable(catalog, schema, table);
@@ -319,18 +323,15 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           e);
     }
 
-    Objects.requireNonNull(response, "loadTable response must not be null");
-    String actualTableId = response.getMetadata() != null
-        && response.getMetadata().getTableUuid() != null
-            ? response.getMetadata().getTableUuid().toString()
-            : null;
-    if (!Objects.equals(tableId, actualTableId)) {
+    TableMetadata metadata = response.getMetadata();
+    UUID actualTableUuid = metadata != null ? metadata.getTableUuid() : null;
+    if (!expectedTableUuid.equals(actualTableUuid)) {
       throw new InvalidTargetTableException(
           String.format(
               "Table UUID mismatch for %s: expected %s but got %s",
               fullName,
-              tableId,
-              actualTableId));
+              expectedTableUuid,
+              actualTableUuid));
     }
 
     Path basePath = CoordinatedCommitsUtils.commitDirPath(
@@ -346,28 +347,32 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
         if (endVersion.isPresent() && version > endVersion.get()) {
           continue;
         }
-
-        commits.add(new Commit(
-            version,
-            new FileStatus(
-                Objects.requireNonNull(
-                    deltaCommit.getFileSize(), "commit fileSize must not be null"),
-                false /* isdir */,
-                0 /* block_replication */,
-                0 /* blocksize */,
-                Objects.requireNonNull(
-                    deltaCommit.getFileModificationTimestamp(),
-                    "commit fileModificationTimestamp must not be null"),
-                new Path(basePath, Objects.requireNonNull(
-                    deltaCommit.getFileName(), "commit fileName must not be null"))),
-            Objects.requireNonNull(
-                deltaCommit.getTimestamp(), "commit timestamp must not be null")));
+        commits.add(fromDeltaCommit(deltaCommit, basePath));
       }
     }
 
     long latestTableVersion = response.getLatestTableVersion() != null
         ? response.getLatestTableVersion() : -1L;
     return new GetCommitsResponse(commits, latestTableVersion);
+  }
+
+  /** Converts a UC SDK {@link DeltaCommit} to a Delta {@link Commit}. */
+  private Commit fromDeltaCommit(DeltaCommit deltaCommit, Path basePath) {
+    FileStatus fileStatus = new FileStatus(
+        Objects.requireNonNull(
+            deltaCommit.getFileSize(), "commit fileSize must not be null"),
+        false /* isdir */,
+        0 /* block_replication */,
+        0 /* blocksize */,
+        Objects.requireNonNull(
+            deltaCommit.getFileModificationTimestamp(),
+            "commit fileModificationTimestamp must not be null"),
+        new Path(basePath, Objects.requireNonNull(
+            deltaCommit.getFileName(), "commit fileName must not be null")));
+    return new Commit(
+        Objects.requireNonNull(deltaCommit.getVersion(), "commit version must not be null"),
+        fileStatus,
+        Objects.requireNonNull(deltaCommit.getTimestamp(), "commit timestamp must not be null"));
   }
 
   @Override

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -18,6 +18,7 @@ package io.delta.storage.commit.uccommitcoordinator;
 
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
+import io.delta.storage.commit.CoordinatedCommitsUtils;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
 import io.delta.storage.commit.actions.AbstractMetadata;
@@ -70,6 +71,8 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
 
 /**
  * A REST client implementation of {@link UCDeltaClient} that uses the UC Delta REST API for
@@ -284,9 +287,87 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       TableIdentifier tableIdentifier,
       Optional<Long> startVersion,
       Optional<Long> endVersion) throws IOException, UCCommitCoordinatorException {
-    throw new UnsupportedOperationException(
-        "getCommits is not yet supported by UCDeltaTokenBasedRestClient. " +
-            "A separate PR will add this once the tableIdentifier mapping is available.");
+    ensureOpen();
+    Objects.requireNonNull(tableId, "tableId must not be null");
+    Objects.requireNonNull(tableUri, "tableUri must not be null");
+    Objects.requireNonNull(tableIdentifier, "tableIdentifier must not be null");
+    Objects.requireNonNull(startVersion, "startVersion must not be null");
+    Objects.requireNonNull(endVersion, "endVersion must not be null");
+
+    String[] namespace = Objects.requireNonNull(
+        tableIdentifier.getNamespace(), "tableIdentifier namespace must not be null");
+    if (namespace.length != 2) {
+      throw new IllegalArgumentException(
+          "tableIdentifier must be a three-part Unity Catalog table name");
+    }
+    String catalog = Objects.requireNonNull(namespace[0], "catalog name must not be null");
+    String schema = Objects.requireNonNull(namespace[1], "schema name must not be null");
+    String table = Objects.requireNonNull(tableIdentifier.getName(), "table name must not be null");
+    String fullName = catalog + "." + schema + "." + table;
+
+    LoadTableResponse response;
+    try {
+      response = deltaTablesApi.loadTable(catalog, schema, table);
+    } catch (ApiException e) {
+      if (e.getCode() == HTTP_NOT_FOUND) {
+        throw new InvalidTargetTableException(
+            String.format("Table not found %s: %s", fullName, e.getResponseBody()));
+      }
+      throw new IOException(
+          String.format("Failed to load commits for table %s (HTTP %s): %s",
+              fullName, e.getCode(), e.getResponseBody()),
+          e);
+    }
+
+    Objects.requireNonNull(response, "loadTable response must not be null");
+    String actualTableId = response.getMetadata() != null
+        && response.getMetadata().getTableUuid() != null
+            ? response.getMetadata().getTableUuid().toString()
+            : null;
+    if (!Objects.equals(tableId, actualTableId)) {
+      throw new InvalidTargetTableException(
+          String.format(
+              "Table UUID mismatch for %s: expected %s but got %s",
+              fullName,
+              tableId,
+              actualTableId));
+    }
+
+    Path basePath = CoordinatedCommitsUtils.commitDirPath(
+        CoordinatedCommitsUtils.logDirPath(new Path(tableUri)));
+    List<Commit> commits = new ArrayList<>();
+    if (response.getCommits() != null) {
+      for (DeltaCommit deltaCommit : response.getCommits()) {
+        long version = Objects.requireNonNull(
+            deltaCommit.getVersion(), "commit version must not be null");
+        if (startVersion.isPresent() && version < startVersion.get()) {
+          continue;
+        }
+        if (endVersion.isPresent() && version > endVersion.get()) {
+          continue;
+        }
+
+        commits.add(new Commit(
+            version,
+            new FileStatus(
+                Objects.requireNonNull(
+                    deltaCommit.getFileSize(), "commit fileSize must not be null"),
+                false /* isdir */,
+                0 /* block_replication */,
+                0 /* blocksize */,
+                Objects.requireNonNull(
+                    deltaCommit.getFileModificationTimestamp(),
+                    "commit fileModificationTimestamp must not be null"),
+                new Path(basePath, Objects.requireNonNull(
+                    deltaCommit.getFileName(), "commit fileName must not be null"))),
+            Objects.requireNonNull(
+                deltaCommit.getTimestamp(), "commit timestamp must not be null")));
+      }
+    }
+
+    long latestTableVersion = response.getLatestTableVersion() != null
+        ? response.getLatestTableVersion() : -1L;
+    return new GetCommitsResponse(commits, latestTableVersion);
   }
 
   @Override

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -669,13 +669,16 @@ class UCDeltaTokenBasedRestClientSuite
     }
   }
 
-  test("getCommits throws InvalidTargetTableException on 404") {
-    deltaHandler = (exchange, _) => sendJson(exchange, HttpStatus.SC_NOT_FOUND, "{}")
+  test("getCommits throws NoSuchTableException on 404") {
+    deltaHandler = (exchange, _) =>
+      sendJson(exchange, HttpStatus.SC_NOT_FOUND, """{"error":"not found"}""")
     withClient { c =>
-      intercept[InvalidTargetTableException] {
+      val e = intercept[NoSuchTableException] {
         c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.empty(), Optional.empty())
       }
+      assert(e.getMessage.contains(s"$testCatalog.$testSchema.$testTable"))
+      assert(e.getMessage.contains("not found"))
     }
   }
 

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -20,6 +20,8 @@ import java.net.{InetSocketAddress, URI}
 import java.nio.charset.StandardCharsets
 import java.util.{Collections, Optional, Set => JSet, UUID}
 
+import scala.jdk.CollectionConverters._
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
 import io.delta.storage.commit.{Commit, CommitFailedException, TableIdentifier}
@@ -32,7 +34,6 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.http.HttpStatus
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
-import scala.jdk.CollectionConverters._
 
 class UCDeltaTokenBasedRestClientSuite
     extends AnyFunSuite
@@ -666,6 +667,14 @@ class UCDeltaTokenBasedRestClientSuite
         c.getCommits(testTableId.toString, new URI("s3://b/t"), null,
           Optional.empty(), Optional.empty())
       }
+      intercept[NullPointerException] {
+        c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+          null, Optional.empty())
+      }
+      intercept[NullPointerException] {
+        c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+          Optional.empty(), null)
+      }
     }
   }
 
@@ -683,14 +692,17 @@ class UCDeltaTokenBasedRestClientSuite
   }
 
   test("getCommits throws InvalidTargetTableException when table UUID does not match") {
+    val actualUuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440001")
     deltaHandler = (exchange, _) =>
-      sendJson(exchange, HttpStatus.SC_OK,
-        loadTableJson(tableUuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440001")))
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson(tableUuid = actualUuid))
     withClient { c =>
-      intercept[InvalidTargetTableException] {
+      val e = intercept[InvalidTargetTableException] {
         c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.empty(), Optional.empty())
       }
+      assert(e.getMessage.contains(s"$testCatalog.$testSchema.$testTable"))
+      assert(e.getMessage.contains(testTableId.toString))
+      assert(e.getMessage.contains(actualUuid.toString))
     }
   }
 

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.http.HttpStatus
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
+import scala.jdk.CollectionConverters._
 
 class UCDeltaTokenBasedRestClientSuite
     extends AnyFunSuite
@@ -81,7 +82,9 @@ class UCDeltaTokenBasedRestClientSuite
       tableUuid: UUID = testTableId,
       format: String = "DELTA",
       location: String = "s3://bucket/table",
-      tableType: String = "MANAGED"): String =
+      tableType: String = "MANAGED",
+      commitsJson: String = "[]",
+      latestTableVersion: Long = -1L): String =
     s"""{"metadata":{"table-uuid":"$tableUuid","data-source-format":"$format",""" +
     s""""table-type":"$tableType",""" +
     s""""location":"$location",""" +
@@ -89,7 +92,17 @@ class UCDeltaTokenBasedRestClientSuite
     s"""{"name":"date","type":"string","nullable":true,"metadata":{}},""" +
     s"""{"name":"value","type":"integer","nullable":true,"metadata":{}}""" +
     s"""]},""" +
-    s""""properties":{"key1":"val1"},"partition-columns":["date"],"created-time":1000}}"""
+    s""""properties":{"key1":"val1"},"partition-columns":["date"],"created-time":1000},""" +
+    s""""commits":$commitsJson,"latest-table-version":$latestTableVersion}"""
+
+  private def deltaCommitJson(
+      version: Long,
+      fileName: String,
+      fileSize: Long,
+      timestamp: Long,
+      fileModificationTimestamp: Long): String =
+    s"""{"version":$version,"file-name":"$fileName","file-size":$fileSize,""" +
+    s""""timestamp":$timestamp,"file-modification-timestamp":$fileModificationTimestamp}"""
 
   private def readBody(exchange: HttpExchange): String = {
     val is = exchange.getRequestBody
@@ -585,9 +598,93 @@ class UCDeltaTokenBasedRestClientSuite
 
   // --------------- getCommits ---------------
 
-  test("getCommits throws UnsupportedOperationException") {
+  test("getCommits loads table by identifier and returns commits") {
+    var capturedMethod: String = null
+    var capturedPath: String = null
+    val commitsJson = "[" +
+      deltaCommitJson(2L, "00000000000000000002.uuid.json", 200L, 2000L, 2001L) +
+      "]"
+    deltaHandler = (exchange, _) => {
+      capturedMethod = exchange.getRequestMethod
+      capturedPath = exchange.getRequestURI.getPath
+      sendJson(exchange, HttpStatus.SC_OK,
+        loadTableJson(commitsJson = commitsJson, latestTableVersion = 2L))
+    }
+
     withClient { c =>
-      intercept[UnsupportedOperationException] {
+      val response = c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.empty(), Optional.empty())
+
+      assert(capturedMethod === "GET")
+      assert(capturedPath ===
+        "/api/2.1/unity-catalog/delta/v1/catalogs/cat/schemas/sch/tables/tbl")
+      assert(response.getLatestTableVersion === 2L)
+      assert(response.getCommits.size() === 1)
+
+      val commit = response.getCommits.get(0)
+      assert(commit.getVersion === 2L)
+      assert(commit.getCommitTimestamp === 2000L)
+      assert(commit.getFileStatus.getLen === 200L)
+      assert(commit.getFileStatus.getModificationTime === 2001L)
+      assert(commit.getFileStatus.getPath.toString ===
+        "s3://b/t/_delta_log/_staged_commits/00000000000000000002.uuid.json")
+    }
+  }
+
+  test("getCommits filters loaded commits by requested version range") {
+    val commitsJson = Seq(
+      deltaCommitJson(1L, "1.uuid.json", 100L, 1000L, 1001L),
+      deltaCommitJson(2L, "2.uuid.json", 200L, 2000L, 2001L),
+      deltaCommitJson(3L, "3.uuid.json", 300L, 3000L, 3001L),
+      deltaCommitJson(4L, "4.uuid.json", 400L, 4000L, 4001L)
+    ).mkString("[", ",", "]")
+    deltaHandler = (exchange, _) =>
+      sendJson(exchange, HttpStatus.SC_OK,
+        loadTableJson(commitsJson = commitsJson, latestTableVersion = 4L))
+
+    withClient { c =>
+      val response = c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.of(java.lang.Long.valueOf(2L)),
+        Optional.of(java.lang.Long.valueOf(3L)))
+
+      assert(response.getLatestTableVersion === 4L)
+      assert(response.getCommits.asScala.map(_.getVersion).toSeq === Seq(2L, 3L))
+    }
+  }
+
+  test("getCommits validates required parameters") {
+    withClient { c =>
+      intercept[NullPointerException] {
+        c.getCommits(null, new URI("s3://b/t"), testIdentifier,
+          Optional.empty(), Optional.empty())
+      }
+      intercept[NullPointerException] {
+        c.getCommits(testTableId.toString, null, testIdentifier,
+          Optional.empty(), Optional.empty())
+      }
+      intercept[NullPointerException] {
+        c.getCommits(testTableId.toString, new URI("s3://b/t"), null,
+          Optional.empty(), Optional.empty())
+      }
+    }
+  }
+
+  test("getCommits throws InvalidTargetTableException on 404") {
+    deltaHandler = (exchange, _) => sendJson(exchange, HttpStatus.SC_NOT_FOUND, "{}")
+    withClient { c =>
+      intercept[InvalidTargetTableException] {
+        c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+          Optional.empty(), Optional.empty())
+      }
+    }
+  }
+
+  test("getCommits throws InvalidTargetTableException when table UUID does not match") {
+    deltaHandler = (exchange, _) =>
+      sendJson(exchange, HttpStatus.SC_OK,
+        loadTableJson(tableUuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440001")))
+    withClient { c =>
+      intercept[InvalidTargetTableException] {
         c.getCommits(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.empty(), Optional.empty())
       }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Storage)

## Description

This PR is stacked on #6788.

#6788 passes the Unity Catalog table identifier (`catalog.schema.table`) through the `UCClient#getCommits` path. This PR builds on top of that and implements `getCommits` in `UCDeltaTokenBasedRestClient`.

The implementation:

- loads the UC Delta table by `catalog.schema.table`
- validates that the returned UC table UUID matches the requested `tableId`
- converts returned UC `DeltaCommit` entries into storage `Commit` entries
- applies the optional start/end version filters locally

Review focus for this stacked PR:

Stack diff: https://github.com/TimothyW553/delta/compare/728930d4ad8a122a4952c71ea4093a30ba81a46c...29c699c52c7f8de17bdc0fa0c175b33034bc9efe

## How was this patch tested?

```bash
build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClientSuite" "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClientSuite"
```

## Does this PR introduce _any_ user-facing changes?

No.
