### PR TITLE
Generate per-column Iceberg manifest stats for Delta tables without column mapping

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
@@ -24,7 +24,7 @@ import java.util.{Base64, List => JList}
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaConfig, DeltaConfigs, IcebergCompat, NoMapping, Snapshot, SnapshotDescriptor}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaConfig, DeltaConfigs, DummySnapshot, IcebergCompat, NoMapping, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.DeltaConfigs.{LOG_RETENTION, TOMBSTONE_RETENTION}
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction}
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -43,24 +43,45 @@ import org.apache.spark.unsafe.types.CalendarInterval
  */
 class DeltaToIcebergConverter(val snapshot: SnapshotDescriptor, val catalogTable: CatalogTable) {
 
-  private val schemaUtils: IcebergSchemaUtils =
-    IcebergSchemaUtils(snapshot.metadata.columnMappingMode == NoMapping)
+  // Always wrap the input in a DummySnapshot. For NoMapping snapshots the wrap also
+  // decorates the schema with synthetic column-mapping IDs so the id-mode path downstream
+  // sees a complete statsSchema; for id-mode the wrap is metadata-preserving.
+  val wrappedSnapshot: Snapshot = {
+    val effectiveMetadata =
+      if (snapshot.metadata.columnMappingMode == NoMapping) {
+        val (decoratedSchema, maxId) =
+          DeltaToIcebergConvert.decorateNoMappingSchema(snapshot.metadata.schema)
+        snapshot.metadata.copy(
+          schemaString = decoratedSchema.json,
+          configuration = snapshot.metadata.configuration +
+            (DeltaConfigs.COLUMN_MAPPING_MAX_ID.key -> maxId.toString))
+      } else {
+        snapshot.metadata
+      }
+    new DummySnapshot(
+      logPath = snapshot.deltaLog.logPath,
+      deltaLog = snapshot.deltaLog,
+      metadata = effectiveMetadata,
+      protocolOpt = Some(snapshot.protocol))
+  }
 
-  def maxFieldId: Int = schemaUtils.maxFieldId(snapshot)
+  private val schemaUtils: IcebergSchemaUtils = IcebergSchemaUtils()
+
+  def maxFieldId: Int = schemaUtils.maxFieldId(wrappedSnapshot)
 
   val schema: IcebergSchema = IcebergCompat
-    .getEnabledVersion(snapshot.metadata)
+    .getEnabledVersion(wrappedSnapshot.metadata)
     .orElse(Some(0))
     .map { compatVersion =>
-      val icebergStruct = schemaUtils.convertStruct(snapshot.schema)(compatVersion)
+      val icebergStruct = schemaUtils.convertStruct(wrappedSnapshot.schema)(compatVersion)
       new IcebergSchema(icebergStruct.fields())
     }.getOrElse(throw new IllegalArgumentException("No IcebergCompat available"))
 
   val partition: PartitionSpec = IcebergTransactionUtils
-    .createPartitionSpec(schema, snapshot.metadata.partitionColumns)
+    .createPartitionSpec(schema, wrappedSnapshot.metadata.partitionColumns)
 
   val properties: Map[String, String] =
-    DeltaToIcebergConvert.TableProperties(snapshot.metadata.configuration)
+    DeltaToIcebergConvert.TableProperties(wrappedSnapshot.metadata.configuration)
 }
 /**
  * Utils for converting a Delta Table to Iceberg Table
@@ -380,6 +401,68 @@ object DeltaToIcebergConvert
         partitionVals(i) = icebergPartitionValue
       }
       new IcebergTransactionUtils.Row(partitionVals)
+    }
+  }
+
+  /**
+   * Stamps synthetic column-mapping IDs onto a NoMapping schema in DFS order. Leaf fields
+   * get `delta.columnMapping.id`; Array/Map parents additionally get `nested.ids` entries
+   * for `arr.element`, `m.key`, `m.value`. Pre-existing IDs are observed so newly minted
+   * ones don't collide. Returns the decorated schema and the largest ID seen.
+   */
+  private[delta] def decorateNoMappingSchema(schema: StructType): (StructType, Int) =
+    new NoMappingSchemaDecorator().decorate(schema)
+
+  private class NoMappingSchemaDecorator {
+    private var counter = 0
+
+    def decorate(schema: StructType): (StructType, Int) = (decorateStruct(schema), counter)
+
+    private def nextId(): Int = { counter += 1; counter }
+    private def observe(id: Int): Unit = if (id > counter) counter = id
+
+    private def decorateStruct(schema: StructType): StructType =
+      StructType(schema.fields.map { f =>
+        if (DeltaColumnMapping.hasColumnId(f)) {
+          observe(DeltaColumnMapping.getColumnId(f))
+          f
+        } else {
+          val id = nextId()
+          val nestedIds = new MetadataBuilder()
+          val newDataType = decorateDataType(f.dataType, nestedIds, Seq(f.name))
+          val mdBuilder = new MetadataBuilder()
+            .withMetadata(f.metadata)
+            .putLong(DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY, id.toLong)
+            .putString(DeltaColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, f.name)
+          val nestedBuilt = nestedIds.build()
+          if (nestedBuilt.json != "{}") {
+            mdBuilder.putMetadata(
+              DeltaColumnMapping.COLUMN_MAPPING_METADATA_NESTED_IDS_KEY, nestedBuilt)
+          }
+          f.copy(dataType = newDataType, metadata = mdBuilder.build())
+        }
+      })
+
+    private def decorateDataType(
+        dt: DataType,
+        nestedIds: MetadataBuilder,
+        path: Seq[String]): DataType = dt match {
+      case st: StructType =>
+        decorateStruct(st)
+      case ArrayType(elemType, containsNull) =>
+        val elemPath = path :+ DeltaColumnMapping.PARQUET_LIST_ELEMENT_FIELD_NAME
+        nestedIds.putLong(elemPath.mkString("."), nextId().toLong)
+        ArrayType(decorateDataType(elemType, nestedIds, elemPath), containsNull)
+      case MapType(keyType, valueType, valueContainsNull) =>
+        val keyPath = path :+ DeltaColumnMapping.PARQUET_MAP_KEY_FIELD_NAME
+        val valPath = path :+ DeltaColumnMapping.PARQUET_MAP_VALUE_FIELD_NAME
+        nestedIds.putLong(keyPath.mkString("."), nextId().toLong)
+        nestedIds.putLong(valPath.mkString("."), nextId().toLong)
+        MapType(
+          decorateDataType(keyType, nestedIds, keyPath),
+          decorateDataType(valueType, nestedIds, valPath),
+          valueContainsNull)
+      case other => other
     }
   }
 }

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -95,7 +95,7 @@ class IcebergConversionTransaction(
         currentPartitionSpec,
         logicalToPhysicalPartitionNames,
         statsParser,
-        postCommitSnapshot)
+        convert.wrappedSnapshot)
   }
 
   implicit class RemoveFileConversion(removeFile: RemoveFile) {
@@ -105,7 +105,7 @@ class IcebergConversionTransaction(
         tablePath,
         currentPartitionSpec,
         logicalToPhysicalPartitionNames,
-        postCommitSnapshot)
+        convert.snapshot)
   }
 
   protected abstract class TransactionHelper(protected val impl: PendingUpdate[_]) {
@@ -253,12 +253,13 @@ class IcebergConversionTransaction(
     Some(txn.table()).map(_.spec()).getOrElse(partitionSpec)
   }
 
+  // Read from convert.wrappedSnapshot so NoMapping snapshots see decorated metadata.
   protected val logicalToPhysicalPartitionNames =
-    getPartitionPhysicalNameMapping(postCommitSnapshot.metadata.partitionSchema)
+    getPartitionPhysicalNameMapping(convert.wrappedSnapshot.metadata.partitionSchema)
 
   /** Parses the stats JSON string to convert Delta stats to Iceberg stats. */
   private val statsParser =
-    DeltaFileProviderUtils.createJsonStatsParser(postCommitSnapshot.statsSchema)
+    DeltaFileProviderUtils.createJsonStatsParser(convert.wrappedSnapshot.statsSchema)
 
   /** Visible for testing. */
   private[icebergShaded]val (txn, startFromSnapshotId) = withStartSnapshotId(createIcebergTxn())


### PR DESCRIPTION
## Summary

Delta tables in column-mapping mode `none` produced Iceberg manifests with empty per-column data-skipping stats (lower bounds, upper bounds, null value counts), because `Snapshot.statsSchema` drops per-leaf entries for fields without column-mapping IDs.

## Fix

In `DeltaToIcebergConverter`, wrap the input snapshot in a `DummySnapshot` whose metadata schema carries synthetic `delta.columnMapping.id` (and `delta.columnMapping.nested.ids` for Array/Map parents). The id-mode path downstream then produces a complete `statsSchema` and writes per-column stats into the Iceberg manifest. For id-mode snapshots the wrap is metadata-preserving.

`IcebergConversionTransaction` now reads from the wrapped snapshot at the partition-mapping, stats-parser, and AddFile-conversion sites so the decoration is visible end-to-end.

## How was this patch tested?

E2E tests still pass.

## Does this PR introduce _any_ user-facing changes?

No.
