### PR TITLE
[Spark] add truncate functionality via analyzer

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -684,6 +684,13 @@ class DeltaAnalysis(protected val session: SparkSession)
     case DeltaReorgTable(ResolvedTable(_, _, t, _), _) =>
       throw DeltaErrors.notADeltaTable(t.name())
 
+    case TruncateTable(child @ ResolvedTable(_, _, _: DeltaTableV2, _)) =>
+      TruncateDeltaTableCommand(child)
+
+    case TruncatePartition(ResolvedTable(_, _, delta: DeltaTableV2, _), _) =>
+      recordDeltaEvent(delta.deltaLog, "delta.unsupported.truncateTablePartition")
+      throw DeltaErrors.truncateTablePartitionNotSupportedException
+
     case cmd @ ShowColumns(child @ ResolvedTable(_, _, table: DeltaTableV2, _), namespace, _) =>
       // Adapted from the rule in spark ResolveSessionCatalog.scala, which V2 tables don't trigger.
       // NOTE: It's probably a spark bug to check head instead of tail, for 3-part identifiers.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/TruncateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/TruncateDeltaTableCommand.scala
@@ -27,10 +27,9 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LogicalPlan, UnaryNode}
+import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedDataShim, LogicalPlan, UnaryNode}
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.execution.command.RunnableCommand
-import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
 // scalastyle:on import.ordering.noEmptyLine
@@ -38,7 +37,7 @@ import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
 case class TruncateDeltaTableCommand(child: LogicalPlan)
     extends RunnableCommand
     with UnaryNode
