### PR TITLE
Add domain metadata support to UCClient.commit API

### DIFF
--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -29,6 +29,7 @@ import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedPublishedDeltaData;
 import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.unitycatalog.adapters.DomainMetadataAdapter;
 import io.delta.kernel.unitycatalog.adapters.MetadataAdapter;
 import io.delta.kernel.unitycatalog.adapters.ProtocolAdapter;
 import io.delta.kernel.unitycatalog.adapters.UniformAdapter;
@@ -38,6 +39,7 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -46,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -317,6 +320,14 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
     return commitMetadata.getNewMetadataOpt();
   }
 
+  /** Adapts the kernel domain metadata list to the storage-layer interface. */
+  private static List<AbstractDomainMetadata> toDomainMetadataAdapters(
+      CommitMetadata commitMetadata) {
+    return commitMetadata.getCommitDomainMetadatas().stream()
+        .map(DomainMetadataAdapter::new)
+        .collect(Collectors.toList());
+  }
+
   ////////////////////
   // Helper methods //
   ////////////////////
@@ -462,7 +473,8 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
                 generateMetadataPayloadOpt(commitMetadata).map(MetadataAdapter::new),
                 Optional.empty() /* oldProtocol */,
                 commitMetadata.getNewProtocolOpt().map(ProtocolAdapter::new),
