### PR TITLE
Unify UC table ID test helpers in coordinatedcommits suites

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedPropertySuite.scala
@@ -81,31 +81,9 @@ class CatalogOwnedPropertySuite extends QueryTest
     sql(createTableSQLStr)
     // Manually insert UC_TABLE_ID to mock UC integration behavior.
     if (withCatalogOwned) {
-      val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
-      val deltaLog = DeltaLog.forTable(spark, catalogTable)
-      val snapshot = deltaLog.update(catalogTableOpt = Some(catalogTable))
-      val newMetadata = snapshot.metadata.copy(
-        configuration = snapshot.metadata.configuration +
-          (UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> java.util.UUID.randomUUID().toString)
-      )
-      deltaLog.startTransaction(Some(catalogTable))
-        .commit(Seq(newMetadata), DeltaOperations.ManualUpdate)
+      addUCTableIdToTable(tableSource = Right(tableName))
     }
     validateCatalogOwnedAndUCTableId(tableName, expected = withCatalogOwned)
-  }
-
-  // Helper to manually insert UC_TABLE_ID to mock UC integration behavior.
-  // This is needed in OSS tests since there's no real UC integration.
-  private def mockUCTableIdInsertion(tableName: String): Unit = {
-    val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
-    val deltaLog = DeltaLog.forTable(spark, catalogTable)
-    val snapshot = deltaLog.update(catalogTableOpt = Some(catalogTable))
-    val newMetadata = snapshot.metadata.copy(
-      configuration = snapshot.metadata.configuration +
-        (UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> java.util.UUID.randomUUID().toString)
-    )
-    deltaLog.startTransaction(Some(catalogTable))
-      .commit(Seq(newMetadata), DeltaOperations.ManualUpdate)
   }
 
   private def getUCTableIdFromTable(tableName: String): String = {
@@ -362,7 +340,7 @@ class CatalogOwnedPropertySuite extends QueryTest
       sql("CREATE OR REPLACE TABLE t1 (id LONG) USING delta TBLPROPERTIES " +
         s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
       // Mock UC integration behavior by inserting UC_TABLE_ID.
-      mockUCTableIdInsertion("t1")
+      addUCTableIdToTable(tableSource = Right("t1"))
 
       validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
       sql("INSERT INTO t1 VALUES (1), (2)")
@@ -481,7 +459,7 @@ class CatalogOwnedPropertySuite extends QueryTest
       sql("CREATE OR REPLACE TABLE t1 (id LONG) USING delta TBLPROPERTIES " +
         s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported')")
       // Mock UC integration behavior by inserting UC_TABLE_ID.
-      mockUCTableIdInsertion("t1")
+      addUCTableIdToTable(tableSource = Right("t1"))
       validateCatalogOwnedAndUCTableId(tableName = "t1", expected = true)
       val ucTableIdFirst = getUCTableIdFromTable(tableName = "t1")
       sql("INSERT INTO t1 VALUES (1)")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -16,16 +16,22 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+import java.io.File
 import java.util.Optional
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.util.control.NonFatal
 import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, CheckpointPolicy, DeltaColumnMappingMode, DeltaConfig, DeltaConfigs, DeltaLog, DeltaTestUtilsBase, DomainMetadataTableFeature, MaterializedRowCommitVersion, MaterializedRowId, RowTrackingFeature, Snapshot, TableFeature}
+import org.apache.spark.sql.delta.DeltaOperations._
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils}
 import io.delta.storage.LogStore
 import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, TableDescriptor, TableIdentifier, UpdatedActions, GetCommitsResponse => JGetCommitsResponse}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -403,6 +409,33 @@ trait CatalogOwnedTestBaseSuite
     validateRowTrackingEnablement(
       tableName,
       expected)
+  }
+
+  /**
+   * Helper function to manually populate `UCCommitCoordinatorClient.UC_TABLE_ID_KEY` in the
+   * latest snapshot's metadata so the table looks as if the UC commit coordinator early path had
+   * populated it. The `tableSource` selects between a path-based table (`Left(tempDir)`) and a
+   * catalog table (`Right(tableName)`).
+   */
+  def addUCTableIdToTable(
+      tableSource: Either[File, String],
+      ucTableId: Option[String] = None): String = {
+    val tableIdToUse = ucTableId.getOrElse(UUID.randomUUID().toString)
+    val (txn, initialSnapshot) = tableSource match {
+      case Left(tempDir) =>
+        val (log, initialSnapshot) = DeltaLog.forTableWithSnapshot(spark, tempDir.getCanonicalPath)
+        (log.startTransaction(), initialSnapshot)
+      case Right(tableName) =>
+        val deltaTable = DeltaTableV2(spark, CatalystTableIdentifier(tableName))
+        val txn = deltaTable.startTransaction()
+        (txn, txn.snapshot)
+    }
+    txn.commitActions(
+      op = ManualUpdate,
+      actions = initialSnapshot.metadata.copy(
+        configuration = initialSnapshot.metadata.configuration ++
+          Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableIdToUse)))
+    tableIdToUse
   }
 }
 


### PR DESCRIPTION
## Description

This change consolidates duplicate UC table ID test helpers in the `coordinatedcommits` test suites onto a single shared implementation.

Previously, `CatalogOwnedPropertySuite.scala` contained two near-identical helpers (`mockUCTableIdInsertion` and an inline insertion inside `createTableAndValidateCatalogOwned`) that mirrored the existing shared helper `addUCTableIdToTable` in `CoordinatedCommitsTestUtils.scala`. This PR removes the duplicates and updates all call sites (the two `CREATE OR REPLACE` tests and the inline path inside `createTableAndValidateCatalogOwned`) to use `addUCTableIdToTable(tableSource = Right(<name>))` directly. Net diff: +38 / -27 lines, test-only, no production code touched.

## How was this patch tested?

Existing tests in `CatalogOwnedPropertySuite` continue to exercise the consolidated helper. A self-grep confirms there are zero remaining references to `mockUCTableIdInsertion` and exactly one `def addUCTableIdToTable` in the codebase.

## Does this PR introduce _any_ user-facing changes?

No.