### PR TITLE
[Spark] Enable Optimize MIN/MAX metadata-only queries for DV enabled tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -24,9 +24,9 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTable, Snapshot}
-import org.apache.spark.sql.delta.commands.DeletionVectorUtils.isTableDVFree
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.stats.DeltaScanGenerator
+import org.apache.spark.sql.delta.stats.DeltaStatistics.TIGHT_BOUNDS
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
@@ -39,7 +39,16 @@ import java.util.Locale
  * ShortType, IntegerType, LongType, FloatType, DoubleType, DateType).
  * - All AddFiles in the Delta Log must have stats on columns used in MIN/MAX expressions,
  * or the columns must be partitioned, in the latter case it uses partitionValues, a required field.
- * - Table has no deletion vectors, or query has no MIN/MAX expressions.
+ * - For MIN/MAX, the per-column stat used must be trustworthy across the whole table. Per the
+ * Delta protocol, files with `stats.tightBounds = false` (only emitted by writers that add
+ * deletion vectors without recomputing stats) have wide bounds: their `stat_min` is a lower
+ * bound on the file's actual min and their `stat_max` is an upper bound on the file's actual
+ * max. The optimization can still apply when wide-bound files are present, provided the
+ * resulting table-wide value would have come from a tight-bound file. Concretely, for each
+ * column the rule checks that `min(stat_min over all files) IS NOT DISTINCT FROM
+ * min(stat_min over tight files only)` (and symmetric for MAX). When that holds, the wide
+ * files do not contribute to the table-wide bound, so the result is exact. MIN and MAX are
+ * evaluated independently per column.
  * - COUNT has no DISTINCT.
  * - Query has no filters.
  * - Query has no GROUP BY.
@@ -62,11 +71,18 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
     val aggColumnsNames = Set(extractMinMaxFieldNames(plan).map(_.toLowerCase(Locale.ROOT)) : _*)
     val (rowCount, columnStats) = extractCountMinMaxFromDeltaLog(tahoeLogFileIndex, aggColumnsNames)
 
-    def checkStatsExists(attrRef: AttributeReference): Boolean = {
+    def checkMinStatsExists(attrRef: AttributeReference): Boolean = {
       columnStats.contains(attrRef.name) &&
+        columnStats(attrRef.name).min.isDefined &&
         // Avoid StructType, it is not supported by this optimization.
         // Sanity check only. If reference is nested column it would be GetStructType
         // instead of AttributeReference.
+        attrRef.references.size == 1 && attrRef.references.head.dataType != StructType
+    }
+
+    def checkMaxStatsExists(attrRef: AttributeReference): Boolean = {
+      columnStats.contains(attrRef.name) &&
+        columnStats(attrRef.name).max.isDefined &&
         attrRef.references.size == 1 && attrRef.references.head.dataType != StructType
     }
 
@@ -87,21 +103,21 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
         tps.copy(child = Literal(rowCount.get)).eval()
       case Alias(AggregateExpression(
       Min(minReference: AttributeReference), Complete, false, None, _), _)
-        if checkStatsExists(minReference) =>
-        convertValueIfRequired(minReference, columnStats(minReference.name).min)
+        if checkMinStatsExists(minReference) =>
+        convertValueIfRequired(minReference, columnStats(minReference.name).min.get)
       case Alias(tps@ToPrettyString(AggregateExpression(
       Min(minReference: AttributeReference), Complete, false, None, _), _), _)
-        if checkStatsExists(minReference) =>
-          val v = columnStats(minReference.name).min
+        if checkMinStatsExists(minReference) =>
+          val v = columnStats(minReference.name).min.get
           tps.copy(child = Literal(v)).eval()
       case Alias(AggregateExpression(
       Max(maxReference: AttributeReference), Complete, false, None, _), _)
-        if checkStatsExists(maxReference) =>
-        convertValueIfRequired(maxReference, columnStats(maxReference.name).max)
+        if checkMaxStatsExists(maxReference) =>
+        convertValueIfRequired(maxReference, columnStats(maxReference.name).max.get)
       case Alias(tps@ToPrettyString(AggregateExpression(
       Max(maxReference: AttributeReference), Complete, false, None, _), _), _)
-        if checkStatsExists(maxReference) =>
-          val v = columnStats(maxReference.name).max
+        if checkMaxStatsExists(maxReference) =>
+          val v = columnStats(maxReference.name).max.get
           tps.copy(child = Literal(v)).eval()
     }
 
