### PR TITLE
[GEO][Delta Spark] Add GeoSpatial table feature

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -45,6 +45,7 @@ object DeltaSharingUtils extends Logging {
       TimestampNTZTableFeature.name,
       TypeWideningPreviewTableFeature.name,
       TypeWideningTableFeature.name,
+      GeoSpatialTableFeature.name,
       VariantTypePreviewTableFeature.name,
       VariantTypeTableFeature.name,
       VariantShreddingPreviewTableFeature.name,
@@ -59,6 +60,7 @@ object DeltaSharingUtils extends Logging {
       TypeWideningPreviewTableFeature.name,
       TypeWideningTableFeature.name,
       VariantTypePreviewTableFeature.name,
+      GeoSpatialTableFeature.name,
       VariantTypeTableFeature.name,
       VariantShreddingPreviewTableFeature.name,
       VariantShreddingTableFeature.name

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -71,6 +71,7 @@ private[spark] class TestClientForDeltaFormatSharing(
     TimestampNTZTableFeature,
     TypeWideningPreviewTableFeature,
     TypeWideningTableFeature,
+    GeoSpatialTableFeature,
     VariantTypePreviewTableFeature,
     VariantTypeTableFeature,
     VariantShreddingPreviewTableFeature,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -380,6 +380,19 @@ trait DeltaErrorsBase
     )
   }
 
+  def cannotDropGeospatialFeature(cols: Seq[StructField]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE",
+      messageParameters = Array(cols.map(_.name).mkString(", ")))
+  }
+
+  def geoSpatialNotSupportedException(): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+      messageParameters = Array.empty
+    )
+  }
+
   def checkConstraintReferToWrongColumns(colName: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_INVALID_CHECK_CONSTRAINT_REFERENCES",
@@ -525,6 +538,20 @@ trait DeltaErrorsBase
       errorClass = "DELTA_ZORDERING_COLUMN_DOES_NOT_EXIST",
       messageParameters = Array(colName))
   }
