### PR TITLE
[Storage] Refactor on getCommits in UC Delta token-based client

### DIFF
--- a/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
@@ -16,11 +16,9 @@
 
 package io.delta.storage.commit;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-
-import org.apache.hadoop.fs.Path;
-
 /**
  * Response container for
  * {@link CommitCoordinatorClient#getCommits(TableDescriptor, Long, Long)}.
@@ -42,6 +40,13 @@ public class GetCommitsResponse {
 
   public long getLatestTableVersion() {
     return latestTableVersion;
+  }
+
+  /** Returns a new response with commits sorted by version. */
+  public GetCommitsResponse sortCommitsByVersion() {
+    List<Commit> sorted = new ArrayList<>(commits);
+    sorted.sort(Comparator.comparingLong(Commit::getVersion));
+    return new GetCommitsResponse(sorted, latestTableVersion);
   }
 }
 

--- a/storage/src/main/java/io/delta/storage/commit/UCDeltaGetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/UCDeltaGetCommitsResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import io.delta.storage.commit.uniform.UniformMetadata;
+
+/**
+ * Extended response for {@link CommitCoordinatorClient#getCommits} implementations backed by the
+ * Delta REST loadTable API.
+ * Currently, it carries additional {@link UniformMetadata} returned
+ * by the loadTable response alongside the standard commits and latest table version.
+ */
+public class UCDeltaGetCommitsResponse extends GetCommitsResponse {
+
+  private final Optional<UniformMetadata> uniformMetadata;
+
+  public UCDeltaGetCommitsResponse(
+      List<Commit> commits,
+      long latestTableVersion,
+      Optional<UniformMetadata> uniformMetadata) {
+    super(commits, latestTableVersion);
+    this.uniformMetadata = uniformMetadata;
+  }
+
+  public Optional<UniformMetadata> getUniformMetadata() {
+    return uniformMetadata;
+  }
+
+  @Override
+  public UCDeltaGetCommitsResponse sortCommitsByVersion() {
+    List<Commit> sorted = new ArrayList<>(getCommits());
+    sorted.sort(Comparator.comparingLong(Commit::getVersion));
+    return new UCDeltaGetCommitsResponse(sorted, getLatestTableVersion(), uniformMetadata);
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -824,13 +824,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       Optional.ofNullable(startVersion),
       Optional.ofNullable(endVersion));
     // Sort by version just in case commits in the response from UC aren't sorted.
-    List<Commit> sortedCommits =
-      resp
-        .getCommits()
-        .stream()
-        .sorted(Comparator.comparingLong(Commit::getVersion))
-        .collect(Collectors.toList());
-    return new GetCommitsResponse(sortedCommits, resp.getLatestTableVersion());
+    return resp.sortCommitsByVersion();
   }
 
   protected GetCommitsResponse getCommitsFromUCImpl(

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
+import io.delta.storage.commit.UCDeltaGetCommitsResponse;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
 import io.delta.storage.commit.actions.AbstractDomainMetadata;
@@ -366,7 +367,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
     long latestTableVersion = response.getLatestTableVersion() != null
         ? response.getLatestTableVersion() : -1L;
-    return new GetCommitsResponse(commits, latestTableVersion);
+    Optional<io.delta.storage.commit.uniform.UniformMetadata> storageUniform =
+        toStorageUniformMetadata(response.getUniform());
+    return new UCDeltaGetCommitsResponse(commits, latestTableVersion, storageUniform);
   }
 
   /** Converts a UC SDK {@link DeltaCommit} to a Delta {@link Commit}. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Refactor on `getCommits` in UC Delta token-based client such that it returns a more general `GetCommitsFromLoadTableResponse` that can be extended in future to carry more metadata. The current `GetCommitsResponse` is a narrow interface that would drop additional metadata from `loadTable` 

## How was this patch tested?
Existing tests
