### PR TITLE
  [Fix][Spark] NoSuchMethodError on ParquetToSparkSchemaConverter with Spark 4.1.2

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -903,10 +903,11 @@ object Snapshot extends DeltaLogging {
       spark: SparkSession,
       deltaLog: DeltaLog,
       file: FileStatus): (StructType, Long) = {
-    // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`
-    val converter = new ParquetToSparkSchemaConverter(
-      assumeBinaryIsString = spark.sessionState.conf.isParquetBinaryAsString,
-      assumeInt96IsTimestamp = spark.sessionState.conf.isParquetINT96AsTimestamp)
+    // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`.
+    // Use the stable SQLConf-based ctor to avoid binary incompatibility across Spark
+    // patch releases that add new parameters to the primary ctor (e.g. Spark 4.0.1
+    // and 4.1.2 each added a boolean param), which manifests as NoSuchMethodError.
+    val converter = new ParquetToSparkSchemaConverter(spark.sessionState.conf)
 
     val conf = deltaLog.newDeltaHadoopConf()
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
@@ -25,8 +25,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetToSparkSchemaConverter}
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.{AtomicType, StructField, StructType}
 import org.apache.spark.util.SerializableConfiguration
 
@@ -109,13 +108,14 @@ trait ReorgTableHelper extends Serializable {
 
     val serializedConf = new SerializableConfiguration(snapshot.deltaLog.newDeltaHadoopConf())
     val dataPath = new Path(snapshot.dataPath.toString)
+    // Captured on the driver and serialized into the executor closure below.
+    val sqlConfEntries = spark.sessionState.conf.getAllConfs
 
     import org.apache.spark.sql.delta.implicits._
 
     files.toDF(spark).as[AddFile].mapPartitions { iter =>
-      val sqlConf = SparkSession.active.sessionState.conf
       filterParquetFiles(
-        sqlConf,
+        sqlConfEntries,
         iter.toList,
         dataPath,
         serializedConf.value,
@@ -124,7 +124,7 @@ trait ReorgTableHelper extends Serializable {
   }
 
   protected def filterParquetFiles(
-      sqlConf: SQLConf,
+      sqlConfEntries: Map[String, String],
       files: Seq[AddFile],
       dataPath: Path,
       configuration: Configuration,
@@ -148,10 +148,7 @@ trait ReorgTableHelper extends Serializable {
       fileStatuses.toList,
       ignoreCorruptFiles)
 
-    // Spark 4.0.1 changed the primary ctor signature (added a param), which breaks binary
-    // compatibility for code compiled against Spark 4.0.0. Use the stable SQLConf-based ctor
-    // that takes the current SparkSession's SQLConf instead.
-    val converter = new ParquetToSparkSchemaConverter(sqlConf)
+    val converter = DeltaFileOperations.buildParquetToSparkSchemaConverter(sqlConfEntries)
 
     val filesNeedToRewrite = footers.filter { footer =>
       val fileSchema = ParquetFileFormat.readSchemaFromFooter(footer, converter)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetFileManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetFileManifest.scala
@@ -25,7 +25,8 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetToSparkSchemaConverter}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -57,10 +58,11 @@ class ManualListingFileManifest(
       }.toMap
       val footerSeq = DeltaFileOperations.readParquetFootersInParallel(
         conf.value.value, fileStatuses.map(_.toFileStatus), fetchConfig.ignoreCorruptFiles)
-      val schemaConverter = new ParquetToSparkSchemaConverter(
-        assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-        assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-      )
+      // Runs on executors: build the converter from the serialized parquet flags.
+      val schemaConverter = DeltaFileOperations.buildParquetToSparkSchemaConverter(
+        Map(
+          SQLConf.PARQUET_BINARY_AS_STRING.key -> fetchConfig.assumeBinaryIsString.toString,
+          SQLConf.PARQUET_INT96_AS_TIMESTAMP.key -> fetchConfig.assumeInt96IsTimestamp.toString))
       footerSeq.map { footer =>
         val fileStatus = pathToStatusMapping(footer.getFile.toString)
         val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)
@@ -138,10 +140,11 @@ class CatalogFileManifest(
           conf.value.value,
           fileStatuses.map(_.toFileStatus),
           fetchConfig.ignoreCorruptFiles)
-        val schemaConverter = new ParquetToSparkSchemaConverter(
-          assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-          assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-        )
+        // Runs on executors: build the converter from the serialized parquet flags.
+        val schemaConverter = DeltaFileOperations.buildParquetToSparkSchemaConverter(
+          Map(
+            SQLConf.PARQUET_BINARY_AS_STRING.key -> fetchConfig.assumeBinaryIsString.toString,
+            SQLConf.PARQUET_INT96_AS_TIMESTAMP.key -> fetchConfig.assumeInt96IsTimestamp.toString))
         footerSeq.map { footer =>
           val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)
           val fileStatus = pathToFile(footer.getFile.toString)
@@ -211,10 +214,11 @@ class MetadataLogFileManifest(
       }.toMap
       val footerSeq = DeltaFileOperations.readParquetFootersInParallel(
         conf.value.value, fileStatuses.map(_.toFileStatus), fetchConfig.ignoreCorruptFiles)
-      val schemaConverter = new ParquetToSparkSchemaConverter(
-        assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-        assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-      )
+      // Runs on executors: build the converter from the serialized parquet flags.
+      val schemaConverter = DeltaFileOperations.buildParquetToSparkSchemaConverter(
+        Map(
+          SQLConf.PARQUET_BINARY_AS_STRING.key -> fetchConfig.assumeBinaryIsString.toString,
+          SQLConf.PARQUET_INT96_AS_TIMESTAMP.key -> fetchConfig.assumeInt96IsTimestamp.toString))
       footerSeq.map { footer =>
         val fileStatus = pathToStatusMapping(footer.getFile.toString)
         val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
@@ -40,6 +40,8 @@ import org.apache.spark.{SparkEnv, SparkException, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetToSparkSchemaConverter
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.{SerializableConfiguration, ThreadUtils}
 
 /**
@@ -417,6 +419,18 @@ object DeltaFileOperations extends DeltaLogging {
         }
       }
     }.flatten
+  }
+
+  /**
+   * Build a [[ParquetToSparkSchemaConverter]] from a serializable snapshot of `SQLConf` entries
+   * (e.g. from `SQLConf.getAllConfs`). Safe to call on executors, and uses the `(conf: SQLConf)`
+   * auxiliary constructor, whose signature is stable across Spark patch releases.
+   */
+  def buildParquetToSparkSchemaConverter(
+      sqlConfEntries: Map[String, String]): ParquetToSparkSchemaConverter = {
+    val sqlConf = new SQLConf()
+    sqlConfEntries.foreach { case (key, value) => sqlConf.setConfString(key, value) }
+    new ParquetToSparkSchemaConverter(sqlConf)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaDistributedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaDistributedSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.Utils
+
+/**
+ * Distributed (multi-JVM) coverage for `CONVERT TO DELTA`'s parquet schema inference, which runs
+ * inside `mapPartitions` on executors. Unlike the rest of the Delta test suite this runs against a
+ * `local-cluster` master so executors are separate JVMs - the only setup that exercises the
+ * executor code path faithfully. Heavier than a unit test; the cheap, single-JVM guard lives in
+ * `DeltaFileOperationsParquetConverterSuite`.
+ */
+class ConvertToDeltaDistributedSuite extends SparkFunSuite {
+
+  /**
+   * Run `f` with a freshly built `local-cluster` SparkSession (2 single-core executor JVMs),
+   * stopping it afterwards. A new session per test keeps executor state from leaking between
+   * tests and mirrors how Spark's own multi-JVM suites are structured.
+   */
+  private def withLocalClusterSession(f: SparkSession => Unit): Unit = {
+    // local-cluster launches executor JVMs via `$SPARK_HOME/bin/spark-class`, so it only works
+    // when a Spark distribution is available. Spark's own multi-JVM suites rely on the
+    // `spark.test.home` system property for this; the Delta build does not set it by default, so
+    // skip (rather than fail) when it is absent. Provide it via, e.g.,
+    // `-Dspark.test.home=<spark-dist>` to exercise this suite.
+    assume(
+      sys.props.get("spark.test.home").exists(_.nonEmpty),
+      "spark.test.home must point to a Spark distribution to launch local-cluster executors")
+
+    val warehouse = Utils.createTempDir()
+    val spark = SparkSession.builder()
+      .master("local-cluster[2, 1, 1024]")
+      .appName("ConvertToDeltaDistributedSuite")
+      .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.warehouse.dir", warehouse.getAbsolutePath)
+      // Ship the driver's classpath (Delta + its deps) to the separately-launched executor JVMs;
+      // the Spark distribution at spark.test.home only provides Spark itself.
+      .config("spark.executor.extraClassPath", sys.props("java.class.path"))
+      // Keep the test light: no need to spread work, and shuffle output stays small.
+      .config(SQLConf.SHUFFLE_PARTITIONS.key, "5")
+      .getOrCreate()
+    try {
+      f(spark)
+    } finally {
+      try spark.stop() finally {
+        Utils.deleteRecursively(warehouse)
+        SparkSession.clearActiveSession()
+        SparkSession.clearDefaultSession()
+      }
+    }
+  }
+
+  test("CONVERT TO DELTA infers parquet schema on executors without an active session") {
+    withLocalClusterSession { spark =>
+      val dir = Utils.createTempDir()
+      try {
+        val path = new File(dir, "parquet_tbl").getCanonicalPath
+        // Write a plain parquet directory (no Delta log) from a distributed job.
+        spark.range(0, 100)
+          .selectExpr("id", "cast(id as string) as s")
+          .repartition(4)
+          .write.format("parquet").save(path)
+
+        // Lists files and reads their footers via ParquetFileManifest inside `mapPartitions`.
+        spark.sql(s"CONVERT TO DELTA parquet.`$path`")
+
+        val converted = spark.read.format("delta").load(path)
+        assert(converted.count() === 100)
+        assert(converted.schema.fieldNames.toSet === Set("id", "s"))
+      } finally {
+        Utils.deleteRecursively(dir)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/DeltaFileOperationsParquetConverterSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/DeltaFileOperationsParquetConverterSuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.parquet.schema.MessageTypeParser
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{BinaryType, StringType}
+
+/**
+ * Single-JVM guard for [[DeltaFileOperations.buildParquetToSparkSchemaConverter]]: it must work
+ * with no active or default `SparkSession` (the condition on executors). The end-to-end
+ * distributed reproduction lives in `ConvertToDeltaDistributedSuite`.
+ */
+class DeltaFileOperationsParquetConverterSuite
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  /** Run `f` with no active or default SparkSession, restoring them afterwards. */
+  private def withoutAnyActiveSession[T](f: => T): T = {
+    val prevActive = SparkSession.getActiveSession
+    val prevDefault = SparkSession.getDefaultSession
+    try {
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+      f
+    } finally {
+      prevActive.foreach(SparkSession.setActiveSession)
+      prevDefault.foreach(SparkSession.setDefaultSession)
+    }
+  }
+
+  test("buildParquetToSparkSchemaConverter works without an active SparkSession") {
+    // A plain (unannotated) parquet binary: assumeBinaryIsString decides String vs Binary.
+    val parquetSchema = MessageTypeParser.parseMessageType(
+      "message root { required binary b; }")
+
+    withoutAnyActiveSession {
+      val asString = DeltaFileOperations.buildParquetToSparkSchemaConverter(
+        Map(SQLConf.PARQUET_BINARY_AS_STRING.key -> "true"))
+      assert(asString.convert(parquetSchema).head.dataType === StringType)
+
+      val asBinary = DeltaFileOperations.buildParquetToSparkSchemaConverter(
+        Map(SQLConf.PARQUET_BINARY_AS_STRING.key -> "false"))
+      assert(asBinary.convert(parquetSchema).head.dataType === BinaryType)
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fixes a `NoSuchMethodError` thrown when running Delta `4.2.0` (built for Spark 4.1) on Spark `4.1.2`:

```
java.lang.NoSuchMethodError: 'void org.apache.spark.sql.execution.datasources.parquet.ParquetToSparkSchemaConverter.<init>(boolean, boolean, boolean, boolean, boolean, boolean, boolean)'
  at org.apache.spark.sql.delta.Snapshot.getParquetFileSchemaAndRowCount(Snapshot.scala:892)
  at org.apache.spark.sql.delta.CheckpointProvider$.getParquetSchema(CheckpointProvider.scala:195)
  ...
```

### Root cause

Spark `4.1.2` added an 8th boolean parameter (`respectUnknownTypeAnnotation`) to the primary constructor of `ParquetToSparkSchemaConverter`. Delta code compiled against Spark `4.1.0` calls the constructor with named arguments, which Scala compiles down to a positional call to the primary constructor (filling defaults). That bytecode references the 7-boolean form, which no longer exists at runtime on Spark `4.1.2`, hence the `NoSuchMethodError`.

- **Spark 4.1.0** ([source](https://github.com/apache/spark/blob/v4.1.0/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala)): 7 boolean params, last is `ignoreVariantAnnotation`.
- **Spark 4.1.2** ([source](https://github.com/apache/spark/blob/v4.1.2/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala)): 8 boolean params, adds `respectUnknownTypeAnnotation`.

This is the same class of issue previously fixed for the Spark 4.0.0 → 4.0.1 transition in #5697 (which added a 6th boolean `useFieldId`). That PR migrated `ReorgTableHelper` off the primary constructor, but the same pattern was still present in `Snapshot.getParquetFileSchemaAndRowCount` and in three locations in `ParquetFileManifest`.

### Fix

Call the stable `ParquetToSparkSchemaConverter(conf: SQLConf)` auxiliary constructor, whose signature does not change across Spark patch releases, instead of the named-args primary constructor. This decouples Delta from the evolving primary constructor signature while preserving behavior — the converter still reads `assumeBinaryIsString` and `assumeInt96IsTimestamp` from the same `SQLConf` the previous code sourced them from.

There is a second problem in the existing pattern, [raised in review](https://github.com/delta-io/delta/pull/6868#issuecomment-4563176856): `ReorgTableHelper` and `ParquetFileManifest` read footers inside `mapPartitions`, i.e. **on executors**, where no `SparkSession` is available. Sourcing the `SQLConf` via `SparkSession.active` there (as the #5697 fix did, and which was never addressed) works in local mode but throws on a real cluster. Instead, this PR captures the relevant `SQLConf` entries on the driver and rebuilds a `SQLConf` on the executor via a new helper, `DeltaFileOperations.buildParquetToSparkSchemaConverter`:

- `ReorgTableHelper` serializes `conf.getAllConfs` into the `mapPartitions` closure.
- The three `ParquetFileManifest` sites build the converter from the parquet flags already serialized in `fetchConfig` (`assumeBinaryIsString`, `assumeInt96IsTimestamp`).

`Snapshot.getParquetFileSchemaAndRowCount` is driver-side (it is handed a `SparkSession` and reads a single footer locally), so it keeps using `spark.sessionState.conf`.

Files changed:
- `spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala`
- `spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala`
- `spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetFileManifest.scala`
- `spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala`

## How was this patch tested?

Two new suites:

- `DeltaFileOperationsParquetConverterSuite` — single-JVM guard that `buildParquetToSparkSchemaConverter` works with **no** active or default `SparkSession` (the executor condition), and that `assumeBinaryIsString` is honored.
- `ConvertToDeltaDistributedSuite` — end-to-end `CONVERT TO DELTA` against a `local-cluster` master, where executors are separate JVMs with no `SparkSession` — the only setup that exercises the executor code path faithfully. It is gated on a Spark distribution being available via `-Dspark.test.home` (since `local-cluster` launches executor JVMs through `$SPARK_HOME/bin/spark-class`) and skips otherwise. Run with, e.g.:

  ```
  SPARK_SCALA_VERSION=2.13 build/sbt \
    'set spark / Test / javaOptions += "-Dspark.test.home=/path/to/spark-4.1.2-bin-hadoop3"' \
    spark/'testOnly org.apache.spark.sql.delta.ConvertToDeltaDistributedSuite'
  ```

The `NoSuchMethodError` itself only manifests when Delta is loaded into a Spark 4.1.2 runtime (the build pins Spark 4.1.0), so it does not reproduce inside the project's own test matrix; the reporter of #6867 has a deterministic repro via `REPLACE TABLE AS SELECT` on Spark 4.1.2, which runs through the patched `Snapshot.getParquetFileSchemaAndRowCount`.

## Does this PR introduce _any_ user-facing changes?

Yes. Users running Delta `4.2.0` on Spark `4.1.2` (and any future Spark releases that further extend the `ParquetToSparkSchemaConverter` primary constructor) previously hit a `NoSuchMethodError` on code paths that read Parquet footers (e.g. `REPLACE TABLE AS SELECT`, checkpoint state reconstruction, `CONVERT TO DELTA`). With this change those code paths run successfully — including `CONVERT TO DELTA` / `REORG` on a real (multi-executor) cluster, which the previous `SparkSession.active`-based approach would have failed on.

Resolves #6867
