### PR TITLE
[SQL] Rename SparkTable to DeltaV2Table

### DIFF
--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.catalog;
 
-import io.delta.spark.internal.v2.catalog.SparkTable;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import org.apache.spark.sql.delta.DeltaV2Mode;
 import java.util.HashMap;
 import java.util.function.Supplier;
@@ -57,7 +57,7 @@ import org.apache.spark.sql.connector.catalog.Table;
  * <p>The unified module can access both implementations:</p>
  * <ul>
  *   <li>V1 connector: {@link DeltaTableV2} - Legacy connector using DeltaLog, full read/write support</li>
- *   <li>V2 connector: {@link SparkTable} - sparkV2 connector, read-only support</li>
+ *   <li>V2 connector: {@link DeltaV2Table} - sparkV2 connector, read-only support</li>
  * </ul>
  *
  * <p>See {@link DeltaV2Mode} for V1 vs V2 connector definitions and enable mode configuration.</p>
@@ -69,18 +69,18 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
    *
    * <p>Routing logic based on {@link DeltaV2Mode}:
    * <ul>
-   *   <li>STRICT: Returns sparkV2 {@link SparkTable} (V2 connector)</li>
+   *   <li>STRICT: Returns sparkV2 {@link DeltaV2Table} (V2 connector)</li>
    *   <li>NONE (default): Returns {@link DeltaTableV2} (V1 connector)</li>
    * </ul>
    *
    * @param ident The identifier of the table in the catalog.
    * @param catalogTable The catalog table metadata containing table properties and location.
-   * @return Table instance (SparkTable for V2, DeltaTableV2 for V1).
+   * @return Table instance (DeltaV2Table for V2, DeltaTableV2 for V1).
    */
   @Override
   public Table loadCatalogTable(Identifier ident, CatalogTable catalogTable) {
     return loadTableInternal(
-        () -> new SparkTable(ident, catalogTable, new HashMap<>()),
+        () -> new DeltaV2Table(ident, catalogTable, new HashMap<>()),
         () -> super.loadCatalogTable(ident, catalogTable));
   }
 
@@ -90,18 +90,18 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
    *
    * <p>Routing logic based on {@link DeltaV2Mode}:
    * <ul>
-   *   <li>STRICT: Returns sparkV2 {@link SparkTable} (V2 connector)</li>
+   *   <li>STRICT: Returns sparkV2 {@link DeltaV2Table} (V2 connector)</li>
    *   <li>NONE (default): Returns {@link DeltaTableV2} (V1 connector)</li>
    * </ul>
    *
    * @param ident The identifier whose name contains the path to the Delta table.
-   * @return Table instance (SparkTable for V2, DeltaTableV2 for V1).
+   * @return Table instance (DeltaV2Table for V2, DeltaTableV2 for V1).
    */
   @Override
   public Table loadPathTable(Identifier ident) {
     return loadTableInternal(
         // delta.`/path/to/table`, where ident.name() is `/path/to/table`
-        () -> new SparkTable(ident, ident.name()),
+        () -> new DeltaV2Table(ident, ident.name()),
         () -> super.loadPathTable(ident));
   }
 
@@ -110,13 +110,14 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
    *
    * <p>This method checks the configuration and delegates to the appropriate supplier:
    * <ul>
-   *   <li>STRICT mode: Uses V2 connector (sparkV2 SparkTable) - for testing V2 capabilities</li>
+   *   <li>STRICT mode: Uses V2 connector (sparkV2 DeltaV2Table) - for testing V2 capabilities</li>
    *   <li>NONE mode (default): Uses V1 connector (DeltaTableV2) - production default with full features</li>
    * </ul>
    *
    * <p>See {@link DeltaV2Mode} for detailed V1 vs V2 connector definitions.
    *
-   * @param v2ConnectorSupplier Supplier for V2 connector (sparkV2 SparkTable) - used in STRICT mode
+   * @param v2ConnectorSupplier Supplier for V2 connector (sparkV2 DeltaV2Table)
+   *                            - used in STRICT mode
    * @param v1ConnectorSupplier Supplier for V1 connector (DeltaTableV2) - used in NONE mode (default)
    * @return Table instance from the selected supplier
    */

--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.catalog
 
-import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.spark.internal.v2.read.changelog.DeltaChangelog
 
 import org.apache.spark.sql.SparkSession
@@ -34,7 +34,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
  * `TableCatalog` implementation.
  *
  * <p>The trait is intentionally thin. `loadChangelog` resolves the table via the catalog's own
