### PR TITLE
[Spark][Storage] Extract UCConfigUtils and default credScopedFs.enabled to true

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.catalog
 
+import io.delta.storage.commit.uccommitcoordinator.UCConfigUtils
 import io.delta.storage.commit.uniform.UniformMetadata
 
 import java.util
@@ -24,7 +25,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 import org.apache.spark.sql.delta.actions.{Action, DomainMetadata, Metadata, Protocol}
-import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.stats.FileSizeHistogram
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -189,8 +189,8 @@ private[delta] object AbstractDeltaCatalogClient extends Logging {
       options: CaseInsensitiveStringMap,
       fallbackLoadTableFunc: Identifier => Table): Option[AbstractDeltaCatalogClient] = {
     val optionsMap = options.asCaseSensitiveMap()
-    val key = UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY
-    if (!optionsMap.getOrDefault(key, "true").toBoolean) {
+    val key = UCConfigUtils.DELTA_REST_API_ENABLED_KEY
+    if (!UCConfigUtils.isDeltaRestApiEnabled(optionsMap)) {
       return None
     }
     val factory = try {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -189,7 +189,6 @@ private[delta] object AbstractDeltaCatalogClient extends Logging {
       options: CaseInsensitiveStringMap,
       fallbackLoadTableFunc: Identifier => Table): Option[AbstractDeltaCatalogClient] = {
     val optionsMap = options.asCaseSensitiveMap()
-    val key = UCConfigUtils.DELTA_REST_API_ENABLED_KEY
     if (!UCConfigUtils.isDeltaRestApiEnabled(optionsMap)) {
       return None
     }
@@ -200,6 +199,7 @@ private[delta] object AbstractDeltaCatalogClient extends Logging {
       cls.getField("MODULE$").get(null).asInstanceOf[AbstractDeltaCatalogClientFactory]
     } catch {
       case e: Exception =>
+        val key = UCConfigUtils.DELTA_REST_API_ENABLED_KEY
         throw new IllegalStateException(
           s"Failed to load $UC_DELTA_CATALOG_CLIENT_IMPL_CLASS_NAME though '$key' is true. " +
             "Ensure the implementation JAR is on the classpath, or remove " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -708,13 +708,10 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
     }
     validateAuthConfigured(options, catalogName)
 
-    val optionsMap = new util.HashMap[String, String](options)
-    optionsMap.putIfAbsent(UCConfigUtils.DELTA_REST_API_ENABLED_KEY, "true")
-
     val ucClient = UCTokenBasedRestClientFactory
-      .createUCClient(optionsMap)
+      .createUCClient(options)
       .asInstanceOf[UCDeltaClient]
-    val sspEnabled = UCConfigUtils.parseBoolean(optionsMap, ServerSidePlanningEnabledKey, false)
+    val sspEnabled = UCConfigUtils.parseBoolean(options, ServerSidePlanningEnabledKey, false)
     new UCDeltaCatalogClientImpl(catalogName, ucClient, sspEnabled, fallbackLoadTableFunc)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 
 import io.delta.storage.commit.{TableIdentifier => StorageTableIdentifier}
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractProtocol}
-import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCDeltaModels}
+import io.delta.storage.commit.uccommitcoordinator.{UCConfigUtils, UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uniform.{UniformMetadata => StorageUniformMetadata}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo
@@ -695,28 +695,26 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
    * Builds a [[UCDeltaCatalogClientImpl]] from catalog options. The `deltaRestApi.enabled` gate
    * is the caller's responsibility ([[AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled]]).
    * `fallbackLoadTableFunc` is invoked when UC reports `UnsupportedTableFormatException`. UC client
-   * construction is delegated to [[UCTokenBasedRestClientFactory]] with `renewCredential.enabled`
-   * defaulted to `true` and `credScopedFs.enabled` defaulted to `false` when not set.
+   * construction is delegated to [[UCTokenBasedRestClientFactory]]; credential-related defaults
+   * (`renewCredential.enabled`, `credScopedFs.enabled`) are applied by the client itself.
    */
   override def fromCatalogOptions(
       catalogName: String,
       options: util.Map[String, String],
       fallbackLoadTableFunc: Identifier => Table): UCDeltaCatalogClientImpl = {
-    if (options.get(UCTokenBasedRestClientFactory.URI_KEY) == null) {
+    if (options.get(UCConfigUtils.URI_KEY) == null) {
       throw new IllegalArgumentException(
-        s"'${UCTokenBasedRestClientFactory.URI_KEY}' is required (catalog '$catalogName')")
+        s"'${UCConfigUtils.URI_KEY}' is required (catalog '$catalogName')")
     }
     validateAuthConfigured(options, catalogName)
 
     val optionsMap = new util.HashMap[String, String](options)
-    optionsMap.putIfAbsent(UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY, "true")
-    optionsMap.putIfAbsent(UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY, "false")
+    optionsMap.putIfAbsent(UCConfigUtils.DELTA_REST_API_ENABLED_KEY, "true")
 
     val ucClient = UCTokenBasedRestClientFactory
       .createUCClient(optionsMap)
       .asInstanceOf[UCDeltaClient]
-    val sspEnabled =
-      optionsMap.getOrDefault(ServerSidePlanningEnabledKey, "false").toBoolean
+    val sspEnabled = UCConfigUtils.parseBoolean(optionsMap, ServerSidePlanningEnabledKey, false)
     new UCDeltaCatalogClientImpl(catalogName, ucClient, sspEnabled, fallbackLoadTableFunc)
   }
 
@@ -728,9 +726,9 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   private[catalog] def validateAuthConfigured(
       options: util.Map[String, String],
       catalogName: String): Unit = {
-    if (UCTokenBasedRestClientFactory.extractAuthConfig(options).isEmpty) {
-      val authPrefix = UCTokenBasedRestClientFactory.AUTH_PREFIX
-      val legacyTokenKey = UCTokenBasedRestClientFactory.LEGACY_TOKEN_KEY
+    if (!UCConfigUtils.hasAuthConfig(options)) {
+      val authPrefix = UCConfigUtils.AUTH_PREFIX
+      val legacyTokenKey = UCConfigUtils.LEGACY_TOKEN_KEY
       throw new IllegalArgumentException(
         s"auth configuration is required (catalog '$catalogName'). " +
           s"Set either '${authPrefix}type' (with the corresponding " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import io.delta.storage.commit.CommitCoordinatorClient
-import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCTokenBasedRestClient}
+import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCConfigUtils, UCTokenBasedRestClient}
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -286,89 +286,51 @@ trait UCClientFactory {
  */
 object UCTokenBasedRestClientFactory extends UCClientFactory {
 
-  final val URI_KEY = "uri"
-  final val AUTH_PREFIX = "auth."
-  final val LEGACY_TOKEN_KEY = "token"
-  final val DELTA_REST_API_ENABLED_KEY = "deltaRestApi.enabled"
-  final val APP_VERSIONS_PREFIX = "appVersions."
-  /** Opt-in: caller wants `UCDeltaTokenBasedRestClient` constructed with credential renewal. */
-  final val RENEW_CREDENTIAL_ENABLED_KEY = "renewCredential.enabled"
-  /** Opt-in: caller wants `UCDeltaTokenBasedRestClient` constructed with cred-scoped FS. */
-  final val CRED_SCOPED_FS_ENABLED_KEY = "credScopedFs.enabled"
-
-  private val DEFAULT_UC_CLIENT_CLASS: String = classOf[UCTokenBasedRestClient].getName
-
   private val DELTA_UC_CLIENT_CLASS: String =
     "io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient"
 
   override def createUCClient(ucConfig: java.util.Map[String, String]): UCClient = {
-    val uri = Option(ucConfig.get(URI_KEY)).getOrElse(
-      throw new IllegalArgumentException(s"UC config must contain '$URI_KEY'"))
+    if (UCConfigUtils.isDeltaRestApiEnabled(ucConfig)) {
+      createDeltaClient(ucConfig)
+    } else {
+      createDefaultClient(ucConfig)
+    }
+  }
 
-    val authConfig = extractAuthConfig(ucConfig)
-    val tokenProvider = TokenProvider.create(authConfig)
-
-    val className =
-      if (ucConfig.getOrDefault(DELTA_REST_API_ENABLED_KEY, "true").toBoolean) {
-        DELTA_UC_CLIENT_CLASS
-      } else {
-        DEFAULT_UC_CLIENT_CLASS
-      }
-
-    val cls = Utils.classForName(className)
-    require(classOf[UCClient].isAssignableFrom(cls),
-      s"$className does not implement ${classOf[UCClient].getName}")
-    val appVersions = extractAppVersions(ucConfig)
-    val renewCred = Option(ucConfig.get(RENEW_CREDENTIAL_ENABLED_KEY)).exists(_.toBoolean)
-    val credScopedFs = Option(ucConfig.get(CRED_SCOPED_FS_ENABLED_KEY)).exists(_.toBoolean)
+  private def createDeltaClient(ucConfig: java.util.Map[String, String]): UCClient = {
     val hadoopConfSupplier: Supplier[Configuration] = () =>
       SparkSession.getActiveSession
         .map(_.sparkContext.hadoopConfiguration)
         .getOrElse(new Configuration())
-    val ctor = cls.getConstructor(
-      classOf[String],
-      classOf[TokenProvider],
-      classOf[java.util.Map[_, _]],
-      java.lang.Boolean.TYPE,
-      java.lang.Boolean.TYPE,
-      classOf[Supplier[_]])
-    ctor
-      .newInstance(
-        uri,
-        tokenProvider,
-        appVersions.asJava,
-        java.lang.Boolean.valueOf(renewCred),
-        java.lang.Boolean.valueOf(credScopedFs),
-        hadoopConfSupplier)
+    // Seed the default app versions, then overlay the caller's config (which may override them).
+    val merged = new java.util.HashMap[String, String]()
+    defaultAppVersions.foreach { case (k, v) =>
+      merged.put(UCConfigUtils.APP_VERSIONS_PREFIX + k, v)
+    }
+    merged.putAll(ucConfig)
+    val cls = Utils.classForName(DELTA_UC_CLIENT_CLASS)
+    require(classOf[UCClient].isAssignableFrom(cls),
+      s"$DELTA_UC_CLIENT_CLASS does not implement ${classOf[UCClient].getName}")
+    cls.getConstructor(classOf[java.util.Map[_, _]], classOf[Supplier[_]])
+      .newInstance(merged, hadoopConfSupplier)
       .asInstanceOf[UCClient]
   }
 
-  /**
-   * Extracts entries whose keys start with `prefix`, strips the prefix, and returns a plain map.
-   */
-  private[coordinatedcommits] def filterByPrefix(
-      ucConfig: java.util.Map[String, String],
-      prefix: String): java.util.Map[String, String] = {
-    val result = new java.util.HashMap[String, String]()
-    ucConfig.asScala.foreach { case (k, v) =>
-      if (k.startsWith(prefix)) {
-        result.put(k.substring(prefix.length), v)
-      }
-    }
-    result
+  private def createDefaultClient(ucConfig: java.util.Map[String, String]): UCClient = {
+    val uri = UCConfigUtils.extractUri(ucConfig)
+    val tokenProvider = TokenProvider.create(extractAuthConfig(ucConfig))
+    val appVersions = extractAppVersions(ucConfig)
+    new UCTokenBasedRestClient(uri, tokenProvider, appVersions.asJava)
   }
 
-  /** Extracts auth config for [[TokenProvider.create]]; prefers `auth.*`, else legacy `token`. */
-  private[delta] def extractAuthConfig(
+  /**
+   * Extracts authentication configuration from ucConfig, preserving the original key casing (e.g.
+   * `oauth.clientId`) so [[TokenProvider.create]] can look them up. Prefers `auth.*` keys; falls
+   * back to the legacy `token` key.
+   */
+  private[coordinatedcommits] def extractAuthConfig(
       ucConfig: java.util.Map[String, String]): java.util.Map[String, String] = {
-    val auth = filterByPrefix(ucConfig, AUTH_PREFIX)
-    if (!auth.isEmpty) {
-      auth
-    } else {
-      Option(ucConfig.get(LEGACY_TOKEN_KEY))
-        .map(token => java.util.Map.of("type", "static", LEGACY_TOKEN_KEY, token))
-        .getOrElse(java.util.Collections.emptyMap())
-    }
+    UCConfigUtils.extractCaseSensitiveAuthConfig(ucConfig)
   }
 
   /**
@@ -377,7 +339,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
    */
   private[coordinatedcommits] def extractAppVersions(
       ucConfig: java.util.Map[String, String]): Map[String, String] = {
-    defaultAppVersions ++ filterByPrefix(ucConfig, APP_VERSIONS_PREFIX).asScala
+    defaultAppVersions ++ UCConfigUtils.extractAppVersions(ucConfig).asScala
   }
 
   private[coordinatedcommits] def defaultAppVersions: Map[String, String] = {
@@ -398,9 +360,15 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
  */
 case class UCCatalogConfig(catalogName: String, ucConfig: Map[String, String]) {
 
-  def uri: String = ucConfig.getOrElse(UCTokenBasedRestClientFactory.URI_KEY,
+  def uri: String = ucConfig.getOrElse(UCConfigUtils.URI_KEY,
     throw new NoSuchElementException(s"No URI in config for catalog $catalogName"))
 
+  /**
+   * Returns the authentication config with original key casing preserved (e.g. `oauth.clientId`).
+   * The casing must survive here because callers serialize it back into a flat ucConfig (via
+   * `UCTableInfo.toUcConfig`) that flows through plain maps into `TokenProvider.create`, which
+   * looks up camelCase keys exactly. Prefers `auth.*` keys; falls back to the legacy `token` key.
+   */
   def authConfig: java.util.Map[String, String] =
-    UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
+    UCConfigUtils.extractCaseSensitiveAuthConfig(ucConfig.asJava)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -318,19 +318,9 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
 
   private def createDefaultClient(ucConfig: java.util.Map[String, String]): UCClient = {
     val uri = UCConfigUtils.extractUri(ucConfig)
-    val tokenProvider = TokenProvider.create(extractAuthConfig(ucConfig))
+    val tokenProvider = TokenProvider.create(UCConfigUtils.extractAuthConfig(ucConfig))
     val appVersions = extractAppVersions(ucConfig)
     new UCTokenBasedRestClient(uri, tokenProvider, appVersions.asJava)
-  }
-
-  /**
-   * Extracts authentication configuration from ucConfig, preserving the original key casing (e.g.
-   * `oauth.clientId`) so [[TokenProvider.create]] can look them up. Prefers `auth.*` keys; falls
-   * back to the legacy `token` key.
-   */
-  private[coordinatedcommits] def extractAuthConfig(
-      ucConfig: java.util.Map[String, String]): java.util.Map[String, String] = {
-    UCConfigUtils.extractCaseSensitiveAuthConfig(ucConfig)
   }
 
   /**
@@ -370,5 +360,5 @@ case class UCCatalogConfig(catalogName: String, ucConfig: Map[String, String]) {
    * looks up camelCase keys exactly. Prefers `auth.*` keys; falls back to the legacy `token` key.
    */
   def authConfig: java.util.Map[String, String] =
-    UCConfigUtils.extractCaseSensitiveAuthConfig(ucConfig.asJava)
+    UCConfigUtils.extractAuthConfig(ucConfig.asJava)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
@@ -20,7 +20,7 @@ import scala.collection.JavaConverters._
 
 import io.delta.kernel.unitycatalog.UCTableIdentifier
 import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo
-import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient}
+import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient, UCConfigUtils}
 import io.unitycatalog.client.auth.TokenProvider
 import org.mockito.{Mock, Mockito}
 import org.mockito.ArgumentMatchers.{any, eq => meq}
@@ -466,7 +466,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       "auth.type" -> "static",
       "auth.token" -> "new-token"
     )
-    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
+    val auth = UCConfigUtils.extractAuthConfig(ucConfig.asJava)
     assert(auth.get("type") == "static")
     assert(auth.get("token") == "new-token")
   }
@@ -476,7 +476,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       "uri" -> "https://test.com",
       "token" -> "legacy-token"
     )
-    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
+    val auth = UCConfigUtils.extractAuthConfig(ucConfig.asJava)
     assert(auth.get("type") == "static")
     assert(auth.get("token") == "legacy-token")
   }
@@ -547,7 +547,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
     ucConfig.put("auth.oauth.clientSecret", "test-secret")
     ucConfig.put("auth.oauth.uri", "https://example.com/token")
     ucConfig.put("uri", "https://uc.example.com")
-    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig)
+    val auth = UCConfigUtils.extractAuthConfig(ucConfig)
     assert(auth.get("oauth.clientId") === "test-id")
     assert(auth.get("oauth.clientSecret") === "test-secret")
     val tp = TokenProvider.create(auth)
@@ -560,7 +560,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
   test("extractAuthConfig with static token produces valid TokenProvider") {
     // Sub-case 1: legacy token key
     val legacyConfig = Map("token" -> "my-token", "uri" -> "https://uc.example.com")
-    val legacyAuth = UCTokenBasedRestClientFactory.extractAuthConfig(legacyConfig.asJava)
+    val legacyAuth = UCConfigUtils.extractAuthConfig(legacyConfig.asJava)
     val tp1 = TokenProvider.create(legacyAuth)
     assert(tp1.accessToken() === "my-token")
 
@@ -569,7 +569,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       "auth.type" -> "static",
       "auth.token" -> "explicit-token"
     ).asJava
-    val explicitAuth = UCTokenBasedRestClientFactory.extractAuthConfig(explicitConfig)
+    val explicitAuth = UCConfigUtils.extractAuthConfig(explicitConfig)
     val tp2 = TokenProvider.create(explicitAuth)
     assert(tp2.accessToken() === "explicit-token")
   }
@@ -597,7 +597,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
     originalConfig.put("auth.oauth.clientSecret", "test-secret")
     originalConfig.put("auth.oauth.uri", "https://example.com/token")
 
-    val authMap = UCTokenBasedRestClientFactory.extractAuthConfig(originalConfig)
+    val authMap = UCConfigUtils.extractAuthConfig(originalConfig)
 
     val tableInfo = new UCTableInfo(
       "table-id",
@@ -607,7 +607,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       authMap)
     val roundTrippedConfig = tableInfo.toUcConfig()
 
-    val roundTrippedAuth = UCTokenBasedRestClientFactory.extractAuthConfig(roundTrippedConfig)
+    val roundTrippedAuth = UCConfigUtils.extractAuthConfig(roundTrippedConfig)
 
     // 5. Verify TokenProvider can be created (proves round-trip preserves values)
     val tp = TokenProvider.create(roundTrippedAuth)
@@ -619,7 +619,7 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
 
   test("extractAuthConfig returns empty map when no auth config present") {
     val noAuthConfig = Map("uri" -> "https://uc.example.com")
-    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(noAuthConfig.asJava)
+    val auth = UCConfigUtils.extractAuthConfig(noAuthConfig.asJava)
     assert(auth.isEmpty)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
@@ -617,12 +617,9 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
     assert(tp.configs().get("oauth.uri") === "https://example.com/token")
   }
 
-  test("filterByPrefix returns empty map when no keys match") {
-    val ucConfig = Map("uri" -> "https://uc.example.com", "token" -> "my-token")
-    assert(UCTokenBasedRestClientFactory.filterByPrefix(ucConfig.asJava, "auth.").isEmpty)
-    // extractAuthConfig with no auth and no token returns empty
-    val noTokenConfig = Map("uri" -> "https://uc.example.com")
-    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(noTokenConfig.asJava)
+  test("extractAuthConfig returns empty map when no auth config present") {
+    val noAuthConfig = Map("uri" -> "https://uc.example.com")
+    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(noAuthConfig.asJava)
     assert(auth.isEmpty)
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -18,6 +18,7 @@ package io.sparkuctest;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import io.delta.storage.commit.uccommitcoordinator.UCConfigUtils;
 import io.unitycatalog.client.api.TablesApi;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -38,7 +39,6 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.delta.catalog.UCDeltaCatalogClientImpl;
-import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -185,10 +185,7 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
       // Default is true. Tests can opt out.
       conf =
           conf.set(
-              "spark.sql.catalog."
-                  + catalogName
-                  + "."
-                  + UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY(),
+              "spark.sql.catalog." + catalogName + "." + UCConfigUtils.DELTA_REST_API_ENABLED_KEY,
               "false");
     }
     return conf;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfo.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfo.java
@@ -18,6 +18,7 @@ package io.delta.spark.internal.v2.snapshot.unitycatalog;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
+import io.delta.storage.commit.uccommitcoordinator.UCConfigUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,13 +30,6 @@ import java.util.Map;
  * without requiring Spark dependencies.
  */
 public final class UCTableInfo {
-
-  // Per-catalog opt-in flag keys whose values must flow from the Spark catalog config into the UC
-  // client factory so the right client implementation is constructed. Mirrors the keys recognized
-  // by UCTokenBasedRestClientFactory.createUCClient.
-  public static final String DELTA_REST_API_ENABLED_KEY = "deltaRestApi.enabled";
-  public static final String RENEW_CREDENTIAL_ENABLED_KEY = "renewCredential.enabled";
-  public static final String CRED_SCOPED_FS_ENABLED_KEY = "credScopedFs.enabled";
 
   private final String tableId;
   private final String tablePath;
@@ -95,13 +89,13 @@ public final class UCTableInfo {
   /**
    * Builds a flat config map suitable for {@code UCTokenBasedRestClientFactory.createUCClient}.
    * Re-adds the {@code auth.} prefix to auth config keys, includes {@code uri}, and forwards any
-   * per-catalog opt-in flags ({@link #DELTA_REST_API_ENABLED_KEY} etc.) so the factory picks the
-   * correct client implementation.
+   * per-catalog opt-in flags ({@link UCConfigUtils#DELTA_REST_API_ENABLED_KEY} etc.) so the factory
+   * picks the correct client implementation.
    */
   public Map<String, String> toUcConfig() {
     Map<String, String> ucConfig = new HashMap<>();
-    ucConfig.put("uri", ucUri);
-    authConfig.forEach((k, v) -> ucConfig.put("auth." + k, v));
+    ucConfig.put(UCConfigUtils.URI_KEY, ucUri);
+    authConfig.forEach((k, v) -> ucConfig.put(UCConfigUtils.AUTH_PREFIX + k, v));
     ucConfig.putAll(optInFlags);
     return ucConfig;
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
@@ -20,6 +20,7 @@ import static scala.jdk.javaapi.CollectionConverters.asJava;
 
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient;
+import io.delta.storage.commit.uccommitcoordinator.UCConfigUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -110,9 +111,9 @@ public final class UCUtils {
     Map<String, String> flags = new HashMap<>();
     for (String key :
         new String[] {
-          UCTableInfo.DELTA_REST_API_ENABLED_KEY,
-          UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY,
-          UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY
+          UCConfigUtils.DELTA_REST_API_ENABLED_KEY,
+          UCConfigUtils.RENEW_CREDENTIAL_ENABLED_KEY,
+          UCConfigUtils.CRED_SCOPED_FS_ENABLED_KEY
         }) {
       String value = ucConfig.get(key);
       if (value != null) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfoTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfoTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
+import io.delta.storage.commit.uccommitcoordinator.UCConfigUtils;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -81,9 +82,9 @@ class UCTableInfoTest {
     authConfig.put("token", "tok");
 
     Map<String, String> optInFlags = new HashMap<>();
-    optInFlags.put(UCTableInfo.DELTA_REST_API_ENABLED_KEY, "true");
-    optInFlags.put(UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY, "true");
-    optInFlags.put(UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY, "false");
+    optInFlags.put(UCConfigUtils.DELTA_REST_API_ENABLED_KEY, "true");
+    optInFlags.put(UCConfigUtils.RENEW_CREDENTIAL_ENABLED_KEY, "true");
+    optInFlags.put(UCConfigUtils.CRED_SCOPED_FS_ENABLED_KEY, "false");
 
     UCTableInfo info =
         new UCTableInfo(
@@ -98,9 +99,9 @@ class UCTableInfoTest {
     assertEquals("https://uc.example.net", ucConfig.get("uri"));
     assertEquals("static", ucConfig.get("auth.type"));
     assertEquals("tok", ucConfig.get("auth.token"));
-    assertEquals("true", ucConfig.get(UCTableInfo.DELTA_REST_API_ENABLED_KEY));
-    assertEquals("true", ucConfig.get(UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY));
-    assertEquals("false", ucConfig.get(UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY));
+    assertEquals("true", ucConfig.get(UCConfigUtils.DELTA_REST_API_ENABLED_KEY));
+    assertEquals("true", ucConfig.get(UCConfigUtils.RENEW_CREDENTIAL_ENABLED_KEY));
+    assertEquals("false", ucConfig.get(UCConfigUtils.CRED_SCOPED_FS_ENABLED_KEY));
   }
 
   @Test
@@ -121,8 +122,8 @@ class UCTableInfoTest {
 
     assertEquals(true, info.getOptInFlags().isEmpty(), "Default optInFlags should be empty");
     Map<String, String> ucConfig = info.toUcConfig();
-    assertEquals(null, ucConfig.get(UCTableInfo.DELTA_REST_API_ENABLED_KEY));
-    assertEquals(null, ucConfig.get(UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY));
-    assertEquals(null, ucConfig.get(UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY));
+    assertEquals(null, ucConfig.get(UCConfigUtils.DELTA_REST_API_ENABLED_KEY));
+    assertEquals(null, ucConfig.get(UCConfigUtils.RENEW_CREDENTIAL_ENABLED_KEY));
+    assertEquals(null, ucConfig.get(UCConfigUtils.CRED_SCOPED_FS_ENABLED_KEY));
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCConfigUtils.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCConfigUtils.java
@@ -58,22 +58,19 @@ public final class UCConfigUtils {
   }
 
   /**
-   * Extracts authentication configuration from a flat ucConfig map, preserving the original key
-   * casing (e.g. {@code oauth.clientId}). Prefers {@code auth.*} keys; falls back to the legacy
-   * {@code token} key.
-   *
-   * <p>Keys are matched case-sensitively against the {@code auth.} prefix, consistent with the rest
-   * of the UC Delta catalog client path. The {@code auth.} prefix is stripped while the suffix
-   * casing is preserved so downstream lookups (e.g. {@code oauth.clientId}) match exactly.
+   * Extracts authentication configuration from a flat ucConfig map. The {@code auth.} prefix is
+   * stripped while the suffix (e.g. {@code oauth.clientId}) is preserved so downstream lookups
+   * match exactly. Prefers {@code auth.*} keys; falls back to the legacy {@code token} key.
    *
    * @param ucConfig the flat configuration map.
    * @return a map suitable for {@code TokenProvider.create}, with the {@code auth.} prefix stripped.
    */
-  public static Map<String, String> extractCaseSensitiveAuthConfig(Map<String, String> ucConfig) {
+  public static Map<String, String> extractAuthConfig(Map<String, String> ucConfig) {
     Map<String, String> authConfig = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : ucConfig.entrySet()) {
-      if (entry.getKey().startsWith(AUTH_PREFIX)) {
-        authConfig.put(entry.getKey().substring(AUTH_PREFIX.length()), entry.getValue());
+      String key = entry.getKey();
+      if (key.startsWith(AUTH_PREFIX)) {
+        authConfig.put(key.substring(AUTH_PREFIX.length()), entry.getValue());
       }
     }
     if (!authConfig.isEmpty()) {
@@ -88,7 +85,7 @@ public final class UCConfigUtils {
 
   /**
    * Returns {@code true} if the ucConfig contains any authentication configuration
-   * ({@code auth.*} keys or legacy {@code token} key). Keys are matched case-sensitively.
+   * ({@code auth.*} keys or legacy {@code token} key).
    */
   public static boolean hasAuthConfig(Map<String, String> ucConfig) {
     for (String key : ucConfig.keySet()) {
@@ -100,8 +97,7 @@ public final class UCConfigUtils {
   }
 
   /**
-   * Extracts {@code appVersions.*} entries from a flat ucConfig map, stripping the prefix. Keys are
-   * matched case-sensitively.
+   * Extracts {@code appVersions.*} entries from a flat ucConfig map, stripping the prefix.
    *
    * @param ucConfig the flat configuration map.
    * @return a map of application name to version string.
@@ -109,8 +105,9 @@ public final class UCConfigUtils {
   public static Map<String, String> extractAppVersions(Map<String, String> ucConfig) {
     Map<String, String> versions = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : ucConfig.entrySet()) {
-      if (entry.getKey().startsWith(APP_VERSIONS_PREFIX)) {
-        versions.put(entry.getKey().substring(APP_VERSIONS_PREFIX.length()), entry.getValue());
+      String key = entry.getKey();
+      if (key.startsWith(APP_VERSIONS_PREFIX)) {
+        versions.put(key.substring(APP_VERSIONS_PREFIX.length()), entry.getValue());
       }
     }
     return versions;

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCConfigUtils.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCConfigUtils.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Shared utility methods for parsing flat UC configuration maps (e.g. auth, appVersions).
+ * Used by both the Scala factory ({@code UCTokenBasedRestClientFactory}) and the Java
+ * client ({@link UCDeltaTokenBasedRestClient}).
+ *
+ * <p>Config key names are the single source of truth and must stay aligned with OSS Unity Catalog.
+ */
+public final class UCConfigUtils {
+
+  public static final String URI_KEY = "uri";
+  public static final String AUTH_PREFIX = "auth.";
+  public static final String APP_VERSIONS_PREFIX = "appVersions.";
+  public static final String DELTA_REST_API_ENABLED_KEY = "deltaRestApi.enabled";
+  public static final String RENEW_CREDENTIAL_ENABLED_KEY = "renewCredential.enabled";
+  public static final String CRED_SCOPED_FS_ENABLED_KEY = "credScopedFs.enabled";
+
+  /** Legacy top-level token key (without {@code auth.} prefix). */
+  public static final String LEGACY_TOKEN_KEY = "token";
+  /** Auth config key for the token provider type. */
+  public static final String AUTH_TYPE_KEY = "type";
+  /** Static token provider type value for legacy {@code token} configs. */
+  public static final String STATIC_AUTH_TYPE = "static";
+
+  private UCConfigUtils() {}
+
+  /**
+   * Extracts the required {@code uri} value from a flat ucConfig map.
+   *
+   * @throws IllegalArgumentException if {@code uri} is not present.
+   */
+  public static String extractUri(Map<String, String> ucConfig) {
+    String uri = ucConfig.get(URI_KEY);
+    if (uri == null) {
+      throw new IllegalArgumentException("UC config must contain '" + URI_KEY + "'");
+    }
+    return uri;
+  }
+
+  /**
+   * Extracts authentication configuration from a flat ucConfig map, preserving the original key
+   * casing (e.g. {@code oauth.clientId}). Prefers {@code auth.*} keys; falls back to the legacy
+   * {@code token} key.
+   *
+   * <p>Keys are matched case-sensitively against the {@code auth.} prefix, consistent with the rest
+   * of the UC Delta catalog client path. The {@code auth.} prefix is stripped while the suffix
+   * casing is preserved so downstream lookups (e.g. {@code oauth.clientId}) match exactly.
+   *
+   * @param ucConfig the flat configuration map.
+   * @return a map suitable for {@code TokenProvider.create}, with the {@code auth.} prefix stripped.
+   */
+  public static Map<String, String> extractCaseSensitiveAuthConfig(Map<String, String> ucConfig) {
+    Map<String, String> authConfig = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : ucConfig.entrySet()) {
+      if (entry.getKey().startsWith(AUTH_PREFIX)) {
+        authConfig.put(entry.getKey().substring(AUTH_PREFIX.length()), entry.getValue());
+      }
+    }
+    if (!authConfig.isEmpty()) {
+      return authConfig;
+    }
+    String token = ucConfig.get(LEGACY_TOKEN_KEY);
+    if (token != null) {
+      return Map.of(AUTH_TYPE_KEY, STATIC_AUTH_TYPE, LEGACY_TOKEN_KEY, token);
+    }
+    return Map.of();
+  }
+
+  /**
+   * Returns {@code true} if the ucConfig contains any authentication configuration
+   * ({@code auth.*} keys or legacy {@code token} key). Keys are matched case-sensitively.
+   */
+  public static boolean hasAuthConfig(Map<String, String> ucConfig) {
+    for (String key : ucConfig.keySet()) {
+      if (key.startsWith(AUTH_PREFIX)) {
+        return true;
+      }
+    }
+    return ucConfig.containsKey(LEGACY_TOKEN_KEY);
+  }
+
+  /**
+   * Extracts {@code appVersions.*} entries from a flat ucConfig map, stripping the prefix. Keys are
+   * matched case-sensitively.
+   *
+   * @param ucConfig the flat configuration map.
+   * @return a map of application name to version string.
+   */
+  public static Map<String, String> extractAppVersions(Map<String, String> ucConfig) {
+    Map<String, String> versions = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : ucConfig.entrySet()) {
+      if (entry.getKey().startsWith(APP_VERSIONS_PREFIX)) {
+        versions.put(entry.getKey().substring(APP_VERSIONS_PREFIX.length()), entry.getValue());
+      }
+    }
+    return versions;
+  }
+
+  /**
+   * Returns whether the Delta REST API client should be used. Defaults to {@code true} when the
+   * key is absent.
+   */
+  public static boolean isDeltaRestApiEnabled(Map<String, String> ucConfig) {
+    return parseBoolean(ucConfig, DELTA_REST_API_ENABLED_KEY, true);
+  }
+
+  /**
+   * Returns whether credential renewal is enabled. Defaults to {@code true} when the key is absent.
+   */
+  public static boolean isCredentialRenewalEnabled(Map<String, String> ucConfig) {
+    return parseBoolean(ucConfig, RENEW_CREDENTIAL_ENABLED_KEY, true);
+  }
+
+  /**
+   * Returns whether credential-scoped filesystem access is enabled. Defaults to {@code true} when
+   * the key is absent.
+   */
+  public static boolean isCredentialScopedFsEnabled(Map<String, String> ucConfig) {
+    return parseBoolean(ucConfig, CRED_SCOPED_FS_ENABLED_KEY, true);
+  }
+
+  /**
+   * Parses a boolean config value with a default fallback. Only {@code "true"} / {@code "false"}
+   * (case-insensitive) are accepted; any other value throws so misconfigured keys surface loudly
+   * rather than silently falling back.
+   *
+   * @throws IllegalArgumentException if the value is present but not a valid boolean.
+   */
+  public static boolean parseBoolean(
+      Map<String, String> ucConfig, String key, boolean defaultValue) {
+    String value = ucConfig.get(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    if (value.equalsIgnoreCase("true")) {
+      return true;
+    }
+    if (value.equalsIgnoreCase("false")) {
+      return false;
+    }
+    throw new IllegalArgumentException(
+        "Invalid boolean value for config '" + key + "': '" + value + "'");
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -118,27 +118,30 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private final boolean credentialScopedFsEnabled;
   private final Supplier<Configuration> hadoopConfSupplier;
 
-  public UCDeltaTokenBasedRestClient(
-      String baseUri,
-      TokenProvider tokenProvider,
-      Map<String, String> appVersions) {
-    this(baseUri, tokenProvider, appVersions, false, false, null);
-  }
-
   /**
+   * Creates an instance by parsing all configuration from a flat config map.
+   * Recognised keys:
+   * <ul>
+   *   <li>{@code uri} (required) -- the UC server endpoint.</li>
+   *   <li>{@code auth.*} / {@code token} (legacy) -- authentication parameters.</li>
+   *   <li>{@code appVersions.*} -- caller-supplied version entries.</li>
+   *   <li>{@code renewCredential.enabled} -- enable credential renewal (default true).</li>
+   *   <li>{@code credScopedFs.enabled} -- enable credential-scoped FS (default true).</li>
+   * </ul>
+   *
+   * @param ucConfig the unified configuration map with all keys.
    * @param hadoopConfSupplier called once per request so engine-level changes are picked up;
    *                           {@code null} defaults to {@code () -> new Configuration()}.
    */
   public UCDeltaTokenBasedRestClient(
-      String baseUri,
-      TokenProvider tokenProvider,
-      Map<String, String> appVersions,
-      boolean credentialRenewalEnabled,
-      boolean credentialScopedFsEnabled,
+      Map<String, String> ucConfig,
       Supplier<Configuration> hadoopConfSupplier) {
-    Objects.requireNonNull(baseUri, "baseUri must not be null");
-    Objects.requireNonNull(tokenProvider, "tokenProvider must not be null");
-    Objects.requireNonNull(appVersions, "appVersions must not be null");
+    Objects.requireNonNull(ucConfig, "ucConfig must not be null");
+
+    String baseUri = UCConfigUtils.extractUri(ucConfig);
+    TokenProvider tokenProvider =
+        TokenProvider.create(UCConfigUtils.extractCaseSensitiveAuthConfig(ucConfig));
+    Map<String, String> appVersions = UCConfigUtils.extractAppVersions(ucConfig);
 
     ApiClientBuilder builder = ApiClientBuilder.create()
         .uri(baseUri)
@@ -156,36 +159,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     this.baseUri = baseUri;
     this.tokenProvider = tokenProvider;
     this.appVersions = appVersions;
-    this.credentialRenewalEnabled = credentialRenewalEnabled;
-    this.credentialScopedFsEnabled = credentialScopedFsEnabled;
+    this.credentialRenewalEnabled = UCConfigUtils.isCredentialRenewalEnabled(ucConfig);
+    this.credentialScopedFsEnabled = UCConfigUtils.isCredentialScopedFsEnabled(ucConfig);
     this.hadoopConfSupplier = hadoopConfSupplier != null ? hadoopConfSupplier : Configuration::new;
-  }
-
-  /**
-   * Factory for callers that can't depend on {@code io.unitycatalog.client} directly: pass
-   * a flat {@code authConfigs} map ({@code type} + provider-specific keys) and the factory
-   * constructs the {@link TokenProvider} internally.
-   */
-  public static UCDeltaTokenBasedRestClient create(
-      String baseUri,
-      Map<String, String> authConfigs,
-      Map<String, String> appVersions,
-      boolean credentialRenewalEnabled,
-      boolean credentialScopedFsEnabled,
-      Supplier<Configuration> hadoopConfSupplier) {
-    Objects.requireNonNull(authConfigs, "authConfigs must not be null");
-    if (authConfigs.isEmpty()) {
-      throw new IllegalArgumentException(
-          "authConfigs must not be empty; expected at least a 'type' key plus the keys " +
-              "required by that TokenProvider type.");
-    }
-    return new UCDeltaTokenBasedRestClient(
-        baseUri,
-        TokenProvider.create(authConfigs),
-        appVersions,
-        credentialRenewalEnabled,
-        credentialScopedFsEnabled,
-        hadoopConfSupplier);
   }
 
   /** Fresh builder per call: scheme depends on the table's location, hadoopConf is live. */

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -140,7 +140,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
     String baseUri = UCConfigUtils.extractUri(ucConfig);
     TokenProvider tokenProvider =
-        TokenProvider.create(UCConfigUtils.extractCaseSensitiveAuthConfig(ucConfig));
+        TokenProvider.create(UCConfigUtils.extractAuthConfig(ucConfig));
     Map<String, String> appVersions = UCConfigUtils.extractAppVersions(ucConfig);
 
     ApiClientBuilder builder = ApiClientBuilder.create()

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -47,14 +47,12 @@ import io.unitycatalog.client.model.CreateTable;
 import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.GetMetastoreSummaryResponse;
 import io.unitycatalog.client.model.TableType;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * A REST client implementation of {@link UCClient} for interacting with Unity Catalog's commit
@@ -130,22 +128,6 @@ public class UCTokenBasedRestClient implements UCClient {
     this.deltaCommitsApi = new DeltaCommitsApi(apiClient);
     this.metastoresApi = new MetastoresApi(apiClient);
     this.tablesApi = new TablesApi(apiClient);
-  }
-
-  /**
-   * 6-arg constructor for symmetry with {@link UCDeltaTokenBasedRestClient}. The
-   * {@code credentialRenewalEnabled}, {@code credentialScopedFsEnabled}, and
-   * {@code hadoopConfSupplier} parameters are not used by this client and are accepted only so
-   * that callers can construct either client uniformly by reflection.
-   */
-  public UCTokenBasedRestClient(
-      String baseUri,
-      TokenProvider tokenProvider,
-      Map<String, String> appVersions,
-      boolean credentialRenewalEnabled,
-      boolean credentialScopedFsEnabled,
-      Supplier<Configuration> hadoopConfSupplier) {
-    this(baseUri, tokenProvider, appVersions);
   }
 
   /**

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCConfigUtilsSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCConfigUtilsSuite.scala
@@ -37,8 +37,8 @@ class UCConfigUtilsSuite extends AnyFunSuite {
     assert(e.getMessage.contains("uri"))
   }
 
-  test("extractCaseSensitiveAuthConfig prefers auth.* and preserves camelCase keys") {
-    val auth = UCConfigUtils.extractCaseSensitiveAuthConfig(config(
+  test("extractAuthConfig prefers auth.* and preserves camelCase keys") {
+    val auth = UCConfigUtils.extractAuthConfig(config(
       "uri" -> "https://uc.example.com",
       "auth.type" -> "oauth",
       "auth.oauth.clientId" -> "id",
@@ -50,16 +50,16 @@ class UCConfigUtilsSuite extends AnyFunSuite {
     assert(!auth.containsKey("token"))
   }
 
-  test("extractCaseSensitiveAuthConfig falls back to legacy token") {
-    val auth = UCConfigUtils.extractCaseSensitiveAuthConfig(config(
+  test("extractAuthConfig falls back to legacy token") {
+    val auth = UCConfigUtils.extractAuthConfig(config(
       "uri" -> "https://uc.example.com",
       "token" -> "my-token"))
     assert(auth.get("type") === "static")
     assert(auth.get("token") === "my-token")
   }
 
-  test("extractCaseSensitiveAuthConfig returns empty when no auth is present") {
-    assert(UCConfigUtils.extractCaseSensitiveAuthConfig(
+  test("extractAuthConfig returns empty when no auth is present") {
+    assert(UCConfigUtils.extractAuthConfig(
       config("uri" -> "https://uc.example.com")).isEmpty)
   }
 
@@ -107,7 +107,7 @@ class UCConfigUtilsSuite extends AnyFunSuite {
 
   test("prefix matching is case-sensitive") {
     assert(!UCConfigUtils.hasAuthConfig(config("Auth.type" -> "static")))
-    assert(UCConfigUtils.extractCaseSensitiveAuthConfig(config("AUTH.token" -> "t")).isEmpty)
+    assert(UCConfigUtils.extractAuthConfig(config("AUTH.token" -> "t")).isEmpty)
     assert(UCConfigUtils.extractAppVersions(config("AppVersions.Kernel" -> "0.7.0")).isEmpty)
   }
 }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCConfigUtilsSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCConfigUtilsSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator
+
+import scala.collection.JavaConverters._
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class UCConfigUtilsSuite extends AnyFunSuite {
+
+  private def config(entries: (String, String)*): java.util.Map[String, String] =
+    entries.toMap.asJava
+
+  test("extractUri returns the uri when present") {
+    assert(UCConfigUtils.extractUri(config("uri" -> "https://uc.example.com")) ===
+      "https://uc.example.com")
+  }
+
+  test("extractUri throws when uri is missing") {
+    val e = intercept[IllegalArgumentException] {
+      UCConfigUtils.extractUri(config("auth.token" -> "t"))
+    }
+    assert(e.getMessage.contains("uri"))
+  }
+
+  test("extractCaseSensitiveAuthConfig prefers auth.* and preserves camelCase keys") {
+    val auth = UCConfigUtils.extractCaseSensitiveAuthConfig(config(
+      "uri" -> "https://uc.example.com",
+      "auth.type" -> "oauth",
+      "auth.oauth.clientId" -> "id",
+      "auth.oauth.clientSecret" -> "secret",
+      "token" -> "legacy-should-be-ignored"))
+    assert(auth.get("type") === "oauth")
+    assert(auth.get("oauth.clientId") === "id")
+    assert(auth.get("oauth.clientSecret") === "secret")
+    assert(!auth.containsKey("token"))
+  }
+
+  test("extractCaseSensitiveAuthConfig falls back to legacy token") {
+    val auth = UCConfigUtils.extractCaseSensitiveAuthConfig(config(
+      "uri" -> "https://uc.example.com",
+      "token" -> "my-token"))
+    assert(auth.get("type") === "static")
+    assert(auth.get("token") === "my-token")
+  }
+
+  test("extractCaseSensitiveAuthConfig returns empty when no auth is present") {
+    assert(UCConfigUtils.extractCaseSensitiveAuthConfig(
+      config("uri" -> "https://uc.example.com")).isEmpty)
+  }
+
+  test("hasAuthConfig detects auth.* keys and legacy token") {
+    assert(UCConfigUtils.hasAuthConfig(config("auth.type" -> "static", "auth.token" -> "t")))
+    assert(UCConfigUtils.hasAuthConfig(config("token" -> "t")))
+    assert(!UCConfigUtils.hasAuthConfig(config("uri" -> "https://uc.example.com")))
+  }
+
+  test("extractAppVersions strips the prefix and ignores other keys") {
+    val versions = UCConfigUtils.extractAppVersions(config(
+      "uri" -> "https://uc.example.com",
+      "appVersions.Kernel" -> "0.7.0",
+      "appVersions.Delta V2 connector" -> "true"))
+    assert(versions.asScala === Map("Kernel" -> "0.7.0", "Delta V2 connector" -> "true"))
+  }
+
+  test("isDeltaRestApiEnabled defaults to true and honors explicit values") {
+    assert(UCConfigUtils.isDeltaRestApiEnabled(config("uri" -> "u")))
+    assert(UCConfigUtils.isDeltaRestApiEnabled(config("deltaRestApi.enabled" -> "true")))
+    assert(!UCConfigUtils.isDeltaRestApiEnabled(config("deltaRestApi.enabled" -> "false")))
+  }
+
+  test("credential flags default to true and honor explicit values") {
+    assert(UCConfigUtils.isCredentialRenewalEnabled(config("uri" -> "u")))
+    assert(UCConfigUtils.isCredentialScopedFsEnabled(config("uri" -> "u")))
+    assert(!UCConfigUtils.isCredentialRenewalEnabled(config("renewCredential.enabled" -> "false")))
+    assert(!UCConfigUtils.isCredentialScopedFsEnabled(config("credScopedFs.enabled" -> "false")))
+  }
+
+  test("parseBoolean uses the default only when the key is absent") {
+    assert(UCConfigUtils.parseBoolean(config("k" -> "true"), "k", false))
+    assert(!UCConfigUtils.parseBoolean(config("k" -> "false"), "k", true))
+    assert(UCConfigUtils.parseBoolean(config("k" -> "TRUE"), "k", false))
+    assert(UCConfigUtils.parseBoolean(config("other" -> "x"), "k", true))
+    assert(!UCConfigUtils.parseBoolean(config("other" -> "x"), "k", false))
+  }
+
+  test("parseBoolean throws on a present but invalid value") {
+    val e = intercept[IllegalArgumentException] {
+      UCConfigUtils.parseBoolean(config("k" -> "yes"), "k", false)
+    }
+    assert(e.getMessage.contains("k"))
+  }
+
+  test("prefix matching is case-sensitive") {
+    assert(!UCConfigUtils.hasAuthConfig(config("Auth.type" -> "static")))
+    assert(UCConfigUtils.extractCaseSensitiveAuthConfig(config("AUTH.token" -> "t")).isEmpty)
+    assert(UCConfigUtils.extractAppVersions(config("AppVersions.Kernel" -> "0.7.0")).isEmpty)
+  }
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -28,7 +28,6 @@ import io.delta.storage.commit.{Commit, CommitFailedException, TableIdentifier}
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.exceptions.NoSuchTableException
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
-import io.unitycatalog.client.auth.TokenProvider
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.http.HttpStatus
@@ -118,15 +117,16 @@ class UCDeltaTokenBasedRestClientSuite
     exchange.getResponseBody.close()
   }
 
-  private def tokenProvider(): TokenProvider = new TokenProvider {
-    override def accessToken(): String = "mock-token"
-    override def initialize(configs: java.util.Map[String, String]): Unit = {}
-    override def configs(): java.util.Map[String, String] = Collections.emptyMap()
+  private def clientConfig: java.util.Map[String, String] = {
+    val config = new java.util.LinkedHashMap[String, String]()
+    config.put("uri", serverUri)
+    config.put("auth.type", "static")
+    config.put("auth.token", "mock-token")
+    config
   }
 
   private def withClient(fn: UCDeltaTokenBasedRestClient => Unit): Unit = {
-    val client = new UCDeltaTokenBasedRestClient(
-      serverUri, tokenProvider(), Collections.emptyMap())
+    val client = new UCDeltaTokenBasedRestClient(clientConfig, null)
     try fn(client) finally client.close()
   }
 
@@ -188,13 +188,13 @@ class UCDeltaTokenBasedRestClientSuite
 
   test("constructor validates required parameters") {
     intercept[NullPointerException] {
-      new UCDeltaTokenBasedRestClient(null, tokenProvider(), Collections.emptyMap())
+      new UCDeltaTokenBasedRestClient(null, null)
     }
-    intercept[NullPointerException] {
-      new UCDeltaTokenBasedRestClient(serverUri, null, Collections.emptyMap())
-    }
-    intercept[NullPointerException] {
-      new UCDeltaTokenBasedRestClient(serverUri, tokenProvider(), null)
+    intercept[IllegalArgumentException] {
+      val noUri = new java.util.LinkedHashMap[String, String]()
+      noUri.put("auth.type", "static")
+      noUri.put("auth.token", "mock-token")
+      new UCDeltaTokenBasedRestClient(noUri, null)
     }
   }
 
@@ -925,8 +925,7 @@ class UCDeltaTokenBasedRestClientSuite
   // --------------- close / ensureOpen ---------------
 
   test("operations after close throw IllegalStateException") {
-    val client = new UCDeltaTokenBasedRestClient(
-      serverUri, tokenProvider(), Collections.emptyMap())
+    val client = new UCDeltaTokenBasedRestClient(clientConfig, null)
     client.close()
     intercept[IllegalStateException] { client.getMetastoreId() }
     intercept[IllegalStateException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
 1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
 2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
 3. Be sure to keep the PR description updated to reflect all changes.
 4. Please write your PR title to summarize what this PR proposes.
 5. If possible, provide a concise example to reproduce the issue for a faster review.
 6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Other (Storage)

## Description

Centralizes Unity Catalog Delta catalog-client configuration handling and removes the duplicated
constants and parsing logic that had accumulated across the Scala factory and the Java clients.

- **New `UCConfigUtils` (storage)** is the single source of truth for UC config key names
  (`uri`, `auth.*`, `token`, `deltaRestApi.enabled`, `appVersions.*`, `renewCredential.enabled`,
  `credScopedFs.enabled`) and their parsing (`extractUri`, `extractCaseSensitiveAuthConfig`,
  `hasAuthConfig`, `extractAppVersions`, `isDeltaRestApiEnabled`, `isCredentialRenewalEnabled`,
  `isCredentialScopedFsEnabled`, `parseBoolean`). Both the Scala factory
  (`UCTokenBasedRestClientFactory`) and the Java clients now delegate to it.
- **Single config-map constructor** for `UCDeltaTokenBasedRestClient`: the old multi-arg /
  reflection-based constructors are removed in favor of one `Map<String, String>` +
  `Supplier<Configuration>` constructor. `UCTokenBasedRestClientFactory` picks the Delta REST
  client vs. the default client and hands it the flat config map; credential-related defaults are
  applied by the client itself.
- **`credScopedFs.enabled` now defaults to `true`** (previously defaulted to `false`).
- Removed the now-duplicated key constants from `UCTableInfo`/`UCUtils` in favor of `UCConfigUtils`.

This is rebased on top of #7203 (the case-sensitive, plain-map catalog client path). To stay
consistent with that change, `UCConfigUtils` matches config prefixes **case-sensitively** and
parses booleans **strictly** — a present-but-invalid boolean value (e.g. `deltaRestApi.enabled=yes`)
throws instead of silently falling back to the default.

## How was this patch tested?

- `storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCConfigUtilsSuite`
- `storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClientSuite`
- `spark/testOnly org.apache.spark.sql.delta.catalog.AbstractDeltaCatalogClientRoutingSuite`
- `spark/testOnly org.apache.spark.sql.delta.coordinatedcommits.UCCommitCoordinatorBuilderSuite`
  (the Mockito-based cases fail only under a local JDK 21 setup due to a known Byte Buddy
  incompatibility, unrelated to this change)
- `sparkV2/testOnly io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfoTest`

## Does this PR introduce _any_ user-facing changes?

Yes. `credScopedFs.enabled` now defaults to `true` (previously `false`); catalogs relying on the
old default must set it to `false` explicitly. Consistent with #7203, UC catalog option keys are
matched case-sensitively, and a present-but-invalid boolean value for a recognized key now raises
an error instead of being silently ignored. Correctly-configured catalogs are unaffected.