-                uniformMetadataOpt);
+                uniformMetadataOpt,
+                toDomainMetadataAdapters(commitMetadata));
             return null;
           } catch (io.delta.storage.commit.CommitFailedException cfe) {
             throw storageCFEtoKernelCFE(cfe);

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.unitycatalog.adapters;
+
+import io.delta.kernel.internal.actions.DomainMetadata;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
+import java.util.Objects;
+
+/**
+ * Adapter from {@link io.delta.kernel.internal.actions.DomainMetadata} to {@link
+ * io.delta.storage.commit.actions.AbstractDomainMetadata}.
+ */
+public class DomainMetadataAdapter implements AbstractDomainMetadata {
+
+  private final DomainMetadata kernelDomainMetadata;
+
+  public DomainMetadataAdapter(DomainMetadata kernelDomainMetadata) {
+    this.kernelDomainMetadata =
+        Objects.requireNonNull(kernelDomainMetadata, "kernelDomainMetadata is null");
+  }
+
+  @Override
+  public String getDomain() {
+    return kernelDomainMetadata.getDomain();
+  }
+
+  @Override
+  public String getConfiguration() {
+    return kernelDomainMetadata.getConfiguration();
+  }
+
+  @Override
+  public boolean isRemoved() {
+    return kernelDomainMetadata.isRemoved();
+  }
+}

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import io.delta.storage.commit.{Commit, CommitFailedException, GetCommitsResponse, TableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{InvalidTargetTableException, UCClient}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
@@ -166,10 +166,12 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata,
       Optional.empty(), // oldProtocol
       newProtocol,
-      Optional.empty() // uniform
+      Optional.empty(), // uniform
+      java.util.Collections.emptyList() // domainMetadatas
     )
   }
 
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -180,7 +182,9 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
-      uniform: Optional[UniformMetadata]): Unit = {
+      uniform: Optional[UniformMetadata],
+      domainMetadatas: java.util.List[AbstractDomainMetadata]): Unit = {
+    // scalastyle:on argcount
     forceThrowInCommitMethod()
 
     val tableData = getOrCreateTableIfNotExists(tableId)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -22,7 +22,7 @@ import java.util.Optional
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import io.delta.storage.commit.{Commit => JCommit, GetCommitsResponse => JGetCommitsResponse, TableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCClient
 import io.delta.storage.commit.uniform.UniformMetadata
 
@@ -58,6 +58,7 @@ class InMemoryUCClient(
 
   override def getMetastoreId: String = metastoreId
 
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -68,7 +69,10 @@ class InMemoryUCClient(
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
-      uniform: Optional[UniformMetadata] = Optional.empty()): Unit = {
+      uniform: Optional[UniformMetadata] = Optional.empty(),
+      domainMetadatas: java.util.List[AbstractDomainMetadata] =
+        java.util.Collections.emptyList()): Unit = {
+    // scalastyle:on argcount
     ucCommitCoordinator.commitToCoordinator(
       tableId,
       tableUri,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -21,7 +21,7 @@ import java.util
 import java.util.{Collections, Optional, UUID}
 
 import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier => StorageTableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{DeltaProtocol, StagingTableInfo, TableInfo, TableType => UcTableType}
 import io.delta.storage.commit.uccommitcoordinator.exceptions.CredentialFetchFailedException
@@ -312,6 +312,7 @@ private class StubUCDeltaClient(loadTableResult: => TableInfo) extends UCDeltaCl
       protocol: DeltaProtocol,
       properties: util.Map[String, String]): AbstractMetadata =
     throw new UnsupportedOperationException
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -322,7 +323,9 @@ private class StubUCDeltaClient(loadTableResult: => TableInfo) extends UCDeltaCl
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
-      uniform: Optional[UniformMetadata]): Unit =
+      uniform: Optional[UniformMetadata],
+      domainMetadatas: java.util.List[AbstractDomainMetadata]): Unit =
+    // scalastyle:on argcount
     throw new UnsupportedOperationException
   override def getCommits(
       tableId: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
@@ -126,7 +126,8 @@ trait UCCommitCoordinatorClientSuiteBase extends CommitCoordinatorClientImplSuit
       Optional.empty(), // newMetadata
       Optional.empty(), // oldProtocol
       Optional.empty(), // newProtocol
-      Optional.empty() /* uniform */)
+      Optional.empty(), // uniform
+      java.util.Collections.emptyList() /* domainMetadatas */)
   }
 
   override protected def validateBackfillStrategy(

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractDomainMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.actions;
+
+/**
+ * An interface representing a domain metadata action for a Delta table. Domain metadata actions
+ * store configuration strings for named metadata domains.
+ *
+ * <p>Each action already encodes its intent:
+ * <ul>
+ *   <li>{@code removed == false}: upsert (set the domain to the given configuration)</li>
+ *   <li>{@code removed == true}: tombstone (logically delete the domain)</li>
+ * </ul>
+ */
+public interface AbstractDomainMetadata {
+
+  /** A string used to identify a specific metadata domain. */
+  String getDomain();
+
+  /** A string containing configuration for the metadata domain. */
+  String getConfiguration();
+
+  /**
+   * When {@code true}, this action serves as a tombstone to logically delete the metadata domain.
+   */
+  boolean isRemoved();
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
@@ -1,19 +1,35 @@
 package org.apache.spark.sql.delta.coordinatedcommits;
 
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.uniform.UniformMetadata;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 public class CatalogTrackedInfo {
-    public static final CatalogTrackedInfo EMPTY = new CatalogTrackedInfo(Optional.empty());
+    public static final CatalogTrackedInfo EMPTY =
+        new CatalogTrackedInfo(Optional.empty(), Collections.emptyList());
 
     private final Optional<UniformMetadata> deltaUniformIceberg;
+    private final List<AbstractDomainMetadata> domainMetadatas;
 
     public CatalogTrackedInfo(Optional<UniformMetadata> deltaUniformIceberg) {
+        this(deltaUniformIceberg, Collections.emptyList());
+    }
+
+    public CatalogTrackedInfo(
+            Optional<UniformMetadata> deltaUniformIceberg,
+            List<AbstractDomainMetadata> domainMetadatas) {
         this.deltaUniformIceberg = deltaUniformIceberg;
+        this.domainMetadatas = Collections.unmodifiableList(domainMetadatas);
     }
 
     public Optional<UniformMetadata> deltaUniformIceberg() {
         return deltaUniformIceberg;
+    }
+
+    public List<AbstractDomainMetadata> domainMetadatas() {
+        return domainMetadatas;
     }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -20,6 +20,7 @@ import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -86,6 +87,10 @@ public interface UCClient extends AutoCloseable {
    * @param uniform An Optional containing UniForm metadata for Delta Universal Format support.
    *                If present, this metadata will be used by UC to manage format conversions
    *                (e.g., Iceberg, Hudi).
+   * @param domainMetadatas The domain metadata actions being committed in this transaction.
+   *                        Each action encodes its own intent: {@code removed == false} means
+   *                        upsert, {@code removed == true} means delete. Implementations that
+   *                        do not support domain metadata may ignore this parameter.
    * @throws IOException if there's an error during the commit process, such as network issues.
    * @throws CommitFailedException if the commit fails due to conflicts or other logical errors.
    * @throws UCCommitCoordinatorException if there's an error specific to the Unity Catalog
@@ -101,7 +106,8 @@ public interface UCClient extends AutoCloseable {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
-      Optional<UniformMetadata> uniform
+      Optional<UniformMetadata> uniform,
+      List<AbstractDomainMetadata> domainMetadatas
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException;
 
   /**

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -33,6 +33,7 @@ import org.apache.spark.sql.delta.coordinatedcommits.CatalogTrackedInfo;
 import io.delta.storage.CloseableIterator;
 import io.delta.storage.LogStore;
 import io.delta.storage.commit.*;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -737,7 +738,8 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       newMetadata,
       oldProtocol,
       newProtocol,
-      catalogTrackedInfo.deltaUniformIceberg()
+      catalogTrackedInfo.deltaUniformIceberg(),
+      catalogTrackedInfo.domainMetadatas()
     );
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -21,6 +21,7 @@ import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo;
@@ -35,6 +36,11 @@ import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.api.TablesApi;
 import io.unitycatalog.client.delta.model.AddCommitUpdate;
 import io.unitycatalog.client.delta.model.AssertTableUUID;
+import io.unitycatalog.client.delta.model.ClusteringDomainMetadata;
+import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
+import io.unitycatalog.client.delta.model.RemoveDomainMetadataUpdate;
+import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
+import io.unitycatalog.client.delta.model.SetDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
 import io.unitycatalog.client.delta.model.CreateTableRequest;
 import io.unitycatalog.client.delta.model.DeltaCommit;
@@ -73,9 +79,13 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A REST client implementation of {@link UCDeltaClient} that uses the UC Delta REST API for
@@ -88,6 +98,9 @@ import org.apache.hadoop.fs.Path;
  */
 public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(UCDeltaTokenBasedRestClient.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final int HTTP_CONFLICT = 409;
   private static final int HTTP_NOT_FOUND = 404;
 
@@ -235,7 +248,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
-      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform)
+      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform,
+      List<AbstractDomainMetadata> domainMetadatas)
       throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
@@ -253,6 +267,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       uniform.ifPresent(u -> addCommit.uniform(toSDKUniformMetadata(u)));
       request.addUpdatesItem(addCommit);
     });
+
+    addDomainMetadataUpdates(request, domainMetadatas);
 
     lastKnownBackfilledVersion.ifPresent(v ->
         request.addUpdatesItem(new SetLatestBackfilledVersionUpdate()
@@ -641,6 +657,100 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       protocol.writerFeatures(new ArrayList<>(p.getWriterFeatures()));
     }
     return protocol;
+  }
+
+  private void addDomainMetadataUpdates(
+      UpdateTableRequest request, List<AbstractDomainMetadata> domainMetadatas) {
+    if (domainMetadatas == null || domainMetadatas.isEmpty()) {
+      return;
+    }
+
+    List<String> removedDomains = new ArrayList<>();
+    DomainMetadataUpdates setUpdates = new DomainMetadataUpdates();
+    boolean hasSetUpdates = false;
+
+    for (AbstractDomainMetadata dm : domainMetadatas) {
+      if (dm.isRemoved()) {
+        removedDomains.add(dm.getDomain());
+      } else {
+        hasSetUpdates |= populateDomainMetadataUpdates(setUpdates, dm);
+      }
+    }
+
+    if (hasSetUpdates) {
+      request.addUpdatesItem(new SetDomainMetadataUpdate()
+          .action("set-domain-metadata")
+          .updates(setUpdates));
+    }
+    if (!removedDomains.isEmpty()) {
+      request.addUpdatesItem(new RemoveDomainMetadataUpdate()
+          .action("remove-domain-metadata")
+          .domains(removedDomains));
+    }
+  }
+
+  /**
+   * Populates the typed SDK model in {@code updates} for a given domain metadata action.
+   * Returns true if the domain was recognized and populated, false otherwise.
+   */
+  private boolean populateDomainMetadataUpdates(
+      DomainMetadataUpdates updates, AbstractDomainMetadata dm) {
+    String config = dm.getConfiguration();
+    switch (dm.getDomain()) {
+      case "delta.clustering":
+        ClusteringDomainMetadata clustering = parseClusteringDomainMetadata(config);
+        if (clustering != null) {
+          updates.deltaClustering(clustering);
+          return true;
+        }
+        return false;
+      case "delta.rowTracking":
+        RowTrackingDomainMetadata rowTracking = parseRowTrackingDomainMetadata(config);
+        if (rowTracking != null) {
+          updates.deltaRowTracking(rowTracking);
+          return true;
+        }
+        return false;
+      default:
+        LOG.warn("Unknown domain metadata domain '{}'; skipping.", dm.getDomain());
+        return false;
+    }
+  }
+
+  private ClusteringDomainMetadata parseClusteringDomainMetadata(String configJson) {
+    try {
+      JsonNode node = OBJECT_MAPPER.readTree(configJson);
+      ClusteringDomainMetadata sdkModel = new ClusteringDomainMetadata();
+      if (node.has("clusteringColumns")) {
+        List<List<String>> columns = new ArrayList<>();
+        for (JsonNode colArray : node.get("clusteringColumns")) {
+          List<String> colParts = new ArrayList<>();
+          for (JsonNode part : colArray) {
+            colParts.add(part.asText());
+          }
+          columns.add(colParts);
+        }
+        sdkModel.clusteringColumns(columns);
+      }
+      return sdkModel;
+    } catch (Exception e) {
+      LOG.warn("Failed to parse clustering domain metadata config; skipping.", e);
+      return null;
+    }
+  }
+
+  private RowTrackingDomainMetadata parseRowTrackingDomainMetadata(String configJson) {
+    try {
+      JsonNode node = OBJECT_MAPPER.readTree(configJson);
+      RowTrackingDomainMetadata sdkModel = new RowTrackingDomainMetadata();
+      if (node.has("rowIdHighWaterMark")) {
+        sdkModel.rowIdHighWaterMark(node.get("rowIdHighWaterMark").asLong());
+      }
+      return sdkModel;
+    } catch (Exception e) {
+      LOG.warn("Failed to parse row tracking domain metadata config; skipping.", e);
+      return null;
+    }
   }
 
   private UniformMetadata toSDKUniformMetadata(

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -21,6 +21,7 @@ import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.IcebergMetadata;
@@ -179,7 +180,8 @@ public class UCTokenBasedRestClient implements UCClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
-      Optional<UniformMetadata> uniform
+      Optional<UniformMetadata> uniform,
+      List<AbstractDomainMetadata> domainMetadatas
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null.");

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -306,7 +306,8 @@ class UCDeltaTokenBasedRestClientSuite
     withClient { c =>
       c.commit(testTableId.toString, new URI("s3://bucket/table"), testIdentifier,
         Optional.of(createCommit(5L)), Optional.of(java.lang.Long.valueOf(3L)),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList())
     }
 
     val json = objectMapper.readTree(captured)
@@ -348,7 +349,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.of(oldMeta), Optional.of(newMeta),
-        Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Collections.emptyList())
     }
 
     val actions = {
@@ -377,7 +378,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(),
-        Optional.of(oldProto), Optional.of(newProto), Optional.empty())
+        Optional.of(oldProto), Optional.of(newProto), Optional.empty(),
+        Collections.emptyList())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -404,7 +406,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.of(m1), Optional.of(m2),
-        Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Collections.emptyList())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -430,7 +432,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(),
-        Optional.of(p1), Optional.of(p2), Optional.empty())
+        Optional.of(p1), Optional.of(p2), Optional.empty(), Collections.emptyList())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -454,7 +456,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(uniform))
+        Optional.of(uniform), Collections.emptyList())
     }
 
     val addCommit = {
@@ -484,7 +486,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(uniform))
+        Optional.of(uniform), Collections.emptyList())
     }
 
     val addCommit = {
@@ -494,6 +496,106 @@ class UCDeltaTokenBasedRestClientSuite
     }
     val iceberg = addCommit.get("uniform").get("iceberg")
     assert(iceberg.get("converted-delta-timestamp").asLong() === 1735960391423L)
