### PR TITLE
[UniForm] Support conflict resolution end to end

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -20,6 +20,7 @@ import java.util.{Collections, Optional, UUID}
 
 import scala.collection.JavaConverters._
 
+import com.databricks.spark.util.Log4jUsageLogger
 import io.delta.storage.commit.{CommitCoordinatorClient => JCommitCoordinatorClient}
 import io.delta.storage.commit.{TableIdentifier => UCTableIdentifier}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
@@ -31,7 +32,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
-import org.apache.spark.sql.delta.{DeltaLog, IcebergConstants}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, DeltaTestUtils, IcebergConstants}
 import org.apache.spark.sql.delta.DeltaConfigs.{
   COORDINATED_COMMITS_COORDINATOR_CONF,
   COORDINATED_COMMITS_COORDINATOR_NAME
@@ -245,7 +246,77 @@ trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
  */
 class UniFormE2EIcebergUCSuite extends UniFormE2EIcebergSuiteBase
     with WriteDeltaUCCCReadIceberg {
-  // No test should go here. Please add tests in [[UniFormE2EIcebergSuiteBase]]
+  // Tests that don't require CC infrastructure should be added in [[UniFormE2EIcebergSuiteBase]].
+  // Tests that specifically exercise the UC commit coordinator path may be added here.
   override def extraTableProperties(compatVersion: Int): String =
     super.extraTableProperties(compatVersion) + requiredTableProperties
+
+  test("conflict resolution refreshes catalogTable with fresh uniform metadata " +
+    "for incremental Iceberg conversion") {
+    val tableName = "test_cc_conflict_iceberg_refresh"
+    withTable(tableName) {
+      // Create a CC + UniForm table.
+      write(
+        s"""CREATE TABLE $tableName (id INT) USING DELTA
+           |TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |  $requiredTableProperties
+           |)""".stripMargin)
+
+      // v1: insert row 1 - triggers atomic Iceberg conversion at v1.
+      write(s"INSERT INTO $tableName VALUES (1)")
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val v1Snapshot = deltaLog.update()
+      val tableId = v1Snapshot.metadata.coordinatedCommitsTableConf
+        .get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY).get
+      val v1IcebergMeta =
+        ucCommitCoordinator.getUniformMetadata(tableId).get.getIcebergMetadata.get
+
+      // Build a stale catalog table: raw HMS catalog enriched with v1 Iceberg metadata.
+      // This simulates a transaction that started before v2 was committed.
+      val rawCatalogTable =
+        spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
+      val staleCatalogTable = rawCatalogTable.copy(
+        storage = rawCatalogTable.storage.copy(
+          properties = rawCatalogTable.storage.properties +
+            (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP ->
+              v1IcebergMeta.getMetadataLocation) +
+            (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
+              v1IcebergMeta.getConvertedDeltaVersion.toString)
+        )
+      )
+
+      // v2: insert row 2 - the "winning" commit that the stale txn will conflict with.
+      write(s"INSERT INTO $tableName VALUES (2)")
+
+      // Start a transaction with stale v1 snapshot and stale v1 Iceberg catalog.
+      // It will try to commit as v2, hit a conflict, then retry as v3.
+      // During conflict resolution, getCommits returns v2's UniformMetadata, which
+      // refreshes catalogTable to convertedDeltaVersion=2. The retry commit then converts
+      // only v3 incrementally (fromVersion=3, toVersion=3) rather than from stale v1.
+      val txn = deltaLog.startTransaction(Some(staleCatalogTable), Some(v1Snapshot))
+      val events = Log4jUsageLogger.track {
+        txn.commit(Seq.empty, DeltaOperations.ManualUpdate)
+      }
+
+      // Latest version is now 3. There are two deltaCommitRange events: one from the failed
+      // first attempt (v2, using stale v1 base) and one from the successful retry (v3).
+      // The retry must use the refreshed catalog (convertedDeltaVersion=2 from v2's
+      // UniformMetadata), so conversion covers only v3 (fromVersion=3, toVersion=3).
+      // Without the fix, the retry would still use the stale v1 base and fromVersion would be 2.
+      val latestVersion = deltaLog.update().version
+      val rangeEvents = DeltaTestUtils.filterUsageRecords(
+        events, "delta.iceberg.conversion.deltaCommitRange")
+      assert(rangeEvents.size >= 2,
+        s"Expected >=2 deltaCommitRange events (failed attempt + retry), got ${rangeEvents.size}")
+      val retryEventData = JsonUtils.fromJson[Map[String, Any]](rangeEvents.last.blob)
+      assert(retryEventData("fromVersion") === latestVersion,
+        s"Expected fromVersion=$latestVersion (fresh v2 base), " +
+          s"got ${retryEventData("fromVersion")} (stale v1 base would give ${latestVersion - 1})")
+      assert(retryEventData("toVersion") === latestVersion,
+        s"Expected toVersion=$latestVersion")
+    }
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -3000,13 +3000,13 @@ trait OptimisticTransactionImpl extends TransactionHelper
         tags = Map(TAG_LOG_STORE_CLASS -> deltaLog.store.getClass.getName)) {
 
     DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
-      val (fileStatuses, uniformMetadataOpt) = getConflictingVersions(checkVersion)
-      val nextAttemptVersion = checkVersion + conflictingContext.fileStatuses.size
+      val conflictingContext = getConflictingVersions(checkVersion)
+      val nextAttemptVersion = checkVersion + conflictingContext.conflictingCommitFiles.size
 
       // validate that information about conflicting winning commit files is continuous and in the
       // right order.
       val expected = (checkVersion until nextAttemptVersion)
-      val found = conflictingContext.fileStatuses.map(deltaVersion)
+      val found = conflictingContext.conflictingCommitFiles.map(deltaVersion)
       val mismatch = expected.zip(found).dropWhile{ case (v1, v2) => v1 == v2 }.take(10)
       assert(mismatch.isEmpty,
         s"Expected ${mismatch.map(_._1).mkString(",")} but got ${mismatch.map(_._2).mkString(",")}")
@@ -3041,7 +3041,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
             currentTransactionInfo = currentTransactionInfo,
             firstWinningVersion = expected.head,
             lastWinningVersion = expected.last,
-            conflictingCommitFiles = conflictingContext.fileStatuses,
+            conflictingCommitFiles = conflictingContext.conflictingCommitFiles,
             commitIsolationLevel = commitIsolationLevel)
         }
       }