-    with IgnoreCachedData
+    with IgnoreCachedDataShim
     with DeltaCommand
 {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/TruncateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/TruncateDeltaTableCommand.scala
@@ -19,16 +19,15 @@ package org.apache.spark.sql.delta.commands
 import scala.util.control.NonFatal
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations}
 import org.apache.spark.sql.delta.actions.RemoveFile
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedDataShim, LogicalPlan, UnaryNode}
-import org.apache.spark.sql.classic.ClassicConversions._
+import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/TruncateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/TruncateDeltaTableCommand.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import scala.util.control.NonFatal
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.actions.RemoveFile
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LogicalPlan, UnaryNode}
+import org.apache.spark.sql.classic.ClassicConversions._
+import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
+// scalastyle:on import.ordering.noEmptyLine
+
+case class TruncateDeltaTableCommand(child: LogicalPlan)
+    extends RunnableCommand
+    with UnaryNode
+    with IgnoreCachedData
+    with DeltaCommand
+{
+
+
+  @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
+
+  override lazy val metrics = Map[String, SQLMetric](
+    "numRemovedFiles" -> createMetric(sc, "number of files removed"),
+    "numDeletedRows" -> createMetric(sc, "number of rows removed"),
+    "executionTimeMs" -> createMetric(sc, "time taken to execute the entire operation"),
+    "numRemovedBytes" -> createMetric(sc, "number of bytes removed")
+  )
+
+  override val output: Seq[Attribute] = Nil
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): TruncateDeltaTableCommand =
+    copy(child = newChild)
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    val startTime = System.nanoTime()
+    val deltaTable = getDeltaTable(child, "TRUNCATE")
+
+
+    recordDeltaOperation(deltaTable, "delta.dml.truncate") {
+      val txn = deltaTable.startTransaction()
+      DeltaLog.assertRemovable(txn.snapshot)
+      val deleteActions: Seq[RemoveFile] = {
+        val reportRowLevelMetrics = conf.getConf(DeltaSQLConf.DELTA_DML_METRICS_FROM_METADATA)
+        val allFiles =
+          txn.filterFiles(Seq.empty, keepNumRecords = reportRowLevelMetrics)
+        val operationTimestamp = System.currentTimeMillis()
+        val numRemovedBytes = allFiles.map(_.getFileSize).sum
+        metrics("numRemovedBytes").set(numRemovedBytes)
+        allFiles.map(_.removeWithTimestamp(operationTimestamp))
+      }
+
+      if (deleteActions.nonEmpty) {
+        metrics("numRemovedFiles").set(deleteActions.size)
+        val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+        metrics("executionTimeMs").set(executionTimeMs)
+
+        if (conf.getConf(DeltaSQLConf.DELTA_DML_METRICS_FROM_METADATA)) {
+          def numDeletedRows: Option[Long] = {
+            var count: Long = 0L
+            for (file <- deleteActions) {
+              if (file.numLogicalRecords.isEmpty) {
+                return None
+              }
+              count += file.numLogicalRecords.get
+            }
+            Some(count)
+          }
+
+          if (numDeletedRows.nonEmpty) {
+            metrics("numDeletedRows").set(numDeletedRows.get)
+          }
+        }
+
+        txn.registerSQLMetrics(sparkSession, metrics)
+        try {
+          txn.commit(deleteActions, DeltaOperations.Truncate())
+        } finally {
+          sendDriverMetrics(sparkSession, metrics)
+        }
+      }
+    }
+
+    // Uncache the relation
+    try {
+      val tableDf = deltaTable.tableIdentifier match {
+        case Some(table) => sparkSession.read.table(table)
+        case _ => sparkSession.read.format("delta").load(deltaTable.path.toString)
+      }
+      sparkSession.sharedState.cacheManager.uncacheQuery(tableDf, cascade = true)
+    } catch {
+      case NonFatal(e) =>
+        log.warn(s"Exception when attempting to uncache Delta table ${deltaTable.name}", e)
+    }
+
+    Seq.empty[Row]
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableMetricsSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
+class TruncateTableMetricsSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  private final val numPartitionsToTest: Seq[Int] = Seq(1, 10)
+  private final val testTable: String = "t"
+
+  private def forEachTruncateTarget(numPartitions: Int)(action: String => Unit): Unit =
+    withTable(testTable) {
+      spark.range(0L).write.format("delta").saveAsTable(testTable)
+      val pathRef = s"delta.`${DeltaLog.forTable(spark, TableIdentifier(testTable)).dataPath}`"
+      Seq(testTable, pathRef).foreach { truncateTarget =>
+        spark.range(start = 0, end = numPartitions * 10L, step = 1, numPartitions = numPartitions)
+          .write.mode("append").format("delta").saveAsTable(testTable)
+        action(truncateTarget)
+      }
+    }
+
+  private def checkTruncateMetrics(
+      metrics: Map[String, Long],
+      expectedNumRemovedFiles: Long): Unit = {
+    assert(metrics.keySet === DeltaOperationMetrics.TRUNCATE)
+    assert(metrics("numRemovedFiles") === expectedNumRemovedFiles)
+    assert(metrics("executionTimeMs") >= 0) // default value is -1 in SQLMetric
+  }
+
+  private def truncateAndCheck(truncateTarget: String, expectedNumRemovedFiles: Long): Unit = {
+    spark.sql(s"TRUNCATE TABLE $truncateTarget")
+    checkTruncateMetrics(
+      DeltaMetricsUtils.getLastOperationMetrics(testTable),
+      expectedNumRemovedFiles)
+  }
+
+  numPartitionsToTest.foreach { numPartitions =>
+    test(s"truncate metrics: truncate non-empty table" +
+      s" (numPartitions=$numPartitions)") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "true",
+        DeltaSQLConf.DELTA_SKIP_RECORDING_EMPTY_COMMITS.key -> "false"
+      ) {
+        forEachTruncateTarget(numPartitions) { truncateTarget =>
+          truncateAndCheck(truncateTarget, numPartitions)
+        }
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableMetricsSuite.scala
@@ -16,10 +16,8 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.test.SharedSparkSession
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableSuite.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class TruncateTableSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaTestUtilsForTempViews {
+
+
+  test("non-partitioned table") {
+    withTable("t1") {
+      sql("CREATE TABLE t1 (a int) USING delta")
+      sql("INSERT into t1 VALUES (3)")
+      sql("INSERT into t1 VALUES (4)")
+
+      sql("TRUNCATE table t1")
+      checkAnswer(sql("select * from t1"), Nil)
+
+      val ae = intercept[AnalysisException] {
+        sql("TRUNCATE table t1 partition (a = 3)")
+      }
+      assert(ae.message.contains("Operation not allowed"))
+    }
+  }
+
+  test("partitioned table") {
+    withTable("t1") {
+      sql("CREATE TABLE t1 (a int, b int) USING delta partitioned by (b)")
+      sql("INSERT into t1 VALUES (1, 1)")
+      sql("INSERT into t1 VALUES (2, 2)")
+
+      sql("TRUNCATE table t1")
+      checkAnswer(sql("select * from t1"), Nil)
+
+      val ae = intercept[AnalysisException] {
+        sql("TRUNCATE table t1 partition (b = 1)")
+      }
+      assert(ae.message.contains("Operation not allowed"))
+    }
+  }
+
+  test("path") {
+    withTempDir { dir =>
+      import testImplicits._
+      val path = dir.getCanonicalPath
+      Seq((1, 2)).toDF("key", "value")
+        .write.format("delta").partitionBy("key").save(path)
+      sql(s"TRUNCATE TABLE delta.`$path`")
+      checkAnswer(sql(s"select * from delta.`$path`"), Nil)
+      val ae = intercept[AnalysisException] {
+        sql(s"TRUNCATE TABLE delta.`$path` partition (key = 1)")
+      }
+      assert(ae.message.contains("Operation not allowed"))
+    }
+  }
+
+  test("truncate should refresh DF cache - table") {
+    withTable("t1") {
+      sql("CREATE TABLE t1 (a int, b int) USING delta partitioned by (b)")
+      sql("INSERT into t1 VALUES (1, 1)")
+      sql("INSERT into t1 VALUES (2, 2)")
+
+      val df = spark.table("t1").cache()
+      sql("TRUNCATE table t1")
+      checkAnswer(df, Nil)
+      checkAnswer(spark.table("t1"), Nil)
+    }
+  }
+
+  test("truncate should refresh DF cache - path") {
+    withTempDir { dir =>
+      import testImplicits._
+      val path = dir.getCanonicalPath
+      Seq((1, 2)).toDF("key", "value")
+        .write.format("delta").partitionBy("key").save(path)
+      val df = sql(s"select * from delta.`$path`").cache()
+      sql(s"TRUNCATE TABLE delta.`$path`")
+      checkAnswer(df, Nil)
+      checkAnswer(sql(s"select * from delta.`$path`"), Nil)
+    }
+  }
+
+  testWithTempView("truncate on temp views") { isSQLTempView =>
+    withTable("t1") {
+      sql("CREATE TABLE t1 (a int) USING delta")
+      sql("INSERT into t1 VALUES (3)")
+      sql("INSERT into t1 VALUES (4)")
+
+      createTempViewFromTable("t1", isSQLTempView)
+
+      val ae = intercept[AnalysisException] {
+        sql("TRUNCATE table v")
+      }
+      assert(ae.message.contains("EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE"))
+    }
+  }
+
+}

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDDLTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDDLTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sparkuctest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UCDeltaTableDDLTest extends UCDeltaTableIntegrationBaseTest {
+
+  private static final Set<String> MUTABLE_CATALOG_PROPERTIES =
+      Set.of("delta.lastCommitTimestamp", "delta.lastUpdateVersion", "transient_lastDdlTime");
+
+  // -------------------------------------------------------------------------
+  // TRUNCATE TABLE
+  // -------------------------------------------------------------------------
+
+  @TestAllTableTypes
+  public void testTruncatePreservesMetadata(TableType tableType) throws Exception {
+    for (boolean partitioned : List.of(false, true)) {
+      String desc = partitioned ? "partitioned" : "unpartitioned";
+      withNewTable(
+          "ddl_truncate_" + desc,
+          "id INT, name STRING, part INT",
+          partitioned ? "part" : null,
+          tableType,
+          tableName -> {
+            Map<String, String> snapshotBefore = stableTableProperties(tableName);
+            for (String truncateTarget : truncateTargets(tableName, tableType)) {
+              sql(
+                  "INSERT INTO %s VALUES (1, 'alpha', 0), (2, 'beta', 1), (3, 'gamma', 1)",
+                  tableName);
+              truncateTable(truncateTarget);
+              check(tableName, List.of());
+              assertPreservedTableSnapshot(tableName, snapshotBefore);
+            }
+            sql("INSERT INTO %s VALUES (4, 'delta', 0), (5, 'epsilon', 2)", tableName);
+            check(tableName, List.of(row("4", "delta", "0"), row("5", "epsilon", "2")));
+          });
+    }
+  }
+
+  @Test
+  public void testTruncateByPathBlockedForManagedTable() throws Exception {
+    withNewTable(
+        "ddl_truncate_path_blocked",
+        "id INT",
+        TableType.MANAGED,
+        tableName -> {
+          sql("INSERT INTO %s VALUES (1), (2), (3)", tableName);
+          String tablePath = tableLocation(tableName);
+          Map<String, String> snapshotBefore = stableTableProperties(tableName);
+          Assertions.assertThrows(
+              Exception.class, () -> truncateTable(String.format("delta.`%s`", tablePath)));
+          check(tableName, List.of(row("1"), row("2"), row("3")));
+          assertPreservedTableSnapshot(tableName, snapshotBefore);
+        });
+  }
+
+  private List<String> truncateTargets(String tableName, TableType tableType) {
+    List<String> targets = new ArrayList<>();
+    targets.add(tableName);
+    if (tableType == TableType.EXTERNAL) {
+      targets.add(String.format("delta.`%s`", tableLocation(tableName)));
+    }
+    return targets;
+  }
+
+  private void truncateTable(String truncateTarget) {
+    if (truncateTarget.startsWith("delta.`")) {
+      S3CredentialFileSystem.credentialCheckEnabled = false;
+      try {
+        sql("TRUNCATE TABLE %s", truncateTarget);
+      } finally {
+        S3CredentialFileSystem.credentialCheckEnabled = true;
+      }
+    } else {
+      sql("TRUNCATE TABLE %s", truncateTarget);
+    }
+  }
+
+  private String tableLocation(String tableName) {
+    return sql("DESCRIBE FORMATTED %s", tableName).stream()
+        .filter(row -> row.size() >= 2 && "Location".equalsIgnoreCase(row.get(0).trim()))
+        .map(row -> row.get(1).trim())
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Could not retrieve table location"));
+  }
+
+  private Map<String, String> stableTableProperties(String tableName) throws Exception {
+    Map<String, String> stable = new LinkedHashMap<>(tableProperties(tableName));
+    stable.keySet().removeAll(MUTABLE_CATALOG_PROPERTIES);
+    return stable;
+  }
+
+  private void assertPreservedTableSnapshot(String tableName, Map<String, String> expected)
+      throws Exception {
+    assertThat(stableTableProperties(tableName)).isEqualTo(expected);
+  }
+
+  private Map<String, String> tableProperties(String tableName) {
+    Map<String, String> properties = new LinkedHashMap<>();
+    for (List<String> row : sql("SHOW TBLPROPERTIES %s", tableName)) {
+      if (row.size() >= 2) {
+        properties.put(row.get(0), row.get(1));
+      }
+    }
+    return properties;
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add `TRUNCATE TABLE` support for Delta tables. Previously, `TRUNCATE TABLE` on a Delta table would fall through to the default Spark behavior. This PR intercepts `TruncateTable` in `DeltaAnalysis` and resolves it to a new `TruncateDeltaTableCommand` that removes all files via a Delta transaction, records operation metrics, and invalidates cached DataFrames. Partition-level truncation is explicitly rejected with a clear error.

## How was this patch tested?

Added `TruncateTableSuite` covering non-partitioned tables, partitioned tables, path-based tables, cache invalidation, temp view rejection, and partition truncation error handling. Added `TruncateTableMetricsSuite` verifying operation metrics. Added `UCDeltaTableDDLTest` for Unity Catalog integration.

## Does this PR introduce _any_ user-facing changes?

Yes. `TRUNCATE TABLE` now works on Delta tables, removing all data while preserving the table schema and metadata. Partition-level truncation (`TRUNCATE TABLE ... PARTITION`) is not supported and returns an error.