### PR TITLE
[Spark] Onboard basic DELETE generated suites to InMemorySparkTable

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -350,7 +350,7 @@ object SuiteGeneratorConfig {
           )
         ),
         TestConfig(
-          List("DeleteSubqueryExistsTests"),
+          List("DeleteSQLTests", "DeleteSubqueryExistsTests", "DeleteBaseTests"),
           List(
             List(Dims.DELETE_SQL, Dims.NAME_BASED, Dims.V2_IN_MEMORY_TABLE)
           )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -35,7 +35,7 @@ trait DeleteSQLTests extends DeleteSQLMixin {
   import testImplicits._
 
   // For EXPLAIN, which is not supported in OSS
-  test("explain") {
+  test("explain", ChecksPhysicalDeltaPlan()) {
     append(Seq((2, 2)).toDF("key", "value"))
     val df = sql(s"EXPLAIN DELETE FROM $tableSQLIdentifier WHERE key = 2")
     val outputs = df.collect().map(_.mkString).mkString
@@ -45,7 +45,8 @@ trait DeleteSQLTests extends DeleteSQLMixin {
     checkAnswer(readDeltaTableByIdentifier(), Row(2, 2))
   }
 
-  test("delete from a temp view") {
+  test("delete from a temp view",
+      DSv2Incompatible("deleting from temp views would not be supported on DSv2")) {
     withTable("tab") {
       withTempView("v") {
         Seq((1, 1), (0, 3), (1, 5)).toDF("key", "value").write.format("delta").saveAsTable("tab")
@@ -56,7 +57,8 @@ trait DeleteSQLTests extends DeleteSQLMixin {
     }
   }
 
-  test("delete from a SQL temp view") {
+  test("delete from a SQL temp view",
+      DSv2Incompatible("deleting from temp views would not be supported on DSv2")) {
     withTable("tab") {
       withTempView("v") {
         Seq((1, 1), (0, 3), (1, 5)).toDF("key", "value").write.format("delta").saveAsTable("tab")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -380,7 +380,8 @@ trait DeleteBaseTests extends DeleteBaseMixin {
       Row("c", "v") :: Row("d", "vv") :: Nil)
   }
 
-  test("do not support non-EXISTS subquery test") {
+  test("do not support non-EXISTS subquery test",
+      DSv2Incompatible("asserts classic Delta DELETE subquery policy")) {
     append(Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value"))
     Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("c", "d").createOrReplaceTempView("source")
 
@@ -445,7 +446,8 @@ trait DeleteBaseTests extends DeleteBaseMixin {
       Row(2, 2) :: Row(1, 4) :: Row(1, 1) :: Nil)
   }
 
-  test("EXISTS subquery kill switch") {
+  test("EXISTS subquery kill switch",
+      DSv2Incompatible("asserts classic Delta DELETE subquery policy")) {
     append(Seq((2, 2), (1, 4)).toDF("key", "value"))
     Seq((2, 2)).toDF("c", "d").createOrReplaceTempView("source")
 
@@ -464,7 +466,8 @@ trait DeleteBaseTests extends DeleteBaseMixin {
     }
   }
 
-  test("schema pruning on data condition") {
+  test("schema pruning on data condition",
+      ChecksPhysicalDeltaPlan("checks Delta file-scan schema pruning")) {
     val input = Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value")
     append(input, Nil)
     // Start from a cached snapshot state
@@ -486,7 +489,8 @@ trait DeleteBaseTests extends DeleteBaseMixin {
   }
 
 
-  test("nested schema pruning on data condition") {
+  test("nested schema pruning on data condition",
+      ChecksPhysicalDeltaPlan("checks Delta file-scan schema pruning")) {
     val input = Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value")
       .select(struct("key", "value").alias("nested"))
     append(input, Nil)
@@ -526,9 +530,20 @@ trait DeleteBaseTests extends DeleteBaseMixin {
 
         val expectedErrorRegex = "(?s).*(?i)unsupported.*(?i).*Invalid expressions.*"
 
-        var catchException = true
+        val isInMemoryV2 = this.isInstanceOf[DeltaSQLInMemoryTestUtils]
+        val inMemoryV2ErrorRegex = functionType match {
+          // Each Spark version emits a different error class for unsupported
+          // expressions in DELETE WHERE (named, legacy, or via the "operator"
+          // fallback), so match on the stable human-readable keywords instead.
+          case "Window" => "(?is).*window function.*"
+          case "Aggregate" => "(?is).*aggregate function.*"
+          case "Generate" => "(?is).*more than one row.*"
+        }
+        var catchException = if (isInMemoryV2) expectException else true
 
-        var errorRegex = if (functionType.equals("Generate")) {
+        var errorRegex = if (isInMemoryV2) {
+          inMemoryV2ErrorRegex
+        } else if (functionType.equals("Generate")) {
           ".*Subqueries are not supported in the DELETE.*"
         } else customErrorRegex.getOrElse(expectedErrorRegex)
 
@@ -541,7 +556,8 @@ trait DeleteBaseTests extends DeleteBaseMixin {
           val message = if (e.getCause != null) {
             e.getCause.getMessage
           } else e.getMessage
-          assert(message.matches(errorRegex))
+          assert(message.matches(errorRegex),
+            s"unexpected error in $functionType case: ${e.getClass.getName}: $message")
           checkAnswer(spark.read.format("delta").table("deltaTable"), dataBeforeException)
         } else {
           executeDelete(target = "deltaTable", where = where)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemoryDeltaCatalog.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.catalog
 
 import java.util
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.jdk.CollectionConverters._
@@ -41,6 +42,7 @@ import org.apache.spark.sql.connector.write.{
   SupportsTruncate,
   V1Write,
   WriteBuilder}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.StructType
 
@@ -146,6 +148,17 @@ object InMemoryDeltaCatalog {
   private val tables = new ConcurrentHashMap[String, InMemorySparkTable]()
 
   /**
+   * Normalize the table [[ident]] using the same case-sensitivity rules as the session catalog.
+   */
+  private def normalize(ident: Identifier): String = {
+    normalize(ident.name())
+  }
+
+  private def normalize(name: String): String = {
+    if (SQLConf.get.caseSensitiveAnalysis) name else name.toLowerCase(Locale.ROOT)
+  }
+
+  /**
    * Get or create a table defined by [[ident]].
    * [[catalogTable]] and [[spark]] are used to discover the table schema.
    *
@@ -155,7 +168,7 @@ object InMemoryDeltaCatalog {
       ident: Identifier,
       catalogTable: CatalogTable,
       spark: SparkSession): InMemorySparkTable = {
-    val tableName = ident.name()
+    val tableName = normalize(ident)
     tables.computeIfAbsent(tableName, _ => {
       val deltaTable = DeltaTableV2(
         spark, new Path(catalogTable.location), catalogTable = Some(catalogTable))
@@ -186,7 +199,7 @@ object InMemoryDeltaCatalog {
       case _ => throw new IllegalArgumentException(
         s"Expected InMemorySparkTable but got ${table.getClass.getName}")
     }
-    tables.put(ident.name(), newTable)
+    tables.put(normalize(ident), newTable)
     newTable
   }
 
@@ -195,12 +208,12 @@ object InMemoryDeltaCatalog {
    * Returns true if there was a table and it was removed, false otherwise.
    */
   def dropTable(ident: Identifier): Boolean =
-    tables.remove(ident.name()) != null
+    tables.remove(normalize(ident)) != null
 
   /**
    * Check whether table [[name]] exists here.
    */
-  def contains(name: String): Boolean = tables.containsKey(name)
+  def contains(name: String): Boolean = tables.containsKey(normalize(name))
 
   /**
    * Reset the catalog, removing all created tables from the storage.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.delta.SparkTableShims
 
 import org.apache.spark.sql.connector.catalog.{InMemoryRowLevelOperationTable, TableCapability}
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -45,8 +45,6 @@ class InMemorySparkTable(
     caps
   }
 
-  // Force DELETE to go through the SupportsRowLevelOperations path instead of
-  // the SupportsDeleteV2.deleteWhere path inherited from InMemoryTable, which
-  // only supports filtering by partition columns.
-  override def canDeleteWhere(filters: Array[Filter]): Boolean = false
+  // Keep conditional DELETE on the row-level path, but allow metadata-only unconditional DELETE.
+  override def canDeleteWhere(filters: Array[Filter]): Boolean = filters.forall(_ == AlwaysTrue)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/delete/DeleteBaseTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/delete/DeleteBaseTests.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
 import org.apache.spark.sql.delta.rowid._
 
+class DeleteBaseSQLNameBasedInMemoryTableSuite
+  extends DeleteBaseTests
+  with DeleteSQLMixin
+  with DeltaDMLTestUtilsNameBased
+  with DeltaDMLInMemoryTestUtils
+
 class DeleteBaseSQLNameBasedSuite
   extends DeleteBaseTests
   with DeleteSQLMixin

--- a/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/delete/DeleteSQLTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/generatedsuites/delete/DeleteSQLTests.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.cdc._
 import org.apache.spark.sql.delta.rowid._
 
+class DeleteSQLSQLNameBasedInMemoryTableSuite
+  extends DeleteSQLTests
+  with DeleteSQLMixin
+  with DeltaDMLTestUtilsNameBased
+  with DeltaDMLInMemoryTestUtils
+
 class DeleteSQLSQLNameBasedSuite
   extends DeleteSQLTests
   with DeleteSQLMixin


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Make `InMemorySparkTable.canDeleteWhere` return `true` if the supplied conditions are `AlwaysTrue`.
- Normalize (lowercase by default) the table names in `InMemoryDeltaCatalog`, controlled by `SQLConf.caseSensitiveAnalysis`.
- Onboard more generated DELETE tests onto `InMemorySparkTable` via the `V2_IN_MEMORY_TABLE` suite dimension.

## How was this patch tested?

This patch includes the testing.
