### PR TITLE
[Spark] Route managed Delta REPLACE / CREATE OR REPLACE through the UC Delta API

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -57,7 +57,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=2c22cf18be7d966003f3ebcd1816ba6499b5a2a2
+UC_PIN_SHA=e1f6e52acc39b925fd6a42180d400ca4e0a3895f
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -503,23 +503,22 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     }
 
   /**
-   * Decides whether a CREATE / REPLACE / CREATE OR REPLACE request is eligible to go
-   * through `deltaCatalogClient` (the catalog-aware path) instead of the default delegate.
+   * Decides whether a CREATE / CTAS request is eligible to go through
+   * `deltaCatalogClient` (the catalog-aware path) instead of the default delegate.
    * A request is eligible when all of the following hold:
    *
    *   - the underlying catalog is Unity Catalog;
-   *   - a `deltaCatalogClient` is wired in (i.e. `deltaRestApi.enabled=true`);
-   *   - the caller does not appear to be creating or replacing an external table -- that
-   *     is, neither `PROP_LOCATION` nor `PROP_EXTERNAL` is set in `properties`, and the
-   *     identifier is not path-based (e.g. `delta`.`/tmp/foo`).
+   *   - a `deltaCatalogClient` is wired in;
+   *   - the caller does not appear to be creating an external table -- that is, neither
+   *     `PROP_LOCATION` nor `PROP_EXTERNAL` is set in `properties`, and the identifier
+   *     is not path-based (e.g. `delta`.`/tmp/foo`).
    *
    * Any other request returns `false` and falls back to the default delegate flow.
    *
    * @param ident      identifier of the target table.
-   * @param properties user-supplied properties from the CREATE / REPLACE / CREATE OR REPLACE
-   *                   statement.
+   * @param properties user-supplied properties from the CREATE / CTAS statement.
    */