@@ -3114,7 +3114,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         preCommitLogSegment,
         readSnapshotTableCommitCoordinatorClientOpt,
         catalogTable)
-    assert(preCommitLogSegment.version + conflictingContext.fileStatuses.size ==
+    assert(preCommitLogSegment.version + conflictingContext.conflictingCommitFiles.size ==
       newPreCommitLogSegment.version)
     preCommitLogSegment = newPreCommitLogSegment
     conflictingContext

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -33,6 +33,7 @@ import com.databricks.spark.util.TagDefinition
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
+import org.apache.spark.sql.delta.IcebergConstants
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
@@ -2735,7 +2736,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       currentTransactionInfo: CurrentTransactionInfo,
       attemptNumber: Int,
       isolationLevel: IsolationLevel): Snapshot = {
-    val targetCatalogTable = catalogTable
+    val targetCatalogTable = currentTransactionInfo.catalogTable
     // If the table requires atomic Iceberg metadata generation
     // , generate iceberg metadata and update the transaction info.
     var icebergMetadataGenerationDurationMsOpt: Option[Long] = None
@@ -2999,13 +3000,13 @@ trait OptimisticTransactionImpl extends TransactionHelper
         tags = Map(TAG_LOG_STORE_CLASS -> deltaLog.store.getClass.getName)) {
 
     DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
-      val fileStatuses = getConflictingVersions(checkVersion)
-      val nextAttemptVersion = checkVersion + fileStatuses.size
+      val (fileStatuses, uniformMetadataOpt) = getConflictingVersions(checkVersion)
+      val nextAttemptVersion = checkVersion + conflictingContext.fileStatuses.size
 
       // validate that information about conflicting winning commit files is continuous and in the
       // right order.
       val expected = (checkVersion until nextAttemptVersion)
-      val found = fileStatuses.map(deltaVersion)
+      val found = conflictingContext.fileStatuses.map(deltaVersion)
       val mismatch = expected.zip(found).dropWhile{ case (v1, v2) => v1 == v2 }.take(10)
       assert(mismatch.isEmpty,
         s"Expected ${mismatch.map(_._1).mkString(",")} but got ${mismatch.map(_._2).mkString(",")}")
@@ -3031,7 +3032,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         log"${MDC(DeltaLogKeys.VERSION2, nextAttemptVersion)}) " +
         log"with current txn having " + txnDetailsLog)
 
