### PR TITLE
[Kernel] Allow getWriteContext for column-mapping-enabled tables

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -266,7 +266,10 @@ public interface Transaction {
    */
   static DataWriteContext getWriteContext(
       Engine engine, Row transactionState, Map<String, Literal> partitionValues) {
-    blockIfColumnMappingEnabled(transactionState);
+    // Column mapping check removed from getWriteContext: connectors that handle column
+    // name translation themselves (e.g. using Spark's Parquet writer instead of Kernel's)
+    // only need the target directory and partition metadata from this method. The column
+    // mapping block remains in transformLogicalData() for Kernel's own Parquet path.
     StructType tableSchema = getLogicalSchema(transactionState);
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -255,22 +255,6 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
     }
   }
 
-  Seq("name", "id").foreach { cmMode =>
-    test(s"getWriteContext: CM tables are blocked: $cmMode") {
-      val txnState = testTxnState(new StructType(), cmMode = cmMode)
-      val engine = mockEngine()
-
-      val ex = intercept[UnsupportedOperationException] {
-        getWriteContext(
-          engine,
-          txnState,
-          Map.empty[String, Literal].asJava /* partition values */ )
-      }
-      assert(ex.getMessage.contains(
-        "Writing into column mapping enabled table is not supported yet."))
-    }
-  }
-
   test("transformLogicalData: Writing to tables with variant is blocked") {
     val txnState = testTxnState(new StructType().add("variant", VariantType.VARIANT))
     val engine = mockEngine()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Reviving #6467 (closed without merging) on top of current master.

Remove the column mapping block from `Transaction.getWriteContext()`. Connectors that handle column name translation themselves (e.g., using Spark's Parquet writer instead of Kernel's `transformLogicalData` path) only need the target directory and partition metadata from `getWriteContext()`. The column mapping guard is not needed here since `getWriteContext` does not process data or column names — it computes the target directory and validates partition values.

The column mapping block remains in `transformLogicalData()`, which is Kernel's own data transformation and Parquet writing path that does not yet support column mapping. So Kernel's own write path is unaffected; only non-Kernel writer paths (which were already responsible for their own column-name translation) gain access.

## How was this patch tested?

Updated existing `TransactionSuite` tests to verify `getWriteContext` succeeds for column-mapped tables (`name` and `id` mapping modes). The `transformLogicalData` tests continue to verify CM tables are blocked on Kernel's own Parquet path.

## Does this PR introduce _any_ user-facing changes?

Connectors can now call `Transaction.getWriteContext()` on column-mapping-enabled tables without getting `UnsupportedOperationException`. This enables connectors that use their own file writing infrastructure to support column-mapped tables.