+  }
+
+  // --------------- domain metadata ---------------
+
+  test("commit sends SetDomainMetadataUpdate for clustering and row tracking") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      if (exchange.getRequestMethod == "POST") {
+        captured = body
+      }
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    import io.delta.storage.commit.actions.AbstractDomainMetadata
+    val domainMetadatas = new java.util.ArrayList[AbstractDomainMetadata]()
+    domainMetadatas.add(new AbstractDomainMetadata {
+      override def getDomain: String = "delta.clustering"
+      override def getConfiguration: String =
+        """{"clusteringColumns":[["col_a"],["col_b","nested"]]}"""
+      override def isRemoved: Boolean = false
+    })
+    domainMetadatas.add(new AbstractDomainMetadata {
+      override def getDomain: String = "delta.rowTracking"
+      override def getConfiguration: String = """{"rowIdHighWaterMark":42}"""
+      override def isRemoved: Boolean = false
+    })
+
+    withClient { c =>
+      c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.of(createCommit(1L)), Optional.empty(),
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Optional.empty(), domainMetadatas)
+    }
+
+    val updates = objectMapper.readTree(captured).get("updates")
+    val setDm = (0 until updates.size()).map(updates.get)
+      .find(_.get("action").asText() == "set-domain-metadata").get
+    val dmUpdates = setDm.get("updates")
+    val clustering = dmUpdates.get("deltaClustering")
+    assert(clustering.get("clusteringColumns").size() === 2)
+    assert(clustering.get("clusteringColumns").get(0).get(0).asText() === "col_a")
+    assert(clustering.get("clusteringColumns").get(1).get(0).asText() === "col_b")
+    assert(clustering.get("clusteringColumns").get(1).get(1).asText() === "nested")
+
+    val rowTracking = dmUpdates.get("deltaRowTracking")
+    assert(rowTracking.get("rowIdHighWaterMark").asLong() === 42L)
+  }
+
+  test("commit sends RemoveDomainMetadataUpdate for removed domains") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      if (exchange.getRequestMethod == "POST") {
+        captured = body
+      }
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    import io.delta.storage.commit.actions.AbstractDomainMetadata
+    val domainMetadatas = new java.util.ArrayList[AbstractDomainMetadata]()
+    domainMetadatas.add(new AbstractDomainMetadata {
+      override def getDomain: String = "delta.clustering"
+      override def getConfiguration: String = ""
+      override def isRemoved: Boolean = true
+    })
+
+    withClient { c =>
+      c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.of(createCommit(1L)), Optional.empty(),
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Optional.empty(), domainMetadatas)
+    }
+
+    val updates = objectMapper.readTree(captured).get("updates")
+    val removeDm = (0 until updates.size()).map(updates.get)
+      .find(_.get("action").asText() == "remove-domain-metadata").get
+    val domains = removeDm.get("domains")
+    assert(domains.size() === 1)
+    assert(domains.get(0).asText() === "delta.clustering")
+  }
+
+  test("commit skips domain metadata update when list is empty") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      if (exchange.getRequestMethod == "POST") {
+        captured = body
+      }
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    withClient { c =>
+      c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.of(createCommit(1L)), Optional.empty(),
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Optional.empty(), Collections.emptyList())
+    }
+
+    val updates = objectMapper.readTree(captured).get("updates")
+    val actions = (0 until updates.size()).map(i => updates.get(i).get("action").asText()).toSet
+    assert(!actions.contains("set-domain-metadata"))
+    assert(!actions.contains("remove-domain-metadata"))
   }
 
   // --------------- error handling ---------------
