### PR TITLE
Require physical UC backfill boundary

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -218,7 +218,8 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     }
   }
 
-  test("getLastKnownBackfilledVersion trusts zero when UC boundary starts at one") {
+  test("getLastKnownBackfilledVersion recovers backfilled 0 via file check " +
+      "when listing is empty and UC tracks commit 1") {
     withTempTableDir { tempDir =>
       val log = DeltaLog.forTable(spark, tempDir.toString)
       val logPath = log.logPath
@@ -232,6 +233,11 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
           Seq(commitRecord(logPath, 1L)).asJava,
           1L))
 
+      // The physical 0.json exists on storage; only the optimized listing comes back empty.
+      // UC's earliest tracked commit is 1, so the inferred boundary is 0. The fallback must
+      // observe 0.json via getFileStatus rather than trust UC's boundary blindly.
+      writeCommitZero(logPath)
+
       assert(ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
         2,
         hadoopConf,
@@ -240,7 +246,8 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     }
   }
 
-  test("getLastKnownBackfilledVersion trusts latest table version zero") {
+  test("getLastKnownBackfilledVersion recovers backfilled 0 via file check " +
+      "when listing is empty and UC tracks no commits") {
     withTempTableDir { tempDir =>
       val log = DeltaLog.forTable(spark, tempDir.toString)
       val logPath = log.logPath
@@ -254,11 +261,44 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
           Seq.empty[JCommit].asJava,
           0L))
 
+      // UC tracks no unbackfilled commits, so the latest table version (0) is the boundary.
+      // It is still confirmed against the physical 0.json, not trusted from UC alone.
+      writeCommitZero(logPath)
+
       assert(ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
         1,
         hadoopConf,
         emptyListingLogStore(log, hadoopConf),
         tableDesc) == 0L)
+    }
+  }
+
+  test("getLastKnownBackfilledVersion fails instead of trusting UC when 0.json is absent") {
+    withTempTableDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.toString)
+      val logPath = log.logPath
+      val hadoopConf = log.newDeltaHadoopConf()
+      val tableDesc = new TableDescriptor(
+        logPath,
+        Optional.empty(),
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
+      val ucCommitCoordinatorClient = clientReturningCommits(
+        new io.delta.storage.commit.GetCommitsResponse(
+          Seq(commitRecord(logPath, 1L)).asJava,
+          1L))
+
+      // UC's boundary infers backfilled version 0, but 0.json is not on storage (writeCommitZero
+      // is intentionally not called). The fallback must fail the commit rather than report a
+      // non-existent backfill to UC, which would risk a Delta log gap. This is the behavior the
+      // earlier "trust UC zero" approach got wrong: it returned 0 here without observing the file.
+      val e = intercept[IllegalStateException] {
+        ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
+          2,
+          hadoopConf,
+          emptyListingLogStore(log, hadoopConf),
+          tableDesc)
+      }
+      assert(e.getMessage.contains("Couldn't find any backfilled commit"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -197,7 +197,7 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
       override def listFrom(
           path: Path,
           hadoopConf: Configuration): java.util.Iterator[FileStatus] = {
-        Collections.emptyIterator[FileStatus]()
+        java.util.Collections.emptyIterator[FileStatus]()
       }
     }
   }
@@ -208,12 +208,13 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     new JCommit(version, fileStatus, version)
   }
 
-  private def clientReturningCommits(response: JGetCommitsResponse): UCCommitCoordinatorClient = {
+  private def clientReturningCommits(
+      response: io.delta.storage.commit.GetCommitsResponse): UCCommitCoordinatorClient = {
     new UCCommitCoordinatorClient(Map.empty[String, String].asJava, null) {
       override def getCommits(
           tableDesc: TableDescriptor,
           startVersion: JLong,
-          endVersion: JLong): JGetCommitsResponse = response
+          endVersion: JLong): io.delta.storage.commit.GetCommitsResponse = response
     }
   }
 
