### PR TITLE
[Spark] Route managed Delta CREATE / CTAS through the UC Delta API

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -57,7 +57,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=af090e73979bc216a0fe8feff59a5bbce0f41f14
+UC_PIN_SHA=47fc969b2f8668e96f4bb00ea148b318a329c7cd
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -57,7 +57,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=47fc969b2f8668e96f4bb00ea148b318a329c7cd
+UC_PIN_SHA=1ae646f7fe8ba65877ff0b9e5f61271bac90b3df
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.delta.storage.commit.actions.{
   AbstractCommitInfo => StorageAbstractCommitInfo,
+  AbstractDomainMetadata => StorageAbstractDomainMetadata,
   AbstractMetadata => StorageAbstractMetadata,
   AbstractProtocol => StorageAbstractProtocol
 }
@@ -668,8 +669,11 @@ case class SetTransaction(
 case class DomainMetadata(
     domain: String,
     configuration: String,
-    removed: Boolean) extends Action {
+    removed: Boolean) extends Action with StorageAbstractDomainMetadata {
   override def wrap: SingleAction = SingleAction(domainMetadata = this)
+  override def getDomain: String = domain
+  override def getConfiguration: String = configuration
+  override def isRemoved: Boolean = removed
 }
 
 /** Actions pertaining to the addition and removal of files. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -302,7 +302,8 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           // path so existing behavior is preserved.
           deltaCatalogClient match {
             case Some(client) if v1Table.tableType == CatalogTableType.MANAGED =>
-              client.createTable(ident, v1Table, snapshot)
+              client.createTable(
+                ident, v1Table, snapshot.metadata, snapshot.protocol, snapshot.timestamp)
             case _ =>
               val t = V1Table(v1Table)
               super.createTable(ident, t.columns(), t.partitioning, t.properties)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -27,13 +27,13 @@ import scala.collection.mutable
 
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD
-import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBy, ClusterBySpec}
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterByTransform => TempClusterByTransform}
 import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaConfigs, DeltaErrors, DeltaTableUtils}
 import org.apache.spark.sql.delta.{DeltaOptions, IdentityColumn}
 import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.constraints.{AddConstraint, DropConstraint}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable
 
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY_OLD
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBy, ClusterBySpec}
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterByTransform => TempClusterByTransform}
@@ -295,9 +296,17 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       //       Before this bug is fixed, we should only call the catalog plugin API to create tables
       //       if UC is enabled to replace `V2SessionCatalog`.
       createTableFunc = Option.when(isUnityCatalog) {
-        v1Table => {
-          val t = V1Table(v1Table)
-          super.createTable(ident, t.columns(), t.partitioning, t.properties)
+        (v1Table: CatalogTable, snapshot: Snapshot) => {
+          // Route to the Delta API endpoint only for MANAGED Delta creates when this client is
+          // wired in. EXTERNAL Delta and the no-client case stay on the legacy `super.createTable`
+          // path so existing behavior is preserved.
+          deltaCatalogClient match {
+            case Some(client) if v1Table.tableType == CatalogTableType.MANAGED =>
+              client.createTable(ident, v1Table, snapshot)
+            case _ =>
+              val t = V1Table(v1Table)
+              super.createTable(ident, t.columns(), t.partitioning, t.properties)
+          }
         }
       }).run(spark)
 
@@ -462,7 +471,8 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         val isUC = isUnityCatalog || properties.containsKey("test.simulateUC")
         setVariantBlockingConfigIfUC()
         val (props, writeOptions) = if (isUC) {
-          val (props, writeOptions) = getTablePropsAndWriteOptions(properties)
+          val effectiveProperties = maybeStageManagedDeltaCreate(ident, properties)
+          val (props, writeOptions) = getTablePropsAndWriteOptions(effectiveProperties)
           expandTableProps(props, writeOptions, spark.sessionState.conf)
           props.remove("test.simulateUC")
           translateUCTableIdProperty(props)
@@ -485,6 +495,36 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         )
       }
     }
+
+  /**
+   * Routing boundary for the UC Delta API path. Stages via
+   * [[AbstractDeltaCatalogClient.createStagingTable]] for a fresh managed-Delta CREATE;
+   * otherwise returns `properties` unchanged so the regular delegate flow handles it. Only
+   * the fresh-create call sites ([[createTable]] / [[stageCreate]]) invoke this.
+   *
+   * Pass-through cases:
+   *   - delegate isn't Unity Catalog;
+   *   - no Delta API client is wired in (`deltaRestApi.enabled=false`);
+   *   - `PROP_LOCATION` or `PROP_EXTERNAL` is set (external create);
+   *   - the identifier is path-based (e.g. `delta`.`/tmp/foo`).
+   */
+  private def maybeStageManagedDeltaCreate(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String] = {
+    if (!isUnityCatalog ||
+        deltaCatalogClient.isEmpty ||
+        properties.containsKey(TableCatalog.PROP_LOCATION) ||
+        properties.containsKey(TableCatalog.PROP_EXTERNAL) ||
+        // CREATE-OR-REPLACE on an existing managed table -- UCSingleCatalog sets this without
+        // setting PROP_LOCATION (location comes from the existing table's snapshot). Skip the
+        // new path so we don't allocate a fresh staging location for an existing table.
+        properties.containsKey(TableCatalog.PROP_IS_MANAGED_LOCATION)) {
+      return properties
+    }
+    val ns = ident.namespace()
+    if (ns.length == 1 && new Path(ident.name()).isAbsolute) return properties
+    deltaCatalogClient.get.createStagingTable(ident, properties)
+  }
 
   override def stageReplace(
       ident: Identifier,
@@ -515,11 +555,14 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       properties: util.Map[String, String]): StagedTable =
     recordFrameProfile("DeltaCatalog", "stageCreateOrReplace") {
       if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+        // Fresh CREATE-OR-REPLACE (no existing PROP_LOCATION) routes through the same
+        // staging boundary as `createTable` / `stageCreate`; REPLACE-existing (PROP_LOCATION
+        // set by the upstream catalog) is filtered out inside the boundary.
         new StagedDeltaTableV2(
           ident,
           schema,
           partitions,
-          properties,
+          maybeStageManagedDeltaCreate(ident, properties),
           TableCreationModes.CreateOrReplace
         )
       } else {
@@ -545,7 +588,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           ident,
           schema,
           partitions,
-          properties,
+          maybeStageManagedDeltaCreate(ident, properties),
           TableCreationModes.Create
         )
       } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -303,7 +303,12 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           deltaCatalogClient match {
             case Some(client) if v1Table.tableType == CatalogTableType.MANAGED =>
               client.createTable(
-                ident, v1Table, snapshot.metadata, snapshot.protocol, snapshot.timestamp)
+                ident,
+                v1Table,
+                snapshot.metadata,
+                snapshot.domainMetadata,
+                snapshot.protocol,
+                snapshot.timestamp)
             case _ =>
               val t = V1Table(v1Table)
               super.createTable(ident, t.columns(), t.partitioning, t.properties)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -50,8 +50,10 @@ private[catalog] trait AbstractDeltaCatalogClient {
    * endpoint) and returns `properties` augmented with the catalog-supplied LOCATION, table
    * id, and credentials.
    *
-   * The caller filters out non-managed-create requests upstream; implementations may
-   * additionally enforce that invariant as defense-in-depth.
+   * The caller is expected to route only fresh managed-Delta CREATE / CTAS requests here
+   * (external / REPLACE-existing / path-based requests are filtered out upstream).
+   * Implementations should re-verify that contract on entry rather than trusting the
+   * caller blindly.
    */
   def createStagingTable(
       ident: Identifier,
@@ -61,6 +63,10 @@ private[catalog] trait AbstractDeltaCatalogClient {
    * Called by [[AbstractDeltaCatalog]] after Delta has written the initial commit, in place
    * of the legacy `super.createTable` call. Implementations register the table with the
    * catalog (e.g. via UC Delta API `createTable` endpoint).
+   *
+   * @param lastCommitTimestampMs wall-clock timestamp of the latest commit that produced
+   *   `metadata` / `protocol`, used by the catalog as the authoritative "last updated"
+   *   timestamp on the registered entry.
    */
   def createTable(
       ident: Identifier,
@@ -68,7 +74,7 @@ private[catalog] trait AbstractDeltaCatalogClient {
       metadata: Metadata,
       domainMetadata: Seq[DomainMetadata],
       protocol: Protocol,
-      snapshotTimestamp: Long): Unit
+      lastCommitTimestampMs: Long): Unit
 }
 
 /** Builds a [[AbstractDeltaCatalogClient]] from catalog options. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -21,7 +21,7 @@ import java.util
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
-import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -66,6 +66,7 @@ private[catalog] trait AbstractDeltaCatalogClient {
       ident: Identifier,
       table: CatalogTable,
       metadata: Metadata,
+      domainMetadata: Seq[DomainMetadata],
       protocol: Protocol,
       snapshotTimestamp: Long): Unit
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -16,8 +16,12 @@
 
 package org.apache.spark.sql.delta.catalog
 
+import java.util
+
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -39,6 +43,29 @@ private[catalog] trait AbstractDeltaCatalogClient {
    *   no record of this identifier
    */
   def loadTable(ident: Identifier): Table
+
+  /**
+   * Called by `AbstractDeltaCatalog.maybeStageManagedDeltaCreate` for a fresh managed-Delta
+   * CREATE / staged CREATE. Stages the table with the catalog (e.g. UC Delta API staging
+   * endpoint) and returns `properties` augmented with the catalog-supplied LOCATION, table
+   * id, and credentials.
+   *
+   * The caller filters out non-managed-create requests upstream; implementations may
+   * additionally enforce that invariant as defense-in-depth.
+   */
+  def createStagingTable(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String]
+
+  /**
+   * Called by [[AbstractDeltaCatalog]] after Delta has written the initial commit, in place
+   * of the legacy `super.createTable` call. Implementations register the table with the
+   * catalog (e.g. via UC Delta API `createTable` endpoint).
+   */
+  def createTable(
+      ident: Identifier,
+      table: CatalogTable,
+      snapshot: Snapshot): Unit
 }
 
 /** Builds a [[AbstractDeltaCatalogClient]] from catalog options. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -21,7 +21,7 @@ import java.util
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
-import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -65,7 +65,9 @@ private[catalog] trait AbstractDeltaCatalogClient {
   def createTable(
       ident: Identifier,
       table: CatalogTable,
-      snapshot: Snapshot): Unit
+      metadata: Metadata,
+      protocol: Protocol,
+      snapshotTimestamp: Long): Unit
 }
 
 /** Builds a [[AbstractDeltaCatalogClient]] from catalog options. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
 import io.delta.storage.commit.{TableIdentifier => StorageTableIdentifier}
-import io.delta.storage.commit.actions.AbstractProtocol
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo
@@ -45,8 +45,8 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTableType
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
-import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.TableFeature
+import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -223,17 +223,26 @@ private[catalog] class UCDeltaCatalogClientImpl(
       ident: Identifier,
       table: CatalogTable,
       metadata: Metadata,
+      domainMetadata: Seq[DomainMetadata],
       protocol: Protocol,
       snapshotTimestamp: Long): Unit = {
     val locationUri = table.storage.locationUri.getOrElse(throw new IllegalArgumentException(
       s"createTable requires a storage location on the CatalogTable for $ident"))
+    // Strip V2-only catalog keys (location, owner, ...) before sending the configuration
+    // to UC; they don't belong in table properties.
+    val cleanedConfiguration =
+      metadata.configuration
+        .filterKeys(k => !UCDeltaCatalogClientImpl.ReservedV2TableProperties.contains(k))
+        .toMap
     ucClient.createTable(
       locationUri,
       toStorageTableIdent(ident),
       toUcTableType(table.tableType),
       metadata.copy(
-        description = table.comment.orNull),
+        description = table.comment.orNull,
+        configuration = cleanedConfiguration),
       protocol,
+      domainMetadata.map(d => d: AbstractDomainMetadata).asJava,
       snapshotTimestamp)
   }
 
@@ -381,6 +390,13 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
    * (no fallback, no rethrow). Not part of any public API.
    */
   def successfulDeltaRestApiLoadsForTesting: Long = successfulDeltaRestApiLoadsCounter.get()
+
+  /**
+   * V2-only catalog property keys that must be stripped before sending the configuration to
+   * UC (`location`, `owner`, `provider`, ...). Reuses Spark's canonical reserved-key list so
+   * future additions on the Spark side flow through automatically.
+   */
+  private val ReservedV2TableProperties: Set[String] = CatalogV2Util.TABLE_RESERVED_PROPERTIES.toSet
 
   private[catalog] val ServerSidePlanningEnabledKey: String = "serverSidePlanning.enabled"
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -17,13 +17,16 @@
 package org.apache.spark.sql.delta.catalog
 
 import java.net.URI
+import java.util
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
 import io.delta.storage.commit.{TableIdentifier => StorageTableIdentifier}
+import io.delta.storage.commit.actions.AbstractProtocol
 import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCDeltaModels}
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo
 import io.delta.storage.commit.uccommitcoordinator.exceptions.{
   CredentialFetchFailedException,
@@ -31,6 +34,7 @@ import io.delta.storage.commit.uccommitcoordinator.exceptions.{
   NoSuchTableException => StorageNoSuchTableException
 }
 
+import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -40,7 +44,8 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTable,
   CatalogTableType
 }