@@ -511,7 +613,8 @@ class UCDeltaTokenBasedRestClientSuite
       val e = intercept[CommitFailedException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList())
       }
       assert(e.getRetryable && e.getConflict)
     }
@@ -530,7 +633,8 @@ class UCDeltaTokenBasedRestClientSuite
       intercept[InvalidTargetTableException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList())
       }
     }
   }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -155,7 +155,8 @@ class UCTokenBasedRestClientSuite
     withClient { client =>
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList())
     }
   }
 
@@ -171,7 +172,8 @@ class UCTokenBasedRestClientSuite
         Optional.of(createMetadata()),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty())
+        Optional.empty(),
+        Collections.emptyList())
     }
   }
 
@@ -180,12 +182,12 @@ class UCTokenBasedRestClientSuite
       intercept[NullPointerException] {
         client.commit(null, testTableUri, null, Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Collections.emptyList())
       }
       intercept[NullPointerException] {
         client.commit(testTableId, null, null, Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Collections.emptyList())
       }
     }
   }
@@ -196,7 +198,8 @@ class UCTokenBasedRestClientSuite
       withClient { client =>
         client.commit(testTableId, testTableUri, null,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList())
       }
     }
 
@@ -301,7 +304,7 @@ class UCTokenBasedRestClientSuite
         client.commit(testTableId, testTableUri, null,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(),
-          Optional.of(new UniformMetadata(icebergMeta)))
+          Optional.of(new UniformMetadata(icebergMeta)), Collections.emptyList())
       }
 
       val json: JsonNode = objectMapper.readTree(capturedBody)
