### PR TITLE
[Kernel][Spark][Storage] Thread domain metadata through UC commits

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/commit/CommitMetadata.java
@@ -28,9 +28,11 @@ import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.internal.util.Tuple2;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -68,6 +70,7 @@ public class CommitMetadata {
   private final Optional<Protocol> newProtocolOpt;
   private final Optional<Metadata> newMetadataOpt;
   private final Optional<Long> maxKnownPublishedDeltaVersion;
+  private final Optional<Set<DomainMetadata>> readDomainMetadatas;
 
   public CommitMetadata(
       long version,
@@ -79,6 +82,30 @@ public class CommitMetadata {
       Optional<Protocol> newProtocolOpt,
       Optional<Metadata> newMetadataOpt,
       Optional<Long> maxKnownPublishedDeltaVersion) {
+    this(
+        version,
+        logPath,
+        commitInfo,
+        commitDomainMetadatas,
+        committerProperties,
+        readPandMOpt,
+        newProtocolOpt,
+        newMetadataOpt,
+        maxKnownPublishedDeltaVersion,
+        Optional.empty());
+  }
+
+  public CommitMetadata(
+      long version,
+      String logPath,
+      CommitInfo commitInfo,
+      List<DomainMetadata> commitDomainMetadatas,
+      Supplier<Map<String, String>> committerProperties,
+      Optional<Tuple2<Protocol, Metadata>> readPandMOpt,
+      Optional<Protocol> newProtocolOpt,
+      Optional<Metadata> newMetadataOpt,
+      Optional<Long> maxKnownPublishedDeltaVersion,
+      Optional<Set<DomainMetadata>> readDomainMetadatas) {
     checkArgument(version >= 0, "version must be non-negative: %d", version);
     this.version = version;
     this.logPath = requireNonNull(logPath, "logPath is null");
@@ -92,6 +119,9 @@ public class CommitMetadata {
     this.newMetadataOpt = requireNonNull(newMetadataOpt, "newMetadataOpt is null");
     this.maxKnownPublishedDeltaVersion =
         requireNonNull(maxKnownPublishedDeltaVersion, "maxKnownPublishedDeltaVersion is null");
+    this.readDomainMetadatas =
+        requireNonNull(readDomainMetadatas, "readDomainMetadatas is null")
+            .map(dm -> Collections.unmodifiableSet(new HashSet<>(dm)));
 
     checkArgument(
         readPandMOpt.isPresent() || newProtocolOpt.isPresent(),
@@ -128,6 +158,11 @@ public class CommitMetadata {
    */
   public List<DomainMetadata> getCommitDomainMetadatas() {
     return commitDomainMetadatas;
+  }
+
+  /** The active domain metadata in the transaction's read snapshot. Empty for version-0 commits. */
+  public Optional<Set<DomainMetadata>> getReadDomainMetadatas() {
+    return readDomainMetadatas;
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -595,7 +595,8 @@ public class TransactionImpl implements Transaction {
               shouldUpdateMetadata ? Optional.of(metadata) : Optional.empty(),
               readSnapshotOpt
                   .map(x -> x.getLogSegment().getMaxPublishedDeltaVersion())
-                  .orElse(Optional.of(-1L)));
+                  .orElse(Optional.of(-1L)),
+              readSnapshotOpt.map(x -> new HashSet<>(x.getActiveDomainMetadataMap().values())));
 
       DirectoryCreationUtils.createAllDeltaDirectoriesAsNeeded(
           engine, logPath, commitAsVersion, commitMetadata.getReadProtocolOpt(), protocol);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/TestFixtures.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/TestFixtures.scala
@@ -69,7 +69,8 @@ trait TestFixtures extends ActionUtils {
       readPandMOpt: Optional[Tuple2[Protocol, Metadata]] = Optional.empty(),
       newProtocolOpt: Optional[Protocol] = Optional.empty(),
       newMetadataOpt: Optional[Metadata] = Optional.empty(),
-      maxKnownPublishedDeltaVersion: Optional[JLong] = Optional.empty()): CommitMetadata = {
+      maxKnownPublishedDeltaVersion: Optional[JLong] = Optional.empty(),
+      readDomainMetadatas: Option[Set[DomainMetadata]] = None): CommitMetadata = {
     new CommitMetadata(
       version,
       logPath,
@@ -79,7 +80,10 @@ trait TestFixtures extends ActionUtils {
       readPandMOpt,
       newProtocolOpt,
       newMetadataOpt,
-      maxKnownPublishedDeltaVersion)
+      maxKnownPublishedDeltaVersion,
+      readDomainMetadatas
+        .map(dm => Optional.of(dm.asJava))
+        .getOrElse(Optional.empty()))
   }
 
   def createStagedCatalogCommit(

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -24,11 +24,13 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.commit.*;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.DomainMetadata;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedPublishedDeltaData;
 import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.unitycatalog.adapters.DomainMetadataAdapter;
 import io.delta.kernel.unitycatalog.adapters.MetadataAdapter;
 import io.delta.kernel.unitycatalog.adapters.ProtocolAdapter;
 import io.delta.kernel.unitycatalog.adapters.UniformAdapter;
@@ -38,14 +40,18 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
 import io.delta.storage.commit.uniform.UniformMetadata;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -450,6 +456,13 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
               });
 
           try {
+            List<DomainMetadata> oldDomainMetadata =
+                commitMetadata
+                    .getReadDomainMetadatas()
+                    .map(ArrayList::new)
+                    .orElseGet(ArrayList::new);
+            List<DomainMetadata> newDomainMetadata =
+                mergeDomainMetadata(oldDomainMetadata, commitMetadata.getCommitDomainMetadatas());
             ucClient.commit(
                 ucTableId,
                 tablePath.toUri(),
@@ -462,6 +475,8 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
                 generateMetadataPayloadOpt(commitMetadata).map(MetadataAdapter::new),
                 Optional.empty() /* oldProtocol */,
                 commitMetadata.getNewProtocolOpt().map(ProtocolAdapter::new),
+                toStorageDomainMetadata(oldDomainMetadata),
+                toStorageDomainMetadata(newDomainMetadata),
                 uniformMetadataOpt);
             return null;
           } catch (io.delta.storage.commit.CommitFailedException cfe) {
@@ -479,6 +494,28 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
                 false /* retryable */, false /* conflict */, ucce.getMessage(), ucce);
           }
         });
+  }
+
+  private List<DomainMetadata> mergeDomainMetadata(
+      List<DomainMetadata> oldDomainMetadata, List<DomainMetadata> commitDomainMetadata) {
+    Map<String, DomainMetadata> mergedDomainMetadata = new HashMap<>();
+    oldDomainMetadata.forEach(dm -> mergedDomainMetadata.put(dm.getDomain(), dm));
+    commitDomainMetadata.forEach(
+        dm -> {
+          if (dm.isRemoved()) {
+            mergedDomainMetadata.remove(dm.getDomain());
+          } else {
+            mergedDomainMetadata.put(dm.getDomain(), dm);
+          }
+        });
+    return new ArrayList<>(mergedDomainMetadata.values());
+  }
+
+  private List<AbstractDomainMetadata> toStorageDomainMetadata(
+      List<DomainMetadata> domainMetadata) {
+    return domainMetadata.stream()
+        .<AbstractDomainMetadata>map(DomainMetadataAdapter::new)
+        .collect(Collectors.toList());
   }
 
   private Commit getUcCommitPayload(

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.unitycatalog.adapters;
+
+import io.delta.kernel.internal.actions.DomainMetadata;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
+import java.util.Objects;
+
+/**
+ * Adapter from {@link io.delta.kernel.internal.actions.DomainMetadata} to {@link
+ * io.delta.storage.commit.actions.AbstractDomainMetadata}.
+ */
+public class DomainMetadataAdapter implements AbstractDomainMetadata {
+
+  private final DomainMetadata kernelDomainMetadata;
+
+  public DomainMetadataAdapter(DomainMetadata kernelDomainMetadata) {
+    this.kernelDomainMetadata =
+        Objects.requireNonNull(kernelDomainMetadata, "kernelDomainMetadata is null");
+  }
+
+  @Override
+  public String getDomain() {
+    return kernelDomainMetadata.getDomain();
+  }
+
+  @Override
+  public String getConfiguration() {
+    return kernelDomainMetadata.getConfiguration();
+  }
+
+  @Override
+  public boolean isRemoved() {
+    return kernelDomainMetadata.isRemoved();
+  }
+}

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -18,14 +18,14 @@ package io.delta.kernel.unitycatalog
 
 import java.lang.{Long => JLong}
 import java.net.URI
-import java.util.Optional
+import java.util.{Collections, List => JList, Optional}
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import io.delta.storage.commit.{Commit, CommitFailedException, GetCommitsResponse, TableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{InvalidTargetTableException, UCClient}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
@@ -145,8 +145,14 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
 
   /** Map from UC_TABLE_ID to TABLE_DATA */
   private val tables = new ConcurrentHashMap[String, TableData]()
+  private var lastCommitOldDomainMetadata: JList[AbstractDomainMetadata] = Collections.emptyList()
+  private var lastCommitNewDomainMetadata: JList[AbstractDomainMetadata] = Collections.emptyList()
 
   override def getMetastoreId: String = ucMetastoreId
+
+  def getLastCommitOldDomainMetadata: JList[AbstractDomainMetadata] = lastCommitOldDomainMetadata
+
+  def getLastCommitNewDomainMetadata: JList[AbstractDomainMetadata] = lastCommitNewDomainMetadata
 
   /** Convenience method for tests to commit with default parameters. */
   def commitWithDefaults(
@@ -166,10 +172,13 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata,
       Optional.empty(), // oldProtocol
       newProtocol,
+      Collections.emptyList(), // oldDomainMetadata
+      Collections.emptyList(), // newDomainMetadata
       Optional.empty() // uniform
     )
   }
 
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -180,9 +189,13 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
+      oldDomainMetadata: JList[AbstractDomainMetadata],
+      newDomainMetadata: JList[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata]): Unit = {
     forceThrowInCommitMethod()
 
+    lastCommitOldDomainMetadata = oldDomainMetadata
+    lastCommitNewDomainMetadata = newDomainMetadata
     val tableData = getOrCreateTableIfNotExists(tableId)
 
     tableData.synchronized {
@@ -202,6 +215,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       }
     }
   }