- * `loadTable`, validates that the result is a V2 [[SparkTable]] (read-time CDF only flows
+ * `loadTable`, validates that the result is a V2 [[DeltaV2Table]] (read-time CDF only flows
  * through the V2 connector. V1 tables go through the legacy Delta CDF path), resolves the
  * requested [[ChangelogRange]] against the table's snapshot manager, and wraps everything into
  * a [[DeltaChangelog]]. All connector-level work (loading snapshots, validating row tracking,
@@ -54,7 +54,7 @@ trait ChangelogSupport extends TableCatalog {
       return super.loadChangelog(ident, changelogInfo)
     }
     val sparkTable = loadTable(ident) match {
-      case st: SparkTable => st
+      case st: DeltaV2Table => st
       case other =>
         // Auto-CDF only supports the V2 connector. V1 Delta tables (DeltaTableV2 under the
         // hood) keep going through the legacy CDF path that DeltaCatalog already exposes.
@@ -71,7 +71,7 @@ trait ChangelogSupport extends TableCatalog {
    * subtracts 1) and are validated. `UnboundedRange` is rejected on batch reads.
    */
   private def resolveRange(
-      sparkTable: SparkTable,
+      sparkTable: DeltaV2Table,
       range: org.apache.spark.sql.connector.catalog.ChangelogRange): (Long, Long) = {
     val snapshotManager = sparkTable.getSnapshotManager
     val latestVersion = snapshotManager.loadLatestSnapshot().getVersion

--- a/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
+++ b/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
@@ -16,7 +16,7 @@
 
 package io.delta.internal
 
-import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -28,13 +28,13 @@ import org.apache.spark.sql.delta.shims.StreamingRelationV2Shim
 
 /**
  * TODO(#5319): remove this class after Spark supports directly create table reflect cdc/trackingLog
- * Plumbs read options into a V2 [[StreamingRelationV2]]'s [[SparkTable]] when those options
+ * Plumbs read options into a V2 [[StreamingRelationV2]]'s [[DeltaV2Table]] when those options
  * change a property the table derives from them.
  */
 class ApplyV2ReadOptions extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
-    case s @ StreamingRelationV2Shim(_, _, table: SparkTable, extraOptions, _, _, _, _)
+    case s @ StreamingRelationV2Shim(_, _, table: DeltaV2Table, extraOptions, _, _, _, _)
         if (CDCReader.isCDCRead(extraOptions) &&
               !s.output.exists(a => CDCSchemaContext.isCDCColumn(a.name))) ||
            MetadataEvolutionHandler.shouldPropagateSchemaTrackingToTable(
@@ -43,9 +43,9 @@ class ApplyV2ReadOptions extends Rule[LogicalPlan] {
       merged.putAll(table.getOptions)
       merged.putAll(extraOptions.asCaseSensitiveMap())
       val rebuilt = if (table.getCatalogTable.isPresent) {
-        new SparkTable(table.getIdentifier, table.getCatalogTable.get, merged)
+        new DeltaV2Table(table.getIdentifier, table.getCatalogTable.get, merged)
       } else {
-        new SparkTable(table.getIdentifier, table.getTablePath.toString, merged)
+        new DeltaV2Table(table.getIdentifier, table.getTablePath.toString, merged)
       }
       s.copy(
         source = None,

--- a/spark-unified/src/main/scala/io/delta/internal/ApplyV2Streaming.scala
+++ b/spark-unified/src/main/scala/io/delta/internal/ApplyV2Streaming.scala
@@ -19,7 +19,7 @@ package io.delta.internal
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
-import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.spark.internal.v2.utils.ScalaUtils
 import org.apache.spark.sql.delta.DeltaV2Mode
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
@@ -35,12 +35,12 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * Rule for applying the V2 streaming path by rewriting V1 StreamingRelation
- * with Delta DataSource to StreamingRelationV2 with SparkTable.
+ * with Delta DataSource to StreamingRelationV2 with DeltaV2Table.
  *
  * This rule handles the case where Spark's FindDataSourceTable rule has converted
  * a StreamingRelationV2 (with DeltaTableV2) back to a StreamingRelation because
  * DeltaTableV2 doesn't advertise STREAMING_READ capability. We convert it back to
- * StreamingRelationV2 with SparkTable (from sparkV2) which does support streaming.
+ * StreamingRelationV2 with DeltaV2Table (from sparkV2) which does support streaming.
  *
  * See [[DeltaV2Mode]] for configuration behavior.
  *
@@ -79,11 +79,11 @@ class ApplyV2Streaming(
       val ident =
         Identifier.of(catalogTable.identifier.database.toArray, catalogTable.identifier.table)
       val table =
-        new SparkTable(
+        new DeltaV2Table(
           ident,
           catalogTable,
           // Use user-specified streaming options to override catalog storage properties.
-          // SparkTable handles merging catalogTable storage props internally.
+          // DeltaV2Table handles merging catalogTable storage props internally.
           ScalaUtils.toJavaMap(s.dataSource.options))
       val catalog = catalogTable.identifier.catalog.map(
         session.sessionState.catalogManager.catalog)

--- a/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -76,7 +76,7 @@ class DeltaSparkSessionExtension extends AbstractDeltaSparkSessionExtension {
     super.apply(extensions)
 
     // Register a post-hoc resolution rule that rewrites V1 StreamingRelation plans that
-    // read catalog owned Delta tables into V2 StreamingRelationV2 plans backed by SparkTable.
+    // read catalog owned Delta tables into V2 StreamingRelationV2 plans backed by DeltaV2Table.
     //
     // NOTE: This rule is functional (not a placeholder). Binary compatibility concerns are
     // handled separately via the nested NoOpRule class below (kept for MiMa).
@@ -84,7 +84,7 @@ class DeltaSparkSessionExtension extends AbstractDeltaSparkSessionExtension {
       new ApplyV2Streaming(session)
     }
 
-    // Plumb read options into V2 StreamingRelationV2's SparkTable when those options change a
+    // Plumb read options into V2 StreamingRelationV2's DeltaV2Table when those options change a
     // property the table derives from them (today: CDC; future: schema evolution). Runs after
     // ApplyV2Streaming so it sees both V1-converted and catalog-loaded relations.
     extensions.injectResolutionRule { _ =>

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
@@ -22,7 +22,7 @@ import java.util.{HashMap => JHashMap}
 import scala.jdk.CollectionConverters._
 
 import io.delta.kernel.internal.SnapshotImpl
-import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -53,7 +53,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
 
   private def assertV2(result: LogicalPlan): Unit = {
     result match {
-      case StreamingRelationV2Shim(_, _, _: SparkTable, _, _, _, _, v1Relation) =>
+      case StreamingRelationV2Shim(_, _, _: DeltaV2Table, _, _, _, _, v1Relation) =>
         assert(v1Relation.isEmpty)
       case other =>
         fail(s"Expected StreamingRelationV2, got $other")
@@ -156,7 +156,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
         catalogTable.identifier.table)
       // Build the input table without the CDC option so its schema lacks CDC columns. The rule
       // should rebuild the table with the CDC option from extraOptions and append CDC columns.
-      val table = new SparkTable(ident, catalogTable, new JHashMap[String, String]())
+      val table = new DeltaV2Table(ident, catalogTable, new JHashMap[String, String]())
       val cdcOpts = new JHashMap[String, String]()
       cdcOpts.put(DeltaOptions.CDC_READ_OPTION, "true")
       val extraOptions = new CaseInsensitiveStringMap(cdcOpts)
@@ -193,7 +193,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
       val ident = Identifier.of(
         catalogTable.identifier.database.toArray,
         catalogTable.identifier.table)
-      val table = new SparkTable(ident, catalogTable, new JHashMap[String, String]())
+      val table = new DeltaV2Table(ident, catalogTable, new JHashMap[String, String]())
 
       val plan = StreamingRelationV2(
         source = None,
@@ -220,7 +220,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
       val ident = Identifier.of(
         catalogTable.identifier.database.toArray,
         catalogTable.identifier.table)
-      val table = new SparkTable(ident, catalogTable, new JHashMap[String, String]())
+      val table = new DeltaV2Table(ident, catalogTable, new JHashMap[String, String]())
       val cdcOpts = new JHashMap[String, String]()
       cdcOpts.put(DeltaOptions.CDC_READ_OPTION, "true")
       val extraOptions = new CaseInsensitiveStringMap(cdcOpts)
@@ -252,7 +252,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
   private val seededFieldNames: Seq[String] = Seq("id", "extra")
 
   private def buildStreamingRelationV2(
-      table: SparkTable, extraOptions: Map[String, String]): StreamingRelationV2 = {
+      table: DeltaV2Table, extraOptions: Map[String, String]): StreamingRelationV2 = {
     StreamingRelationV2(
       source = None,
       sourceName = "delta",
@@ -291,29 +291,29 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
   }
 
   /** Asserts the table's schema matches the entry written by [[seedSchemaLogWithExtraColumn]]. */
-  private def assertSchemaMatchesSeededLogEntry(table: SparkTable): Unit = {
+  private def assertSchemaMatchesSeededLogEntry(table: DeltaV2Table): Unit = {
     assert(table.schema.fieldNames.toSeq == seededFieldNames)
     assert(table.schema.fields(1).dataType == StringType)
   }
 
   /**
-   * Build a catalog-backed SparkTable rooted at `tableLocationUri`. Mirrors the common production
+   * Build a catalog-backed DeltaV2Table rooted at `tableLocationUri`. Mirrors the common production
    * path through DeltaCatalog and is the default for tests that do not specifically distinguish
    * between path-based and catalog-based construction.
    */
   private def buildCatalogBasedSparkTable(
-      tableLocationUri: URI, options: JHashMap[String, String]): SparkTable = {
+      tableLocationUri: URI, options: JHashMap[String, String]): DeltaV2Table = {
     val catalogTable = createCatalogTable(tableLocationUri, ucManaged = false)
     val identifier = Identifier.of(
       catalogTable.identifier.database.toArray, catalogTable.identifier.table)
-    new SparkTable(identifier, catalogTable, options)
+    new DeltaV2Table(identifier, catalogTable, options)
   }
 
   private def applyReadOptions(plan: LogicalPlan): LogicalPlan = {
     new ApplyV2ReadOptions().apply(plan)
   }
 
-  test("schema-tracking rebuild: path-based SparkTable picks up the persisted schema") {
+  test("schema-tracking rebuild: path-based DeltaV2Table picks up the persisted schema") {
     withTempDir { tableDir =>
       withTempDir { schemaLogDir =>
         val tablePath = tableDir.getCanonicalPath
@@ -322,16 +322,16 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
         seedSchemaLogWithExtraColumn(tablePath, schemaLogPath)
 
         val identifier = Identifier.of(Array("default"), "tbl")
-        val table = new SparkTable(identifier, tablePath)
+        val table = new DeltaV2Table(identifier, tablePath)
         assert(!table.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
 
         val plan = buildStreamingRelationV2(
           table, Map(DeltaOptions.SCHEMA_TRACKING_LOCATION -> schemaLogPath))
         val result = applyReadOptions(plan)
         assertV2(result)
-        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[DeltaV2Table]
 
-        assert(rebuiltTable ne table, "rebuild should produce a new SparkTable")
+        assert(rebuiltTable ne table, "rebuild should produce a new DeltaV2Table")
         assert(rebuiltTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
         assert(rebuiltTable.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION) ==
           schemaLogPath)
@@ -349,7 +349,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
     }
   }
 
-  test("schema-tracking rebuild: catalog-based SparkTable picks up the persisted schema and " +
+  test("schema-tracking rebuild: catalog-based DeltaV2Table picks up the persisted schema and " +
       "keeps its CatalogTable") {
     withTempDir { tableDir =>
       withTempDir { schemaLogDir =>
@@ -366,7 +366,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
           table, Map(DeltaOptions.SCHEMA_TRACKING_LOCATION -> schemaLogPath))
         val result = applyReadOptions(plan)
         assertV2(result)
-        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[DeltaV2Table]
 
         assert(rebuiltTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
         assert(rebuiltTable.getCatalogTable.isPresent,
@@ -390,7 +390,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
           table, Map(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS -> schemaLogPath))
         val result = applyReadOptions(plan)
         assertV2(result)
-        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+        val rebuiltTable = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[DeltaV2Table]
 
         assert(rebuiltTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS))
         assert(rebuiltTable.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS) ==
@@ -412,7 +412,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
     }
   }
 
-  test("schema-tracking rebuild: skipped when SparkTable already carries the " +
+  test("schema-tracking rebuild: skipped when DeltaV2Table already carries the " +
       "schema-tracking option") {
     withTempDir { tableDir =>
       withTempDir { schemaLogDir =>
@@ -436,7 +436,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
     // Counterpart to the V2 rebuild tests above: those start from StreamingRelationV2 and exercise
     // the rebuild branch. This test starts from a V1 StreamingRelation carrying the schema-tracking
     // option in dataSource.options, and verifies the V1 -> V2 conversion branch hands the option to
-    // the new SparkTable so its schema is driven by the persisted log entry.
+    // the new DeltaV2Table so its schema is driven by the persisted log entry.
     withTempDir { tableDir =>
       withTempDir { schemaLogDir =>
         val tablePath = tableDir.getCanonicalPath
@@ -460,7 +460,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
           val result = applyRules(plan)
           assertV2(result)
           val convertedTable =
-            result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+            result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[DeltaV2Table]
           assert(convertedTable.getOptions.containsKey(DeltaOptions.SCHEMA_TRACKING_LOCATION))
           assert(convertedTable.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION) ==
             schemaLogPath)
@@ -487,7 +487,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
 
         val result = applyReadOptions(plan)
         assertV2(result)
-        val rebuilt = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[SparkTable]
+        val rebuilt = result.asInstanceOf[StreamingRelationV2].table.asInstanceOf[DeltaV2Table]
 
         // Both options land on the rebuilt table in a single pass.
         assert(rebuilt.getOptions.get(DeltaOptions.SCHEMA_TRACKING_LOCATION) == schemaLogPath)

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2StreamingSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2StreamingSuite.scala
@@ -21,7 +21,7 @@ import java.util.{HashMap => JHashMap}
 
 import scala.jdk.CollectionConverters._
 
-import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -46,7 +46,7 @@ class ApplyV2StreamingSuite extends DeltaSQLCommandTest {
 
   private def assertV2(result: LogicalPlan): Unit = {
     result match {
-      case StreamingRelationV2Shim(_, _, _: SparkTable, _, _, _, _, v1Relation) =>
+      case StreamingRelationV2Shim(_, _, _: DeltaV2Table, _, _, _, _, v1Relation) =>
         assert(v1Relation.isEmpty)
       case other =>
         fail(s"Expected StreamingRelationV2, got $other")
@@ -101,7 +101,7 @@ class ApplyV2StreamingSuite extends DeltaSQLCommandTest {
       val ident = Identifier.of(
         catalogTable.identifier.database.toArray,
         catalogTable.identifier.table)
-      val table = new SparkTable(ident, catalogTable, new JHashMap[String, String]())
+      val table = new DeltaV2Table(ident, catalogTable, new JHashMap[String, String]())
       DataSourceV2Relation.create(
         table,
         None,

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/DataFrameWriterV2WithV2ConnectorSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/DataFrameWriterV2WithV2ConnectorSuite.scala
@@ -30,7 +30,7 @@ class DataFrameWriterV2WithV2ConnectorSuite
    * Tests that we expect to fail because they require write operations after initial
    * table creation.
    *
-   * Kernel's SparkTable (V2 connector) only implements SupportsRead, not SupportsWrite.
+   * Kernel's DeltaV2Table (V2 connector) only implements SupportsRead, not SupportsWrite.
    * Tests that perform append/replace operations after table creation are expected to fail.
    */
   override protected def shouldFail(testName: String): Boolean = {
@@ -49,8 +49,8 @@ class DataFrameWriterV2WithV2ConnectorSuite
       "OverwritePartitions: overwrite all rows if not partitioned",
       "OverwritePartitions: by name not position",
 
-      // Create operations - TODO: fix SparkTable's name() to match DeltaTableV2
-      // SparkTable.name() returns simple table name, but tests expect catalog.schema.table format
+      // Create operations - TODO: fix DeltaV2Table's name() to match DeltaTableV2
+      // DeltaV2Table.name() returns simple table name, but tests expect catalog.schema.table format
       "Create: basic behavior",
       "Create: with using",
       "Create: with property",

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/catalog/DeltaCatalogSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/catalog/DeltaCatalogSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.catalog
 
-import io.delta.spark.internal.v2.catalog.SparkTable
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
@@ -28,13 +28,13 @@ import java.util.Locale
  *
  * Verifies that DeltaCatalog correctly routes table loading based on
  * DeltaSQLConf.V2_ENABLE_MODE:
- * - STRICT mode: Kernel's SparkTable (V2 connector)
+ * - STRICT mode: Kernel's DeltaV2Table (V2 connector)
  * - NONE mode (default): DeltaTableV2 (V1 connector)
  */
 class DeltaCatalogSuite extends DeltaSQLCommandTest {
 
   private val modeTestCases = Seq(
-    ("STRICT", classOf[SparkTable], "Kernel SparkTable"),
+    ("STRICT", classOf[DeltaV2Table], "Kernel DeltaV2Table"),
     ("NONE", classOf[DeltaTableV2], "DeltaTableV2")
   )
 

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable
 
 /**
  * Trait that forces Delta V2 connector mode to STRICT, ensuring all operations
- * use the Kernel-based SparkTable implementation (V2 connector) instead of
+ * use the Kernel-based DeltaV2Table implementation (V2 connector) instead of
  * DeltaTableV2 (V1 connector).
  *
  * See [[DeltaSQLConf.V2_ENABLE_MODE]] for V1 vs V2 connector definitions.
@@ -85,7 +85,7 @@ trait V2ForceTest extends DeltaSQLCommandTest {
 
   /**
    * Override `sparkConf` to set V2_ENABLE_MODE to "STRICT".
-   * This ensures all catalog operations use Kernel SparkTable (V2 connector).
+   * This ensures all catalog operations use Kernel DeltaV2Table (V2 connector).
    */
   abstract override protected def sparkConf: SparkConf = {
     super.sparkConf
@@ -94,7 +94,7 @@ trait V2ForceTest extends DeltaSQLCommandTest {
 
   /**
    * Run a SQL statement through the V1 connector by temporarily setting
-   * V2_ENABLE_MODE to NONE. Useful for DDL/DML that SparkTable (V2) doesn't support.
+   * V2_ENABLE_MODE to NONE. Useful for DDL/DML that DeltaV2Table (V2) doesn't support.
    */
   protected def executeInV1Mode(sqlText: String): Unit = {
     withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/columnmapping/RemoveColumnMappingStreamingReadV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/columnmapping/RemoveColumnMappingStreamingReadV2Suite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.test.V2ForceTest
  * Test suite that runs [[RemoveColumnMappingStreamingReadSuite]] using the V2 connector
  * (V2_ENABLE_MODE=STRICT).
  *
- * SparkTable (V2) is read-only and does not support DDL, so DDL/DML operations are routed
+ * DeltaV2Table (V2) is read-only and does not support DDL, so DDL/DML operations are routed
  * through the V1 connector via `executeDml`. Only streaming reads use the V2 connector.
  */
 class RemoveColumnMappingStreamingReadV2Suite

--- a/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
+++ b/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
@@ -73,7 +73,7 @@ public class DeltaV2Mode {
   }
 
   /**
-   * Determines if catalog should return sparkV2 (SparkTable) or sparkV1 (DeltaTableV2) tables.
+   * Determines if catalog should return sparkV2 (DeltaV2Table) or sparkV1 (DeltaTableV2) tables.
    *
    * @return true if catalog should return sparkV2 tables
    */

--- a/spark/src/main/scala-shims/spark-4.0/SparkTableShims.scala
+++ b/spark/src/main/scala-shims/spark-4.0/SparkTableShims.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.connector.catalog.TableCapability
 
-/** Shim to build [[SparkTable]] against different Spark versions. */
+/** Shim to build [[DeltaV2Table]] against different Spark versions. */
 object SparkTableShims {
   // Capability [[TableCapability.AUTOMATIC_SCHEMA_EVOLUTION]] is not available in Spark 4.0.
   val schemaEvolutionCapability: Option[TableCapability] = None

--- a/spark/src/main/scala-shims/spark-4.1/SparkTableShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1/SparkTableShims.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.connector.catalog.TableCapability
 
-/** Shim to build [[SparkTable]] against different Spark versions. */
+/** Shim to build [[DeltaV2Table]] against different Spark versions. */
 object SparkTableShims {
   // Capability [[TableCapability.AUTOMATIC_SCHEMA_EVOLUTION]] is available in Spark 4.1, but
   // schema evolution isn't properly supported yet in MERGE/INSERT there so ignore it.

--- a/spark/src/main/scala-shims/spark-4.2/SparkTableShims.scala
+++ b/spark/src/main/scala-shims/spark-4.2/SparkTableShims.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.connector.catalog.TableCapability
 
 /**
- * Shim to build [[SparkTable]] against different Spark versions.
+ * Shim to build [[DeltaV2Table]] against different Spark versions.
  * This is the shim for the latest version - Spark 4.2.
  */
 object SparkTableShims {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -1026,7 +1026,7 @@ class DeltaAnalysis(protected val session: SparkSession)
         DeltaDataSource.extractSchemaTrackingLocationConfig(session, opts)
           .foreach { rootSchemaTrackingLocation =>
             // TODO(#5319): use table path instead of name so path vs catalog access of the same
-            //  table conflicts at analysis time (matches V1). Needs a SparkTable-side accessor.
+            //  table conflicts at analysis time (matches V1). Needs a DeltaV2Table-side accessor.
             val tableId = table.name.replace(":", "").replace("/", "_")
             val sourceIdOpt = opts.get(DeltaOptions.STREAMING_SOURCE_TRACKING_ID)
             val schemaTrackingLocation =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -614,7 +614,7 @@ trait DeltaErrorsBase
 
   /**
    * Auto-CDF batch read rejected because the table resolved by the catalog is not a V2
-   * [[io.delta.spark.internal.v2.catalog.SparkTable]]. The V2 connector is the only path that
+   * [[io.delta.spark.internal.v2.catalog.DeltaV2Table]]. The V2 connector is the only path that
    * implements the catalog-driven CHANGES surface. V1 Delta tables (`DeltaTableV2`) continue to
    * use the legacy CDF path that does not go through `TableCatalog.loadChangelog`.
    *

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3365,15 +3365,15 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
    *
    * Valid values:
    * - NONE: sparkV2 connector is disabled, always use sparkV1 connector (DeltaTableV2) - default
-   * - AUTO: Automatically use sparkV2 connector (SparkTable) for Unity Catalog managed tables
+   * - AUTO: Automatically use sparkV2 connector (DeltaV2Table) for Unity Catalog managed tables
    *         in streaming queries and sparkV1 connector (DeltaTableV2) for all other tables
-   * - STRICT: sparkV2 connector is strictly enforced, always use sparkV2 connector (SparkTable).
+   * - STRICT: sparkV2 connector is strictly enforced, always use sparkV2 connector (DeltaV2Table).
    *           Intended for testing sparkV2 connector capabilities
    *
    * sparkV1 vs sparkV2 Connectors:
    * - sparkV1 Connector (DeltaTableV2): Legacy Delta connector with full read/write support,
    *   uses DeltaLog for metadata management
-   * - sparkV2 Connector (SparkTable): New kernel-based connector with read-only support,
+   * - sparkV2 Connector (DeltaV2Table): New kernel-based connector with read-only support,
    *   uses Kernel's Table API for metadata management
    *
    * See [[org.apache.spark.sql.delta.DeltaV2Mode]] for the centralized logic that interprets

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
@@ -38,7 +38,7 @@ trait DeltaSourceDeletionVectorTests extends StreamTest
   /**
    * Executes a DML SQL statement (DELETE, INSERT, etc.).
    * Overridable so that V2 suites can route DML through the V1 connector,
-   * since SparkTable (V2) is read-only and does not support writes.
+   * since DeltaV2Table (V2) is read-only and does not support writes.
    */
   protected def executeDml(sqlText: String): Unit = sql(sqlText)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -251,7 +251,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
 
   /**
    * Executes a DDL/DML SQL statement. Overridable so that V2 suites can route it through the V1
-   * connector, since SparkTable (V2) is read-only and does not support writes/DDL.
+   * connector, since DeltaV2Table (V2) is read-only and does not support writes/DDL.
    */
   protected def executeDml(sqlText: String): Unit = sql(sqlText)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1359,7 +1359,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
   /**
    * Executes a DML SQL statement (DELETE, INSERT, etc.).
    * Overridable so that V2 suites can route DML through the V1 connector,
-   * since SparkTable (V2) is read-only and does not support writes.
+   * since DeltaV2Table (V2) is read-only and does not support writes.
    */
   protected def executeDml(sqlText: String): Unit = sql(sqlText)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1359,7 +1359,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
   /**
    * Executes a DML SQL statement (DELETE, INSERT, etc.).
    * Overridable so that V2 suites can route DML through the V1 connector,
-   * since DeltaV2Table (V2) is read-only and does not support writes.
+   * since SparkTable (V2) is read-only and does not support writes.
    */
   protected def executeDml(sqlText: String): Unit = sql(sqlText)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/InMemorySparkTable.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
 /**
- * In-memory DSv2 table used as a test stand-in for SparkTable (the Kernel-based Delta V2
+ * In-memory DSv2 table used as a test stand-in for DeltaV2Table (the Kernel-based Delta V2
  * connector).
  *
  * Created by [[InMemoryDeltaCatalog]] when used as the session catalog in tests.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -116,7 +116,7 @@ trait TypeWideningStreamingSourceTestMixin
 
   /**
    * Executes a DDL/DML SQL statement. Overridable so that V2 suites can route it through the V1
-   * connector, since SparkTable (V2) is read-only and does not support writes/DDL.
+   * connector, since DeltaV2Table (V2) is read-only and does not support writes/DDL.
    */
   protected def executeDml(sqlText: String): Unit = sql(sqlText)
 

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelog.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelog.java
@@ -1,7 +1,7 @@
 package io.delta.spark.internal.v2.read.changelog;
 
 import io.delta.kernel.Snapshot;
-import io.delta.spark.internal.v2.catalog.SparkTable;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import org.apache.spark.sql.connector.catalog.CatalogV2Util;
 import org.apache.spark.sql.connector.catalog.Changelog;
@@ -16,7 +16,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 /**
  * V2 Changelog implementation for Delta tables.
  *
- * <p>Wraps the {@link SparkTable} resolved by {@code TableCatalog.loadTable(ident)}. The
+ * <p>Wraps the {@link DeltaV2Table} resolved by {@code TableCatalog.loadTable(ident)}. The
  * connector-level work (snapshot loads, row tracking validation, metadata-action inspection
  * across the range) is deferred to the read path inside {@link DeltaChangelogBatch}. The schema
  * exposed by {@link #columns()} is the end-version schema. It matches the {@code dataSchema} the
@@ -29,7 +29,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 public class DeltaChangelog implements Changelog {
 
   private final String tableName;
-  private final SparkTable sparkTable;
+  private final DeltaV2Table sparkTable;
   private final long startVersion;
   private final long endVersion;
 
@@ -42,7 +42,7 @@ public class DeltaChangelog implements Changelog {
           .add(ROW_COMMIT_VERSION_FIELD, DataTypes.LongType, false);
 
   public DeltaChangelog(
-      String tableName, SparkTable sparkTable, long startVersion, long endVersion) {
+      String tableName, DeltaV2Table sparkTable, long startVersion, long endVersion) {
     this.tableName = tableName;
     this.sparkTable = sparkTable;
     this.startVersion = startVersion;

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScanBuilder.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScanBuilder.java
@@ -6,7 +6,7 @@ import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
-import io.delta.spark.internal.v2.catalog.SparkTable;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import java.util.Objects;
@@ -22,13 +22,13 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class DeltaChangelogScanBuilder implements ScanBuilder {
 
-  private final SparkTable sparkTable;
+  private final DeltaV2Table sparkTable;
   private final long startVersion;
   private final long endVersion;
   private final CaseInsensitiveStringMap options;
 
   public DeltaChangelogScanBuilder(
-      SparkTable sparkTable, long startVersion, long endVersion, CaseInsensitiveStringMap options) {
+      DeltaV2Table sparkTable, long startVersion, long endVersion, CaseInsensitiveStringMap options) {
     this.sparkTable = sparkTable;
     this.startVersion = startVersion;
     this.endVersion = endVersion;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -59,7 +59,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /** DataSource V2 Table implementation for Delta Lake using the Delta Kernel API. */
-public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsMetadataColumns {
+public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, SupportsMetadataColumns {
   private static final String METADATA_COLUMN_NAME = FileFormat$.MODULE$.METADATA_NAME();
   private static final String ROW_ID_METADATA_FIELD_NAME = RowId$.MODULE$.ROW_ID();
   private static final String ROW_COMMIT_VERSION_METADATA_FIELD_NAME =
@@ -96,25 +96,25 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
   private final boolean isCDCRead;
 
   /**
-   * Creates a SparkTable from a filesystem path without a catalog table.
+   * Creates a DeltaV2Table from a filesystem path without a catalog table.
    *
    * @param identifier logical table identifier used by Spark's catalog
    * @param tablePath filesystem path to the Delta table root
    * @throws NullPointerException if identifier or tablePath is null
    */
-  public SparkTable(Identifier identifier, String tablePath) {
+  public DeltaV2Table(Identifier identifier, String tablePath) {
     this(identifier, tablePath, Collections.emptyMap(), Optional.empty());
   }
 
   /**
-   * Creates a SparkTable from a filesystem path with options.
+   * Creates a DeltaV2Table from a filesystem path with options.
    *
    * @param identifier logical table identifier used by Spark's catalog
    * @param tablePath filesystem path to the Delta table root
    * @param options table options used to configure the Hadoop conf, table reads and writes
    * @throws NullPointerException if identifier or tablePath is null
    */
-  public SparkTable(Identifier identifier, String tablePath, Map<String, String> options) {
+  public DeltaV2Table(Identifier identifier, String tablePath, Map<String, String> options) {
     this(identifier, tablePath, options, Optional.empty());
   }
 
@@ -127,7 +127,8 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
    * @param catalogTable the Spark CatalogTable containing table metadata including location
    * @param options user-provided options to override catalog properties
    */
-  public SparkTable(Identifier identifier, CatalogTable catalogTable, Map<String, String> options) {
+  public DeltaV2Table(
+      Identifier identifier, CatalogTable catalogTable, Map<String, String> options) {
     this(
         identifier,
         getDecodedPath(requireNonNull(catalogTable, "catalogTable is null").location()),
@@ -136,7 +137,7 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
   }
 
   /**
-   * Creates a SparkTable backed by a Delta Kernel snapshot manager and initializes Spark-facing
+   * Creates a DeltaV2Table backed by a Delta Kernel snapshot manager and initializes Spark-facing
    * metadata (schemas, partitioning, capabilities).
    *
    * <p>Side effects: - Initializes a SnapshotManager for the given tablePath. - Loads the latest
@@ -147,7 +148,7 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
    * after data columns in the public Spark schema, per Spark conventions. - Read-time scan options
    * are later merged with these options.
    */
-  private SparkTable(
+  private DeltaV2Table(
       Identifier identifier,
       String tablePath,
       Map<String, String> userOptions,
@@ -224,7 +225,7 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
   }
 
   /**
-   * Returns the CatalogTable if this SparkTable was created from a catalog table.
+   * Returns the CatalogTable if this DeltaV2Table was created from a catalog table.
    *
    * @return Optional containing the CatalogTable, or empty if this table was created from a path
    */
@@ -386,7 +387,7 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
 
   @Override
   public String toString() {
-    return "SparkTable{identifier=" + identifier + '}';
+    return "DeltaV2Table{identifier=" + identifier + '}';
   }
 
   @Override
@@ -397,7 +398,7 @@ public class SparkTable implements Table, SupportsRead, SupportsWrite, SupportsM
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SparkTable that = (SparkTable) o;
+    DeltaV2Table that = (DeltaV2Table) o;
     return Objects.equals(identifier, that.identifier)
         && Objects.equals(tablePath, that.tablePath)
         && Objects.equals(options, that.options)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -541,7 +541,7 @@ public class MetadataEvolutionHandler {
 
   /**
    * Returns true when the read options carry a schema-tracking location but the table's own options
-   * do not — i.e. the {@code SparkTable} was built before the user-supplied {@code
+   * do not — i.e. the {@code DeltaV2Table} was built before the user-supplied {@code
    * schemaTrackingLocation}/{@code schemaLocation} option was observed, so callers must rebuild the
    * table with the option folded in for its schema to be driven by the tracking log.
    */

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -271,7 +271,7 @@ public class SparkMicroBatchStream
     // The effective snapshot for reading, mirroring v1's readSnapshotDescriptor. When schema
     // tracking has a persisted entry, layer it onto the freshly loaded snapshotAtSourceInit so
     // the read schema/protocol/config reflect the evolved state. The merged entry has already
-    // been written to the durable schema log during analysis (by SparkTable's call to
+    // been written to the durable schema log during analysis (by DeltaV2Table's call to
     // getPersistedMetadataForMicroBatchStream with mergeConsecutiveSchemaChanges=true), so
     // reading it back from the log here yields the same value V1 obtains.
     Option<PersistedMetadata> persistedMetadataAtSourceInit =

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -271,7 +271,7 @@ public class SparkMicroBatchStream
     // The effective snapshot for reading, mirroring v1's readSnapshotDescriptor. When schema
     // tracking has a persisted entry, layer it onto the freshly loaded snapshotAtSourceInit so
     // the read schema/protocol/config reflect the evolved state. The merged entry has already
-    // been written to the durable schema log during analysis (by DeltaV2Table's call to
+    // been written to the durable schema log during analysis (by SparkTable's call to
     // getPersistedMetadataForMicroBatchStream with mergeConsecutiveSchemaChanges=true), so
     // reading it back from the log here yields the same value V1 obtains.
     Option<PersistedMetadata> persistedMetadataAtSourceInit =

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -46,7 +46,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
   private final LogicalWriteInfo writeInfo;
 
   /**
-   * @param engine Kernel engine (persisted in SparkTable, shared across operations)
+   * @param engine Kernel engine (persisted in DeltaV2Table, shared across operations)
    * @param tablePath filesystem path to the Delta table root
    * @param hadoopConf Hadoop configuration (with merged table options)
    * @param initialSnapshot Kernel snapshot loaded at table construction time

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -68,7 +68,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import scala.Option;
 
-public class SparkTableTest extends DeltaV2TestBase {
+public class DeltaV2TableTest extends DeltaV2TestBase {
 
   @ParameterizedTest(name = "{0} - {1}")
   @MethodSource("tableTestCases")
@@ -80,18 +80,18 @@ public class SparkTableTest extends DeltaV2TestBase {
     testCase.createTableSql.apply(tableName, path);
     Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
 
-    // Create SparkTable based on construction method
-    SparkTable kernelTable;
+    // Create DeltaV2Table based on construction method
+    DeltaV2Table kernelTable;
     CatalogTable catalogTable = null;
 
     switch (method) {
       case FROM_PATH:
-        kernelTable = new SparkTable(identifier, path);
+        kernelTable = new DeltaV2Table(identifier, path);
         break;
       case FROM_CATALOG_TABLE:
         catalogTable =
             spark.sessionState().catalog().getTableMetadata(new TableIdentifier(tableName));
-        kernelTable = new SparkTable(identifier, catalogTable, Collections.emptyMap());
+        kernelTable = new DeltaV2Table(identifier, catalogTable, Collections.emptyMap());
         break;
       default:
         throw new IllegalArgumentException("Unknown construction method: " + method);
@@ -131,7 +131,7 @@ public class SparkTableTest extends DeltaV2TestBase {
     }
 
     // ===== Verify schema consistency with DeltaTableV2 =====
-    // This ensures SparkTable (Kernel-based) returns the same schema as DeltaTableV2 (V1-based)
+    // This ensures DeltaV2Table (Kernel-based) returns the same schema as DeltaTableV2 (V1-based)
     // Both should properly remove internal Delta metadata (e.g., column mapping physical names)
     DeltaTableV2 deltaTableV2;
     switch (method) {
@@ -163,7 +163,7 @@ public class SparkTableTest extends DeltaV2TestBase {
     assertEquals(
         deltaTableV2.schema(),
         sparkSchema,
-        "SparkTable schema should match DeltaTableV2 schema for test case: " + testCase.name);
+        "DeltaV2Table schema should match DeltaTableV2 schema for test case: " + testCase.name);
 
     // ===== Test partitioning =====
     Transform[] partitioning = kernelTable.partitioning();
@@ -194,12 +194,12 @@ public class SparkTableTest extends DeltaV2TestBase {
       case FROM_PATH:
         assertFalse(
             retrievedCatalogTable.isPresent(),
-            "Path-based SparkTable should not have catalog table");
+            "Path-based DeltaV2Table should not have catalog table");
         break;
       case FROM_CATALOG_TABLE:
         assertTrue(
             retrievedCatalogTable.isPresent(),
-            "CatalogTable-based SparkTable should have catalog table");
+            "CatalogTable-based DeltaV2Table should have catalog table");
         assertEquals(
             catalogTable,
             retrievedCatalogTable.get(),
@@ -212,7 +212,7 @@ public class SparkTableTest extends DeltaV2TestBase {
     assertEquals(new Path(path), retrievedPath, "getTablePath should return Path from tablePath");
   }
 
-  /** Enum to represent different construction methods for SparkTable */
+  /** Enum to represent different construction methods for DeltaV2Table */
   enum ConstructionMethod {
     FROM_PATH("Path"),
     FROM_CATALOG_TABLE("CatalogTable");
@@ -368,7 +368,7 @@ public class SparkTableTest extends DeltaV2TestBase {
       throws Exception {
     // Access the private static method via reflection
     Method getDecodedPath =
-        SparkTable.class.getDeclaredMethod("getDecodedPath", java.net.URI.class);
+        DeltaV2Table.class.getDeclaredMethod("getDecodedPath", java.net.URI.class);
     getDecodedPath.setAccessible(true);
 
     URI uri = new URI(uriString);
@@ -386,7 +386,7 @@ public class SparkTableTest extends DeltaV2TestBase {
   public void testGetDecodedPathDecodesUrlEncodedCharacters() throws Exception {
     // Access the private static method via reflection
     Method getDecodedPath =
-        SparkTable.class.getDeclaredMethod("getDecodedPath", java.net.URI.class);
+        DeltaV2Table.class.getDeclaredMethod("getDecodedPath", java.net.URI.class);
     getDecodedPath.setAccessible(true);
 
     // Test URL-encoded path: "spark%25dir%25prefix" should decode to "spark%dir%prefix"
@@ -419,9 +419,9 @@ public class SparkTableTest extends DeltaV2TestBase {
     Identifier identifier = Identifier.of(new String[] {"default"}, "test_equals");
     Map<String, String> options = Collections.singletonMap("key", "value");
 
-    SparkTable table1 = new SparkTable(identifier, path, options);
-    SparkTable table2 = new SparkTable(identifier, path, options);
-    SparkTable table3 = new SparkTable(identifier, path, Collections.emptyMap());
+    DeltaV2Table table1 = new DeltaV2Table(identifier, path, options);
+    DeltaV2Table table2 = new DeltaV2Table(identifier, path, options);
+    DeltaV2Table table3 = new DeltaV2Table(identifier, path, Collections.emptyMap());
 
     // Same identifier, path, and options should be equal
     assertEquals(table1, table2);
@@ -444,13 +444,13 @@ public class SparkTableTest extends DeltaV2TestBase {
     Identifier identifier = Identifier.of(new String[] {"default"}, "test_catalog");
 
     // Create table1 and table2 with separately fetched CatalogTable objects (not same instance)
-    SparkTable table1 =
-        new SparkTable(
+    DeltaV2Table table1 =
+        new DeltaV2Table(
             identifier,
             spark.sessionState().catalog().getTableMetadata(new TableIdentifier("test_catalog1")),
             Collections.emptyMap());
-    SparkTable table2 =
-        new SparkTable(
+    DeltaV2Table table2 =
+        new DeltaV2Table(
             identifier,
             spark.sessionState().catalog().getTableMetadata(new TableIdentifier("test_catalog1")),
             Collections.emptyMap());
@@ -460,8 +460,8 @@ public class SparkTableTest extends DeltaV2TestBase {
     assertEquals(table1.hashCode(), table2.hashCode());
 
     // Different catalogTable should not be equal
-    SparkTable table3 =
-        new SparkTable(
+    DeltaV2Table table3 =
+        new DeltaV2Table(
             identifier,
             spark.sessionState().catalog().getTableMetadata(new TableIdentifier("test_catalog2")),
             Collections.emptyMap());
@@ -469,7 +469,7 @@ public class SparkTableTest extends DeltaV2TestBase {
     assertNotEquals(table1.hashCode(), table3.hashCode());
 
     // Path-based table (no catalogTable) should not equal catalog-based table
-    SparkTable table4 = new SparkTable(identifier, path1, Collections.emptyMap());
+    DeltaV2Table table4 = new DeltaV2Table(identifier, path1, Collections.emptyMap());
     assertNotEquals(table1, table4);
     assertNotEquals(table1.hashCode(), table4.hashCode());
   }
@@ -481,20 +481,20 @@ public class SparkTableTest extends DeltaV2TestBase {
 
     Identifier identifier = Identifier.of(new String[] {"default"}, "test_snapshot");
 
-    // Create first SparkTable instance at version 0
-    SparkTable table1 = new SparkTable(identifier, path);
+    // Create first DeltaV2Table instance at version 0
+    DeltaV2Table table1 = new DeltaV2Table(identifier, path);
 
     // Modify the table to create a new version
     spark.sql("INSERT INTO test_snapshot VALUES (1)");
 
-    // Create second SparkTable instance at version 1
-    SparkTable table2 = new SparkTable(identifier, path);
+    // Create second DeltaV2Table instance at version 1
+    DeltaV2Table table2 = new DeltaV2Table(identifier, path);
 
     // Same identifier and path but different snapshot versions should not be equal
     assertNotEquals(
         table1,
         table2,
-        "SparkTable instances with different snapshot versions should not be equal");
+        "DeltaV2Table instances with different snapshot versions should not be equal");
     assertNotEquals(
         table1.hashCode(),
         table2.hashCode(),
@@ -507,8 +507,8 @@ public class SparkTableTest extends DeltaV2TestBase {
     spark.sql(
         String.format("CREATE TABLE test_write_builder (id INT) USING delta LOCATION '%s'", path));
 
-    SparkTable table =
-        new SparkTable(Identifier.of(new String[] {"default"}, "test_write_builder"), path);
+    DeltaV2Table table =
+        new DeltaV2Table(Identifier.of(new String[] {"default"}, "test_write_builder"), path);
     LogicalWriteInfo writeInfo =
         new LogicalWriteInfo() {
           @Override
@@ -537,7 +537,7 @@ public class SparkTableTest extends DeltaV2TestBase {
 
     Identifier identifier = Identifier.of(new String[] {"default"}, "test_cdc_on");
     Map<String, String> options = Collections.singletonMap("readChangeFeed", "true");
-    SparkTable table = new SparkTable(identifier, path, options);
+    DeltaV2Table table = new DeltaV2Table(identifier, path, options);
 
     StructType schema = table.schema();
     List<String> names = Arrays.asList(schema.fieldNames());
@@ -563,7 +563,7 @@ public class SparkTableTest extends DeltaV2TestBase {
     spark.sql(String.format("CREATE TABLE test_cdc_off (id INT) USING delta LOCATION '%s'", path));
 
     Identifier identifier = Identifier.of(new String[] {"default"}, "test_cdc_off");
-    SparkTable table = new SparkTable(identifier, path, Collections.emptyMap());
+    DeltaV2Table table = new DeltaV2Table(identifier, path, Collections.emptyMap());
 
     StructType schema = table.schema();
     List<String> names = Arrays.asList(schema.fieldNames());
@@ -593,7 +593,7 @@ public class SparkTableTest extends DeltaV2TestBase {
     Map<String, String> options = new HashMap<>();
     options.put(DeltaOptions.SCHEMA_TRACKING_LOCATION(), schemaLogPath);
 
-    SparkTable table = new SparkTable(identifier, tablePath, options);
+    DeltaV2Table table = new DeltaV2Table(identifier, tablePath, options);
 
     StructType schema = table.schema();
     assertEquals(2, schema.fields().length);
@@ -656,15 +656,15 @@ public class SparkTableTest extends DeltaV2TestBase {
     // Evolve the table — version 2 has an extra non-partition column.
     spark.sql(String.format("ALTER TABLE %s ADD COLUMNS (value DOUBLE)", tableName));
 
-    // Construct SparkTable with the schema-tracking option pointing at the seeded log. The
+    // Construct DeltaV2Table with the schema-tracking option pointing at the seeded log. The
     // snapshot is at v2 (3 columns) but the persisted entry is at v0 (2 columns). Default to
     // the catalog-table constructor since that's how production code typically loads the table.
     Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
     Map<String, String> options = new HashMap<>();
     options.put(optionKey, schemaLogPath);
-    SparkTable table;
+    DeltaV2Table table;
     if (usePathBasedConstructor) {
-      table = new SparkTable(identifier, tablePath, options);
+      table = new DeltaV2Table(identifier, tablePath, options);
     } else {
       CatalogTable catalogTable;
       try {
@@ -673,7 +673,7 @@ public class SparkTableTest extends DeltaV2TestBase {
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-      table = new SparkTable(identifier, catalogTable, options);
+      table = new DeltaV2Table(identifier, catalogTable, options);
     }
 
     // Persisted metadata wins: schema reflects v0 (2 columns), not v2 (3 columns).
@@ -748,7 +748,7 @@ public class SparkTableTest extends DeltaV2TestBase {
           UnsupportedOperationException ex =
               assertThrows(
                   UnsupportedOperationException.class,
-                  () -> new SparkTable(identifier, tablePath, options));
+                  () -> new DeltaV2Table(identifier, tablePath, options));
           assertEquals(
               "Schema tracking location is not supported for Delta streaming source",
               ex.getMessage());

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -653,11 +653,11 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
     // default) cannot fast-forward the seeded v0 entry past the upcoming v2 ALTER TABLE.
     spark.sql(String.format("INSERT INTO %s VALUES (1, 'a')", tableName));
 
-    // Evolve the table — version 2 has an extra non-partition column.
+    // Evolve the table — version 1 has an extra non-partition column.
     spark.sql(String.format("ALTER TABLE %s ADD COLUMNS (value DOUBLE)", tableName));
 
     // Construct DeltaV2Table with the schema-tracking option pointing at the seeded log. The
-    // snapshot is at v2 (3 columns) but the persisted entry is at v0 (2 columns). Default to
+    // snapshot is at v1 (3 columns) but the persisted entry is at v0 (2 columns). Default to
     // the catalog-table constructor since that's how production code typically loads the table.
     Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
     Map<String, String> options = new HashMap<>();
@@ -676,7 +676,7 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
       table = new DeltaV2Table(identifier, catalogTable, options);
     }
 
-    // Persisted metadata wins: schema reflects v0 (2 columns), not v2 (3 columns).
+    // Persisted metadata wins: schema reflects v0 (2 columns), not v1 (3 columns).
     // Public schema layout is data fields followed by partition fields, so [id, name].
     StructType schema = table.schema();
     assertEquals(2, schema.fields().length, "Persisted entry should override snapshot schema");

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/TestCatalog.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/TestCatalog.java
@@ -79,7 +79,7 @@ public class TestCatalog implements TableCatalog {
       throw new NoSuchTableException(ident);
     }
     try {
-      return new SparkTable(ident, tablePath);
+      return new DeltaV2Table(ident, tablePath);
     } catch (Exception e) {
       throw new RuntimeException("Failed to load table: " + ident, e);
     }
@@ -111,8 +111,8 @@ public class TestCatalog implements TableCatalog {
           .build(engine)
           .commit(engine, CloseableIterable.emptyIterable());
 
-      // Load the created table and return SparkTable
-      return new SparkTable(ident, tablePath);
+      // Load the created table and return DeltaV2Table
+      return new DeltaV2Table(ident, tablePath);
 
     } catch (Exception e) {
       // Remove the table entry if creation fails

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkBatchTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkBatchTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import io.delta.spark.internal.v2.DeltaV2TestBase;
-import io.delta.spark.internal.v2.catalog.SparkTable;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import java.io.File;
 import java.util.List;
 import java.util.stream.Stream;
@@ -51,8 +51,8 @@ public class SparkBatchTest extends DeltaV2TestBase {
   private final CaseInsensitiveStringMap options =
       new CaseInsensitiveStringMap(new java.util.HashMap<>());
 
-  private final SparkTable table =
-      new SparkTable(
+  private final DeltaV2Table table =
+      new DeltaV2Table(
           Identifier.of(new String[] {"spark_catalog", "default"}, tableName), tablePath, options);
 
   // Cases where two batches built from the same table must be equal. city/date are partition

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
@@ -22,7 +22,7 @@ import io.delta.golden.GoldenTableUtils$;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.expressions.Predicate;
-import io.delta.spark.internal.v2.catalog.SparkTable;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
@@ -94,8 +94,8 @@ public class SparkGoldenTableTest {
                 put("key2", "value2");
               }
             });
-    SparkTable table =
-        new SparkTable(
+    DeltaV2Table table =
+        new DeltaV2Table(
             Identifier.of(new String[] {"spark_catalog", "default"}, tableName),
             tablePath,
             options);
@@ -378,7 +378,7 @@ public class SparkGoldenTableTest {
   }
 
   private void checkSupportsPushDownFilters(
-      SparkTable table,
+      DeltaV2Table table,
       CaseInsensitiveStringMap scanOptions,
       Filter[] inputFilters,
       Filter[] expectedPostScanFilters,
@@ -445,8 +445,8 @@ public class SparkGoldenTableTest {
   public void testDsv2InteralWithNestedStruct() {
     String tableName = "data-reader-nested-struct";
     String tablePath = goldenTablePath(tableName);
-    SparkTable table =
-        new SparkTable(
+    DeltaV2Table table =
+        new DeltaV2Table(
             Identifier.of(new String[] {"spark_catalog", "default"}, tableName), tablePath);
 
     StructType expectedSchema =

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -3,7 +3,7 @@ package io.delta.spark.internal.v2.read;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.delta.spark.internal.v2.DeltaV2TestBase;
-import io.delta.spark.internal.v2.catalog.SparkTable;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
 import java.io.File;
 import java.lang.reflect.Field;
@@ -52,8 +52,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   private final CaseInsensitiveStringMap options =
       new CaseInsensitiveStringMap(new java.util.HashMap<>());
 
-  private final SparkTable table =
-      new SparkTable(
+  private final DeltaV2Table table =
+      new DeltaV2Table(
           Identifier.of(new String[] {"spark_catalog", "default"}, tableName), tablePath, options);
 
   protected static final Predicate cityPredicate =
@@ -156,8 +156,8 @@ public class SparkScanTest extends DeltaV2TestBase {
               "spark.sql.parquet.enableNestedColumnVectorizedReader",
               "false",
               () -> {
-                SparkTable mapTable =
-                    new SparkTable(
+                DeltaV2Table mapTable =
+                    new DeltaV2Table(
                         Identifier.of(new String[] {"spark_catalog", "default"}, mapTableName),
                         path,
                         options);
@@ -230,8 +230,8 @@ public class SparkScanTest extends DeltaV2TestBase {
                   dvTableName, dvPath));
           spark.sql(String.format("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", dvTableName));
 
-          SparkTable dvTable =
-              new SparkTable(
+          DeltaV2Table dvTable =
+              new DeltaV2Table(
                   Identifier.of(new String[] {"spark_catalog", "default"}, dvTableName),
                   dvPath,
                   options);
@@ -487,7 +487,7 @@ public class SparkScanTest extends DeltaV2TestBase {
   }
 
   protected static void checkSupportsRuntimeFilters(
-      SparkTable table,
+      DeltaV2Table table,
       CaseInsensitiveStringMap scanOptions,
       org.apache.spark.sql.connector.expressions.filter.Predicate[] runtimeFilters,
       List<String> remainingPartitionValueAfterDpp)
@@ -678,8 +678,8 @@ public class SparkScanTest extends DeltaV2TestBase {
       spark.sql("INSERT INTO " + tblName + " VALUES (2, 'sh')");
 
       // Table now has two AddFile entries: one with stats (first insert), one without (second).
-      SparkTable mixedStatsTable =
-          new SparkTable(
+      DeltaV2Table mixedStatsTable =
+          new DeltaV2Table(
               Identifier.of(new String[] {"spark_catalog", "default"}, tblName), path, options);
 
       withSQLConf(
@@ -1369,7 +1369,7 @@ public class SparkScanTest extends DeltaV2TestBase {
         "true",
         () -> {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
           SparkScanBuilder builder =
               (SparkScanBuilder)
@@ -1427,7 +1427,7 @@ public class SparkScanTest extends DeltaV2TestBase {
         "true",
         () -> {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
           SparkScanBuilder builder =
               (SparkScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
@@ -1473,7 +1473,7 @@ public class SparkScanTest extends DeltaV2TestBase {
           "true",
           () -> {
             Identifier id = Identifier.of(new String[] {"default"}, tblName);
-            SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+            DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
             SparkScanBuilder builder =
                 (SparkScanBuilder)
                     sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
@@ -1522,7 +1522,7 @@ public class SparkScanTest extends DeltaV2TestBase {
         "false",
         () -> {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
           SparkScanBuilder builder =
               (SparkScanBuilder)
@@ -1568,7 +1568,8 @@ public class SparkScanTest extends DeltaV2TestBase {
               "true",
               () -> {
                 Identifier id = Identifier.of(new String[] {"default"}, tblName);
-                SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+                DeltaV2Table sparkTable =
+                    new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
                 SparkScanBuilder builder =
                     (SparkScanBuilder)
@@ -1604,7 +1605,7 @@ public class SparkScanTest extends DeltaV2TestBase {
         () -> {
           // Path-based table — no catalog table, no ANALYZE TABLE stats
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          SparkTable sparkTable = new SparkTable(id, path);
+          DeltaV2Table sparkTable = new DeltaV2Table(id, path);
 
           SparkScanBuilder builder =
               (SparkScanBuilder)
@@ -1672,7 +1673,7 @@ public class SparkScanTest extends DeltaV2TestBase {
         "true",
         () -> {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
           SparkScanBuilder builder =
               (SparkScanBuilder)
@@ -1738,7 +1739,8 @@ public class SparkScanTest extends DeltaV2TestBase {
               "false",
               () -> {
                 Identifier id = Identifier.of(new String[] {"default"}, tblName);
-                SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+                DeltaV2Table sparkTable =
+                    new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
                 SparkScanBuilder builder =
                     (SparkScanBuilder)
@@ -1798,7 +1800,7 @@ public class SparkScanTest extends DeltaV2TestBase {
           CatalogTable catalogTable =
               spark.sessionState().catalog().getTableMetadata(new TableIdentifier(tblName));
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
           SparkScanBuilder builder =
               (SparkScanBuilder)
@@ -1843,7 +1845,7 @@ public class SparkScanTest extends DeltaV2TestBase {
         "true",
         () -> {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          SparkTable sparkTable = new SparkTable(id, catalogTable, Collections.emptyMap());
+          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
           SparkScanBuilder builder =
               (SparkScanBuilder)

--- a/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -78,7 +78,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                   spark.sql(String.format("INSERT INTO %s VALUES (5, 'Eve')", tableName));
                   // Auto-CDF requires the V2 connector at read time. Writes above run in the
                   // session-default mode (AUTO → V1 connector for INSERT). The CHANGES read in
-                  // the test body needs STRICT to ensure loadTable returns a V2 SparkTable.
+                  // the test body needs STRICT to ensure loadTable returns a V2 DeltaV2Table.
                   withSQLConf(
                       "spark.databricks.delta.v2.enableMode",
                       "STRICT",

--- a/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDirectBatchExecutionTest.java
+++ b/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDirectBatchExecutionTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.delta.spark.internal.v2.catalog.SparkTable;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
 import java.sql.Timestamp;
@@ -78,7 +78,7 @@ public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBa
           DeltaChangelog changelog =
               new DeltaChangelog(
                   tableName,
-                  new SparkTable(Identifier.of(new String[0], tableName), tablePath),
+                  new DeltaV2Table(Identifier.of(new String[0], tableName), tablePath),
                   0L,
                   latestVersion);
           ScanBuilder scanBuilder =
@@ -149,7 +149,7 @@ public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBa
           DeltaChangelog changelog =
               new DeltaChangelog(
                   tableName,
-                  new SparkTable(Identifier.of(new String[0], tableName), tablePath),
+                  new DeltaV2Table(Identifier.of(new String[0], tableName), tablePath),
                   0L,
                   latestVersion);
 
@@ -199,7 +199,7 @@ public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBa
           DeltaChangelog changelog =
               new DeltaChangelog(
                   tableName,
-                  new SparkTable(Identifier.of(new String[0], tableName), tablePath),
+                  new DeltaV2Table(Identifier.of(new String[0], tableName), tablePath),
                   0L,
                   latestVersion);
           Scan scan =
@@ -272,7 +272,7 @@ public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBa
           DeltaChangelog changelog =
               new DeltaChangelog(
                   tableName,
-                  new SparkTable(Identifier.of(new String[0], tableName), tablePath),
+                  new DeltaV2Table(Identifier.of(new String[0], tableName), tablePath),
                   2L,
                   3L);
           Scan scan =


### PR DESCRIPTION
## Description

Re-submit rename of the Delta Kernel DSv2 table implementation
`io.delta.spark.internal.v2.catalog.SparkTable` to `DeltaV2Table`.

The rename only changes identifiers (class file, class name, imports,
`instanceOf`/`asInstanceOf` checks, pattern matches, `toString` prefix,
comments, and shim docs). No behavior change beyond the JVM type name and the
debug string emitted by `toString()`.

### Renamed files
- `spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/SparkTable.java`
  -> `DeltaV2Table.java`
- `spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/SparkTableTest.java`
  -> `DeltaV2TableTest.java`

## How was this patch tested?

Existing tests, with all class references updated to the new name.

## Does this PR introduce _any_ user-facing change?

No.