### PR TITLE
[Spark] Add Deletion Vector support to V2 changelog read path

### DIFF
--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -7,6 +7,7 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.RemoveFile;
 import io.delta.kernel.internal.commitrange.CommitRangeImpl;
@@ -106,6 +107,10 @@ public class DeltaChangelogBatch implements Batch {
               Optional<AddFile> addOpt = StreamingHelper.getAddFileWithDataChange(batch, rowId);
               if (addOpt.isPresent()) {
                 AddFile add = addOpt.get();
+                String deletionVectorBase64 =
+                    add.getDeletionVector()
+                        .map(DeletionVectorDescriptor::serializeToBase64)
+                        .orElse(null);
                 commitAdds.add(
                     buildPartition(
                         add.getPath(),
@@ -115,11 +120,17 @@ public class DeltaChangelogBatch implements Batch {
                         commit.getTimestamp(),
                         add::getBaseRowId,
                         add::getDefaultRowCommitVersion,
-                        "AddFile"));
+                        "AddFile",
+                        deletionVectorBase64));
               }
               Optional<RemoveFile> removeOpt = StreamingHelper.getDataChangeRemove(batch, rowId);
               if (removeOpt.isPresent()) {
                 RemoveFile remove = removeOpt.get();
+                String deletionVectorBase64 =
+                    remove
+                        .getDeletionVector()
+                        .map(DeletionVectorDescriptor::serializeToBase64)
+                        .orElse(null);
                 commitRemoves.add(
                     buildPartition(
                         remove.getPath(),
@@ -129,7 +140,8 @@ public class DeltaChangelogBatch implements Batch {
                         commit.getTimestamp(),
                         remove::getBaseRowId,
                         remove::getDefaultRowCommitVersion,
-                        "RemoveFile"));
+                        "RemoveFile",
+                        deletionVectorBase64));
               }
               // Validate Metadata actions: schema and row-tracking config must match the
               // end-version baseline established by DeltaChangelogScanBuilder. Mid-range
@@ -155,7 +167,10 @@ public class DeltaChangelogBatch implements Batch {
         } catch (RuntimeException e) {
           throw e;
         } catch (Exception e) {
-          throw new RuntimeException("Failed to process CDC commit actions", e);
+          // Include the inner message so AnalysisException error classes
+          // (e.g. DELTA_CHANGELOG_ROW_TRACKING_DISABLED_IN_RANGE) reach the user.
+          throw new RuntimeException(
+              "Failed to process CDC commit actions: " + e.getMessage(), e);
         }
         partitions.addAll(commitRemoves);
         partitions.addAll(commitAdds);
@@ -163,7 +178,8 @@ public class DeltaChangelogBatch implements Batch {
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
-      throw new RuntimeException("Failed to plan CDC input partitions", e);
+      throw new RuntimeException(
+          "Failed to plan CDC input partitions: " + e.getMessage(), e);
     }
     return partitions.toArray(new InputPartition[0]);
   }
@@ -182,7 +198,8 @@ public class DeltaChangelogBatch implements Batch {
       long commitTimestampMillis,
       Supplier<Optional<Long>> baseRowIdAccessor,
       Supplier<Optional<Long>> defaultRowCommitVersionAccessor,
-      String actionDescription) {
+      String actionDescription,
+      String deletionVector) {
     long baseRowId =
         baseRowIdAccessor
             .get()
@@ -198,7 +215,14 @@ public class DeltaChangelogBatch implements Batch {
                     new IllegalStateException(
                         actionDescription + " " + path + " missing defaultRowCommitVersion"));
     return new CDCInputPartition(
-        path, size, commitVersion, commitTimestampMillis, changeType, baseRowId, defaultRcv);
+        path,
+        size,
+        commitVersion,
+        commitTimestampMillis,
+        changeType,
+        baseRowId,
+        defaultRcv,
+        deletionVector);
   }
 
   @Override
