### PR TITLE
[kernel-spark] Migrate DeltaSourceColumnMappingSuite to V2 connector

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceColumnMappingSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceColumnMappingSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.ColumnMappingStreamingBlockedWorkflowSuiteBase
+import org.apache.spark.sql.delta.DeltaSourceIdColumnMappingSuite
+import org.apache.spark.sql.delta.DeltaSourceNameColumnMappingSuite
+import org.apache.spark.sql.delta.DeltaSourceSuite
+
+/**
+ * Test suite that runs DeltaSourceColumnMappingSuite using the V2 connector
+ * (V2_ENABLE_MODE=STRICT).
+ *
+ * SparkTable (V2) is read-only and does not support DDL, so DDL/DML operations are routed
+ * through the V1 connector via `executeDml`. Only streaming reads use the V2 connector.
+ *
+ * The pass/fail sets compose [[DeltaV2SourceSuite.PassingTests]] and
+ * [[DeltaV2SourceSuite.FailingTests]] with the column-mapping-specific tests added to the
+ * pass list - we want all of them to pass eventually, so any real failure should surface as a
+ * test failure rather than be silenced via shouldFailTests.
+ */
+trait DeltaV2SourceColumnMappingSuiteBase
+  extends V2ForceTest
+    with DeltaColumnMappingSelectedTestMixin {
+  self: ColumnMappingStreamingBlockedWorkflowSuiteBase with DeltaSourceSuite =>
+
+  override protected def useDsv2: Boolean = true
+
+  override protected def executeDml(sqlText: String): Unit = executeInV1Mode(sqlText)
+
+  // V1's selection - DeltaV2SourceSuite already covers the rest, no point rerunning them
+  // under column mapping.
+  override protected def runOnlyTests: Seq[String] = Seq(
+    "basic",
+    "maxBytesPerTrigger: metadata checkpoint",
+    "maxFilesPerTrigger: metadata checkpoint",
+    "allow to change schema before starting a streaming query",
+    "column mapping + streaming - allowed workflows - column addition",
+    "column mapping + streaming - allowed workflows - upgrade to name mode",
+    "column mapping + streaming: blocking workflow - drop column",
+    "column mapping + streaming: blocking workflow - rename column",
+    "column mapping + streaming: blocking workflow - " +
+      "should not generate latestOffset past schema change",
+    "unsafe flag can unblock drop or rename column"
+  )
+
+  override protected def shouldPassTests: Set[String] =
+    DeltaV2SourceSuite.PassingTests ++ Set(
+      // Column-mapping-only blocked-workflow tests from
+      // [[ColumnMappingStreamingBlockedWorkflowSuiteBase]].
+      "column mapping + streaming - allowed workflows - column addition",
+      "column mapping + streaming - allowed workflows - upgrade to name mode",
+      "column mapping + streaming: blocking workflow - drop column",
+      "column mapping + streaming: blocking workflow - rename column",
+      "column mapping + streaming: blocking workflow - " +
+        "should not generate latestOffset past schema change",
+      "unsafe flag can unblock drop or rename column"
+    )
+
+  override protected def shouldFailTests: Set[String] = DeltaV2SourceSuite.FailingTests ++ Set(
+    // V2 source doesn't use delta log.
+    "deltaLog snapshot should not be updated outside of the stream"
+  )
+}
+
+class DeltaV2SourceIdColumnMappingSuite
+  extends DeltaSourceIdColumnMappingSuite
+    with DeltaV2SourceColumnMappingSuiteBase
+
+class DeltaV2SourceNameColumnMappingSuite
+  extends DeltaSourceNameColumnMappingSuite
+    with DeltaV2SourceColumnMappingSuiteBase

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -48,7 +48,19 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     )
   }
 
