### PR TITLE
[Spark] Inline SupportsPathIdentifier trait into AbstractDeltaCatalog

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -78,7 +78,6 @@ class DeltaCatalogV1 extends AbstractDeltaCatalog
  */
 class AbstractDeltaCatalog extends DelegatingCatalogExtension
   with StagingTableCatalog
-  with SupportsPathIdentifier
   with DeltaLogging {
 
 
@@ -1106,13 +1105,15 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       case _ => throw DeltaErrors.unsupportedWriteStagedTable(name)
     }
   }
-}
 
-/**
- * A trait for handling table access through delta.`/some/path`. This is a stop-gap solution
- * until PathIdentifiers are implemented in Apache Spark.
- */
-trait SupportsPathIdentifier extends TableCatalog { self: AbstractDeltaCatalog =>
+  // Inlined from former `SupportsPathIdentifier` trait. The trait's self-type
+  // `self: AbstractDeltaCatalog =>` triggered a Scala-emitted runtime cast that failed
+  // for Java subclasses (e.g., the hybrid `DeltaCatalog` in `spark-unified`) under
+  // Spark 4.2's catalog plug-in dispatch. Moving the methods directly onto the class
+  // removes the self-type indirection while preserving all behavior.
+  //
+  // Handles table access through delta.`/some/path`. Stop-gap solution until
+  // PathIdentifiers are implemented in Apache Spark.
 
   private def supportSQLOnFile: Boolean = spark.sessionState.conf.runSQLonFile
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][Spark] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Removes the self-typed `SupportsPathIdentifier` trait from `AbstractDeltaCatalog` and inlines its body directly into the class. No public API change, no behavior change.

### Why

`SupportsPathIdentifier` was declared as:

```scala
trait SupportsPathIdentifier extends TableCatalog { self: AbstractDeltaCatalog => ... }
```

Scala compiles the `self: AbstractDeltaCatalog =>` self-type into a runtime cast on the receiver of every trait method call (a `checkcast` against `AbstractDeltaCatalog` at the head of each method). When the trait is mixed into a class whose concrete subclass is **implemented in Java** and registered via Spark's catalog plug-in mechanism (`spark.sql.catalog.spark_catalog`), Spark's plug-in dispatch produces a receiver shape that the Scala-emitted cast does not expect, and the cast fails at runtime with:

```
java.lang.ClassCastException: class <JavaSubclass> cannot be cast to
  class org.apache.spark.sql.delta.catalog.AbstractDeltaCatalog
  at org.apache.spark.sql.delta.catalog.SupportsPathIdentifier.supportSQLOnFile$(...)
```

The very first method called on the catalog plug-in is `supportSQLOnFile` (via `isPathIdentifier`), so the crash surfaces immediately when the Java subclass is loaded as the session catalog under Spark 4.2.

Moving the methods directly onto `AbstractDeltaCatalog` removes the self-type indirection without changing visibility or call sites.

### History of the issue

- 2020 (commit `5cc38349`): `SupportsPathIdentifier` introduced as a Scala-only trait on the Scala-only `DeltaCatalog`. No cast problem at the time because there was no Java subclass.
- Oct/Nov 2025 (#5320, commit `156e41f27`): `DeltaCatalog` split into `AbstractDeltaCatalog` (Scala) + `DeltaCatalog` (Java). The trait still mixes into the Scala class, but the Java subclass is now the one Spark loads. The self-type cast now fires against the Java receiver.
- 2026-05-19 (commit `95a417659`, follow-up to #6657): `Assumptions.assumeFalse` skip added in `RowTrackingDsv2WriteTest` to mask the same crash for write-path tests, with a TODO to remove once the cast is fixed.

### Validation

- Disassembled the relevant `SupportsPathIdentifier$class.supportSQLOnFile` to confirm the Scala compiler emits a `checkcast` on the receiver against `AbstractDeltaCatalog`.
- Reproduced the failure on master in an isolated worktree (clean checkout, no other changes), confirmed identical stack trace.
- Applied this change in the same worktree and confirmed the `ClassCastException` no longer fires from `supportSQLOnFile`.

### Note on Spark 4.2 cross-build

This refactor fixes one of two ABI/dispatch issues that block running the Java-subclass `DeltaCatalog` against Spark 4.2:

1. **This PR**: removes the Scala self-type cast that crashes immediately on plug-in dispatch.
2. **Out of scope**: the released `delta-spark_2.13-4.0.0` artifact (pulled in as a transitive dep by the Unity Catalog Spark connector) contains pre-Spark-4.2 bytecode that calls `CatalogStorageFormat.copy` with 6 arguments. Spark 4.2 changed that signature to 7 arguments, so this surfaces as a `NoSuchMethodError` once the cast is resolved. Fixing it requires either (a) cutting a new `delta-spark` release built against Spark 4.2 and updating UC's connector to pin to it, or (b) shipping the UC connector with a Spark-4.2-compatible build of its embedded `DeltaCatalog`. Neither is in scope here.

The behavior verified by this PR is the elimination of the runtime cast: with this change applied, the failure shifts from `ClassCastException` in `SupportsPathIdentifier.supportSQLOnFile` to the unrelated `NoSuchMethodError` from item (2). The cast fix is required regardless of how (2) is resolved.

## How was this patch tested?

- Existing `DeltaCatalog` unit tests pass (`build/sbt "spark/testOnly *DeltaCatalog*"`).
- Reproduced the original `ClassCastException` against Spark 4.2 prior to the change and verified it no longer fires after the change.
- No new tests added: the change is a structural refactor (trait inline) with no new code paths to cover.

## Does this PR introduce _any_ user-facing changes?

No.