### PR TITLE
[UniForm] Support incremental conversion end to end

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -948,6 +948,15 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
       }
     },
 
+    // Add delta-iceberg compiled classes so that UniForm Iceberg conversion works in integration
+    // tests.
+    Test / unmanagedJars ++= {
+      if (supportIceberg) Seq(
+        Attributed.blank((iceberg / Compile / packageBin).value)
+      ) else Seq.empty
+    },
+
+    Test / javaOptions += s"-DsupportIceberg=${supportIceberg}",
     Test / testOptions += Tests.Argument("-oDF"),
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
   )

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -234,12 +234,13 @@ class IcebergConverter
       catalogTable: CatalogTable,
       deltaLog: DeltaLog,
       enablingUniForm: Boolean): LastConvertedIcebergInfo = {
-    val icebergProps = catalogTable.storage.properties
     val baseMetadataLocation =
-      icebergProps.get(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP)
+      catalogTable.storage.properties
+        .get(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP)
     val lastDeltaVersionConverted =
-      icebergProps.get(
-        IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP).map(_.toLong)
+      catalogTable.storage.properties
+        .get(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP)
+        .map(_.toLong)
     val lastConvertedIcebergTable =
       baseMetadataLocation.map(new HadoopTables(deltaLog.newDeltaHadoopConf()).load(_))
     val lastConvertedIcebergSnapshotId =

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -226,7 +226,7 @@ class IcebergConverter
 
 
   /**
-   * Reads the last converted Iceberg state from the catalogTable properties.
+   * Reads the last converted Iceberg state from the catalogTable storage properties.
    * The catalogTable does not have a deltaUniformIceberg field; instead the metadata location
    * and last converted delta version are stored as plain table properties as a workaround
    */
@@ -234,10 +234,11 @@ class IcebergConverter
       catalogTable: CatalogTable,
       deltaLog: DeltaLog,
       enablingUniForm: Boolean): LastConvertedIcebergInfo = {
+    val icebergProps = catalogTable.storage.properties
     val baseMetadataLocation =
-      catalogTable.properties.get(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP)
+      icebergProps.get(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP)
     val lastDeltaVersionConverted =
-      catalogTable.properties.get(
+      icebergProps.get(
         IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP).map(_.toLong)
     val lastConvertedIcebergTable =
       baseMetadataLocation.map(new HadoopTables(deltaLog.newDeltaHadoopConf()).load(_))

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormConverterSuite.scala
@@ -93,15 +93,18 @@ class UniFormConverterSuite extends
     )
   }
 
