### PR TITLE
[Spark] Fix Spark 4.2-SNAPSHOT compile failures

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -705,8 +705,10 @@ class DeltaAnalysis(protected val session: SparkSession)
 
     case origStreamWrite: WriteToStream =>
       // The command could have Delta as source and/or sink. We need to look at both.
-      val streamWrite = origStreamWrite match {
-        case WriteToStream(_, _, sink @ DeltaSink(_, _, _, _, _, None), _, _, _, _, Some(ct)) =>
+      // Use field access rather than positional destructuring because WriteToStream's
+      // constructor signature differs across Spark versions.
+      val streamWrite = (origStreamWrite.sink, origStreamWrite.catalogTable) match {
+        case (sink @ DeltaSink(_, _, _, _, _, None), Some(ct)) =>
           // The command has a catalog table, but the DeltaSink does not. This happens because
           // DeltaDataSource.createSink (Spark API) didn't have access to the catalog table when it
           // created the DeltaSink. Fortunately we can fix it up here.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Fix Spark 4.2-SNAPSHOT compile failures

`DeltaAnalysis.WriteToStream`: Spark 4.2 added a `sinkName: Option[String]` parameter, breaking the 8-arg positional pattern. Switched to field access (`.sink`, `.catalogTable`) so the code compiles across 4.0 / 4.1 / 4.2.

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
no