+  // scalastyle:on argcount
 
   override def getCommits(
       tableId: String,

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
@@ -22,10 +22,10 @@ import java.util.Optional
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
-import io.delta.kernel.commit.{CommitFailedException, CommitMetadata}
+import io.delta.kernel.commit.CommitFailedException
 import io.delta.kernel.commit.CommitMetadata.CommitType
 import io.delta.kernel.data.Row
-import io.delta.kernel.internal.actions.{Metadata, Protocol}
+import io.delta.kernel.internal.actions.{DomainMetadata, Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.{Tuple2 => KernelTuple2}
 import io.delta.kernel.test.{BaseMockJsonHandler, MockFileSystemClientUtils, TestFixtures, VectorTestUtils}
@@ -244,6 +244,52 @@ class UCCatalogManagedCommitterSuite
       assert(latestProtocol.getReaderFeatures === protocolUpgrade.getReaderFeatures)
       assert(latestProtocol.getWriterFeatures === protocolUpgrade.getWriterFeatures)
       assert(latestMetadata.getConfiguration === metadataUpgrade.getConfiguration)
+    }
+  }
+
+  test("CATALOG_WRITE: domain metadata is passed to UC client") {
+    withTempDirAndAllDeltaSubDirs { case (tablePath, logPath) =>
+      // ===== GIVEN =====
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      ucClient.insertTableDataAfterCreate(testUcTableId)
+      val committer = new UCCatalogManagedCommitter(ucClient, testUcTableId, tablePath)
+
+      // ===== WHEN =====
+      val domainMetadata = new DomainMetadata(
+        "delta.rowTracking",
+        """{"rowIdHighWaterMark":10}""",
+        false /* removed */ )
+      val removedDomainMetadata = new DomainMetadata(
+        "delta.clustering",
+        """{"clusteringColumns":[["s"]]}""",
+        true /* removed */ )
+      val oldClusteringDomainMetadata = new DomainMetadata(
+        "delta.clustering",
+        """{"clusteringColumns":[["s"]]}""",
+        false /* removed */ )
+      val commitMetadata = createCommitMetadata(
+        version = 1,
+        logPath = logPath,
+        commitDomainMetadatas = List(domainMetadata, removedDomainMetadata),
+        readDomainMetadatas = Some(Set(oldClusteringDomainMetadata)),
+        readPandMOpt = Optional.of(
+          new KernelTuple2[Protocol, Metadata](
+            protocolWithCatalogManagedSupport,
+            basicPartitionedMetadata)))
+      committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
+
+      // ===== THEN =====
+      val passedOldDomainMetadata = ucClient.getLastCommitOldDomainMetadata.asScala
+      assert(passedOldDomainMetadata.map(_.getDomain) === Seq("delta.clustering"))
+      val passedNewDomainMetadata = ucClient.getLastCommitNewDomainMetadata.asScala
+      assert(passedNewDomainMetadata.size === 1)
+      val passedDomainMetadataByDomain =
+        passedNewDomainMetadata.map(dm => dm.getDomain -> dm).toMap
+      assert(
+        passedDomainMetadataByDomain("delta.rowTracking").getConfiguration ===
+          """{"rowIdHighWaterMark":10}""")
+      assert(!passedDomainMetadataByDomain("delta.rowTracking").isRemoved)
+      assert(!passedDomainMetadataByDomain.contains("delta.clustering"))
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -67,8 +67,9 @@ private[delta] case class CurrentTransactionInfo(
     val readRowIdHighWatermark: Long,
     val catalogTable: Option[CatalogTable],
     val domainMetadata: Seq[DomainMetadata],
-    val op: DeltaOperations.Operation
-    , val convertedIcebergMetadata: Option[UniformMetadata] = None
+    val op: DeltaOperations.Operation,
+    val convertedIcebergMetadata: Option[UniformMetadata] = None,
+    val readDomainMetadataOpt: Option[Seq[DomainMetadata]] = None
  ) {
 
   /**
@@ -85,6 +86,30 @@ private[delta] case class CurrentTransactionInfo(
     case m: Metadata => newMetadata = Some(m)
     case _ => // do nothing
   }
+
+  /**
+   * Domain metadata that should be sent with the commit. This is derived from the final action
+   * list instead of the side-channel `domainMetadata`, because conflict resolution may rewrite
+   * `actions` after `domainMetadata` was computed.
+   */
+  private[delta] lazy val domainMetadataToCommit: Seq[DomainMetadata] =
+    DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(actions, protocol)
+
+  lazy val readDomainMetadata: Seq[DomainMetadata] =
+    readDomainMetadataOpt.getOrElse {
+      if (domainMetadataToCommit.isEmpty &&
+          !DomainMetadataUtils.domainMetadataSupported(protocol)) {
+        Seq.empty
+      } else {
+        readSnapshot.domainMetadata
+      }
+    }
+
+  private[delta] lazy val latestDomainMetadata: Seq[DomainMetadata] =
+    DomainMetadataUtils
+      .mergeDomainMetadata(readDomainMetadata, domainMetadataToCommit)
+      .filterNot(_.removed)
+
   def getUpdatedActions(
       oldMetadata: Metadata,
       oldProtocol: Protocol): UpdatedActions = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DomainMetadataUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DomainMetadataUtils.scala
@@ -96,6 +96,21 @@ trait DomainMetadataUtilsBase extends DeltaLogging {
   }
 
   /**
+   * Generates a new sequence of DomainMetadata by combining the provided
+   * new and old domain metadatas. Any duplicate domains will be removed
+   * from the old domain metadatas and replaced with the new domain metadatas.
+   * The returned list will be duplicate free.
+   */
+  def mergeDomainMetadata(
+      existingDomainMetadatas: Seq[DomainMetadata],
+      newDomainMetadatas: Seq[DomainMetadata]): Seq[DomainMetadata] = {
+    val newDomainNames: Set[String] = newDomainMetadatas.map(_.domain).toSet
+    existingDomainMetadatas
+      // Only use existing domain metadata if it is not present in the new domain metadata.
+      .filter(m => !newDomainNames.contains(m.domain)) ++ newDomainMetadatas
+  }
+
+  /**
    * Generates a new sequence of DomainMetadata to commits for RESTORE TABLE.
    *  - Domains in the toSnapshot will be copied if they appear in the pre-defined
    *    "copy" list (e.g., table features require some specific domains to be copied).

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.nio.file.FileAlreadyExistsException
 import java.time.Instant
-import java.util.{ConcurrentModificationException, Optional, UUID}
+import java.util.{ArrayList, ConcurrentModificationException, Optional, UUID}
 import java.util.concurrent.TimeUnit.{MINUTES, NANOSECONDS}
 
 import scala.collection.JavaConverters._
@@ -58,7 +58,7 @@ import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils, PartitionUtils, TransactionHelper}
 import org.apache.spark.sql.util.ScalaExtensions._
 import io.delta.storage.commit._
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 import org.apache.commons.lang3.NotImplementedException
@@ -1808,7 +1808,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // Check for duplicated [[MetadataAction]] with the same domain names and validate the table
       // feature is enabled if [[MetadataAction]] is submitted.
       val domainMetadata =
-        DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(finalActions, protocol)
+        DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(preparedActions, protocol)
 
       isBlindAppend = {
         val dependsOnFiles = !readPredicates.isEmpty || readFiles.nonEmpty
@@ -2110,7 +2110,28 @@ trait OptimisticTransactionImpl extends TransactionHelper
         deltaLog.createLogDirectoriesIfNotExists()
       }
       val fsWriteStartNano = System.nanoTime()
-      val jsonActions = allActions.map(_.json)
+      val oldDomainMetadata = snapshot.domainMetadata.map(dm => dm: AbstractDomainMetadata).asJava
+      val latestDomainMetadata = new ArrayList[AbstractDomainMetadata](oldDomainMetadata)
+      def applyDomainMetadataAction(domainMetadata: DomainMetadata): Unit = {
+        val iterator = latestDomainMetadata.iterator()
+        while (iterator.hasNext) {
+          if (iterator.next().getDomain == domainMetadata.domain) {
+            iterator.remove()
+          }
+        }
+        if (!domainMetadata.removed) {
+          latestDomainMetadata.add(domainMetadata)
+        }
+      }
+      val jsonActions = allActions.map { action =>
+        action match {
+          // commitLarge streams actions, so keep the active post-commit domain metadata state
+          // in a mutable list that is populated as jsonActions is consumed by the commit path.
+          case dm: DomainMetadata => applyDomainMetadataAction(dm)
+          case _ =>
+        }
+        action.json
+      }
       var commitSizeBytes = 0L
       jsonActions.map { action =>
           commitSizeBytes += action.size
@@ -2131,7 +2152,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
           jsonActions,
           updatedActions,
           catalogTable.map(_.identifier),
-          catalogTrackedInfo
+          new CatalogTrackedInfo(
+            catalogTrackedInfo.deltaUniformIceberg(),
+            oldDomainMetadata,
+            latestDomainMetadata)
         )
       }
       // TODO(coordinated-commits): Use the right timestamp method on top of CommitInfo once ICT is
@@ -2926,7 +2950,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
         jsonActions,
         updatedActions,
         catalogTable.map(_.identifier),
-        new CatalogTrackedInfo(currentTransactionInfo.convertedIcebergMetadata.toJava)
+        new CatalogTrackedInfo(
+          currentTransactionInfo.convertedIcebergMetadata.toJava,
+          currentTransactionInfo.readDomainMetadata.map(dm => dm: AbstractDomainMetadata).asJava,
+          currentTransactionInfo.latestDomainMetadata.map(dm => dm: AbstractDomainMetadata).asJava)
       )
     }
     if (attemptVersion == 0L) {
@@ -3074,7 +3101,23 @@ trait OptimisticTransactionImpl extends TransactionHelper
           winningCommitSummary,
           commitIsolationLevel)
 
-        updatedCurrentTransactionInfo = conflictChecker.checkConflictsAndValidateActions()
+        val rebasedCurrentTransactionInfo = conflictChecker.checkConflictsAndValidateActions()
+        // Conflict resolution already rebases this transaction's actions. Rebase the old active
+        // domain metadata baseline too, so CatalogTrackedInfo.oldDomainMetadata reflects the
+        // table state immediately before this rebased commit.
+        val winningDomainMetadata = winningCommitSummary.actions.collect {
+          case dm: DomainMetadata => dm
+        }
+        updatedCurrentTransactionInfo = if (winningDomainMetadata.nonEmpty) {
+          rebasedCurrentTransactionInfo.copy(
+            readDomainMetadataOpt = Some(DomainMetadataUtils
+              .mergeDomainMetadata(
+                updatedCurrentTransactionInfo.readDomainMetadata,
+                winningDomainMetadata)
+              .filterNot(_.removed)))
+        } else {
+          rebasedCurrentTransactionInfo
+        }
 
         logInfo(logPrefix +
           log"No conflicts in version ${MDC(DeltaLogKeys.VERSION, otherCommitVersion)}, " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -18,11 +18,11 @@ package org.apache.spark.sql.delta.coordinatedcommits
 
 import java.lang.{Long => JLong}
 import java.net.URI
-import java.util.Optional
+import java.util.{List => JList, Optional}
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import io.delta.storage.commit.{Commit => JCommit, GetCommitsResponse => JGetCommitsResponse, TableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCClient
 import io.delta.storage.commit.uniform.UniformMetadata
 
@@ -58,6 +58,7 @@ class InMemoryUCClient(
 
   override def getMetastoreId: String = metastoreId
 
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -68,6 +69,8 @@ class InMemoryUCClient(
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
+      oldDomainMetadata: JList[AbstractDomainMetadata],
+      newDomainMetadata: JList[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata] = Optional.empty()): Unit = {
     ucCommitCoordinator.commitToCoordinator(
       tableId,
@@ -84,6 +87,7 @@ class InMemoryUCClient(
       Option(uniform.orElse(null))
     )
   }
+  // scalastyle:on argcount
 
   override def getCommits(
       tableId: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -726,6 +726,7 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       domainMetadata: util.List[AbstractDomainMetadata],
       lastCommitTimestampMs: Long): TableInfo =
     throw new UnsupportedOperationException
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -736,8 +737,11 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
+      oldDomainMetadata: util.List[AbstractDomainMetadata],
+      newDomainMetadata: util.List[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata]): Unit =
     throw new UnsupportedOperationException
+  // scalastyle:on argcount
   override def getCommits(
       tableId: String,
       tableUri: URI,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalArgumentException, 
 import org.apache.spark.sql.delta.CommitCoordinatorGetCommitsFailedException
 import org.apache.spark.sql.delta.DeltaConfigs.{COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
-import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{CommitInfo, DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogTrackedInfo
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -46,6 +46,11 @@ import io.delta.storage.commit.{
   TableDescriptor,
   TableIdentifier => JTableIdentifier,
   UpdatedActions
+}
+import io.delta.storage.commit.actions.{
+  AbstractDomainMetadata,
+  AbstractMetadata,
+  AbstractProtocol
 }
 import io.delta.storage.commit.uccommitcoordinator.{
   UCCommitCoordinatorClient,
@@ -95,7 +100,9 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     withTempTableDir { tempDir =>
       val log = DeltaLog.forTable(spark, tempDir.toString)
       var capturedTableIdentifier: JTableIdentifier = null
+      // scalastyle:off argcount
       val capturingUCClient = new InMemoryUCClient(metastoreId.toString, ucCommitCoordinator) {
+        // scalastyle:off argcount
         override def getCommits(
             tableId: String,
             tableUri: java.net.URI,
@@ -105,7 +112,9 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
           capturedTableIdentifier = tableIdentifier
           new JGetCommitsResponse(Collections.emptyList(), -1L)
         }
+        // scalastyle:on argcount
       }
+      // scalastyle:on argcount
       val tableCommitCoordinatorClient = TableCommitCoordinatorClient(
         new UCCommitCoordinatorClient(Map.empty[String, String].asJava, capturingUCClient),
         log,
@@ -118,6 +127,69 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
       assert(capturedTableIdentifier != null)
       assert(capturedTableIdentifier.getNamespace.toSeq == Seq("main", "default"))
       assert(capturedTableIdentifier.getName == "tbl")
+    }
+  }
+
+  test("direct UC commit forwards latest domain metadata from CatalogTrackedInfo") {
+    withTempTableDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.toString)
+      val logPath = log.logPath
+      var capturedOldDomainMetadata: JList[AbstractDomainMetadata] = null
+      var capturedNewDomainMetadata: JList[AbstractDomainMetadata] = null
+      val capturingUCClient = new InMemoryUCClient(metastoreId.toString, ucCommitCoordinator) {
+        // scalastyle:off argcount
+        override def commit(
+            tableId: String,
+            tableUri: java.net.URI,
+            tableIdentifier: JTableIdentifier,
+            commit: Optional[JCommit],
+            lastKnownBackfilledVersion: Optional[JLong],
+            oldMetadata: Optional[AbstractMetadata],
+            newMetadata: Optional[AbstractMetadata],
+            oldProtocol: Optional[AbstractProtocol],
+            newProtocol: Optional[AbstractProtocol],
+            oldDomainMetadata: JList[AbstractDomainMetadata],
+            newDomainMetadata: JList[AbstractDomainMetadata],
+            uniform: Optional[UniformMetadata]): Unit = {
+          capturedOldDomainMetadata = oldDomainMetadata
+          capturedNewDomainMetadata = newDomainMetadata
+        }
+        // scalastyle:on argcount
+      }
+      val commitCoordinatorClient =
+        new UCCommitCoordinatorClient(Map.empty[String, String].asJava, capturingUCClient)
+      commitCoordinatorClient.registerTable(
+        logPath, Optional.empty(), -1L, initMetadata(), Protocol(1, 1))
+      writeCommitZero(logPath)
+      val tableDesc = new TableDescriptor(
+        logPath,
+        Optional.empty(),
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
+      val commitInfo = CommitInfo.empty(version = Some(1)).withTimestamp(1)
+        .copy(inCommitTimestamp = Some(1))
+      val updatedActions = getUpdatedActionsForNonZerothCommit(commitInfo)
+      val domainMetadata = DomainMetadata(
+        "delta.clustering",
+        """{"clusteringColumns":[["id"]]}""",
+        removed = false)
+      val oldDomainMetadata = DomainMetadata("old", "1", removed = false)
+      val catalogTrackedInfo =
+        new CatalogTrackedInfo(
+          Optional.empty(),
+          Collections.singletonList(oldDomainMetadata: AbstractDomainMetadata),
+          Collections.singletonList(domainMetadata: AbstractDomainMetadata))
+
+      commitCoordinatorClient.commit(
+        LogStoreInverseAdaptor(log.store, log.newDeltaHadoopConf()),
+        log.newDeltaHadoopConf(),
+        tableDesc,
+        1L,
+        Iterator(commitInfo.json).asJava,
+        catalogTrackedInfo,
+        updatedActions)
+
+      assert(capturedOldDomainMetadata.asScala.map(_.getDomain) === Seq("old"))
+      assert(capturedNewDomainMetadata.asScala.map(_.getDomain) === Seq("delta.clustering"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta.coordinatedcommits
 
 import java.io.File
-import java.util.{Optional, UUID}
+import java.util.{Collections, Optional, UUID}
 
 import scala.collection.JavaConverters._
 
@@ -126,6 +126,8 @@ trait UCCommitCoordinatorClientSuiteBase extends CommitCoordinatorClientImplSuit
       Optional.empty(), // newMetadata
       Optional.empty(), // oldProtocol
       Optional.empty(), // newProtocol
+      Collections.emptyList(), // oldDomainMetadata
+      Collections.emptyList(), // newDomainMetadata
       Optional.empty() /* uniform */)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -19,15 +19,17 @@ package org.apache.spark.sql.delta.rowtracking
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
-import org.apache.spark.sql.delta.actions.{Metadata, Protocol, RemoveFile}
+import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol, RemoveFile}
 import org.apache.spark.sql.delta.commands.backfill.{BackfillCommandStats, RowTrackingBackfillExecutor}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.FileNames
 import io.delta.exceptions.MetadataChangedException
 
 import org.apache.spark.SparkConf
+import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -150,6 +152,76 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       assert(committedAddFile.head.baseRowId === Some(numInitialRecords + numConcurrentRecords))
       val currentHighWaterMark = RowId.extractHighWatermark(latestSnapshot).get
       assert(currentHighWaterMark === numInitialRecords + numConcurrentRecords)
+    }
+  }
+
+  test("updated actions include row tracking domain metadata after conflict resolution") {
+    withTestTable {
+      val filePath = "file_path"
+      val numInitialRecords = 7
+      val numConcurrentRecords = 11
+
+      activateRowTracking()
+      commitRecords(numInitialRecords)
+      val readSnapshot = latestSnapshot
+      val readHighWaterMark = RowId.extractHighWatermark(readSnapshot).get
+      val initialActions = RowId.assignFreshRowIds(
+        spark,
+        readSnapshot.protocol,
+        readSnapshot,
+        Iterator(addFile(filePath)),
+        DeltaOperations.ManualUpdate).toSeq
+      val initialDomainMetadata = DomainMetadataUtils
+        .validateDomainMetadataSupportedAndNoDuplicate(initialActions, readSnapshot.protocol)
+
+      val winningCommitVersion = readSnapshot.version + 1
+      val winningCommitSummary = new WinningCommitSummary(
+        actions = Seq(
+          CommitInfo.empty(version = Some(winningCommitVersion)),
+          RowId.RowTrackingMetadataDomain(readHighWaterMark + numConcurrentRecords)
+            .toDomainMetadata),
+        fileStatus = new FileStatus(
+          1L,
+          false,
+          1,
+          1L,
+          1L,
+          FileNames.unsafeDeltaFile(deltaLog.logPath, winningCommitVersion)),
+        readTimeMs = 0L)
+
+      val currentTransactionInfo = CurrentTransactionInfo(
+        txnId = "txn",
+        readPredicates = Vector.empty,
+        readFiles = Set.empty,
+        readWholeTable = false,
+        readAppIds = Set.empty,
+        metadata = readSnapshot.metadata,
+        protocol = readSnapshot.protocol,
+        actions = initialActions,
+        readSnapshot = readSnapshot,
+        commitInfo = Some(CommitInfo.empty(version = Some(winningCommitVersion + 1))),
+        readRowIdHighWatermark = readHighWaterMark,
+        catalogTable = None,
+        domainMetadata = initialDomainMetadata,
+        op = DeltaOperations.ManualUpdate)
+
+      val updatedInfo = new ConflictChecker(
+        spark,
+        currentTransactionInfo,
+        winningCommitSummary,
+        WriteSerializable).checkConflictsAndValidateActions()
+
+      val finalHighWaterMark = updatedInfo.actions.collectFirst {
+        case RowId.RowTrackingMetadataDomain(domain) => domain.rowIdHighWaterMark
+      }.get
+      val updatedActionsHighWaterMark = updatedInfo
+        .latestDomainMetadata
+        .collectFirst {
+          case RowId.RowTrackingMetadataDomain(domain) => domain.rowIdHighWaterMark
+        }
+        .get
+
+      assert(updatedActionsHighWaterMark === finalHighWaterMark)
     }
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
@@ -375,14 +375,10 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
   }
 
   // Replacing a clustered managed Delta table with a non-clustered, non-partitioned one