+  /** Simulates the UC REST catalog path: Iceberg props in storage.properties. */
   def catalogTableWithDeltaUniformIceberg(
       catalogTable: CatalogTable,
       metadataPath: String,
       convertedDeltaVersion: Long): CatalogTable =
     catalogTable.copy(
-      properties = catalogTable.properties +
-        (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP -> metadataPath) +
-        (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
-          convertedDeltaVersion.toString)
+      storage = catalogTable.storage.copy(
+        properties = catalogTable.storage.properties +
+          (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP -> metadataPath) +
+          (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
+            convertedDeltaVersion.toString)
+      )
     )
 
   def assertDeltaCommitRangeEvent(

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -97,13 +97,17 @@ trait WriteDeltaHMSReadIceberg extends UniFormE2ETest
 /**
  * A [[DeltaCatalog]] subclass that enriches [[CatalogTable]] with the last converted Iceberg
  * metadata from [[InMemoryUCCommitCoordinator]] before loading the table. This simulates what
- * the real UC catalog does: returning
+ * the real UC REST catalog does: injecting
  * [[IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP]]
- * and [[IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP]] as catalog table
- * properties so that [[IcebergConverter]] can perform incremental conversion.
+ * and [[IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP]] into
+ * catalog storage properties, matching the UC REST path in [[UCDeltaCatalogClientImpl]].
  */
 class UCBackedDeltaCatalog extends DeltaCatalog {
   override def loadCatalogTable(ident: Identifier, catalogTable: CatalogTable): Table = {
+    val forbiddenKeys = catalogTable.properties.keys.filter(_.startsWith("deltaUniformIceberg."))
+    assert(forbiddenKeys.isEmpty,
+      s"deltaUniformIceberg.* keys must only appear in storage.properties, " +
+        s"never in catalogTable.properties. Found: ${forbiddenKeys.mkString(", ")}")
     val enriched = UCBackedDeltaCatalog.currentCoordinator.flatMap { coordinator =>
       val deltaLog = DeltaLog.forTable(spark, new Path(catalogTable.location))
       val tableConf = deltaLog.update().metadata.coordinatedCommitsTableConf
@@ -112,11 +116,12 @@ class UCBackedDeltaCatalog extends DeltaCatalog {
           .filter(_.getIcebergMetadata.isPresent)
           .map { meta =>
             val icebergMeta = meta.getIcebergMetadata.get
-            catalogTable.copy(properties = catalogTable.properties +
-              (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP->
-                icebergMeta.getMetadataLocation) +
-              (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
-                icebergMeta.getConvertedDeltaVersion.toString))
+            catalogTable.copy(storage = catalogTable.storage.copy(
+              properties = catalogTable.storage.properties +
+                (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP ->
+                  icebergMeta.getMetadataLocation) +
+                (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
+                  icebergMeta.getConvertedDeltaVersion.toString)))
           }
       }
     }.getOrElse(catalogTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -20,6 +20,7 @@ import java.net.URI
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
 
 import io.delta.storage.commit.{TableIdentifier => StorageTableIdentifier}
 import io.delta.storage.commit.uccommitcoordinator.{UCDeltaClient, UCDeltaModels}
@@ -42,6 +43,7 @@ import org.apache.spark.sql.catalyst.catalog.{
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, V1Table}
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
+import org.apache.spark.sql.delta.IcebergConstants
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -122,9 +124,23 @@ private[catalog] class UCDeltaCatalogClientImpl(
     val schema = Option(m.getSchemaString)
       .map(DataType.fromJson(_).asInstanceOf[StructType])
       .getOrElse(new StructType())
+    // workaround for tracking UniForm metadata inside catalogTable
+    // Those are only kept in-memory by client and would not be written back to UC
+    val uniformProps = Option(info.getUniformMetadata)
+      .flatMap(u => u.getIcebergMetadata.toScala)
+      .map { iceberg =>
+        Map(
+          IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP ->
+            iceberg.getMetadataLocation,
+          IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
+            iceberg.getConvertedDeltaVersion.toString,
+          IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP ->
+            iceberg.getConvertedDeltaTimestamp
+        )
+      }.getOrElse(Map.empty[String, String])
     val storage = CatalogStorageFormat.empty.copy(
       locationUri = Some(new URI(info.getLocation)),
-      properties = properties ++ info.getStorageProperties.asScala.toMap)
+      properties = properties ++ info.getStorageProperties.asScala.toMap ++ uniformProps)
     val catalogTable = CatalogTable(
       identifier = TableIdentifier(ident.name(), ident.namespace().headOption, Some(catalogName)),
       tableType = fromUcTableType(info.getTableType),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -126,7 +126,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
       .getOrElse(new StructType())
     // workaround for tracking UniForm metadata inside catalogTable
     // Those are only kept in-memory by client and would not be written back to UC
-    val uniformProps = Option(info.getUniformMetadata)
+    val uniformProps = info.getUniformMetadata.toScala
       .flatMap(u => u.getIcebergMetadata.toScala)
       .map { iceberg =>
         Map(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -30,6 +30,7 @@ import io.delta.storage.commit.uniform.UniformMetadata
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, V1Table}
+import org.apache.spark.sql.delta.IcebergConstants
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -201,6 +202,77 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
         case None => spark.conf.unset(sspKey)
       }
     }
+  }
+
+  test("toV1Table propagates UniForm Iceberg metadata into storage.properties") {
+    val tableId = UUID.randomUUID()
+    val metadata = new AbstractMetadata {
+      override def getId: String = null
+      override def getName: String = "tbl"
+      override def getDescription: String = null
+      override def getProvider: String = "DELTA"
+      override def getFormatOptions: util.Map[String, String] = Collections.emptyMap()
+      override def getSchemaString: String =
+        """{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}"""
+      override def getPartitionColumns: util.List[String] = Collections.emptyList()
+      override def getConfiguration: util.Map[String, String] = Collections.emptyMap()
+      override def getCreatedTime: java.lang.Long = 0L
+    }
+    val iceberg = new io.delta.storage.commit.uniform.IcebergMetadata(
+      "s3://bucket/metadata/v1.metadata.json", 42L, "2025-01-04T03:13:11.423")
+    val uniform = new io.delta.storage.commit.uniform.UniformMetadata(iceberg)
+    val info = new TableInfo(
+      tableId,
+      UCDeltaModels.TableType.EXTERNAL,
+      "s3://bucket/table",
+      metadata,
+      Collections.emptyMap(),
+      uniform)
+
+    val client = new UCDeltaCatalogClientImpl(
+      catalogName = "main",
+      ucClient = new StubUCDeltaClient(info))
+
+    val v1 = client.loadTable(Identifier.of(Array("sch"), "tbl")).asInstanceOf[V1Table].catalogTable
+    val props = v1.storage.properties
+    assert(props.get(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP) ===
+      Some("s3://bucket/metadata/v1.metadata.json"))
+    assert(props.get(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP) ===
+      Some("42"))
+    assert(props.get(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP) ===
+      Some("2025-01-04T03:13:11.423"))
+  }
+
+  test("toV1Table with no UniForm metadata leaves storage.properties without iceberg keys") {
+    val tableId = UUID.randomUUID()
+    val metadata = new AbstractMetadata {
+      override def getId: String = null
+      override def getName: String = "tbl"
+      override def getDescription: String = null
+      override def getProvider: String = "DELTA"
+      override def getFormatOptions: util.Map[String, String] = Collections.emptyMap()
+      override def getSchemaString: String =
+        """{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}"""
+      override def getPartitionColumns: util.List[String] = Collections.emptyList()
+      override def getConfiguration: util.Map[String, String] = Collections.emptyMap()
+      override def getCreatedTime: java.lang.Long = 0L
+    }
+    val info = new TableInfo(
+      tableId,
+      UCDeltaModels.TableType.EXTERNAL,
+      "s3://bucket/table",
+      metadata,
+      Collections.emptyMap())
+
+    val client = new UCDeltaCatalogClientImpl(
+      catalogName = "main",
+      ucClient = new StubUCDeltaClient(info))
+
+    val v1 = client.loadTable(Identifier.of(Array("sch"), "tbl")).asInstanceOf[V1Table].catalogTable
+    val props = v1.storage.properties
+    assert(!props.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP))
+    assert(!props.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP))
+    assert(!props.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP))
   }
 
   test("loadTable without serverSidePlanningEnabled rethrows CredentialFetchFailedException") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -25,7 +25,7 @@ import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{DeltaProtocol, StagingTableInfo, TableInfo, TableType => UcTableType}
 import io.delta.storage.commit.uccommitcoordinator.exceptions.CredentialFetchFailedException
