### PR TITLE
[Flink][Upsert Step 2] Add upsert merge strategy implementations

### DIFF
--- a/flink/src/main/java/io/delta/flink/kernel/ExpressionUtils.java
+++ b/flink/src/main/java/io/delta/flink/kernel/ExpressionUtils.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.kernel;
+
+import io.delta.kernel.expressions.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Helpers for building Kernel {@link Predicate} expressions that aren't natively expressible in
+ * Kernel's expression API. Currently this is just the row-{@code IN} builder used to construct
+ * partition / primary-key membership filters in the upsert merge path; expand as needed when other
+ * compound expressions earn their own helper.
+ */
+public class ExpressionUtils {
+  /**
+   * Generate a predicate equivalent to <code>(colNames) IN (values)</code>. Empty {@code values} →
+   * {@link AlwaysFalse#ALWAYS_FALSE}. Single-column → native {@link In} for engine pushdown.
+   * Multi-column → left-deep OR-of-ANDs ({@code (c1=v11 AND ...) OR (c1=v21 AND ...) OR ...}),
+   * since Kernel has no row-IN expression.
+   *
+   * @param colNames left-side tuple of column names; must be non-empty
+   * @param values right-side list of value tuples; each row must have the same arity as {@code
+   *     colNames}
+   * @throws IllegalArgumentException if {@code colNames} is empty or any tuple arity mismatches
+   */
+  public static Predicate in(List<String> colNames, List<List<Literal>> values) {
+    if (colNames.isEmpty()) {
+      throw new IllegalArgumentException("in() requires at least one column");
+    }
+    if (values.isEmpty()) {
+      return AlwaysFalse.ALWAYS_FALSE;
+    }
+    for (List<Literal> row : values) {
+      if (row.size() != colNames.size()) {
+        throw new IllegalArgumentException(
+            "Value tuple arity " + row.size() + " does not match column count " + colNames.size());
+      }
+    }
+
+    // Single-column fast path: use the native IN predicate (the engine can push it down better
+    // than an OR chain).
+    if (colNames.size() == 1) {
+      Column col = new Column(colNames.get(0));
+      List<Expression> literals =
+          values.stream().map(row -> (Expression) row.get(0)).collect(Collectors.toList());
+      return new In(col, literals);
+    }
+
+    // Multi-column: build (c1=v11 AND c2=v12 AND ...) OR (c1=v21 AND c2=v22 AND ...) OR ...
+    // We accumulate left-deep AND/OR trees rather than building everything as a flat predicate,
+    // because Kernel's And/Or only support binary children.
+    Predicate result = null;
+    for (List<Literal> row : values) {
+      Predicate rowEq = null;
+      for (int i = 0; i < colNames.size(); i++) {
+        Predicate eq = new Predicate("=", new Column(colNames.get(i)), row.get(i));
+        rowEq = (rowEq == null) ? eq : new And(rowEq, eq);
+      }
+      result = (result == null) ? rowEq : new Or(result, rowEq);
+    }
+    return result;
+  }
+}

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import io.delta.flink.sink.DeltaSinkConf;
+import io.delta.flink.sink.MergeStrategy;
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * No-op {@link MergeStrategy} used by {@link DeltaSinkConf.WriteMode#APPEND}.
+ *
+ * <p>In append mode every incoming row is written via {@link DeltaTable#writeParquet} and no
+ * existing files need to be modified. The writer must never call {@link #recordUpsert} or {@link
+ * #recordDelete} in append mode; if it does, that's a programming error and we fail loudly.
+ */
+public class AppendOnly implements MergeStrategy {
+
+  @Override
+  public void recordUpsert(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
+    throw new IllegalStateException(
+        "AppendOnlyMergeStrategy received an upsert record; this should only happen in "
+            + "upsert mode.");
+  }
+
+  @Override
+  public void recordDelete(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
+    throw new IllegalStateException(
+        "AppendOnlyMergeStrategy received a delete record; this should only happen in "
+            + "upsert mode.");
+  }
+
+  @Override
+  public List<Row> merge(DeltaTable table, DeltaSinkConf conf) {
+    return Collections.emptyList();
+  }
+}

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * No-op {@link MergeStrategy} used by {@link DeltaSinkConf.WriteMode#APPEND}.
+ * No-op {@link MergeStrategy} used by append-mode sinks.
  *
  * <p>In append mode every incoming row is written via {@link DeltaTable#writeParquet} and no
  * existing files need to be modified. The writer must never call {@link #recordUpsert} or {@link

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/CoWUpsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/CoWUpsert.java
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
+
+import io.delta.flink.kernel.ColumnVectorUtils;
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.types.*;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+
+/**
+ * Copy-on-write {@link Upsert}: for each candidate file, read it through Kernel, build a selection
+ * vector that masks out rows matching the deletion filter, write the survivors to a new Parquet
+ * file co-located with the source, and emit a {@code RemoveFile} for the source plus zero-or-more
+ * {@code AddFile}s for the rewrite.
+ *
+ * <p>The {@code RemoveFile} is built via {@link
+ * io.delta.kernel.internal.actions.AddFile#toRemoveFileRow}, so it carries over the source's stats,
+ * partition values, tags, baseRowId, defaultRowCommitVersion and deletion vector — every field
+ * Delta requires for an {@code extendedFileMetadata} RemoveFile.
+ */
+public class CoWUpsert extends Upsert {
+
+  public CoWUpsert() {
+    super(new ScanLocator());
+  }
+
+  /**
+   * Read the source Parquet, mask out rows matching {@code filter} via a selection vector, stream
+   * the survivors through {@link DeltaTable#writeParquet} (co-located with the source), and prepend
+   * a {@code RemoveFile} for the source to the resulting {@code AddFile} stream. If every row
+   * matches the filter, no {@code AddFile} is emitted — just the {@code RemoveFile}.
+   *
+   * @throws UncheckedIOException if the Parquet read or write fails
+   */
+  @Override
+  protected CloseableIterator<Row> deleteRecords(
+      Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
+    Engine engine = table.getEngine();
+    final StructType schema = table.getSchema();
+
+    // Source file metadata from the scan file row.
+    final FileStatus source = InternalScanFileUtils.getAddFileStatus(addFile);
+    final Map<String, String> partStrings = InternalScanFileUtils.getPartitionValues(addFile);
+    // addFile has the SCAN_FILE_SCHEMA shape (add, tableRoot), not the SingleAction shape.
+    // Use InternalScanFileUtils.ADD_FILE_ORDINAL — the ordinal of "add" within SCAN_FILE_SCHEMA.
+    final AddFile sourceAddFile =
+        new AddFile(addFile.getStruct(InternalScanFileUtils.ADD_FILE_ORDINAL));
+
+    // Convert serialized partition values to typed Literals — required by table.writeParquet for
+    // the new AddFile.
+    final Map<String, Literal> partLiterals = toLiteralPartitionMap(schema, partStrings);
+
+    // Read → filter → write pipeline. The filter is applied lazily, batch-by-batch, via a
+    // selection vector so we don't materialize whole rows just to drop a few.
+    final CloseableIterator<FilteredColumnarBatch> survivors;
+    final CloseableIterator<Row> addActions;
+    try {
+      survivors =
+          engine
+              .getParquetHandler()
+              .readParquetFiles(singletonCloseableIterator(source), schema, Optional.empty())
+              .map(result -> applyDeletionFilter(result.getData(), filter));
+
+      // Co-locate the rewrite with the source file so the new file inherits the same partition
+      // directory layout (Delta requires AddFile.partitionValues to match the path-encoded
+      // partition; staying in the same folder is the safest way to keep them consistent).
+      // ParquetFileWriter generates UUID-suffixed filenames so two rewrites of the same source
+      // file can't collide.
+      String pathSuffix = sourceAddFile.getPath();
+      int slash = sourceAddFile.getPath().lastIndexOf('/');
+      if (slash >= 0) {
+        pathSuffix = sourceAddFile.getPath().substring(0, slash);
+      }
+      addActions = table.writeParquet(pathSuffix, survivors, partLiterals);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to rewrite " + sourceAddFile.getPath(), e);
+    }
+
+    // RemoveFile for the source file. AddFile.toRemoveFileRow carries over path, partition
+    // values, size, stats, tags, baseRowId, defaultRowCommitVersion and deletionVector — i.e.
+    // every field Delta requires for an "extendedFileMetadata" RemoveFile.
+    final Row removeAction =
+        SingleAction.createRemoveFileSingleAction(
+            sourceAddFile.toRemoveFileRow(true /* dataChange */, Optional.empty()));
+
+    // Emit RemoveFile first, then the AddFile(s). Delta commits don't care about action order
+    // within the same commit, but emitting Remove-before-Add reads more naturally.
+    return singletonCloseableIterator(removeAction).combine(addActions);
+  }
+
+  /**
+   * Wrap {@code batch} with a selection vector that excludes rows matching {@code filter}.
+   *
+   * <p>{@link FilteredColumnarBatch}'s selection vector follows the SQL convention <em>"true =
+   * keep, false = drop"</em>. Our caller's contract is the opposite — {@code filter.test(...)}
+   * returns {@code true} for rows to be <em>deleted</em> — so we negate when building the selection
+   * vector. The underlying batch's column vectors are reused unmodified; no per-row materialization
+   * on the rewrite path.
+   */
+  private static FilteredColumnarBatch applyDeletionFilter(
+      ColumnarBatch batch, BiPredicate<ColumnarBatch, Integer> filter) {
+    return new FilteredColumnarBatch(
+        batch, ColumnVectorUtils.filter(batch.getSize(), rowId -> !filter.test(batch, rowId)));
+  }
+
+  /**
+   * Convert the partition string map from a scan-file row into a typed-Literal map keyed by the
+   * partition column names — the form expected by {@link DeltaTable#writeParquet}.
+   */
+  private static Map<String, Literal> toLiteralPartitionMap(
+      StructType schema, Map<String, String> partitionStrings) {
+    final Map<String, Literal> out = new HashMap<>(partitionStrings.size());
+    for (Map.Entry<String, String> e : partitionStrings.entrySet()) {
+      final int idx = schema.indexOf(e.getKey());
+      if (idx < 0) {
+        throw new IllegalStateException(
+            "Partition column " + e.getKey() + " not found in table schema " + schema);
+      }
+      final DataType type = schema.fields().get(idx).getDataType();
+      out.put(e.getKey(), parsePartitionLiteral(type, e.getValue()));
+    }
+    return out;
+  }
+
+  /**
+   * Parse the Delta-serialized string form of a partition value into a typed {@link Literal}.
+   *
+   * <p>Mirrors {@code io.delta.kernel.internal.util.PartitionUtils#literalForPartitionValue}, which
+   * is package-private and not callable from here.
+   *
+   * <p>Timestamp, decimal, and binary partition values aren't yet covered — they require Delta's
+   * specific string-to-microseconds / string-to-BigDecimal parsing logic; add support for them when
+   * a real workload demands them.
+   */
+  private static Literal parsePartitionLiteral(DataType type, String value) {
+    if (value == null) {
+      return Literal.ofNull(type);
+    }
+    if (type instanceof BooleanType) return Literal.ofBoolean(Boolean.parseBoolean(value));
+    if (type instanceof ByteType) return Literal.ofByte(Byte.parseByte(value));
+    if (type instanceof ShortType) return Literal.ofShort(Short.parseShort(value));
+    if (type instanceof IntegerType) return Literal.ofInt(Integer.parseInt(value));
+    if (type instanceof LongType) return Literal.ofLong(Long.parseLong(value));
+    if (type instanceof FloatType) return Literal.ofFloat(Float.parseFloat(value));
+    if (type instanceof DoubleType) return Literal.ofDouble(Double.parseDouble(value));
+    if (type instanceof StringType) return Literal.ofString(value);
+    if (type instanceof DateType) {
+      return Literal.ofDate((int) LocalDate.parse(value).toEpochDay());
+    }
+    throw new UnsupportedOperationException(
+        "Unsupported partition column type for upsert rewrite: " + type);
+  }
+}

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/IndexLocator.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/IndexLocator.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.utils.CloseableIterator;
+import java.util.List;
+
+/**
+ * {@link RowLocator} that consults an externally-maintained secondary index (Hudi-Bloom-style) over
+ * the PK columns to skip files Bloom-misses. Intended for tables where PKs aren't clustered by file
+ * and {@link ScanLocator} degrades to a full scan.
+ *
+ * <p><b>Status:</b> not implemented. {@link #find} throws; needs the index storage, write path, and
+ * lookup logic to be built out.
+ */
+public class IndexLocator implements RowLocator {
+
+  @Override
+  public CloseableIterator<Row> find(DeltaTable table, int[] pkIndices, List<List<Literal>> pks) {
+    throw new UnsupportedOperationException("Not implemented. WIP");
+  }
+}

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/MoRUpsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/MoRUpsert.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.utils.CloseableIterator;
+import java.util.function.BiPredicate;
+
+/**
+ * Merge-on-read {@link Upsert} (stub). Logically deletes rows by writing deletion vectors over the
+ * existing data files; readers combine each base file with its DV at scan time.
+ *
+ * <p><b>Status:</b> not implemented. {@link #deleteRecords} throws; needs DV writing, the {@code
+ * deletionVectors} table feature, and concurrent-commit retry handling before it can ship.
+ */
+public class MoRUpsert extends Upsert {
+
+  public MoRUpsert() {
+    super(new ScanLocator());
+  }
+
+  @Override
+  protected CloseableIterator<Row> deleteRecords(
+      Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+}

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/ScanLocator.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/ScanLocator.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import static io.delta.flink.kernel.ExpressionUtils.in;
+
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.utils.CloseableIterator;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Default {@link RowLocator}: builds an {@code (pkCols) IN (pks)} predicate via {@link
+ * io.delta.flink.kernel.ExpressionUtils#in} and runs it through Kernel's snapshot scan-files step,
+ * so only files whose stats overlap the PK set are returned.
+ *
+ * <p>Correct on any Delta table, no extra index required. Pruning quality depends on the Parquet
+ * min/max stats; tight for time-ordered PKs, degrades toward a full scan for UUID-like PKs (use
+ * {@link IndexLocator} once implemented for that case).
+ */
+public class ScanLocator implements RowLocator {
+
+  @Override
+  public CloseableIterator<Row> find(DeltaTable table, int[] pkIndices, List<List<Literal>> pks) {
+
+    List<String> pkNames =
+        Arrays.stream(pkIndices)
+            .mapToObj(idx -> table.getSchema().fieldNames().get(idx))
+            .collect(Collectors.toList());
+    Predicate filterPk = in(pkNames, pks);
+
+    return table.scan(filterPk);
+  }
+}

--- a/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
+++ b/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
@@ -16,6 +16,8 @@
 
 package io.delta.flink.table;
 
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
+
 import dev.failsafe.Failsafe;
 import dev.failsafe.Fallback;
 import dev.failsafe.RetryPolicy;
@@ -34,6 +36,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.TableAlreadyExistsException;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.data.TransactionStateRow;
 import io.delta.kernel.metrics.TransactionReport;
@@ -316,6 +319,19 @@ public abstract class AbstractKernelTable implements DeltaTable {
           return Transaction.generateAppendActions(
               localEngine, writeState, dataFiles, writeContext);
         });
+  }
+
+  @Override
+  public CloseableIterator<Row> scan(Predicate predicate) {
+    return snapshot()
+        .map(
+            s ->
+                s.getScanBuilder()
+                    .withFilter(predicate)
+                    .build()
+                    .getScanFiles(getEngine())
+                    .flatMap(FilteredColumnarBatch::getRows))
+        .orElse(toCloseableIterator(Collections.emptyIterator()));
   }
 
   /**

--- a/flink/src/main/java/io/delta/flink/table/DeltaTable.java
+++ b/flink/src/main/java/io/delta/flink/table/DeltaTable.java
@@ -20,6 +20,7 @@ import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.kernel.utils.CloseableIterator;
@@ -165,4 +166,6 @@ public interface DeltaTable extends Serializable, AutoCloseable {
       CloseableIterator<FilteredColumnarBatch> data,
       Map<String, Literal> partitionValues)
       throws IOException;
+
+  CloseableIterator<Row> scan(Predicate predicate);
 }

--- a/flink/src/test/java/io/delta/flink/sink/mergestrategy/CoWUpsertTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/mergestrategy/CoWUpsertTest.java
@@ -1,0 +1,516 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.flink.TestHelper;
+import io.delta.flink.sink.DeltaSinkConf;
+import io.delta.flink.sink.DeltaWriterResult;
+import io.delta.flink.sink.DeltaWriterTask;
+import io.delta.flink.sink.TestSinkWriterContext;
+import io.delta.flink.table.AbstractKernelTable;
+import io.delta.flink.table.HadoopTable;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.AlwaysTrue;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.RemoveFile;
+import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Per-file tests for {@link CoWUpsert#deleteRecords}.
+ *
+ * <p>This suite exercises the file-rewrite half of the upsert pipeline in isolation — it supplies a
+ * scan-file row and a row-level filter directly, bypassing {@link
+ * io.delta.flink.sink.MergeStrategy#recordUpsert} / {@link
+ * io.delta.flink.sink.MergeStrategy#recordDelete} / {@link Upsert#merge}. End-to-end tests of the
+ * full merge pipeline (including {@link RowLocator} and the PK-driven filter construction) are out
+ * of scope here.
+ *
+ * <p>{@link CoWUpsert#deleteRecords} is {@code protected}, so we wrap it in a tiny test-only
+ * subclass ({@link ExposedCoWUpsert}) that exposes the method plus the {@code table} field.
+ */
+class CoWUpsertTest extends TestHelper {
+
+  private static final StructType SCHEMA =
+      new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+
+  /** Column ordinal of {@code id} in {@link #SCHEMA}. */
+  private static final int ID_ORDINAL = 0;
+
+  // -------------------------------------------------------------------------
+  // Tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testDropSomeRows() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          Row scanFileRow = writeAndScan(table, SCHEMA, 10, Collections.emptyMap());
+
+          // Drop rows whose id is even — 5 survivors expected.
+          BiPredicate<ColumnarBatch, Integer> deleteEvens = idMatches(i -> i % 2 == 0);
+
+          List<Row> actions = runDeleteRecords(table, scanFileRow, deleteEvens).toInMemoryList();
+
+          assertEquals(2, actions.size(), "expected RemoveFile + AddFile");
+          assertIsRemoveAction(actions.get(0));
+          assertIsAddAction(actions.get(1));
+
+          AddFile addFile = addFileOf(actions.get(1));
+          Path newFile = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+          List<Row> survivors = readParquet(newFile, SCHEMA);
+          assertEquals(5, survivors.size());
+          for (Row r : survivors) {
+            assertEquals(1, r.getInt(0) % 2, "even id leaked through filter");
+          }
+
+          // RemoveFile path matches source AddFile path (same relative form).
+          RemoveFile removeFile =
+              new RemoveFile(actions.get(0).getStruct(SingleAction.REMOVE_FILE_ORDINAL));
+          assertEquals(sourceAddFile(scanFileRow).getPath(), removeFile.getPath());
+        });
+  }
+
+  @Test
+  void testDropAllRows() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          Row scanFileRow = writeAndScan(table, SCHEMA, 10, Collections.emptyMap());
+
+          List<Row> actions =
+              runDeleteRecords(table, scanFileRow, /* drop all */ (b, r) -> true).toInMemoryList();
+
+          // Exactly one RemoveFile is required (the source file must be retired).
+          int removes = 0;
+          int addsWithSurvivors = 0;
+          for (Row action : actions) {
+            if (!action.isNullAt(SingleAction.REMOVE_FILE_ORDINAL)) {
+              removes++;
+            }
+            if (!action.isNullAt(SingleAction.ADD_FILE_ORDINAL)) {
+              // Whether the writer emits an empty-file AddFile is implementation-defined; if it
+              // does, the resulting Parquet file must be row-empty.
+              AddFile addFile = addFileOf(action);
+              Path newFile = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+              if (!readParquet(newFile, SCHEMA).isEmpty()) {
+                addsWithSurvivors++;
+              }
+            }
+          }
+          assertEquals(1, removes, "expected exactly one RemoveFile");
+          assertEquals(
+              0, addsWithSurvivors, "no AddFile should contain any rows when all are deleted");
+        });
+  }
+
+  @Test
+  void testKeepAllRows() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          final int numRows = 7;
+          Row scanFileRow = writeAndScan(table, SCHEMA, numRows, Collections.emptyMap());
+
+          List<Row> actions =
+              runDeleteRecords(table, scanFileRow, /* keep all */ (b, r) -> false).toInMemoryList();
+
+          assertEquals(2, actions.size(), "expected RemoveFile + AddFile");
+          assertIsRemoveAction(actions.get(0));
+          assertIsAddAction(actions.get(1));
+
+          AddFile addFile = addFileOf(actions.get(1));
+          Path newFile = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+          List<Row> survivors = readParquet(newFile, SCHEMA);
+          assertEquals(numRows, survivors.size());
+          for (int i = 0; i < numRows; i++) {
+            assertEquals(i, survivors.get(i).getInt(0), "row order changed");
+          }
+        });
+  }
+
+  @Test
+  void testPreservesPartitionValues() {
+    withTempDir(
+        dir -> {
+          StructType partSchema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table = openTable(dir, partSchema, List.of("part"));
+
+          Map<String, Literal> partValues = Map.of("part", Literal.ofString("p0"));
+          Row scanFileRow = writeAndScan(table, partSchema, 6, partValues);
+
+          List<Row> actions =
+              runDeleteRecords(table, scanFileRow, idMatches(i -> i < 3)).toInMemoryList();
+
+          assertEquals(2, actions.size());
+          AddFile addFile = addFileOf(actions.get(1));
+
+          // Partition values round-trip onto the new AddFile.
+          MapValue pm = addFile.getPartitionValues();
+          assertEquals(1, pm.getSize());
+          assertEquals("part", pm.getKeys().getString(0));
+          assertEquals("p0", pm.getValues().getString(0));
+
+          Path newFile = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+          List<Row> survivors = readParquet(newFile, partSchema);
+          assertEquals(3, survivors.size());
+          for (Row r : survivors) {
+            assertTrue(r.getInt(0) >= 3);
+          }
+        });
+  }
+
+  @Test
+  void testRewriteCoLocatedWithSource() {
+    withTempDir(
+        dir -> {
+          StructType partSchema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table = openTable(dir, partSchema, List.of("part"));
+
+          Map<String, Literal> partValues = Map.of("part", Literal.ofString("p7"));
+          Row scanFileRow = writeAndScan(table, partSchema, 4, partValues);
+
+          List<Row> actions =
+              runDeleteRecords(table, scanFileRow, idMatches(i -> i == 0)).toInMemoryList();
+
+          assertEquals(2, actions.size());
+          String sourcePath = sourceAddFile(scanFileRow).getPath();
+          String newPath = addFileOf(actions.get(1)).getPath();
+
+          // The actual co-location guarantee: rewrite shares the source's parent directory.
+          // Note: the on-disk layout for Flink-Delta writes is NOT partition-based — files land
+          // under <jobId>-<subtaskId>-<attemptNumber>/<uuid>.parquet and the partition is
+          // tracked only in AddFile.partitionValues. So we don't assert anything about a
+          // "part=p7/" prefix in the path; we just check the parent dirs agree.
+          assertEquals(
+              parentDir(sourcePath),
+              parentDir(newPath),
+              "rewrite must land in the same folder as the source");
+        });
+  }
+
+  @Test
+  void testCarriesOverStatsFromSourceAddFileToRemove() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          Row scanFileRow = writeAndScan(table, SCHEMA, 10, Collections.emptyMap());
+
+          List<Row> actions =
+              runDeleteRecords(table, scanFileRow, /* keep all */ (b, r) -> false).toInMemoryList();
+
+          // The RemoveFile constructed via AddFile.toRemoveFileRow carries over size and path;
+          // verify the metadata wasn't silently dropped during the conversion.
+          AddFile srcAdd = sourceAddFile(scanFileRow);
+          RemoveFile removeFile =
+              new RemoveFile(actions.get(0).getStruct(SingleAction.REMOVE_FILE_ORDINAL));
+
+          // RemoveFile.getSize() is Optional<Long>; AddFile.getSize() is a plain long. Compare
+          // the values (the Optional should always be present here because toRemoveFileRow
+          // copies the source's size unconditionally).
+          assertTrue(removeFile.getSize().isPresent(), "RemoveFile.size missing");
+          assertEquals(srcAdd.getSize(), removeFile.getSize().get().longValue());
+          assertEquals(srcAdd.getPath(), removeFile.getPath());
+        });
+  }
+
+  @Test
+  void testFilterReceivesEveryRow() {
+    // Defensive: ensure the filter is invoked for every input row exactly once, in row order.
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          final int numRows = 8;
+          Row scanFileRow = writeAndScan(table, SCHEMA, numRows, Collections.emptyMap());
+
+          List<Integer> idsSeen = new ArrayList<>();
+          BiPredicate<ColumnarBatch, Integer> recording =
+              (batch, rowId) -> {
+                idsSeen.add(batch.getColumnVector(ID_ORDINAL).getInt(rowId));
+                return false; // keep all
+              };
+
+          List<Row> actions = runDeleteRecords(table, scanFileRow, recording).toInMemoryList();
+          // Force survivor materialization (writeParquet is lazy until the iterator is consumed).
+          AddFile addFile = addFileOf(actions.get(1));
+          readParquet(dir.toPath().resolve(addFile.getPath()).toAbsolutePath(), SCHEMA);
+
+          // 8 ids observed, in ascending order matching how writeAndScan populated the file.
+          assertEquals(numRows, idsSeen.size());
+          for (int i = 0; i < numRows; i++) {
+            assertEquals(Integer.valueOf(i), idsSeen.get(i));
+          }
+        });
+  }
+
+  @Test
+  void testDropByCompositeKey() {
+    // Exercises a multi-column primary-key delete. The filter reads two columns
+    // (org_id, region) and removes the rows whose tuple is in a delete set — the same shape an
+    // Upsert strategy uses when the PK has more than one column.
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType()
+                  .add("org_id", IntegerType.INTEGER)
+                  .add("region", StringType.STRING)
+                  .add("payload", StringType.STRING);
+
+          HadoopTable table = openTable(dir, schema, Collections.emptyList());
+
+          // 6 rows; (org_id, region) is the composite PK.
+          List<GenericRowData> rows =
+              List.of(
+                  GenericRowData.of(1, StringData.fromString("us"), StringData.fromString("p0")),
+                  GenericRowData.of(1, StringData.fromString("eu"), StringData.fromString("p1")),
+                  GenericRowData.of(2, StringData.fromString("us"), StringData.fromString("p2")),
+                  GenericRowData.of(2, StringData.fromString("eu"), StringData.fromString("p3")),
+                  GenericRowData.of(3, StringData.fromString("us"), StringData.fromString("p4")),
+                  GenericRowData.of(3, StringData.fromString("eu"), StringData.fromString("p5")));
+          Row scanFileRow = writeAndScanRows(table, schema, rows);
+
+          // Delete two specific PKs: (1, "eu") and (3, "us"). 4 survivors expected.
+          Set<List<Object>> deleteKeys = Set.of(List.of(1, "eu"), List.of(3, "us"));
+          BiPredicate<ColumnarBatch, Integer> filter =
+              (batch, rowId) -> {
+                int orgId = batch.getColumnVector(0).getInt(rowId);
+                String region = batch.getColumnVector(1).getString(rowId);
+                return deleteKeys.contains(List.of(orgId, region));
+              };
+
+          List<Row> actions = runDeleteRecords(table, scanFileRow, filter).toInMemoryList();
+
+          assertEquals(2, actions.size(), "expected RemoveFile + AddFile");
+          assertIsRemoveAction(actions.get(0));
+          assertIsAddAction(actions.get(1));
+
+          AddFile addFile = addFileOf(actions.get(1));
+          Path newFile = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+          List<Row> survivors = readParquet(newFile, schema);
+
+          // 4 survivors, none matching any delete key.
+          assertEquals(4, survivors.size(), "expected 4 surviving rows");
+          for (Row r : survivors) {
+            int orgId = r.getInt(0);
+            String region = r.getString(1);
+            assertFalse(
+                deleteKeys.contains(List.of(orgId, region)),
+                "row (" + orgId + ", " + region + ") should have been deleted");
+          }
+
+          // Order-preserving spot-check by payload: expected survivors in source order are
+          // p0 (1,us), p2 (2,us), p3 (2,eu), p5 (3,eu).
+          assertEquals("p0", survivors.get(0).getString(2));
+          assertEquals("p2", survivors.get(1).getString(2));
+          assertEquals("p3", survivors.get(2).getString(2));
+          assertEquals("p5", survivors.get(3).getString(2));
+        });
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Test-only subclass of {@link CoWUpsert} that exposes the {@code protected} {@code
+   * deleteRecords(...)} method and the inherited {@code table} field. Bypassing {@link
+   * Upsert#merge} lets us hand the strategy a scan-file row and a synthetic filter directly,
+   * isolating the file-rewrite behavior from the locator and PK-bookkeeping concerns.
+   */
+  private static final class ExposedCoWUpsert extends CoWUpsert {
+    ExposedCoWUpsert(AbstractKernelTable backingTable) {
+      this.table = backingTable;
+    }
+
+    CloseableIterator<Row> deleteRecordsForTest(
+        Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
+      return deleteRecords(addFile, filter);
+    }
+  }
+
+  /** Build a "drop rows where {@code id} matches {@code idTest}" filter. */
+  private static BiPredicate<ColumnarBatch, Integer> idMatches(
+      java.util.function.IntPredicate idTest) {
+    return (batch, rowId) -> idTest.test(batch.getColumnVector(ID_ORDINAL).getInt(rowId));
+  }
+
+  /** Open a fresh HadoopTable rooted at {@code dir} with the given schema and partition cols. */
+  private HadoopTable openTable(File dir, StructType schema, List<String> partitionCols) {
+    HadoopTable table =
+        new HadoopTable(
+            URI.create(dir.getAbsolutePath()),
+            Collections.emptyMap(),
+            schema,
+            partitionCols.isEmpty() ? Collections.emptyList() : partitionCols);
+    table.open();
+    return table;
+  }
+
+  /**
+   * Write {@code numRows} rows into {@code table} via a {@link DeltaWriterTask}, commit the
+   * resulting AddFile actions, and return the scan-file row for the (single) data file produced.
+   *
+   * <p>Rows are populated as {@code (id=i, name="row-i")} for unpartitioned tables, or {@code
+   * (id=i, part=<partition-value>)} when {@code partitionValues} is non-empty.
+   */
+  private Row writeAndScan(
+      HadoopTable table, StructType schema, int numRows, Map<String, Literal> partitionValues) {
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Collections.emptyMap());
+    DeltaWriterTask task =
+        new DeltaWriterTask(
+            "test-job", /* subtaskId= */ 0, /* attemptNumber= */ 0, table, conf, partitionValues);
+
+    String partString =
+        partitionValues.isEmpty()
+            ? null
+            : String.valueOf(partitionValues.values().iterator().next().getValue());
+
+    for (int i = 0; i < numRows; i++) {
+      Object[] cells = new Object[schema.length()];
+      cells[0] = Integer.valueOf(i);
+      cells[1] =
+          partString != null
+              ? StringData.fromString(partString)
+              : StringData.fromString("row-" + i);
+      try {
+        task.write(GenericRowData.of(cells), new TestSinkWriterContext(0, 0));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return commitAndScan(table, task);
+  }
+
+  /**
+   * Variant of {@link #writeAndScan} for callers that have already built the rows themselves —
+   * useful for schemas with more than two columns or non-trivial row payloads.
+   *
+   * <p>The DeltaWriterTask is created with empty partition values (i.e. unpartitioned), so this
+   * helper is only suitable for unpartitioned tables.
+   */
+  private Row writeAndScanRows(HadoopTable table, StructType schema, List<GenericRowData> rows) {
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Collections.emptyMap());
+    DeltaWriterTask task =
+        new DeltaWriterTask(
+            "test-job", /* subtaskId= */ 0, /* attemptNumber= */ 0, table, conf, Map.of());
+    try {
+      for (GenericRowData row : rows) {
+        task.write(row, new TestSinkWriterContext(0, 0));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return commitAndScan(table, task);
+  }
+
+  /**
+   * Shared tail of {@link #writeAndScan} and {@link #writeAndScanRows}: finalize the writer task,
+   * commit the produced AddFile actions to the table, and return the (single) scan-file row.
+   */
+  private Row commitAndScan(HadoopTable table, DeltaWriterTask task) {
+    List<DeltaWriterResult> results;
+    try {
+      results = task.complete();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    List<Row> actions = new ArrayList<>();
+    for (DeltaWriterResult r : results) {
+      actions.addAll(r.getDeltaActions());
+    }
+    table.commit(
+        CloseableIterable.inMemoryIterable(toCloseableIterator(actions.iterator())),
+        "test-app",
+        /* txnId= */ 0L,
+        Collections.emptyMap());
+
+    // Materialize scan-file rows so they outlive the scan iterator. We don't wrap in
+    // try-with-resources here: toInMemoryList() closes the iterator internally, and an explicit
+    // double-close triggers an IllegalStateException inside Kernel's ScanImpl close path
+    // (it calls hasNext() on an already-closed underlying iterator).
+    List<Row> all = table.scan(AlwaysTrue.ALWAYS_TRUE).toInMemoryList();
+    assertEquals(1, all.size(), "expected exactly one scan file from commitAndScan");
+    return all.get(0);
+  }
+
+  /**
+   * Invoke {@link CoWUpsert#deleteRecords} for the given scan-file row and filter, going through
+   * the test-only subclass that exposes the protected method.
+   */
+  private CloseableIterator<Row> runDeleteRecords(
+      HadoopTable table, Row scanFileRow, BiPredicate<ColumnarBatch, Integer> filter) {
+    return new ExposedCoWUpsert(table).deleteRecordsForTest(scanFileRow, filter);
+  }
+
+  private static AddFile addFileOf(Row singleAction) {
+    return new AddFile(singleAction.getStruct(SingleAction.ADD_FILE_ORDINAL));
+  }
+
+  /** Unwrap the {@code add} struct from a scan-file row, using the public ordinal constant. */
+  private static AddFile sourceAddFile(Row scanFileRow) {
+    return new AddFile(scanFileRow.getStruct(InternalScanFileUtils.ADD_FILE_ORDINAL));
+  }
+
+  private static String parentDir(String relativePath) {
+    int slash = relativePath.lastIndexOf('/');
+    return slash >= 0 ? relativePath.substring(0, slash) : "";
+  }
+
+  private static void assertIsRemoveAction(Row action) {
+    assertFalse(
+        action.isNullAt(SingleAction.REMOVE_FILE_ORDINAL),
+        "expected the action to carry a RemoveFile");
+    assertTrue(
+        action.isNullAt(SingleAction.ADD_FILE_ORDINAL),
+        "did not expect the action to also carry an AddFile");
+  }
+
+  private static void assertIsAddAction(Row action) {
+    assertFalse(
+        action.isNullAt(SingleAction.ADD_FILE_ORDINAL), "expected the action to carry an AddFile");
+    assertTrue(
+        action.isNullAt(SingleAction.REMOVE_FILE_ORDINAL),
+        "did not expect the action to also carry a RemoveFile");
+  }
+}

--- a/flink/src/test/java/io/delta/flink/sink/mergestrategy/ScanLocatorTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/mergestrategy/ScanLocatorTest.java
@@ -1,0 +1,257 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.flink.TestHelper;
+import io.delta.flink.sink.DeltaSinkConf;
+import io.delta.flink.sink.DeltaWriterResult;
+import io.delta.flink.sink.DeltaWriterTask;
+import io.delta.flink.sink.TestSinkWriterContext;
+import io.delta.flink.table.HadoopTable;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.utils.CloseableIterable;
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.junit.jupiter.api.Test;
+
+/** JUnit test suite for {@link ScanLocator}. */
+class ScanLocatorTest extends TestHelper {
+
+  private static final io.delta.kernel.types.StructType SCHEMA =
+      new io.delta.kernel.types.StructType()
+          .add("id", io.delta.kernel.types.IntegerType.INTEGER)
+          .add("name", io.delta.kernel.types.StringType.STRING);
+
+  /** PK = single column "id" at ordinal 0. */
+  private static final int[] SINGLE_PK = {0};
+
+  // -------------------------------------------------------------------------
+  // Tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testFindReturnsFileWhenPkExists() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          writeRows(table, SCHEMA, 10, Collections.emptyMap());
+
+          // Single PK 5 — exists in the file (id range 0..9). Expect the file to be returned.
+          List<List<Literal>> pks = List.of(List.of(Literal.ofInt(5)));
+          List<Row> files = new ScanLocator().find(table, SINGLE_PK, pks).toInMemoryList();
+
+          assertEquals(1, files.size(), "expected exactly one candidate file");
+          // The row should be a scan-file row carrying an `add` substruct.
+          AddFile addFile =
+              new AddFile(files.get(0).getStruct(InternalScanFileUtils.ADD_FILE_ORDINAL));
+          assertNotNull(addFile.getPath(), "scan-file row should carry a non-null AddFile.path");
+        });
+  }
+
+  @Test
+  void testFindReturnsFileForMultiplePks() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          writeRows(table, SCHEMA, 10, Collections.emptyMap());
+
+          // Multiple PKs all exist in the (single) file.
+          List<List<Literal>> pks =
+              List.of(
+                  List.of(Literal.ofInt(2)), List.of(Literal.ofInt(4)), List.of(Literal.ofInt(7)));
+          List<Row> files = new ScanLocator().find(table, SINGLE_PK, pks).toInMemoryList();
+
+          assertEquals(1, files.size(), "expected exactly one candidate file");
+        });
+  }
+
+  @Test
+  void testFindReturnsEmptyForEmptyPks() {
+    // Empty pks list → ExpressionUtils.in returns AlwaysFalse → scan returns no files at all.
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          writeRows(table, SCHEMA, 10, Collections.emptyMap());
+
+          List<Row> files =
+              new ScanLocator().find(table, SINGLE_PK, Collections.emptyList()).toInMemoryList();
+
+          assertTrue(files.isEmpty(), "empty pks list should yield no candidate files");
+        });
+  }
+
+  @Test
+  void testFindEmptyTableReturnsEmpty() {
+    withTempDir(
+        dir -> {
+          // Open the table without writing any data.
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          // We need to create the empty table first by going through the open() path; that's
+          // already done by openTable(). No commits → no scan files.
+
+          List<List<Literal>> pks = List.of(List.of(Literal.ofInt(5)));
+          List<Row> files = new ScanLocator().find(table, SINGLE_PK, pks).toInMemoryList();
+
+          assertTrue(files.isEmpty(), "no files have been committed; scan should return empty");
+        });
+  }
+
+  @Test
+  void testFindWithCompositeKey() {
+    withTempDir(
+        dir -> {
+          io.delta.kernel.types.StructType compositeSchema =
+              new io.delta.kernel.types.StructType()
+                  .add("org_id", io.delta.kernel.types.IntegerType.INTEGER)
+                  .add("region", io.delta.kernel.types.StringType.STRING)
+                  .add("payload", io.delta.kernel.types.StringType.STRING);
+
+          HadoopTable table = openTable(dir, compositeSchema, Collections.emptyList());
+
+          List<GenericRowData> rows =
+              List.of(
+                  GenericRowData.of(1, StringData.fromString("us"), StringData.fromString("p0")),
+                  GenericRowData.of(2, StringData.fromString("eu"), StringData.fromString("p1")),
+                  GenericRowData.of(3, StringData.fromString("us"), StringData.fromString("p2")));
+          writeRowData(table, compositeSchema, rows, Collections.emptyMap());
+
+          // (org_id, region) → ordinals (0, 1). Find tuples (1, "us") and (3, "us").
+          int[] compositePk = {0, 1};
+          List<List<Literal>> pks =
+              List.of(
+                  List.of(Literal.ofInt(1), Literal.ofString("us")),
+                  List.of(Literal.ofInt(3), Literal.ofString("us")));
+
+          List<Row> files = new ScanLocator().find(table, compositePk, pks).toInMemoryList();
+
+          assertEquals(1, files.size(), "expected the single file containing matching tuples");
+        });
+  }
+
+  @Test
+  void testFindPreservesPkOrdinalOrder() {
+    // ScanLocator maps int[] pkIndices → List<String> column names by indexing the schema's
+    // fieldNames. Verify the order is preserved when the caller passes ordinals in reverse.
+    withTempDir(
+        dir -> {
+          io.delta.kernel.types.StructType compositeSchema =
+              new io.delta.kernel.types.StructType()
+                  .add("a", io.delta.kernel.types.IntegerType.INTEGER)
+                  .add("b", io.delta.kernel.types.IntegerType.INTEGER);
+          HadoopTable table = openTable(dir, compositeSchema, Collections.emptyList());
+
+          // Write rows (a=1, b=10), (a=2, b=20), (a=3, b=30).
+          List<GenericRowData> rows =
+              List.of(GenericRowData.of(1, 10), GenericRowData.of(2, 20), GenericRowData.of(3, 30));
+          writeRowData(table, compositeSchema, rows, Collections.emptyMap());
+
+          // Pass ordinals in (b, a) order — the value tuples must be (b-value, a-value).
+          int[] reversedPk = {1, 0};
+          List<List<Literal>> pks = List.of(List.of(Literal.ofInt(10), Literal.ofInt(1)));
+
+          List<Row> files = new ScanLocator().find(table, reversedPk, pks).toInMemoryList();
+          assertEquals(1, files.size(), "expected the file containing (a=1, b=10)");
+        });
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers (kept consistent with CoWUpsertTest)
+  // -------------------------------------------------------------------------
+
+  /** Open a HadoopTable at {@code dir} with the given schema/partition cols. */
+  private HadoopTable openTable(
+      File dir, io.delta.kernel.types.StructType schema, List<String> partitionCols) {
+    HadoopTable table =
+        new HadoopTable(
+            URI.create(dir.getAbsolutePath()),
+            Collections.emptyMap(),
+            schema,
+            partitionCols.isEmpty() ? Collections.emptyList() : partitionCols);
+    table.open();
+    return table;
+  }
+
+  /** Write {@code numRows} rows {@code (id=i, name="row-i")} via a DeltaWriterTask and commit. */
+  private void writeRows(
+      HadoopTable table,
+      io.delta.kernel.types.StructType schema,
+      int numRows,
+      Map<String, Literal> partitionValues) {
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Collections.emptyMap());
+    DeltaWriterTask task = new DeltaWriterTask("test-job", 0, 0, table, conf, partitionValues);
+    for (int i = 0; i < numRows; i++) {
+      try {
+        task.write(
+            GenericRowData.of(i, StringData.fromString("row-" + i)),
+            new TestSinkWriterContext(0, 0));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    commit(table, task);
+  }
+
+  /**
+   * Variant that takes pre-built rows — for schemas that don't fit the {@code (int, string)} mold.
+   */
+  private void writeRowData(
+      HadoopTable table,
+      io.delta.kernel.types.StructType schema,
+      List<GenericRowData> rows,
+      Map<String, Literal> partitionValues) {
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Collections.emptyMap());
+    DeltaWriterTask task = new DeltaWriterTask("test-job", 0, 0, table, conf, partitionValues);
+    try {
+      for (GenericRowData row : rows) {
+        task.write(row, new TestSinkWriterContext(0, 0));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    commit(table, task);
+  }
+
+  private void commit(HadoopTable table, DeltaWriterTask task) {
+    List<DeltaWriterResult> results;
+    try {
+      results = task.complete();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    List<Row> actions = new ArrayList<>();
+    for (DeltaWriterResult r : results) {
+      actions.addAll(r.getDeltaActions());
+    }
+    table.commit(
+        CloseableIterable.inMemoryIterable(toCloseableIterator(actions.iterator())),
+        "test-app",
+        /* txnId= */ 0L,
+        Collections.emptyMap());
+  }
+}


### PR DESCRIPTION
## Summary

Step 2 of the Flink upsert sink stack. This PR depends on #6809 and adds the concrete merge-strategy implementation pieces and tests.

`Upsert` itself now lives in #6809. Relative to that interface/base-strategy PR, this change supplies the concrete locators and rewrite strategies that plug into it.

## Changes

- Adds `ExpressionUtils` helpers for building Kernel row `IN` predicates.
- Adds `DeltaTable.scan(Predicate)` for row-locator candidate-file scans.
- Adds `AppendOnly`, `ScanLocator`, `CoWUpsert`, and placeholder `IndexLocator` / `MoRUpsert` strategies.
- Wires concrete upsert strategies to use `ScanLocator` through the `Upsert` base class from step 1.
- Adds focused tests for `ScanLocator` and copy-on-write upsert file rewrites.

## Validation

- `build/sbt "flink / Test / compile"`
- `build/sbt "flink / Compile / doc"`
- `build/sbt "flink/testOnly io.delta.flink.sink.mergestrategy.*"` (14 passed)