### PR TITLE
[Build] Add more people as code owners of project/scripts/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /build/                         @tdas
 /build.sbt                      @tdas
 /project/                       @tdas
+/project/scripts/               @tdas @openinx @yili-db
 /version.sbt                    @tdas
 
 # Python client, examples, and tooling


### PR DESCRIPTION
## Summary
- Add `@tdas`, `@openinx`, and `@yili-db` as code owners for the `/project/scripts/` directory so that changes to build/CI scripts require their approval.
- Bump Unity Catalog pinned SHA from `af090e73` to `1ae646f` to fix Spark 4.2 CI failures caused by the UC connector resolving Spark 4.2 as `4.2.0-SNAPSHOT` instead of the published `4.2.0-preview5`.

## Test plan
- No code changes; only CODEOWNERS file updated and UC pin bumped.
- CI should now pass for all Spark versions including Spark 4.2.