-import io.delta.storage.commit.uniform.UniformMetadata
+import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
@@ -112,19 +112,10 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
 
   test("loadTable converts TableInfo to V1Table with catalog-supplied fields") {
     val tableId = UUID.randomUUID()
-    val metadata = new AbstractMetadata {
-      override def getId: String = null
-      override def getName: String = "tbl"
-      override def getDescription: String = "a test table"
-      override def getProvider: String = "DELTA"
-      override def getFormatOptions: util.Map[String, String] = Collections.emptyMap()
-      override def getSchemaString: String =
-        """{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}"""
-      override def getPartitionColumns: util.List[String] = Collections.emptyList()
-      override def getConfiguration: util.Map[String, String] =
-        util.Map.of("ucTableId", tableId.toString, "delta.feature.x", "supported")
-      override def getCreatedTime: java.lang.Long = 42L
-    }
+    val metadata = new TestMetadata(
+      description = "a test table",
+      configuration = util.Map.of("ucTableId", tableId.toString, "delta.feature.x", "supported"),
+      createdTime = 42L)
     val info = new TableInfo(
       tableId,
       UCDeltaModels.TableType.EXTERNAL,
@@ -155,19 +146,7 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
 
   test("loadTable falls back to SSP on CredentialFetchFailedException when SSP is enabled") {
     val tableId = UUID.randomUUID()
-    val metadata = new AbstractMetadata {
-      override def getId: String = null
-      override def getName: String = "tbl"
-      override def getDescription: String = null
-      override def getProvider: String = "DELTA"
-      override def getFormatOptions: util.Map[String, String] = Collections.emptyMap()
-      override def getSchemaString: String =
-        """{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}"""
-      override def getPartitionColumns: util.List[String] = Collections.emptyList()
-      // No credential properties; this is the "without credentials" TableInfo.
-      override def getConfiguration: util.Map[String, String] = Collections.emptyMap()
-      override def getCreatedTime: java.lang.Long = 0L
-    }
+    val metadata = new TestMetadata() // no credential properties
     val tableInfoNoCreds = new TableInfo(
       tableId,
       UCDeltaModels.TableType.EXTERNAL,
@@ -206,24 +185,13 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
 
   test("toV1Table propagates UniForm Iceberg metadata into storage.properties") {
     val tableId = UUID.randomUUID()
-    val metadata = new AbstractMetadata {
-      override def getId: String = null
-      override def getName: String = "tbl"
-      override def getDescription: String = null
-      override def getProvider: String = "DELTA"
-      override def getFormatOptions: util.Map[String, String] = Collections.emptyMap()
-      override def getSchemaString: String =
-        """{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}"""
-      override def getPartitionColumns: util.List[String] = Collections.emptyList()
-      override def getConfiguration: util.Map[String, String] = Collections.emptyMap()
-      override def getCreatedTime: java.lang.Long = 0L
-    }
-    val iceberg = new io.delta.storage.commit.uniform.IcebergMetadata(
-      "s3://bucket/metadata/v1.metadata.json", 42L, "2025-01-04T03:13:11.423")
-    val uniform = new io.delta.storage.commit.uniform.UniformMetadata(iceberg)
+    val metadata = new TestMetadata()
+    val iceberg =
+      new IcebergMetadata("s3://bucket/metadata/v1.metadata.json", 42L, "2025-01-04T03:13:11.423")
+    val uniform = new UniformMetadata(iceberg)
     val info = new TableInfo(
       tableId,
-      UCDeltaModels.TableType.EXTERNAL,
+      UCDeltaModels.TableType.MANAGED,
       "s3://bucket/table",
       metadata,
       Collections.emptyMap(),
@@ -241,25 +209,20 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       Some("42"))
     assert(props.get(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP) ===
       Some("2025-01-04T03:13:11.423"))
+    // uniform keys must NOT appear in catalogTable.properties (only in storage.properties)
+    assert(!v1.properties.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP))
+    assert(!v1.properties.contains(
+      IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP)
+    )
+    assert(!v1.properties.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP))
   }
 
   test("toV1Table with no UniForm metadata leaves storage.properties without iceberg keys") {
     val tableId = UUID.randomUUID()
-    val metadata = new AbstractMetadata {
-      override def getId: String = null
-      override def getName: String = "tbl"
-      override def getDescription: String = null
-      override def getProvider: String = "DELTA"
-      override def getFormatOptions: util.Map[String, String] = Collections.emptyMap()
-      override def getSchemaString: String =
-        """{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}"""
-      override def getPartitionColumns: util.List[String] = Collections.emptyList()
-      override def getConfiguration: util.Map[String, String] = Collections.emptyMap()
-      override def getCreatedTime: java.lang.Long = 0L
-    }
+    val metadata = new TestMetadata()
     val info = new TableInfo(
       tableId,
-      UCDeltaModels.TableType.EXTERNAL,
+      UCDeltaModels.TableType.MANAGED,
       "s3://bucket/table",
       metadata,
       Collections.emptyMap())
@@ -273,6 +236,11 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     assert(!props.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP))
     assert(!props.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP))
     assert(!props.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP))
+    assert(!v1.properties.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP))
+    assert(!v1.properties.contains(
+      IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP)
+    )
+    assert(!v1.properties.contains(IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP))
   }
 
   test("loadTable without serverSidePlanningEnabled rethrows CredentialFetchFailedException") {
@@ -287,6 +255,31 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     }
     assert(thrown eq ex)
   }
+}
+
+/**
+ * Concrete [[AbstractMetadata]] for tests. All fields default to sensible no-op values so
+ * callers only override what they care about.
+ */
+private class TestMetadata(
+    id: String = null,
+    name: String = "tbl",
+    description: String = null,
+    provider: String = "DELTA",
+    schemaString: String =
+      """{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}""",
+    configuration: util.Map[String, String] = Collections.emptyMap(),
+    createdTime: java.lang.Long = 0L
+) extends AbstractMetadata {
+  override def getId: String = id
+  override def getName: String = name
+  override def getDescription: String = description
+  override def getProvider: String = provider
+  override def getFormatOptions: util.Map[String, String] = Collections.emptyMap()
+  override def getSchemaString: String = schemaString
+  override def getPartitionColumns: util.List[String] = Collections.emptyList()
+  override def getConfiguration: util.Map[String, String] = configuration
+  override def getCreatedTime: java.lang.Long = createdTime
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -121,7 +121,8 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       UCDeltaModels.TableType.EXTERNAL,
       "s3://bucket/table",
       metadata,
-      util.Map.of("fs.s3a.access.key", "key"))
+      util.Map.of("fs.s3a.access.key", "key"),
+      Optional.empty())
 
     val client = new UCDeltaCatalogClientImpl(
       catalogName = "main",
@@ -152,7 +153,8 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       UCDeltaModels.TableType.EXTERNAL,
       "s3://bucket/no-creds-table",
       metadata,
-      Collections.emptyMap()) // no storage properties either
+      Collections.emptyMap(),
+      Optional.empty()) // no storage properties either
     val credEx = new CredentialFetchFailedException(
       "creds exhausted", new RuntimeException("simulated"), tableInfoNoCreds)
 