-  // succeeds at the data plane (the table is queryable with the new schema, INSERTs land
-  // correctly), but UC's metastore retains the seed's `clusteringColumns` and
-  // `delta.feature.clustering` properties. The REPLACE does not propagate the cluster
-  // removal to UC's domain metadata. Pinned so we notice if the behavior changes; when
-  // fixed, update the assertion to reflect the cleared state.
-  // TODO: fix this issue https://github.com/delta-io/delta/issues/6915
+  // succeeds at the data plane and propagates the cleared clustering domain metadata to UC.
+  // The clustering table feature remains supported, but the active clustering columns are empty.
   @Test
-  public void testReplaceClusteredManagedTableWithNoneRetainsStaleUcClustering() throws Exception {
+  public void testReplaceClusteredManagedTableWithNoneClearsUcClustering() throws Exception {
     String tableName = "cluster_to_none_" + UUID.randomUUID().toString().replace("-", "");
     String fullTableName = fullTableName(tableName);
     try {
@@ -402,7 +398,7 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
       TablesApi tablesApi = new TablesApi(unityCatalogInfo().createApiClient());
       TableInfo info = tablesApi.getTable(fullTableName, false, false);
       assertThat(info.getProperties())
-          .containsEntry("clusteringColumns", "[[\"col1\"]]")
+          .containsEntry("clusteringColumns", "[]")
           .containsEntry("delta.feature.clustering", "supported");
     } finally {
       sql("DROP TABLE IF EXISTS %s", fullTableName);

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
@@ -18,6 +18,7 @@ package io.sparkuctest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.unitycatalog.client.delta.api.TablesApi;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
@@ -25,6 +26,7 @@ import io.unitycatalog.client.delta.model.StructField;
 import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.model.TableInfo;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
@@ -82,10 +84,29 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
           response = loadTableViaDeltaRest(tableName);
           assertEquals(
               "supported", response.getMetadata().getProperties().get("delta.feature.clustering"));
+          assertEquals(
+              "[[\"id\"]]", response.getMetadata().getProperties().get("clusteringColumns"));
+          TableInfo tableInfo = loadTableInfoViaUc(tableName);
+          assertEquals("[[\"id\"]]", tableInfo.getProperties().get("clusteringColumns"));
+
+          sql("ALTER TABLE %s CLUSTER BY (name)", tableName);
+
+          response = loadTableViaDeltaRest(tableName);
+          assertEquals(
+              "[[\"name\"]]", response.getMetadata().getProperties().get("clusteringColumns"));
+          tableInfo = loadTableInfoViaUc(tableName);
+          assertEquals("[[\"name\"]]", tableInfo.getProperties().get("clusteringColumns"));
+
+          sql("ALTER TABLE %s CLUSTER BY NONE", tableName);
+
+          response = loadTableViaDeltaRest(tableName);
+          assertNoClusteringColumns(response.getMetadata().getProperties());
+          tableInfo = loadTableInfoViaUc(tableName);
+          assertNoClusteringColumns(tableInfo.getProperties());
 
           sql("COMMENT ON TABLE %s IS 'table comment'", tableName);
 
-          TableInfo tableInfo = loadTableInfoViaUc(tableName);
+          tableInfo = loadTableInfoViaUc(tableName);
           assertEquals("table comment", tableInfo.getComment());
         });
   }
