### PR TITLE
[kernel-spark] Fix ColumnVectorWithFilter.getChild to wrap non-struct children with row-ID mapping

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceDeletionVectorsSuite.scala
@@ -57,7 +57,9 @@ class DeltaV2SourceDeletionVectorsSuite
     "multiple deletion vectors per file - List((ignoreChanges,true))",
     "multiple deletion vectors per file - List((ignoreFileDeletion,true))",
     "streaming read with nulls and deletion vectors does not NPE",
-    "streaming read with variant column and deletion vectors does not ClassCastException"
+    "streaming read with variant column and deletion vectors does not ClassCastException",
+    "variant column and deletion vectors preserve payload identity",
+    "array column and deletion vectors preserve element identity"
   )
 
   override protected def shouldFailTests: Set[String] = Set.empty

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
@@ -468,6 +468,52 @@ trait DeltaSourceDeletionVectorTests extends StreamTest
     }
   }
 
+  test("variant column and deletion vectors preserve payload identity") {
+    withTempDir { inputDir =>
+      val path = inputDir.getAbsolutePath
+      sql(s"CREATE TABLE delta.`$path` (id INT, v VARIANT) USING delta")
+      // Coalesce into one file so DELETE creates a DV rather than a file rewrite.
+      spark.range(10)
+        .selectExpr("cast(id as int) as id", "parse_json(concat('{\"row\":', id, '}')) as v")
+        .coalesce(1)
+        .write.format("delta").mode("append").save(path)
+      executeDml(s"DELETE FROM delta.`$path` WHERE id % 2 = 0")
+
+      val df = loadStreamWithOptions(path, Map.empty)
+        .selectExpr("id", "variant_get(v, '$.row', 'long') as row_in_payload")
+      testStream(df)(
+        AssertOnQuery { q =>
+          q.processAllAvailable()
+          true
+        },
+        CheckAnswer((1, 1L), (3, 3L), (5, 5L), (7, 7L), (9, 9L)))
+    }
+  }
+
+  test("array column and deletion vectors preserve element identity") {
+    withTempDir { inputDir =>
+      val path = inputDir.getAbsolutePath
+      sql(s"CREATE TABLE delta.`$path` (id INT, arr ARRAY<INT>) USING delta")
+      // Coalesce into one file so DELETE creates a DV rather than a file rewrite.
+      spark.range(10)
+        .selectExpr(
+          "cast(id as int) as id",
+          "array(cast(id*10 as int), cast(id*10+1 as int)) as arr")
+        .coalesce(1)
+        .write.format("delta").mode("append").save(path)
+      executeDml(s"DELETE FROM delta.`$path` WHERE id % 2 = 0")
+
+      val df = loadStreamWithOptions(path, Map.empty)
+        .selectExpr("id", "arr[0] as a0", "arr[1] as a1")
+      testStream(df)(
+        AssertOnQuery { q =>
+          q.processAllAvailable()
+          true
+        },
+        CheckAnswer((1, 10, 11), (3, 30, 31), (5, 50, 51), (7, 70, 71), (9, 90, 91)))
+    }
+  }
+
   test("multiple deletion vectors per file with initial snapshot") {
     withTempDir { inputDir =>
       val path = inputDir.getAbsolutePath

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/deletionvector/ColumnVectorWithFilter.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/deletionvector/ColumnVectorWithFilter.java
@@ -149,10 +149,9 @@ public class ColumnVectorWithFilter extends ColumnVector {
    */
   @Override
   public ColumnVector getChild(int ordinal) {
-    // Non-struct types (VARIANT, ARRAY, MAP) don't have named struct children —
-    // pass through to the delegate directly instead of attempting a StructType cast.
+    // For non-struct types like VARIANT, getVariant(rowId) calls getChild(0).getBinary(rowId).
     if (!(dataType() instanceof StructType)) {
-      return delegate.getChild(ordinal);
+      return new ColumnVectorWithFilter(delegate.getChild(ordinal), rowIdMapping);
     }
     if (children == null) {
       synchronized (this) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/deletionvector/ColumnVectorWithFilterTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/deletionvector/ColumnVectorWithFilterTest.java
@@ -23,6 +23,9 @@ import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.unsafe.types.CalendarInterval;
+import org.apache.spark.unsafe.types.VariantVal;
 import org.junit.jupiter.api.Test;
 
 public class ColumnVectorWithFilterTest {
@@ -113,6 +116,84 @@ public class ColumnVectorWithFilterTest {
           mappedNameColumn,
           i -> mappedNameColumn.getUTF8String(i).toString(),
           new String[] {"a", "c"});
+    }
+  }
+
+  @Test
+  void testIntervalColumnVector() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(5, DataTypes.CalendarIntervalType)) {
+      for (int i = 0; i < 5; i++) {
+        delegate.putInterval(i, new CalendarInterval(i, i * 10, i * 100L));
+      }
+      ColumnVectorWithFilter mappedVector = new ColumnVectorWithFilter(delegate, new int[] {1, 3});
+
+      CalendarInterval row0 = mappedVector.getInterval(0);
+      assertNotNull(row0);
+      assertEquals(1, row0.months);
+      assertEquals(10, row0.days);
+      assertEquals(100L, row0.microseconds);
+
+      CalendarInterval row1 = mappedVector.getInterval(1);
+      assertNotNull(row1);
+      assertEquals(3, row1.months);
+      assertEquals(30, row1.days);
+      assertEquals(300L, row1.microseconds);
+    }
+  }
+
+  @Test
+  void testVariantColumnVector() {
+    try (WritableColumnVector delegate = new OnHeapColumnVector(5, DataTypes.VariantType)) {
+      WritableColumnVector valueChild = (WritableColumnVector) delegate.getChild(0);
+      WritableColumnVector metadataChild = (WritableColumnVector) delegate.getChild(1);
+      for (int i = 0; i < 5; i++) {
+        valueChild.putByteArray(i, ("value-" + i).getBytes());
+        metadataChild.putByteArray(i, ("meta-" + i).getBytes());
+      }
+      ColumnVectorWithFilter mappedVector = new ColumnVectorWithFilter(delegate, new int[] {1, 3});
+
+      VariantVal row0 = mappedVector.getVariant(0);
+      assertNotNull(row0);
+      assertArrayEquals("value-1".getBytes(), row0.getValue());
+      assertArrayEquals("meta-1".getBytes(), row0.getMetadata());
+
+      VariantVal row1 = mappedVector.getVariant(1);
+      assertNotNull(row1);
+      assertArrayEquals("value-3".getBytes(), row1.getValue());
+      assertArrayEquals("meta-3".getBytes(), row1.getMetadata());
+    }
+  }
+
+  @Test
+  void testArrayColumnVector() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(3, DataTypes.createArrayType(DataTypes.IntegerType))) {
+      // 3 rows: row 0 = [10, 20], row 1 = [30], row 2 = [40, 50, 60].
+      // All elements live contiguously in the single int element child.
+      WritableColumnVector elementChild = (WritableColumnVector) delegate.getChild(0);
+      elementChild.reserve(6);
+      int[] flatElements = {10, 20, 30, 40, 50, 60};
+      for (int i = 0; i < flatElements.length; i++) {
+        elementChild.putInt(i, flatElements[i]);
+      }
+      delegate.putArray(0, 0, 2);
+      delegate.putArray(1, 2, 1);
+      delegate.putArray(2, 3, 3);
+
+      // Selected rows: [0, 2] -> survivors are row 0 ([10, 20]) and row 2 ([40, 50, 60]).
+      ColumnVectorWithFilter mappedVector = new ColumnVectorWithFilter(delegate, new int[] {0, 2});
+
+      ColumnarArray mappedRow0 = mappedVector.getArray(0);
+      assertEquals(2, mappedRow0.numElements());
+      assertEquals(10, mappedRow0.getInt(0));
+      assertEquals(20, mappedRow0.getInt(1));
+
+      ColumnarArray mappedRow1 = mappedVector.getArray(1);
+      assertEquals(3, mappedRow1.numElements());
+      assertEquals(40, mappedRow1.getInt(0));
+      assertEquals(50, mappedRow1.getInt(1));
+      assertEquals(60, mappedRow1.getInt(2));
     }
   }
 


### PR DESCRIPTION
## Which Delta project/connector is this PR for?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`ColumnVectorWithFilter.getChild()` returned the unwrapped delegate child for non-struct types. Spark's `getVariant(rowId)` and `getInterval(rowId)` read child data at the outer rowId, so survivors silently received their deleted neighbors' VARIANT/INTERVAL payloads on DV-enabled tables. Fix: wrap the child too.

## How was this patch tested?

New VARIANT / INTERVAL / ARRAY tests in `ColumnVectorWithFilterTest` (unit) and `DeltaSourceDeletionVectorsSuite` (E2E, wired to the V2 suite).

## Does this PR introduce _any_ user-facing changes?

No.