-import org.apache.spark.sql.connector.catalog.{Identifier, Table, V1Table}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
+import org.apache.spark.sql.delta.{Snapshot, TableFeature}
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.IcebergConstants
@@ -49,8 +54,9 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
- * [[AbstractDeltaCatalogClient]] backed by a [[UCDeltaClient]]; translates between
- * Spark/Delta types and the storage-side UC types.
+ * [[AbstractDeltaCatalogClient]] backed by a [[UCDeltaClient]]. Owns all of the catalog-specific
+ * managed-Delta create work (staging + finalization), so that `AbstractDeltaCatalog` only
+ * needs to invoke the trait entry points (`loadTable`, `createStagingTable`, `createTable`).
  */
 private[catalog] class UCDeltaCatalogClientImpl(
     catalogName: String,
@@ -59,6 +65,10 @@ private[catalog] class UCDeltaCatalogClientImpl(
     fallbackLoadTableFunc: Identifier => Table
     = UCDeltaCatalogClientImpl.defaultFallbackLoadTableFunc)
   extends AbstractDeltaCatalogClient with Logging {
+
+  // -------------------------------------------------------------------------
+  // DeltaCatalogClient: loadTable
+  // -------------------------------------------------------------------------
 
   override def loadTable(ident: Identifier): Table = {
     UCDeltaCatalogClientImpl.loadTableInvocationsCounter.incrementAndGet()
@@ -82,6 +92,193 @@ private[catalog] class UCDeltaCatalogClientImpl(
       }
     UCDeltaCatalogClientImpl.successfulDeltaRestApiLoadsCounter.incrementAndGet()
     toV1Table(ident, info)
+  }
+
+  // -------------------------------------------------------------------------
+  // DeltaCatalogClient: createStagingTable
+  // -------------------------------------------------------------------------
+
+  override def createStagingTable(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String] = {
+    requireUnpreparedManagedDeltaCreate(ident, properties)
+    val stagingInfo = ucClient.createStagingTable(toStorageTableIdent(ident))
+    val augmented = new util.HashMap[String, String](properties)
+    augmented.put(TableCatalog.PROP_LOCATION, stagingInfo.getLocation)
+    augmented.put(UC_TABLE_ID_KEY, stagingInfo.getTableId.toString)
+    augmented.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+    // Required first so the conflict-check sees only user input; suggested then defers via
+    // putIfAbsent, silently yielding to any required value already set.
+    applyRequiredProperties(augmented, stagingInfo.getRequiredProperties, ident)
+    applyProtocolFeatures(
+      augmented,
+      stagingInfo.getRequiredProtocol,
+      ident,
+      required = true)
+    applySuggestedProperties(augmented, stagingInfo.getSuggestedProperties)
+    applyProtocolFeatures(
+      augmented,
+      stagingInfo.getSuggestedProtocol,
+      ident,
+      required = false)
+    stagingInfo.getStorageProperties.asScala.foreach { case (k, v) =>
+      augmented.put(k, v)
+      // Delta currently expects credential options under both the bare and `option.`-prefixed
+      // keys (mirrors UCSingleCatalog#setCredentialProps); duplicate so the downstream
+      // `getTablePropsAndWriteOptions` routes credentials into writeOptions.
+      augmented.put(TableCatalog.OPTION_PREFIX + k, v)
+    }
+    augmented
+  }
+
+  /**
+   * Applies UC's suggested properties via `putIfAbsent` (caller value wins). `null` values
+   * are engine-generated-at-commit sentinels (e.g. row-tracking materialized column names) --
+   * Delta rejects them as unknown configs at stage time, so skip them here and let the
+   * engine substitute them on the finalize step.
+   */
+  private def applySuggestedProperties(
+      augmented: util.Map[String, String],
+      suggested: util.Map[String, String]): Unit = {
+    if (suggested == null) return
+    suggested.asScala.foreach { case (k, v) => if (v != null) augmented.putIfAbsent(k, v) }
+  }
+
+  /**
+   * Applies UC's required properties. A caller-supplied value that conflicts with a required
+   * key throws (see [[putRequiredOrThrow]]); `null` values are skipped (engine-generated
+   * sentinels, see [[applySuggestedProperties]]).
+   */
+  private def applyRequiredProperties(
+      augmented: util.Map[String, String],
+      required: util.Map[String, String],
+      ident: Identifier): Unit = {
+    if (required == null) return
+    required.asScala.foreach { case (k, v) =>
+      if (v != null) putRequiredOrThrow(augmented, k, v, ident)
+    }
+  }
+
+  /**
+   * Encodes a UC protocol as `delta.feature.<name>=supported` keys so the standard
+   * `CreateDeltaTableCommand` protocol-upgrade flow picks them up. A feature unknown to
+   * this Delta version throws when `required`, is silently skipped when suggested.
+   *
+   * We intentionally do NOT emit `delta.minReaderVersion`/`delta.minWriterVersion`: Delta
+   * derives those from the feature list, and pinning them here would put Delta into
+   * explicit table-features mode, suppressing implicit legacy writer features
+   * (appendOnly, invariants) in the resulting protocol.
+   */
+  private def applyProtocolFeatures(
+      augmented: util.Map[String, String],
+      protocol: AbstractProtocol,
+      ident: Identifier,
+      required: Boolean): Unit = {
+    if (protocol == null) return
+    val features =
+      Option(protocol.getReaderFeatures).map(_.asScala).getOrElse(Iterable.empty) ++
+        Option(protocol.getWriterFeatures).map(_.asScala).getOrElse(Iterable.empty)
+    features.foreach { feature =>
+      if (TableFeature.featureNameToFeature(feature).isDefined) {
+        val key = s"delta.feature.$feature"
+        if (required) putRequiredOrThrow(augmented, key, "supported", ident)
+        else augmented.putIfAbsent(key, "supported")
+      } else if (required) {
+        throw new IllegalArgumentException(
+          s"Cannot create table $ident: catalog requires Delta protocol feature " +
+            s"'$feature' but this Delta version does not support it. Upgrade Delta or " +
+            s"ask the catalog to relax the requirement.")
+      }
+    }
+  }
+
+  /**
+   * Puts a UC-required key/value, but if the caller already supplied a different value for
+   * the same key (i.e. it's in `augmented` and didn't come from us), surfaces the conflict
+   * as an `IllegalArgumentException`. UC's `required` properties are policy-level
+   * enforcement and overriding them silently would defeat that purpose.
+   */
+  private def putRequiredOrThrow(
+      augmented: util.Map[String, String],
+      key: String,
+      requiredValue: String,
+      ident: Identifier): Unit = {
+    val existing = augmented.get(key)
+    if (existing != null && existing != requiredValue) {
+      throw new IllegalArgumentException(
+        s"Cannot create table $ident: catalog requires table property '$key'=" +
+          s"'$requiredValue' but the caller supplied '$key'='$existing'. Remove the " +
+          s"conflicting TBLPROPERTIES entry and retry.")
+    }
+    augmented.put(key, requiredValue)
+  }
+
+  // -------------------------------------------------------------------------
+  // DeltaCatalogClient: createTable
+  // -------------------------------------------------------------------------
+
+  override def createTable(
+      ident: Identifier,
+      table: CatalogTable,
+      snapshot: Snapshot): Unit = {
+    val locationUri = table.storage.locationUri.getOrElse(throw new IllegalArgumentException(
+      s"createTable requires a storage location on the CatalogTable for $ident"))
+    val tableId = table.properties.getOrElse(
+      UC_TABLE_ID_KEY,
+      throw new IllegalStateException(
+        s"createTable requires the staged UC table id ('$UC_TABLE_ID_KEY') in table " +
+          s"properties for $ident; the upstream stage step must populate it."))
+    // Strip V2-only catalog keys (location, owner, ...) before sending the configuration
+    // to UC; they don't belong in table properties.
+    val cleanedConfiguration =
+      table.properties
+        .filterKeys(k => !UCDeltaCatalogClientImpl.ReservedV2TableProperties.contains(k))
+        .toMap
+    val metadata = snapshot.metadata.copy(
+      description = table.comment.orNull,
+      configuration = cleanedConfiguration)
+    ucClient.createTable(
+      tableId,
+      locationUri,
+      toStorageTableIdent(ident),
+      toUcTableType(table.tableType),
+      metadata,
+      snapshot.protocol,
+      snapshot.timestamp)
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Defense-in-depth invariant: `AbstractDeltaCatalog.maybeStageManagedDeltaCreate` is the
+   * primary filter for non-managed-create requests (external / REPLACE-existing / path-based).
+   * If any of those markers reach this client anyway, a call site bypassed the boundary --
+   * fail loud rather than re-stage an already-prepared or mislabeled request.
+   */
+  private def requireUnpreparedManagedDeltaCreate(
+      ident: Identifier,
+      properties: util.Map[String, String]): Unit = {
+    def bail(reason: String): Nothing = throw new IllegalStateException(
+      s"Managed Delta create for $ident reached the UC Delta API path in an unexpected " +
+        s"state: $reason. The upstream catalog must only route fresh managed Delta CREATE / " +
+        "CTAS here with raw caller-supplied properties.")
+    if (properties.containsKey(TableCatalog.PROP_LOCATION)) {
+      bail(s"${TableCatalog.PROP_LOCATION} is already set")
+    }
+    if (properties.containsKey(TableCatalog.PROP_IS_MANAGED_LOCATION)) {
+      bail(s"${TableCatalog.PROP_IS_MANAGED_LOCATION} is already set")
+    }
+    if (properties.containsKey(TableCatalog.PROP_EXTERNAL)) {
+      bail(s"${TableCatalog.PROP_EXTERNAL} is set (EXTERNAL request on the managed path)")
+    }
+    // Path-based identifiers come in as a single-component namespace whose name is an
+    // absolute filesystem path (e.g. `delta`.`/tmp/foo`); UC has no entry for those.
+    val ns = ident.namespace()
+    if (ns.length == 1 && new Path(ident.name()).isAbsolute) {
+      bail("identifier is path-based")
+    }
   }
 
   private def enableServerSidePlanningConfig(ident: Identifier): Unit = {
@@ -154,6 +351,13 @@ private[catalog] class UCDeltaCatalogClientImpl(
     V1Table(catalogTable)
   }
 
+  private def toUcTableType(t: CatalogTableType): UCDeltaModels.TableType = t match {
+    case CatalogTableType.MANAGED => UCDeltaModels.TableType.MANAGED
+    case CatalogTableType.EXTERNAL => UCDeltaModels.TableType.EXTERNAL
+    case other =>
+      throw new IllegalArgumentException(s"Unsupported CatalogTableType for UC: $other")
+  }
+
   private def fromUcTableType(t: UCDeltaModels.TableType): CatalogTableType = t match {
     case UCDeltaModels.TableType.MANAGED => CatalogTableType.MANAGED
     case UCDeltaModels.TableType.EXTERNAL => CatalogTableType.EXTERNAL
@@ -170,29 +374,36 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   private val loadTableInvocationsCounter: AtomicLong = new AtomicLong(0L)
 
   /**
-   * Bumped only when `loadTable` returned a Delta table via the Delta REST API (no fallback,
+   * Bumped only when `loadTable` returned a Delta table via the UC Delta API (no fallback,
    * no rethrow). Read via the *ForTesting API.
    */
   private val successfulDeltaRestApiLoadsCounter: AtomicLong = new AtomicLong(0L)
 
   /**
    * Test-only read accessor for the `loadTable` invocation counter. Used by integration
-   * tests to verify the Delta REST API code path ran. Not part of any public API; production
+   * tests to verify the UC Delta API code path ran. Not part of any public API; production
    * code must not depend on it.
    */
   def loadTableInvocationsForTesting: Long = loadTableInvocationsCounter.get()
 
   /**
-   * Test-only read accessor for the count of `loadTable` calls served by the Delta REST API
+   * Test-only read accessor for the count of `loadTable` calls served by the UC Delta API
    * (no fallback, no rethrow). Not part of any public API.
    */
   def successfulDeltaRestApiLoadsForTesting: Long = successfulDeltaRestApiLoadsCounter.get()
+
+  /**
+   * V2-only catalog property keys that must be stripped before sending the configuration to
+   * UC (`location`, `owner`, `provider`, ...). Reuses Spark's canonical reserved-key list so
+   * future additions on the Spark side flow through automatically.
+   */
+  private val ReservedV2TableProperties: Set[String] = CatalogV2Util.TABLE_RESERVED_PROPERTIES.toSet
 
   private[catalog] val ServerSidePlanningEnabledKey: String = "serverSidePlanning.enabled"
 
   private[catalog] val defaultFallbackLoadTableFunc: Identifier => Table = ident =>
     throw new IllegalStateException(
-      s"Non-Delta table $ident cannot be served via the Delta REST API path and no " +
+      s"Non-Delta table $ident cannot be served via the UC Delta API path and no " +
         "fallback catalog was configured.")
 
   /**
@@ -205,8 +416,7 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   override def fromCatalogOptions(
       catalogName: String,
       options: CaseInsensitiveStringMap,
-      fallbackLoadTableFunc: Identifier => Table
-  ): UCDeltaCatalogClientImpl = {
+      fallbackLoadTableFunc: Identifier => Table): UCDeltaCatalogClientImpl = {
     // Pre-flight: keep our user-facing errors instead of the factory's less specific ones.
     if (options.get(UriKey) == null) {
       throw new IllegalArgumentException(s"'$UriKey' is required (catalog '$catalogName')")
@@ -219,8 +429,9 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
     Seq(
       UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY -> "true",
       UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY -> "true",
-      UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false"
-    ).foreach { case (k, v) => if (!options.containsKey(k)) merged.put(k, v) }
+      UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false").foreach { case (k, v) =>
+      if (!options.containsKey(k)) merged.put(k, v)
+    }
     val ucClient = UCTokenBasedRestClientFactory
       .createUCClient(new CaseInsensitiveStringMap(merged))
       .asInstanceOf[UCDeltaClient]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -46,7 +46,8 @@ import org.apache.spark.sql.catalyst.catalog.{
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
-import org.apache.spark.sql.delta.{Snapshot, TableFeature}
+import org.apache.spark.sql.delta.TableFeature
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.IcebergConstants
@@ -182,8 +183,8 @@ private[catalog] class UCDeltaCatalogClientImpl(
     features.foreach { feature =>
       if (TableFeature.featureNameToFeature(feature).isDefined) {
         val key = s"delta.feature.$feature"
-        if (required) putRequiredOrThrow(augmented, key, "supported", ident)
-        else augmented.putIfAbsent(key, "supported")
+        if (required) putRequiredOrThrow(augmented, key, FEATURE_PROP_SUPPORTED, ident)
+        else augmented.putIfAbsent(key, FEATURE_PROP_SUPPORTED)
       } else if (required) {
         throw new IllegalArgumentException(
           s"Cannot create table $ident: catalog requires Delta protocol feature " +
@@ -226,19 +227,12 @@ private[catalog] class UCDeltaCatalogClientImpl(
       snapshotTimestamp: Long): Unit = {
     val locationUri = table.storage.locationUri.getOrElse(throw new IllegalArgumentException(
       s"createTable requires a storage location on the CatalogTable for $ident"))
-    // Strip V2-only catalog keys (location, owner, ...) before sending the configuration
-    // to UC; they don't belong in table properties.
-    val cleanedConfiguration =
-      table.properties
-        .filterKeys(k => !UCDeltaCatalogClientImpl.ReservedV2TableProperties.contains(k))
-        .toMap
     ucClient.createTable(
       locationUri,
       toStorageTableIdent(ident),
       toUcTableType(table.tableType),
       metadata.copy(
-        description = table.comment.orNull,
-        configuration = cleanedConfiguration),
+        description = table.comment.orNull),
       protocol,
       snapshotTimestamp)
   }
@@ -295,7 +289,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
     val ns = ident.namespace()
     require(
       ns.length == 1,
-      s"UC identifiers must be of the form <schema>.<table>; got namespace of length " +
+      s"UC table identifiers must be of the form <schema>.<table>; got namespace of length " +
         s"${ns.length}: '${ns.mkString(".")}' (full identifier: '${ident.toString}')")
     new StorageTableIdentifier(Array(catalogName, ns(0)), ident.name())
   }
@@ -388,13 +382,6 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
    */
   def successfulDeltaRestApiLoadsForTesting: Long = successfulDeltaRestApiLoadsCounter.get()
 
-  /**
-   * V2-only catalog property keys that must be stripped before sending the configuration to
-   * UC (`location`, `owner`, `provider`, ...). Reuses Spark's canonical reserved-key list so
-   * future additions on the Spark side flow through automatically.
-   */
-  private val ReservedV2TableProperties: Set[String] = CatalogV2Util.TABLE_RESERVED_PROPERTIES.toSet
-
   private[catalog] val ServerSidePlanningEnabledKey: String = "serverSidePlanning.enabled"
 
   private[catalog] val defaultFallbackLoadTableFunc: Identifier => Table = ident =>
@@ -425,9 +412,8 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
     Seq(
       UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY -> "true",
       UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY -> "true",
-      UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false").foreach { case (k, v) =>
-      if (!options.containsKey(k)) merged.put(k, v)
-    }
+      UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false"
+    ).foreach { case (k, v) => if (!options.containsKey(k)) merged.put(k, v) }
     val ucClient = UCTokenBasedRestClientFactory
       .createUCClient(new CaseInsensitiveStringMap(merged))
       .asInstanceOf[UCDeltaClient]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -45,6 +45,7 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTableType
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.{Snapshot, TableFeature}
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -176,8 +177,8 @@ private[catalog] class UCDeltaCatalogClientImpl(
       required: Boolean): Unit = {
     if (protocol == null) return
     val features =
-      Option(protocol.getReaderFeatures).map(_.asScala).getOrElse(Iterable.empty) ++
-        Option(protocol.getWriterFeatures).map(_.asScala).getOrElse(Iterable.empty)
+      (Option(protocol.getReaderFeatures).map(_.asScala).getOrElse(Iterable.empty) ++
+        Option(protocol.getWriterFeatures).map(_.asScala).getOrElse(Iterable.empty)).toSet
     features.foreach { feature =>
       if (TableFeature.featureNameToFeature(feature).isDefined) {
         val key = s"delta.feature.$feature"
@@ -220,31 +221,26 @@ private[catalog] class UCDeltaCatalogClientImpl(
   override def createTable(
       ident: Identifier,
       table: CatalogTable,
-      snapshot: Snapshot): Unit = {
+      metadata: Metadata,
+      protocol: Protocol,
+      snapshotTimestamp: Long): Unit = {
     val locationUri = table.storage.locationUri.getOrElse(throw new IllegalArgumentException(
       s"createTable requires a storage location on the CatalogTable for $ident"))
-    val tableId = table.properties.getOrElse(
-      UC_TABLE_ID_KEY,
-      throw new IllegalStateException(
-        s"createTable requires the staged UC table id ('$UC_TABLE_ID_KEY') in table " +
-          s"properties for $ident; the upstream stage step must populate it."))
     // Strip V2-only catalog keys (location, owner, ...) before sending the configuration
     // to UC; they don't belong in table properties.
     val cleanedConfiguration =
       table.properties
         .filterKeys(k => !UCDeltaCatalogClientImpl.ReservedV2TableProperties.contains(k))
         .toMap
-    val metadata = snapshot.metadata.copy(
-      description = table.comment.orNull,
-      configuration = cleanedConfiguration)
     ucClient.createTable(
-      tableId,
       locationUri,
       toStorageTableIdent(ident),
       toUcTableType(table.tableType),
-      metadata,
-      snapshot.protocol,
-      snapshot.timestamp)
+      metadata.copy(
+        description = table.comment.orNull,
+        configuration = cleanedConfiguration),
+      protocol,
+      snapshotTimestamp)
   }
 
   // -------------------------------------------------------------------------

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -86,7 +86,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
           return fallbackLoadTableFunc(ident)
         case e: CredentialFetchFailedException if serverSidePlanningEnabled =>
           logWarning(log"Credential fetch failed for " +
-            log"${MDC(DeltaLogKeys.TABLE_NAME, fullQualifiedTableName(tid))}; enabling " +
+            log"${MDC(DeltaLogKeys.TABLE_NAME, fullQualifiedTableName(ident))}; enabling " +
             log"server-side planning fallback. Cause: " +
             log"${MDC(DeltaLogKeys.EXCEPTION, e.getMessage)}")
           enableServerSidePlanningConfig(ident)
@@ -166,6 +166,13 @@ private[catalog] class UCDeltaCatalogClientImpl(
    * `CreateDeltaTableCommand` protocol-upgrade flow picks them up. A feature unknown to
    * this Delta version throws when `required`, is silently skipped when suggested.
    *
+   * Treat the "unknown feature" branch as a hard compatibility gap, not a bug: the
+   * catalog server enforces the Delta protocol features it requires, and this client only
+   * supports the subset that its bundled Delta version understands. If the catalog
+   * requires a newer feature, upgrade Delta on the client side (or, if appropriate,
+   * relax the requirement on the server). See the Delta protocol spec for the full
+   * feature list: https://github.com/delta-io/delta/blob/master/PROTOCOL.md
+   *
    * We intentionally do NOT emit `delta.minReaderVersion`/`delta.minWriterVersion`: Delta
    * derives those from the feature list, and pinning them here would put Delta into
    * explicit table-features mode, suppressing implicit legacy writer features
@@ -183,13 +190,16 @@ private[catalog] class UCDeltaCatalogClientImpl(
     features.foreach { feature =>
       if (TableFeature.featureNameToFeature(feature).isDefined) {
         val key = s"delta.feature.$feature"
-        if (required) putRequiredOrThrow(augmented, key, FEATURE_PROP_SUPPORTED, ident)
+        if (required) putRequiredFeatureOrThrow(augmented, key, ident)
         else augmented.putIfAbsent(key, FEATURE_PROP_SUPPORTED)
       } else if (required) {
+        val qualifiedName = fullQualifiedTableName(ident)
         throw new IllegalArgumentException(
-          s"Cannot create table $ident: catalog requires Delta protocol feature " +
+          s"Cannot create table $qualifiedName: catalog requires Delta protocol feature " +
             s"'$feature' but this Delta version does not support it. Upgrade Delta or " +
-            s"ask the catalog to relax the requirement.")
+            "ask the catalog to relax the requirement. See " +
+            "https://github.com/delta-io/delta/blob/master/PROTOCOL.md for the full " +
+            "Delta protocol feature list.")
       }
     }
   }
@@ -207,12 +217,35 @@ private[catalog] class UCDeltaCatalogClientImpl(
       ident: Identifier): Unit = {
     val existing = augmented.get(key)
     if (existing != null && existing != requiredValue) {
+      val qualifiedName = fullQualifiedTableName(ident)
       throw new IllegalArgumentException(
-        s"Cannot create table $ident: catalog requires table property '$key'=" +
+        s"Cannot create table $qualifiedName: catalog requires table property '$key'=" +
           s"'$requiredValue' but the caller supplied '$key'='$existing'. Remove the " +
           s"conflicting TBLPROPERTIES entry and retry.")
     }
     augmented.put(key, requiredValue)
+  }
+
+  /**
+   * Specialized variant of [[putRequiredOrThrow]] for `delta.feature.<name>=supported` keys.
+   * The error message phrases the conflict in terms of "table feature" rather than "table
+   * property" because `delta.feature.<name>` is a feature flag that only accepts the value
+   * `supported`; any other value reaching here is a user-side mistake, not a property
+   * override.
+   */
+  private def putRequiredFeatureOrThrow(
+      augmented: util.Map[String, String],
+      featureKey: String,
+      ident: Identifier): Unit = {
+    val existing = augmented.get(featureKey)
+    if (existing != null && existing != FEATURE_PROP_SUPPORTED) {
+      val qualifiedName = fullQualifiedTableName(ident)
+      throw new IllegalArgumentException(
+        s"Cannot create table $qualifiedName: catalog requires Delta table feature " +
+          s"'$featureKey'='$FEATURE_PROP_SUPPORTED' but the caller supplied " +
+          s"'$featureKey'='$existing'. Remove the conflicting TBLPROPERTIES entry and retry.")
+    }
+    augmented.put(featureKey, FEATURE_PROP_SUPPORTED)
   }
 
   // -------------------------------------------------------------------------
@@ -225,13 +258,19 @@ private[catalog] class UCDeltaCatalogClientImpl(
       metadata: Metadata,
       domainMetadata: Seq[DomainMetadata],
       protocol: Protocol,
-      snapshotTimestamp: Long): Unit = {
+      lastCommitTimestampMs: Long): Unit = {
+    if (table.tableType != CatalogTableType.MANAGED) {
+      throw new IllegalArgumentException(
+        s"UC Delta API createTable only supports MANAGED tables; " +
+          s"got ${table.tableType} for ${fullQualifiedTableName(ident)}.")
+    }
     val locationUri = table.storage.locationUri.getOrElse(throw new IllegalArgumentException(
-      s"createTable requires a storage location on the CatalogTable for $ident"))
+      s"createTable requires a storage location on the CatalogTable for " +
+        s"${fullQualifiedTableName(ident)}"))
     // Strip V2-only catalog keys (location, owner, ...) before sending the configuration
     // to UC; they don't belong in table properties.
     val cleanedConfiguration =
-      metadata.configuration
+      metadata.configuration.view
         .filterKeys(k => !UCDeltaCatalogClientImpl.ReservedV2TableProperties.contains(k))
         .toMap
     ucClient.createTable(
@@ -243,7 +282,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
         configuration = cleanedConfiguration),
       protocol,
       domainMetadata.map(d => d: AbstractDomainMetadata).asJava,
-      snapshotTimestamp)
+      lastCommitTimestampMs)
   }
 
   // -------------------------------------------------------------------------
@@ -259,10 +298,11 @@ private[catalog] class UCDeltaCatalogClientImpl(
   private def requireUnpreparedManagedDeltaCreate(
       ident: Identifier,
       properties: util.Map[String, String]): Unit = {
+    val qualifiedName = fullQualifiedTableName(ident)
     def bail(reason: String): Nothing = throw new IllegalStateException(
-      s"Managed Delta create for $ident reached the UC Delta API path in an unexpected " +
-        s"state: $reason. The upstream catalog must only route fresh managed Delta CREATE / " +
-        "CTAS here with raw caller-supplied properties.")
+      s"Managed Delta create for $qualifiedName reached the UC Delta API path in an " +
+        s"unexpected state: $reason. The upstream catalog must only route fresh managed " +
+        "Delta CREATE / CTAS here with raw caller-supplied properties.")
     if (properties.containsKey(TableCatalog.PROP_LOCATION)) {
       bail(s"${TableCatalog.PROP_LOCATION} is already set")
     }
@@ -298,16 +338,15 @@ private[catalog] class UCDeltaCatalogClientImpl(
     val ns = ident.namespace()
     require(
       ns.length == 1,
-      s"UC table identifiers must be of the form <schema>.<table>; got namespace of length " +
-        s"${ns.length}: '${ns.mkString(".")}' (full identifier: '${ident.toString}')")
+      s"UC table identifier must be one of <schema>.<table> or <catalog>.<schema>.<table>; " +
+        s"got namespace of length ${ns.length}: '${ns.mkString(".")}' " +
+        s"(full identifier: '${ident.toString}')")
     new StorageTableIdentifier(Array(catalogName, ns(0)), ident.name())
   }
 
-  /** Three-part dotted name from a `[catalog, schema]` + `name` storage identifier. */
-  private def fullQualifiedTableName(t: StorageTableIdentifier): String = {
-    val ns = t.getNamespace
-    s"${ns(0)}.${ns(1)}.${t.getName}"
-  }
+  /** Three-part dotted `catalog.schema.table` name for a Spark V2 `Identifier`. */
+  private def fullQualifiedTableName(ident: Identifier): String =
+    s"$catalogName.${ident.namespace().mkString(".")}.${ident.name()}"
 
   private def toV1Table(ident: Identifier, info: TableInfo): V1Table = {
     val m = info.getMetadata

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -67,8 +67,11 @@ import org.apache.spark.util.Utils
  * @param output SQL output of the command
  * @param protocol This is used to create a table with specific protocol version
  * @param allowCatalogManaged This is used to create UC managed table with catalogManaged feature
- * @param createTableFunc If specified, call this function to create the table, instead of
- *                        Spark `SessionCatalog#createTable` which is backed by Hive Metastore.
+ * @param createTableFunc If specified, call this function (with the cleaned [[CatalogTable]] and
+ *                        the post-commit [[Snapshot]]) to create the table, instead of Spark
+ *                        `SessionCatalog#createTable` which is backed by Hive Metastore. The
+ *                        snapshot is included so callers that need committed protocol/metadata
+ *                        (e.g. catalog-managed Delta) can avoid re-loading the table.
  */
 case class CreateDeltaTableCommand(
     override val table: CatalogTable,
@@ -80,7 +83,7 @@ case class CreateDeltaTableCommand(
     override val output: Seq[Attribute] = Nil,
     protocol: Option[Protocol] = None,
     override val allowCatalogManaged: Boolean = false,
-    createTableFunc: Option[CatalogTable => Unit] = None)
+    createTableFunc: Option[(CatalogTable, Snapshot) => Unit] = None)
   extends LeafRunnableCommand
   with DeltaCommand
   with DeltaLogging

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableLike.scala
@@ -91,14 +91,14 @@ trait CreateDeltaTableLike extends SQLConfHelper {
       snapshot: Snapshot,
       query: Option[LogicalPlan],
       didNotChangeMetadata: Boolean,
-      createTableFunc: Option[CatalogTable => Unit] = None
+      createTableFunc: Option[(CatalogTable, Snapshot) => Unit] = None
   ): Unit = {
     val cleaned = cleanupTableDefinition(spark, table, snapshot)
     operation match {
       case _ if tableByPath => // do nothing with the metastore if this is by path
       case TableCreationModes.Create =>
         if (createTableFunc.isDefined) {
-          createTableFunc.get.apply(cleaned)
+          createTableFunc.get.apply(cleaned, snapshot)
         } else {
           spark.sessionState.catalog.createTable(
             cleaned,
@@ -120,7 +120,7 @@ trait CreateDeltaTableLike extends SQLConfHelper {
           case Some(createFunc) =>
             // This is the new missing-table path where creation is delegated through the V2
             // catalog plugin (for example Unity Catalog) instead of SessionCatalog.createTable().
-            createFunc(cleaned)
+            createFunc(cleaned, snapshot)
           case None =>
             spark.sessionState.catalog.createTable(
               cleaned,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.util.UUID
 
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.commands.{
   CreateDeltaTableCommand,
@@ -381,7 +382,7 @@ class DeltaCreateTableLikeSuite extends QueryTest
             snapshot,
             query = None,
             didNotChangeMetadata = true,
-            createTableFunc = Some((_: CatalogTable) => {
+            createTableFunc = Some((_: CatalogTable, _: Snapshot) => {
               createCallbackCalls += 1
             }))
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -20,6 +20,8 @@ import java.net.URI
 import java.util
 import java.util.{Collections, Optional, UUID}
 
+import scala.jdk.CollectionConverters._
+
 import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier => StorageTableIdentifier}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCDeltaClient, UCDeltaModels}
@@ -29,14 +31,14 @@ import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
-import org.apache.spark.sql.connector.catalog.{Identifier, Table, V1Table}
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, V1Table}
 import org.apache.spark.sql.delta.IcebergConstants
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
- * Unit tests for the Delta REST API client wiring on [[AbstractDeltaCatalog]]. These verify
+ * Unit tests for the UC Delta API client wiring on [[AbstractDeltaCatalog]]. These verify
  * only the catalog-option / initialize plumbing and the loadTable dispatch decision; they do
  * not require a UC server.
  */
@@ -52,7 +54,7 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     val catalog = new AbstractDeltaCatalog
     catalog.initialize("test_cat", options())
     assert(catalog.deltaCatalogClient.isEmpty,
-      "Delta REST API client should not be constructed when the catalog opts out")
+      "UC Delta API client should not be constructed when the catalog opts out")
   }
 
   test("deltaRestApi.enabled=true requires uri") {
@@ -83,14 +85,14 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     assert(catalog.deltaCatalogClient.isDefined)
   }
 
-  test("deltaRestApi.enabled=true with uri+token constructs the Delta REST API client") {
+  test("deltaRestApi.enabled=true with uri+token constructs the UC Delta API client") {
     val catalog = new AbstractDeltaCatalog
     catalog.initialize("test_cat",
       options("deltaRestApi.enabled" -> "true", "uri" -> "http://uc", "token" -> "tok"))
     val client = catalog.deltaCatalogClient.getOrElse(
-      fail("Delta REST API client should be constructed when the catalog opts in"))
+      fail("UC Delta API client should be constructed when the catalog opts in"))
     assert(client.isInstanceOf[UCDeltaCatalogClientImpl],
-      s"Delta REST API client should be UCDeltaCatalogClientImpl, was ${client.getClass}")
+      s"UC Delta API client should be UCDeltaCatalogClientImpl, was ${client.getClass}")
   }
 
   test("AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled returns None when flag is off") {
@@ -109,6 +111,281 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
 
   private val noFallback: Identifier => Table =
     _ => throw new UnsupportedOperationException("fallback not expected in this test")
+
+  /**
+   * createStagingTable contract tests. The contract: only fresh managed Delta CREATE / CTAS
+   * requests with raw caller-supplied properties may reach this client. The routing boundary
+   * (`AbstractDeltaCatalog.maybeStageManagedDeltaCreate`) is responsible for that separation;
+   * if any "already-prepared" marker (LOCATION / IS_MANAGED_LOCATION / EXTERNAL / path-based
+   * ident) is seen here, it means some call site bypassed the boundary -- the impl fails
+   * loudly as defense-in-depth.
+   */
+  private def newRecordingClient(
+      requiredProtocol: UCDeltaModels.DeltaProtocol = null,
+      suggestedProtocol: UCDeltaModels.DeltaProtocol = null,
+      requiredProperties: util.Map[String, String] = java.util.Collections.emptyMap(),
+      suggestedProperties: util.Map[String, String] = java.util.Collections.emptyMap()
+  ): (UCDeltaCatalogClientImpl, RecordingStubUCDeltaClient) = {
+    val stub = new RecordingStubUCDeltaClient(
+      new StagingTableInfo(
+        /* tableId = */ UUID.fromString("00000000-0000-0000-0000-000000000001"),
+        /* tableType = */ UCDeltaModels.TableType.MANAGED,
+        /* location = */ "s3://bucket/staging/tbl",
+        requiredProtocol,
+        suggestedProtocol,
+        requiredProperties,
+        suggestedProperties,
+        /* storageProperties = */ java.util.Map.of("fs.s3a.access.key", "stage-key")))
+    val client = new UCDeltaCatalogClientImpl(catalogName = "main", ucClient = stub)
+    (client, stub)
+  }
+
+  private def protocol(
+      minReader: Int = 0,
+      minWriter: Int = 0,
+      readerFeatures: Seq[String] = Nil,
+      writerFeatures: Seq[String] = Nil): UCDeltaModels.DeltaProtocol = {
+    val p = new UCDeltaModels.DeltaProtocol()
+    if (minReader > 0) p.minReaderVersion(minReader)
+    if (minWriter > 0) p.minWriterVersion(minWriter)
+    if (readerFeatures.nonEmpty) p.readerFeatures(readerFeatures.asJava)
+    if (writerFeatures.nonEmpty) p.writerFeatures(writerFeatures.asJava)
+    p
+  }
+
+  private def javaMap(kv: (String, String)*): util.Map[String, String] = {
+    val m = new util.HashMap[String, String]()
+    kv.foreach { case (k, v) => m.put(k, v) }
+    m
+  }
+
+  private def stageProps(kv: (String, String)*): util.Map[String, String] = {
+    val m = new util.HashMap[String, String]()
+    kv.foreach { case (k, v) => m.put(k, v) }
+    m
+  }
+
+  test("createStagingTable: managed Delta create on the new path stages + augments props") {
+    val (client, stub) = newRecordingClient()
+    val ident = Identifier.of(Array("sch"), "tbl")
+    val out = client.createStagingTable(ident, stageProps("delta.catalogManaged" -> "supported"))
+    assert(stub.stagedRequests.size === 1, "should call UC createStagingTable exactly once")
+    assert(stub.stagedRequests.head === ("main", "sch", "tbl"))
+    assert(out.get(TableCatalog.PROP_LOCATION) === "s3://bucket/staging/tbl")
+    assert(out.get(TableCatalog.PROP_IS_MANAGED_LOCATION) === "true")
+    assert(out.get("fs.s3a.access.key") === "stage-key",
+      "credential properties must be copied onto the bare key")
+    assert(out.get(TableCatalog.OPTION_PREFIX + "fs.s3a.access.key") === "stage-key",
+      "credential properties must also be copied onto the `option.`-prefixed key so they " +
+        "are picked up as writeOptions downstream")
+  }
+
+  test("createStagingTable: PROP_LOCATION already set throws") {
+    val (client, stub) = newRecordingClient()
+    val ident = Identifier.of(Array("sch"), "tbl")
+    val in = stageProps(
+      "delta.catalogManaged" -> "supported",
+      TableCatalog.PROP_LOCATION -> "s3://already/staged")
+    val ex = intercept[IllegalStateException](client.createStagingTable(ident, in))
+    assert(ex.getMessage.contains(TableCatalog.PROP_LOCATION))
+    assert(stub.stagedRequests.isEmpty, "must not stage when failing the invariant check")
+  }
+
+  test("createStagingTable: PROP_IS_MANAGED_LOCATION already set throws") {
+    val (client, stub) = newRecordingClient()
+    val ident = Identifier.of(Array("sch"), "tbl")
+    val in = stageProps(
+      "delta.catalogManaged" -> "supported",
+      TableCatalog.PROP_IS_MANAGED_LOCATION -> "true")
+    val ex = intercept[IllegalStateException](client.createStagingTable(ident, in))
+    assert(ex.getMessage.contains(TableCatalog.PROP_IS_MANAGED_LOCATION))
+    assert(stub.stagedRequests.isEmpty)
+  }
+
+  test("createStagingTable: PROP_EXTERNAL set throws") {
+    val (client, stub) = newRecordingClient()
+    val ident = Identifier.of(Array("sch"), "tbl")
+    val in = stageProps(TableCatalog.PROP_EXTERNAL -> "true")
+    val ex = intercept[IllegalStateException](client.createStagingTable(ident, in))
+    assert(ex.getMessage.contains(TableCatalog.PROP_EXTERNAL))
+    assert(stub.stagedRequests.isEmpty)
+  }
+
+  // -------------------------------------------------------------------------
+  // createStagingTable: UC-returned required/suggested protocol + properties merging
+  // -------------------------------------------------------------------------
+
+  test("createStagingTable: required properties are merged into augmented props") {
+    val (client, _) = newRecordingClient(
+      requiredProperties = javaMap("delta.enableInCommitTimestamps" -> "true"))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.catalogManaged" -> "supported"))
+    assert(out.get("delta.enableInCommitTimestamps") === "true")
+    assert(out.get("delta.catalogManaged") === "supported", "user props must survive merging")
+  }
+
+  test("createStagingTable: required property matching user value is fine (no throw)") {
+    val (client, _) = newRecordingClient(
+      requiredProperties = javaMap("delta.enableInCommitTimestamps" -> "true"))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps(
+        "delta.catalogManaged" -> "supported",
+        "delta.enableInCommitTimestamps" -> "true"))
+    assert(out.get("delta.enableInCommitTimestamps") === "true")
+  }
+
+  test("createStagingTable: required property conflicting with user value throws") {
+    val (client, _) = newRecordingClient(
+      requiredProperties = javaMap("delta.enableInCommitTimestamps" -> "true"))
+    val ident = Identifier.of(Array("sch"), "tbl")
+    val e = intercept[IllegalArgumentException] {
+      client.createStagingTable(ident, stageProps(
+        "delta.catalogManaged" -> "supported",
+        "delta.enableInCommitTimestamps" -> "false"))
+    }
+    assert(e.getMessage.contains("'delta.enableInCommitTimestamps'='true'"),
+      "error must name the required key and value")
+    assert(e.getMessage.contains("'delta.enableInCommitTimestamps'='false'"),
+      "error must name the caller-supplied conflicting value")
+  }
+
+  test("createStagingTable: suggested property is applied when caller hasn't set it") {
+    val (client, _) = newRecordingClient(
+      suggestedProperties = javaMap("delta.someSuggested" -> "ucs-val"))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.catalogManaged" -> "supported"))
+    assert(out.get("delta.someSuggested") === "ucs-val")
+  }
+
+  test("createStagingTable: suggested property defers to caller when both set") {
+    val (client, _) = newRecordingClient(
+      suggestedProperties = javaMap("delta.someSuggested" -> "ucs-val"))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps(
+        "delta.catalogManaged" -> "supported",
+        "delta.someSuggested" -> "caller-val"))
+    assert(out.get("delta.someSuggested") === "caller-val",
+      "user TBLPROPERTIES must win over a suggested value")
+  }
+
+  test("createStagingTable: required protocol features are encoded as delta.feature.*") {
+    val (client, _) = newRecordingClient(
+      requiredProtocol = protocol(
+        minReader = 3, minWriter = 7,
+        readerFeatures = Seq("deletionVectors"),
+        writerFeatures = Seq("catalogManaged", "rowTracking")))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.catalogManaged" -> "supported"))
+    assert(out.get("delta.feature.deletionVectors") === "supported")
+    assert(out.get("delta.feature.catalogManaged") === "supported")
+    assert(out.get("delta.feature.rowTracking") === "supported")
+    // Min reader/writer versions are intentionally not emitted -- Delta derives them from
+    // the feature list. Pinning them here would tell Delta we're explicitly in table-
+    // features mode and suppress legacy writer features (appendOnly, invariants) in the
+    // resulting protocol.
+    assert(!out.containsKey("delta.minReaderVersion"))
+    assert(!out.containsKey("delta.minWriterVersion"))
+  }
+
+  test("createStagingTable: suggested protocol features known to Delta are applied") {
+    val (client, _) = newRecordingClient(
+      suggestedProtocol = protocol(
+        readerFeatures = Seq("columnMapping"),
+        writerFeatures = Seq("domainMetadata")))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.catalogManaged" -> "supported"))
+    assert(out.get("delta.feature.columnMapping") === "supported")
+    assert(out.get("delta.feature.domainMetadata") === "supported")
+  }
+
+  test("createStagingTable: suggested protocol feature unknown to Delta is silently skipped") {
+    // Capability negotiation: UC may suggest a feature this Delta version hasn't shipped.
+    // We just don't apply it -- the suggestion is opt-in, so skipping is graceful.
+    val (client, _) = newRecordingClient(
+      suggestedProtocol = protocol(writerFeatures = Seq("someFutureUnknownFeature")))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.catalogManaged" -> "supported"))
+    assert(!out.containsKey("delta.feature.someFutureUnknownFeature"))
+  }
+
+  test("createStagingTable: required protocol feature unknown to Delta throws") {
+    val (client, _) = newRecordingClient(
+      requiredProtocol = protocol(writerFeatures = Seq("someFutureUnknownFeature")))
+    val e = intercept[IllegalArgumentException] {
+      client.createStagingTable(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps("delta.catalogManaged" -> "supported"))
+    }
+    assert(e.getMessage.contains("someFutureUnknownFeature"))
+    assert(e.getMessage.contains("Delta version does not support"),
+      "error must explain that the local Delta lacks the feature")
+  }
+
+  test("createStagingTable: suggested protocol feature defers to caller's existing value") {
+    val (client, _) = newRecordingClient(
+      suggestedProtocol = protocol(writerFeatures = Seq("rowTracking")))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps(
+        "delta.catalogManaged" -> "supported",
+        "delta.feature.rowTracking" -> "disabled"))
+    assert(out.get("delta.feature.rowTracking") === "disabled",
+      "a caller-set delta.feature.* must win over a suggestion")
+  }
+
+  test("createStagingTable: required protocol feature conflicting with caller value throws") {
+    val (client, _) = newRecordingClient(
+      requiredProtocol = protocol(writerFeatures = Seq("catalogManaged")))
+    val e = intercept[IllegalArgumentException] {
+      client.createStagingTable(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps(
+          "delta.catalogManaged" -> "supported",
+          "delta.feature.catalogManaged" -> "disabled"))
+    }
+    assert(e.getMessage.contains("'delta.feature.catalogManaged'='supported'"))
+    assert(e.getMessage.contains("'delta.feature.catalogManaged'='disabled'"))
+  }
+
+  test("createStagingTable: null-valued required/suggested entries are skipped") {
+    // UC's contract: null on the wire means "engine substitutes at commit time" (e.g. the
+    // row-tracking materialized column names). They must not leak into stage-time TBLPROPERTIES
+    // -- Delta would reject them as unknown configs. The required-property branch is defensive
+    // against future engine-generated required keys; UC's current contract has none.
+    val req = new util.HashMap[String, String]()
+    req.put("delta.checkpointPolicy", "v2")                                   // non-null -> applied
+    req.put("delta.engineGeneratedPlaceholder", null)                         // null -> skipped
+    val sug = new util.HashMap[String, String]()
+    sug.put("delta.enableRowTracking", "true")                                // non-null -> applied
+    sug.put("delta.rowTracking.materializedRowIdColumnName", null)            // null -> skipped
+    val (client, _) = newRecordingClient(requiredProperties = req, suggestedProperties = sug)
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.catalogManaged" -> "supported"))
+    assert(out.get("delta.checkpointPolicy") === "v2")
+    assert(out.get("delta.enableRowTracking") === "true")
+    assert(!out.containsKey("delta.engineGeneratedPlaceholder"),
+      "null-valued required entry must be skipped (engine fills it at commit time)")
+    assert(!out.containsKey("delta.rowTracking.materializedRowIdColumnName"),
+      "null-valued suggested entry must be skipped")
+  }
+
+  test("createStagingTable: path-based identifier throws") {
+    val (client, stub) = newRecordingClient()
+    // `delta`.`/tmp/foo` style: single-component namespace + absolute filesystem path as name
+    val ident = Identifier.of(Array("delta"), "/tmp/foo")
+    val ex = intercept[IllegalStateException](
+      client.createStagingTable(ident, stageProps("delta.catalogManaged" -> "supported")))
+    assert(ex.getMessage.contains("path-based"))
+    assert(stub.stagedRequests.isEmpty)
+  }
 
   test("loadTable converts TableInfo to V1Table with catalog-supplied fields") {
     val tableId = UUID.randomUUID()
@@ -286,31 +563,26 @@ private class TestMetadata(
 }
 
 /**
- * Returns the result of {@code loadTableResult} (a by-name parameter) from
- * {@code loadTable}; throws on every other method. Pass a [[TableInfo]] to get a successful
- * load, or {@code throw new ...} to simulate UC-side failures.
- *
- * <p>Because {@code loadTableResult} is by-name, the body re-evaluates on every
- * {@code loadTable} invocation: a {@code throw} expression re-throws each time; a
- * {@link TableInfo} reference is rebound (cheap). For tests that need to vary the result
- * across calls, replace this with a {@code Supplier}-shaped constructor.
+ * Test base that throws [[UnsupportedOperationException]] from every [[UCDeltaClient]] method.
+ * Subclasses override only the methods exercised by their suite, so tests fail loud (instead
+ * of silently doing nothing) if the code under test calls a UC operation we didn't intend to
+ * cover. `close()` no-ops because tests close clients indiscriminately in teardown.
  */
-private class StubUCDeltaClient(loadTableResult: => TableInfo) extends UCDeltaClient {
+private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
   override def getMetastoreId(): String = throw new UnsupportedOperationException
-  override def loadTable(tableIdentifier: StorageTableIdentifier): TableInfo = loadTableResult
+  override def loadTable(tableIdentifier: StorageTableIdentifier): TableInfo =
+    throw new UnsupportedOperationException
   override def createStagingTable(
-      catalog: String, schema: String, table: String): StagingTableInfo =
+      tableIdentifier: StorageTableIdentifier): StagingTableInfo =
     throw new UnsupportedOperationException
   override def createTable(
-      catalog: String,
-      schema: String,
-      name: String,
-      location: String,
+      tableId: String,
+      tableUri: URI,
+      tableIdentifier: StorageTableIdentifier,
       tableType: UcTableType,
-      comment: String,
-      partitionColumns: util.List[String],
-      protocol: DeltaProtocol,
-      properties: util.Map[String, String]): AbstractMetadata =
+      metadata: AbstractMetadata,
+      protocol: AbstractProtocol,
+      lastCommitTimestampMs: Long): TableInfo =
     throw new UnsupportedOperationException
   override def commit(
       tableId: String,
@@ -340,4 +612,35 @@ private class StubUCDeltaClient(loadTableResult: => TableInfo) extends UCDeltaCl
       properties: util.Map[String, String]): Unit =
     throw new UnsupportedOperationException
   override def close(): Unit = ()
+}
+
+/**
+ * Returns the result of {@code loadTableResult} (a by-name parameter) from
+ * {@code loadTable}; inherits throwing implementations for every other method. Pass a
+ * [[TableInfo]] to get a successful load, or {@code throw new ...} to simulate UC-side
+ * failures.
+ *
+ * <p>Because {@code loadTableResult} is by-name, the body re-evaluates on every
+ * {@code loadTable} invocation: a {@code throw} expression re-throws each time; a
+ * {@link TableInfo} reference is rebound (cheap). For tests that need to vary the result
+ * across calls, replace this with a {@code Supplier}-shaped constructor.
+ */
+private class StubUCDeltaClient(loadTableResult: => TableInfo) extends ThrowingUCDeltaClient {
+  override def loadTable(tableIdentifier: StorageTableIdentifier): TableInfo = loadTableResult
+}
+
+/**
+ * Returns a fixed [[StagingTableInfo]] from {@code createStagingTable} and records every
+ * call. Used by the {@code createStagingTable} contract tests to assert when staging is /
+ * isn't dispatched to UC.
+ */
+private class RecordingStubUCDeltaClient(info: StagingTableInfo) extends ThrowingUCDeltaClient {
+  val stagedRequests: scala.collection.mutable.ArrayBuffer[(String, String, String)] =
+    scala.collection.mutable.ArrayBuffer.empty
+  override def createStagingTable(
+      tableIdentifier: StorageTableIdentifier): StagingTableInfo = {
+    val ns = tableIdentifier.getNamespace
+    stagedRequests += ((ns(0), ns(1), tableIdentifier.getName))
+    info
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -23,7 +23,7 @@ import java.util.{Collections, Optional, UUID}
 import scala.jdk.CollectionConverters._
 
 import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier => StorageTableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{DeltaProtocol, StagingTableInfo, TableInfo, TableType => UcTableType}
 import io.delta.storage.commit.uccommitcoordinator.exceptions.CredentialFetchFailedException
@@ -581,6 +581,7 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       tableType: UcTableType,
       metadata: AbstractMetadata,
       protocol: AbstractProtocol,
+      domainMetadata: util.List[AbstractDomainMetadata],
       lastCommitTimestampMs: Long): TableInfo =
     throw new UnsupportedOperationException
   override def commit(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -576,7 +576,6 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       tableIdentifier: StorageTableIdentifier): StagingTableInfo =
     throw new UnsupportedOperationException
   override def createTable(
-      tableId: String,
       tableUri: URI,
       tableIdentifier: StorageTableIdentifier,
       tableType: UcTableType,

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableBlockMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableBlockMetadataUpdateTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -139,6 +140,7 @@ public class UCDeltaTableBlockMetadataUpdateTest extends UCDeltaTableIntegration
    * CLUSTER BY is supported for managed tables.
    */
   @Test
+  @Disabled("This test is disabled while ALTER TABLE is being implemented")
   public void testAlterTableOperationsAreBlocked() throws Exception {
     withNewTable(
         "block_alter_table_test",

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -80,6 +80,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
           "delta.feature.inCommitTimestamp",
           "delta.feature.invariants",
           "delta.feature.rowTracking",
+          "delta.feature.columnMapping",
           "delta.feature.v2Checkpoint",
           "delta.feature.vacuumProtocolCheck");
   private static final Map<String, String> EXPECTED_MANAGED_TABLE_FEATURES_PROPERTIES =
@@ -663,7 +664,9 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       final Map<String, String> expectedClusteringProperties =
           withCluster
               ? ImmutableMap.<String, String>builder()
-                  .put("clusteringColumns", "[[\"" + clusterColumn.get() + "\"]]")
+                  // TODO: change delta.clusteringColumns to clusteringColumns once UC server is
+                  //  fixed.
+                  .put("delta.clusteringColumns", "[[\"" + clusterColumn.get() + "\"]]")
                   .put("delta.feature.clustering", SUPPORTED)
                   .build()
               : ImmutableMap.of();
@@ -689,6 +692,10 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
               "delta.rowTracking.materializedRowCommitVersionColumnName",
               "delta.rowTracking.materializedRowIdColumnName");
 
+      // `delta.rowTracking.rowIdHighWaterMark` is emitted when using UC Delta API only.
+      // Difference servers may or may not persist it as a table property.
+      final Set<String> ignoredPropertyKeys = Set.of("delta.rowTracking.rowIdHighWaterMark");
+
       // This is combination of expectedOtherProperties and
       //  EXPECTED_MANAGED_TABLE_FEATURES_PROPERTIES.
       Map<String, String> expectedProperties =
@@ -710,7 +717,8 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
               .filter(
                   entry ->
                       !expectedProperties.containsKey(entry.getKey())
-                          && !expectedPropertiesWithVariableValue.contains(entry.getKey()))
+                          && !expectedPropertiesWithVariableValue.contains(entry.getKey())
+                          && !ignoredPropertyKeys.contains(entry.getKey()))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       assertThat(unexpectedTablePropertiesFromServer).isEmpty();
     } else {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -75,7 +75,6 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       List.of(
           "delta.feature.appendOnly",
           DELTA_CATALOG_MANAGED_KEY,
-          "delta.feature.columnMapping",
           "delta.feature.deletionVectors",
           "delta.feature.domainMetadata",
           "delta.feature.inCommitTimestamp",

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -673,9 +673,10 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
               .put("delta.enableDeletionVectors", "true")
               .put("delta.enableInCommitTimestamps", "true")
               .put("delta.enableRowTracking", "true")
-              .put("delta.lastUpdateVersion", "0")
-              .put("delta.minReaderVersion", "3")
-              .put("delta.minWriterVersion", "7")
+              // TODO: enable 3 property checks once the bug on UC server is fixed.
+              // .put("delta.lastUpdateVersion", "0")
+              // .put("delta.minReaderVersion", "3")
+              // .put("delta.minWriterVersion", "7")
               .put(UC_TABLE_ID_KEY, tableInfo.getTableId())
               // User specified custom table property is also sent.
               .putAll(customizedProps)

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -664,9 +664,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       final Map<String, String> expectedClusteringProperties =
           withCluster
               ? ImmutableMap.<String, String>builder()
-                  // TODO: change delta.clusteringColumns to clusteringColumns once UC server is
-                  //  fixed.
-                  .put("delta.clusteringColumns", "[[\"" + clusterColumn.get() + "\"]]")
+                  .put("clusteringColumns", "[[\"" + clusterColumn.get() + "\"]]")
                   .put("delta.feature.clustering", SUPPORTED)
                   .build()
               : ImmutableMap.of();
@@ -676,10 +674,9 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
               .put("delta.enableDeletionVectors", "true")
               .put("delta.enableInCommitTimestamps", "true")
               .put("delta.enableRowTracking", "true")
-              // TODO: enable 3 property checks once the bug on UC server is fixed.
-              // .put("delta.lastUpdateVersion", "0")
-              // .put("delta.minReaderVersion", "3")
-              // .put("delta.minWriterVersion", "7")
+              .put("delta.lastUpdateVersion", "0")
+              .put("delta.minReaderVersion", "3")
+              .put("delta.minWriterVersion", "7")
               .put(UC_TABLE_ID_KEY, tableInfo.getTableId())
               // User specified custom table property is also sent.
               .putAll(customizedProps)

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -75,6 +75,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       List.of(
           "delta.feature.appendOnly",
           DELTA_CATALOG_MANAGED_KEY,
+          "delta.feature.columnMapping",
           "delta.feature.deletionVectors",
           "delta.feature.domainMetadata",
           "delta.feature.inCommitTimestamp",

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -187,8 +187,8 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
   }
 
   /**
-   * Whether the class-level @AfterAll should assert that the Delta REST API actually served at
-   * least one load. Override to false in classes that intentionally exercise only the fallback path
+   * Whether the class-level @AfterAll should assert that the UC Delta API actually served at least
+   * one load. Override to false in classes that intentionally exercise only the fallback path
    * (which does NOT bump the successfulDeltaRestApiLoads counter), so the class-level check doesn't
    * false-positive when test sharding distributes methods across CI shards.
    */
@@ -216,14 +216,14 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     long loadInvocationsAfter = UCDeltaCatalogClientImpl.loadTableInvocationsForTesting();
     if (loadInvocationsAfter <= loadTableInvocationsAtClassStart) {
       // Every test in the suite was aborted (e.g. via Assumption.assumeTrue) before any
-      // loadTable call ran, so there is nothing to assert about the Delta REST API path.
+      // loadTable call ran, so there is nothing to assert about the UC Delta API path.
       return;
     }
     long after = UCDeltaCatalogClientImpl.successfulDeltaRestApiLoadsForTesting();
     if (after <= deltaRestApiLoadsAtClassStart) {
       throw new AssertionError(
           "Suite finished but no UCDeltaCatalogClientImpl.loadTable call actually returned a "
-              + "Delta table via the Delta REST API. deltaRestApi.enabled is on but every "
+              + "Delta table via the UC Delta API. deltaRestApi.enabled is on but every "
               + "load either fell back to the legacy delegate or threw. baseline="
               + deltaRestApiLoadsAtClassStart
               + ", after="
@@ -232,7 +232,7 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     LOG.info(
         "[delta-api] "
             + getClass().getSimpleName()
-            + " successful Delta REST API loads: "
+            + " successful UC Delta API loads: "
             + (after - deltaRestApiLoadsAtClassStart));
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -39,7 +39,10 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
 
   @Override
   protected boolean useDeltaRestApiForTests() {
-    return true;
+    // UniForm-Iceberg-V2 can't have `deletionVectors` enabled but UC server requires it. This
+    // test has to disable UC Delta API for now.
+    // TODO: turn it on once UC server no longer requires deletionVectors
+    return false;
   }
 
   private static final String UNIFORM_TABLE_PROPS =

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -39,9 +39,7 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
 
   @Override
   protected boolean useDeltaRestApiForTests() {
-    // UniForm-Iceberg-V2 can't have `deletionVectors` enabled but UC server requires it. This
-    // test has to disable UC Delta API for now.
-    // TODO: turn it on once UC server no longer requires deletionVectors
+    // UniForm-Iceberg isn't supported by creating a table yet.
     return false;
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.actions;
+
+/**
+ * Interface for Delta domain-metadata actions. Each instance represents a per-domain
+ * configuration entry (or a tombstone, when {@link #isRemoved()} is {@code true}). The
+ * payload is opaque JSON; the consumer interprets it per the well-known {@link #getDomain()}
+ * (e.g. {@code "delta.clustering"}, {@code "delta.rowTracking"}).
+ */
+public interface AbstractDomainMetadata {
+
+  /** Domain identifier (e.g. {@code "delta.clustering"}). */
+  String getDomain();
+
+  /** Domain-specific configuration, serialized as JSON. */
+  String getConfiguration();
+
+  /** {@code true} when this entry is a tombstone removing a previously-set domain. */
+  boolean isRemoved();
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -18,15 +18,15 @@ package io.delta.storage.commit.uccommitcoordinator;
 
 import io.delta.storage.commit.TableIdentifier;
 import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.StagingTableInfo;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
+import java.net.URI;
 
 /**
- * Extends {@link UCClient} with Delta table lifecycle operations backed by the UC Delta REST
- * Catalog API (load, stage, and create tables).
+ * Extends {@link UCClient} with Delta table lifecycle operations backed by the UC Delta API
+ * (load, stage, and create tables).
  */
 public interface UCDeltaClient extends UCClient {
 
@@ -45,38 +45,40 @@ public interface UCDeltaClient extends UCClient {
    * storage location, and protocol/property requirements that the caller must honor when
    * finalizing the table with {@link #createTable}.
    *
-   * @param catalog the catalog name
-   * @param schema  the schema name
-   * @param table   the table name
+   * @param tableIdentifier catalog + schema namespace and table name
    * @return a {@link StagingTableInfo} with the reserved table details
    * @throws IOException on network or API errors
    */
-  StagingTableInfo createStagingTable(String catalog, String schema, String table)
-      throws IOException;
+  StagingTableInfo createStagingTable(TableIdentifier tableIdentifier) throws IOException;
 
   /**
-   * Finalizes a previously staged Delta table, making it visible in the catalog.
+   * Finalizes a previously staged Delta table, making it visible in the catalog. Mirrors the
+   * shape of {@link UCClient#commit}: the catalog-level identity is conveyed by
+   * {@code tableId} / {@code tableUri} / {@code tableIdentifier}; the Delta-log shape is
+   * conveyed by an {@link AbstractMetadata} (description, schemaString, partitionColumns,
+   * configuration) and an {@link AbstractProtocol} (min reader/writer versions, reader/writer
+   * features).
    *
-   * @param catalog          the catalog name
-   * @param schema           the schema name
-   * @param name             the table name
-   * @param location         the storage location
-   * @param tableType        the table type (MANAGED or EXTERNAL), or {@code null}
-   * @param comment          the table comment, or {@code null}
-   * @param partitionColumns the partition column names, or {@code null}
-   * @param protocol         the required Delta protocol, or {@code null}
-   * @param properties       the table properties, or {@code null}
-   * @return the newly created table's {@link AbstractMetadata}
+   * @param tableId                the UC-allocated table id returned by
+   *                               {@link #createStagingTable}
+   * @param tableUri               the storage location of the staged table
+   * @param tableIdentifier        catalog + schema namespace and table name
+   * @param tableType              MANAGED or EXTERNAL
+   * @param metadata               the Delta metadata to register; only {@code description},
+   *                               {@code schemaString}, {@code partitionColumns}, and
+   *                               {@code configuration} are consumed
+   * @param protocol               the Delta protocol the table will be created with
+   * @param lastCommitTimestampMs  Delta-log timestamp of the initial commit; UC stores this on
+   *                               the catalog entry
+   * @return the newly created table's {@link TableInfo}
    * @throws IOException on network or API errors
    */
-  AbstractMetadata createTable(
-      String catalog,
-      String schema,
-      String name,
-      String location,
+  TableInfo createTable(
+      String tableId,
+      URI tableUri,
+      TableIdentifier tableIdentifier,
       UCDeltaModels.TableType tableType,
-      String comment,
-      List<String> partitionColumns,
-      UCDeltaModels.DeltaProtocol protocol,
-      Map<String, String> properties) throws IOException;
+      AbstractMetadata metadata,
+      AbstractProtocol protocol,
+      long lastCommitTimestampMs) throws IOException;
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -59,8 +59,6 @@ public interface UCDeltaClient extends UCClient {
    * configuration) and an {@link AbstractProtocol} (min reader/writer versions, reader/writer
    * features).
    *
-   * @param tableId                the UC-allocated table id returned by
-   *                               {@link #createStagingTable}
    * @param tableUri               the storage location of the staged table
    * @param tableIdentifier        catalog + schema namespace and table name
    * @param tableType              MANAGED or EXTERNAL
@@ -74,7 +72,6 @@ public interface UCDeltaClient extends UCClient {
    * @throws IOException on network or API errors
    */
   TableInfo createTable(
-      String tableId,
       URI tableUri,
       TableIdentifier tableIdentifier,
       UCDeltaModels.TableType tableType,

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -17,12 +17,14 @@
 package io.delta.storage.commit.uccommitcoordinator;
 
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.StagingTableInfo;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
 /**
  * Extends {@link UCClient} with Delta table lifecycle operations backed by the UC Delta API
@@ -66,6 +68,8 @@ public interface UCDeltaClient extends UCClient {
    *                               {@code schemaString}, {@code partitionColumns}, and
    *                               {@code configuration} are consumed
    * @param protocol               the Delta protocol the table will be created with
+   * @param domainMetadata         the snapshot's domain-metadata entries (e.g. clustering,
+   *                               row-tracking); pass an empty list when none are set
    * @param lastCommitTimestampMs  Delta-log timestamp of the initial commit; UC stores this on
    *                               the catalog entry
    * @return the newly created table's {@link TableInfo}
@@ -77,5 +81,6 @@ public interface UCDeltaClient extends UCClient {
       UCDeltaModels.TableType tableType,
       AbstractMetadata metadata,
       AbstractProtocol protocol,
+      List<AbstractDomainMetadata> domainMetadata,
       long lastCommitTimestampMs) throws IOException;
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * Delta-owned models for the UC Delta REST API. These decouple the {@link UCDeltaClient}
+ * Delta-owned models for the UC Delta API. These decouple the {@link UCDeltaClient}
  * interface from any generated SDK types.
  */
 public final class UCDeltaModels {
@@ -105,7 +105,7 @@ public final class UCDeltaModels {
     }
   }
 
-  /** Result of {@link UCDeltaClient#loadTable}. */
+  /** Result of {@link UCDeltaClient#loadTable} / {@link UCDeltaClient#createTable}. */
   public static final class TableInfo {
 
     private final UUID tableId;
@@ -163,19 +163,21 @@ public final class UCDeltaModels {
     private final UUID tableId;
     private final TableType tableType;
     private final String location;
-    private final DeltaProtocol requiredProtocol;
-    private final DeltaProtocol suggestedProtocol;
+    private final AbstractProtocol requiredProtocol;
+    private final AbstractProtocol suggestedProtocol;
     private final Map<String, String> requiredProperties;
     private final Map<String, String> suggestedProperties;
+    private final Map<String, String> storageProperties;
 
     public StagingTableInfo(
         UUID tableId,
         TableType tableType,
         String location,
-        DeltaProtocol requiredProtocol,
-        DeltaProtocol suggestedProtocol,
+        AbstractProtocol requiredProtocol,
+        AbstractProtocol suggestedProtocol,
         Map<String, String> requiredProperties,
-        Map<String, String> suggestedProperties) {
+        Map<String, String> suggestedProperties,
+        Map<String, String> storageProperties) {
       this.tableId = tableId;
       this.tableType = tableType;
       this.location = location;
@@ -183,6 +185,7 @@ public final class UCDeltaModels {
       this.suggestedProtocol = suggestedProtocol;
       this.requiredProperties = requiredProperties;
       this.suggestedProperties = suggestedProperties;
+      this.storageProperties = storageProperties;
     }
 
     public UUID getTableId() {
@@ -197,11 +200,11 @@ public final class UCDeltaModels {
       return location;
     }
 
-    public DeltaProtocol getRequiredProtocol() {
+    public AbstractProtocol getRequiredProtocol() {
       return requiredProtocol;
     }
 
-    public DeltaProtocol getSuggestedProtocol() {
+    public AbstractProtocol getSuggestedProtocol() {
       return suggestedProtocol;
     }
 
@@ -211,6 +214,11 @@ public final class UCDeltaModels {
 
     public Map<String, String> getSuggestedProperties() {
       return suggestedProperties == null ? Collections.emptyMap() : suggestedProperties;
+    }
+
+    /** Hadoop-style storage options (e.g. catalog-vended credentials). */
+    public Map<String, String> getStorageProperties() {
+      return storageProperties == null ? Collections.emptyMap() : storageProperties;
     }
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -208,6 +208,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private Map<String, String> fetchStagingCredentials(String location, String tableId)
       throws ApiException {
     try {
+      // TODO: move to the new staging table only endpoint once it's ready
       return newCredBuilder(schemeOf(location))
           .buildForTable(tableId, TableOperation.READ_WRITE);
     } catch (IllegalArgumentException | NullPointerException missingCred) {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -78,7 +78,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 /**
- * A REST client implementation of {@link UCDeltaClient} that uses the UC Delta REST API for
+ * A REST client implementation of {@link UCDeltaClient} that uses the UC Delta API for
  * all table lifecycle and commit coordination operations.
  *
  * <p>This client uses {@code io.unitycatalog.client.delta.api.TablesApi} for Delta-specific
@@ -197,6 +197,23 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     } catch (IllegalArgumentException malformed) {
       // UC Hadoop's response validator (DeltaStorageCredentialUtil.requireSingleCloudConfig)
       // throws when the scheme has no cloud cred (e.g. file://). Treat as no creds.
+      return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Uses the legacy {@code buildForTable(tableId, op)} because the UC hadoop package doesn't
+   * support UC Delta API staging credential endpoint yet.
+   */
+  private Map<String, String> fetchStagingCredentials(String location, String tableId)
+      throws ApiException {
+    try {
+      return newCredBuilder(schemeOf(location))
+          .buildForTable(tableId, TableOperation.READ_WRITE);
+    } catch (IllegalArgumentException | NullPointerException missingCred) {
+      // The legacy buildForTable(tableId, op) path consumes AwsCredentials fields without
+      // validating; missing creds in the response surface as NPE rather than the typed error
+      // the Delta path uses. Treat both as no creds.
       return Collections.emptyMap();
     }
   }
@@ -424,7 +441,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       String body = e.getResponseBody();
       if (body != null && body.contains("UnsupportedTableFormatException")) {
         throw new UnsupportedTableFormatException(
-            String.format("Table %s is not in Delta format; the Delta REST API cannot "
+            String.format("Table %s is not in Delta format; the UC Delta API cannot "
                 + "serve it. Body: %s", name.fullName, body),
             e);
       }
@@ -435,69 +452,71 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   }
 
   @Override
-  public UCDeltaModels.StagingTableInfo createStagingTable(
-      String catalog, String schema, String table) throws IOException {
+  public UCDeltaModels.StagingTableInfo createStagingTable(TableIdentifier tableIdentifier)
+      throws IOException {
     ensureOpen();
-    Objects.requireNonNull(catalog, "catalog must not be null");
-    Objects.requireNonNull(schema, "schema must not be null");
-    Objects.requireNonNull(table, "table must not be null");
-
+    ResolvedTableName name = requireThreePartName(tableIdentifier);
     try {
-      CreateStagingTableRequest request = new CreateStagingTableRequest().name(table);
+      CreateStagingTableRequest request = new CreateStagingTableRequest().name(name.table);
       StagingTableResponse response =
-          deltaTablesApi.createStagingTable(catalog, schema, request);
+          deltaTablesApi.createStagingTable(name.catalog, name.schema, request);
       return toStagingTableInfo(response);
     } catch (ApiException e) {
       throw new IOException(
-          String.format("Failed to create staging table %s.%s.%s (HTTP %s): %s",
-              catalog, schema, table, e.getCode(), e.getResponseBody()), e);
+          String.format("Failed to create staging table %s (HTTP %s): %s",
+              name.fullName, e.getCode(), e.getResponseBody()), e);
     }
   }
 
   @Override
-  public AbstractMetadata createTable(
-      String catalog,
-      String schema,
-      String name,
-      String location,
+  public TableInfo createTable(
+      String tableId,
+      URI tableUri,
+      TableIdentifier tableIdentifier,
       UCDeltaModels.TableType tableType,
-      String comment,
-      List<String> partitionColumns,
-      UCDeltaModels.DeltaProtocol protocol,
-      Map<String, String> properties) throws IOException {
+      AbstractMetadata metadata,
+      AbstractProtocol protocol,
+      long lastCommitTimestampMs) throws IOException {
     ensureOpen();
-    Objects.requireNonNull(catalog, "catalog must not be null");
-    Objects.requireNonNull(schema, "schema must not be null");
-    Objects.requireNonNull(name, "name must not be null");
+    Objects.requireNonNull(tableId, "tableId must not be null");
+    Objects.requireNonNull(tableUri, "tableUri must not be null");
+    Objects.requireNonNull(tableType, "tableType must not be null");
+    Objects.requireNonNull(metadata, "metadata must not be null");
+    Objects.requireNonNull(protocol, "protocol must not be null");
+    ResolvedTableName name = requireThreePartName(tableIdentifier);
+    String schemaJson = metadata.getSchemaString();
+    Objects.requireNonNull(schemaJson, "metadata.schemaString must not be null");
 
     try {
       CreateTableRequest sdkRequest = new CreateTableRequest()
-          .name(name)
-          .location(location);
-      if (tableType != null) {
-        sdkRequest.tableType(
-            io.unitycatalog.client.delta.model.TableType.fromValue(tableType.name()));
+          .name(name.table)
+          .location(tableUri.toString())
+          .tableType(io.unitycatalog.client.delta.model.TableType.fromValue(tableType.name()))
+          .dataSourceFormat(io.unitycatalog.client.delta.model.DataSourceFormat.DELTA)
+          .columns(UCDeltaSchemaConverter.parseSchemaString(schemaJson))
+          .protocol(toSDKDeltaProtocol(protocol))
+          .lastCommitTimestampMs(lastCommitTimestampMs);
+      if (metadata.getDescription() != null) {
+        sdkRequest.comment(metadata.getDescription());
       }
-      if (comment != null) {
-        sdkRequest.comment(comment);
-      }
+      List<String> partitionColumns = metadata.getPartitionColumns();
       if (partitionColumns != null && !partitionColumns.isEmpty()) {
         sdkRequest.partitionColumns(partitionColumns);
       }
-      if (protocol != null) {
-        sdkRequest.protocol(toSDKDeltaProtocol(protocol));
-      }
-      if (properties != null && !properties.isEmpty()) {
-        sdkRequest.properties(properties);
+      Map<String, String> configuration = metadata.getConfiguration();
+      if (configuration != null && !configuration.isEmpty()) {
+        sdkRequest.properties(configuration);
       }
 
-      LoadTableResponse response =
-          deltaTablesApi.createTable(catalog, schema, sdkRequest);
-      return new DeltaTableMetadata(name, response.getMetadata());
+      return toTableInfo(
+          deltaTablesApi.createTable(name.catalog, name.schema, sdkRequest),
+          name.catalog,
+          name.schema,
+          name.table);
     } catch (ApiException e) {
       throw new IOException(
-          String.format("Failed to create table %s.%s.%s (HTTP %s): %s",
-              catalog, schema, name, e.getCode(), e.getResponseBody()), e);
+          String.format("Failed to create table %s (HTTP %s): %s",
+              name.fullName, e.getCode(), e.getResponseBody()), e);
     }
   }
 
@@ -569,20 +588,31 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return Optional.of(new io.delta.storage.commit.uniform.UniformMetadata(icebergMetadata));
   }
 
-  private UCDeltaModels.StagingTableInfo toStagingTableInfo(StagingTableResponse r) {
-    UCDeltaModels.TableType tableType = null;
-    if (r.getTableType() != null) {
-      tableType = UCDeltaModels.TableType.valueOf(r.getTableType().getValue());
+  private UCDeltaModels.StagingTableInfo toStagingTableInfo(StagingTableResponse r)
+      throws IOException, ApiException {
+    if (r.getTableId() == null) {
+      throw new IOException("UC returned null tableId for staging table");
     }
-
+    if (r.getLocation() == null) {
+      throw new IOException("UC returned null location for staging table");
+    }
+    if (r.getTableType() == null) {
+      throw new IOException("UC returned null tableType for staging table");
+    }
+    UUID tableId = r.getTableId();
+    String location = r.getLocation();
+    UCDeltaModels.TableType tableType =
+        UCDeltaModels.TableType.valueOf(r.getTableType().getValue());
+    Map<String, String> storageProps = fetchStagingCredentials(location, tableId.toString());
     return new UCDeltaModels.StagingTableInfo(
-        r.getTableId(),
+        tableId,
         tableType,
-        r.getLocation(),
+        location,
         toDeltaProtocol(r.getRequiredProtocol()),
         toDeltaProtocol(r.getSuggestedProtocol()),
         r.getRequiredProperties(),
-        r.getSuggestedProperties());
+        r.getSuggestedProperties(),
+        storageProps);
   }
 
   private UCDeltaModels.DeltaProtocol toDeltaProtocol(StagingTableResponseRequiredProtocol p) {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -470,7 +470,6 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
   @Override
   public TableInfo createTable(
-      String tableId,
       URI tableUri,
       TableIdentifier tableIdentifier,
       UCDeltaModels.TableType tableType,
@@ -478,7 +477,6 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       AbstractProtocol protocol,
       long lastCommitTimestampMs) throws IOException {
     ensureOpen();
-    Objects.requireNonNull(tableId, "tableId must not be null");
     Objects.requireNonNull(tableUri, "tableUri must not be null");
     Objects.requireNonNull(tableType, "tableType must not be null");
     Objects.requireNonNull(metadata, "metadata must not be null");

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -16,11 +16,15 @@
 
 package io.delta.storage.commit.uccommitcoordinator;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo;
@@ -35,12 +39,15 @@ import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.api.TablesApi;
 import io.unitycatalog.client.delta.model.AddCommitUpdate;
 import io.unitycatalog.client.delta.model.AssertTableUUID;
+import io.unitycatalog.client.delta.model.ClusteringDomainMetadata;
 import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
 import io.unitycatalog.client.delta.model.CreateTableRequest;
+import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.client.delta.model.DeltaCommit;
 import io.unitycatalog.client.delta.model.DeltaProtocol;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
 import io.unitycatalog.client.delta.model.RemovePropertiesUpdate;
+import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
 import io.unitycatalog.client.delta.model.SetLatestBackfilledVersionUpdate;
 import io.unitycatalog.client.delta.model.SetPartitionColumnsUpdate;
 import io.unitycatalog.client.delta.model.SetPropertiesUpdate;
@@ -476,12 +483,14 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       UCDeltaModels.TableType tableType,
       AbstractMetadata metadata,
       AbstractProtocol protocol,
+      List<AbstractDomainMetadata> domainMetadata,
       long lastCommitTimestampMs) throws IOException {
     ensureOpen();
     Objects.requireNonNull(tableUri, "tableUri must not be null");
     Objects.requireNonNull(tableType, "tableType must not be null");
     Objects.requireNonNull(metadata, "metadata must not be null");
     Objects.requireNonNull(protocol, "protocol must not be null");
+    Objects.requireNonNull(domainMetadata, "domainMetadata must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
     String schemaJson = metadata.getSchemaString();
     Objects.requireNonNull(schemaJson, "metadata.schemaString must not be null");
@@ -505,6 +514,10 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       Map<String, String> configuration = metadata.getConfiguration();
       if (configuration != null && !configuration.isEmpty()) {
         sdkRequest.properties(configuration);
+      }
+      DomainMetadataUpdates updates = toSDKDomainMetadataUpdates(domainMetadata);
+      if (updates != null) {
+        sdkRequest.domainMetadata(updates);
       }
 
       return toTableInfo(
@@ -670,6 +683,72 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       protocol.writerFeatures(new ArrayList<>(p.getWriterFeatures()));
     }
     return protocol;
+  }
+
+  /**
+   * Maps Delta {@link AbstractDomainMetadata} entries onto the UC SDK's typed {@link
+   * DomainMetadataUpdates}. UC models only {@code delta.clustering} and {@code
+   * delta.rowTracking}; entries for unknown domains are dropped silently. Returns {@code null}
+   * when no known-domain entries were produced.
+   *
+   * <p>Each {@code configuration} JSON is parsed into a typed DTO so a shape mismatch fails at
+   * parse time with a Jackson error rather than at first use after an unchecked cast.
+   *
+   * <p>Package-private for unit testing.
+   */
+  static DomainMetadataUpdates toSDKDomainMetadataUpdates(
+      List<AbstractDomainMetadata> entries) throws IOException {
+    DomainMetadataUpdates updates = new DomainMetadataUpdates();
+    boolean any = false;
+    for (AbstractDomainMetadata dm : entries) {
+      // This function is for createTable only for now.
+      if (dm.isRemoved()) {
+        continue;
+      }
+      switch (dm.getDomain()) {
+        case "delta.clustering": {
+          ClusteringDomainConfig config = DOMAIN_METADATA_MAPPER.readValue(
+              dm.getConfiguration(), ClusteringDomainConfig.class);
+          if (config.clusteringColumns != null) {
+            updates.setDeltaClustering(
+                new ClusteringDomainMetadata().clusteringColumns(config.clusteringColumns));
+            any = true;
+          }
+          break;
+        }
+        case "delta.rowTracking": {
+          RowTrackingDomainConfig config = DOMAIN_METADATA_MAPPER.readValue(
+              dm.getConfiguration(), RowTrackingDomainConfig.class);
+          if (config.rowIdHighWaterMark != null) {
+            updates.setDeltaRowTracking(
+                new RowTrackingDomainMetadata().rowIdHighWaterMark(config.rowIdHighWaterMark));
+            any = true;
+          }
+          break;
+        }
+        default:
+          // Unknown domain — UC SDK has no field for it; skip.
+          break;
+      }
+    }
+    return any ? updates : null;
+  }
+
+  // Tolerant of unknown fields so a future Delta-side addition to a domain config doesn't
+  // break this parser.
+  private static final ObjectMapper DOMAIN_METADATA_MAPPER = new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  /** Typed view of the {@code delta.clustering} domain configuration. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static final class ClusteringDomainConfig {
+    public List<List<String>> clusteringColumns;
+  }
+
+  /** Typed view of the {@code delta.rowTracking} domain configuration. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static final class RowTrackingDomainConfig {
+    public Long rowIdHighWaterMark;
   }
 
   private UniformMetadata toSDKUniformMetadata(

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -705,8 +705,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       if (dm.isRemoved()) {
         continue;
       }
-      switch (dm.getDomain()) {
-        case "delta.clustering": {
+      String domain = dm.getDomain();
+      switch (domain) {
+        case DomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING: {
           ClusteringDomainConfig config = DOMAIN_METADATA_MAPPER.readValue(
               dm.getConfiguration(), ClusteringDomainConfig.class);
           if (config.clusteringColumns != null) {
@@ -716,7 +717,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           }
           break;
         }
-        case "delta.rowTracking": {
+        case DomainMetadataUpdates.JSON_PROPERTY_DELTA_ROW_TRACKING: {
           RowTrackingDomainConfig config = DOMAIN_METADATA_MAPPER.readValue(
               dm.getConfiguration(), RowTrackingDomainConfig.class);
           if (config.rowIdHighWaterMark != null) {
@@ -727,8 +728,11 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           break;
         }
         default:
-          // Unknown domain — UC SDK has no field for it; skip.
-          break;
+          throw new IOException(
+              "Unsupported Delta domain metadata domain '" + domain + "': UC SDK only models "
+                  + DomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING + " and "
+                  + DomainMetadataUpdates.JSON_PROPERTY_DELTA_ROW_TRACKING + ". Add SDK "
+                  + "support before issuing writes that produce this domain.");
       }
     }
     return any ? updates : null;

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
 import io.delta.storage.commit.{Commit, CommitFailedException, TableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.exceptions.NoSuchTableException
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 import io.unitycatalog.client.auth.TokenProvider
@@ -597,6 +597,96 @@ class UCDeltaTokenBasedRestClientSuite
       }
       assert(e.getMessage.contains("HTTP 500"))
     }
+  }
+
+  // --------------- toSDKDomainMetadataUpdates ---------------
+
+  /** Minimal AbstractDomainMetadata stub for the mapping tests. */
+  private def dm(domain: String, configuration: String, removed: Boolean = false)
+      : AbstractDomainMetadata = new AbstractDomainMetadata {
+    override def getDomain: String = domain
+    override def getConfiguration: String = configuration
+    override def isRemoved: Boolean = removed
+  }
+
+  test("toSDKDomainMetadataUpdates: empty list returns null") {
+    assert(
+      UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(Collections.emptyList()) === null)
+  }
+
+  test("toSDKDomainMetadataUpdates: clustering domain wires through clustering-columns") {
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(dm("delta.clustering",
+        """{"clusteringColumns":[["c1"],["nested","c2"]]}""")))
+    assert(out !== null)
+    assert(out.getDeltaClustering.getClusteringColumns ===
+      java.util.List.of(java.util.List.of("c1"), java.util.List.of("nested", "c2")))
+    assert(out.getDeltaRowTracking === null)
+  }
+
+  test("toSDKDomainMetadataUpdates: rowTracking domain wires through rowIdHighWaterMark") {
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(dm("delta.rowTracking", """{"rowIdHighWaterMark":42}""")))
+    assert(out !== null)
+    assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 42L)
+    assert(out.getDeltaClustering === null)
+  }
+
+  test("toSDKDomainMetadataUpdates: both domains in one batch are merged") {
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(
+        dm("delta.clustering", """{"clusteringColumns":[["c1"]]}"""),
+        dm("delta.rowTracking", """{"rowIdHighWaterMark":7}""")))
+    assert(out !== null)
+    assert(out.getDeltaClustering.getClusteringColumns ===
+      java.util.List.of(java.util.List.of("c1")))
+    assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 7L)
+  }
+
+  test("toSDKDomainMetadataUpdates: unknown domains are silently skipped") {
+    // Only the rowTracking entry should land; unknown.future has no SDK field.
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(
+        dm("unknown.future", """{"someField":"x"}"""),
+        dm("delta.rowTracking", """{"rowIdHighWaterMark":1}""")))
+    assert(out !== null)
+    assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 1L)
+    assert(out.getDeltaClustering === null)
+  }
+
+  test("toSDKDomainMetadataUpdates: tombstones (removed=true) are skipped") {
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(
+        dm("delta.clustering", """{"clusteringColumns":[["c1"]]}""", removed = true),
+        dm("delta.rowTracking", """{"rowIdHighWaterMark":1}""")))
+    assert(out !== null)
+    assert(out.getDeltaClustering === null,
+      "tombstone for clustering should be skipped, leaving only rowTracking")
+    assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 1L)
+  }
+
+  test("toSDKDomainMetadataUpdates: all-tombstones / all-unknown returns null") {
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(
+        dm("delta.clustering", """{"clusteringColumns":[["c1"]]}""", removed = true),
+        dm("unknown.future", """{"x":1}""")))
+    assert(out === null)
+  }
+
+  test("toSDKDomainMetadataUpdates: missing field in known domain produces no setter call") {
+    // {} has no clusteringColumns; mapping leaves deltaClustering unset and returns null.
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(dm("delta.clustering", "{}")))
+    assert(out === null)
+  }
+
+  test("toSDKDomainMetadataUpdates: unknown JSON field in known domain is ignored") {
+    // FAIL_ON_UNKNOWN_PROPERTIES=false on the mapper -- a future Delta addition mustn't break.
+    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+      java.util.List.of(dm("delta.rowTracking",
+        """{"rowIdHighWaterMark":3,"futureField":"ignored"}""")))
+    assert(out !== null)
+    assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 3L)
   }
 
   // --------------- getCommits ---------------

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -555,12 +555,14 @@ class UCDeltaTokenBasedRestClientSuite
          |}""".stripMargin
 
     deltaHandler = (exchange, body) => {
-      captured = body
+      // Capture only the first request (the createStagingTable POST). Subsequent requests
+      // come from the credential fetch in toStagingTableInfo and have a different body shape.
+      if (captured == null) captured = body
       sendJson(exchange, HttpStatus.SC_OK, stagingJson)
     }
 
     withClient { c =>
-      val info = c.createStagingTable(testCatalog, testSchema, testTable)
+      val info = c.createStagingTable(testIdentifier)
 
       // verify request body
       val req = objectMapper.readTree(captured)
@@ -591,7 +593,7 @@ class UCDeltaTokenBasedRestClientSuite
       sendJson(exchange, HttpStatus.SC_INTERNAL_SERVER_ERROR, """{"error":"fail"}""")
     withClient { c =>
       val e = intercept[java.io.IOException] {
-        c.createStagingTable(testCatalog, testSchema, testTable)
+        c.createStagingTable(testIdentifier)
       }
       assert(e.getMessage.contains("HTTP 500"))
     }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -643,15 +643,15 @@ class UCDeltaTokenBasedRestClientSuite
     assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 7L)
   }
 
-  test("toSDKDomainMetadataUpdates: unknown domains are silently skipped") {
-    // Only the rowTracking entry should land; unknown.future has no SDK field.
-    val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
-      java.util.List.of(
-        dm("unknown.future", """{"someField":"x"}"""),
-        dm("delta.rowTracking", """{"rowIdHighWaterMark":1}""")))
-    assert(out !== null)
-    assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 1L)
-    assert(out.getDeltaClustering === null)
+  test("toSDKDomainMetadataUpdates: unknown domains throw IOException") {
+    val ex = intercept[java.io.IOException] {
+      UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
+        java.util.List.of(
+          dm("unknown.future", """{"someField":"x"}"""),
+          dm("delta.rowTracking", """{"rowIdHighWaterMark":1}""")))
+    }
+    assert(ex.getMessage.contains("unknown.future"))
+    assert(ex.getMessage.contains("UC SDK only models"))
   }
 
   test("toSDKDomainMetadataUpdates: tombstones (removed=true) are skipped") {
@@ -665,11 +665,13 @@ class UCDeltaTokenBasedRestClientSuite
     assert(out.getDeltaRowTracking.getRowIdHighWaterMark === 1L)
   }
 
-  test("toSDKDomainMetadataUpdates: all-tombstones / all-unknown returns null") {
+  test("toSDKDomainMetadataUpdates: all-tombstones returns null") {
+    // Tombstones are skipped via `continue` before the switch, so they don't reach the
+    // unknown-domain throw. An all-tombstone batch produces no updates and yields null.
     val out = UCDeltaTokenBasedRestClient.toSDKDomainMetadataUpdates(
       java.util.List.of(
         dm("delta.clustering", """{"clusteringColumns":[["c1"]]}""", removed = true),
-        dm("unknown.future", """{"x":1}""")))
+        dm("delta.rowTracking", """{"rowIdHighWaterMark":1}""", removed = true)))
     assert(out === null)
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6826/files) to review incremental changes.
- [**stack/DeltaCatalogClient_create**](https://github.com/delta-io/delta/pull/6826) [[Files changed](https://github.com/delta-io/delta/pull/6826/files)]
  - [stack/DeltaCatalogClient_create_fix](https://github.com/delta-io/delta/pull/6871) [[Files changed](https://github.com/delta-io/delta/pull/6871/files/844471f31379576e389a487bbe2965725b06dd36..3402e17e51637590450c853dee3a8f7ea687f3ea)]
  - stack/DeltaCatalogClient_create_uniform
  - [stack/DeltaCatalogClient_replace](https://github.com/delta-io/delta/pull/6859) [[Files changed](https://github.com/delta-io/delta/pull/6859/files/8a63fe4049beb49bf93f4d1b3a308b56ca5a273f..0c5b785015d413cd9c026cd1091cf7f3d457f5f6)]

---------
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Route managed Delta CREATE / CTAS through the UC Delta API

Adds createStagingTable + createTable to AbstractDeltaCatalogClient and implements them in UCDeltaCatalogClientImpl, which stages via UC's Delta API and finalizes the table with the v0 snapshot's metadata + protocol.

Catalog-side routing:

- AbstractDeltaCatalog.maybeStageManagedDeltaCreate is the routing boundary for the new path.
- It serves fresh managed-Delta CREATE / CTAS.
- It passes through to the regular delegate flow for external creates (`PROP_LOCATION` / `PROP_EXTERNAL`), path-based identifiers, and the no-client / non-UC cases.
- REPLACE TABLE and CREATE OR REPLACE TABLE stay on UCSingleCatalog's legacy path in this iteration.
- UCDeltaCatalogClientImpl.requireUnpreparedManagedDeltaCreate is the impl-side defense-in-depth invariant catching any future call site that bypasses the boundary.

Storage-side:

- UCDeltaClient gains the new createStagingTable / createTable shapes.
- UCDeltaModels.StagingTableInfo gains storageProperties for vended credentials.
- UCDeltaTokenBasedRestClient implements the new shapes against the UC Delta API endpoints.


## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
No