@@ -372,6 +393,12 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
   private TableInfo loadTableInfoViaUc(String tableName) throws Exception {
     return new io.unitycatalog.client.api.TablesApi(unityCatalogInfo().createApiClient())
         .getTable(tableName, false, false);
+  }
+
+  private static void assertNoClusteringColumns(Map<String, String> properties) {
+    assertTrue(
+        !properties.containsKey("clusteringColumns")
+            || "[]".equals(properties.get("clusteringColumns")));
   }
 
   private static List<String> fieldNames(StructType structType) {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -440,7 +440,6 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     }
 
     // Verify that table information maintained at the uc server side are expected.
-    boolean isManagedReplace = isReplace && tableType == TableType.MANAGED;
     assertUCTableInfo(
         tableType,
         fullTableName,
@@ -451,9 +450,8 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         withCluster,
         options.getClusterColumn(),
         options.getPartitionColumn(),
-        // For MANAGED+REPLACE: seed CREATE=v0, seed INSERT=v1, REPLACE=v2.
-        isManagedReplace ? "2" : "0",
-        !isManagedReplace);
+        expectedLastUpdateVersion(tableType, fullTableName),
+        withCluster);
   }
 
   @Test
@@ -588,7 +586,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         withCluster,
         options.getClusterColumn(),
         options.getPartitionColumn(),
