### PR TITLE
[Spark] broaden visibility of DSv2 test trait members

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -618,7 +618,7 @@ trait DeltaSQLInMemoryTestUtils
    * Override for [[withTable]] that asserts no leftover physical parquet as a sanity-check
    * for V2 paths.
    */
-  override protected def withTable(tableNames: String*)(f: => Unit): Unit = {
+  override def withTable(tableNames: String*)(f: => Unit): Unit = {
     try {
       super.withTable(tableNames: _*) {
         f
@@ -634,7 +634,7 @@ trait DeltaSQLInMemoryTestUtils
   /**
    * Overrides for [[afterEach]], cleans the [[InMemoryDeltaCatalog]] after each test.
    */
-  override protected def afterEach(): Unit = {
+  override def afterEach(): Unit = {
     try {
       InMemoryDeltaCatalog.reset()
     } finally {
@@ -649,7 +649,7 @@ trait DeltaSQLInMemoryTestUtils
     }
   }
 
-  override protected def withTempDir(f: File => Unit): Unit = {
+  override def withTempDir(f: File => Unit): Unit = {
     super.withTempPath { dir =>
       f(dir)
       assertNoV1Writes(dir)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
@@ -74,7 +74,7 @@ trait InMemoryTestTableMixin extends SharedSparkSession with InMemoryTestTableMi
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.spark_catalog", classOf[InMemoryDeltaCatalog].getName)
 
-  override def test
+  override protected def test
       (testName: String, testTags: org.scalatest.Tag*)
       (testFun: => Any)
       (implicit pos: org.scalactic.source.Position): Unit = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InMemoryTestTableMixin.scala
@@ -71,10 +71,10 @@ case object DSv2DMLSchemaEvolution extends org.scalatest.Tag("DSv2DMLSchemaEvolu
  */
 trait InMemoryTestTableMixin extends SharedSparkSession with InMemoryTestTableMixinShims  {
 
-  override protected def sparkConf: SparkConf = super.sparkConf
+  override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.spark_catalog", classOf[InMemoryDeltaCatalog].getName)
 
-  override protected def test
+  override def test
       (testName: String, testTags: org.scalatest.Tag*)
       (testFun: => Any)
       (implicit pos: org.scalactic.source.Position): Unit = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Broadens visibility of often-overriden members like `sparkConf` and `afterEach` from `protected` to `public`. This is required to mixin the `InMemoryTestTableMixinin` some places in the codebase, where e.g. `FooSuite` has overriden `sparkConf` and accidentally broadened visibility to public.

## How was this patch tested?

This is a test-only change.

## Does this PR introduce _any_ user-facing changes?

No