@@ -334,7 +337,8 @@ class UCTokenBasedRestClientSuite
     withClient { client =>
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList())
     }
 
     val json = objectMapper.readTree(capturedBody)
@@ -352,7 +356,7 @@ class UCTokenBasedRestClientSuite
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(new UniformMetadata(null)))
+        Optional.of(new UniformMetadata(null)), Collections.emptyList())
     }
 
     val json = objectMapper.readTree(capturedBody)


### PR DESCRIPTION
## Summary
- Plumbs domain metadata actions through the UC commit path so that `UCDeltaTokenBasedRestClient` can send them to the UC Delta API alongside commits
- `UCTokenBasedRestClient` (legacy API) accepts but ignores the new parameter
- Kernel path adapts `DomainMetadata` via `DomainMetadataAdapter` before passing to UC

## Changes
- **New**: `AbstractDomainMetadata` interface in `storage/.../commit/actions/`
- **New**: `DomainMetadataAdapter` in `kernel/unitycatalog/.../adapters/`
- **Modified**: `UCClient.commit()` — added `List<AbstractDomainMetadata> domainMetadatas` parameter
- **Modified**: `UCDeltaTokenBasedRestClient` — converts domain metadata into `SetDomainMetadataUpdate` / `RemoveDomainMetadataUpdate` update items using the UC Delta SDK typed models (`ClusteringDomainMetadata`, `RowTrackingDomainMetadata`)
- **Modified**: `UCCommitCoordinatorClient` — passes domain metadata from `CatalogTrackedInfo`
- **Modified**: `CatalogTrackedInfo` — carries `List<AbstractDomainMetadata>`
- **Modified**: `UCCatalogManagedCommitter` — adapts kernel domain metadata and passes to UC
- **Modified**: `InMemoryUCClient` (both Spark and Kernel) — updated signatures

## Design Decisions
- Domain metadata does **not** require old/new diffing (unlike table metadata properties). Each `DomainMetadata` action is self-describing: `removed=false` means upsert, `removed=true` means delete.
- The `UCDeltaTokenBasedRestClient` adds domain metadata as separate `SetDomainMetadataUpdate` and `RemoveDomainMetadataUpdate` update items in the `UpdateTableRequest`, consistent with the UC Delta SDK's intent-based typed API.
- Known domains (`delta.clustering`, `delta.rowTracking`) are parsed from their JSON configuration into the corresponding typed SDK models. Unknown domains are logged and skipped.
- The `UCTokenBasedRestClient` (legacy API) does not support domain metadata and silently ignores the parameter.

## Test plan
- [ ] Existing `UCTokenBasedRestClientSuite` passes with updated signatures
- [ ] Existing `UCDeltaTokenBasedRestClientSuite` passes with updated signatures
- [ ] Existing `InMemoryUCClientSuite` passes
- [ ] Existing `UCCatalogManagedCommitterSuite` passes
- [ ] Kernel Unity Catalog tests pass