@@ -134,9 +150,12 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
   }
 
   /**
-   * Min and max values from Delta Log stats or partitionValues.
-  */
-  case class DeltaColumnStat(min: Any, max: Any)
+   * Min and max values from Delta Log stats or partitionValues. Each side is `None` when the
+   * corresponding aggregate cannot be answered from metadata for that column (e.g. some file
+   * has stat bounds wide enough to potentially set the table-wide min/max). `Some(value)`
+   * carries the computed bound; `value` may be `null` when the column is all-null.
+   */
+  case class DeltaColumnStat(min: Option[Any], max: Option[Any])
 
   private def extractCountMinMaxFromStats(
       deltaScanGenerator: DeltaScanGenerator,
@@ -148,6 +167,22 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
     val numLogicalRecords = (col("stats.numRecords") - dvCardinality).as("numLogicalRecords")
 
     val filesWithStatsForScan = deltaScanGenerator.filesWithStatsForScan(Nil)
+
+    // The `tightBounds` field is only present in the parsed stats schema when the table was
+    // written with deletion-vector support. When the field is absent, the protocol mandates
+    // that every file be treated as having tight bounds.
+    val hasTightBoundsField = filesWithStatsForScan.schema("stats").dataType match {
+      case s: StructType => s.fieldNames.contains(TIGHT_BOUNDS)
+      case _ => false
+    }
+    // Per-file `tight_bounds` flag projection. NULL or absent `tightBounds` is treated as
+    // tight per the Delta protocol; only an explicit `false` marks the file as wide.
+    val tightBoundsCol = if (hasTightBoundsField) {
+      coalesce(col(s"stats.$TIGHT_BOUNDS"), lit(true))
+    } else {
+      lit(true)
+    }
+
     // Validate all the files has stats
     val filesStatsCount = filesWithStatsForScan.select(
       sum(numLogicalRecords).as("numLogicalRecords"),
@@ -177,7 +212,6 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
 
     if (dataColumns.isEmpty
       || dataColumns.size != lowerCaseColumnNames.size
-      || !isTableDVFree(snapshot) // When DV enabled we can't rely on stats values easily
       || numFiles == 0
       || !statsMinMaxNullColumns.columns.contains(minColName)
       || !statsMinMaxNullColumns.columns.contains(maxColName)
@@ -206,28 +240,43 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
       Seq(col(s"stats.$minColName.`$physicalName`").cast(dataType).as(s"min.$physicalName"),
         col(s"stats.$maxColName.`$physicalName`").cast(dataType).as(s"max.$physicalName"),
         col(s"stats.$nullColName.`$physicalName`").as(s"null_count.$physicalName"))
-    } ++ Seq(col(s"stats.numRecords").as(s"numRecords"))
+    } ++ Seq(
+      col(s"stats.numRecords").as(s"numRecords"),
+      tightBoundsCol.as("tight_bounds"))
 
     val minMaxExpr = dataColumnsWithStats.flatMap { columnAndPhysicalName =>
       val physicalName = columnAndPhysicalName._2
 
-      // To validate if the column has stats we do two validation:
+      // To validate if the column has stats for one direction (MIN or MAX) we do two
+      // validations followed by a tight-bounds check:
       // 1-) COUNT(null_count.columnName) should be equals to numFiles,
       // since null_count is always non-null.
-      // 2-) The number of files with non-null min/max:
-      // a. count(min.columnName)|count(max.columnName) +
+      // 2-) For MIN, the number of files with non-null min:
+      // a. count(min.columnName) +
       // the number of files where all rows are NULL:
       // b. count of (ISNULL(min.columnName) and null_count.columnName == numRecords)
-      // should be equals to numFiles
+      // should be equals to numFiles. Symmetric check for MAX.
+      // 3-) Tight-bounds check. Wide-bound files have stat_min <= actual min and
+      // stat_max >= actual max, so the table-wide MIN/MAX over all files' stats might be
+      // looser than the true table-wide MIN/MAX. We can still trust the value when it
+      // equals the same aggregate computed over only tight files: that proves the wide
+      // files cannot push the bound, so the answer is exact. Null-safe `<=>` handles
+      // empty / all-null cases (both sides NULL means the column is all-null overall).
       Seq(
         s"""case when $numFiles = count(`null_count.$physicalName`)
             | AND $numFiles = (count(`min.$physicalName`) + sum(case when
             |  ISNULL(`min.$physicalName`) and `null_count.$physicalName` = numRecords
             |   then 1 else 0 end))
+            | AND min(`min.$physicalName`) <=>
+            |   min(case when `tight_bounds` then `min.$physicalName` end)
+            | then TRUE else FALSE end as `min_complete_$physicalName`""".stripMargin,
+        s"""case when $numFiles = count(`null_count.$physicalName`)
             | AND $numFiles = (count(`max.$physicalName`) + sum(case when
             |  ISNULL(`max.$physicalName`) AND `null_count.$physicalName` = numRecords
             |   then 1 else 0 end))
-            | then TRUE else FALSE end as `complete_$physicalName`""".stripMargin,
+            | AND max(`max.$physicalName`) <=>
+            |   max(case when `tight_bounds` then `max.$physicalName` end)
+            | then TRUE else FALSE end as `max_complete_$physicalName`""".stripMargin,
         s"min(`min.$physicalName`) as `min_$physicalName`",
         s"max(`max.$physicalName`) as `max_$physicalName`")
     }
@@ -235,14 +284,22 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
     val statsResults = files.select(columnsToQuery: _*).selectExpr(minMaxExpr: _*).head
 
     (Some(numRecords), dataColumnsWithStats
-      .filter(x => statsResults.getAs[Boolean](s"complete_${x._2}"))
-      .map { columnAndPhysicalName =>
+      .flatMap { columnAndPhysicalName =>
         val column = columnAndPhysicalName._1
         val physicalName = columnAndPhysicalName._2
-        column.name ->
-          DeltaColumnStat(
-            statsResults.getAs(s"min_$physicalName"),
-            statsResults.getAs(s"max_$physicalName"))
+        val minComplete = statsResults.getAs[Boolean](s"min_complete_$physicalName")
+        val maxComplete = statsResults.getAs[Boolean](s"max_complete_$physicalName")
+        if (!minComplete && !maxComplete) {
+          None
+        } else {
+          // Use explicit Some(...) to preserve all-null state. Option(...) would
+          // wrongly turn an all-null optimizable column into None.
+          val minValue =
+            if (minComplete) Some(statsResults.getAs[Any](s"min_$physicalName")) else None
+          val maxValue =
+            if (maxComplete) Some(statsResults.getAs[Any](s"max_$physicalName")) else None
+          Some(column.name -> DeltaColumnStat(minValue, maxValue))
+        }
       }.toMap)
   }
 
@@ -280,8 +337,10 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
 
         partitionedColumn._1.name ->
           DeltaColumnStat(
-            partitionedColumnsQuery.getAs(s"min_$physicalName"),
-            partitionedColumnsQuery.getAs(s"max_$physicalName"))
+            // Partition values are exact (no wide-bounds notion applies), so both
+            // directions are always optimizable.
+            Some(partitionedColumnsQuery.getAs[Any](s"min_$physicalName")),
+            Some(partitionedColumnsQuery.getAs[Any](s"max_$physicalName")))
       }.toMap
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -17,13 +17,14 @@
 package org.apache.spark.sql.delta.perf
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTable, Snapshot}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTable}
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.stats.DeltaScanGenerator
 import org.apache.spark.sql.delta.stats.DeltaStatistics.TIGHT_BOUNDS
@@ -39,6 +40,9 @@ import java.util.Locale
  * ShortType, IntegerType, LongType, FloatType, DoubleType, DateType).
  * - All AddFiles in the Delta Log must have stats on columns used in MIN/MAX expressions,
  * or the columns must be partitioned, in the latter case it uses partitionValues, a required field.
+ * Files that contribute no rows to the table (no records at all, or a deletion vector that
+ * invalidates every record) are excluded, so that a partition value that no live row has cannot
+ * become the table-wide MIN/MAX.
  * - For MIN/MAX, the per-column stat used must be trustworthy across the whole table. Per the
  * Delta protocol, files with `stats.tightBounds = false` (only emitted by writers that add
  * deletion vectors without recomputing stats) have wide bounds: their `stat_min` is a lower
@@ -304,8 +308,9 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
   }
 
   private def extractMinMaxFromPartitionValue(
-      snapshot: Snapshot,
+      deltaScanGenerator: DeltaScanGenerator,
       lowerCaseColumnNames: Set[String]): Map[String, DeltaColumnStat] = {
+    val snapshot = deltaScanGenerator.snapshotToScan
 
     val partitionedColumns = snapshot.metadata.partitionSchema
       .filter(col => lowerCaseColumnNames.contains(col.name.toLowerCase(Locale.ROOT)))
@@ -327,7 +332,7 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
           max(s"`$physicalName`").as(s"max_$physicalName"))
       }
 
-      val partitionedColumnsQuery = snapshot.allFiles
+      val partitionedColumnsQuery = filesWithLogicalRecords(deltaScanGenerator)
         .select(partitionedColumnsValues: _*)
         .agg(partitionedColumnsAgg.head, partitionedColumnsAgg.tail: _*)
         .head()
@@ -346,6 +351,27 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
   }
 
   /**
+   * Files that are known to contribute at least one row to the table.
+   *
+   * A partition value must only be considered when the file actually contributes data, otherwise
+   * MIN/MAX over a partition column can return a value that no live row has. Two kinds of files
+   * contribute nothing: files with no records at all (e.g. the empty `AddFile`s that DELETE can
+   * produce) and files whose deletion vector invalidates every record.
+   *
+   * Files whose `numRecords` is unknown are conservatively kept, which cannot hide a deletion
+   * vector: the protocol requires that "when adding a logical file with a deletion vector, then
+   * that logical file must have correct `numRecords` information for the data file in the `stats`
+   * field", so a file with an unknown record count has no deletion vector.
+   */
+  private def filesWithLogicalRecords(deltaScanGenerator: DeltaScanGenerator): DataFrame = {
+    val dvCardinality = coalesce(col("deletionVector.cardinality"), lit(0))
+    val numLogicalRecords = col("stats.numRecords") - dvCardinality
+    deltaScanGenerator
+      .filesWithStatsForScan(Nil)
+      .where(numLogicalRecords.isNull || numLogicalRecords > 0)
+  }
+
+  /**
   * Extract the Count, Min and Max values from Delta Log stats and partitionValues.
   * The first field is the rows count in the table or `None` if we cannot calculate it from stats
   * If the column is not partitioned, the values are extracted from stats when it exists.
@@ -358,7 +384,7 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
     val deltaScanGen = getDeltaScanGenerator(tahoeLogFileIndex)
 
     val partitionedValues = extractMinMaxFromPartitionValue(
-      deltaScanGen.snapshotToScan,
+      deltaScanGen,
       lowerCaseColumnNames)
 
     val partitionedColNames = partitionedValues.keySet.map(_.toLowerCase(Locale.ROOT))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -21,11 +21,14 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaLog, DeltaTestUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.DeltaStatistics.TIGHT_BOUNDS
 import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.test.DeltaColumnMappingSelectedTestMixin
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.JsonUtils
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.delta.tables.DeltaTable
 import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterAll
@@ -847,6 +850,123 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       DeltaTable.forPath(spark, tempPath).delete("id = 1")
       assert(!getFilesWithDeletionVectors(DeltaLog.forTable(spark, new Path(tempPath))).isEmpty)
       checkOptimizationIsNotTriggered(querySql)
+    }
+  }
+
+  test("min-max - dv-enabled table without any DV files") {
+    // When a table has the deletion-vectors table feature enabled but no AddFile actually
+    // carries a deletion vector, every file still has tight stat bounds (the protocol
+    // treats absent `stats.tightBounds` as tight). The MIN/MAX optimization should apply.
+    withTempDir { dir =>
+      val tempPath = dir.getCanonicalPath
+      spark.range(1, 10, 1, 1).write.format("delta").save(tempPath)
+      enableDeletionVectorsInTable(new Path(tempPath), true)
+      assert(getFilesWithDeletionVectors(DeltaLog.forTable(spark, new Path(tempPath))).isEmpty)
+      checkResultsAndOptimizedPlan(
+        s"SELECT MIN(id), MAX(id) FROM delta.`$tempPath`",
+        "LocalRelation [none#0L, none#1L]")
+    }
+  }
+
+  test("min-max - dv-enabled table with tight bounds after stats recompute") {
+    // Simulate an external "compute stats" that recomputes per-file stats with tight bounds
+    // on files that still carry a deletion vector. The MIN/MAX optimization should apply
+    // because every file's per-column bounds are now tight, even though DVs are present.
+    withTempDir { dir =>
+      val tempPath = dir.getCanonicalPath
+      spark.range(1, 10, 1, 1).write.format("delta").save(tempPath)
+      val querySql = s"SELECT MIN(id), MAX(id) FROM delta.`$tempPath`"
+      checkResultsAndOptimizedPlan(querySql, "LocalRelation [none#0L, none#1L]")
+
+      enableDeletionVectorsInTable(new Path(tempPath), true)
+      // Delete an interior id so the file's stored min/max (1 and 9) remain accurate
+      // after the deletion: the only thing that needs to change to make the bounds
+      // tight is the `tightBounds` flag itself.
+      DeltaTable.forPath(spark, tempPath).delete("id = 5")
+      val log = DeltaLog.forTable(spark, new Path(tempPath))
+      assert(!getFilesWithDeletionVectors(log).isEmpty)
+      // After DELETE, stats have wide bounds. MIN/MAX optimization must NOT trigger here.
+      checkOptimizationIsNotTriggered(querySql)
+
+      // Recommit the same AddFiles with `tightBounds` set to true, preserving the
+      // existing min/max from the original stats (which remain accurate because we
+      // only removed an interior value).
+      val txn = log.startTransaction()
+      val rewrittenAddFiles = txn.snapshot.allFiles.collect().toSeq.map { action =>
+        val statsNode = JsonUtils.mapper.readTree(action.stats).asInstanceOf[ObjectNode]
+        statsNode.put(TIGHT_BOUNDS, true)
+        action.copy(stats = JsonUtils.toJson(statsNode))
+      }
+      txn.commitManually(rewrittenAddFiles: _*)
+
+      // Optimization should now apply and produce the correct MIN=1, MAX=9.
+      checkResultsAndOptimizedPlan(querySql, "LocalRelation [none#0L, none#1L]")
+    }
+  }
+
+  test("min-max - mixed wide and tight files where tight file dominates both bounds") {
+    // A wide-bound file co-exists with a tight-bound file, and the tight file's stat
+    // bounds completely contain the wide file's actual data, so the table-wide MIN/MAX
+    // coincide with the aggregate over only the tight files. The optimization should
+    // therefore still apply for both MIN and MAX.
+    withTempDir { dir =>
+      val tempPath = dir.getCanonicalPath
+      // File A: ids 5..10 (single file). Stats: min=5, max=10, tight.
+      spark.range(5, 11, 1, 1).write.format("delta").save(tempPath)
+
+      enableDeletionVectorsInTable(new Path(tempPath), true)
+      // Delete an interior id of File A so its stored min/max remain 5 and 10, but
+      // the AddFile is rewritten with tightBounds=false (wide) due to the new DV.
+      DeltaTable.forPath(spark, tempPath).delete("id = 7")
+      val log = DeltaLog.forTable(spark, new Path(tempPath))
+      assert(!getFilesWithDeletionVectors(log).isEmpty)
+
+      // File B: ids 3..11 (single file). Stats: min=3, max=11, tight (no DV on this file).
+      spark.range(3, 12, 1, 1).write.format("delta").mode("append").save(tempPath)
+
+      val querySql = s"SELECT MIN(id), MAX(id) FROM delta.`$tempPath`"
+      // Table-wide MIN=3, MAX=11 are both achieved by the tight file B. Even though
+      // File A is wide, its stat range [5..10] cannot push the table-wide MIN below
+      // 3 or the MAX above 11, so the optimization is sound.
+      checkResultsAndOptimizedPlan(querySql, "LocalRelation [none#0L, none#1L]")
+    }
+  }
+
+  test("min-max - mixed wide and tight files where only one direction is recoverable") {
+    // A wide file's stat range extends past the tight file in the MAX direction but not
+    // in the MIN direction. The MIN optimization should still be applicable (because
+    // min_all equals min_tight), but the MAX side cannot be answered from metadata
+    // (max_all is from the wide file, max_tight is strictly smaller). Because the
+    // optimizer requires every aggregate in the query to be answerable, asking for both
+    // MIN and MAX falls back to a normal scan, but asking for MIN alone is optimized.
+    withTempDir { dir =>
+      val tempPath = dir.getCanonicalPath
+      // File A: ids 5..14 (single file). Stats: min=5, max=14, tight.
+      spark.range(5, 15, 1, 1).write.format("delta").save(tempPath)
+
+      enableDeletionVectorsInTable(new Path(tempPath), true)
+      // Delete id=14, which only File A contains. The AddFile is rewritten with
+      // wide bounds (tightBounds=false), but the stored stat_max stays at 14 even
+      // though the file's actual max is now 13. The MAX side of the optimization
+      // therefore cannot trust the wide file.
+      DeltaTable.forPath(spark, tempPath).delete("id = 14")
+      val log = DeltaLog.forTable(spark, new Path(tempPath))
+      assert(!getFilesWithDeletionVectors(log).isEmpty)
+
+      // File B: ids 3..11 (single file). Stats: min=3, max=11, tight.
+      spark.range(3, 12, 1, 1).write.format("delta").mode("append").save(tempPath)
+
+      // MIN: min_all = min(5,3) = 3, min_tight = min(3) = 3 => optimization triggers.
+      val minOnly = s"SELECT MIN(id) FROM delta.`$tempPath`"
+      checkResultsAndOptimizedPlan(minOnly, "LocalRelation [none#0L]")
+
+      // MAX: max_all = max(14,11) = 14, max_tight = max(11) = 11 => cannot optimize.
+      val maxOnly = s"SELECT MAX(id) FROM delta.`$tempPath`"
+      checkOptimizationIsNotTriggered(maxOnly)
+
+      // Mixed query: MAX cannot be optimized, so the entire query falls back.
+      val both = s"SELECT MIN(id), MAX(id) FROM delta.`$tempPath`"
+      checkOptimizationIsNotTriggered(both)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -970,6 +970,86 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     }
   }
 
+  test("min-max - partition values ignore files fully removed by a deletion vector") {
+    // A file whose deletion vector invalidates every record contributes no rows to the
+    // table, so its partition value must not be able to set the table-wide MIN/MAX.
+    // Such files are protocol-legal: nothing requires `cardinality < numRecords`.
+    withTempDir { dir =>
+      val tempPath = dir.getCanonicalPath
+      // A single Spark partition writes exactly one file per partition value. Partition 1
+      // gets two rows and is the only one kept, so the files to fully delete are exactly
+      // the single-row ones. Identifying them by row count rather than by partition value
+      // keeps this test independent of the column mapping mode.
+      spark.range(0, 4, 1, 1)
+        .select(
+          col("id").cast("int").as("Column1"),
+          when(col("id") === 0, lit(0))
+            .when(col("id") === 3, lit(2))
+            .otherwise(lit(1)).as("Column2"))
+        .write.format("delta").partitionBy("Column2").save(tempPath)
+
+      val log = DeltaLog.forTable(spark, new Path(tempPath))
+      enableDeletionVectorsInTable(new Path(tempPath), true)
+
+      val files = log.update().allFiles.collect()
+      assert(files.length === 3)
+      val (filesToFullyDelete, filesToKeep) = files.partition(_.numPhysicalRecords.contains(1L))
+      assert(filesToFullyDelete.length === 2)
+      assert(filesToKeep.length === 1)
+
+      // Cover every row of each file with a deletion vector instead of removing the
+      // AddFile, which is what a writer does when it cannot prove the file is fully
+      // replaced (see TouchedFileWithDV.isFullyReplaced).
+      filesToFullyDelete.foreach { file =>
+        removeRowsFromFile(log, file, Seq.range(0, file.numPhysicalRecords.get))
+      }
+      val remainingFiles = log.update().allFiles.collect()
+      assert(remainingFiles.length === 3)
+      assert(remainingFiles.count(_.numLogicalRecords.contains(0L)) === 2)
+
+      // Only partition 1 still has rows, so MIN and MAX must both be 1.
+      checkResultsAndOptimizedPlan(
+        s"SELECT MIN(Column2), MAX(Column2) FROM delta.`$tempPath`",
+        "LocalRelation [none#0, none#1]")
+      checkAnswer(
+        spark.sql(s"SELECT MIN(Column2), MAX(Column2) FROM delta.`$tempPath`"),
+        Row(1, 1))
+    }
+  }
+
+  test("min-max - partition values keep files partially removed by a deletion vector") {
+    // A file that still has live rows genuinely contributes its partition value, so the
+    // optimization must keep using it.
+    withTempDir { dir =>
+      val tempPath = dir.getCanonicalPath
+      // A single Spark partition writes exactly one file per partition value, each with
+      // two rows, so removing one row per file leaves every file non-empty.
+      spark.range(0, 4, 1, 1)
+        .select(
+          col("id").cast("int").as("Column1"),
+          (col("id") % 2).cast("int").as("Column2"))
+        .write.format("delta").partitionBy("Column2").save(tempPath)
+
+      val log = DeltaLog.forTable(spark, new Path(tempPath))
+      enableDeletionVectorsInTable(new Path(tempPath), true)
+
+      val files = log.update().allFiles.collect()
+      assert(files.length === 2)
+      files.foreach { file =>
+        assert(file.numPhysicalRecords.get === 2)
+        removeRowsFromFile(log, file, Seq(0L))
+      }
+      assert(log.update().allFiles.collect().forall(_.numLogicalRecords.contains(1L)))
+
+      checkResultsAndOptimizedPlan(
+        s"SELECT MIN(Column2), MAX(Column2) FROM delta.`$tempPath`",
+        "LocalRelation [none#0, none#1]")
+      checkAnswer(
+        spark.sql(s"SELECT MIN(Column2), MAX(Column2) FROM delta.`$tempPath`"),
+        Row(0, 1))
+    }
+  }
+
   test("optimization not supported - filter on partitioned column") {
     val tableName = "TestPartitionedFilter"
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The MIN/MAX metadata-only rewrite in OptimizeMetadataOnlyDeltaQuery previously bailed out whenever the table was not DV-free. The real precondition required by the Delta protocol is per-file `stats.tightBounds`: with wide bounds, `stat_min <= actual_min` and `stat_max >= actual_max`, so the table-wide aggregate over all files' stats might be looser than the true value.

That gate was unnecessarily coarse. The rewrite can still be applied when wide-bound files exist, as long as wide files don't actually push the table-wide bound. Concretely, for each column the table-wide MIN is exact iff `min(stat_min over all files) <=> min(stat_min over tight files only)` (null-safe equal), and symmetrically for MAX. When that holds, the minimum was achieved by a tight file (whose `stat_min` equals the file's `actual_min`) and every wide file's `actual_min` is necessarily >= that value, so the result is correct.

Changes:
- Replace the `!isTableDVFree(snapshot)` bail-out with a per-column, per-direction tight-vs-all aggregate comparison driven by a `tight_bounds` projection (`coalesce(stats.tightBounds, true)`).
- Split `checkStatsExists` into `checkMinStatsExists` / `checkMaxStatsExists` so MIN and MAX are evaluated independently per column.
- Change `DeltaColumnStat` to `(min: Option[Any], max: Option[Any])` to distinguish "not optimizable in this direction" from "all-null column" (still optimizable, value is null).
- Update `extractMinMaxFromPartitionValue` accordingly; partition values are always exact, so both sides are `Some(...)`.

Tests:
- Tight bounds restored after stats recompute on DV files: optimizes.
- DV table feature enabled but no DV files present: optimizes.
- Mixed wide+tight where tight file dominates both bounds: optimizes MIN and MAX.
- Mixed wide+tight where only MIN direction is recoverable: MIN optimizes, MAX and mixed MIN/MAX fall back.

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
Yes, enable optimization for tables with DV