-        "0",
+        expectedLastUpdateVersion(TableType.MANAGED, fullTableName),
         true);
 
     // Second CREATE OR REPLACE: identical metadata; goes through
@@ -606,8 +604,8 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     } else {
       check(fullTableName, List.of(List.of("3", "c")));
     }
-    // Identical metadata: UC's view of `lastUpdateVersion` and `clusteringColumns` is
-    // unchanged from the first COR.
+    // Identical table metadata: clusteringColumns is unchanged. Row-tracking domain metadata
+    // still advances on the post-replace INSERT, so lastUpdateVersion tracks the current version.
     assertUCTableInfo(
         TableType.MANAGED,
         fullTableName,
@@ -618,7 +616,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         withCluster,
         options.getClusterColumn(),
         options.getPartitionColumn(),
-        "0",
+        expectedLastUpdateVersion(TableType.MANAGED, fullTableName),
         true);
   }
 
@@ -798,8 +796,12 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         false,
         Optional.empty(),
         Optional.empty(),
-        "0",
+        expectedLastUpdateVersion(tableType, fullTableName),
         true);
+  }
+
+  private String expectedLastUpdateVersion(TableType tableType, String fullTableName) {
+    return tableType == TableType.MANAGED ? Long.toString(currentVersion(fullTableName)) : "0";
   }
 
   private void assertUCTableInfo(

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
@@ -16,14 +16,25 @@
 
 package io.sparkuctest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.model.TableInfo;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /** Tests metadata-changing operations on Unity Catalog managed (CatalogOwned) tables. */
 public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseTest {
 
+  private static final String MANAGED_PROPS =
+      "TBLPROPERTIES ('delta.feature.catalogManaged'='supported')";
   private static final String CLUSTERING_KILL_SWITCH_ERROR =
       "Clustering column changes on Unity Catalog managed tables";
+  private static final String CLUSTERING_COLUMNS = "clusteringColumns";
+  private static final String ROW_ID_HIGH_WATERMARK = "delta.rowTracking.rowIdHighWaterMark";
 
   // ---------------------------------------------------------------------------
   // Metadata updates supported through UC updateTable
@@ -102,6 +113,40 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
         });
   }
 
+  @Test
+  public void testReplaceTableWithoutClusterByRemovesClusteringDomainMetadata() throws Exception {
+    String tableName = fullTableName("replace_remove_clustering_test");
+    try {
+      sql(
+          "CREATE TABLE %s (id INT, name STRING) USING DELTA CLUSTER BY (id) %s",
+          tableName, MANAGED_PROPS);
+      assertClusteringColumnsEverywhere(tableName, "[[\"id\"]]");
+
+      sql("REPLACE TABLE %s (id INT, name STRING) USING DELTA %s", tableName, MANAGED_PROPS);
+
+      assertNoClusteringColumnsEverywhere(tableName);
+    } finally {
+      sql("DROP TABLE IF EXISTS %s", tableName);
+    }
+  }
+
+  @Test
+  public void testReplaceTableWithClusterByAddsClusteringDomainMetadata() throws Exception {
+    String tableName = fullTableName("replace_add_clustering_test");
+    try {
+      sql("CREATE TABLE %s (id INT, name STRING) USING DELTA %s", tableName, MANAGED_PROPS);
+      assertNoClusteringColumnsEverywhere(tableName);
+
+      sql(
+          "REPLACE TABLE %s (id INT, name STRING) USING DELTA CLUSTER BY (id) %s",
+          tableName, MANAGED_PROPS);
+
+      assertClusteringColumnsEverywhere(tableName, "[[\"id\"]]");
+    } finally {
+      sql("DROP TABLE IF EXISTS %s", tableName);
+    }
+  }
+
   /**
    * RESTORE TABLE to a version with unchanged clustering must succeed. The clustering kill switch
    * only fires when clustering actually changes.
@@ -125,11 +170,11 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
   }
 
   /**
-   * RESTORE TABLE to a version whose clustering differs from the current version must be blocked
-   * until UC updateTable supports domain metadata updates.
+   * RESTORE TABLE to a version whose clustering differs from the current version is still blocked.
+   * A failed restore must not partially update UC clustering domain metadata.
    */
   @Test