-  override protected def shouldPassTests: Set[String] = Set(
+  override protected def shouldPassTests: Set[String] = DeltaV2SourceSuite.PassingTests
+
+  override protected def shouldFailTests: Set[String] = DeltaV2SourceSuite.FailingTests
+}
+
+/**
+ * Shared V2-connector test classifications for `DeltaSourceSuite`. Other V2 suites that inherit
+ * from `DeltaSourceSuite` (e.g. the V2 column-mapping suites) can compose these sets with
+ * their own additions or overrides.
+ */
+object DeltaV2SourceSuite {
+
+  val PassingTests: Set[String] = Set(
     // ========== Core streaming tests ==========
     "basic",
     "initial snapshot ends at base index of next version",
@@ -147,7 +159,7 @@ class DeltaV2SourceSuite extends DeltaSourceSuite with V2ForceTest {
     "initial snapshot: checkpoint resume after new commits produces all rows"
   )
 
-  override protected def shouldFailTests: Set[String] = Set(
+  val FailingTests: Set[String] = Set(
     // === Null Type Column Handling ===
     "streaming delta source should not drop null columns",
     "streaming delta source should drop null columns without feature flag",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
@@ -36,7 +36,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.StreamingExecutionRelation
-import org.apache.spark.sql.streaming.{DataStreamReader, StreamTest}
+import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
 
@@ -104,18 +104,25 @@ trait ColumnMappingStreamingTestUtils extends StreamTest with DeltaColumnMapping
 }
 
 trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStreamingTestUtils {
+  self: DeltaSourceConnectorTrait =>
 
   import testImplicits._
 
-  // DataStreamReader to use
-  // Set a small max file per trigger to ensure we could catch failures ASAP
-  private def dsr: DataStreamReader = if (isCdcTest) {
-    spark.readStream.format("delta")
-      .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
-      .option(DeltaOptions.CDC_READ_OPTION, "true")
-  } else {
-    spark.readStream.format("delta")
-      .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
+  /**
+   * Executes a DML SQL statement (DELETE, INSERT, etc.).
+   * Overridable so that V2 suites can route DML through the V1 connector,
+   * since SparkTable (V2) is read-only and does not support writes.
+   */
+  protected def executeDml(sqlText: String): Unit = sql(sqlText)
+
+  // Start a streaming read on the configured connector (V1 vs V2). MAX_FILES_PER_TRIGGER=1
+  // ensures we catch failures ASAP; CDC_READ_OPTION is layered in for CDC variants.
+  private def loadStream(
+      path: String,
+      extraOptions: Map[String, String] = Map.empty): DataFrame = {
+    val base = Map(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION -> "1") ++
+      (if (isCdcTest) Map(DeltaOptions.CDC_READ_OPTION -> "true") else Map.empty)
+    loadStreamWithOptions(path, base ++ extraOptions)
   }
 
   private def checkStreamStartBlocked(
@@ -153,7 +160,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       // record initial snapshot version and warm DeltaLog cache
       val initialDeltaLog = DeltaLog.forTable(spark, tablePath)
       // start streaming
-      val df = spark.readStream.format("delta").load(tablePath)
+      val df = loadStreamWithOptions(tablePath, Map.empty)
       testStream(df)(
         StartStream(),
         ProcessAllAvailable(),
@@ -184,14 +191,14 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
 
       val checkpointDir = new File(inputDir, "_checkpoint")
 
-      def loadDf(): DataFrame = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      def loadDf(): DataFrame = dropCDCFields(loadStream(inputDir.getCanonicalPath))
 
       testStream(loadDf())(
         StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
         ProcessAllAvailable(),
         CheckAnswer((0 until 5).map(i => (i.toString, i.toString)): _*),
         Execute { _ =>
-          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (value2 string)")
+          executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (value2 string)")
         },
         Execute { _ =>
           writeDeltaData(5 until 10, deltaLog)
@@ -218,7 +225,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         writeDeltaData(0 until 5, deltaLog, Some(StructType.fromDDL("id string, name string")))
       }
 
-      def createNewDf(): DataFrame = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      def createNewDf(): DataFrame = dropCDCFields(loadStream(inputDir.getCanonicalPath))
 
       val checkpointDir = new File(inputDir, "_checkpoint")
 
@@ -227,7 +234,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         ProcessAllAvailable(),
         CheckAnswer((0 until 5).map(i => (i.toString, i.toString)): _*),
         Execute { _ =>
-          sql(
+          executeDml(
             s"""
                |ALTER TABLE delta.`${inputDir.getCanonicalPath}`
                |SET TBLPROPERTIES (
@@ -242,7 +249,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         CheckAnswer((0 until 10).map(i => (i.toString, i.toString)): _*),
         // add column schema evolution should fail the stream
         Execute { _ =>
-          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (value2 string)")
+          executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (value2 string)")
         },
         Execute { _ =>
           writeDeltaData(10 until 15, deltaLog)
@@ -276,7 +283,8 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       deltaLog.update()
       // test read prior to upgrade batches with latest metadata should also work
       val checkpointDir3 = new File(inputDir, "_checkpoint3")
-      testStream(dropCDCFields(dsr.option("startingVersion", 0).load(inputDir.getCanonicalPath)))(
+      testStream(dropCDCFields(loadStream(
+          inputDir.getCanonicalPath, Map(DeltaOptions.STARTING_VERSION_OPTION -> "0"))))(
         StartStream(checkpointLocation = checkpointDir3.getCanonicalPath),
         ProcessAllAvailable(),
         // Since the latest schema contain the additional column, it is null for previous batches.
@@ -318,7 +326,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
             .max(ColumnMappingTableFeature.minWriterVersion))
       }
 
-      sql(
+      executeDml(
         s"""
            |ALTER TABLE delta.`${tablePath}`
            |SET TBLPROPERTIES (
@@ -348,7 +356,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       setupTestTable(deltaLog)
 
       // change schema
-      sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
+      executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
 
       // write more data post change schema
       writeDeltaData(10 until 15, deltaLog)
@@ -360,7 +368,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       //          But once the initial snapshot is served, all subsequent batches will fail if
       //          encountering a schema change during streaming, and all restart effort should fail.
       val checkpointDir = new File(inputDir, "_checkpoint")
-      val df = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      val df = dropCDCFields(loadStream(inputDir.getCanonicalPath))
 
       testStream(df)(
         StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
@@ -378,7 +386,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         // Note here we are restoring back the original schema, see next case for how we test
         // some extra special cases when schemas are reverted.
         Execute { _ =>
-          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
+          executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
         },
         // write more data in updated schema again
         Execute { _ =>
@@ -392,14 +400,14 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         ExistingRetryableInStreamSchemaChangeFailure
       )
 
-      val df2 = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      def df2: DataFrame = dropCDCFields(loadStream(inputDir.getCanonicalPath))
       // Since the initial snapshot ignores all schema changes, the most recent schema change
       // is just ADD COLUMN, which can be retried.
       testStream(df2)(
         StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
         // but an additional drop should fail the stream as we are capturing data changes now
         Execute { _ =>
-          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
+          executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
         },
         ProcessAllAvailableIgnoreError,
         ExpectInStreamSchemaChangeFailure
@@ -416,9 +424,8 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       //          in a streaming fashion, ignoring the initialSnapshot.
       //          Here we test the special case when the latest schema is "restored".
       val checkpointDir2 = new File(inputDir, "_checkpoint2")
-      val dfStartAtZero = dropCDCFields(dsr
-        .option(DeltaOptions.STARTING_VERSION_OPTION, "0")
-        .load(inputDir.getCanonicalPath))
+      def dfStartAtZero: DataFrame = dropCDCFields(loadStream(
+        inputDir.getCanonicalPath, Map(DeltaOptions.STARTING_VERSION_OPTION -> "0")))
 
       if (isCdcTest) {
         checkStreamStartBlocked(
@@ -429,7 +436,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         // old logical name now will have a different physical name we would have data loss
 
         // lets add back the column we just dropped before
-        sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
+        executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
         assert(DeltaLog.forTable(spark, inputDir.getCanonicalPath).snapshot.schema.size == 2)
 
         // restart should block right away
@@ -449,7 +456,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       setupTestTable(deltaLog)
 
       // change schema
-      sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
+      executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
 
       // write more data post change schema
       writeDeltaData(10 until 15, deltaLog)
@@ -461,7 +468,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       //          But once the initial snapshot is served, all subsequent batches will fail if
       //          encountering a schema change during streaming, and all restart effort should fail.
       val checkpointDir = new File(inputDir, "_checkpoint")
-      def df: DataFrame = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      def df: DataFrame = dropCDCFields(loadStream(inputDir.getCanonicalPath))
 
       testStream(df)(
         StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
@@ -482,11 +489,11 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         // some extra special cases when schemas are reverted.
         Execute { _ =>
           writeDeltaData(20 until 25, deltaLog)
-          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
+          executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
         }
       )
 
-      val df2 = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      val df2 = dropCDCFields(loadStream(inputDir.getCanonicalPath))
       testStream(df2)(
         // Restart stream
         StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
@@ -504,9 +511,8 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       //          Here we test the special case when the latest schema is "restored".
       if (isCdcTest) {
         val checkpointDir2 = new File(inputDir, "_checkpoint2")
-        val dfStartAtZero = dropCDCFields(dsr
-          .option(DeltaOptions.STARTING_VERSION_OPTION, "0")
-          .load(inputDir.getCanonicalPath))
+        val dfStartAtZero = dropCDCFields(loadStream(
+          inputDir.getCanonicalPath, Map(DeltaOptions.STARTING_VERSION_OPTION -> "0")))
         testStream(dfStartAtZero)(
           StartStream(checkpointLocation = checkpointDir2.getCanonicalPath),
           ProcessAllAvailableIgnoreError,
@@ -518,9 +524,8 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         // This is fine because the batches served will be compatible until the in-stream check
         // finds another schema change action and fail.
         val checkpointDir2 = new File(inputDir, s"_checkpoint_${UUID.randomUUID.toString}")
-        val dfStartAtZero = dropCDCFields(dsr
-          .option(DeltaOptions.STARTING_VERSION_OPTION, "0")
-          .load(inputDir.getCanonicalPath))
+        val dfStartAtZero = dropCDCFields(loadStream(
+          inputDir.getCanonicalPath, Map(DeltaOptions.STARTING_VERSION_OPTION -> "0")))
         testStream(dfStartAtZero)(
           // The stream could not move past version 10, because batches after which
           // will be incompatible with the latest schema.
@@ -533,7 +538,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
           ExpectInStreamSchemaChangeFailure
         )
         // restart won't move forward either
-        val df2 = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+        val df2 = dropCDCFields(loadStream(inputDir.getCanonicalPath))
         checkStreamStartBlocked(df2, checkpointDir2, ExpectInStreamSchemaChangeFailure)
       }
     }
@@ -549,7 +554,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
           .add("id", StringType, true)
           .add("value", StringType, true)))
       // rename column
-      sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` RENAME COLUMN value TO value2")
+      executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` RENAME COLUMN value TO value2")
       val renameVersion = deltaLog.update().version
       // write more data
       writeDeltaData(5 until 10, deltaLog)
@@ -558,9 +563,9 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       // Since we had a rename, the data files prior to that should not be served with the renamed
       // schema <id, value2>, but the original schema <id, value>. latestOffset() should not create
       // a new offset moves past the schema change.
+      // start from 1 to ignore the initial schema change
       val df1 = dropCDCFields(
-        dsr.option("startingVersion", "1") // start from 1 to ignore the initial schema change
-           .load(inputDir.getCanonicalPath))
+        loadStream(inputDir.getCanonicalPath, Map("startingVersion" -> "1")))
       testStream(df1)(
         StartStream(), // fresh checkpoint
         ProcessAllAvailableIgnoreError,
@@ -573,14 +578,14 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
       )
 
       // try drop column now
-      sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` DROP COLUMN value2")
+      executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` DROP COLUMN value2")
       val dropVersion = deltaLog.update().version
       // write more data
       writeDeltaData(10 until 15, deltaLog)
 
-      val df2 = dropCDCFields(
-        dsr.option("startingVersion", renameVersion + 1) // so we could detect drop column
-          .load(inputDir.getCanonicalPath))
+      // so we could detect drop column
+      val df2 = dropCDCFields(loadStream(
+        inputDir.getCanonicalPath, Map("startingVersion" -> (renameVersion + 1).toString)))
       testStream(df2)(
         StartStream(), // fresh checkpoint
         ProcessAllAvailableIgnoreError,
@@ -594,9 +599,9 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
 
       // Case 2 - in stream failure should not progress latest offset too
       // This is the handle prior to SC-111607, which should cover the major cases.
-      def loadDf(): DataFrame = dropCDCFields(
-        dsr.option("startingVersion", dropVersion + 1) // so we could move on to in stream failure
-           .load(inputDir.getCanonicalPath))
+      // so we could move on to in stream failure
+      def loadDf(): DataFrame = dropCDCFields(loadStream(
+        inputDir.getCanonicalPath, Map("startingVersion" -> (dropVersion + 1).toString)))
 
       val ckpt = Utils.createTempDir().getCanonicalPath
       var latestAvailableOffsets: Seq[String] = null
@@ -609,7 +614,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         },
         // add more data and rename column
         Execute { _ =>
-          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` RENAME COLUMN id TO id2")
+          executeDml(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` RENAME COLUMN id TO id2")
           writeDeltaData(15 until 16, deltaLog)
         },
         ProcessAllAvailableIgnoreError,
@@ -624,9 +629,10 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
         ExpectInStreamSchemaChangeFailure
       )
 
-      // Case 3 - resuming from existing checkpoint, note that getBatch's stream start check
-      // should be called instead of latestOffset for recovery.
-      // This is also the handle prior to SC-111607, which should cover the major cases.
+      // Case 3 - resuming from existing checkpoint. V1 re-constructs the last batch via
+      // `getBatch` on restart, so its stream-start check lands there; V2 skips that step
+      // and the check fires from `latestOffset` instead.
+      val streamStartFrame = if (useDsv2) "latestOffset" else "getBatch"
       testStream(loadDf())(
         StartStream(checkpointLocation = ckpt), // existing checkpoint
         ProcessAllAvailableIgnoreError,
@@ -635,7 +641,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
           // This should come from the latestOffset in-stream checker
           q.availableOffsets.values.map(_.json()) == latestAvailableOffsets &&
             q.latestOffsets.isEmpty &&
-            q.exception.get.cause.getStackTrace.exists(_.toString.contains("getBatch"))
+            q.exception.get.cause.getStackTrace.exists(_.toString.contains(streamStartFrame))
         },
         ExpectStreamStartInCompatibleSchemaFailure
       )
@@ -656,7 +662,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
             Some(StructType.fromDDL("id string, value string")))
         }
 
-        def createNewDf(): DataFrame = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+        def createNewDf(): DataFrame = dropCDCFields(loadStream(inputDir.getCanonicalPath))
 
         val checkpointDir = new File(inputDir, s"_checkpoint_${schemaChangeQuery.hashCode}")
         val isRename = schemaChangeQuery.contains("RENAME")
@@ -665,7 +671,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
           ProcessAllAvailable(),
           CheckAnswer((0 until 5).map(i => (i.toString, i.toString)): _*),
           Execute { _ =>
-            sql(
+            executeDml(
               s"""
                  |ALTER TABLE delta.`${inputDir.getCanonicalPath}`
                  |SET TBLPROPERTIES (
@@ -675,8 +681,9 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
             // Add another schema change to ensure even after enable the flag, we would still hit
             // a schema change with more columns than read schema so `verifySchemaChange` would see
             // that can complain.
-            sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (random STRING)")
-            sql(schemaChangeQuery)
+            executeDml(
+              s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (random STRING)")
+            executeDml(schemaChangeQuery)
             writeDeltaData(5 until 10, deltaLog)
           },
           ProcessAllAvailableIgnoreError,
@@ -709,7 +716,8 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
             Execute { _ =>
               // But any schema change post the stream analysis would still cause exceptions
               // as usual, which is critical to avoid data loss.
-              sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (random2 STRING)")
+              executeDml(
+                s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (random2 STRING)")
             },
             ProcessAllAvailableIgnoreError,
             ExistingRetryableInStreamSchemaChangeFailure
@@ -745,6 +753,9 @@ class DeltaSourceIdColumnMappingSuite extends DeltaSourceSuite
 
   override protected def isCdcTest: Boolean = false
 
+  // Disambiguates the `executeDml` inherited from both DeltaSourceSuite and
+  // ColumnMappingStreamingBlockedWorkflowSuiteBase (Scala requires an explicit override).
+  override protected def executeDml(sqlText: String): Unit = sql(sqlText)
 }
 
 class DeltaSourceNameColumnMappingSuite extends DeltaSourceSuite
@@ -754,6 +765,9 @@ class DeltaSourceNameColumnMappingSuite extends DeltaSourceSuite
 
   override protected def isCdcTest: Boolean = false
 
+  // Disambiguates the `executeDml` inherited from both DeltaSourceSuite and
+  // ColumnMappingStreamingBlockedWorkflowSuiteBase (Scala requires an explicit override).
+  override protected def executeDml(sqlText: String): Unit = sql(sqlText)
 }
 
 // Batch sizes 1, 2, and 100 exercise different backfill behaviors in the commit coordinator.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark

## Description

Adopts `DeltaSourceColumnMappingSuite` for the V2 (Kernel-based) connector, mirroring `DeltaV2SourceSuite`. Streaming reads go through V2; path-based DDL/DML continues through V1 (SparkTable is read-only).

**V1 (`DeltaSourceColumnMappingSuite.scala`):**
- Routed `readStream` calls through `loadStream` → `loadStreamWithOptions` and ALTER TABLE statements through `executeDml` so V2 can override each.
- Switched `df2` / `dfStartAtZero` from `val` to `def` so each restart re-analyzes against the current snapshot (otherwise V2's stale-DataFrame check would shadow the column-mapping check).
- Made Case 3's stack-frame assertion in `should not generate latestOffset past schema change` connector-aware: V1 fires the stream-start check from `getBatch`; V2 skips the re-construction step on restart and fires from `latestOffset`.

**V2 (new `DeltaV2SourceColumnMappingSuite.scala`):**
- Extracted `DeltaV2SourceSuite`'s pass/fail sets into its companion object so column-mapping V2 can compose with them.
- New `DeltaV2SourceColumnMappingSuiteBase` trait + concrete Id/Name suites; reuses V1's `runOnlyTests` so we don't redundantly rerun the full DeltaSourceSuite under column mapping.

## How was this patch tested?

\`\`\`
build/sbt \"spark/testOnly org.apache.spark.sql.delta.DeltaSource{Id,Name}ColumnMappingSuite \\
                          org.apache.spark.sql.delta.test.DeltaV2Source{Id,Name}ColumnMappingSuite\"
\`\`\`

## Does this PR introduce _any_ user-facing changes?

No. Test-only.