### PR TITLE
[Spark][Tests] Use WITH SCHEMA EVOLUTION syntax in DeltaInsertIntoTest

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -74,6 +74,9 @@ trait DeltaInsertIntoTest
     /** SQL keyword for this type of insert.  */
     def intoOrOverwrite: String = if (mode == SaveMode.Append) "INTO" else "OVERWRITE"
 
+    def schemaEvolutionClause(enabled: Boolean): String =
+      if (enabled) "WITH SCHEMA EVOLUTION " else ""
+
     /** The expected content of the table after the insert. */
     def expectedResult(initialDF: DataFrame, insertedDF: DataFrame): DataFrame = {
       // Always union with the initial data even if we're overwriting it to ensure the resulting
@@ -93,10 +96,8 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      withSQLConf(DeltaSQLConf.
-          DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
-        sql(s"INSERT $intoOrOverwrite target SELECT * FROM source")
-      }
+      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}" +
+        s"$intoOrOverwrite target SELECT * FROM source")
     }
   }
 
@@ -111,10 +112,8 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       val colList = columns.mkString(", ")
-      withSQLConf(DeltaSQLConf.
-          DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
-        sql(s"INSERT $intoOrOverwrite target ($colList) SELECT $colList FROM source")
-      }
+      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}" +
+        s"$intoOrOverwrite target ($colList) SELECT $colList FROM source")
     }
   }
 
@@ -128,11 +127,8 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      withSQLConf(DeltaSQLConf.
-          DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
-        sql(s"INSERT $intoOrOverwrite target BY NAME " +
-          s"SELECT ${columns.mkString(", ")} FROM source")
-      }
+      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}" +
+        s"$intoOrOverwrite target BY NAME SELECT ${columns.mkString(", ")} FROM source")
     }
   }
 
@@ -147,11 +143,9 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      withSQLConf(DeltaSQLConf.
-          DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
-        sql(s"INSERT INTO target REPLACE WHERE $whereCol = $whereValue " +
-          s"SELECT ${columns.mkString(", ")} FROM source")
-      }
+      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}INTO target " +
+        s"REPLACE WHERE $whereCol = $whereValue " +
+        s"SELECT ${columns.mkString(", ")} FROM source")
     }
   }
 
@@ -167,11 +161,9 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       val assignments = columns.filterNot(_ == whereCol).mkString(", ")
-      withSQLConf(DeltaSQLConf.
-          DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
-        sql(s"INSERT OVERWRITE target PARTITION ($whereCol = $whereValue) " +
-          s"SELECT $assignments FROM source")
-      }
+      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}OVERWRITE target " +
+        s"PARTITION ($whereCol = $whereValue) " +
+        s"SELECT $assignments FROM source")
     }
   }
 
@@ -187,12 +179,9 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       val assignments = columns.filterNot(_ == whereCol).mkString(", ")
-      withSQLConf(DeltaSQLConf.
-          DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
-        sql(s"INSERT OVERWRITE target " +
-          s"PARTITION ($whereCol = $whereValue) ($assignments) " +
-          s"SELECT $assignments FROM source")
-      }
+      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}OVERWRITE target " +
+        s"PARTITION ($whereCol = $whereValue) ($assignments) " +
+        s"SELECT $assignments FROM source")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -74,8 +74,28 @@ trait DeltaInsertIntoTest
     /** SQL keyword for this type of insert.  */
     def intoOrOverwrite: String = if (mode == SaveMode.Append) "INTO" else "OVERWRITE"
 
-    def schemaEvolutionClause(enabled: Boolean): String =
-      if (enabled) "WITH SCHEMA EVOLUTION " else ""
+    /**
+     * Runs a SQL INSERT, enabling Delta schema evolution when [[withSchemaEvolution]] is set.
+     *
+     * Spark 4.2 introduced the `INSERT WITH SCHEMA EVOLUTION` syntax. On 4.2+ the clause is
+     * spliced into the statement right after the leading `INSERT` keyword. Earlier versions
+     * cannot parse that syntax, so schema evolution is toggled through
+     * [[DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE]] instead.
+     *
+     * @param buildInsert builds the INSERT statement given the schema evolution clause to splice
+     *                    in right after the leading `INSERT` keyword.
+     */
+    def runInsertSql(withSchemaEvolution: Boolean)(buildInsert: String => String): Unit = {
+      if (spark.version >= "4.2") {
+        val clause = if (withSchemaEvolution) "WITH SCHEMA EVOLUTION " else ""
+        sql(buildInsert(clause))
+      } else {
+        withSQLConf(
+            DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
+          sql(buildInsert(""))
+        }
+      }
+    }
 
     /** The expected content of the table after the insert. */
     def expectedResult(initialDF: DataFrame, insertedDF: DataFrame): DataFrame = {
@@ -96,8 +116,9 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}" +
-        s"$intoOrOverwrite target SELECT * FROM source")
+      runInsertSql(withSchemaEvolution) { clause =>
+        s"INSERT $clause$intoOrOverwrite target SELECT * FROM source"
+      }
     }
   }
 
