### PR TITLE
[kernel-spark] Expose column IDs on DeltaV2Table for column mapping

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -30,6 +30,7 @@ import io.delta.spark.internal.v2.read.SparkScanBuilder;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
+import io.delta.spark.internal.v2.utils.ColumnV2Utils;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.write.DeltaV2WriteBuilder;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,6 +64,7 @@ import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.delta.DeltaColumnMapping$;
 import org.apache.spark.sql.delta.DeltaTableUtils;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
@@ -310,7 +313,28 @@ public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, Support
 
   @Override
   public Column[] columns() {
-    return CatalogV2Util.structTypeToV2Columns(schema());
+    Column[] mappedColumns = schemaProvider.getColumns();
+    if (!isCDCRead) {
+      return mappedColumns;
+    }
+
+    Map<String, Column> mappedByName = new LinkedHashMap<>();
+    for (Column column : mappedColumns) {
+      mappedByName.put(column.name(), column);
+    }
+
+    List<Column> result = new ArrayList<>();
+    for (StructField field : schema().fields()) {
+      Column mapped = mappedByName.get(field.name());
+      if (mapped != null) {
+        result.add(mapped);
+      } else {
+        Column[] synthetic =
+            CatalogV2Util.structTypeToV2Columns(new StructType(new StructField[] {field}));
+        result.add(synthetic[0]);
+      }
+    }
+    return result.toArray(new Column[0]);
   }
 
   @Override
@@ -460,6 +484,7 @@ public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, Support
     private StructType dataSchema;
     private StructType partitionSchema;
     private Transform[] partitionTransforms;
+    private Column[] columns;
 
     SchemaProvider(SparkSession sparkSession, StructType rawSchema, List<String> partColNames) {
       this.sparkSession = sparkSession;
@@ -511,6 +536,19 @@ public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, Support
       this.partitionTransforms =
           partColNames.stream().map(Expressions::identity).toArray(Transform[]::new);
 
+      List<Column> v2Columns = new ArrayList<>();
+      for (StructField publicField : publicSchema.fields()) {
+        StructField rawField = fieldMap.get(publicField.name());
+        String columnId = null;
+        if (rawField != null && DeltaColumnMapping$.MODULE$.hasColumnId(rawField)) {
+          columnId = String.valueOf(DeltaColumnMapping$.MODULE$.getColumnId(rawField));
+        }
+        v2Columns.add(
+            ColumnV2Utils.createColumn(
+                publicField.name(), publicField.dataType(), publicField.nullable(), columnId));
+      }
+      this.columns = v2Columns.toArray(new Column[0]);
+
       this.initialized = true;
     }
 
