### PR TITLE
[Kernel] Add data skipping support for STARTS_WITH predicate

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -28,6 +28,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.CollationIdentifier;
+import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.util.*;
@@ -307,6 +308,82 @@ public class DataSkippingUtils {
                     "ST_GEOMETRY_BOXES_INTERSECT_ON_STATS",
                     Arrays.asList(minCol, maxCol, queryMin, queryMax),
                     refCols));
+          }
+        }
+        break;
+
+      case "STARTS_WITH":
+        // For predicate: column STARTS_WITH 'prefix'
+        // Data skipping rule:
+        //   SUBSTRING(minValue, 1, prefixLen) <= prefix AND
+        //   SUBSTRING(maxValue, 1, prefixLen) >= prefix
+        //
+        // A file can be skipped if the prefix falls completely outside the min/max range
+        // of the column's string prefixes.
+        Expression startsWithLeft = getLeft(dataFilters);
+        Expression startsWithRight = getRight(dataFilters);
+        Optional<CollationIdentifier> startsWithCollation = dataFilters.getCollationIdentifier();
+
+        if (startsWithCollation
+            .filter(ci -> !ci.isSparkUTF8BinaryCollation() && ci.getVersion().isEmpty())
+            .isPresent()) {
+          // Collation must specify a version to be used for data skipping
+          return Optional.empty();
+        }
+
+        if (startsWithLeft instanceof Column && startsWithRight instanceof Literal) {
+          Column leftCol = (Column) startsWithLeft;
+          Literal prefixLit = (Literal) startsWithRight;
+
+          // STARTS_WITH only works with strings
+          if (!(prefixLit.getDataType() instanceof StringType)) {
+            return Optional.empty();
+          }
+
+          if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol)) {
+            String prefix = (String) prefixLit.getValue();
+            int prefixLen = prefix.length();
+
+            // Get min and max columns
+            Column minCol = schemaHelper.getMinColumn(leftCol, startsWithCollation)._1;
+            Column maxCol = schemaHelper.getMaxColumn(leftCol, startsWithCollation)._1;
+
+            // Create SUBSTRING expressions: SUBSTRING(col, 1, prefixLen)
+            // Note: SUBSTRING uses 1-based indexing
+            ScalarExpression minSubstring =
+                new ScalarExpression(
+                    "SUBSTRING", Arrays.asList(minCol, Literal.ofInt(1), Literal.ofInt(prefixLen)));
+            ScalarExpression maxSubstring =
+                new ScalarExpression(
+                    "SUBSTRING", Arrays.asList(maxCol, Literal.ofInt(1), Literal.ofInt(prefixLen)));
+
+            // Build: SUBSTRING(min, 1, len) <= prefix AND SUBSTRING(max, 1, len) >= prefix
+            DataSkippingPredicate minPredicate;
+            DataSkippingPredicate maxPredicate;
+
+            if (startsWithCollation.isPresent()) {
+              minPredicate =
+                  new DataSkippingPredicate(
+                      "<=",
+                      Arrays.asList(minSubstring, prefixLit),
+                      startsWithCollation.get(),
+                      Collections.singleton(minCol));
+              maxPredicate =
+                  new DataSkippingPredicate(
+                      ">=",
+                      Arrays.asList(maxSubstring, prefixLit),
+                      startsWithCollation.get(),
+                      Collections.singleton(maxCol));
+            } else {
+              minPredicate =
+                  new DataSkippingPredicate(
+                      "<=", Arrays.asList(minSubstring, prefixLit), Collections.singleton(minCol));
+              maxPredicate =
+                  new DataSkippingPredicate(
+                      ">=", Arrays.asList(maxSubstring, prefixLit), Collections.singleton(maxCol));
+            }
+
+            return Optional.of(new DataSkippingPredicate("AND", minPredicate, maxPredicate));
           }
         }
         break;

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/DataSkippingUtilsSuite.scala
@@ -19,7 +19,7 @@ import java.util.Optional
 
 import scala.collection.JavaConverters._
 