+
+  def operationNotSupportedForDataTypes(
+      operation: String,
+      unsupportedDataType: UnsupportedDataTypeInfo,
+      moreUnsupportedDataTypes: UnsupportedDataTypeInfo*): Throwable = {
+    val prettyMessage = (unsupportedDataType +: moreUnsupportedDataTypes)
+      .map(dt => s"${dt.column}: ${dt.dataType}")
+      .mkString("[", ", ", "]")
+    new DeltaAnalysisException(
+      errorClass = "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES",
+      messageParameters = Array(operation, prettyMessage)
+    )
+  }
+
 
   /**
    * Throwable used when CDC options contain no 'start'.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -32,6 +32,7 @@ import scala.util.control.NonFatal
 import com.databricks.spark.util.TagDefinition
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
 import org.apache.spark.sql.delta.ClassicColumnConversions._
+import org.apache.spark.sql.delta.DeltaGeoSpatial
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
@@ -1078,6 +1079,19 @@ trait OptimisticTransactionImpl extends TransactionHelper
         throw DeltaErrors.unsupportedDataTypes(unsupportedTypes.head, unsupportedTypes.tail: _*)
       }
     }
+
+    // even though we've just called SchemaUtils.findUnsupportedDataTypes, we didn't have
+    // spark config there.
+    // so we need to check again here.
+    if (!DeltaGeoSpatial.isPreviewEnabled(spark)) {
+      val geoTypeOpt = DeltaGeoSpatial.findGeoColumnsRecursively(metadata.schema)
+      geoTypeOpt.foreach { geoType =>
+        throw new AnalysisException("UNSUPPORTED_DATATYPE", Map("typeName" -> geoType.toString))
+      }
+    } else {
+      DeltaGeoSpatial.assertSridSupported(metadata.schema)
+    }
+
 
     if (spark.conf.get(DeltaSQLConf.DELTA_TABLE_PROPERTY_CONSTRAINTS_CHECK_ENABLED)) {
       Protocol.assertTablePropertyConstraintsSatisfied(spark, metadata, snapshot)
@@ -2494,6 +2508,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
     newMetadata = metadataUpdate1.orElse(newMetadata)
 
     var finalActions = newMetadata.toSeq ++ newProtocol.toSeq ++ otherActions
+
+    DeltaGeoSpatial.validateCommitActions(spark, protocol, finalActions)
 
     // Block future cases of CDF + Column Mapping changes + file changes
     // This check requires having called

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -590,6 +590,27 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
     true
   }
 }
+
+case class GeospatialPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand {
+
+  /**
+   * Throws an exception if the table has geospatial types, and returns false otherwise.
+   * We currently do not remove the geospatial statistics in the current table version so no
+   * action is required.
+   */
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): PreDowngradeStatus = {
+    if (GeoSpatialPreviewTableFeature.validateDropInvariants(table, table.initialSnapshot)) {
+      return PreDowngradeStatus.DID_NOT_PERFORM_CHANGES
+    }
+    val geospatialCols = table.initialSnapshot.schema.fields
+      .filter(field => DeltaGeoSpatial.containsGeoColumns(field.dataType))
+    // We ask the user to explicitly drop the geospatial columns before the table feature
+    // can be dropped.
+    throw DeltaErrors.cannotDropGeospatialFeature(geospatialCols)
+  }
+}
+
 case class ColumnMappingPreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand
     with DeltaLogging {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV1.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV1.scala
@@ -48,6 +48,7 @@ case class ProtocolMetadataAdapterV1(
 
   override def assertTableReadable(sparkSession: SparkSession): Unit = {
     TypeWidening.assertTableReadable(sparkSession.sessionState.conf, protocol, metadata)
+    DeltaGeoSpatial.assertTableReadable(sparkSession.sessionState.conf, protocol, metadata)
   }
 
   override def createRowTrackingMetadataFields(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -388,6 +388,8 @@ object TableFeature {
       IcebergCompatV2TableFeature,
       IcebergCompatV3TableFeature,
       DeletionVectorsTableFeature,
+      GeoSpatialPreviewTableFeature,
+      GeoSpatialTableFeature,
       VacuumProtocolCheckTableFeature,
       V2CheckpointTableFeature,
       RowTrackingFeature,
@@ -649,6 +651,55 @@ object IdentityColumnsTableFeature
       spark: SparkSession): Boolean = {
     ColumnWithDefaultExprUtils.hasIdentityColumn(metadata.schema)
   }
+}
+
+
+/** Common base shared by the preview and geospatial table features. */
+abstract class GeoSpatialTableFeatureBase(name: String)
+  extends ReaderWriterFeature(name)
+  with RemovableFeature {
+
+  override def validateDropInvariants(table: DeltaTableV2, snapshot: Snapshot): Boolean =
+    !DeltaGeoSpatial.containsGeoColumns(snapshot.metadata.schema)
+
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
+    GeospatialPreDowngradeCommand(table)
+
+  override def actionUsesFeature(action: Action): Boolean = false
+}
+
+/**
+ * Feature used for the private preview phase of geospatial support. Tables that have this
+ * feature are still supported even after the preview.
+ */
+object GeoSpatialPreviewTableFeature
+  extends GeoSpatialTableFeatureBase(name = "geospatial-dev")
+
+/**
+ * Stable feature for geospatial support.
+ *
+ * Table feature that adds support for GeoSpatial types (Geometry and Geography).
+ * Feature is automatically added whenever schema contains any of these two types.
+ * Additionally, feature is gated behind a delta.geo.preview.enabled config.
+ */
+object GeoSpatialTableFeature
+  extends GeoSpatialTableFeatureBase(name = "geospatial")
+  with FeatureAutomaticallyEnabledByMetadata {
+  override def metadataRequiresFeatureToBeEnabled(
+      protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
+    val hasGeoColumns = DeltaGeoSpatial.containsGeoColumns(metadata.schema)
+
+    if (hasGeoColumns && !DeltaGeoSpatial.isPreviewEnabled(spark)) {
+      throw DeltaErrors.geoSpatialNotSupportedException()
+    }
+
+    hasGeoColumns &&
+    // Don't automatically enable the stable feature if the preview feature is already supported, to
+    // avoid possibly breaking old clients that only support the preview feature.
+    !protocol.isFeatureSupported(GeoSpatialPreviewTableFeature)
+  }
+
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
 }
 
 object TimestampNTZTableFeature extends ReaderWriterFeature(name = "timestampNtz")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -340,9 +340,10 @@ class DeltaDataSource
   }
 
   /**
-   * Extend the default `supportsDataType` to allow VariantType.
+   * Extend the default `supportsDataType` to allow GeoSpatial types and VariantType.
    */
   override def supportsDataType(dt: DataType): Boolean = {
+    DeltaGeoSpatial.isGeoSpatialType(dt) ||
     dt.isInstanceOf[VariantType] || super.supportsDataType(dt)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3168,6 +3168,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  //////////////////
+  // GeoSpatial
+  //////////////////
+
+  val DELTA_GEO_PREVIEW_ENABLED =
+    buildConf("geo.preview.enabled")
+      .internal()
+      .doc("Enable GeoSpatial features that are part of the preview scope.")
+      .booleanConf
+      .createWithDefault(true)
+
   ///////////
   // VARIANT
   ///////////////////

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -47,7 +47,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaErrors}
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaErrors, DeltaGeoSpatial}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -615,8 +615,10 @@ private[delta] object PartitionUtils {
 
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
       field => field.dataType match {
-        // Variant types are not orderable and thus cannot be partition columns.
-        case a: AtomicType if !a.isInstanceOf[VariantType] => // OK
+        // Variant, Geometry and Geography types are not orderable and thus cannot be partition
+        // columns.
+        case a: AtomicType
+          if !a.isInstanceOf[VariantType] && !DeltaGeoSpatial.isGeoSpatialType(a) => // OK
         case _ => throw DeltaErrors.cannotUseDataTypeForPartitionColumnError(field)
       }
     }


### PR DESCRIPTION
## Description

Adds support for GeoSpatial types (Geometry and Geography) in Delta tables through a new `geospatial` table feature, with a corresponding `geospatial-dev` preview feature for the private preview phase.

### Changes

- Introduces `GeoSpatialTableFeature` and `GeoSpatialPreviewTableFeature` (`ReaderWriterFeature` + `RemovableFeature`) — the stable feature is `FeatureAutomaticallyEnabledByMetadata` and activates whenever a Delta table schema contains geospatial columns.
- Adds `GeospatialPreDowngradeCommand` to validate that the feature can only be dropped after geospatial columns have been removed from the schema.
- Adds validation in `OptimisticTransaction` that throws when a geospatial column is added while the preview is disabled, and ensures SRID values are supported.
- Wires `DeltaGeoSpatial.assertTableReadable` into `ProtocolMetadataAdapterV1`.
- Adds `DELTA_GEO_PREVIEW_ENABLED` (config key `geo.preview.enabled`, default `true`) to gate the preview functionality.
- `DeltaDataSource.supportsDataType` now recognizes geospatial types.
- `PartitionUtils` now rejects geospatial (and reaffirms variant) types as partition columns, since these types are not orderable.
- Adds new error messages: `DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE`, `DELTA_GEOSPATIAL_NOT_SUPPORTED`, `DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES`.
- Registers the new feature in delta-sharing client utilities.

## How was this patch tested?

Existing test suites.