@@ -537,6 +575,10 @@ public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, Support
 
     Transform[] getPartitionTransforms() {
       return withInit(() -> partitionTransforms);
+    }
+
+    Column[] getColumns() {
+      return withInit(() -> columns);
     }
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ColumnV2Utils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/ColumnV2Utils.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import org.apache.spark.sql.connector.catalog.Column;
+import org.apache.spark.sql.connector.catalog.ColumnDefaultValue;
+import org.apache.spark.sql.connector.catalog.IdentityColumnSpec;
+import org.apache.spark.sql.internal.connector.ColumnImpl;
+import org.apache.spark.sql.types.DataType;
+
+/**
+ * Spark-version compatibility helpers for DSv2 {@link Column} column IDs.
+ *
+ * <p>Column IDs ({@code Column#id()}) and the 9-arg {@link ColumnImpl} constructor are available on
+ * newer Spark builds. Reflection keeps the same source compatible with Spark CI builds that may not
+ * yet expose {@code Column#id()}.
+ */
+public final class ColumnV2Utils {
+  private static final boolean COLUMN_ID_SUPPORTED = detectColumnIdSupport();
+
+  private ColumnV2Utils() {}
+
+  /** Returns true when the runtime Spark build supports {@link Column#id()}. */
+  public static boolean supportsColumnId() {
+    return COLUMN_ID_SUPPORTED;
+  }
+
+  /** Creates a DSv2 column, attaching {@code columnId} when the runtime Spark build supports it. */
+  public static Column createColumn(
+      String name, DataType dataType, boolean nullable, @Nullable String columnId) {
+    if (columnId != null && COLUMN_ID_SUPPORTED) {
+      return newColumnWithId(name, dataType, nullable, columnId);
+    }
+    return newColumnWithoutId(name, dataType, nullable);
+  }
+
+  /** Returns {@link Column#id()} when supported, otherwise null. */
+  @Nullable
+  public static String getColumnId(Column column) {
+    if (!COLUMN_ID_SUPPORTED) {
+      return null;
+    }
+    try {
+      Method idMethod = Column.class.getMethod("id");
+      return (String) idMethod.invoke(column);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to read Column.id()", e);
+    }
+  }
+
+  private static Column newColumnWithoutId(String name, DataType dataType, boolean nullable) {
+    try {
+      Constructor<ColumnImpl> ctor =
+          ColumnImpl.class.getConstructor(
+              String.class,
+              DataType.class,
+              boolean.class,
+              String.class,
+              ColumnDefaultValue.class,
+              String.class,
+              IdentityColumnSpec.class,
+              String.class);
+      return ctor.newInstance(
+          name,
+          dataType,
+          nullable,
+          /* comment = */ null,
+          /* defaultValue = */ null,
+          /* generationExpression = */ null,
+          /* identityColumnSpec = */ null,
+          /* metadataInJSON = */ null);
+    } catch (NoSuchMethodException e) {
+      return newColumnWithId(name, dataType, nullable, /* columnId = */ null);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to create ColumnImpl without column id", e);
+    }
+  }
+
+  private static Column newColumnWithId(
+      String name, DataType dataType, boolean nullable, String columnId) {
+    try {
+      Constructor<ColumnImpl> ctor =
+          ColumnImpl.class.getConstructor(
+              String.class,
+              DataType.class,
+              boolean.class,
+              String.class,
+              ColumnDefaultValue.class,
+              String.class,
+              IdentityColumnSpec.class,
+              String.class,
+              String.class);
+      return ctor.newInstance(
+          name,
+          dataType,
+          nullable,
+          /* comment = */ null,
+          /* defaultValue = */ null,
+          /* generationExpression = */ null,
+          /* identityColumnSpec = */ null,
+          /* metadataInJSON = */ null,
+          columnId);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to create ColumnImpl with column id", e);
+    }
+  }
+
+  private static boolean detectColumnIdSupport() {
+    try {
+      Column.class.getMethod("id");
+      ColumnImpl.class.getConstructor(
+          String.class,
+          DataType.class,
+          boolean.class,
+          String.class,
+          ColumnDefaultValue.class,
+          String.class,
+          IdentityColumnSpec.class,
+          String.class,
+          String.class);
+      return true;
+    } catch (NoSuchMethodException e) {
+      return false;
+    }
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -21,8 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
@@ -32,6 +34,7 @@ import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
 import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import io.delta.spark.internal.v2.utils.ColumnV2Utils;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -803,6 +806,93 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
         DeltaOptions.SCHEMA_TRACKING_LOCATION(),
         "path_based_constructor",
         /* usePathBasedConstructor= */ true);
+  }
+
+  @Test
+  public void testColumnsHaveNullIdWithoutColumnMapping(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "cm_no_mapping_" + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, data STRING) USING delta LOCATION '%s'", tableName, path));
+    DeltaV2Table table = new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+    for (Column column : table.columns()) {
+      assertNull(
+          ColumnV2Utils.getColumnId(column),
+          "Expected null column id without column mapping: " + column.name());
+    }
+  }
+
+  @Test
+  public void testColumnsExposeIdsForNameMappingTable(@TempDir File tempDir) throws Exception {
+    assumeTrue(ColumnV2Utils.supportsColumnId(), "Column.id() not supported on this Spark version");
+    String path = tempDir.getAbsolutePath();
+    String tableName = "cm_name_" + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING, value DOUBLE) USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode'='name') LOCATION '%s'",
+            tableName, path));
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'test', 100.0)", tableName));
+    DeltaV2Table table = new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+    for (Column column : table.columns()) {
+      String columnId = ColumnV2Utils.getColumnId(column);
+      assertNotNull(
+          columnId, "Expected non-null column id for name-mapping table column: " + column.name());
+      assertTrue(
+          columnId.matches("\\d+"), "Column id should be a numeric string, got: " + columnId);
+    }
+  }
+
+  @Test
+  public void testColumnsExposeIdsForIdMappingTable(@TempDir File tempDir) throws Exception {
+    assumeTrue(ColumnV2Utils.supportsColumnId(), "Column.id() not supported on this Spark version");
+    String path = tempDir.getAbsolutePath();
+    String tableName = "cm_id_" + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING, value DOUBLE) USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode'='id') LOCATION '%s'",
+            tableName, path));
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'test', 100.0)", tableName));
+    DeltaV2Table table = new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+    for (Column column : table.columns()) {
+      assertNotNull(
+          ColumnV2Utils.getColumnId(column),
+          "Expected non-null column id for id-mapping table column: " + column.name());
+    }
+  }
+
+  @Test
+  public void testColumnIdStableAfterRename(@TempDir File tempDir) throws Exception {
+    assumeTrue(ColumnV2Utils.supportsColumnId(), "Column.id() not supported on this Spark version");
+    String path = tempDir.getAbsolutePath();
+    String tableName = "cm_rename_" + UUID.randomUUID().toString().replace('-', '_');
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, old_name STRING) USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode'='name') LOCATION '%s'",
+            tableName, path));
+    DeltaV2Table beforeRename =
+        new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+    String oldNameColumnId =
+        Arrays.stream(beforeRename.columns())
+            .filter(c -> c.name().equals("old_name"))
+            .findFirst()
+            .map(ColumnV2Utils::getColumnId)
+            .orElseThrow();
+
+    spark.sql(String.format("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName));
+
+    DeltaV2Table afterRename =
+        new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+    String newNameColumnId =
+        Arrays.stream(afterRename.columns())
+            .filter(c -> c.name().equals("new_name"))
+            .findFirst()
+            .map(ColumnV2Utils::getColumnId)
+            .orElseThrow();
+    assertEquals(oldNameColumnId, newNameColumnId);
   }
 
   /** Setting the option while the feature flag is off throws at construction. */


### PR DESCRIPTION
## Summary

Populate `Column.id()` from `delta.columnMapping.id` metadata on the raw kernel schema while keeping logical column names from the public schema on DSv2 `DeltaV2Table`.

Companion DBR PR: https://github.com/databricks-eng/runtime/pull/222058

## Test plan

- [x] Added `DeltaV2TableTest` coverage for name- and id-mode column mapping tables
- [ ] OSS CI