@@ -112,8 +133,9 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       val colList = columns.mkString(", ")
-      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}" +
-        s"$intoOrOverwrite target ($colList) SELECT $colList FROM source")
+      runInsertSql(withSchemaEvolution) { clause =>
+        s"INSERT $clause$intoOrOverwrite target ($colList) SELECT $colList FROM source"
+      }
     }
   }
 
@@ -127,8 +149,10 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}" +
-        s"$intoOrOverwrite target BY NAME SELECT ${columns.mkString(", ")} FROM source")
+      runInsertSql(withSchemaEvolution) { clause =>
+        s"INSERT $clause$intoOrOverwrite target BY NAME " +
+          s"SELECT ${columns.mkString(", ")} FROM source"
+      }
     }
   }
 
@@ -143,9 +167,11 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}INTO target " +
-        s"REPLACE WHERE $whereCol = $whereValue " +
-        s"SELECT ${columns.mkString(", ")} FROM source")
+      runInsertSql(withSchemaEvolution) { clause =>
+        s"INSERT ${clause}INTO target " +
+          s"REPLACE WHERE $whereCol = $whereValue " +
+          s"SELECT ${columns.mkString(", ")} FROM source"
+      }
     }
   }
 
@@ -161,9 +187,11 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       val assignments = columns.filterNot(_ == whereCol).mkString(", ")
-      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}OVERWRITE target " +
-        s"PARTITION ($whereCol = $whereValue) " +
-        s"SELECT $assignments FROM source")
+      runInsertSql(withSchemaEvolution) { clause =>
+        s"INSERT ${clause}OVERWRITE target " +
+          s"PARTITION ($whereCol = $whereValue) " +
+          s"SELECT $assignments FROM source"
+      }
     }
   }
 
@@ -179,9 +207,11 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       val assignments = columns.filterNot(_ == whereCol).mkString(", ")
-      sql(s"INSERT ${schemaEvolutionClause(withSchemaEvolution)}OVERWRITE target " +
-        s"PARTITION ($whereCol = $whereValue) ($assignments) " +
-        s"SELECT $assignments FROM source")
+      runInsertSql(withSchemaEvolution) { clause =>
+        s"INSERT ${clause}OVERWRITE target " +
+          s"PARTITION ($whereCol = $whereValue) ($assignments) " +
+          s"SELECT $assignments FROM source"
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -86,7 +86,7 @@ trait DeltaInsertIntoTest
      *                    in right after the leading `INSERT` keyword.
      */
     def runInsertSql(withSchemaEvolution: Boolean)(buildInsert: String => String): Unit = {
-      if (spark.version >= "4.2") {
+      if (sparkVersionBucket(spark) == "4.2+") {
         val clause = if (withSchemaEvolution) "WITH SCHEMA EVOLUTION " else ""
         sql(buildInsert(clause))
       } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -80,6 +80,18 @@ trait DeltaTestUtilsBase {
   // Re-define here to avoid the need to import it before using
   final def BOOLEAN_DOMAIN: Seq[Boolean] = DeltaTestUtilsBase.BOOLEAN_DOMAIN
 
+  /** Spark version bucket ("4.0", "4.1", "4.2+") that version-dependent behavior keys off. */
+  def sparkVersionBucket(spark: SparkSession): String = {
+    // Parse major and minor numerically so the bucket stays correct once Spark reaches 4.10,
+    // where a lexicographic string compare would wrongly rank "4.10" below "4.2".
+    val versionParts = spark.version.split('.')
+    val major = versionParts(0).toInt
+    val minor = versionParts(1).toInt
+    if (major > 4 || (major == 4 && minor >= 2)) "4.2+"
+    else if (major == 4 && minor >= 1) "4.1"
+    else "4.0"
+  }
+
   class PlanCapturingListener() extends QueryExecutionListener {
 
     private[this] var capturedPlans = List.empty[Plans]


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`DeltaInsertIntoTest` previously enabled schema evolution for its SQL inserts by toggling the
`spark.databricks.delta.schema.autoMerge.enabled` SQL conf (`DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE`)
around each `INSERT`. This PR exercises the dedicated `INSERT WITH SCHEMA EVOLUTION ...` SQL syntax
instead, so the tests cover the same statement-level syntax that users write.

The `WITH SCHEMA EVOLUTION` clause for `INSERT` is only available on Spark 4.2+. To keep the suite
green across all supported Spark versions, the six SQL insert variants now route through a single
`runInsertSql` helper that:
- on **Spark 4.2+**, splices the `WITH SCHEMA EVOLUTION` clause into the statement, and
- on **older Spark versions (4.0 / 4.1)**, falls back to toggling `DELTA_SCHEMA_AUTO_MIGRATE`
  (the previous behavior), since those parsers reject the new syntax with `PARSE_SYNTAX_ERROR`.

This mirrors the version-gating approach used in #6936.

## How was this patch tested?

Test-only change. The existing `DeltaInsertIntoTest` scenarios run unchanged across the Spark
4.0 / 4.1 / 4.2 CI shards: 4.2 exercises the `WITH SCHEMA EVOLUTION` syntax path, while 4.0 / 4.1
exercise the conf-toggle fallback path.

## Does this PR introduce _any_ user-facing changes?

No. This only changes test code.
