### PR TITLE
Add a sanity check for duplicate file actions in commitImpl

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -957,6 +957,14 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_DUPLICATE_ACTIONS_FOUND" : {
+    "message" : [
+      "File operation '<actionType>' for path <path> was specified several times.",
+      "It conflicts with <conflictingPath>. ",
+      "It is not valid for multiple file operations with the same path to exist in a single commit."
+    ],
+    "sqlState" : "2D521"
+  },
   "DELTA_DUPLICATE_COLUMNS_FOUND" : {
     "message" : [
       "Found duplicate column(s): <duplicateCols>."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -233,9 +233,36 @@ private[delta] class ConflictChecker(
   /**
    * This function checks conflict of the `initialCurrentTransactionInfo` against the
    * `winningCommitVersion` and returns an updated [[CurrentTransactionInfo]] that represents
+   * the transaction as if it had started while reading the `winningCommitVersion`. It also
+   * validates the actions.
+   */
+  def checkConflictsAndValidateActions(): CurrentTransactionInfo = {
+    val updatedInfo = checkConflicts()
+
+    // In case the actions of the current transaction changed, we need to validate
+    // again that there are no duplicate actions.
+    checkNoDuplicateActionsIfApplicable(updatedInfo)
+    updatedInfo
+  }
+
+  /**
+   * Validates that `updatedInfo` does not contain duplicate actions, but only when conflict
+   * resolution actually changed the actions of the current transaction.
+   */
+  protected def checkNoDuplicateActionsIfApplicable(
+      updatedInfo: CurrentTransactionInfo): Unit = {
+    if ((updatedInfo.actions ne initialCurrentTransactionInfo.actions) &&
+        spark.conf.get(DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED)) {
+      ConflictChecker.checkNoDuplicateActions(updatedInfo.actions.iterator).foreach(_ => ())
+    }
+  }
+
+  /**
+   * This function checks conflict of the `initialCurrentTransactionInfo` against the
+   * `winningCommitVersion` and returns an updated [[CurrentTransactionInfo]] that represents
    * the transaction as if it had started while reading the `winningCommitVersion`.
    */
-  def checkConflicts(): CurrentTransactionInfo = {
+  protected def checkConflicts(): CurrentTransactionInfo = {
     // Add time to read commit in the metrics.
     recordTime("initialize-old-commit", winningCommitSummary.readTimeMs)
 
@@ -1415,5 +1442,57 @@ private[delta] class ConflictChecker(
     log"[tableId=${MDC(DeltaLogKeys.TABLE_ID,
       truncate(initialCurrentTransactionInfo.readSnapshot.metadata.id))}," +
     log"txnId=${MDC(DeltaLogKeys.TXN_ID, truncate(initialCurrentTransactionInfo.txnId))}] "
+  }
+}
+
+private[delta] object ConflictChecker {
+  /**
+   * Returns an iterator that validates no duplicate file actions exist as it
+   * streams. Checks: duplicate adds, duplicate removes, and same path+DV both
+   * added and removed. Single pass, no materialization.
+   */
+  def checkNoDuplicateActions(actions: Iterator[Action]): Iterator[Action] = {
+    val addPaths = mutable.Map.empty[String, Option[String]]
+    val removePaths = mutable.Map.empty[String, Option[String]]
+    def pathAndDVString(path: String, dvIdOpt: Option[String]): String = {
+      dvIdOpt.map(dvId => s"$path DV $dvId").getOrElse(path)
+    }
+    def failDuplicate(
+      actionType: String, path: String,
+      addingDVId: Option[String],
+      existingDVId: Option[String]): Unit = {
+      throw DeltaErrors.duplicateActionCheckFailed(
+        actionType,
+        pathAndDVString(path, addingDVId),
+        pathAndDVString(path, existingDVId))
+    }
+    actions.map { action =>
+      action match {
+        case add: AddFile =>
+          val dvId = add.getDeletionVectorUniqueId
+          addPaths.put(add.path, dvId).foreach { existingDVId =>
+            failDuplicate("add", add.path, dvId, existingDVId)
+          }
+          // Check add/remove overlap inline.
+          removePaths.get(add.path).foreach { removeDVId =>
+            if (dvId == removeDVId) {
+              failDuplicate("add/remove", add.path, dvId, removeDVId)
+            }
+          }
+        case remove: RemoveFile =>
+          val dvId = remove.getDeletionVectorUniqueId
+          removePaths.put(remove.path, dvId).foreach { existingDVId =>
+            failDuplicate("remove", remove.path, dvId, existingDVId)
+          }
+          // Check add/remove overlap inline.
+          addPaths.get(remove.path).foreach { addDVId =>
+            if (dvId == addDVId) {
+              failDuplicate("add/remove", remove.path, addDVId, dvId)
+            }
+          }
+        case _ =>
+      }
+      action
+    }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -681,6 +681,16 @@ trait DeltaErrorsBase
         s"different versions ${version1} and ${version2}.")
   }
 
+  def duplicateActionCheckFailed(
+      actionType: String,
+      path: String,
+      conflictingPath: String): Throwable = {
+    new DeltaRuntimeException(
+      errorClass = "DELTA_DUPLICATE_ACTIONS_FOUND",
+      messageParameters = Array(actionType, path, conflictingPath)
+    )
+  }
+
   def unexpectedChangeFilesFound(changeFiles: String): Throwable = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_UNEXPECTED_CHANGE_FILES_FOUND",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1553,6 +1553,11 @@ trait OptimisticTransactionImpl extends TransactionHelper
     }
   }
 