-      val updatedCurrentTransactionInfo = {
+      val resolvedCurrentTransactionInfo = {
         if (expected.isEmpty) {
           currentTransactionInfo
         }
@@ -3040,11 +3041,15 @@ trait OptimisticTransactionImpl extends TransactionHelper
             currentTransactionInfo = currentTransactionInfo,
             firstWinningVersion = expected.head,
             lastWinningVersion = expected.last,
-            conflictingCommitFiles = fileStatuses,
+            conflictingCommitFiles = conflictingContext.fileStatuses,
             commitIsolationLevel = commitIsolationLevel)
         }
       }
 
+      val updatedCurrentTransactionInfo =
+        updateCatalogTableWithUniformMetadata(
+          resolvedCurrentTransactionInfo, conflictingContext.uniformMetadata
+        )
 
       logInfo(logPrefix +
         log"No conflicts with versions " +
@@ -3102,16 +3107,17 @@ trait OptimisticTransactionImpl extends TransactionHelper
   private[delta] def getFirstAttemptVersion: Long = readVersion + 1L
 
   /** Returns the conflicting commit information */
-  protected def getConflictingVersions(previousAttemptVersion: Long): Seq[FileStatus] = {
+  protected def getConflictingVersions(previousAttemptVersion: Long): ConflictingContext = {
     assert(previousAttemptVersion == preCommitLogSegment.version + 1)
-    val (newPreCommitLogSegment, newCommitFileStatuses) = deltaLog.getUpdatedLogSegment(
-      preCommitLogSegment,
-      readSnapshotTableCommitCoordinatorClientOpt,
-      catalogTable)
-    assert(preCommitLogSegment.version + newCommitFileStatuses.size ==
+    val (newPreCommitLogSegment, conflictingContext) =
+      deltaLog.getUpdatedLogSegment(
+        preCommitLogSegment,
+        readSnapshotTableCommitCoordinatorClientOpt,
+        catalogTable)
+    assert(preCommitLogSegment.version + conflictingContext.fileStatuses.size ==
       newPreCommitLogSegment.version)
     preCommitLogSegment = newPreCommitLogSegment
-    newCommitFileStatuses
+    conflictingContext
   }
 
   protected def setCommitted(
@@ -3223,6 +3229,31 @@ trait OptimisticTransactionImpl extends TransactionHelper
         throwError("WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED",
           Array("ALTER TABLE"))
       case _ =>
+    }
+  }
+
+  /**
+   * Updates the catalogTable in CurrentTransactionInfo with fresh uniform metadata from
+   * getCommits, so that iceberg incremental conversion on retry uses the correct base version.
+   */
+  protected def updateCatalogTableWithUniformMetadata(
+      txnInfo: CurrentTransactionInfo,
+      uniformMetadataOpt: Option[UniformMetadata]): CurrentTransactionInfo = {
+    uniformMetadataOpt.flatMap(_.getIcebergMetadata.toScala) match {
+      case None => txnInfo
+      case Some(iceberg) =>
+        txnInfo.catalogTable.map { ct =>
+          val newUniFormPropes = Map(
+            IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP ->
+              iceberg.getMetadataLocation,
+            IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
+              iceberg.getConvertedDeltaVersion.toString,
+            IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP ->
+              iceberg.getConvertedDeltaTimestamp
+          )
+          val newStorage = ct.storage.copy(properties = ct.storage.properties ++ newUniFormPropes)
+          txnInfo.copy(catalogTable = Some(ct.copy(storage = newStorage)))
+        }.getOrElse(txnInfo)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.delta.storage.commit.{Commit, GetCommitsResponse}
+import io.delta.storage.commit.uniform.{UniformMetadata => StorageUniformMetadata}
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
 
 import org.apache.spark.{SparkContext, SparkException}
@@ -171,7 +172,8 @@ trait SnapshotManagement { self: DeltaLog =>
       tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient],
       catalogTableOpt: Option[CatalogTable],
       versionToLoad: Option[Long],
-      includeMinorCompactions: Boolean): (Option[Array[FileStatus]], Option[FileStatus]) = {
+      includeMinorCompactions: Boolean)
+  : (Option[Array[FileStatus]], Option[FileStatus], ListingExtras) = {
     val tableCommitCoordinatorClient = tableCommitCoordinatorClientOpt.getOrElse {
       val (filesOpt, checksumOpt) =
         listFromFileSystemInternal(
@@ -179,7 +181,7 @@ trait SnapshotManagement { self: DeltaLog =>
           versionToLoad,
           includeMinorCompactions
         )
-      return (filesOpt.map(_.map(_._1)), checksumOpt)
+      return (filesOpt.map(_.map(_._1)), checksumOpt, ListingExtras(None))
     }
 
     // Submit a potential async call to get commits from commit coordinator if available
@@ -316,7 +318,13 @@ trait SnapshotManagement { self: DeltaLog =>
       logTuplesFromFsListing.map(_._1) ++ unbackfilledCommitsFiltered
     }
     val latestChecksumOpt = additionalChecksumOpt.orElse(initialChecksumOpt)
-    (logTuplesToReturn, latestChecksumOpt)
+    val uniformMetadataOpt =
+      Option(unbackfilledCommitsResponse.getUniformMetadata.orElse(null))
+<<<<<<< HEAD
+    (logTuplesToReturn, latestChecksumOpt, uniformMetadataOpt)
+=======
+    (logTuplesToReturn, latestChecksumOpt, ListingExtras(uniformMetadataOpt))
+>>>>>>> 0a285f60b (Squashed commits:)
   }
 
   /**
@@ -342,9 +350,10 @@ trait SnapshotManagement { self: DeltaLog =>
       tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient],
       catalogTableOpt: Option[CatalogTable],
       versionToLoad: Option[Long],
-      includeMinorCompactions: Boolean): Option[Array[FileStatus]] = {
+      includeMinorCompactions: Boolean)
+  : (Option[Array[FileStatus]], ListingExtras) = {
     recordDeltaOperation(self, "delta.deltaLog.listDeltaAndCheckpointFiles") {
-      val (logTuplesOpt, latestChecksumOpt) =
+      val (logTuplesOpt, latestChecksumOpt, listingExtras) =
         listDeltaCompactedDeltaCheckpointFilesAndLatestChecksumFile(
           startVersion,
           tableCommitCoordinatorClientOpt,
@@ -352,7 +361,7 @@ trait SnapshotManagement { self: DeltaLog =>
           versionToLoad,
           includeMinorCompactions)
       lastSeenChecksumFileStatusOpt = latestChecksumOpt
-      logTuplesOpt
+      (logTuplesOpt, listingExtras)
     }
   }
 
@@ -393,7 +402,7 @@ trait SnapshotManagement { self: DeltaLog =>
       tableCommitCoordinatorClientOpt,
       catalogTableOpt,
       versionToLoad,
-      includeMinorCompactions)
+      includeMinorCompactions)._1
     getLogSegmentForVersion(
       versionToLoad,
       newFiles,
@@ -788,7 +797,7 @@ trait SnapshotManagement { self: DeltaLog =>
           catalogTableOpt = catalogTableOpt,
           versionToLoad = Some(snapshotVersion),
           includeMinorCompactions = false
-        ).getOrElse(Array.empty)
+        )._1.getOrElse(Array.empty)
         val (checkpoints, deltas) = filesSinceCheckpointVersion.partition(isCheckpointFile)
         if (deltas.isEmpty) {
           // We cannot find any delta files. Returns None as we cannot construct a `LogSegment` only
@@ -837,7 +846,7 @@ trait SnapshotManagement { self: DeltaLog =>
             versionToLoad = Some(snapshotVersion),
             includeMinorCompactions = false)
         val (deltas, deltaVersions) =
-          listFromResult
+          listFromResult._1
             .getOrElse(Array.empty)
             .flatMap(DeltaFile.unapply(_))
             .unzip
@@ -983,9 +992,9 @@ trait SnapshotManagement { self: DeltaLog =>
       oldLogSegment: LogSegment,
       tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient],
       catalogTableOpt: Option[CatalogTable]
-  ): (LogSegment, Seq[FileStatus]) = {
+  ): (LogSegment, ConflictingContext) = {
     val includeCompactions = spark.conf.get(DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS)
-    val newFilesOpt = listDeltaCompactedDeltaAndCheckpointFiles(
+    val (newFilesOpt, listingExtras) = listDeltaCompactedDeltaAndCheckpointFiles(
         startVersion = oldLogSegment.version + 1,
         tableCommitCoordinatorClientOpt = tableCommitCoordinatorClientOpt,
         catalogTableOpt = catalogTableOpt,
@@ -999,7 +1008,7 @@ trait SnapshotManagement { self: DeltaLog =>
     val newFiles = newFilesOpt.filter(_.nonEmpty).getOrElse {
       // An empty listing likely implies a list-after-write inconsistency or that somebody clobbered
       // the Delta log.
-      return (oldLogSegment, Nil)
+      return (oldLogSegment, ConflictingContext(Nil, listingExtras.uniformMetadata))
     }
     val allFiles = (
       oldLogSegment.checkpointProvider.topLevelFiles ++
@@ -1019,7 +1028,9 @@ trait SnapshotManagement { self: DeltaLog =>
     val fileStatusesOfConflictingCommits = newFiles.collect {
       case DeltaFile(f, v) if v <= newLogSegment.version => f
     }
-    (newLogSegment, fileStatusesOfConflictingCommits)
+    (newLogSegment, ConflictingContext(
+      fileStatusesOfConflictingCommits, listingExtras.uniformMetadata)
+    )
   }
 
   /**
@@ -1622,6 +1633,12 @@ trait SnapshotManagement { self: DeltaLog =>
   // Visible for testing
   private[delta] def getCapturedSnapshot(): CapturedSnapshot = currentSnapshot
 }
+
+case class ListingExtras(uniformMetadata: Option[StorageUniformMetadata])
+
+case class ConflictingContext(
+    fileStatuses: Seq[FileStatus],
+    uniformMetadata: Option[StorageUniformMetadata])
 
 object SnapshotManagement extends DeltaLogging {
   // A thread pool for reading checkpoint files and collecting checkpoint v2 actions like

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -320,11 +320,7 @@ trait SnapshotManagement { self: DeltaLog =>
     val latestChecksumOpt = additionalChecksumOpt.orElse(initialChecksumOpt)
     val uniformMetadataOpt =
       Option(unbackfilledCommitsResponse.getUniformMetadata.orElse(null))
-<<<<<<< HEAD
-    (logTuplesToReturn, latestChecksumOpt, uniformMetadataOpt)
-=======
     (logTuplesToReturn, latestChecksumOpt, ListingExtras(uniformMetadataOpt))
->>>>>>> 0a285f60b (Squashed commits:)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1637,7 +1637,7 @@ trait SnapshotManagement { self: DeltaLog =>
 case class ListingExtras(uniformMetadata: Option[StorageUniformMetadata])
 
 case class ConflictingContext(
-    fileStatuses: Seq[FileStatus],
+    conflictingCommitFiles: Seq[FileStatus],
     uniformMetadata: Option[StorageUniformMetadata])
 
 object SnapshotManagement extends DeltaLogging {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCCommitCoordinator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCCommitCoordinator.scala
@@ -362,7 +362,12 @@ class InMemoryUCCommitCoordinator {
     withLock[JGetCommitsResponse](tableUUID) {
       val tableData = perTableMap.get(tableUUID)
       val commits = tableData.getCommits(startVersion, endVersion)
-      new JGetCommitsResponse(commits.asJava, tableData.lastRatifiedCommitVersion)
+      new JGetCommitsResponse(
+        commits.asJava,
+        tableData.lastRatifiedCommitVersion
+        // Simulates OSS Delta-Rest client impl that fetches UniForm along with getCommits
+        , java.util.Optional.ofNullable(tableData.getCurrentUniformMetadataOpt.orNull)
+      )
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -656,7 +656,7 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       val deltaLog = DeltaLog.forTable(spark, path)
       deltaLog.checkpoint()
       val snapshot = deltaLog.update()
-      val (updatedLogSegment, _) = deltaLog.getUpdatedLogSegment(
+      val (updatedLogSegment, _, _) = deltaLog.getUpdatedLogSegment(
         snapshot.logSegment,
         tableCommitCoordinatorClientOpt = None,
         catalogTableOpt = None

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -656,7 +656,7 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       val deltaLog = DeltaLog.forTable(spark, path)
       deltaLog.checkpoint()
       val snapshot = deltaLog.update()
-      val (updatedLogSegment, _, _) = deltaLog.getUpdatedLogSegment(
+      val (updatedLogSegment, _) = deltaLog.getUpdatedLogSegment(
         snapshot.logSegment,
         tableCommitCoordinatorClientOpt = None,
         catalogTableOpt = None

--- a/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
@@ -18,7 +18,9 @@ package io.delta.storage.commit;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import io.delta.storage.commit.uniform.UniformMetadata;
 import org.apache.hadoop.fs.Path;
 
 /**
@@ -31,9 +33,20 @@ public class GetCommitsResponse {
 
   private long latestTableVersion;
 
+  private Optional<UniformMetadata> uniformMetadata;
+
   public GetCommitsResponse(List<Commit> commits, long latestTableVersion) {
+    this(commits, latestTableVersion, Optional.empty());
+  }
+
+
+  public GetCommitsResponse(
+      List<Commit> commits,
+      long latestTableVersion,
+      Optional<UniformMetadata> uniformMetadata) {
     this.commits = commits;
     this.latestTableVersion = latestTableVersion;
+    this.uniformMetadata = uniformMetadata;
   }
 
   public List<Commit> getCommits() {
@@ -42,6 +55,10 @@ public class GetCommitsResponse {
 
   public long getLatestTableVersion() {
     return latestTableVersion;
+  }
+
+  public Optional<UniformMetadata> getUniformMetadata() {
+    return uniformMetadata;
   }
 }
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -842,7 +842,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
         .stream()
         .sorted(Comparator.comparingLong(Commit::getVersion))
         .collect(Collectors.toList());
-    return new GetCommitsResponse(sortedCommits, resp.getLatestTableVersion());
+    return new GetCommitsResponse(sortedCommits, resp.getLatestTableVersion(), resp.getUniformMetadata());
   }
 
   protected GetCommitsResponse getCommitsFromUCImpl(

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -342,7 +342,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
     long latestTableVersion = response.getLatestTableVersion() != null
         ? response.getLatestTableVersion() : -1L;
-    return new GetCommitsResponse(commits, latestTableVersion);
+    Optional<io.delta.storage.commit.uniform.UniformMetadata> storageUniform =
+        toStorageUniformMetadata(response.getUniform());
+    return new GetCommitsResponse(commits, latestTableVersion, storageUniform);
   }
 
   /** Converts a UC SDK {@link DeltaCommit} to a Delta {@link Commit}. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->


## Description
When a Delta transaction backed by a UC commit coordinator retries after a conflict, the `catalogTable.storage.properties` it carries — which encodes the last converted Iceberg metadataLocation and
   convertedDeltaVersion — can be stale. `IcebergConverter` uses those properties to determine the base version for incremental conversion, so it would cause a stable base and would lead to failure to commit on server side

This PR fixes the problem by threading `UniformMetadata` from the `getCommits` response back to the conflict-resolution retry path, so the retry always sees the freshest Iceberg base version. It is possible as `getCommits` is now implemented using `loadTable` API (https://github.com/delta-io/delta/pull/6814)

## How was this patch tested?
Add UTs
```
build/sbt -DsparkVersion=4.0 "iceberg/testOnly *UniFormE2EIcebergUCSuite"
```