-import io.delta.kernel.expressions.{Column, Expression, Predicate}
+import io.delta.kernel.expressions.{Column, Expression, Predicate, ScalarExpression}
 import io.delta.kernel.internal.skipping.DataSkippingUtils.constructDataSkippingFilter
 import io.delta.kernel.internal.skipping.StatsSchemaHelper.{MAX, MIN, STATS_WITH_COLLATION}
 import io.delta.kernel.internal.util.ExpressionUtils.createPredicate
@@ -397,7 +397,81 @@ class DataSkippingUtilsSuite extends AnyFunSuite with TestUtils {
           dataSkippingPredicate(
             "<=",
             Seq(nestedCol(s"$MIN.b"), literal(7)),
-            Set(nestedCol(s"$MIN.b")))))))
+            Set(nestedCol(s"$MIN.b")))))),
+      // STARTS_WITH: column STARTS_WITH 'prefix'
+      // Expected: SUBSTRING(min, 1, 3) <= 'abc' AND SUBSTRING(max, 1, 3) >= 'abc'
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        createPredicate(
+          "STARTS_WITH",
+          col("a"),
+          literal("abc"),
+          Optional.empty[CollationIdentifier]),
+        Some(dataSkippingPredicate(
+          "AND",
+          dataSkippingPredicate(
+            "<=",
+            Seq(
+              new ScalarExpression(
+                "SUBSTRING",
+                Seq(nestedCol(s"$MIN.a"), literal(1), literal(3)).asJava),
+              literal("abc")),
+            Set(nestedCol(s"$MIN.a"))),
+          dataSkippingPredicate(
+            ">=",
+            Seq(
+              new ScalarExpression(
+                "SUBSTRING",
+                Seq(nestedCol(s"$MAX.a"), literal(1), literal(3)).asJava),
+              literal("abc")),
+            Set(nestedCol(s"$MAX.a")))))),
+      // STARTS_WITH with empty string prefix - should still work with length 0
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        createPredicate("STARTS_WITH", col("a"), literal(""), Optional.empty[CollationIdentifier]),
+        Some(dataSkippingPredicate(
+          "AND",
+          dataSkippingPredicate(
+            "<=",
+            Seq(
+              new ScalarExpression(
+                "SUBSTRING",
+                Seq(nestedCol(s"$MIN.a"), literal(1), literal(0)).asJava),
+              literal("")),
+            Set(nestedCol(s"$MIN.a"))),
+          dataSkippingPredicate(
+            ">=",
+            Seq(
+              new ScalarExpression(
+                "SUBSTRING",
+                Seq(nestedCol(s"$MAX.a"), literal(1), literal(0)).asJava),
+              literal("")),
+            Set(nestedCol(s"$MAX.a")))))),
+      // STARTS_WITH with non-string literal should return None
+      (
+        new StructType()
+          .add("a", StringType.STRING),
+        createPredicate("STARTS_WITH", col("a"), literal(123), Optional.empty[CollationIdentifier]),
+        None),
+      // STARTS_WITH with column on right side (unsupported) should return None
+      (
+        new StructType()
+          .add("a", StringType.STRING)
+          .add("b", StringType.STRING),
+        createPredicate("STARTS_WITH", col("a"), col("b"), Optional.empty[CollationIdentifier]),
+        None),
+      // STARTS_WITH on non-skipping-eligible column should return None
+      (
+        new StructType()
+          .add("a", new StructType().add("nested", StringType.STRING)),
+        createPredicate(
+          "STARTS_WITH",
+          col("a"),
+          literal("abc"),
+          Optional.empty[CollationIdentifier]),
+        None))
 
     testCases.foreach { case (schema, predicate, expectedDataSkippingPredicateOpt) =>
       val dataSkippingPredicateOpt =


### PR DESCRIPTION
## Summary
- Implement STARTS_WITH data skipping in Delta Kernel to improve query performance when filtering string columns with prefix matching
- For a predicate `column STARTS_WITH 'prefix'`, files can be skipped where the prefix falls outside the min/max range of the column's string prefixes
- Follows the same approach used in the Spark connector

## Test plan
- [x] Added unit tests for STARTS_WITH data skipping in `DataSkippingUtilsSuite`
- [x] Tests cover basic prefix matching, empty string prefix, and edge cases (non-string literal, column on right side, non-eligible column)
- [x] All existing tests pass

Addresses #2539