@@ -195,7 +197,7 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       "s3://bucket/table",
       metadata,
       Collections.emptyMap(),
-      uniform)
+      Optional.of(uniform))
 
     val client = new UCDeltaCatalogClientImpl(
       catalogName = "main",
@@ -225,7 +227,8 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       UCDeltaModels.TableType.MANAGED,
       "s3://bucket/table",
       metadata,
-      Collections.emptyMap())
+      Collections.emptyMap(),
+      Optional.empty())
 
     val client = new UCDeltaCatalogClientImpl(
       catalogName = "main",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -153,8 +153,8 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       UCDeltaModels.TableType.EXTERNAL,
       "s3://bucket/no-creds-table",
       metadata,
-      Collections.emptyMap(),
-      Optional.empty()) // no storage properties either
+      Collections.emptyMap(), // no storage properties either
+      Optional.empty())
     val credEx = new CredentialFetchFailedException(
       "creds exhausted", new RuntimeException("simulated"), tableInfoNoCreds)
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.delta.api.TablesApi;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,9 +68,11 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
    * never be written back to the UC catalog.
    */
   private void assertNoUniformPropsOnServer(String fullTableName) throws Exception {
-    io.unitycatalog.client.api.TablesApi ucApi =
-        new io.unitycatalog.client.api.TablesApi(unityCatalogInfo().createApiClient());
-    Map<String, String> serverProps = ucApi.getTable(fullTableName, false, false).getProperties();
+    String[] parts = fullTableName.split("\\.");
+    TablesApi deltaApi = new TablesApi(unityCatalogInfo().createApiClient());
+    LoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
+    Map<String, String> serverProps =
+        resp.getMetadata() != null ? resp.getMetadata().getProperties() : null;
     if (serverProps == null) return;
     for (String key : serverProps.keySet()) {
       Assertions.assertFalse(
@@ -79,18 +82,29 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
   }
 
   /**
-   * Calls {@code loadTable} on the Delta REST API to get the Iceberg metadata JSON file path for
-   * the given table. The path points to the exact {@code .metadata.json} file written by the last
-   * UniForm conversion.
+   * Calls {@code loadTable} on the Delta REST API, validates the uniform fields in the response,
+   * and returns the Iceberg metadata JSON file path for the given table.
+   *
+   * @param expectedConvertedDeltaVersion the Delta version the server should report as converted
    */
-  private String icebergMetadataPath(String fullTableName) throws Exception {
+  private String verifyUCMetadataAndFetchIcebergPath(
+      String fullTableName, long expectedConvertedDeltaVersion) throws Exception {
     String[] parts = fullTableName.split("\\.");
     TablesApi deltaApi = new TablesApi(unityCatalogInfo().createApiClient());
     LoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
     if (resp.getUniform() == null || resp.getUniform().getIceberg() == null) {
       throw new IllegalStateException("No Iceberg metadata found for table: " + fullTableName);
     }
-    return resp.getUniform().getIceberg().getMetadataLocation();
+    var iceberg = resp.getUniform().getIceberg();
+    Assertions.assertEquals(
+        expectedConvertedDeltaVersion,
+        iceberg.getConvertedDeltaVersion().longValue(),
+        "loadTable response convertedDeltaVersion mismatch");
+    Assertions.assertNotNull(
+        iceberg.getConvertedDeltaTimestamp(), "loadTable response convertedDeltaTimestamp is null");
+    // Validate timestamp is a valid epoch-millis value by parsing it as an Instant.
+    Instant.ofEpochMilli(iceberg.getConvertedDeltaTimestamp());
+    return iceberg.getMetadataLocation();
   }
 
   /**
@@ -123,7 +137,7 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
           sql("INSERT INTO %s VALUES (1, 'a')", fullTableName);
           check(fullTableName, List.of(row("1", "a")));
           assertNoUniformPropsOnServer(fullTableName);
-          IcebergMeta meta1 = readIcebergMeta(fullTableName);
+          IcebergMeta meta1 = verifyUCMetadataAndReadIceberg(fullTableName, 1L);
           Assertions.assertEquals(
               "1",
               meta1.properties.get("delta-version"),
@@ -138,7 +152,7 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
           sql("INSERT INTO %s VALUES (2, 'b')", fullTableName);
           check(fullTableName, List.of(row("1", "a"), row("2", "b")));
           assertNoUniformPropsOnServer(fullTableName);
-          IcebergMeta meta2 = readIcebergMeta(fullTableName);
+          IcebergMeta meta2 = verifyUCMetadataAndReadIceberg(fullTableName, 2L);
           Assertions.assertEquals(
               "2",
               meta2.properties.get("delta-version"),
@@ -171,8 +185,10 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
     }
   }
 
-  private IcebergMeta readIcebergMeta(String fullTableName) throws Exception {
-    String icebergMetadataPath = icebergMetadataPath(fullTableName);
+  private IcebergMeta verifyUCMetadataAndReadIceberg(
+      String fullTableName, long expectedConvertedDeltaVersion) throws Exception {
+    String icebergMetadataPath =
+        verifyUCMetadataAndFetchIcebergPath(fullTableName, expectedConvertedDeltaVersion);
     Configuration conf = buildTestHadoopConf();
     return readIcebergMetaViaHadoopTables(icebergMetadataPath, conf);
   }
@@ -191,46 +207,3 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
 
     return new IcebergMeta(properties, currentSnapshotId, parentSnapshotId);
   }
-
-  private IcebergMeta readIcebergMetaViaJson(String icebergMetadataPath, Configuration conf)
-      throws Exception {
-    // icebergMetadataPath is the specific metadata JSON file — read it directly.
-    Path metadataFilePath = new Path(icebergMetadataPath);
-    FileSystem fs = metadataFilePath.getFileSystem(conf);
-
-    String json;
-    try (InputStream in = fs.open(metadataFilePath)) {
-      json = new String(in.readAllBytes());
-    }
-
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode root = mapper.readTree(json);
-
-    // Extract table properties
-    Map<String, String> properties = new HashMap<>();
-    JsonNode propsNode = root.get("properties");
-    if (propsNode != null && !propsNode.isNull()) {
-      propsNode.fields().forEachRemaining(e -> properties.put(e.getKey(), e.getValue().asText()));
-    }
-
-    // Extract current-snapshot-id
-    long currentSnapshotId =
-        root.has("current-snapshot-id") ? root.get("current-snapshot-id").asLong(-1L) : -1L;
-
-    // Find parent-snapshot-id for the current snapshot in the snapshots array
-    long parentSnapshotId = -1L;
-    JsonNode snapshots = root.get("snapshots");
-    if (snapshots != null && currentSnapshotId != -1L) {
-      for (JsonNode snap : snapshots) {
-        if (snap.get("snapshot-id").asLong() == currentSnapshotId) {
-          if (snap.has("parent-snapshot-id")) {
-            parentSnapshotId = snap.get("parent-snapshot-id").asLong(-1L);
-          }
-          break;
-        }
-      }
-    }
-
-    return new IcebergMeta(properties, currentSnapshotId, parentSnapshotId);
-  }
-}

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -58,10 +58,7 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
     String[] parts = fullTableName.split("\\.");
     TablesApi deltaApi = new TablesApi(unityCatalogInfo().createApiClient());
     LoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
-    Map<String, String> serverProps =
-        resp.getMetadata() != null ? resp.getMetadata().getProperties() : null;
-    if (serverProps == null) return;
-    for (String key : serverProps.keySet()) {
+    for (String key : resp.getMetadata().getProperties().keySet()) {
       Assertions.assertFalse(
           key.startsWith("deltaUniformIceberg."),
           "Server-side table properties must not contain in-memory-only key: " + key);

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -34,9 +34,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
-/**
- * Integration test that verifies UniForm Iceberg behaviors
- */
+/** Integration test that verifies UniForm Iceberg behaviors */
 public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseTest {
 
   @Override
@@ -115,8 +113,8 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
   }
 
   /**
-   * Verifies UniForm Iceberg incremental conversion works correctly on the UC
-   * REST path (real embedded UC server).
+   * Verifies UniForm Iceberg incremental conversion works correctly on the UC REST path (real
+   * embedded UC server).
    *
    * <p>The test creates a UniForm-enabled Delta table, writes twice, and verifies:
    *

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -35,23 +35,13 @@ import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
 /**
- * Integration test that verifies UniForm Iceberg incremental conversion works correctly on the UC
- * REST path (real embedded UC server).
- *
- * <p>The test creates a UniForm-enabled Delta table, writes twice, and verifies:
- *
- * <ul>
- *   <li>Write 1 → full Iceberg conversion: no {@code base-delta-version} table property.
- *   <li>Write 2 → incremental conversion: {@code base-delta-version} equals the prior converted
- *       Delta version, and the Iceberg snapshot chain is preserved.
- * </ul>
+ * Integration test that verifies UniForm Iceberg behaviors
  */
 public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseTest {
 
   @Override
   protected boolean useDeltaRestApiForTests() {
-    // Todo: return true once updateTable endpoint is fully implemented on server side
-    return false;
+    return true;
   }
 
   private static final String UNIFORM_TABLE_PROPS =
@@ -124,6 +114,18 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
     return conf;
   }
 
+  /**
+   * Verifies UniForm Iceberg incremental conversion works correctly on the UC
+   * REST path (real embedded UC server).
+   *
+   * <p>The test creates a UniForm-enabled Delta table, writes twice, and verifies:
+   *
+   * <ul>
+   *   <li>Write 1 → full Iceberg conversion: no {@code base-delta-version} table property.
+   *   <li>Write 2 → incremental conversion: {@code base-delta-version} equals the prior converted
+   *       Delta version, and the Iceberg snapshot chain is preserved.
+   * </ul>
+   */
   @Test
   public void uniformIcebergIncrementalConversion() throws Exception {
     Assumptions.assumeTrue(

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test that verifies UniForm Iceberg incremental conversion works correctly on the UC
+ * REST path (real embedded UC server).
+ *
+ * <p>The test creates a UniForm-enabled Delta table, writes twice, and verifies:
+ *
+ * <ul>
+ *   <li>Write 1 → full Iceberg conversion: no {@code base-delta-version} table property.
+ *   <li>Write 2 → incremental conversion: {@code base-delta-version} equals the prior converted
+ *       Delta version, and the Iceberg snapshot chain is preserved.
+ * </ul>
+ */
+public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseTest {
+
+  @Override
+  protected boolean useDeltaRestApiForTests() {
+    // Todo: return true once updateTable endpoint is fully implemented on server side
+    return false;
+  }
+
+  private static final String UNIFORM_TABLE_PROPS =
+      "'delta.universalFormat.enabledFormats'='iceberg', "
+          + "'delta.columnMapping.mode'='name', "
+          + "'delta.enableIcebergCompatV2'='true', "
+          + "'delta.enableDeletionVectors'='false'";
+
+  /**
+   * Asserts that none of the in-memory-only {@code deltaUniformIceberg.*} keys are present in the
+   * table's server-side properties. These keys are populated transiently in {@code
+   * catalogTable.storage.properties} from the {@code LoadTableResponse.uniform} field and must
+   * never be written back to the UC catalog.
+   */
+  private void assertNoUniformPropsOnServer(String fullTableName) throws Exception {
+    io.unitycatalog.client.api.TablesApi ucApi =
+        new io.unitycatalog.client.api.TablesApi(unityCatalogInfo().createApiClient());
+    Map<String, String> serverProps = ucApi.getTable(fullTableName, false, false).getProperties();
+    if (serverProps == null) return;
+    for (String key : serverProps.keySet()) {
+      Assertions.assertFalse(
+          key.startsWith("deltaUniformIceberg."),
+          "Server-side table properties must not contain in-memory-only key: " + key);
+    }
+  }
+
+  /**
+   * Calls {@code loadTable} on the Delta REST API to get the Iceberg metadata JSON file path for
+   * the given table. The path points to the exact {@code .metadata.json} file written by the last
+   * UniForm conversion.
+   */
+  private String icebergMetadataPath(String fullTableName) throws Exception {
+    String[] parts = fullTableName.split("\\.");
+    TablesApi deltaApi = new TablesApi(unityCatalogInfo().createApiClient());
+    LoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
+    if (resp.getUniform() == null || resp.getUniform().getIceberg() == null) {
+      throw new IllegalStateException("No Iceberg metadata found for table: " + fullTableName);
+    }
+    return resp.getUniform().getIceberg().getMetadataLocation();
+  }
+
+  /**
+   * Builds a Hadoop {@link Configuration} for reading Iceberg metadata from the embedded UC test's
+   * fake S3 filesystem. {@link S3CredentialFileSystem} maps {@code s3://fakeS3Bucket/...} to local
+   * paths and asserts that the static fake credentials are present in the conf.
+   */
+  private Configuration buildTestHadoopConf() {
+    Configuration conf = new Configuration(false);
+    conf.set("fs.s3.impl", S3CredentialFileSystem.class.getName());
+    conf.set("fs.s3a.access.key", "fakeAccessKey");
+    conf.set("fs.s3a.secret.key", "fakeSecretKey");
+    conf.set("fs.s3a.session.token", "fakeSessionToken");
+    return conf;
+  }
+
+  @Test
+  public void uniformIcebergIncrementalConversion() throws Exception {
+    Assumptions.assumeTrue(
+        Boolean.getBoolean("supportIceberg"),
+        "Skipping: Iceberg support not available for this Spark version");
+    withNewTable(
+        "uniform_iceberg",
+        "id INT, data STRING",
+        null,
+        TableType.MANAGED,
+        UNIFORM_TABLE_PROPS,
+        fullTableName -> {
+          // Write 1 — full Iceberg conversion (no prior Iceberg state)
+          sql("INSERT INTO %s VALUES (1, 'a')", fullTableName);
+          check(fullTableName, List.of(row("1", "a")));
+          assertNoUniformPropsOnServer(fullTableName);
+          IcebergMeta meta1 = readIcebergMeta(fullTableName);
+          Assertions.assertEquals(
+              "1",
+              meta1.properties.get("delta-version"),
+              "After first write, delta-version in Iceberg metadata should be 1");
+          Assertions.assertNull(
+              meta1.properties.get("base-delta-version"),
+              "First (full) conversion must NOT set base-delta-version");
+          Assertions.assertTrue(
+              meta1.currentSnapshotId != -1L, "Iceberg snapshot should exist after first write");
+
+          // Write 2 — must produce an incremental conversion on the Delta REST API path
+          sql("INSERT INTO %s VALUES (2, 'b')", fullTableName);
+          check(fullTableName, List.of(row("1", "a"), row("2", "b")));
+          assertNoUniformPropsOnServer(fullTableName);
+          IcebergMeta meta2 = readIcebergMeta(fullTableName);
+          Assertions.assertEquals(
+              "2",
+              meta2.properties.get("delta-version"),
+              "After second write, delta-version in Iceberg metadata should be 2");
+          if (useDeltaRestApiForTests()) {
+            Assertions.assertEquals(
+                "1",
+                meta2.properties.get("base-delta-version"),
+                "Second conversion must be incremental: base-delta-version should equal 1");
+            Assertions.assertEquals(
+                meta1.currentSnapshotId,
+                meta2.currentSnapshotParentId,
+                "Iceberg snapshot chain must be preserved: parent of snapshot-2 must be snapshot-1");
+          }
+        });
+  }
+
+  // ---------- Iceberg metadata reading ----------
+
+  private static final class IcebergMeta {
+    final Map<String, String> properties;
+    final long currentSnapshotId;
+    final long currentSnapshotParentId;
+
+    IcebergMeta(
+        Map<String, String> properties, long currentSnapshotId, long currentSnapshotParentId) {
+      this.properties = properties;
+      this.currentSnapshotId = currentSnapshotId;
+      this.currentSnapshotParentId = currentSnapshotParentId;
+    }
+  }
+
+  private IcebergMeta readIcebergMeta(String fullTableName) throws Exception {
+    String icebergMetadataPath = icebergMetadataPath(fullTableName);
+    Configuration conf = buildTestHadoopConf();
+    return readIcebergMetaViaHadoopTables(icebergMetadataPath, conf);
+  }
+
+  private IcebergMeta readIcebergMetaViaHadoopTables(String icebergMetadataPath, Configuration conf)
+      throws Exception {
+    HadoopTables tables = new HadoopTables(conf);
+    Table table = tables.load(icebergMetadataPath);
+
+    Map<String, String> properties = new HashMap<>(table.properties());
+
+    Snapshot current = table.currentSnapshot();
+    long currentSnapshotId = current != null ? current.snapshotId() : -1L;
+    long parentSnapshotId =
+        (current != null && current.parentId() != null) ? current.parentId() : -1L;
+
+    return new IcebergMeta(properties, currentSnapshotId, parentSnapshotId);
+  }
+
+  private IcebergMeta readIcebergMetaViaJson(String icebergMetadataPath, Configuration conf)
+      throws Exception {
+    // icebergMetadataPath is the specific metadata JSON file — read it directly.
+    Path metadataFilePath = new Path(icebergMetadataPath);
+    FileSystem fs = metadataFilePath.getFileSystem(conf);
+
+    String json;
+    try (InputStream in = fs.open(metadataFilePath)) {
+      json = new String(in.readAllBytes());
+    }
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode root = mapper.readTree(json);
+
+    // Extract table properties
+    Map<String, String> properties = new HashMap<>();
+    JsonNode propsNode = root.get("properties");
+    if (propsNode != null && !propsNode.isNull()) {
+      propsNode.fields().forEachRemaining(e -> properties.put(e.getKey(), e.getValue().asText()));
+    }
+
+    // Extract current-snapshot-id
+    long currentSnapshotId =
+        root.has("current-snapshot-id") ? root.get("current-snapshot-id").asLong(-1L) : -1L;
+
+    // Find parent-snapshot-id for the current snapshot in the snapshots array
+    long parentSnapshotId = -1L;
+    JsonNode snapshots = root.get("snapshots");
+    if (snapshots != null && currentSnapshotId != -1L) {
+      for (JsonNode snap : snapshots) {
+        if (snap.get("snapshot-id").asLong() == currentSnapshotId) {
+          if (snap.has("parent-snapshot-id")) {
+            parentSnapshotId = snap.get("parent-snapshot-id").asLong(-1L);
+          }
+          break;
+        }
+      }
+    }
+
+    return new IcebergMeta(properties, currentSnapshotId, parentSnapshotId);
+  }
+}

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -16,24 +16,23 @@
 
 package io.sparkuctest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.delta.api.TablesApi;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.delta.catalog.DeltaTableV2;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import scala.collection.JavaConverters;
 
 /**
  * Integration test that verifies UniForm Iceberg incremental conversion works correctly on the UC
@@ -108,16 +107,20 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
   }
 
   /**
-   * Builds a Hadoop {@link Configuration} for reading Iceberg metadata from the embedded UC test's
-   * fake S3 filesystem. {@link S3CredentialFileSystem} maps {@code s3://fakeS3Bucket/...} to local
-   * paths and asserts that the static fake credentials are present in the conf.
+   * Builds a Hadoop {@link Configuration} seeded from the Spark session (which registers {@link
+   * S3CredentialFileSystem} as {@code fs.s3.impl}) and enriched with the UC-vended storage
+   * credentials from the table's catalog storage properties.
    */
-  private Configuration buildTestHadoopConf() {
-    Configuration conf = new Configuration(false);
-    conf.set("fs.s3.impl", S3CredentialFileSystem.class.getName());
-    conf.set("fs.s3a.access.key", "fakeAccessKey");
-    conf.set("fs.s3a.secret.key", "fakeSecretKey");
-    conf.set("fs.s3a.session.token", "fakeSessionToken");
+  private Configuration buildTestHadoopConf(String fullTableName) throws Exception {
+    String[] parts = fullTableName.split("\\.");
+    TableCatalog catalog = (TableCatalog) spark().sessionState().catalogManager().catalog(parts[0]);
+    DeltaTableV2 table =
+        (DeltaTableV2) catalog.loadTable(Identifier.of(new String[] {parts[1]}, parts[2]));
+    Configuration conf = spark().sessionState().newHadoopConf();
+    if (table.catalogTable().isDefined()) {
+      JavaConverters.mapAsJavaMap(table.catalogTable().get().storage().properties())
+          .forEach(conf::set);
+    }
     return conf;
   }
 
@@ -189,7 +192,7 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
       String fullTableName, long expectedConvertedDeltaVersion) throws Exception {
     String icebergMetadataPath =
         verifyUCMetadataAndFetchIcebergPath(fullTableName, expectedConvertedDeltaVersion);
-    Configuration conf = buildTestHadoopConf();
+    Configuration conf = buildTestHadoopConf(fullTableName);
     return readIcebergMetaViaHadoopTables(icebergMetadataPath, conf);
   }
 
@@ -207,3 +210,4 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
 
     return new IcebergMeta(properties, currentSnapshotId, parentSnapshotId);
   }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
@@ -18,6 +18,7 @@ package io.delta.storage.commit.uccommitcoordinator;
 
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.commit.uniform.UniformMetadata;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -111,6 +112,7 @@ public final class UCDeltaModels {
     private final String location;
     private final AbstractMetadata metadata;
     private final Map<String, String> storageProperties;
+    private final UniformMetadata uniformMetadata;
 
     public TableInfo(
         UUID tableId,
@@ -118,11 +120,22 @@ public final class UCDeltaModels {
         String location,
         AbstractMetadata metadata,
         Map<String, String> storageProperties) {
+      this(tableId, tableType, location, metadata, storageProperties, null);
+    }
+
+    public TableInfo(
+        UUID tableId,
+        TableType tableType,
+        String location,
+        AbstractMetadata metadata,
+        Map<String, String> storageProperties,
+        UniformMetadata uniformMetadata) {
       this.tableId = tableId;
       this.tableType = tableType;
       this.location = location;
       this.metadata = metadata;
       this.storageProperties = storageProperties;
+      this.uniformMetadata = uniformMetadata;
     }
 
     /** UC's {@code table_uuid}; distinct from {@link AbstractMetadata#getId()} (the Delta id). */
@@ -145,6 +158,11 @@ public final class UCDeltaModels {
     /** Hadoop-style storage options (e.g. catalog-vended credentials). */
     public Map<String, String> getStorageProperties() {
       return storageProperties == null ? Collections.emptyMap() : storageProperties;
+    }
+
+    /** UniForm conversion metadata, or {@code null} if the table has no UniForm enabled. */
+    public UniformMetadata getUniformMetadata() {
+      return uniformMetadata;
     }
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -112,16 +113,7 @@ public final class UCDeltaModels {
     private final String location;
     private final AbstractMetadata metadata;
     private final Map<String, String> storageProperties;
-    private final UniformMetadata uniformMetadata;
-
-    public TableInfo(
-        UUID tableId,
-        TableType tableType,
-        String location,
-        AbstractMetadata metadata,
-        Map<String, String> storageProperties) {
-      this(tableId, tableType, location, metadata, storageProperties, null);
-    }
+    private final Optional<UniformMetadata> uniformMetadata;
 
     public TableInfo(
         UUID tableId,
@@ -129,7 +121,7 @@ public final class UCDeltaModels {
         String location,
         AbstractMetadata metadata,
         Map<String, String> storageProperties,
-        UniformMetadata uniformMetadata) {
+        Optional<UniformMetadata> uniformMetadata) {
       this.tableId = tableId;
       this.tableType = tableType;
       this.location = location;
@@ -160,8 +152,8 @@ public final class UCDeltaModels {
       return storageProperties == null ? Collections.emptyMap() : storageProperties;
     }
 
-    /** UniForm conversion metadata, or {@code null} if the table has no UniForm enabled. */
-    public UniformMetadata getUniformMetadata() {
+    /** UniForm conversion metadata, or empty if the table has no UniForm enabled. */
+    public Optional<UniformMetadata> getUniformMetadata() {
       return uniformMetadata;
     }
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -51,6 +51,7 @@ import io.unitycatalog.client.delta.model.StagingTableResponse;
 import io.unitycatalog.client.delta.model.StagingTableResponseRequiredProtocol;
 import io.unitycatalog.client.delta.model.StagingTableResponseSuggestedProtocol;
 import io.unitycatalog.client.delta.model.TableMetadata;
+import io.delta.storage.commit.uniform.IcebergMetadata;
 import io.unitycatalog.client.delta.model.UniformMetadata;
 import io.unitycatalog.client.delta.model.UniformMetadataIceberg;
 import io.unitycatalog.client.delta.model.UpdateTableRequest;
@@ -60,6 +61,7 @@ import io.unitycatalog.hadoop.UCCredentialHadoopConfs.TableOperation;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -520,6 +522,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     UCDeltaModels.TableType tableType =
         UCDeltaModels.TableType.valueOf(m.getTableType().getValue());
     DeltaTableMetadata adapted = new DeltaTableMetadata(name, m);
+    io.delta.storage.commit.uniform.UniformMetadata uniformMetadata =
+        toStorageUniformMetadata(response.getUniform());
     Map<String, String> storageProps;
     try {
       storageProps = fetchTableCredentials(catalog, schema, name, location);
@@ -528,13 +532,41 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       // recover. The exception carries the catalog-side TableInfo (with empty storageProperties)
       // so the caller can still build a CatalogTable.
       TableInfo withoutCreds = new TableInfo(
-          ucTableId, tableType, location, adapted, Collections.emptyMap());
+          ucTableId, tableType, location, adapted, Collections.emptyMap(), uniformMetadata);
       throw new CredentialFetchFailedException(
           String.format("Credential fetch failed for table %s.%s.%s (HTTP %s): %s",
               catalog, schema, name, e.getCode(), e.getResponseBody()),
           e, withoutCreds);
     }
-    return new TableInfo(ucTableId, tableType, location, adapted, storageProps);
+    return new TableInfo(ucTableId, tableType, location, adapted, storageProps, uniformMetadata);
+  }
+
+  private static io.delta.storage.commit.uniform.UniformMetadata toStorageUniformMetadata(
+      UniformMetadata sdkUniform) {
+    if (sdkUniform == null) {
+      return null;
+    }
+    UniformMetadataIceberg sdkIceberg = sdkUniform.getIceberg();
+    if (sdkIceberg == null) {
+      return new io.delta.storage.commit.uniform.UniformMetadata(null);
+    }
+    String metadataLocation = sdkIceberg.getMetadataLocation();
+    Long rawVersion = sdkIceberg.getConvertedDeltaVersion();
+    Long rawTimestamp = sdkIceberg.getConvertedDeltaTimestamp();
+    if (metadataLocation == null || rawVersion == null || rawTimestamp == null) {
+      throw new IllegalStateException(
+          "UC returned a non-null UniformMetadataIceberg with missing required fields: "
+              + "metadataLocation="
+              + metadataLocation
+              + ", convertedDeltaVersion="
+              + rawVersion
+              + ", convertedDeltaTimestamp="
+              + rawTimestamp);
+    }
+    String convertedDeltaTimestamp = Instant.ofEpochMilli(rawTimestamp).toString();
+    IcebergMetadata icebergMetadata =
+        new IcebergMetadata(metadataLocation, rawVersion, convertedDeltaTimestamp);
+    return new io.delta.storage.commit.uniform.UniformMetadata(icebergMetadata);
   }
 
   private UCDeltaModels.StagingTableInfo toStagingTableInfo(StagingTableResponse r) {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -522,7 +522,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     UCDeltaModels.TableType tableType =
         UCDeltaModels.TableType.valueOf(m.getTableType().getValue());
     DeltaTableMetadata adapted = new DeltaTableMetadata(name, m);
-    io.delta.storage.commit.uniform.UniformMetadata uniformMetadata =
+    Optional<io.delta.storage.commit.uniform.UniformMetadata> uniformMetadata =
         toStorageUniformMetadata(response.getUniform());
     Map<String, String> storageProps;
     try {
@@ -541,14 +541,14 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return new TableInfo(ucTableId, tableType, location, adapted, storageProps, uniformMetadata);
   }
 
-  private static io.delta.storage.commit.uniform.UniformMetadata toStorageUniformMetadata(
-      UniformMetadata sdkUniform) {
+  private static Optional<io.delta.storage.commit.uniform.UniformMetadata>
+      toStorageUniformMetadata(UniformMetadata sdkUniform) {
     if (sdkUniform == null) {
-      return null;
+      return Optional.empty();
     }
     UniformMetadataIceberg sdkIceberg = sdkUniform.getIceberg();
     if (sdkIceberg == null) {
-      return new io.delta.storage.commit.uniform.UniformMetadata(null);
+      return Optional.of(new io.delta.storage.commit.uniform.UniformMetadata(null));
     }
     String metadataLocation = sdkIceberg.getMetadataLocation();
     Long rawVersion = sdkIceberg.getConvertedDeltaVersion();
@@ -566,7 +566,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     String convertedDeltaTimestamp = Instant.ofEpochMilli(rawTimestamp).toString();
     IcebergMetadata icebergMetadata =
         new IcebergMetadata(metadataLocation, rawVersion, convertedDeltaTimestamp);
-    return new io.delta.storage.commit.uniform.UniformMetadata(icebergMetadata);
+    return Optional.of(new io.delta.storage.commit.uniform.UniformMetadata(icebergMetadata));
   }
 
   private UCDeltaModels.StagingTableInfo toStagingTableInfo(StagingTableResponse r) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
This PR proposes to support incremental conversion for UniForm end to end with integration of Delta-Rest API. As a workaround, this PR tracks UniForm metadata inside `catalogTable.storage.properties`.

## How was this patch tested?
Add UTs and integration tests
