### PR TITLE
Use buildForStagingTable when creating a staging table.

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -57,7 +57,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=1ae646f7fe8ba65877ff0b9e5f61271bac90b3df
+UC_PIN_SHA=2c22cf18be7d966003f3ebcd1816ba6499b5a2a2
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -215,9 +215,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private Map<String, String> fetchStagingCredentials(String location, String tableId)
       throws ApiException {
     try {
-      // TODO: move to the new staging table only endpoint once it's ready
-      return newCredBuilder(schemeOf(location))
-          .buildForTable(tableId, TableOperation.READ_WRITE);
+      return newCredBuilder(schemeOf(location)).buildForStagingTable(tableId, location);
     } catch (IllegalArgumentException | NullPointerException missingCred) {
       // The legacy buildForTable(tableId, op) path consumes AwsCredentials fields without
       // validating; missing creds in the response surface as NPE rather than the typed error


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6883/files) to review incremental changes.
- [**stack/DeltaCatalogClient_staging_cred**](https://github.com/delta-io/delta/pull/6883) [[Files changed](https://github.com/delta-io/delta/pull/6883/files)]

---------

#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (storage)

## Description
Use buildForStagingTable when creating a staging table.

Previously it used `buildForTable` before `buildForStagingTable` is ready.

## How was this patch tested?
Existing CI

## Does this PR introduce _any_ user-facing changes?
No.