@@ -227,7 +228,9 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
         Optional.empty(),
         Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
       val ucCommitCoordinatorClient = clientReturningCommits(
-        new JGetCommitsResponse(Seq(commitRecord(logPath, 1L)).asJava, 1L))
+        new io.delta.storage.commit.GetCommitsResponse(
+          Seq(commitRecord(logPath, 1L)).asJava,
+          1L))
 
       writeCommitZero(logPath)
 
@@ -249,7 +252,9 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
         Optional.empty(),
         Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
       val ucCommitCoordinatorClient = clientReturningCommits(
-        new JGetCommitsResponse(Seq(commitRecord(logPath, 1L)).asJava, 1L))
+        new io.delta.storage.commit.GetCommitsResponse(
+          Seq(commitRecord(logPath, 1L)).asJava,
+          1L))
 
       val e = intercept[IllegalStateException] {
         ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
@@ -272,7 +277,9 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
         Optional.empty(),
         Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
       val ucCommitCoordinatorClient = clientReturningCommits(
-        new JGetCommitsResponse(Seq(commitRecord(logPath, 2L)).asJava, 2L))
+        new io.delta.storage.commit.GetCommitsResponse(
+          Seq(commitRecord(logPath, 2L)).asJava,
+          2L))
 
       writeCommitZero(logPath)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -190,6 +190,103 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     }
   }
 
+  private def emptyListingLogStore(
+      log: DeltaLog,
+      hadoopConf: Configuration): io.delta.storage.LogStore = {
+    new LogStoreInverseAdaptor(log.store, hadoopConf) {
+      override def listFrom(
+          path: Path,
+          hadoopConf: Configuration): java.util.Iterator[FileStatus] = {
+        Collections.emptyIterator[FileStatus]()
+      }
+    }
+  }
+
+  private def commitRecord(logPath: Path, version: Long): JCommit = {
+    val commitPath = new Path(new Path(logPath, "_staged_commits"), s"$version.json")
+    val fileStatus = new FileStatus(1L, false, 0, 0L, version, commitPath)
+    new JCommit(version, fileStatus, version)
+  }
+
+  private def clientReturningCommits(response: JGetCommitsResponse): UCCommitCoordinatorClient = {
+    new UCCommitCoordinatorClient(Map.empty[String, String].asJava, null) {
+      override def getCommits(
+          tableDesc: TableDescriptor,
+          startVersion: JLong,
+          endVersion: JLong): JGetCommitsResponse = response
+    }
+  }
+
+  test("getLastKnownBackfilledVersion verifies physical zero when UC boundary is zero") {
+    withTempTableDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.toString)
+      val logPath = log.logPath
+      val hadoopConf = log.newDeltaHadoopConf()
+      val tableDesc = new TableDescriptor(
+        logPath,
+        Optional.empty(),
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
+      val ucCommitCoordinatorClient = clientReturningCommits(
+        new JGetCommitsResponse(Seq(commitRecord(logPath, 1L)).asJava, 1L))
+
+      writeCommitZero(logPath)
+
+      assert(ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
+        2,
+        hadoopConf,
+        emptyListingLogStore(log, hadoopConf),
+        tableDesc) == 0L)
+    }
+  }
+
+  test("getLastKnownBackfilledVersion rejects missing physical zero") {
+    withTempTableDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.toString)
+      val logPath = log.logPath
+      val hadoopConf = log.newDeltaHadoopConf()
+      val tableDesc = new TableDescriptor(
+        logPath,
+        Optional.empty(),
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
+      val ucCommitCoordinatorClient = clientReturningCommits(
+        new JGetCommitsResponse(Seq(commitRecord(logPath, 1L)).asJava, 1L))
+
+      val e = intercept[IllegalStateException] {
+        ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
+          2,
+          hadoopConf,
+          emptyListingLogStore(log, hadoopConf),
+          tableDesc)
+      }
+      assert(e.getMessage.contains("Couldn't find any backfilled commit"))
+    }
+  }
+
+  test("getLastKnownBackfilledVersion rejects missing inferred predecessor") {
+    withTempTableDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.toString)
+      val logPath = log.logPath
+      val hadoopConf = log.newDeltaHadoopConf()
+      val tableDesc = new TableDescriptor(
+        logPath,
+        Optional.empty(),
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
+      val ucCommitCoordinatorClient = clientReturningCommits(
+        new JGetCommitsResponse(Seq(commitRecord(logPath, 2L)).asJava, 2L))
+
+      writeCommitZero(logPath)
+
+      val e = intercept[IllegalStateException] {
+        ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
+          3,
+          hadoopConf,
+          emptyListingLogStore(log, hadoopConf),
+          tableDesc)
+      }
+      assert(e.getMessage.contains("Couldn't find any backfilled commit"))
+    }
+  }
+
   test("commit-limit-reached exception handling") {
     withTempTableDir { tempDir =>
       val log = DeltaLog.forTable(spark, tempDir.toString)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -218,7 +218,7 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     }
   }
 