+  /** Ensure that actions do not contain duplicates for the same path. */
+  protected def checkNoDuplicateActions(actions: Seq[Action]): Unit = {
+    ConflictChecker.checkNoDuplicateActions(actions.iterator).foreach(_ => ())
+  }
+
   /**
    * Checks if the passed-in actions have internal SetTransaction conflicts, will throw exceptions
    * in case of conflicts. This function will also remove duplicated [[SetTransaction]]s.
@@ -1833,6 +1838,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
         }
 
       validateActionsAddFileInvariants(preparedActions, metadata)
+
+      if (spark.conf.get(DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED)) {
+        checkNoDuplicateActions(preparedActions)
+      }
 
       // Find the isolation level to use for this commit
       val isolationLevelToUse = getIsolationLevelToUse(preparedActions, op)
@@ -3104,7 +3113,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
           winningCommitSummary,
           commitIsolationLevel)
 
-        updatedCurrentTransactionInfo = conflictChecker.checkConflicts()
+        updatedCurrentTransactionInfo = conflictChecker.checkConflictsAndValidateActions()
 
         logInfo(logPrefix +
           log"No conflicts in version ${MDC(DeltaLogKeys.VERSION, otherCommitVersion)}, " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -18,10 +18,13 @@ package org.apache.spark.sql.delta
 
 import java.util.ConcurrentModificationException
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
@@ -199,5 +202,139 @@ trait OptimisticTransactionSuiteBase
       }
     }
     checkErrorFun(e)
+  }
+
+  def testDuplicateActions(actions: Seq[FileAction], deltaLog: DeltaLog): Unit = {
+    withSQLConf(
+        DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED.key -> "true"
+        ) {
+      testRuntimeErrorOnCommit(actions, deltaLog) { e =>
+        checkError(
+          exception = e,
+          condition = "DELTA_DUPLICATE_ACTIONS_FOUND",
+          sqlState = "2D521",
+          // Don't check params.
+          parameters = e.getMessageParameters.asScala.toMap)
+      }
+    }
+  }
+
+  test("Duplicate action - remove file twice") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val removedFile = writeDuplicateActionsData(path).head.remove
+      testDuplicateActions(Seq(removedFile, removedFile), deltaLog)
+    }
+  }
+
+  test("Duplicate action - remove file twice - same DV") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val firstFile = writeDuplicateActionsData(path).head
+      enableDeletionVectorsInTable(deltaLog)
+      val (addFileWithDV, removeFileWithoutDV) = addDVToFileInTable(path, firstFile)
+      deltaLog.startTransaction().commitManually(addFileWithDV, removeFileWithoutDV)
+      val removedFileWithDV = addFileWithDV.remove
+      testDuplicateActions(Seq(removedFileWithDV, removedFileWithDV), deltaLog)
+    }
+  }
+
+  test("Duplicate action - remove file twice - DV vs. no DV") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val firstFile = writeDuplicateActionsData(path).head
+      enableDeletionVectorsInTable(deltaLog)
+      val (addFileWithDV, removeFileWithoutDV) = addDVToFileInTable(path, firstFile)
+      deltaLog.startTransaction().commitManually(addFileWithDV, removeFileWithoutDV)
+      val removedFileWithDV = addFileWithDV.remove
+      // This isn't legal for other reasons, either, but should fail on the duplicate action
+      // check first.
+      testDuplicateActions(Seq(removedFileWithDV, removeFileWithoutDV), deltaLog)
+    }
+  }
+
+  test("Duplicate action - remove file twice - different DVs") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val firstFile = writeDuplicateActionsData(path).head
+      enableDeletionVectorsInTable(deltaLog)
+      val (addFileWithDV, removeFileWithoutDV) = addDVToFileInTable(path, firstFile)
+      deltaLog.startTransaction().commitManually(addFileWithDV, removeFileWithoutDV)
+      val removedFileWithDV = addFileWithDV.remove
+      val removedFileWithDifferentDV = removedFileWithDV.copy(
+        // Doesn't have to be a legal DV. The other one's relative, so these won't match.
+        deletionVector = removedFileWithDV.deletionVector.copy(storageType = "i"))
+      // This isn't legal for other reasons, either, but should fail on the duplicate action
+      // check first.
+      testDuplicateActions(Seq(removedFileWithDV, removedFileWithDifferentDV), deltaLog)
+    }
+  }
+
+  test("Duplicate action - add file twice") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val addFile = writeDuplicateActionsData(path).head
+      testDuplicateActions(Seq(addFile, addFile), deltaLog)
+    }
+  }
+
+  test("Duplicate action - add file twice - same DV") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val firstFile = writeDuplicateActionsData(path).head
+      enableDeletionVectorsInTable(deltaLog)
+      val (addFileWithDV, _) = addDVToFileInTable(path, firstFile)
+      testDuplicateActions(Seq(addFileWithDV, addFileWithDV), deltaLog)
+    }
+  }
+
+  test("Duplicate action - add file twice - DV vs. no DV") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val firstFile = writeDuplicateActionsData(path).head
+      enableDeletionVectorsInTable(deltaLog)
+      val (addFileWithDV, _) = addDVToFileInTable(path, firstFile)
+      testDuplicateActions(Seq(firstFile, addFileWithDV), deltaLog)
+    }
+  }
+
+  test("Duplicate action - add file twice - different DVs") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val firstFile = writeDuplicateActionsData(path).head
+      enableDeletionVectorsInTable(deltaLog)
+      // These will produce different UUIDs so shouldn't match.
+      val (addFileWithDV1, _) = addDVToFileInTable(path, firstFile)
+      val (addFileWithDV2, _) = addDVToFileInTable(path, firstFile)
+      testDuplicateActions(Seq(addFileWithDV1, addFileWithDV2), deltaLog)
+    }
+  }
+
+  test("Duplicate action - remove and add file") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val addFile = writeDuplicateActionsData(path).head
+      testDuplicateActions(Seq(addFile, addFile.remove), deltaLog)
+    }
+  }
+  test("Duplicate action - remove and add file - same DV") {
+    withTempPath { tempPath =>
+      val path = tempPath.getPath
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val firstFile = writeDuplicateActionsData(path).head
+      enableDeletionVectorsInTable(deltaLog)
+      val (addFileWithDV, _) = addDVToFileInTable(path, firstFile)
+      val removeFileWithDV = addFileWithDV.remove
+      testDuplicateActions(Seq(addFileWithDV, removeFileWithDV), deltaLog)
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a sanity check to the commit path that rejects a commit containing duplicate file actions for the same `(path, deletion vector id)`.`commitImpl` previously did not validate that the prepared actions were free of duplicates. This change adds that validation:
- A new `checkNoDuplicateActions` helper on the `ConflictChecker` companion object that streams the actions in a single pass and throws if it finds the same file added twice, the same file removed twice, or the same path + deletion vector both added and removed within one commit.
- A new error class `DELTA_DUPLICATE_ACTIONS_FOUND` and the corresponding `DeltaErrors.duplicateActionCheckFailed` helper.
- A call site in `commitImpl`, guarded by the `DELTA_DUPLICATE_ACTION_CHECK_ENABLED` configuration, that runs the check on the prepared actions before a commit is written.
- Re-validation after conflict resolution: `ConflictChecker.checkConflictsAndValidateActions` re-runs the duplicate check whenever conflict resolution changes the current transaction's actions.

## How was this patch tested?
Added 10 tests to `OptimisticTransactionSuiteBase` covering duplicate add, duplicate remove, and add/remove overlap on the same path, including deletion-vector variants (same DV, DV vs. no DV, and different DVs). They run in every concrete suite that mixes in the base trait.

## Does this PR introduce _any_ user-facing changes?
No.