### PR TITLE
[Spark] Add per-key conflict validator for delta.checkpointPolicy in ConflictChecker

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -790,6 +790,9 @@ private[delta] class ConflictChecker(
         case DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key =>
           currentTransactionInfo.protocol.isFeatureSupported(DeletionVectorsTableFeature) &&
             value.toBoolean
+        case DeltaConfigs.CHECKPOINT_POLICY.key =>
+          currentTransactionInfo.protocol.isFeatureSupported(V2CheckpointTableFeature) &&
+            value == CheckpointPolicy.V2.name
         case _ => true
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds a per-key conflict validator for the `delta.checkpointPolicy` configuration key in `ConflictChecker.checkConfigurationChangesForConflicts`.

Previously, any concurrent transaction that modified `delta.checkpointPolicy` would be flagged as a conflict. This change allows a concurrent `delta.checkpointPolicy` change to be treated as non-conflicting when:
1. The table protocol already supports `V2CheckpointTableFeature`, and
2. The new value is `v2` (i.e., the write is enabling V2 checkpoints, not disabling them).

This mirrors the existing per-key validators for `delta.enableDeletionVectors` and `delta.enableRowTracking`.

## How was this patch tested?

Existing `ConflictChecker` unit tests cover the configuration-change conflict logic. The pattern follows the existing validators for `DeletionVectorsTableFeature` and `RowTrackingFeature`.

## Does this PR introduce _any_ user-facing changes?

No.