-  test("getLastKnownBackfilledVersion verifies physical zero when UC boundary is zero") {
+  test("getLastKnownBackfilledVersion trusts zero when UC boundary starts at one") {
     withTempTableDir { tempDir =>
       val log = DeltaLog.forTable(spark, tempDir.toString)
       val logPath = log.logPath
@@ -231,8 +231,6 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
         new io.delta.storage.commit.GetCommitsResponse(
           Seq(commitRecord(logPath, 1L)).asJava,
           1L))
-
-      writeCommitZero(logPath)
 
       assert(ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
         2,
@@ -242,7 +240,7 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
     }
   }
 
-  test("getLastKnownBackfilledVersion rejects missing physical zero") {
+  test("getLastKnownBackfilledVersion trusts latest table version zero") {
     withTempTableDir { tempDir =>
       val log = DeltaLog.forTable(spark, tempDir.toString)
       val logPath = log.logPath
@@ -253,17 +251,14 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
         Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
       val ucCommitCoordinatorClient = clientReturningCommits(
         new io.delta.storage.commit.GetCommitsResponse(
-          Seq(commitRecord(logPath, 1L)).asJava,
-          1L))
+          Seq.empty[JCommit].asJava,
+          0L))
 
-      val e = intercept[IllegalStateException] {
-        ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
-          2,
-          hadoopConf,
-          emptyListingLogStore(log, hadoopConf),
-          tableDesc)
-      }
-      assert(e.getMessage.contains("Couldn't find any backfilled commit"))
+      assert(ucCommitCoordinatorClient.getLastKnownBackfilledVersion(
+        1,
+        hadoopConf,
+        emptyListingLogStore(log, hadoopConf),
+        tableDesc) == 0L)
     }
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -211,8 +211,8 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       listAndGetLastKnownBackfilledVersion(listFromVersion, logStore, hadoopConf, logPath);
     if (!lastKnownBackfilledVersion.isPresent()) {
       // If the recent listing has no physical backfilled delta file, ask UC for the boundary.
-      // The commit before UC's first retained commit must exist as an exact Delta file, including
-      // version 0, because reporting a missing file as backfilled would hide a real log gap.
+      // Version 0 is written to the log before UC registers the table.
+      // Versions above 0 still need an exact file check because missing N.json is a log gap.
       recordDeltaEvent(
         UCCoordinatedCommitsUsageLogs.UC_LAST_KNOWN_BACKFILLED_VERSION_NOT_FOUND,
         new HashMap<String, Object>() {{
@@ -236,7 +236,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
             logPath + " at version " + commitVersion);
         }
-        lastKnownBackfilledVersion = getBackfilledVersionIfFileExists(
+        lastKnownBackfilledVersion = getTrustedOrPhysicalBackfilledVersion(
           inferredLastKnownBackfilledVersion, hadoopConf, logPath);
         if (!lastKnownBackfilledVersion.isPresent()) {
           throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
@@ -245,7 +245,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       } else {
         long latestTableVersion = commitsResponse.getLatestTableVersion();
         if (latestTableVersion >= 0 && latestTableVersion < commitVersion) {
-          lastKnownBackfilledVersion = getBackfilledVersionIfFileExists(
+          lastKnownBackfilledVersion = getTrustedOrPhysicalBackfilledVersion(
             latestTableVersion, hadoopConf, logPath);
           if (!lastKnownBackfilledVersion.isPresent()) {
             throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
@@ -258,6 +258,18 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       }
     }
     return lastKnownBackfilledVersion.get();
+  }
+
+  private Optional<Long> getTrustedOrPhysicalBackfilledVersion(
+      long version,
+      Configuration hadoopConf,
+      Path logPath) {
+    // CREATE writes 0.json before registering the table in UC.
+    // A UC response for the table therefore implies 0.json is present.
+    if (version == 0) {
+      return Optional.of(version);
+    }
+    return getBackfilledVersionIfFileExists(version, hadoopConf, logPath);
   }
 
   private Optional<Long> getBackfilledVersionIfFileExists(

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -210,9 +210,9 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
     Optional<Long> lastKnownBackfilledVersion =
       listAndGetLastKnownBackfilledVersion(listFromVersion, logStore, hadoopConf, logPath);
     if (!lastKnownBackfilledVersion.isPresent()) {
-      // In case we don't find anything in the last 100 commits (should not happen)
-      // we go to UC to find the earliest commit it is tracking as the commit prior
-      // to that must have been backfilled.
+      // If the recent listing has no physical backfilled delta file, ask UC for the boundary.
+      // The commit before UC's first retained commit must exist as an exact Delta file, including
+      // version 0, because reporting a missing file as backfilled would hide a real log gap.
       recordDeltaEvent(
         UCCoordinatedCommitsUsageLogs.UC_LAST_KNOWN_BACKFILLED_VERSION_NOT_FOUND,
         new HashMap<String, Object>() {{
@@ -223,22 +223,54 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
         }},
         logPath.getParent()
       );
-      long minVersion =
-        getCommits(tableDesc, null, null)
+      GetCommitsResponse commitsResponse = getCommits(tableDesc, null, null);
+      Optional<Long> minVersion =
+        commitsResponse
           .getCommits()
           .stream()
           .min(Comparator.comparingLong(Commit::getVersion))
-          .map(Commit::getVersion)
-          .orElseThrow(() -> new IllegalStateException("Couldn't find any unbackfilled commit " +
-            "for table at " + logPath + " at version " + commitVersion));
-      lastKnownBackfilledVersion = listAndGetLastKnownBackfilledVersion(
-        minVersion - 1, logStore, hadoopConf, logPath);
-      if (!lastKnownBackfilledVersion.isPresent()) {
-        throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
-          logPath + " at version " + commitVersion);
+          .map(Commit::getVersion);
+      if (minVersion.isPresent()) {
+        long inferredLastKnownBackfilledVersion = minVersion.get() - 1;
+        if (inferredLastKnownBackfilledVersion < 0) {
+          throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
+            logPath + " at version " + commitVersion);
+        }
+        lastKnownBackfilledVersion = getBackfilledVersionIfFileExists(
+          inferredLastKnownBackfilledVersion, hadoopConf, logPath);
+        if (!lastKnownBackfilledVersion.isPresent()) {
+          throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
+            logPath + " at version " + commitVersion);
+        }
+      } else {
+        long latestTableVersion = commitsResponse.getLatestTableVersion();
+        if (latestTableVersion >= 0 && latestTableVersion < commitVersion) {
+          lastKnownBackfilledVersion = getBackfilledVersionIfFileExists(
+            latestTableVersion, hadoopConf, logPath);
+          if (!lastKnownBackfilledVersion.isPresent()) {
+            throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
+              logPath + " at version " + commitVersion);
+          }
+        } else {
+          throw new IllegalStateException("Couldn't find any unbackfilled commit " +
+            "for table at " + logPath + " at version " + commitVersion);
+        }
       }
     }
     return lastKnownBackfilledVersion.get();
+  }
+
+  private Optional<Long> getBackfilledVersionIfFileExists(
+      long version,
+      Configuration hadoopConf,
+      Path logPath) {
+    Path deltaFilePath = CoordinatedCommitsUtils.getBackfilledDeltaFilePath(logPath, version);
+    try {
+      FileSystem fs = logPath.getFileSystem(hadoopConf);
+      return fs.exists(deltaFilePath) ? Optional.of(version) : Optional.empty();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   protected Iterator<FileStatus> listFrom(

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -210,9 +210,15 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
     Optional<Long> lastKnownBackfilledVersion =
       listAndGetLastKnownBackfilledVersion(listFromVersion, logStore, hadoopConf, logPath);
     if (!lastKnownBackfilledVersion.isPresent()) {
-      // If the recent listing has no physical backfilled delta file, ask UC for the boundary.
-      // Version 0 is written to the log before UC registers the table.
-      // Versions above 0 still need an exact file check because missing N.json is a log gap.
+      // An empty listing here does not prove nothing is backfilled: this optimized listing
+      // can transiently observe no backfilled delta file even when one exists on storage.
+      // Fall back to UC for the boundary. The earliest commit UC still tracks implies its
+      // predecessor was backfilled, and if UC tracks no commits, everything up to the latest
+      // table version was backfilled. Confirm that inferred boundary with a direct
+      // getFileStatus check, which observes the specific file even when the listing did not,
+      // for version 0 too. We never trust UC alone: CREATE writes a physical 0.json before
+      // registering the table, so it must be observable, and a missing N.json is a real log
+      // gap that must fail the commit.
       recordDeltaEvent(
         UCCoordinatedCommitsUsageLogs.UC_LAST_KNOWN_BACKFILLED_VERSION_NOT_FOUND,
         new HashMap<String, Object>() {{
@@ -236,7 +242,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
             logPath + " at version " + commitVersion);
         }
-        lastKnownBackfilledVersion = getTrustedOrPhysicalBackfilledVersion(
+        lastKnownBackfilledVersion = getBackfilledVersionIfFileExists(
           inferredLastKnownBackfilledVersion, hadoopConf, logPath);
         if (!lastKnownBackfilledVersion.isPresent()) {
           throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
@@ -245,7 +251,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       } else {
         long latestTableVersion = commitsResponse.getLatestTableVersion();
         if (latestTableVersion >= 0 && latestTableVersion < commitVersion) {
-          lastKnownBackfilledVersion = getTrustedOrPhysicalBackfilledVersion(
+          lastKnownBackfilledVersion = getBackfilledVersionIfFileExists(
             latestTableVersion, hadoopConf, logPath);
           if (!lastKnownBackfilledVersion.isPresent()) {
             throw new IllegalStateException("Couldn't find any backfilled commit for table at " +
@@ -260,18 +266,14 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
     return lastKnownBackfilledVersion.get();
   }
 
-  private Optional<Long> getTrustedOrPhysicalBackfilledVersion(
-      long version,
-      Configuration hadoopConf,
-      Path logPath) {
-    // CREATE writes 0.json before registering the table in UC.
-    // A UC response for the table therefore implies 0.json is present.
-    if (version == 0) {
-      return Optional.of(version);
-    }
-    return getBackfilledVersionIfFileExists(version, hadoopConf, logPath);
-  }
-
+  /**
+   * Confirms a candidate backfilled version by checking that its delta file physically
+   * exists via a direct getFileStatus call. This is the correctness anchor for the UC
+   * fallback: getFileStatus observes a backfilled file (including 0.json) even when the
+   * directory listing transiently did not. Returns empty if the file is absent so the
+   * caller fails the commit instead of reporting a non-existent backfilled version to UC,
+   * which would risk a Delta log gap.
+   */
   private Optional<Long> getBackfilledVersionIfFileExists(
       long version,
       Configuration hadoopConf,


### PR DESCRIPTION
## Description

This requires the UC commit-coordinator fallback to verify the inferred backfilled boundary against the exact physical Delta commit file. Version 0 is not a catalog-only boundary: `0.json` is the CREATE commit and must exist before the client can report version 0 as backfilled.

## How was this patch tested?

Ported from the Runtime test coverage for `UCCommitCoordinatorClient.getLastKnownBackfilledVersion`.