-  public void testRestoreTableWithClusteringChangeIsBlocked() throws Exception {
+  public void testRestoreTableWithClusteringChangeIsBlockedWithoutUcDrift() throws Exception {
     String tableName = fullTableName("restore_clustering_change_test");
     try {
       sql(
@@ -139,6 +184,7 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
       sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tableName);
       long versionBeforeClusteringChange = currentVersion(tableName);
       sql("ALTER TABLE %s CLUSTER BY (name)", tableName);
+      assertClusteringColumnsEverywhere(tableName, "[[\"name\"]]");
 
       assertThrowsWithCauseContaining(
           CLUSTERING_KILL_SWITCH_ERROR,
@@ -146,9 +192,76 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
               sql(
                   "RESTORE TABLE %s TO VERSION AS OF %d",
                   tableName, versionBeforeClusteringChange));
+
+      assertClusteringColumnsEverywhere(tableName, "[[\"name\"]]");
+      check(tableName, List.of(row("1", "a"), row("2", "b")));
     } finally {
       sql("DROP TABLE IF EXISTS %s", tableName);
     }
+  }
+
+  /**
+   * RESTORE from an unclustered current table to a clustered previous version is also a clustering
+   * change, so it must be blocked and leave UC clustering domain metadata unchanged.
+   */
+  @Test
+  public void testRestoreTableFromUnclusteredCurrentToClusteredVersionIsBlockedWithoutUcDrift()
+      throws Exception {
+    String tableName = fullTableName("restore_to_clustered_version_test");
+    try {
+      sql(
+          "CREATE TABLE %s (id INT, name STRING) USING DELTA CLUSTER BY (id)"
+              + " TBLPROPERTIES ('delta.feature.catalogManaged'='supported')",
+          tableName);
+      sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tableName);
+      long clusteredVersion = currentVersion(tableName);
+      assertClusteringColumnsEverywhere(tableName, "[[\"id\"]]");
+
+      sql("ALTER TABLE %s CLUSTER BY NONE", tableName);
+      assertNoClusteringColumnsEverywhere(tableName);
+
+      assertThrowsWithCauseContaining(
+          CLUSTERING_KILL_SWITCH_ERROR,
+          () -> sql("RESTORE TABLE %s TO VERSION AS OF %d", tableName, clusteredVersion));
+
+      assertNoClusteringColumnsEverywhere(tableName);
+      check(tableName, List.of(row("1", "a"), row("2", "b")));
+    } finally {
+      sql("DROP TABLE IF EXISTS %s", tableName);
+    }
+  }
+
+  @Test
+  public void testRowTrackingHighWatermarkDomainMetadataAdvancesInUc() throws Exception {
+    withNewTable(
+        "row_tracking_domain_metadata_test",
+        "id INT, name STRING",
+        TableType.MANAGED,
+        tableName -> {
+          sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tableName);
+          long firstHighWatermark = rowTrackingHighWatermark(tableName);
+
+          sql("INSERT INTO %s VALUES (3, 'c')", tableName);
+          long secondHighWatermark = rowTrackingHighWatermark(tableName);
+
+          assertTrue(secondHighWatermark > firstHighWatermark);
+        });
+  }
+
+  @Test
+  public void testRowTrackingBackfillHighWatermarkDomainMetadataSyncsToUc() throws Exception {
+    withNewTable(
+        "row_tracking_backfill_domain_metadata_test",
+        "id INT, name STRING",
+        TableType.MANAGED,
+        tableName -> {
+          sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tableName);
+
+          sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking' = 'true')", tableName);
+
+          long highWatermarkAfterBackfill = rowTrackingHighWatermark(tableName);
+          assertTrue(highWatermarkAfterBackfill >= 1);
+        });
   }
 
   @Test
@@ -274,5 +387,42 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
                 }
               });
         });