-  private def shouldRouteThroughDeltaCatalogClient(
+  private def shouldRouteCreateThroughDeltaCatalogClient(
       ident: Identifier,
       properties: util.Map[String, String]): Boolean = {
     if (!isUnityCatalog ||
@@ -533,14 +532,51 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   }
 
   /**
+   * Decides whether a REPLACE / RTAS / CREATE OR REPLACE request is eligible to go
+   * through `deltaCatalogClient`. A request is eligible when all of the following hold:
+   *
+   *   - the underlying catalog is Unity Catalog;
+   *   - a `deltaCatalogClient` is wired in;
+   *   - the identifier is not path-based (e.g. `delta`.`/tmp/foo`).
+   *
+   * Any other request returns `false` and falls back to the default delegate flow.
+   *
+   * Unlike the CREATE variant, this throws an `UnsupportedOperationException` when
+   * `PROP_LOCATION` or `PROP_EXTERNAL` is set on a UC catalog with `deltaCatalogClient`
+   * wired in. Only catalog-managed Delta tables (no user-supplied LOCATION) can be
+   * replaced on this path; rejecting up front guarantees non-managed REPLACEs never
+   * reach the staged-table flow, which would otherwise write a Delta commit before
+   * Delta's post-commit catalog-update hook discovered the inconsistency (leaving the
+   * Delta log and UC's metastore out of sync).
+   *
+   * @param ident      identifier of the target table.
+   * @param properties user-supplied properties from the REPLACE / RTAS / CREATE OR REPLACE
+   *                   statement.
+   */
+  private def shouldRouteReplaceThroughDeltaCatalogClient(
+      ident: Identifier,
+      properties: util.Map[String, String]): Boolean = {
+    if (!isUnityCatalog || deltaCatalogClient.isEmpty) return false
+    if (properties.containsKey(TableCatalog.PROP_LOCATION) ||
+        properties.containsKey(TableCatalog.PROP_EXTERNAL)) {
+      throw new UnsupportedOperationException(
+        s"REPLACE TABLE on $ident cannot specify '${TableCatalog.PROP_LOCATION}' or " +
+          s"'${TableCatalog.PROP_EXTERNAL}': only catalog-managed Delta tables can " +
+          "be replaced on this path.")
+    }
+    val ns = ident.namespace()
+    !(ns.length == 1 && new Path(ident.name()).isAbsolute)
+  }
+
+  /**
    * Reserves a catalog-side staging entry for a fresh Delta table and returns the property
    * map that downstream code will use to write the initial commit. The returned map is the
    * caller's `properties` augmented with the catalog-assigned table id, the staged storage
    * location, and the storage credentials Delta needs to write to that location.
    *
    * When the request is not eligible for this path (see
-   * [[shouldRouteThroughDeltaCatalogClient]]), the input `properties` is returned unchanged
-   * and the caller falls back to the legacy catalog flow.
+   * [[shouldRouteCreateThroughDeltaCatalogClient]]), the input `properties` is returned
+   * unchanged and the caller falls back to the legacy catalog flow.
    *
    * @param ident      identifier of the table being created.
    * @param properties user-supplied properties from the CREATE statement.
@@ -550,7 +586,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   private def maybeStageDeltaCreate(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
-    if (!shouldRouteThroughDeltaCatalogClient(ident, properties)) return properties
+    if (!shouldRouteCreateThroughDeltaCatalogClient(ident, properties)) return properties
     deltaCatalogClient.get.createStagingTable(ident, properties)
   }
 
@@ -563,9 +599,10 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
    * downstream Delta resolves the write location from the existing table snapshot.
    *
    * When the request is not eligible for this path (see
-   * [[shouldRouteThroughDeltaCatalogClient]]), the input `properties` is returned unchanged
-   * and the caller falls back to the legacy catalog flow. Throws via the catalog client if
-   * the table does not exist or is not a catalog-managed Delta table.
+   * [[shouldRouteReplaceThroughDeltaCatalogClient]]), the input `properties` is returned
+   * unchanged and the caller falls back to the legacy catalog flow. Throws via the
+   * catalog client if the table does not exist or is not a catalog-managed Delta table
+   * (`PROP_LOCATION` / `PROP_EXTERNAL` are rejected earlier at the routing gate).
    *
    * @param ident      identifier of the table being replaced.
    * @param properties user-supplied properties from the REPLACE statement.
@@ -575,7 +612,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   private def maybeLoadForDeltaReplace(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
-    if (!shouldRouteThroughDeltaCatalogClient(ident, properties)) return properties
+    if (!shouldRouteReplaceThroughDeltaCatalogClient(ident, properties)) return properties
     deltaCatalogClient.get.loadTableAndBuildReplaceProps(ident, properties)
   }
 
@@ -597,8 +634,8 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
    *     throws via the catalog client.
    *
    * When the request is not eligible for this path (see
-   * [[shouldRouteThroughDeltaCatalogClient]]), the input `properties` is returned unchanged
-   * and the caller falls back to the legacy catalog flow.
+   * [[shouldRouteReplaceThroughDeltaCatalogClient]]), the input `properties` is returned
+   * unchanged and the caller falls back to the legacy catalog flow.
    *
    * @param ident      identifier of the target table.
    * @param properties user-supplied properties from the CREATE OR REPLACE statement.
@@ -608,7 +645,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   private def maybeStageDeltaCreateOrReplace(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
-    if (!shouldRouteThroughDeltaCatalogClient(ident, properties)) return properties
+    if (!shouldRouteReplaceThroughDeltaCatalogClient(ident, properties)) return properties
     try deltaCatalogClient.get.loadTableAndBuildReplaceProps(ident, properties)
     catch {
       case _: NoSuchTableException =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -839,18 +839,22 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
    * where the V1 SessionCatalog lookup does not surface the existing table entry.
    *
    * [[getExistingTableIfExists]] first checks the V1 catalog using a [[TableIdentifier]]. For
-   * Unity Catalog, some staged create/replace paths need a delegated V2 catalog lookup on the
-   * original [[Identifier]] to recover the existing table metadata.
+   * Unity Catalog, some staged create/replace paths need a delegated catalog lookup on the
+   * original [[Identifier]] to recover the existing table metadata. The lookup prefers the
+   * `deltaCatalogClient` (Delta API) when wired, and falls back to the V2 delegate plugin
+   * otherwise.
    *
-   * Even though this goes through the delegated V2 catalog plugin, Spark can still surface the
-   * result as a [[V1Table]] wrapper when the delegated catalog is exposing V1-backed table
-   * metadata. In that case we unwrap the embedded [[CatalogTable]] and continue on the V1 Delta
-   * path.
+   * Spark surfaces the result as a [[V1Table]] wrapper when the catalog is exposing V1-backed
+   * table metadata. In that case we unwrap the embedded [[CatalogTable]] and continue on the
+   * V1 Delta path.
    */
   private def getExistingTableFromDelegatedCatalog(ident: Identifier): Option[CatalogTable] = {
     if (isUnityCatalog) {
       try {
-        super.loadTable(ident) match {
+        val table = deltaCatalogClient
+          .map(_.loadTable(ident))
+          .getOrElse(super.loadTable(ident))
+        table match {
           case v1: V1Table if DeltaTableUtils.isDeltaTable(v1.catalogTable) =>
             Some(v1.catalogTable)
           case _ =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -559,8 +559,9 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     if (!isUnityCatalog || deltaCatalogClient.isEmpty) return false
     if (properties.containsKey(TableCatalog.PROP_LOCATION) ||
         properties.containsKey(TableCatalog.PROP_EXTERNAL)) {
+      val qualifiedName = s"${name()}.${ident.namespace().mkString(".")}.${ident.name()}"
       throw new UnsupportedOperationException(
-        s"REPLACE TABLE on $ident cannot specify '${TableCatalog.PROP_LOCATION}' or " +
+        s"REPLACE TABLE on $qualifiedName cannot specify '${TableCatalog.PROP_LOCATION}' or " +
           s"'${TableCatalog.PROP_EXTERNAL}': only catalog-managed Delta tables can " +
           "be replaced on this path.")
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -297,7 +297,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       //       if UC is enabled to replace `V2SessionCatalog`.
       createTableFunc = Option.when(isUnityCatalog) {
         (v1Table: CatalogTable, snapshot: Snapshot) => {
-          // Route to the Delta API endpoint only for MANAGED Delta creates when this client is
+          // Route to the deltaCatalogClient only for MANAGED Delta creates when this client is
           // wired in. EXTERNAL Delta and the no-client case stay on the legacy `super.createTable`
           // path so existing behavior is preserved.
           deltaCatalogClient match {
@@ -477,7 +477,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         val isUC = isUnityCatalog || properties.containsKey("test.simulateUC")
         setVariantBlockingConfigIfUC()
         val (props, writeOptions) = if (isUC) {
-          val effectiveProperties = maybeStageManagedDeltaCreate(ident, properties)
+          val effectiveProperties = maybeStageDeltaCreate(ident, properties)
           val (props, writeOptions) = getTablePropsAndWriteOptions(effectiveProperties)
           expandTableProps(props, writeOptions, spark.sessionState.conf)
           props.remove("test.simulateUC")
@@ -503,17 +503,23 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     }
 
   /**
-   * Returns true when this request should be routed through the UC Delta API path (whether
-   * via [[AbstractDeltaCatalogClient.createStagingTable]] for CREATE or
-   * [[AbstractDeltaCatalogClient.loadTable]] for REPLACE / CREATE OR REPLACE).
+   * Decides whether a CREATE / REPLACE / CREATE OR REPLACE request is eligible to go
+   * through `deltaCatalogClient` (the catalog-aware path) instead of the default delegate.
+   * A request is eligible when all of the following hold:
    *
-   * Pass-through cases:
-   *   - delegate isn't Unity Catalog;
-   *   - no Delta API client is wired in (`deltaRestApi.enabled=false`);
-   *   - `PROP_LOCATION` or `PROP_EXTERNAL` is set (external create);
-   *   - the identifier is path-based (e.g. `delta`.`/tmp/foo`).
+   *   - the underlying catalog is Unity Catalog;
+   *   - a `deltaCatalogClient` is wired in (i.e. `deltaRestApi.enabled=true`);
+   *   - the caller does not appear to be creating or replacing an external table -- that
+   *     is, neither `PROP_LOCATION` nor `PROP_EXTERNAL` is set in `properties`, and the
+   *     identifier is not path-based (e.g. `delta`.`/tmp/foo`).
+   *
+   * Any other request returns `false` and falls back to the default delegate flow.
+   *
+   * @param ident      identifier of the target table.
+   * @param properties user-supplied properties from the CREATE / REPLACE / CREATE OR REPLACE
+   *                   statement.
    */
-  private def shouldRouteThroughDeltaApi(
+  private def shouldRouteThroughDeltaCatalogClient(
       ident: Identifier,
       properties: util.Map[String, String]): Boolean = {
     if (!isUnityCatalog ||
@@ -527,40 +533,83 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
   }
 
   /**
-   * Routing boundary for the UC Delta API fresh CREATE path. Stages via
-   * [[AbstractDeltaCatalogClient.createStagingTable]] for a fresh managed-Delta CREATE;
-   * otherwise returns `properties` unchanged so the regular delegate flow handles it. Only
-   * the fresh-create call sites ([[createTable]] / [[stageCreate]]) invoke this.
+   * Reserves a catalog-side staging entry for a fresh Delta table and returns the property
+   * map that downstream code will use to write the initial commit. The returned map is the
+   * caller's `properties` augmented with the catalog-assigned table id, the staged storage
+   * location, and the storage credentials Delta needs to write to that location.
+   *
+   * When the request is not eligible for this path (see
+   * [[shouldRouteThroughDeltaCatalogClient]]), the input `properties` is returned unchanged
+   * and the caller falls back to the legacy catalog flow.
+   *
+   * @param ident      identifier of the table being created.
+   * @param properties user-supplied properties from the CREATE statement.
+   * @return augmented properties (eligible) or the input `properties` reference unchanged
+   *         (not eligible).
    */
-  private def maybeStageManagedDeltaCreate(
+  private def maybeStageDeltaCreate(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
-    if (!shouldRouteThroughDeltaApi(ident, properties)) return properties
+    if (!shouldRouteThroughDeltaCatalogClient(ident, properties)) return properties
     deltaCatalogClient.get.createStagingTable(ident, properties)
   }
 
   /**
-   * Routing boundary for REPLACE / RTAS. Delegates the load + property-build to
-   * [[AbstractDeltaCatalogClient.buildReplaceProps]]; throws via that client when the
-   * existing table is missing or non-MANAGED.
+   * Loads the existing catalog entry for a Delta REPLACE / RTAS and returns the property
+   * map that downstream code will use to write the REPLACE commit. The returned map is the
+   * caller's `properties` augmented with `PROP_IS_MANAGED_LOCATION=true` (signaling that
+   * the table's location is system-managed) and the storage credentials Delta needs to
+   * write at that location. The map intentionally does not carry `PROP_LOCATION`, so
+   * downstream Delta resolves the write location from the existing table snapshot.
+   *
+   * When the request is not eligible for this path (see
+   * [[shouldRouteThroughDeltaCatalogClient]]), the input `properties` is returned unchanged
+   * and the caller falls back to the legacy catalog flow. Throws via the catalog client if
+   * the table does not exist or is not a catalog-managed Delta table.
+   *
+   * @param ident      identifier of the table being replaced.
+   * @param properties user-supplied properties from the REPLACE statement.
+   * @return augmented properties (eligible) or the input `properties` reference unchanged
+   *         (not eligible).
    */
-  private def maybeLoadForManagedDeltaReplace(
+  private def maybeLoadForDeltaReplace(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
-    if (!shouldRouteThroughDeltaApi(ident, properties)) return properties
-    deltaCatalogClient.get.buildReplaceProps(ident, properties)
+    if (!shouldRouteThroughDeltaCatalogClient(ident, properties)) return properties
+    deltaCatalogClient.get.loadTableAndBuildReplaceProps(ident, properties)
   }
 
   /**
-   * Combined boundary for CREATE OR REPLACE:
-   *   - existing table -> [[AbstractDeltaCatalogClient.buildReplaceProps]]
-   *   - missing ([[NoSuchTableException]]) -> fresh-create staging
+   * Resolves a Delta CREATE OR REPLACE against the catalog and returns the property map
+   * that downstream code will use to write the next commit. The behavior depends on what
+   * the catalog reports for the target identifier:
+   *
+   *   - No table at that identifier: reserves a fresh staging entry with the catalog and
+   *     returns the caller's `properties` augmented with its assigned LOCATION, table id,
+   *     and storage credentials so Delta can write the initial commit (the CREATE branch).
+   *   - Exists as a catalog-managed Delta table: returns the caller's `properties`
+   *     augmented with `PROP_IS_MANAGED_LOCATION=true` and the storage credentials Delta
+   *     needs to write at the existing location; `PROP_LOCATION` is intentionally not set,
+   *     so downstream Delta resolves the write location from the existing table snapshot
+   *     (the REPLACE branch).
+   *   - Exists but fails any of the catalog-managed-Delta preconditions (tableType is not
+   *     MANAGED, provider is not Delta, or the catalog-managed feature flag is absent):
+   *     throws via the catalog client.
+   *
+   * When the request is not eligible for this path (see
+   * [[shouldRouteThroughDeltaCatalogClient]]), the input `properties` is returned unchanged
+   * and the caller falls back to the legacy catalog flow.
+   *
+   * @param ident      identifier of the target table.
+   * @param properties user-supplied properties from the CREATE OR REPLACE statement.
+   * @return augmented properties (eligible) or the input `properties` reference unchanged
+   *         (not eligible).
    */
-  private def maybeStageManagedDeltaCreateOrReplace(
+  private def maybeStageDeltaCreateOrReplace(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
-    if (!shouldRouteThroughDeltaApi(ident, properties)) return properties
-    try deltaCatalogClient.get.buildReplaceProps(ident, properties)
+    if (!shouldRouteThroughDeltaCatalogClient(ident, properties)) return properties
+    try deltaCatalogClient.get.loadTableAndBuildReplaceProps(ident, properties)
     catch {
       case _: NoSuchTableException =>
         deltaCatalogClient.get.createStagingTable(ident, properties)
@@ -578,7 +627,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           ident,
           schema,
           partitions,
-          maybeLoadForManagedDeltaReplace(ident, properties),
+          maybeLoadForDeltaReplace(ident, properties),
           TableCreationModes.Replace
         )
       } else {
@@ -600,7 +649,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           ident,
           schema,
           partitions,
-          maybeStageManagedDeltaCreateOrReplace(ident, properties),
+          maybeStageDeltaCreateOrReplace(ident, properties),
           TableCreationModes.CreateOrReplace
         )
       } else {
@@ -626,7 +675,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           ident,
           schema,
           partitions,
-          maybeStageManagedDeltaCreate(ident, properties),
+          maybeStageDeltaCreate(ident, properties),
           TableCreationModes.Create
         )
       } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -503,10 +503,9 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     }
 
   /**
-   * Routing boundary for the UC Delta API path. Stages via
-   * [[AbstractDeltaCatalogClient.createStagingTable]] for a fresh managed-Delta CREATE;
-   * otherwise returns `properties` unchanged so the regular delegate flow handles it. Only
-   * the fresh-create call sites ([[createTable]] / [[stageCreate]]) invoke this.
+   * Returns true when this request should be routed through the UC Delta API path (whether
+   * via [[AbstractDeltaCatalogClient.createStagingTable]] for CREATE or
+   * [[AbstractDeltaCatalogClient.loadTable]] for REPLACE / CREATE OR REPLACE).
    *
    * Pass-through cases:
    *   - delegate isn't Unity Catalog;
@@ -514,22 +513,58 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
    *   - `PROP_LOCATION` or `PROP_EXTERNAL` is set (external create);
    *   - the identifier is path-based (e.g. `delta`.`/tmp/foo`).
    */
-  private def maybeStageManagedDeltaCreate(
+  private def shouldRouteThroughDeltaApi(
       ident: Identifier,
-      properties: util.Map[String, String]): util.Map[String, String] = {
+      properties: util.Map[String, String]): Boolean = {
     if (!isUnityCatalog ||
         deltaCatalogClient.isEmpty ||
         properties.containsKey(TableCatalog.PROP_LOCATION) ||
-        properties.containsKey(TableCatalog.PROP_EXTERNAL) ||
-        // CREATE-OR-REPLACE on an existing managed table -- UCSingleCatalog sets this without
-        // setting PROP_LOCATION (location comes from the existing table's snapshot). Skip the
-        // new path so we don't allocate a fresh staging location for an existing table.
-        properties.containsKey(TableCatalog.PROP_IS_MANAGED_LOCATION)) {
-      return properties
+        properties.containsKey(TableCatalog.PROP_EXTERNAL)) {
+      return false
     }
     val ns = ident.namespace()
-    if (ns.length == 1 && new Path(ident.name()).isAbsolute) return properties
+    !(ns.length == 1 && new Path(ident.name()).isAbsolute)
+  }
+
+  /**
+   * Routing boundary for the UC Delta API fresh CREATE path. Stages via
+   * [[AbstractDeltaCatalogClient.createStagingTable]] for a fresh managed-Delta CREATE;
+   * otherwise returns `properties` unchanged so the regular delegate flow handles it. Only
+   * the fresh-create call sites ([[createTable]] / [[stageCreate]]) invoke this.
+   */
+  private def maybeStageManagedDeltaCreate(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String] = {
+    if (!shouldRouteThroughDeltaApi(ident, properties)) return properties
     deltaCatalogClient.get.createStagingTable(ident, properties)
+  }
+
+  /**
+   * Routing boundary for REPLACE / RTAS. Delegates the load + property-build to
+   * [[AbstractDeltaCatalogClient.buildReplaceProps]]; throws via that client when the
+   * existing table is missing or non-MANAGED.
+   */
+  private def maybeLoadForManagedDeltaReplace(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String] = {
+    if (!shouldRouteThroughDeltaApi(ident, properties)) return properties
+    deltaCatalogClient.get.buildReplaceProps(ident, properties)
+  }
+
+  /**
+   * Combined boundary for CREATE OR REPLACE:
+   *   - existing table -> [[AbstractDeltaCatalogClient.buildReplaceProps]]
+   *   - missing ([[NoSuchTableException]]) -> fresh-create staging
+   */
+  private def maybeStageManagedDeltaCreateOrReplace(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String] = {
+    if (!shouldRouteThroughDeltaApi(ident, properties)) return properties
+    try deltaCatalogClient.get.buildReplaceProps(ident, properties)
+    catch {
+      case _: NoSuchTableException =>
+        deltaCatalogClient.get.createStagingTable(ident, properties)
+    }
   }
 
   override def stageReplace(
@@ -543,7 +578,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           ident,
           schema,
           partitions,
-          properties,
+          maybeLoadForManagedDeltaReplace(ident, properties),
           TableCreationModes.Replace
         )
       } else {
@@ -561,14 +596,11 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       properties: util.Map[String, String]): StagedTable =
     recordFrameProfile("DeltaCatalog", "stageCreateOrReplace") {
       if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
-        // Fresh CREATE-OR-REPLACE (no existing PROP_LOCATION) routes through the same
-        // staging boundary as `createTable` / `stageCreate`; REPLACE-existing (PROP_LOCATION
-        // set by the upstream catalog) is filtered out inside the boundary.
         new StagedDeltaTableV2(
           ident,
           schema,
           partitions,
-          maybeStageManagedDeltaCreate(ident, properties),
+          maybeStageManagedDeltaCreateOrReplace(ident, properties),
           TableCreationModes.CreateOrReplace
         )
       } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -39,50 +39,71 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 private[catalog] trait AbstractDeltaCatalogClient {
 
   /**
+   * Loads the table identified by `ident` from the catalog.
+   *
+   * @param ident identifier of the table to load.
+   * @return the resolved [[Table]].
    * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException if the catalog has
-   *   no record of this identifier
+   *   no record of this identifier.
    */
   def loadTable(ident: Identifier): Table
 
   /**
-   * Called by `AbstractDeltaCatalog.maybeStageManagedDeltaCreate` for a fresh managed-Delta
-   * CREATE / staged CREATE. Stages the table with the catalog (e.g. UC Delta API staging
-   * endpoint) and returns `properties` augmented with the catalog-supplied LOCATION, table
-   * id, and credentials.
+   * Reserves a fresh staging entry with the catalog for a new Delta table and returns
+   * `properties` augmented with the catalog-supplied LOCATION, the catalog-assigned table
+   * id, and the storage credentials Delta needs to write the initial commit.
    *
-   * The caller is expected to route only fresh managed-Delta CREATE / CTAS requests here
-   * (external / REPLACE-existing / path-based requests are filtered out upstream).
-   * Implementations should re-verify that contract on entry rather than trusting the
-   * caller blindly.
+   * This entry point is meant for fresh CREATE / CTAS only -- external, REPLACE-existing,
+   * and path-based requests are filtered out upstream. Implementations should re-verify
+   * that contract on entry rather than trusting the caller blindly.
+   *
+   * @param ident      identifier of the table being created.
+   * @param properties user-supplied properties from the CREATE statement.
+   * @return augmented properties carrying the staged LOCATION, the catalog-assigned table
+   *         id, and the storage credentials Delta needs to write the initial commit.
    */
   def createStagingTable(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String]
 
   /**
-   * Called by `AbstractDeltaCatalog.maybeLoadForManagedDeltaReplace` and
-   * `AbstractDeltaCatalog.maybeStageManagedDeltaCreateOrReplace` (existing-branch) for
-   * REPLACE / RTAS / CREATE OR REPLACE on an existing managed-Delta table. Loads the
-   * existing table from the catalog and returns `properties` augmented with
-   * `PROP_IS_MANAGED_LOCATION=true` plus storage credentials.
+   * Loads the existing table from the catalog and returns `properties` augmented with
+   * `PROP_IS_MANAGED_LOCATION=true` and the storage credentials Delta needs to write the
+   * REPLACE commit at the existing location. Used for REPLACE / RTAS / CREATE OR REPLACE
+   * on an existing catalog-managed Delta table.
    *
+   * @param ident      identifier of the table being replaced.
+   * @param properties user-supplied properties from the REPLACE / RTAS / CREATE OR REPLACE
+   *                   statement.
+   * @return augmented properties carrying `PROP_IS_MANAGED_LOCATION=true` and the storage
+   *         credentials Delta needs to write at the existing location. `PROP_LOCATION` is
+   *         intentionally not set; downstream Delta resolves it from the existing table.
    * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException
    *   if the catalog has no record of this identifier.
    * @throws UnsupportedOperationException
    *   if the existing table is not MANAGED.
    */
-  def buildReplaceProps(
+  def loadTableAndBuildReplaceProps(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String]
 
   /**
-   * Called by [[AbstractDeltaCatalog]] after Delta has written the initial commit, in place
-   * of the legacy `super.createTable` call. Implementations register the table with the
-   * catalog (e.g. via UC Delta API `createTable` endpoint).
+   * Registers a newly-written Delta table with the catalog, taking the place of the legacy
+   * `super.createTable` call once Delta has produced the initial commit.
    *
+   * @param ident                 identifier of the table to register.
+   * @param table                 Spark V1 [[CatalogTable]] describing the table (identifier,
+   *                              storage, schema, partitioning, properties, comment).
+   * @param metadata              Delta [[Metadata]] action produced by the initial commit
+   *                              (schema, partition columns, configuration).
+   * @param domainMetadata        Delta [[DomainMetadata]] actions produced by the initial
+   *                              commit, if any.
+   * @param protocol              Delta [[Protocol]] action produced by the initial commit
+   *                              (reader / writer versions and table features).
    * @param lastCommitTimestampMs wall-clock timestamp of the latest commit that produced
-   *   `metadata` / `protocol`, used by the catalog as the authoritative "last updated"
-   *   timestamp on the registered entry.
+   *                              `metadata` / `protocol`, used by the catalog as the
+   *                              authoritative "last updated" timestamp on the registered
+   *                              entry.
    */
   def createTable(
       ident: Identifier,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -60,6 +60,22 @@ private[catalog] trait AbstractDeltaCatalogClient {
       properties: util.Map[String, String]): util.Map[String, String]
 
   /**
+   * Called by `AbstractDeltaCatalog.maybeLoadForManagedDeltaReplace` and
+   * `AbstractDeltaCatalog.maybeStageManagedDeltaCreateOrReplace` (existing-branch) for
+   * REPLACE / RTAS / CREATE OR REPLACE on an existing managed-Delta table. Loads the
+   * existing table from the catalog and returns `properties` augmented with
+   * `PROP_IS_MANAGED_LOCATION=true` plus storage credentials.
+   *
+   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+   *   if the catalog has no record of this identifier.
+   * @throws UnsupportedOperationException
+   *   if the existing table is not MANAGED.
+   */
+  def buildReplaceProps(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String]
+
+  /**
    * Called by [[AbstractDeltaCatalog]] after Delta has written the initial commit, in place
    * of the legacy `super.createTable` call. Implementations register the table with the
    * catalog (e.g. via UC Delta API `createTable` endpoint).

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.catalyst.catalog.{
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
 import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaErrors, TableFeature}
-import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -175,7 +175,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
         Option(protocol.getWriterFeatures).map(_.asScala).getOrElse(Iterable.empty)).toSet
     features.foreach { feature =>
       if (TableFeature.featureNameToFeature(feature).isDefined) {
-        val key = s"delta.feature.$feature"
+        val key = TableFeatureProtocolUtils.propertyKey(feature)
         if (required) putRequiredFeatureOrThrow(augmented, key, ident)
         else augmented.putIfAbsent(key, FEATURE_PROP_SUPPORTED)
       } else if (required) {
@@ -258,7 +258,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
     val existingProvider =
       Option(info.getMetadata.getProvider)
         .map(_.toLowerCase(java.util.Locale.ROOT))
-        .getOrElse("delta")
+        .get
     // REPLACE cannot change the table's storage format.
     Option(properties.get(TableCatalog.PROP_PROVIDER))
       .filterNot(_.equalsIgnoreCase(existingProvider))
@@ -294,12 +294,13 @@ private[catalog] class UCDeltaCatalogClientImpl(
   /** Reject `delta.feature.catalogManaged` override to anything other than `supported`. */
   private def rejectCatalogManagedOverride(
       properties: util.Map[String, String], qualifiedName: String): Unit = {
-    val key = s"delta.feature.${CatalogOwnedTableFeature.name}"
-    Option(properties.get(key))
-      .filter(_ != FEATURE_PROP_SUPPORTED)
-      .foreach(v => throw new IllegalArgumentException(
-        s"REPLACE TABLE on $qualifiedName cannot override '$key'='$v'; expected " +
-          s"'$FEATURE_PROP_SUPPORTED'."))
+    val key = TableFeatureProtocolUtils.propertyKey(CatalogOwnedTableFeature)
+    val value = properties.get(key)
+    if (value != FEATURE_PROP_SUPPORTED) {
+      throw new IllegalArgumentException(
+        s"REPLACE TABLE on $qualifiedName cannot override '$key'='$value'; expected " +
+          s"'$FEATURE_PROP_SUPPORTED'.")
+    }
   }
 
   /**
@@ -316,7 +317,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
     if (!provider.contains("delta")) {
       throw DeltaErrors.notADeltaTableException("REPLACE TABLE", qualified)
     }
-    val catalogManagedKey = s"delta.feature.${CatalogOwnedTableFeature.name}"
+    val catalogManagedKey = TableFeatureProtocolUtils.propertyKey(CatalogOwnedTableFeature)
     val isCatalogManaged = Option(info.getMetadata.getConfiguration)
       .map(_.asScala.toMap)
       .exists(_.get(catalogManagedKey).contains(FEATURE_PROP_SUPPORTED))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -190,6 +190,10 @@ private[catalog] class UCDeltaCatalogClientImpl(
             "Delta protocol feature list.")
       }
     }
+    // Intentionally do NOT emit `delta.minReaderVersion` / `delta.minWriterVersion`: Delta
+    // derives those from the feature list, and pinning them here would put Delta into
+    // explicit table-features mode, suppressing implicit legacy writer features
+    // (appendOnly, invariants) in the resulting protocol.
   }
 
   /**
@@ -296,7 +300,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
       properties: util.Map[String, String], qualifiedName: String): Unit = {
     val key = TableFeatureProtocolUtils.propertyKey(CatalogOwnedTableFeature)
     val value = properties.get(key)
-    if (value != FEATURE_PROP_SUPPORTED) {
+    if (value != null && value != FEATURE_PROP_SUPPORTED) {
       throw new IllegalArgumentException(
         s"REPLACE TABLE on $qualifiedName cannot override '$key'='$value'; expected " +
           s"'$FEATURE_PROP_SUPPORTED'.")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTableType
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
-import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, TableFeature}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaErrors, TableFeature}
 import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
@@ -80,8 +80,8 @@ private[catalog] class UCDeltaCatalogClientImpl(
       catch {
         case _: StorageNoSuchTableException => throw new NoSuchTableException(ident)
         case e: UnsupportedTableFormatException =>
-          logInfo(log"Table ${MDC(DeltaLogKeys.TABLE_NAME, ident)} is not in Delta format; " +
-            log"falling back to the legacy catalog path. Cause: " +
+          logInfo(log"Table ${MDC(DeltaLogKeys.TABLE_NAME, ident)} is not supported by " +
+            log"UCDeltaClient; falling back to the legacy catalog path. Cause: " +
             log"${MDC(DeltaLogKeys.EXCEPTION, e.getMessage)}")
           return fallbackLoadTableFunc(ident)
         case e: CredentialFetchFailedException if serverSidePlanningEnabled =>
@@ -133,29 +133,27 @@ private[catalog] class UCDeltaCatalogClientImpl(
     augmented
   }
 
-  /**
-   * Applies UC's suggested properties via `putIfAbsent` (caller value wins). `null` values
-   * are engine-generated-at-commit sentinels (e.g. row-tracking materialized column names) --
-   * Delta rejects them as unknown configs at stage time, so skip them here and let the
-   * engine substitute them on the finalize step.
-   */
+  /** Applies UC's suggested properties to `augmented`. Caller-supplied values win. */
   private def applySuggestedProperties(
       augmented: util.Map[String, String],
       suggested: util.Map[String, String]): Unit = {
     if (suggested == null) return
+    // `null` values are engine-generated-at-commit sentinels (e.g. row-tracking materialized
+    // column names); Delta rejects them as unknown configs at stage time, so skip and let
+    // the engine substitute them on finalize.
     suggested.asScala.foreach { case (k, v) => if (v != null) augmented.putIfAbsent(k, v) }
   }
 
   /**
-   * Applies UC's required properties. A caller-supplied value that conflicts with a required
-   * key throws (see [[putRequiredOrThrow]]); `null` values are skipped (engine-generated
-   * sentinels, see [[applySuggestedProperties]]).
+   * Applies UC's required properties to `augmented`. Caller-supplied values that conflict
+   * with a required key throw.
    */
   private def applyRequiredProperties(
       augmented: util.Map[String, String],
       required: util.Map[String, String],
       ident: Identifier): Unit = {
     if (required == null) return
+    // `null` values are engine-generated-at-commit sentinels (see [[applySuggestedProperties]]).
     required.asScala.foreach { case (k, v) =>
       if (v != null) putRequiredOrThrow(augmented, k, v, ident)
     }
@@ -165,18 +163,6 @@ private[catalog] class UCDeltaCatalogClientImpl(
    * Encodes a UC protocol as `delta.feature.<name>=supported` keys so the standard
    * `CreateDeltaTableCommand` protocol-upgrade flow picks them up. A feature unknown to
    * this Delta version throws when `required`, is silently skipped when suggested.
-   *
-   * Treat the "unknown feature" branch as a hard compatibility gap, not a bug: the
-   * catalog server enforces the Delta protocol features it requires, and this client only
-   * supports the subset that its bundled Delta version understands. If the catalog
-   * requires a newer feature, upgrade Delta on the client side (or, if appropriate,
-   * relax the requirement on the server). See the Delta protocol spec for the full
-   * feature list: https://github.com/delta-io/delta/blob/master/PROTOCOL.md
-   *
-   * We intentionally do NOT emit `delta.minReaderVersion`/`delta.minWriterVersion`: Delta
-   * derives those from the feature list, and pinning them here would put Delta into
-   * explicit table-features mode, suppressing implicit legacy writer features
-   * (appendOnly, invariants) in the resulting protocol.
    */
   private def applyProtocolFeatures(
       augmented: util.Map[String, String],
@@ -193,6 +179,8 @@ private[catalog] class UCDeltaCatalogClientImpl(
         if (required) putRequiredFeatureOrThrow(augmented, key, ident)
         else augmented.putIfAbsent(key, FEATURE_PROP_SUPPORTED)
       } else if (required) {
+        // Compatibility gap: the catalog requires a Delta protocol feature this client's
+        // bundled Delta version does not understand. Throw with guidance.
         val qualifiedName = fullQualifiedTableName(ident)
         throw new IllegalArgumentException(
           s"Cannot create table $qualifiedName: catalog requires Delta protocol feature " +
@@ -205,10 +193,8 @@ private[catalog] class UCDeltaCatalogClientImpl(
   }
 
   /**
-   * Puts a UC-required key/value, but if the caller already supplied a different value for
-   * the same key (i.e. it's in `augmented` and didn't come from us), surfaces the conflict
-   * as an `IllegalArgumentException`. UC's `required` properties are policy-level
-   * enforcement and overriding them silently would defeat that purpose.
+   * Puts a UC-required key/value into `augmented`, throwing if the caller already supplied
+   * a different value for the same key.
    */
   private def putRequiredOrThrow(
       augmented: util.Map[String, String],
@@ -217,6 +203,8 @@ private[catalog] class UCDeltaCatalogClientImpl(
       ident: Identifier): Unit = {
     val existing = augmented.get(key)
     if (existing != null && existing != requiredValue) {
+      // UC's required properties are policy-level enforcement; overriding silently would
+      // defeat the policy.
       val qualifiedName = fullQualifiedTableName(ident)
       throw new IllegalArgumentException(
         s"Cannot create table $qualifiedName: catalog requires table property '$key'=" +
@@ -226,19 +214,16 @@ private[catalog] class UCDeltaCatalogClientImpl(
     augmented.put(key, requiredValue)
   }
 
-  /**
-   * Specialized variant of [[putRequiredOrThrow]] for `delta.feature.<name>=supported` keys.
-   * The error message phrases the conflict in terms of "table feature" rather than "table
-   * property" because `delta.feature.<name>` is a feature flag that only accepts the value
-   * `supported`; any other value reaching here is a user-side mistake, not a property
-   * override.
-   */
+  /** Variant of [[putRequiredOrThrow]] for `delta.feature.<name>` feature flags. */
   private def putRequiredFeatureOrThrow(
       augmented: util.Map[String, String],
       featureKey: String,
       ident: Identifier): Unit = {
     val existing = augmented.get(featureKey)
     if (existing != null && existing != FEATURE_PROP_SUPPORTED) {
+      // `delta.feature.<name>` only accepts the value `supported`; any other value reaching
+      // here is a user-side mistake. Phrase the error as "table feature" rather than "table
+      // property" so the user knows it's a feature-flag conflict.
       val qualifiedName = fullQualifiedTableName(ident)
       throw new IllegalArgumentException(
         s"Cannot create table $qualifiedName: catalog requires Delta table feature " +
@@ -249,37 +234,16 @@ private[catalog] class UCDeltaCatalogClientImpl(
   }
 
   // -------------------------------------------------------------------------
-  // DeltaCatalogClient: buildReplaceProps
+  // DeltaCatalogClient: loadTableAndBuildReplaceProps
   // -------------------------------------------------------------------------
 
-  /**
-   * Loads the existing table from UC and builds the REPLACE-augmented property map.
-   * Mirrors master `UCSingleCatalog.loadExistingManagedTablePropsForReplace`. Caller
-   * validations:
-   *   - reject caller-supplied `UC_TABLE_ID_KEY` (UC owns the table identity);
-   *   - reject `delta.feature.catalogManaged` override (must equal `supported`);
-   *   - reject `PROP_LOCATION` (cannot relocate an existing managed table);
-   *   - reject `PROP_PROVIDER` that differs from the existing table's provider
-   *     (cannot change table format via REPLACE).
-   *
-   * `PROP_IS_MANAGED_LOCATION` is not rejected here -- Spark V2's REPLACE / CREATE OR REPLACE
-   * paths inject it for existing managed tables, and `buildReplaceProps` overrides it to
-   * `true` regardless.
-   *
-   * Existing-table preconditions:
-   *   - tableType MANAGED + provider DELTA + `delta.feature.catalogManaged=supported`
-   *     (catalog-managed Delta table).
-   *
-   * Augments:
-   *   - `PROP_PROVIDER` = existing provider (defense if caller omitted USING);
-   *   - `PROP_IS_MANAGED_LOCATION` = `true`;
-   *   - storage credentials from `info.getStorageProperties`, filtered through the
-   *     `fs.*` Hadoop credential namespace, mirrored bare + `option.`-prefixed.
-   */
-  override def buildReplaceProps(
+  /** Loads the existing UC table and builds the REPLACE-augmented property map. */
+  override def loadTableAndBuildReplaceProps(
       ident: Identifier,
       properties: util.Map[String, String]): util.Map[String, String] = {
     val qualifiedName = fullQualifiedTableName(ident)
+    // Reject caller-supplied UC-system keys, `delta.feature.catalogManaged` overrides, and
+    // `PROP_LOCATION` (the existing managed table cannot be relocated via REPLACE).
     rejectSystemManagedProperties(properties, qualifiedName)
     rejectCatalogManagedOverride(properties, qualifiedName)
     if (properties.containsKey(TableCatalog.PROP_LOCATION)) {
@@ -295,12 +259,14 @@ private[catalog] class UCDeltaCatalogClientImpl(
       Option(info.getMetadata.getProvider)
         .map(_.toLowerCase(java.util.Locale.ROOT))
         .getOrElse("delta")
+    // REPLACE cannot change the table's storage format.
     Option(properties.get(TableCatalog.PROP_PROVIDER))
       .filterNot(_.equalsIgnoreCase(existingProvider))
-      .foreach(p => throw new UnsupportedOperationException(
-        s"REPLACE TABLE on $qualifiedName cannot change table format from " +
-          s"'$existingProvider' to '${p.toLowerCase(java.util.Locale.ROOT)}'."))
+      .foreach(_ => throw DeltaErrors.cannotChangeProvider())
     val augmented = new util.HashMap[String, String](properties)
+    // Re-emit the existing provider so downstream sees USING <provider> even if the caller
+    // omitted it. Mark the location as system-managed; `PROP_LOCATION` is intentionally not
+    // set so downstream Delta resolves the location from the existing table snapshot.
     augmented.put(TableCatalog.PROP_PROVIDER, existingProvider)
     augmented.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
     // Mirror credentials into the `option.`-prefixed namespace so
@@ -338,8 +304,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
 
   /**
    * Existing table must be tableType=MANAGED, provider=delta, and carry the
-   * `delta.feature.catalogManaged=supported` configuration. Mirrors
-   * `UCSingleCatalog.isCatalogManagedDeltaTable`.
+   * `delta.feature.catalogManaged=supported` configuration.
    */
   private def requireCatalogManagedDeltaTable(info: TableInfo, qualified: String): Unit = {
     if (info.getTableType != UCDeltaModels.TableType.MANAGED) {
@@ -349,9 +314,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
     }
     val provider = Option(info.getMetadata.getProvider).map(_.toLowerCase(java.util.Locale.ROOT))
     if (!provider.contains("delta")) {
-      throw new UnsupportedOperationException(
-        s"REPLACE TABLE is only supported for UC Delta tables; $qualified is " +
-          s"${provider.getOrElse("<unknown>")}.")
+      throw DeltaErrors.notADeltaTableException("REPLACE TABLE", qualified)
     }
     val catalogManagedKey = s"delta.feature.${CatalogOwnedTableFeature.name}"
     val isCatalogManaged = Option(info.getMetadata.getConfiguration)
@@ -377,7 +340,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
       lastCommitTimestampMs: Long): Unit = {
     if (table.tableType != CatalogTableType.MANAGED) {
       throw new IllegalArgumentException(
-        s"UC Delta API createTable only supports MANAGED tables; " +
+        s"UCDeltaClient createTable only supports MANAGED tables; " +
           s"got ${table.tableType} for ${fullQualifiedTableName(ident)}.")
     }
     val locationUri = table.storage.locationUri.getOrElse(throw new IllegalArgumentException(
@@ -406,17 +369,19 @@ private[catalog] class UCDeltaCatalogClientImpl(
   // -------------------------------------------------------------------------
 
   /**
-   * Defense-in-depth invariant: `AbstractDeltaCatalog.maybeStageManagedDeltaCreate` is the
-   * primary filter for non-managed-create requests (external / REPLACE-existing / path-based).
-   * If any of those markers reach this client anyway, a call site bypassed the boundary --
-   * fail loud rather than re-stage an already-prepared or mislabeled request.
+   * Asserts that `properties` is the raw, caller-supplied form expected on the fresh-create
+   * entrypoint -- no LOCATION / IS_MANAGED_LOCATION / EXTERNAL markers set, and the
+   * identifier is not path-based.
    */
   private def requireUnpreparedManagedDeltaCreate(
       ident: Identifier,
       properties: util.Map[String, String]): Unit = {
+    // Defense in depth: upstream routing is supposed to filter external / REPLACE-existing /
+    // path-based requests before reaching this client. If those markers appear here, fail
+    // loud rather than re-stage an already-prepared or mislabeled request.
     val qualifiedName = fullQualifiedTableName(ident)
     def bail(reason: String): Nothing = throw new IllegalStateException(
-      s"Managed Delta create for $qualifiedName reached the UC Delta API path in an " +
+      s"Managed Delta create for $qualifiedName reached the UCDeltaClient path in an " +
         s"unexpected state: $reason. The upstream catalog must only route fresh managed " +
         "Delta CREATE / CTAS here with raw caller-supplied properties.")
     if (properties.containsKey(TableCatalog.PROP_LOCATION)) {
@@ -489,7 +454,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
             iceberg.getConvertedDeltaTimestamp
         )
       }.getOrElse(Map.empty[String, String])
-    // Match master UC's V1Table shape: pack tableConfig + credentials + UniForm into
+    // Match UCSingleCatalog's V1Table shape: pack tableConfig + credentials + UniForm into
     // `storage.properties`, leave `catalogTable.properties` empty. Required for
     // downstream streaming/routing compatibility.
     val storage = CatalogStorageFormat.empty.copy(
@@ -531,20 +496,20 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   private val loadTableInvocationsCounter: AtomicLong = new AtomicLong(0L)
 
   /**
-   * Bumped only when `loadTable` returned a Delta table via the UC Delta API (no fallback,
+   * Bumped only when `loadTable` returned a Delta table via the UCDeltaClient (no fallback,
    * no rethrow). Read via the *ForTesting API.
    */
   private val successfulDeltaRestApiLoadsCounter: AtomicLong = new AtomicLong(0L)
 
   /**
    * Test-only read accessor for the `loadTable` invocation counter. Used by integration
-   * tests to verify the UC Delta API code path ran. Not part of any public API; production
+   * tests to verify the UCDeltaClient code path ran. Not part of any public API; production
    * code must not depend on it.
    */
   def loadTableInvocationsForTesting: Long = loadTableInvocationsCounter.get()
 
   /**
-   * Test-only read accessor for the count of `loadTable` calls served by the UC Delta API
+   * Test-only read accessor for the count of `loadTable` calls served by the UCDeltaClient
    * (no fallback, no rethrow). Not part of any public API.
    */
   def successfulDeltaRestApiLoadsForTesting: Long = successfulDeltaRestApiLoadsCounter.get()
@@ -560,7 +525,7 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
 
   private[catalog] val defaultFallbackLoadTableFunc: Identifier => Table = ident =>
     throw new IllegalStateException(
-      s"Non-Delta table $ident cannot be served via the UC Delta API path and no " +
+      s"Non-Delta table $ident cannot be served via the UCDeltaClient path and no " +
         "fallback catalog was configured.")
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTableType
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
-import org.apache.spark.sql.delta.TableFeature
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, TableFeature}
 import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
@@ -249,6 +249,122 @@ private[catalog] class UCDeltaCatalogClientImpl(
   }
 
   // -------------------------------------------------------------------------
+  // DeltaCatalogClient: buildReplaceProps
+  // -------------------------------------------------------------------------
+
+  /**
+   * Loads the existing table from UC and builds the REPLACE-augmented property map.
+   * Mirrors master `UCSingleCatalog.loadExistingManagedTablePropsForReplace`. Caller
+   * validations:
+   *   - reject caller-supplied `UC_TABLE_ID_KEY` (UC owns the table identity);
+   *   - reject `delta.feature.catalogManaged` override (must equal `supported`);
+   *   - reject `PROP_LOCATION` (cannot relocate an existing managed table);
+   *   - reject `PROP_PROVIDER` that differs from the existing table's provider
+   *     (cannot change table format via REPLACE).
+   *
+   * `PROP_IS_MANAGED_LOCATION` is not rejected here -- Spark V2's REPLACE / CREATE OR REPLACE
+   * paths inject it for existing managed tables, and `buildReplaceProps` overrides it to
+   * `true` regardless.
+   *
+   * Existing-table preconditions:
+   *   - tableType MANAGED + provider DELTA + `delta.feature.catalogManaged=supported`
+   *     (catalog-managed Delta table).
+   *
+   * Augments:
+   *   - `PROP_PROVIDER` = existing provider (defense if caller omitted USING);
+   *   - `PROP_IS_MANAGED_LOCATION` = `true`;
+   *   - storage credentials from `info.getStorageProperties`, filtered through the
+   *     `fs.*` Hadoop credential namespace, mirrored bare + `option.`-prefixed.
+   */
+  override def buildReplaceProps(
+      ident: Identifier,
+      properties: util.Map[String, String]): util.Map[String, String] = {
+    val qualifiedName = fullQualifiedTableName(ident)
+    rejectSystemManagedProperties(properties, qualifiedName)
+    rejectCatalogManagedOverride(properties, qualifiedName)
+    if (properties.containsKey(TableCatalog.PROP_LOCATION)) {
+      throw new UnsupportedOperationException(
+        s"REPLACE TABLE cannot specify '${TableCatalog.PROP_LOCATION}' on the existing " +
+          s"UC-managed Delta table $qualifiedName.")
+    }
+    val info =
+      try ucClient.loadTable(toStorageTableIdent(ident))
+      catch { case _: StorageNoSuchTableException => throw new NoSuchTableException(ident) }
+    requireCatalogManagedDeltaTable(info, qualifiedName)
+    val existingProvider =
+      Option(info.getMetadata.getProvider)
+        .map(_.toLowerCase(java.util.Locale.ROOT))
+        .getOrElse("delta")
+    Option(properties.get(TableCatalog.PROP_PROVIDER))
+      .filterNot(_.equalsIgnoreCase(existingProvider))
+      .foreach(p => throw new UnsupportedOperationException(
+        s"REPLACE TABLE on $qualifiedName cannot change table format from " +
+          s"'$existingProvider' to '${p.toLowerCase(java.util.Locale.ROOT)}'."))
+    val augmented = new util.HashMap[String, String](properties)
+    augmented.put(TableCatalog.PROP_PROVIDER, existingProvider)
+    augmented.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+    // Mirror credentials into the `option.`-prefixed namespace so
+    // `getTablePropsAndWriteOptions` routes them into writeOptions for Hadoop config
+    // injection (mirrors `UCSingleCatalog.setCredentialProps`).
+    info.getStorageProperties.asScala.foreach { case (k, v) =>
+      if (k.startsWith("fs.")) {
+        augmented.put(k, v)
+        augmented.put(TableCatalog.OPTION_PREFIX + k, v)
+      }
+    }
+    augmented
+  }
+
+  /** Reject caller attempts to set properties that the catalog manages. */
+  private def rejectSystemManagedProperties(
+      properties: util.Map[String, String], qualifiedName: String): Unit = {
+    if (properties.containsKey(UC_TABLE_ID_KEY)) {
+      throw new IllegalArgumentException(
+        s"REPLACE TABLE on $qualifiedName cannot specify catalog-managed property " +
+          s"'$UC_TABLE_ID_KEY'.")
+    }
+  }
+
+  /** Reject `delta.feature.catalogManaged` override to anything other than `supported`. */
+  private def rejectCatalogManagedOverride(
+      properties: util.Map[String, String], qualifiedName: String): Unit = {
+    val key = s"delta.feature.${CatalogOwnedTableFeature.name}"
+    Option(properties.get(key))
+      .filter(_ != FEATURE_PROP_SUPPORTED)
+      .foreach(v => throw new IllegalArgumentException(
+        s"REPLACE TABLE on $qualifiedName cannot override '$key'='$v'; expected " +
+          s"'$FEATURE_PROP_SUPPORTED'."))
+  }
+
+  /**
+   * Existing table must be tableType=MANAGED, provider=delta, and carry the
+   * `delta.feature.catalogManaged=supported` configuration. Mirrors
+   * `UCSingleCatalog.isCatalogManagedDeltaTable`.
+   */
+  private def requireCatalogManagedDeltaTable(info: TableInfo, qualified: String): Unit = {
+    if (info.getTableType != UCDeltaModels.TableType.MANAGED) {
+      throw new UnsupportedOperationException(
+        s"REPLACE TABLE is only supported for catalog-managed UC Delta tables; " +
+          s"$qualified is ${info.getTableType}.")
+    }
+    val provider = Option(info.getMetadata.getProvider).map(_.toLowerCase(java.util.Locale.ROOT))
+    if (!provider.contains("delta")) {
+      throw new UnsupportedOperationException(
+        s"REPLACE TABLE is only supported for UC Delta tables; $qualified is " +
+          s"${provider.getOrElse("<unknown>")}.")
+    }
+    val catalogManagedKey = s"delta.feature.${CatalogOwnedTableFeature.name}"
+    val isCatalogManaged = Option(info.getMetadata.getConfiguration)
+      .map(_.asScala.toMap)
+      .exists(_.get(catalogManagedKey).contains(FEATURE_PROP_SUPPORTED))
+    if (!isCatalogManaged) {
+      throw new UnsupportedOperationException(
+        s"REPLACE TABLE is only supported for catalog-managed UC Delta tables; " +
+          s"$qualified is not catalog-managed ('$catalogManagedKey' is not set).")
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // DeltaCatalogClient: createTable
   // -------------------------------------------------------------------------
 
@@ -350,7 +466,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
 
   private def toV1Table(ident: Identifier, info: TableInfo): V1Table = {
     val m = info.getMetadata
-    val properties = Option(m.getConfiguration)
+    val tableConfig = Option(m.getConfiguration)
       .map(_.asScala.toMap)
       .getOrElse(Map.empty[String, String])
     val partitionColumns = Option(m.getPartitionColumns)
@@ -373,9 +489,12 @@ private[catalog] class UCDeltaCatalogClientImpl(
             iceberg.getConvertedDeltaTimestamp
         )
       }.getOrElse(Map.empty[String, String])
+    // Match master UC's V1Table shape: pack tableConfig + credentials + UniForm into
+    // `storage.properties`, leave `catalogTable.properties` empty. Required for
+    // downstream streaming/routing compatibility.
     val storage = CatalogStorageFormat.empty.copy(
       locationUri = Some(new URI(info.getLocation)),
-      properties = properties ++ info.getStorageProperties.asScala.toMap ++ uniformProps)
+      properties = tableConfig ++ info.getStorageProperties.asScala.toMap ++ uniformProps)
     val catalogTable = CatalogTable(
       identifier = TableIdentifier(ident.name(), ident.namespace().headOption, Some(catalogName)),
       tableType = fromUcTableType(info.getTableType),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -481,7 +481,9 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     assert(e.getMessage.contains("catalog-managed"))
   }
 
-  test("loadTableAndBuildReplaceProps: existing non-Delta provider throws notADeltaTableException") {
+  test(
+      "loadTableAndBuildReplaceProps: existing non-Delta provider throws " +
+        "notADeltaTableException") {
     val client = replaceClient(
       existingDeltaTableInfo(provider = "PARQUET", catalogManaged = false))
     val e = intercept[org.apache.spark.sql.delta.DeltaAnalysisException] {
@@ -502,7 +504,9 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     assert(e.getMessage.contains("catalog-managed"))
   }
 
-  test("loadTableAndBuildReplaceProps: caller PROP_PROVIDER different from existing throws cannotChangeProvider") {
+  test(
+      "loadTableAndBuildReplaceProps: caller PROP_PROVIDER different from existing throws " +
+        "cannotChangeProvider") {
     val client = replaceClient(existingDeltaTableInfo())
     val e = intercept[org.apache.spark.sql.delta.DeltaAnalysisException] {
       client.loadTableAndBuildReplaceProps(
@@ -514,7 +518,9 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     assert(e.getMessage.contains("provider"))
   }
 
-  test("loadTableAndBuildReplaceProps: StorageNoSuchTableException is wrapped as NoSuchTableException") {
+  test(
+      "loadTableAndBuildReplaceProps: StorageNoSuchTableException is wrapped as " +
+        "NoSuchTableException") {
     val client = replaceClient(throw new StorageNoSuchTableException("no such table"))
     intercept[org.apache.spark.sql.catalyst.analysis.NoSuchTableException] {
       client.loadTableAndBuildReplaceProps(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -113,12 +113,11 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     _ => throw new UnsupportedOperationException("fallback not expected in this test")
 
   /**
-   * createStagingTable contract tests. The contract: only fresh managed Delta CREATE / CTAS
-   * requests with raw caller-supplied properties may reach this client. The routing boundary
-   * (`AbstractDeltaCatalog.maybeStageManagedDeltaCreate`) is responsible for that separation;
-   * if any "already-prepared" marker (LOCATION / IS_MANAGED_LOCATION / EXTERNAL / path-based
-   * ident) is seen here, it means some call site bypassed the boundary -- the impl fails
-   * loudly as defense-in-depth.
+   * createStagingTable contract tests. The contract: only fresh Delta CREATE / CTAS requests
+   * with raw caller-supplied properties may reach this client; upstream routing filters out
+   * external / REPLACE-existing / path-based requests. If any "already-prepared" marker
+   * (LOCATION / IS_MANAGED_LOCATION / EXTERNAL / path-based ident) is seen here, the impl
+   * fails loudly as defense-in-depth.
    */
   private def newRecordingClient(
       requiredProtocol: UCDeltaModels.DeltaProtocol = null,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -26,7 +26,7 @@ import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier => S
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{DeltaProtocol, StagingTableInfo, TableInfo, TableType => UcTableType}
-import io.delta.storage.commit.uccommitcoordinator.exceptions.CredentialFetchFailedException
+import io.delta.storage.commit.uccommitcoordinator.exceptions.{CredentialFetchFailedException, NoSuchTableException => StorageNoSuchTableException}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
 import org.apache.spark.sql.QueryTest
@@ -384,6 +384,143 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       client.createStagingTable(ident, stageProps("delta.catalogManaged" -> "supported")))
     assert(ex.getMessage.contains("path-based"))
     assert(stub.stagedRequests.isEmpty)
+  }
+
+  // -------------------------------------------------------------------------
+  // loadTableAndBuildReplaceProps: validation + augmentation for REPLACE / RTAS /
+  // CREATE OR REPLACE on an existing catalog-managed Delta table.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds a TableInfo that, by default, satisfies all catalog-managed-Delta preconditions
+   * (tableType=MANAGED, provider=delta, `delta.feature.catalogManaged=supported`). Tests
+   * override individual fields to exercise the rejection branches.
+   */
+  private def existingDeltaTableInfo(
+      tableType: UCDeltaModels.TableType = UCDeltaModels.TableType.MANAGED,
+      provider: String = "DELTA",
+      catalogManaged: Boolean = true,
+      storageProperties: util.Map[String, String] =
+        util.Map.of("fs.s3a.access.key", "existing-key")): TableInfo = {
+    val config = new util.HashMap[String, String]()
+    if (catalogManaged) config.put("delta.feature.catalogManaged", "supported")
+    val metadata = new TestMetadata(provider = provider, configuration = config)
+    new TableInfo(
+      UUID.fromString("00000000-0000-0000-0000-000000000002"),
+      tableType,
+      "s3://bucket/existing/tbl",
+      metadata,
+      storageProperties,
+      Optional.empty())
+  }
+
+  private def replaceClient(loadResult: => TableInfo): UCDeltaCatalogClientImpl =
+    new UCDeltaCatalogClientImpl(catalogName = "main", ucClient = new StubUCDeltaClient(loadResult))
+
+  test(
+      "loadTableAndBuildReplaceProps: happy path augments props with provider + " +
+        "is_managed_location + credentials, and does NOT set PROP_LOCATION") {
+    val client = replaceClient(existingDeltaTableInfo())
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.feature.catalogManaged" -> "supported"))
+    assert(out.get(TableCatalog.PROP_PROVIDER) === "delta",
+      "existing provider must be re-emitted")
+    assert(out.get(TableCatalog.PROP_IS_MANAGED_LOCATION) === "true")
+    assert(!out.containsKey(TableCatalog.PROP_LOCATION),
+      "PROP_LOCATION must NOT be set; downstream resolves location from existing snapshot")
+    assert(out.get("fs.s3a.access.key") === "existing-key",
+      "fs.* storage credentials must be mirrored bare")
+    assert(out.get(TableCatalog.OPTION_PREFIX + "fs.s3a.access.key") === "existing-key",
+      "fs.* storage credentials must also be mirrored under the option.-prefixed key")
+  }
+
+  test("loadTableAndBuildReplaceProps: caller-supplied UC_TABLE_ID_KEY throws") {
+    val client = replaceClient(existingDeltaTableInfo())
+    val e = intercept[IllegalArgumentException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps(
+          "delta.feature.catalogManaged" -> "supported",
+          "io.unitycatalog.tableId" -> "user-supplied"))
+    }
+    assert(e.getMessage.contains("io.unitycatalog.tableId"))
+  }
+
+  test("loadTableAndBuildReplaceProps: caller-supplied catalogManaged != supported throws") {
+    val client = replaceClient(existingDeltaTableInfo())
+    val e = intercept[IllegalArgumentException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps("delta.feature.catalogManaged" -> "disabled"))
+    }
+    assert(e.getMessage.contains("catalogManaged"))
+    assert(e.getMessage.contains("disabled"))
+  }
+
+  test("loadTableAndBuildReplaceProps: caller-supplied PROP_LOCATION throws") {
+    val client = replaceClient(existingDeltaTableInfo())
+    val e = intercept[UnsupportedOperationException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps(
+          "delta.feature.catalogManaged" -> "supported",
+          TableCatalog.PROP_LOCATION -> "s3://other/location"))
+    }
+    assert(e.getMessage.contains(TableCatalog.PROP_LOCATION))
+  }
+
+  test("loadTableAndBuildReplaceProps: existing EXTERNAL table is rejected") {
+    val client = replaceClient(
+      existingDeltaTableInfo(tableType = UCDeltaModels.TableType.EXTERNAL))
+    val e = intercept[UnsupportedOperationException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps("delta.feature.catalogManaged" -> "supported"))
+    }
+    assert(e.getMessage.contains("catalog-managed"))
+  }
+
+  test("loadTableAndBuildReplaceProps: existing non-Delta provider throws notADeltaTableException") {
+    val client = replaceClient(
+      existingDeltaTableInfo(provider = "PARQUET", catalogManaged = false))
+    val e = intercept[org.apache.spark.sql.delta.DeltaAnalysisException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps("delta.feature.catalogManaged" -> "supported"))
+    }
+    assert(e.getMessage.contains("not a Delta table"))
+  }
+
+  test("loadTableAndBuildReplaceProps: existing table missing catalogManaged config is rejected") {
+    val client = replaceClient(existingDeltaTableInfo(catalogManaged = false))
+    val e = intercept[UnsupportedOperationException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps("delta.feature.catalogManaged" -> "supported"))
+    }
+    assert(e.getMessage.contains("catalog-managed"))
+  }
+
+  test("loadTableAndBuildReplaceProps: caller PROP_PROVIDER different from existing throws cannotChangeProvider") {
+    val client = replaceClient(existingDeltaTableInfo())
+    val e = intercept[org.apache.spark.sql.delta.DeltaAnalysisException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps(
+          "delta.feature.catalogManaged" -> "supported",
+          TableCatalog.PROP_PROVIDER -> "parquet"))
+    }
+    assert(e.getMessage.contains("provider"))
+  }
+
+  test("loadTableAndBuildReplaceProps: StorageNoSuchTableException is wrapped as NoSuchTableException") {
+    val client = replaceClient(throw new StorageNoSuchTableException("no such table"))
+    intercept[org.apache.spark.sql.catalyst.analysis.NoSuchTableException] {
+      client.loadTableAndBuildReplaceProps(
+        Identifier.of(Array("sch"), "tbl"),
+        stageProps("delta.feature.catalogManaged" -> "supported"))
+    }
   }
 
   test("loadTable converts TableInfo to V1Table with catalog-supplied fields") {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException;
 import org.junit.jupiter.api.Test;
 
 public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationBaseTest {
@@ -379,6 +380,7 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
   // `delta.feature.clustering` properties. The REPLACE does not propagate the cluster
   // removal to UC's domain metadata. Pinned so we notice if the behavior changes; when
   // fixed, update the assertion to reflect the cleared state.
+  // TODO: fix this issue https://github.com/delta-io/delta/issues/6915
   @Test
   public void testReplaceClusteredManagedTableWithNoneRetainsStaleUcClustering() throws Exception {
     String tableName = "cluster_to_none_" + UUID.randomUUID().toString().replace("-", "");
@@ -430,6 +432,28 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
     } finally {
       sql("DROP TABLE IF EXISTS %s", fullTableName);
     }
+  }
+
+  // Path-based identifiers (e.g. `delta.`/tmp/foo``) are not valid UC table references --
+  // UC has no entry for them. `shouldRouteReplaceThroughDeltaCatalogClient` skips routing on
+  // those, so the request falls through to the standard Spark V2 REPLACE flow, which surfaces
+  // `CannotReplaceMissingTableException` for the unresolved identifier. Pinned so that any
+  // future change to the routing gate's path-based predicate (or the fall-through behavior)
+  // is caught here instead of silently regressing.
+  @Test
+  public void testReplaceOnPathBasedIdentifierIsRejected() throws Exception {
+    withTempDir(
+        (Path location) -> {
+          assertThatThrownBy(
+                  () ->
+                      sql(
+                          "REPLACE TABLE delta.`%s` (i INT, s STRING) USING DELTA "
+                              + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported')",
+                          location.toString()))
+              .isInstanceOf(CannotReplaceMissingTableException.class)
+              .hasMessageContaining("TABLE_OR_VIEW_NOT_FOUND")
+              .hasMessageContaining(location.toString());
+        });
   }
 
   // CREATE OR REPLACE on a non-existent identifier must take the fresh-CREATE fallback in

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
@@ -17,10 +17,14 @@
 package io.sparkuctest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import io.unitycatalog.client.api.TablesApi;
+import io.unitycatalog.client.model.TableInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
 
 public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationBaseTest {
@@ -284,6 +288,169 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
                 buildStatement(
                     operation, fullTableName, "i INT, s STRING", "", null, "2 AS i, 'new' AS s"));
           });
+    }
+  }
+
+  // REPLACE with `USING <non-Delta>` on a managed Delta table is rejected. The statement's
+  // non-Delta provider makes `shouldDelegateReplaceToDeltaApi` return false in
+  // UCSingleCatalog, so the legacy validation throws before the Delta-side
+  // `loadTableAndBuildReplaceProps` is reached. The existing table must survive intact.
+  @Test
+  public void testProviderChangeIsRejectedAndPreservesExistingTable() throws Exception {
+    String tableName = "provider_change_" + UUID.randomUUID().toString().replace("-", "");
+    withNewTable(
+        tableName,
+        "i INT, s STRING",
+        TableType.MANAGED,
+        fullTableName -> {
+          sql("INSERT INTO %s VALUES (1, 'old')", fullTableName);
+          String ucTableIdBefore = currentUcTableId(fullTableName);
+          long versionBefore = currentVersion(fullTableName);
+
+          assertThrowsWithCauseContaining(
+              "Cannot change table format from DELTA to PARQUET",
+              () ->
+                  sql(
+                      "REPLACE TABLE %s USING PARQUET AS SELECT 2 AS i, 'new' AS s",
+                      fullTableName));
+
+          assertThat(currentUcTableId(fullTableName)).isEqualTo(ucTableIdBefore);
+          assertThat(currentVersion(fullTableName)).isEqualTo(versionBefore);
+          assertThat(sql("SELECT * FROM %s", fullTableName)).containsExactly(row("1", "old"));
+        });
+  }
+
+  // REPLACE that specifies a `LOCATION` on an existing UC-managed Delta table is
+  // rejected by `loadTableAndBuildReplaceProps` before any Delta commit lands. The
+  // REPLACE routes through the Delta-side path even when `PROP_LOCATION` is set so the
+  // validation can fire early (a previous version skipped routing on `PROP_LOCATION`,
+  // which let the REPLACE write a Delta commit before the post-commit catalog-update
+  // hook discovered the inconsistency).
+  @Test
+  public void testReplaceManagedTableWithLocationIsRejected() throws Exception {
+    withNewTable(
+        "managed_replace_with_location",
+        "i INT, s STRING",
+        TableType.MANAGED,
+        fullTableName ->
+            withTempDir(
+                (Path externalLocation) ->
+                    assertThatThrownBy(
+                            () ->
+                                sql(
+                                    "REPLACE TABLE %s (i INT, s STRING) USING DELTA LOCATION '%s'",
+                                    fullTableName, externalLocation.toString()))
+                        .hasMessageContaining(
+                            "only catalog-managed Delta tables can be replaced on this path")));
+  }
+
+  // Same as above for the EXTERNAL->EXTERNAL same-location case: the legacy UC path
+  // would have rejected this with a clear "REPLACE TABLE is only supported for
+  // catalog-managed UC Delta tables" message. With the delegation gate in place, the
+  // Delta-side validation now fires and produces the location-rejection error.
+  @Test
+  public void testReplaceExternalTableWithSameLocationIsRejected() throws Exception {
+    withTempDir(
+        (Path location) -> {
+          String tableName =
+              "external_same_loc_replace_" + UUID.randomUUID().toString().replace("-", "");
+          String fullTableName = fullTableName(tableName);
+          try {
+            sql("DROP TABLE IF EXISTS %s", fullTableName);
+            sql(
+                "CREATE TABLE %s (i INT, s STRING) USING DELTA LOCATION '%s'",
+                fullTableName, location.toString());
+            assertThatThrownBy(
+                    () ->
+                        sql(
+                            "REPLACE TABLE %s (i INT, s STRING) USING DELTA LOCATION '%s'",
+                            fullTableName, location.toString()))
+                .hasMessageContaining(
+                    "only catalog-managed Delta tables can be replaced on this path");
+          } finally {
+            sql("DROP TABLE IF EXISTS %s", fullTableName);
+          }
+        });
+  }
+
+  // Replacing a clustered managed Delta table with a non-clustered, non-partitioned one
+  // succeeds at the data plane (the table is queryable with the new schema, INSERTs land
+  // correctly), but UC's metastore retains the seed's `clusteringColumns` and
+  // `delta.feature.clustering` properties. The REPLACE does not propagate the cluster
+  // removal to UC's domain metadata. Pinned so we notice if the behavior changes; when
+  // fixed, update the assertion to reflect the cleared state.
+  @Test
+  public void testReplaceClusteredManagedTableWithNoneRetainsStaleUcClustering() throws Exception {
+    String tableName = "cluster_to_none_" + UUID.randomUUID().toString().replace("-", "");
+    String fullTableName = fullTableName(tableName);
+    try {
+      sql(
+          "CREATE TABLE %s (col1 STRING, col2 STRING) USING DELTA "
+              + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported') CLUSTER BY (col1)",
+          fullTableName);
+
+      sql(
+          "REPLACE TABLE %s (i INT, s STRING) USING DELTA "
+              + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported')",
+          fullTableName);
+
+      sql("INSERT INTO %s VALUES (1, 'a')", fullTableName);
+      assertThat(sql("SELECT * FROM %s", fullTableName)).containsExactly(row("1", "a"));
+
+      TablesApi tablesApi = new TablesApi(unityCatalogInfo().createApiClient());
+      TableInfo info = tablesApi.getTable(fullTableName, false, false);
+      assertThat(info.getProperties())
+          .containsEntry("clusteringColumns", "[[\"col1\"]]")
+          .containsEntry("delta.feature.clustering", "supported");
+    } finally {
+      sql("DROP TABLE IF EXISTS %s", fullTableName);
+    }
+  }
+
+  // Delta unconditionally rejects replacing a clustered table with a partitioned one
+  // (`DELTA_CLUSTERING_REPLACE_TABLE_WITH_PARTITIONED_TABLE`, raised by
+  // `CreateDeltaTableCommand.validatePrerequisitesForClusteredTable`).
+  @Test
+  public void testReplaceClusteredManagedTableWithPartitionedIsRejected() throws Exception {
+    String tableName = "cluster_to_partition_" + UUID.randomUUID().toString().replace("-", "");
+    String fullTableName = fullTableName(tableName);
+    try {
+      sql(
+          "CREATE TABLE %s (col1 STRING, col2 STRING) USING DELTA "
+              + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported') CLUSTER BY (col1)",
+          fullTableName);
+
+      assertThatThrownBy(
+              () ->
+                  sql(
+                      "REPLACE TABLE %s (i INT, s STRING) USING DELTA "
+                          + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported') PARTITIONED BY (i)",
+                      fullTableName))
+          .hasMessageContaining("DELTA_CLUSTERING_REPLACE_TABLE_WITH_PARTITIONED_TABLE");
+    } finally {
+      sql("DROP TABLE IF EXISTS %s", fullTableName);
+    }
+  }
+
+  // CREATE OR REPLACE on a non-existent identifier must take the fresh-CREATE fallback in
+  // `AbstractDeltaCatalog.maybeStageDeltaCreateOrReplace` (catching `NoSuchTableException`
+  // from `loadTableAndBuildReplaceProps` and calling `createStagingTable` instead).
+  @Test
+  public void testCreateOrReplaceCreatesNewTableWhenMissing() throws Exception {
+    String tableName = "cor_missing_" + UUID.randomUUID().toString().replace("-", "");
+    String fullTableName = fullTableName(tableName);
+    try {
+      sql("DROP TABLE IF EXISTS %s", fullTableName);
+
+      sql(
+          "CREATE OR REPLACE TABLE %s (i INT, s STRING) USING DELTA "
+              + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported')",
+          fullTableName);
+
+      sql("INSERT INTO %s VALUES (1, 'a')", fullTableName);
+      assertThat(sql("SELECT * FROM %s", fullTableName)).containsExactly(row("1", "a"));
+    } finally {
+      sql("DROP TABLE IF EXISTS %s", fullTableName);
     }
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -42,7 +42,6 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.assertj.core.api.Assertions;
@@ -89,6 +88,23 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
 
   private static final String EXTERNAL_TBLPROPERTIES_CLAUSE = "TBLPROPERTIES ('Foo'='Bar')";
 
+  /** The DDL command that introduces a CREATE / REPLACE / CTAS / RTAS statement. */
+  private enum DdlMode {
+    CREATE("CREATE"),
+    REPLACE("REPLACE"),
+    CREATE_OR_REPLACE("CREATE OR REPLACE");
+
+    private final String sql;
+
+    DdlMode(String sql) {
+      this.sql = sql;
+    }
+
+    String sql() {
+      return sql;
+    }
+  }
+
   String tempDir;
   private Set<String> tablesToCleanUp = new HashSet<>();
 
@@ -124,7 +140,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     private Optional<String> clusterColumn = Optional.empty();
     private Optional<Pair<Integer, String>> asSelect = Optional.empty();
     private Optional<String> comment = Optional.empty();
-    private boolean replaceTable = false;
+    private DdlMode ddlMode = DdlMode.CREATE;
 
     public TableSetupOptions() {}
 
@@ -182,7 +198,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     }
 
     public String ddlCommand() {
-      return replaceTable ? "REPLACE" : "CREATE";
+      return ddlMode.sql();
     }
 
     private String createManagedTableSql() {
@@ -237,37 +253,110 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
   public Stream<DynamicTest> testCreateTable() {
     int counter = 0;
     List<DynamicTest> tests = new ArrayList<>();
-    for (TableType tableType : TableType.values()) {
-      for (boolean withPartition : List.of(true, false)) {
-        for (boolean withCluster : List.of(true, false)) {
-          if (withCluster && withPartition) {
-            // Can not have CLUSTER BY and PARTITIONED BY on the same table
-            continue;
-          }
-          for (boolean withAsSelect : List.of(true, false)) {
-            for (boolean replaceTable : List.of(true, false)) {
-              String displayName =
-                  String.format(
-                      "tableType=%s, withPartition=%s, withCluster=%s, withAsSelect=%s, replaceTable=%s",
-                      tableType, withPartition, withCluster, withAsSelect, replaceTable);
-              counter++;
-              int finalCounter = counter;
-              tests.add(
-                  DynamicTest.dynamicTest(
-                      displayName,
-                      () ->
-                          runTableCreationTest(
-                              finalCounter,
-                              tableType,
-                              withPartition,
-                              withCluster,
-                              withAsSelect,
-                              replaceTable)));
-            }
+
+    // Matrix 1: EXTERNAL tables -- CREATE only. REPLACE on EXTERNAL fails for an unrelated
+    // Delta-side reason (UpdateCatalog post-commit hook) and is covered by the dedicated
+    // testExternalReplaceIsRejected test.
+    for (boolean withPartition : List.of(true, false)) {
+      for (boolean withCluster : List.of(true, false)) {
+        if (withCluster && withPartition) {
+          // Can not have CLUSTER BY and PARTITIONED BY on the same table
+          continue;
+        }
+        for (boolean withAsSelect : List.of(true, false)) {
+          String displayName =
+              String.format(
+                  "tableType=EXTERNAL, withPartition=%s, withCluster=%s, withAsSelect=%s, ddlMode=CREATE",
+                  withPartition, withCluster, withAsSelect);
+          counter++;
+          int finalCounter = counter;
+          tests.add(
+              DynamicTest.dynamicTest(
+                  displayName,
+                  () ->
+                      runTableCreationTest(
+                          finalCounter,
+                          TableType.EXTERNAL,
+                          withPartition,
+                          withCluster,
+                          withAsSelect,
+                          DdlMode.CREATE,
+                          /* withPartitionBeforeReplace */ false,
+                          /* withClusterBeforeReplace */ false)));
+        }
+      }
+    }
+
+    // Matrix 2: MANAGED tables -- CREATE and REPLACE (seed has no partition / cluster).
+    for (boolean withPartition : List.of(true, false)) {
+      for (boolean withCluster : List.of(true, false)) {
+        if (withCluster && withPartition) {
+          // Can not have CLUSTER BY and PARTITIONED BY on the same table
+          continue;
+        }
+        for (boolean withAsSelect : List.of(true, false)) {
+          for (DdlMode ddlMode : List.of(DdlMode.CREATE, DdlMode.REPLACE)) {
+            String displayName =
+                String.format(
+                    "tableType=MANAGED, withPartition=%s, withCluster=%s, withAsSelect=%s, ddlMode=%s",
+                    withPartition, withCluster, withAsSelect, ddlMode);
+            counter++;
+            int finalCounter = counter;
+            tests.add(
+                DynamicTest.dynamicTest(
+                    displayName,
+                    () ->
+                        runTableCreationTest(
+                            finalCounter,
+                            TableType.MANAGED,
+                            withPartition,
+                            withCluster,
+                            withAsSelect,
+                            ddlMode,
+                            /* withPartitionBeforeReplace */ false,
+                            /* withClusterBeforeReplace */ false)));
           }
         }
       }
     }
+
+    // Matrix 3: MANAGED REPLACE — partition / cluster shape transitions on existing
+    // tables. Only the transitions exercised through the standard runner live here:
+    //   - partition->cluster, partition->none
+    // The other two (`cluster->none` pins a known UC-side stale-metadata issue; and
+    // `cluster->partition` is unconditionally rejected by Delta) are in
+    // UCDeltaManagedReplaceSemanticsTest because they don't use this runner.
+    counter++;
+    int partitionToClusterCounter = counter;
+    tests.add(
+        DynamicTest.dynamicTest(
+            "tableType=MANAGED, ddlMode=REPLACE, transition=partition->cluster",
+            () ->
+                runTableCreationTest(
+                    partitionToClusterCounter,
+                    TableType.MANAGED,
+                    /* withPartition */ false,
+                    /* withCluster */ true,
+                    /* withAsSelect */ false,
+                    DdlMode.REPLACE,
+                    /* withPartitionBeforeReplace */ true,
+                    /* withClusterBeforeReplace */ false)));
+    counter++;
+    int partitionToNoneCounter = counter;
+    tests.add(
+        DynamicTest.dynamicTest(
+            "tableType=MANAGED, ddlMode=REPLACE, transition=partition->none",
+            () ->
+                runTableCreationTest(
+                    partitionToNoneCounter,
+                    TableType.MANAGED,
+                    /* withPartition */ false,
+                    /* withCluster */ false,
+                    /* withAsSelect */ false,
+                    DdlMode.REPLACE,
+                    /* withPartitionBeforeReplace */ true,
+                    /* withClusterBeforeReplace */ false)));
+
     return tests.stream();
   }
 
@@ -277,7 +366,9 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       boolean withPartition,
       boolean withCluster,
       boolean withAsSelect,
-      boolean replaceTable)
+      DdlMode ddlMode,
+      boolean withPartitionBeforeReplace,
+      boolean withClusterBeforeReplace)
       throws Exception {
     UnityCatalogInfo uc = unityCatalogInfo();
     final String comment = "This is comment.";
@@ -292,7 +383,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
             .setSchemaName(schemaName)
             .setTableName(tableName)
             .setTableType(tableType)
-            .setReplaceTable(replaceTable)
+            .setDdlMode(ddlMode)
             .setComment(comment);
     if (withPartition) {
       options.setPartitionColumn("i");
@@ -306,22 +397,40 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     LOG.info("Running table creation test: " + options);
 
     String fullTableName = options.fullTableName();
-    if (replaceTable) {
-      // First, create a different table to replace.
+    boolean isReplace = ddlMode == DdlMode.REPLACE;
+    if (isReplace) {
+      // Seed a different table with the configured pre-replace shape and write a row
+      // into it. The seed schema is unrelated to the REPLACE schema -- REPLACE swaps
+      // everything. Two columns are needed so `PARTITIONED BY (col1)` is legal (Delta
+      // forbids partitioning by every column of a table). The seed row anchors the
+      // post-REPLACE row-count assertion in `assertReplaceLikeIdentityPreserved`, which
+      // confirms the seed data was wiped.
+      String seedPartitionClause = withPartitionBeforeReplace ? "PARTITIONED BY (col1)" : "";
+      String seedClusterClause = withClusterBeforeReplace ? "CLUSTER BY (col1)" : "";
       sql(
-          "CREATE TABLE %s USING DELTA %s AS SELECT %s AS col1",
-          fullTableName, MANAGED_TBLPROPERTIES_CLAUSE_OTHER, "0.1");
+          "CREATE TABLE %s (col1 STRING, col2 STRING) USING DELTA %s %s %s",
+          fullTableName,
+          MANAGED_TBLPROPERTIES_CLAUSE_OTHER,
+          seedPartitionClause,
+          seedClusterClause);
+      sql("INSERT INTO %s VALUES ('seed_col1', 'seed_col2')", fullTableName);
       tablesToCleanUp.add(fullTableName);
     }
 
-    if (replaceTable && tableType == TableType.EXTERNAL) {
-      assertThatThrownBy(() -> sql(options.createTableSql()));
-      return;
-    }
+    // Capture UC identity before the REPLACE so we can verify it survives and that the
+    // seed table's rows are discarded.
+    String ucTableIdBefore = isReplace ? currentUcTableId(fullTableName) : null;
+    long versionBefore = isReplace ? currentVersion(fullTableName) : -1L;
 
     // Create table
     sql(options.createTableSql());
     tablesToCleanUp.add(fullTableName);
+
+    if (isReplace) {
+      assertReplaceLikeIdentityPreserved(
+          fullTableName, ucTableIdBefore, versionBefore, withAsSelect);
+    }
+
     // Basic read/write test
     sql("INSERT INTO %s SELECT 2, 'b'", fullTableName);
     if (withAsSelect) {
@@ -331,6 +440,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     }
 
     // Verify that table information maintained at the uc server side are expected.
+    boolean isManagedReplace = isReplace && tableType == TableType.MANAGED;
     assertUCTableInfo(
         tableType,
         fullTableName,
@@ -341,8 +451,9 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         withCluster,
         options.getClusterColumn(),
         options.getPartitionColumn(),
-        replaceTable && tableType == TableType.MANAGED ? "1" : "0",
-        !(replaceTable && tableType == TableType.MANAGED));
+        // For MANAGED+REPLACE: seed CREATE=v0, seed INSERT=v1, REPLACE=v2.
+        isManagedReplace ? "2" : "0",
+        !isManagedReplace);
   }
 
   @Test
@@ -398,56 +509,132 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
                 DELTA_CATALOG_MANAGED_KEY, SUPPORTED));
   }
 
-  @TestAllTableTypes
-  public void testCreateOrReplaceTable(TableType tableType) throws Exception {
-    UnityCatalogInfo uc = unityCatalogInfo();
-    String tableName =
-        String.format(
-            "%s.%s.create_or_replace_%s",
-            uc.catalogName(), uc.schemaName(), UUID.randomUUID().toString().replace("-", ""));
-    withTempDir(
-        (Path dir) -> {
-          try {
-            if (tableType == TableType.MANAGED) {
-              sql(
-                  "CREATE OR REPLACE TABLE %s (id INT, name STRING) USING DELTA %s ",
-                  tableName, MANAGED_TBLPROPERTIES_CLAUSE);
-              sql("INSERT INTO %s VALUES (1, 'Alice')", tableName);
-              check(tableName, List.of(List.of("1", "Alice")));
-              assertUCTableInfo(
-                  tableType,
-                  tableName,
-                  List.of("id", "name"),
-                  Map.of("Foo", "Bar"),
-                  null,
-                  null,
-                  false,
-                  Optional.empty(),
-                  Optional.empty(),
-                  "0",
-                  true);
-              String ucTableIdBeforeReplace = currentUcTableId(tableName);
-              long versionBeforeReplace = currentVersion(tableName);
-
-              sql(
-                  "CREATE OR REPLACE TABLE %s (id INT, name STRING) USING DELTA %s ",
-                  tableName, MANAGED_TBLPROPERTIES_CLAUSE);
-              assertThat(currentUcTableId(tableName)).isEqualTo(ucTableIdBeforeReplace);
-              assertThat(currentVersion(tableName)).isEqualTo(versionBeforeReplace + 1);
-              sql("INSERT INTO %s VALUES (2, 'Bob')", tableName);
-              check(tableName, List.of(List.of("2", "Bob")));
-            } else {
-              assertThatThrownBy(
+  // EXTERNAL is intentionally excluded: CREATE OR REPLACE is not supported yet.
+  @TestFactory
+  public Stream<DynamicTest> testCreateOrReplaceTable() {
+    int counter = 0;
+    List<DynamicTest> tests = new ArrayList<>();
+    for (boolean withPartition : List.of(true, false)) {
+      for (boolean withCluster : List.of(true, false)) {
+        if (withCluster && withPartition) {
+          // Can not have CLUSTER BY and PARTITIONED BY on the same table
+          continue;
+        }
+        for (boolean withAsSelect : List.of(true, false)) {
+          String displayName =
+              String.format(
+                  "withPartition=%s, withCluster=%s, withAsSelect=%s",
+                  withPartition, withCluster, withAsSelect);
+          counter++;
+          int finalCounter = counter;
+          tests.add(
+              DynamicTest.dynamicTest(
+                  displayName,
                   () ->
-                      sql(
-                          "CREATE OR REPLACE TABLE %s (id INT, name STRING) USING DELTA LOCATION '%s'",
-                          tableName, dir.toString()));
-            }
+                      runCreateOrReplaceTableTest(
+                          finalCounter, withPartition, withCluster, withAsSelect)));
+        }
+      }
+    }
+    return tests.stream();
+  }
 
-          } finally {
-            sql("DROP TABLE IF EXISTS %s", tableName);
-          }
-        });
+  private void runCreateOrReplaceTableTest(
+      int count, boolean withPartition, boolean withCluster, boolean withAsSelect)
+      throws Exception {
+    UnityCatalogInfo uc = unityCatalogInfo();
+    final String comment = "This is comment.";
+    final String catalogName = uc.catalogName();
+    final String schemaName = uc.schemaName();
+    String tableName = "test_cor_table_" + count;
+
+    TableSetupOptions options =
+        new TableSetupOptions()
+            .setCatalogName(catalogName)
+            .setSchemaName(schemaName)
+            .setTableName(tableName)
+            .setTableType(TableType.MANAGED)
+            .setDdlMode(DdlMode.CREATE_OR_REPLACE)
+            .setComment(comment);
+    if (withPartition) {
+      options.setPartitionColumn("i");
+    }
+    if (withCluster) {
+      options.setClusterColumn("s");
+    }
+    if (withAsSelect) {
+      options.setAsSelect(1, "a");
+    }
+    String fullTableName = options.fullTableName();
+
+    // First CREATE OR REPLACE: table does not exist yet; must succeed and create the table
+    // via the `NoSuchTableException` fallback in
+    // `AbstractDeltaCatalog.maybeStageDeltaCreateOrReplace`.
+    sql(options.createTableSql());
+    tablesToCleanUp.add(fullTableName);
+    sql("INSERT INTO %s SELECT 2, 'b'", fullTableName);
+    if (withAsSelect) {
+      check(fullTableName, List.of(List.of("1", "a"), List.of("2", "b")));
+    } else {
+      check(fullTableName, List.of(List.of("2", "b")));
+    }
+    assertUCTableInfo(
+        TableType.MANAGED,
+        fullTableName,
+        List.of("i", "s"),
+        Map.of("Foo", "Bar"),
+        comment,
+        options.getExternalTableLocation(),
+        withCluster,
+        options.getClusterColumn(),
+        options.getPartitionColumn(),
+        "0",
+        true);
+
+    // Second CREATE OR REPLACE: identical metadata; goes through
+    // `loadTableAndBuildReplaceProps`. Identity must survive and the post-create INSERT
+    // row must be discarded.
+    String ucTableIdBefore = currentUcTableId(fullTableName);
+    long versionBefore = currentVersion(fullTableName);
+    sql(options.createTableSql());
+    assertReplaceLikeIdentityPreserved(fullTableName, ucTableIdBefore, versionBefore, withAsSelect);
+
+    // Read/write again to confirm the replaced table works end-to-end.
+    sql("INSERT INTO %s VALUES (3, 'c')", fullTableName);
+    if (withAsSelect) {
+      check(fullTableName, List.of(List.of("1", "a"), List.of("3", "c")));
+    } else {
+      check(fullTableName, List.of(List.of("3", "c")));
+    }
+    // Identical metadata: UC's view of `lastUpdateVersion` and `clusteringColumns` is
+    // unchanged from the first COR.
+    assertUCTableInfo(
+        TableType.MANAGED,
+        fullTableName,
+        List.of("i", "s"),
+        Map.of("Foo", "Bar"),
+        comment,
+        options.getExternalTableLocation(),
+        withCluster,
+        options.getClusterColumn(),
+        options.getPartitionColumn(),
+        "0",
+        true);
+  }
+
+  /**
+   * Asserts the post-REPLACE invariants common to {@link #runTableCreationTest} (REPLACE branch)
+   * and {@link #runCreateOrReplaceTableTest} (second-COR branch): UC table id preserved, Delta
+   * version advanced, and rows from before the replace are discarded (only the AS-SELECT row
+   * survives, if any).
+   */
+  private void assertReplaceLikeIdentityPreserved(
+      String fullTableName, String ucTableIdBefore, long versionBefore, boolean withAsSelect)
+      throws Exception {
+    assertThat(currentUcTableId(fullTableName)).isEqualTo(ucTableIdBefore);
+    assertThat(currentVersion(fullTableName)).isGreaterThan(versionBefore);
+    assertThat(sql("SELECT COUNT(*) FROM %s", fullTableName))
+        .containsExactly(row(withAsSelect ? "1" : "0"));
   }
 
   @TestAllTableTypes


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6859/files) to review incremental changes.
- [**stack/DeltaCatalogClient_replace**](https://github.com/delta-io/delta/pull/6859) [[Files changed](https://github.com/delta-io/delta/pull/6859/files)]
  - [stack/DeltaCatalogClient_replace_delta_prefix](https://github.com/delta-io/delta/pull/6916) [[Files changed](https://github.com/delta-io/delta/pull/6916/files/28d12eb681701b75ce8d8141e65ec168d4e81f72..ade38265d021eb05af0b9f8763170d06cc2b22b7)]

---------
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Route managed Delta REPLACE / CREATE OR REPLACE through the UC Delta API

- Add `shouldRouteReplaceThroughDeltaCatalogClient` (REPLACE-side routing predicate) alongside the existing CREATE-side `shouldRouteThroughDeltaCatalogClient`. The REPLACE predicate additionally throws on `PROP_LOCATION` / `PROP_EXTERNAL` since only catalog-managed Delta tables can be replaced on this path.
- Add `maybeLoadForDeltaReplace` (REPLACE / RTAS) and `maybeStageDeltaCreateOrReplace` (CREATE OR REPLACE; falls back to fresh-create on `NoSuchTableException`).
- Add `AbstractDeltaCatalogClient.loadTableAndBuildReplaceProps`; `UCDeltaCatalogClientImpl` loads the existing UC table, validates it is a catalog-managed Delta table, rejects caller-supplied system/override properties, and augments with provider, `is_managed_location`, and `fs.*` storage credentials.
- Route the 2nd REPLACE-side load (`getExistingTableFromDelegatedCatalog`) through `deltaCatalogClient` when wired, so REPLACE consults UC via the Delta API on both loads instead of falling back to the V2 delegate for the recovery probe.

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
No