@@ -243,6 +267,7 @@ public class DeltaChangelogBatch implements Batch {
     private final String changeType;
     private final long baseRowId;
     private final long defaultRowCommitVersion;
+    private final String deletionVectorInfo;
 
     CDCInputPartition(
         String filePath,
@@ -251,7 +276,8 @@ public class DeltaChangelogBatch implements Batch {
         long commitTimestampMillis,
         String changeType,
         long baseRowId,
-        long defaultRowCommitVersion) {
+        long defaultRowCommitVersion,
+        String deletionVectorInfo) {
       this.filePath = filePath;
       this.fileSize = fileSize;
       this.commitVersion = commitVersion;
@@ -259,6 +285,7 @@ public class DeltaChangelogBatch implements Batch {
       this.changeType = changeType;
       this.baseRowId = baseRowId;
       this.defaultRowCommitVersion = defaultRowCommitVersion;
+      this.deletionVectorInfo = deletionVectorInfo;
     }
 
     public String getFilePath() {
@@ -287,6 +314,10 @@ public class DeltaChangelogBatch implements Batch {
 
     public long getDefaultRowCommitVersion() {
       return defaultRowCommitVersion;
+    }
+
+    public String getDeletionVectorInfo() {
+      return deletionVectorInfo;
     }
   }
 
@@ -321,6 +352,15 @@ public class DeltaChangelogBatch implements Batch {
               new Tuple2<>(
                   DefaultRowCommitVersion$.MODULE$.METADATA_STRUCT_FIELD_NAME(),
                   cdcPartition.getDefaultRowCommitVersion()));
+
+      // When the action carries a DV, set both Parquet reader constants together. Setting only
+      // one triggers IllegalStateException in DeltaParquetFileFormat. IF_CONTAINED makes the
+      // reader drop physical rows whose index is in the DV bitmap (visible-rows semantics).
+      for (java.util.Map.Entry<String, Object> entry :
+          PartitionUtils.buildDvMetadata(cdcPartition.getDeletionVectorInfo()).entrySet()) {
+        constantMetadata =
+            constantMetadata.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
+      }
 
       PartitionedFile file =
           new PartitionedFile(

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -495,9 +495,9 @@ public class PartitionUtils {
   /**
    * Build metadata map for PartitionedFile containing DV descriptor if present.
    *
-   * <p>The metadata is used by DeltaParquetFileFormat to generate the is_row_deleted column.
-   * Uses {@code IF_CONTAINED} filter semantics (visible-rows semantics). Returns an empty map
-   * when {@code dvBase64} is {@code null}.
+   * <p>The metadata is used by DeltaParquetFileFormat to generate the is_row_deleted column. Uses
+   * {@code IF_CONTAINED} filter semantics (visible-rows semantics). Returns an empty map when
+   * {@code dvBase64} is {@code null}.
    */
   public static Map<String, Object> buildDvMetadata(String dvBase64) {
     Map<String, Object> metadata = new HashMap<>();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -519,6 +519,21 @@ public class PartitionUtils {
   }
 
   /**
+   * Public overload that takes a base64-serialized DV string directly and uses {@code IF_CONTAINED}
+   * filter semantics (visible-rows semantics for the changelog read path). Returns an empty map
+   * when {@code dvBase64} is {@code null}.
+   */
+  public static Map<String, Object> buildDvMetadata(String dvBase64) {
+    Map<String, Object> metadata = new HashMap<>();
+    if (dvBase64 != null) {
+      metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED(), dvBase64);
+      metadata.put(
+          DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE(), RowIndexFilterType.IF_CONTAINED);
+    }
+    return metadata;
+  }
+
+  /**
    * Build metadata map for PartitionedFile containing row tracking descriptor if present.
    *
    * <p>The metadata is used by DeltaParquetFileFormat to generate row-tracking values.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -198,7 +198,7 @@ public class PartitionUtils {
       AddFile addFile, StructType partitionSchema, String tablePath, ZoneId zoneId) {
     scala.collection.immutable.Map<String, Object> metadata =
         mergeIntoScalaMap(
-            buildDvMetadata(addFile.getDeletionVector()),
+            buildDvMetadataScala(addFile.getDeletionVector()),
             buildRowTrackingMetadata(addFile.getBaseRowId(), addFile.getDefaultRowCommitVersion()));
     return makePartitionedFile(
         new Path(tablePath, addFile.getPath()).toString(),
@@ -496,31 +496,7 @@ public class PartitionUtils {
    * Build metadata map for PartitionedFile containing DV descriptor if present.
    *
    * <p>The metadata is used by DeltaParquetFileFormat to generate the is_row_deleted column.
-   */
-  private static scala.collection.immutable.Map<String, Object> buildDvMetadata(
-      Optional<DeletionVectorDescriptor> dvOpt) {
-    Map<String, Object> metadata = new HashMap<>();
-    if (dvOpt.isPresent()) {
-      metadata.put(
-          DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED(),
-          dvOpt.get().serializeToBase64());
-      metadata.put(
-          DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE(), RowIndexFilterType.IF_CONTAINED);
-    }
-    return scala.collection.immutable.Map$.MODULE$.from(CollectionConverters.asScala(metadata));
-  }
-
-  private static scala.collection.immutable.Map<String, Object> buildDvMetadata(
-      String dvBase64, RowIndexFilterType filterType) {
-    Map<String, Object> metadata = new HashMap<>();
-    metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED(), dvBase64);
-    metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE(), filterType);
-    return scala.collection.immutable.Map$.MODULE$.from(CollectionConverters.asScala(metadata));
-  }
-
-  /**
-   * Public overload that takes a base64-serialized DV string directly and uses {@code IF_CONTAINED}
-   * filter semantics (visible-rows semantics for the changelog read path). Returns an empty map
+   * Uses {@code IF_CONTAINED} filter semantics (visible-rows semantics). Returns an empty map
    * when {@code dvBase64} is {@code null}.
    */
   public static Map<String, Object> buildDvMetadata(String dvBase64) {
@@ -531,6 +507,21 @@ public class PartitionUtils {
           DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE(), RowIndexFilterType.IF_CONTAINED);
     }
     return metadata;
+  }
+
+  private static scala.collection.immutable.Map<String, Object> buildDvMetadataScala(
+      Optional<DeletionVectorDescriptor> dvOpt) {
+    Map<String, Object> metadata =
+        buildDvMetadata(dvOpt.map(DeletionVectorDescriptor::serializeToBase64).orElse(null));
+    return scala.collection.immutable.Map$.MODULE$.from(CollectionConverters.asScala(metadata));
+  }
+
+  private static scala.collection.immutable.Map<String, Object> buildDvMetadata(
+      String dvBase64, RowIndexFilterType filterType) {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED(), dvBase64);
+    metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE(), filterType);
+    return scala.collection.immutable.Map$.MODULE$.from(CollectionConverters.asScala(metadata));
   }
 
   /**

--- a/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDirectBatchExecutionTest.java
+++ b/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDirectBatchExecutionTest.java
@@ -43,6 +43,8 @@ import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Direct (non-analyzer) batch execution contract test for Delta changelog classes.
@@ -52,9 +54,11 @@ import org.junit.jupiter.api.Test;
  */
 public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBase {
 
-  @Test
-  public void testDirectBatchExecutionWithExplicitExpectedRows() throws Exception {
-    String tableName = "dsv2_changelog_direct_" + System.nanoTime();
+  @ParameterizedTest(name = "enableDvs={0}")
+  @ValueSource(booleans = {false, true})
+  public void testDirectBatchExecutionWithExplicitExpectedRows(boolean enableDvs) throws Exception {
+    String tableName =
+        "dsv2_changelog_direct_dv" + enableDvs + "_" + System.nanoTime();
     String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
@@ -64,8 +68,8 @@ public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBa
               String.format(
                   "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
                       + "LOCATION '%s' TBLPROPERTIES "
-                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
-                  tableName, tablePath));
+                      + "('delta.enableDeletionVectors'='%s', 'delta.enableRowTracking'='true')",
+                  tableName, tablePath, enableDvs));
           spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", tableName));
           spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
 
@@ -173,9 +177,11 @@ public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBa
    * connector must surface both halves of that pair as raw DELETE + INSERT rows so Spark's
    * post-processor can derive the update.
    */
-  @Test
-  public void testUpdateProducesPairedDeleteAndInsert() throws Exception {
-    String tableName = "dsv2_changelog_direct_update_" + System.nanoTime();
+  @ParameterizedTest(name = "enableDvs={0}")
+  @ValueSource(booleans = {false, true})
+  public void testUpdateProducesPairedDeleteAndInsert(boolean enableDvs) throws Exception {
+    String tableName =
+        "dsv2_changelog_direct_update_dv" + enableDvs + "_" + System.nanoTime();
     String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
@@ -185,8 +191,8 @@ public class DeltaChangelogDirectBatchExecutionTest extends DeltaChangelogTestBa
               String.format(
                   "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
                       + "TBLPROPERTIES "
-                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
-                  tableName, tablePath));
+                      + "('delta.enableDeletionVectors'='%s', 'delta.enableRowTracking'='true')",
+                  tableName, tablePath, enableDvs));
           spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
           spark.sql(String.format("UPDATE %s SET name = 'AliceX' WHERE id = 1", tableName));
 