+  }
+
+  private LoadTableResponse loadTableViaDeltaRest(String tableName) throws Exception {
+    String[] parts = tableName.split("\\.", 3);
+    return new TablesApi(unityCatalogInfo().createApiClient())
+        .loadTable(parts[0], parts[1], parts[2]);
+  }
+
+  private TableInfo loadTableInfoViaUc(String tableName) throws Exception {
+    return new io.unitycatalog.client.api.TablesApi(unityCatalogInfo().createApiClient())
+        .getTable(tableName, false, false);
+  }
+
+  private void assertClusteringColumnsEverywhere(String tableName, String expected)
+      throws Exception {
+    assertEquals(
+        expected,
+        loadTableViaDeltaRest(tableName).getMetadata().getProperties().get(CLUSTERING_COLUMNS));
+    assertEquals(expected, loadTableInfoViaUc(tableName).getProperties().get(CLUSTERING_COLUMNS));
+  }
+
+  private void assertNoClusteringColumnsEverywhere(String tableName) throws Exception {
+    assertNoClusteringColumns(loadTableViaDeltaRest(tableName).getMetadata().getProperties());
+    assertNoClusteringColumns(loadTableInfoViaUc(tableName).getProperties());
+  }
+
+  private static void assertNoClusteringColumns(Map<String, String> properties) {
+    assertTrue(
+        !properties.containsKey(CLUSTERING_COLUMNS)
+            || "[]".equals(properties.get(CLUSTERING_COLUMNS)));
+  }
+
+  private long rowTrackingHighWatermark(String tableName) throws Exception {
+    Map<String, String> properties = loadTableViaDeltaRest(tableName).getMetadata().getProperties();
+    String highWatermark = properties.get(ROW_ID_HIGH_WATERMARK);
+    assertTrue(highWatermark != null, "UC Delta loadTable is missing row-tracking high watermark");
+    return Long.parseLong(highWatermark);
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
@@ -1,7 +1,10 @@
 package org.apache.spark.sql.delta.coordinatedcommits;
 
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.uniform.UniformMetadata;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 public class CatalogTrackedInfo {
@@ -9,11 +12,32 @@ public class CatalogTrackedInfo {
 
     private final Optional<UniformMetadata> deltaUniformIceberg;
 
+    private final List<AbstractDomainMetadata> oldDomainMetadata;
+
+    private final List<AbstractDomainMetadata> latestDomainMetadata;
+
     public CatalogTrackedInfo(Optional<UniformMetadata> deltaUniformIceberg) {
+        this(deltaUniformIceberg, Collections.emptyList(), Collections.emptyList());
+    }
+
+    public CatalogTrackedInfo(
+            Optional<UniformMetadata> deltaUniformIceberg,
+            List<AbstractDomainMetadata> oldDomainMetadata,
+            List<AbstractDomainMetadata> latestDomainMetadata) {
         this.deltaUniformIceberg = deltaUniformIceberg;
+        this.oldDomainMetadata = oldDomainMetadata;
+        this.latestDomainMetadata = latestDomainMetadata;
     }
 
     public Optional<UniformMetadata> deltaUniformIceberg() {
         return deltaUniformIceberg;
+    }
+
+    public List<AbstractDomainMetadata> oldDomainMetadata() {
+        return oldDomainMetadata;
+    }
+
+    public List<AbstractDomainMetadata> latestDomainMetadata() {
+        return latestDomainMetadata;
     }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -20,6 +20,7 @@ import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -83,6 +84,12 @@ public interface UCClient extends AutoCloseable {
    *                    If present, UC can validate the current protocol state.
    * @param newProtocol An Optional containing a new protocol version to be applied to the table.
    *                    If present, the table's protocol will be updated atomically with the commit.
+   * @param oldDomainMetadata A list containing domain metadata before this commit.
+   *                          Implementations that do not support domain metadata may ignore
+   *                          this list.
+   * @param newDomainMetadata A list containing domain metadata after this commit.
+   *                          Implementations that do not support domain metadata may ignore
+   *                          this list.
    * @param uniform An Optional containing UniForm metadata for Delta Universal Format support.
    *                If present, this metadata will be used by UC to manage format conversions
    *                (e.g., Iceberg, Hudi).
@@ -101,6 +108,8 @@ public interface UCClient extends AutoCloseable {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
+      List<AbstractDomainMetadata> oldDomainMetadata,
+      List<AbstractDomainMetadata> newDomainMetadata,
       Optional<UniformMetadata> uniform
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException;
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -33,7 +33,6 @@ import org.apache.spark.sql.delta.coordinatedcommits.CatalogTrackedInfo;
 import io.delta.storage.CloseableIterator;
 import io.delta.storage.LogStore;
 import io.delta.storage.commit.*;
-import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -468,9 +467,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           oldMetadata,
           newMetadata,
           oldProtocol,
-          newProtocol,
-          catalogTrackedInfo.oldDomainMetadata(),
-          catalogTrackedInfo.latestDomainMetadata()
+          newProtocol
         );
         break;
       } catch (CommitFailedException cfe) {
@@ -677,9 +674,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional.empty() /* oldMetadata */,
       Optional.empty() /* newMetadata */,
       Optional.empty() /* oldProtocol */,
-      Optional.empty() /* newProtocol */,
-      Collections.emptyList() /* oldDomainMetadata */,
-      Collections.emptyList() /* newDomainMetadata */
+      Optional.empty() /* newProtocol */
     );
     long commitDuration = System.currentTimeMillis() - commitStartTime;
 
@@ -710,9 +705,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional<AbstractMetadata> oldMetadata,
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
-      Optional<AbstractProtocol> newProtocol,
-      List<AbstractDomainMetadata> oldDomainMetadata,
-      List<AbstractDomainMetadata> newDomainMetadata
+      Optional<AbstractProtocol> newProtocol
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException
   {
     Optional<Commit> commit = commitFile.map(f -> new Commit(
@@ -732,8 +725,8 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       newMetadata,
       oldProtocol,
       newProtocol,
-      oldDomainMetadata,
-      newDomainMetadata,
+      catalogTrackedInfo.oldDomainMetadata(),
+      catalogTrackedInfo.latestDomainMetadata(),
       catalogTrackedInfo.deltaUniformIceberg()
     );
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -33,6 +33,7 @@ import org.apache.spark.sql.delta.coordinatedcommits.CatalogTrackedInfo;
 import io.delta.storage.CloseableIterator;
 import io.delta.storage.LogStore;
 import io.delta.storage.commit.*;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -467,7 +468,9 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           oldMetadata,
           newMetadata,
           oldProtocol,
-          newProtocol
+          newProtocol,
+          catalogTrackedInfo.oldDomainMetadata(),
+          catalogTrackedInfo.latestDomainMetadata()
         );
         break;
       } catch (CommitFailedException cfe) {
@@ -674,7 +677,9 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional.empty() /* oldMetadata */,
       Optional.empty() /* newMetadata */,
       Optional.empty() /* oldProtocol */,
-      Optional.empty() /* newProtocol */
+      Optional.empty() /* newProtocol */,
+      Collections.emptyList() /* oldDomainMetadata */,
+      Collections.emptyList() /* newDomainMetadata */
     );
     long commitDuration = System.currentTimeMillis() - commitStartTime;
 
@@ -705,7 +710,9 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional<AbstractMetadata> oldMetadata,
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
-      Optional<AbstractProtocol> newProtocol
+      Optional<AbstractProtocol> newProtocol,
+      List<AbstractDomainMetadata> oldDomainMetadata,
+      List<AbstractDomainMetadata> newDomainMetadata
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException
   {
     Optional<Commit> commit = commitFile.map(f -> new Commit(
@@ -725,6 +732,8 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       newMetadata,
       oldProtocol,
       newProtocol,
+      oldDomainMetadata,
+      newDomainMetadata,
       catalogTrackedInfo.deltaUniformIceberg()
     );
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -47,8 +47,10 @@ import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.client.delta.model.DeltaCommit;
 import io.unitycatalog.client.delta.model.DeltaProtocol;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.RemoveDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.RemovePropertiesUpdate;
 import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
+import io.unitycatalog.client.delta.model.SetDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.SetLatestBackfilledVersionUpdate;
 import io.unitycatalog.client.delta.model.SetPartitionColumnsUpdate;
 import io.unitycatalog.client.delta.model.SetPropertiesUpdate;
@@ -73,6 +75,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -260,10 +263,14 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
+      List<AbstractDomainMetadata> oldDomainMetadata,
+      List<AbstractDomainMetadata> newDomainMetadata,
       Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform)
       throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
+    Objects.requireNonNull(oldDomainMetadata, "oldDomainMetadata must not be null");
+    Objects.requireNonNull(newDomainMetadata, "newDomainMetadata must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     UpdateTableRequest request = new UpdateTableRequest();
@@ -296,12 +303,72 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .action("set-protocol")
           .protocol(toSDKDeltaProtocol(newProtocol.get())));
     }
+    Map<String, AbstractDomainMetadata> oldActiveDomainMetadata =
+        toActiveDomainMetadataMap(oldDomainMetadata, "oldDomainMetadata");
+    Map<String, AbstractDomainMetadata> newActiveDomainMetadata =
+        toActiveDomainMetadataMap(newDomainMetadata, "newDomainMetadata");
+    List<AbstractDomainMetadata> domainMetadataToSet =
+        changedDomainMetadata(oldActiveDomainMetadata, newActiveDomainMetadata);
+    List<String> domainMetadataToRemove =
+        removedDomainMetadata(oldActiveDomainMetadata, newActiveDomainMetadata);
+    DomainMetadataUpdates domainMetadataUpdates = toSDKDomainMetadataUpdates(domainMetadataToSet);
+    if (domainMetadataUpdates != null) {
+      request.addUpdatesItem(new SetDomainMetadataUpdate()
+          .action("set-domain-metadata")
+          .updates(domainMetadataUpdates));
+    }
+    if (!domainMetadataToRemove.isEmpty()) {
+      request.addUpdatesItem(new RemoveDomainMetadataUpdate()
+          .action("remove-domain-metadata")
+          .domains(domainMetadataToRemove));
+    }
 
     try {
       deltaTablesApi.updateTable(name.catalog, name.schema, name.table, request);
     } catch (ApiException e) {
       handleUpdateTableException(e, name.catalog, name.schema, name.table);
     }
+  }
+
+  private static Map<String, AbstractDomainMetadata> toActiveDomainMetadataMap(
+      List<AbstractDomainMetadata> domainMetadata,
+      String argumentName) {
+    Map<String, AbstractDomainMetadata> activeDomainMetadata = new HashMap<>();
+    for (AbstractDomainMetadata dm : domainMetadata) {
+      Objects.requireNonNull(dm, argumentName + " entry must not be null");
+      if (dm.isRemoved()) {
+        activeDomainMetadata.remove(dm.getDomain());
+      } else {
+        activeDomainMetadata.put(dm.getDomain(), dm);
+      }
+    }
+    return activeDomainMetadata;
+  }
+
+  private static List<AbstractDomainMetadata> changedDomainMetadata(
+      Map<String, AbstractDomainMetadata> oldDomainMetadata,
+      Map<String, AbstractDomainMetadata> newDomainMetadata) {
+    List<AbstractDomainMetadata> changedDomainMetadata = new ArrayList<>();
+    for (Map.Entry<String, AbstractDomainMetadata> entry : newDomainMetadata.entrySet()) {
+      AbstractDomainMetadata old = oldDomainMetadata.get(entry.getKey());
+      AbstractDomainMetadata latest = entry.getValue();
+      if (old == null || !Objects.equals(old.getConfiguration(), latest.getConfiguration())) {
+        changedDomainMetadata.add(latest);
+      }
+    }
+    return changedDomainMetadata;
+  }
+
+  private static List<String> removedDomainMetadata(
+      Map<String, AbstractDomainMetadata> oldDomainMetadata,
+      Map<String, AbstractDomainMetadata> newDomainMetadata) {
+    List<String> removedDomainMetadata = new ArrayList<>();
+    for (String domain : oldDomainMetadata.keySet()) {
+      if (!newDomainMetadata.containsKey(domain)) {
+        removedDomainMetadata.add(domain);
+      }
+    }
+    return removedDomainMetadata;
   }
 
   @Override
@@ -690,8 +757,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   /**
    * Maps Delta {@link AbstractDomainMetadata} entries onto the UC SDK's typed {@link
    * DomainMetadataUpdates}. UC models only {@code delta.clustering} and {@code
-   * delta.rowTracking}; entries for unknown domains are dropped silently. Returns {@code null}
-   * when no known-domain entries were produced.
+   * delta.rowTracking}; entries for unknown domains fail loudly to avoid silently dropping Delta
+   * log state. Returns {@code null} when no known-domain entries were produced.
    *
    * <p>Each {@code configuration} JSON is parsed into a typed DTO so a shape mismatch fails at
    * parse time with a Jackson error rather than at first use after an unchecked cast.
@@ -703,7 +770,6 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     DomainMetadataUpdates updates = new DomainMetadataUpdates();
     boolean any = false;
     for (AbstractDomainMetadata dm : entries) {
-      // This function is for createTable only for now.
       if (dm.isRemoved()) {
         continue;
       }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -21,6 +21,7 @@ import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.IcebergMetadata;
@@ -179,6 +180,8 @@ public class UCTokenBasedRestClient implements UCClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
+      List<AbstractDomainMetadata> oldDomainMetadata,
+      List<AbstractDomainMetadata> newDomainMetadata,
       Optional<UniformMetadata> uniform
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
@@ -203,8 +206,9 @@ public class UCTokenBasedRestClient implements UCClient {
     uniform.flatMap(u -> u.getIcebergMetadata().map(this::toDeltaUniformIceberg))
         .ifPresent(iceberg -> deltaCommit.uniform(new DeltaUniform().iceberg(iceberg)));
 
-    // Note: tableIdentifier, oldMetadata, oldProtocol, and newProtocol are not part of the
-    // DeltaCommit schema in the Unity Catalog OpenAPI spec. They are intentionally not sent.
+    // Note: tableIdentifier, oldMetadata, oldProtocol, newProtocol, and domain metadata are not
+    // part of the legacy DeltaCommit schema in the Unity Catalog OpenAPI spec. They are
+    // intentionally not sent.
 
     try {
       deltaCommitsApi.commit(deltaCommit);

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -306,7 +306,8 @@ class UCDeltaTokenBasedRestClientSuite
     withClient { c =>
       c.commit(testTableId.toString, new URI("s3://bucket/table"), testIdentifier,
         Optional.of(createCommit(5L)), Optional.of(java.lang.Long.valueOf(3L)),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList(), Collections.emptyList(), Optional.empty())
     }
 
     val json = objectMapper.readTree(captured)
@@ -348,7 +349,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.of(oldMeta), Optional.of(newMeta),
-        Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Collections.emptyList(),
+        Collections.emptyList(), Optional.empty())
     }
 
     val actions = {
@@ -377,7 +379,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(),
-        Optional.of(oldProto), Optional.of(newProto), Optional.empty())
+        Optional.of(oldProto), Optional.of(newProto), Collections.emptyList(),
+        Collections.emptyList(), Optional.empty())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -385,6 +388,72 @@ class UCDeltaTokenBasedRestClientSuite
       .find(_.get("action").asText() == "set-protocol").get.get("protocol")
     assert(proto.get("min-reader-version").asInt() === 3)
     assert(proto.get("min-writer-version").asInt() === 7)
+  }
+
+  test("commit sends changed and removed domain metadata updates") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      if (exchange.getRequestMethod == "POST") {
+        captured = body
+      }
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    withClient { c =>
+      c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.of(createCommit(1L)), Optional.empty(),
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        java.util.List.of(
+          dm("delta.rowTracking", """{"rowIdHighWaterMark":0}""")),
+        java.util.List.of(
+          dm("delta.clustering", """{"clusteringColumns":[["id"]]}""")),
+        Optional.empty())
+    }
+
+    val updates = objectMapper.readTree(captured).get("updates")
+    val setDomainMetadata = (0 until updates.size()).map(updates.get)
+      .find(_.get("action").asText() == "set-domain-metadata").get
+    val clusteringColumns = setDomainMetadata
+      .get("updates")
+      .get("delta.clustering")
+      .get("clusteringColumns")
+    assert(clusteringColumns.get(0).get(0).asText() === "id")
+
+    val removeDomainMetadata = (0 until updates.size()).map(updates.get)
+      .find(_.get("action").asText() == "remove-domain-metadata").get
+    assert(removeDomainMetadata.get("domains").get(0).asText() === "delta.rowTracking")
+  }
+
+  test("commit skips unchanged domains in domain metadata updates") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      if (exchange.getRequestMethod == "POST") {
+        captured = body
+      }
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    val oldDomainMetadata = java.util.List.of(
+      dm("delta.clustering", """{"clusteringColumns":[["id"]]}"""),
+      dm("delta.rowTracking", """{"rowIdHighWaterMark":1}"""))
+    val newDomainMetadata = java.util.List.of(
+      dm("delta.clustering", """{"clusteringColumns":[["id"]]}"""),
+      dm("delta.rowTracking", """{"rowIdHighWaterMark":2}"""))
+
+    withClient { c =>
+      c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.of(createCommit(1L)), Optional.empty(),
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        oldDomainMetadata, newDomainMetadata, Optional.empty())
+    }
+
+    val updates = objectMapper.readTree(captured).get("updates")
+    val setDomainMetadata = (0 until updates.size()).map(updates.get)
+      .find(_.get("action").asText() == "set-domain-metadata").get
+    assert(setDomainMetadata.get("updates").has("delta.rowTracking"))
+    assert(!setDomainMetadata.get("updates").has("delta.clustering"))
+    val actions = (0 until updates.size()).map(i => updates.get(i).get("action").asText()).toSet
+    assert(!actions.contains("remove-domain-metadata"))
   }
 
   test("commit skips metadata updates when old and new are equal") {
@@ -404,7 +473,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.of(m1), Optional.of(m2),
-        Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Collections.emptyList(),
+        Collections.emptyList(), Optional.empty())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -430,7 +500,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(),
-        Optional.of(p1), Optional.of(p2), Optional.empty())
+        Optional.of(p1), Optional.of(p2), Collections.emptyList(),
+        Collections.emptyList(), Optional.empty())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -454,7 +525,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(uniform))
+        Collections.emptyList(), Collections.emptyList(), Optional.of(uniform))
     }
 
     val addCommit = {
@@ -484,7 +555,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(uniform))
+        Collections.emptyList(), Collections.emptyList(), Optional.of(uniform))
     }
 
     val addCommit = {
@@ -511,7 +582,8 @@ class UCDeltaTokenBasedRestClientSuite
       val e = intercept[CommitFailedException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(), Collections.emptyList(),
+          Collections.emptyList(), Optional.empty())
       }
       assert(e.getRetryable && e.getConflict)
     }
@@ -530,7 +602,8 @@ class UCDeltaTokenBasedRestClientSuite
       val e = intercept[CommitFailedException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList(), Collections.emptyList(), Optional.empty())
       }
       assert(!e.getRetryable && !e.getConflict)
       assert(e.getMessage.contains("Invalid updateTable request"))
@@ -550,7 +623,8 @@ class UCDeltaTokenBasedRestClientSuite
       intercept[InvalidTargetTableException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(), Collections.emptyList(),
+          Collections.emptyList(), Optional.empty())
       }
     }
   }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -155,7 +155,8 @@ class UCTokenBasedRestClientSuite
     withClient { client =>
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Collections.emptyList(),
+        Collections.emptyList(), Optional.empty())
     }
   }
 
@@ -171,7 +172,7 @@ class UCTokenBasedRestClientSuite
         Optional.of(createMetadata()),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty())
+        Collections.emptyList(), Collections.emptyList(), Optional.empty())
     }
   }
 
@@ -180,12 +181,12 @@ class UCTokenBasedRestClientSuite
       intercept[NullPointerException] {
         client.commit(null, testTableUri, null, Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty())
+          Optional.empty(), Collections.emptyList(), Collections.emptyList(), Optional.empty())
       }
       intercept[NullPointerException] {
         client.commit(testTableId, null, null, Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty())
+          Optional.empty(), Collections.emptyList(), Collections.emptyList(), Optional.empty())
       }
     }
   }
@@ -196,7 +197,8 @@ class UCTokenBasedRestClientSuite
       withClient { client =>
         client.commit(testTableId, testTableUri, null,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(), Collections.emptyList(),
+          Collections.emptyList(), Optional.empty())
       }
     }
 
@@ -301,6 +303,7 @@ class UCTokenBasedRestClientSuite
         client.commit(testTableId, testTableUri, null,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList(), Collections.emptyList(),
           Optional.of(new UniformMetadata(icebergMeta)))
       }
 
@@ -334,7 +337,8 @@ class UCTokenBasedRestClientSuite
     withClient { client =>
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Collections.emptyList(),
+        Collections.emptyList(), Optional.empty())
     }
 
     val json = objectMapper.readTree(capturedBody)
@@ -352,7 +356,7 @@ class UCTokenBasedRestClientSuite
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(new UniformMetadata(null)))
+        Collections.emptyList(), Collections.emptyList(), Optional.of(new UniformMetadata(null)))
     }
 
     val json = objectMapper.readTree(capturedBody)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [x] Other (Storage / Unity Catalog commit coordinator)

## Description

This PR adds a `domainMetadata` argument to the Unity Catalog commit APIs.

Spark, Kernel, and the storage commit coordinator now pass Delta `DomainMetadata` actions into the UC commit call, together with the existing commit, metadata, protocol, and UniForm data.

For the UC Delta REST path, these actions are sent as `set-domain-metadata` and `remove-domain-metadata` updates in `updateTable`.

The legacy UC commit client accepts the new argument, but it does not send it in the legacy request because that API does not support domain metadata.

## How was this patch tested?

- `build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClientSuite"`
- `build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClientSuite"`
- `build/sbt "kernelUnityCatalog/testOnly io.delta.kernel.unitycatalog.UCCatalogManagedCommitterSuite -- -z domain"`
- `build/sbt "kernelUnityCatalog/test:compile" "spark/test:compile"`
- `build/sbt "kernelUnityCatalog/test:scalafmtCheck"`

## Does this PR introduce _any_ user-facing changes?

No.