--- a/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDvTest.java
+++ b/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDvTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read.changelog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for Auto-CDF / DSv2 changelog with Deletion Vectors (DVs) that are NOT
+ * covered by parameterized DV-on/off variants of
+ * {@link DeltaChangelogDirectBatchExecutionTest}. The parameterized tests already cover the
+ * basic single-file DELETE and UPDATE; this file holds scenarios that need DV-specific table
+ * shape (multi-file, multi-commit).
+ *
+ * <p>Correctness relies on Catalyst post-processing (Phase 1 carry-over removal via
+ * {@code row_commit_version} comparison, Phase 2 net-changes matrix).
+ */
+public class DeltaChangelogDvTest extends DeltaChangelogTestBase {
+
+  // ===========================================================================================
+  // Fixtures
+  // ===========================================================================================
+
+  /**
+   * Create a DV-enabled, row-tracking-enabled table. The body is expected to wrap CHANGES reads
+   * in {@link #withStrictV2} so they route through the V2 path.
+   */
+  private void withDvTable(String suffix, ThrowingConsumer body) throws Exception {
+    String tableName = "dsv2_cdc_dv_" + suffix + "_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='true', "
+                              + "'delta.enableRowTracking'='true')",
+                          tableName, tablePath));
+                  body.accept(tableName, tablePath);
+                }));
+  }
+
+  /**
+   * Run the given action under {@code spark.databricks.delta.v2.enableMode=STRICT} so {@code
+   * TableCatalog.loadChangelog} routes the CHANGES read through the V2 path.
+   */
+  private void withStrictV2(ThrowingRunnable action) throws Exception {
+    withSQLConf("spark.databricks.delta.v2.enableMode", "STRICT", action);
+  }
+
+  @FunctionalInterface
+  private interface ThrowingConsumer {
+    void accept(String tableName, String tablePath) throws Exception;
+  }
+
+  /** Read changelog as ordered list of (id, name, _change_type, _commit_version) rows. */
+  private List<Row> readChanges(String tableName, long startVersion, long endVersion) {
+    return spark
+        .sql(
+            String.format(
+                "SELECT id, name, _change_type, _commit_version "
+                    + "FROM %s CHANGES FROM VERSION %d TO VERSION %d",
+                tableName, startVersion, endVersion))
+        .orderBy("_commit_version", "id", "_change_type", "name")
+        .collectAsList();
+  }
+
+  private static void assertChange(
+      Row row, long expectedId, String expectedName, String expectedChangeType,
+      long expectedVersion) {
+    assertEquals(
+        expectedId, ((Number) row.getAs("id")).longValue(), "id mismatch in row: " + row);
+    assertEquals(expectedName, row.getAs("name"), "name mismatch in row: " + row);
+    assertEquals(
+        expectedChangeType, row.getAs("_change_type"), "_change_type mismatch in row: " + row);
+    assertEquals(
+        expectedVersion,
+        ((Number) row.getAs("_commit_version")).longValue(),
+        "_commit_version mismatch in row: " + row);
+  }
+
+  // ===========================================================================================
+  // Test cases
+  // ===========================================================================================
+
+  /**
+   * Two files in one commit, each with its own DV after the DELETE. Verifies that the per-file
+   * DV branch in {@code planInputPartitions} sets the DV constants independently per file.
+   */
+  @Test
+  public void test_mixedDvDelete_perFileBranching() throws Exception {
+    withDvTable(
+        "mixed_dv_delete",
+        (tableName, tablePath) -> {
+          spark.sql(String.format("INSERT INTO %s VALUES (1,'a'),(2,'b'),(3,'c')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (4,'d'),(5,'e'),(6,'f')", tableName));
+          spark.sql(String.format("DELETE FROM %s WHERE id IN (2, 5)", tableName));
+
+          withStrictV2(
+              () -> {
+                List<Row> rows = readChanges(tableName, 3, 3);
+                assertEquals(2, rows.size(), "Expected two deletes (one per file) at v3");
+                assertChange(rows.get(0), 2L, "b", "delete", 3L);
+                assertChange(rows.get(1), 5L, "e", "delete", 3L);
+              });
+        });
+  }
+
+  /**
+   * Multi-version range covering two DV-DELETE commits. Phase 1 partitions on
+   * {@code (row_id, version)} so each commit's carry-overs collapse independently.
+   */
+  @Test
+  public void test_multiVersionDvDeletes_perCommitIsolation() throws Exception {
+    withDvTable(
+        "multi_version_dv",
+        (tableName, tablePath) -> {
+          spark.sql(
+              String.format(
+                  "INSERT INTO %s VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e')", tableName));
+          spark.sql(String.format("DELETE FROM %s WHERE id = 2", tableName)); // v2
+          spark.sql(String.format("DELETE FROM %s WHERE id = 4", tableName)); // v3
+
+          withStrictV2(
+              () -> {
+                List<Row> rows = readChanges(tableName, 2, 3);
+                assertEquals(2, rows.size(), "Expected one delete per commit in v2..v3");
+                assertChange(rows.get(0), 2L, "b", "delete", 2L);
+                assertChange(rows.get(1), 4L, "d", "delete", 3L);
+              });
+        });
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Follow-up to [#6794](https://github.com/delta-io/delta/pull/6794). Adds Deletion Vector (DV) support to the V2 changelog read path so `CHANGES FROM VERSION x TO VERSION y` returns correct results on tables with `delta.enableDeletionVectors=true`. 

**In short,** I apply change_type delete to every removeFile and change_type insert to every row in addFile per commit. A carry-over pair (delete+insert) will be filtered out as carry-over, but with the DVs we apply the DV as filter to the AddFile, leading to delete rows without insert partner, which represent actual delets.

### Implementation

`DeltaChangelogBatch.java`:

- `CDCInputPartition` carries a per-file `deletionVectorInfo: String` (the base64-serialized DV descriptor, or `null` when the file has no DV).
- `planInputPartitions` extracts the DV per `AddFile`/`RemoveFile` via `DeletionVectorDescriptor::serializeToBase64` and threads it onto the partition.
- `createReader` uses the new public `PartitionUtils.buildDvMetadata(...)` helper to set `FILE_ROW_INDEX_FILTER_ID_ENCODED` and `FILE_ROW_INDEX_FILTER_TYPE` together (with `RowIndexFilterType.IF_CONTAINED`) on the per-file metadata, so the existing `DropMarkedRowsFilter` machinery picks up the DV and produces the correct `delete` change rows.
- Wrapper `RuntimeException` messages now include the inner cause's `getMessage()` so `AnalysisException` error classes (e.g. `DELTA_CHANGELOG_*`) reach the user instead of being hidden behind a generic "Failed to process CDC commit actions".

`PartitionUtils.java`:

- New public 1-arg `buildDvMetadata(String dvBase64)` overload that takes the base64 string directly and uses `IF_CONTAINED` semantics. Returns `java.util.Map` for ergonomic iteration from the changelog caller. Existing private overloads are unchanged.

### Tests

`DeltaChangelogDirectBatchExecutionTest.java`:

- `testDirectBatchExecutionWithExplicitExpectedRows` and `testUpdateProducesPairedDeleteAndInsert` are now parameterized via `@ParameterizedTest @ValueSource(booleans = {false, true})` so each runs once with DVs off (rewrite-on-delete) and once with DVs on (DV-on-delete). The expected row sets are identical, so the same assertions cover both physical layouts.

`DeltaChangelogDvTest.java` (new):

DV-specific scenarios that don't fit the parameterized variants.

- `test_mixedDvDelete_perFileBranching`: two `AddFile`s in one commit, a single `DELETE` touching both; asserts the per-file DV branch in `planInputPartitions` sets the DV constants independently per file.
- `test_multiVersionDvDeletes_perCommitIsolation`: two `DELETE` commits in sequence on a DV-enabled table; asserts Catalyst's batch CDC post-processor partitions on `(row_id, version)` so each commit's carry-overs collapse independently.

## Note on Spark 4.2 lane

The Spark 4.2 lane is non-blocking (`continue-on-error: true`); a follow-up PR ([#6830](https://github.com/delta-io/delta/pull/6830)) relocates these tests to `spark-unified/test` where the in-tree `DeltaCatalog` is on the classpath, making the 4.2 lane green for these tests too.

## How was this patch tested?

Locally against Spark 4.0 / 4.1 (default lane, green) and Spark 4.2 (with PR #6830 applied to verify the tests pass end-to-end). 25 / 25 changelog tests pass with both PRs combined.

## Does this PR introduce _any_ user-facing changes?

The V2 changelog path is gated behind `spark.databricks.delta.changelogV2.enabled` and not yet on a released code path. With this PR, when enabled, it now returns correct results on DV-enabled tables.