### PR TITLE
[UniForm] Support conflict resolution end to end

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2EIcebergSuite.scala
@@ -20,7 +20,8 @@ import java.util.{Collections, Optional, UUID}
 
 import scala.collection.JavaConverters._
 
-import io.delta.storage.commit.{CommitCoordinatorClient => JCommitCoordinatorClient}
+import com.databricks.spark.util.Log4jUsageLogger
+import io.delta.storage.commit.{CommitCoordinatorClient => JCommitCoordinatorClient, DeltaRESTGetCommitsResponse, GetCommitsResponse}
 import io.delta.storage.commit.{TableIdentifier => UCTableIdentifier}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
@@ -31,7 +32,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
-import org.apache.spark.sql.delta.{DeltaLog, IcebergConstants}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, DeltaTestUtils, IcebergConstants}
 import org.apache.spark.sql.delta.DeltaConfigs.{
   COORDINATED_COMMITS_COORDINATOR_CONF,
   COORDINATED_COMMITS_COORDINATOR_NAME
@@ -185,6 +186,21 @@ trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
     }
   }
 
+  private class InMemoryUCCommitCoordinatorWithUniForm extends InMemoryUCCommitCoordinator {
+    override def getCommitsFromCoordinator(
+        tableId: String,
+        tableUri: java.net.URI,
+        startVersion: Option[Long],
+        endVersion: Option[Long]): GetCommitsResponse = {
+      val base = super.getCommitsFromCoordinator(tableId, tableUri, startVersion, endVersion)
+      val uniform = getUniformMetadata(tableId)
+      new DeltaRESTGetCommitsResponse(
+        base.getCommits,
+        base.getLatestTableVersion,
+        uniform.map(u => Optional.of(u)).getOrElse(Optional.empty()))
+    }
+  }
+
   protected var ucCommitCoordinator: InMemoryUCCommitCoordinator = _
   private var testCoordinator: TestUCBackedCommitCoordinator = _
 
@@ -192,7 +208,7 @@ trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
     super.beforeEach()
     DeltaLog.clearCache()
     CommitCoordinatorProvider.clearAllBuilders()
-    ucCommitCoordinator = new InMemoryUCCommitCoordinator()
+    ucCommitCoordinator = new InMemoryUCCommitCoordinatorWithUniForm()
     UCBackedDeltaCatalog.currentCoordinator = Some(ucCommitCoordinator)
     val ucClient = new InMemoryUCClient("test-metastore", ucCommitCoordinator)
     testCoordinator = new TestUCBackedCommitCoordinator(ucClient)
@@ -245,7 +261,80 @@ trait WriteDeltaUCCCReadIceberg extends UniFormE2ETest
  */
 class UniFormE2EIcebergUCSuite extends UniFormE2EIcebergSuiteBase
     with WriteDeltaUCCCReadIceberg {
-  // No test should go here. Please add tests in [[UniFormE2EIcebergSuiteBase]]
+  // Tests that don't require CC infrastructure should be added in [[UniFormE2EIcebergSuiteBase]].
+  // Tests that specifically exercise the UC commit coordinator path may be added here.
   override def extraTableProperties(compatVersion: Int): String =
     super.extraTableProperties(compatVersion) + requiredTableProperties
+
+  test("conflict resolution refreshes catalogTable with fresh uniform metadata " +
+    "for incremental Iceberg conversion") {
+    val tableName = "test_cc_conflict_iceberg_refresh"
+    withTable(tableName) {
+      // Create a CC + UniForm table.
+      write(
+        s"""CREATE TABLE $tableName (id INT) USING DELTA
+           |TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |  $requiredTableProperties
+           |)""".stripMargin)
+
+      // v1: insert row 1 - triggers atomic Iceberg conversion at v1.
+      write(s"INSERT INTO $tableName VALUES (1)")
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val v1Snapshot = deltaLog.update()
+      val tableId = v1Snapshot.metadata.coordinatedCommitsTableConf
+        .get(UCCommitCoordinatorClient.UC_TABLE_ID_KEY).get
+      val v1IcebergMeta =
+        ucCommitCoordinator.getUniformMetadata(tableId).get.getIcebergMetadata.get
+
+      // Build a catalog table enriched with v1 Iceberg metadata.
+      // This simulates a transaction that started before v2 was committed.
+      val rawCatalogTable =
+        spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
+      val v1CatalogTable = rawCatalogTable.copy(
+        storage = rawCatalogTable.storage.copy(
+          properties = rawCatalogTable.storage.properties +
+            (IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP ->
+              v1IcebergMeta.getMetadataLocation) +
+            (IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
+              v1IcebergMeta.getConvertedDeltaVersion.toString)
+        )
+      )
+
+      // Start a transaction with v1 snapshot and v1 Iceberg catalog.
+      val txn = deltaLog.startTransaction(Some(v1CatalogTable), Some(v1Snapshot))
+
+      // v2: insert row 2 - the "winning" commit that the stale txn will conflict with.
+      // Now v1 snapshot and v1 Iceberg catalog becomes stale so txn's commit would hit
+      // conflict
+      write(s"INSERT INTO $tableName VALUES (2)")
+
+      // Try to commit the transaction as v2, hit a conflict, then retry as v3.
+      // During conflict resolution, getCommits returns v2's UniformMetadata, which
+      // refreshes catalogTable to convertedDeltaVersion=2. The retry commit then converts
+      // only v3 incrementally (fromVersion=3, toVersion=3) rather than from stale v1.
+      val events = Log4jUsageLogger.track {
+        txn.commit(Seq.empty, DeltaOperations.ManualUpdate)
+      }
+
+      // Latest version is now 3. There are two deltaCommitRange events: one from the failed
+      // first attempt (v2, using stale v1 base) and one from the successful retry (v3).
+      // The retry must use the refreshed catalog (convertedDeltaVersion=2 from v2's
+      // UniformMetadata), so conversion covers only v3 (fromVersion=3, toVersion=3).
+      // Without the fix, the retry would still use the stale v1 base and fromVersion would be 2.
+      val latestVersion = deltaLog.update().version
+      val rangeEvents = DeltaTestUtils.filterUsageRecords(
+        events, "delta.iceberg.conversion.deltaCommitRange")
+      assert(rangeEvents.size == 2,
+        s"Expected 2 deltaCommitRange events (failed attempt + retry), got ${rangeEvents.size}")
+      val retryEventData = JsonUtils.fromJson[Map[String, Any]](rangeEvents.last.blob)
+      assert(retryEventData("fromVersion") === latestVersion,
+        s"Expected fromVersion=$latestVersion (fresh v2 base), " +
+          s"got ${retryEventData("fromVersion")} (stale v1 base would give ${latestVersion - 1})")
+      assert(retryEventData("toVersion") === latestVersion,
+        s"Expected toVersion=$latestVersion")
+    }
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -3230,9 +3230,19 @@ trait OptimisticTransactionImpl extends TransactionHelper
   protected def updateCatalogTableWithUniformMetadata(
       txnInfo: CurrentTransactionInfo,
       uniformMetadataOpt: Option[UniformMetadata]): CurrentTransactionInfo = {
+    val isUniformEnabled = UniversalFormat.icebergEnabled(txnInfo.metadata)
     uniformMetadataOpt.flatMap(_.getIcebergMetadata.toScala) match {
-      case None => txnInfo
+      case None if !isUniformEnabled =>
+        logInfo(log"Skipping uniform metadata update: UniForm is not enabled.")
+        txnInfo
+      case None if isUniformEnabled =>
+        logWarning(log"UniForm is enabled but no uniform metadata was found " +
+          log"during conflict resolution listing.")
+        txnInfo
       case Some(iceberg) =>
+        logInfo(log"Updating catalogTable with uniform metadata, " +
+          log"whose convertedDeltaVersion=" +
+          log"${MDC(DeltaLogKeys.VERSION, iceberg.getConvertedDeltaVersion)}.")
         txnInfo.catalogTable.map { ct =>
           val newUniFormPropes = Map(
             IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP ->

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -34,6 +34,7 @@ import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.DeltaGeoSpatial
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
+import org.apache.spark.sql.delta.IcebergConstants
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
@@ -2726,7 +2727,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       currentTransactionInfo: CurrentTransactionInfo,
       attemptNumber: Int,
       isolationLevel: IsolationLevel): Snapshot = {
-    val targetCatalogTable = catalogTable
+    val targetCatalogTable = currentTransactionInfo.catalogTable
     // If the table requires atomic Iceberg metadata generation
     // , generate iceberg metadata and update the transaction info.
     var icebergMetadataGenerationDurationMsOpt: Option[Long] = None
@@ -2990,13 +2991,13 @@ trait OptimisticTransactionImpl extends TransactionHelper
         tags = Map(TAG_LOG_STORE_CLASS -> deltaLog.store.getClass.getName)) {
 
     DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
-      val fileStatuses = getConflictingVersions(checkVersion)
-      val nextAttemptVersion = checkVersion + fileStatuses.size
+      val txnConflictContext = getConflictingVersions(checkVersion)
+      val nextAttemptVersion = checkVersion + txnConflictContext.conflictingCommitFiles.size
 
       // validate that information about conflicting winning commit files is continuous and in the
       // right order.
       val expected = (checkVersion until nextAttemptVersion)
-      val found = fileStatuses.map(deltaVersion)
+      val found = txnConflictContext.conflictingCommitFiles.map(deltaVersion)
       val mismatch = expected.zip(found).dropWhile{ case (v1, v2) => v1 == v2 }.take(10)
       assert(mismatch.isEmpty,
         s"Expected ${mismatch.map(_._1).mkString(",")} but got ${mismatch.map(_._2).mkString(",")}")
@@ -3022,7 +3023,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         log"${MDC(DeltaLogKeys.VERSION2, nextAttemptVersion)}) " +
         log"with current txn having " + txnDetailsLog)
 
-      val updatedCurrentTransactionInfo = {
+      val resolvedCurrentTransactionInfo = {
         if (expected.isEmpty) {
           currentTransactionInfo
         }
@@ -3031,11 +3032,15 @@ trait OptimisticTransactionImpl extends TransactionHelper
             currentTransactionInfo = currentTransactionInfo,
             firstWinningVersion = expected.head,
             lastWinningVersion = expected.last,
-            conflictingCommitFiles = fileStatuses,
+            conflictingCommitFiles = txnConflictContext.conflictingCommitFiles,
             commitIsolationLevel = commitIsolationLevel)
         }
       }
 
+      val updatedCurrentTransactionInfo =
+        updateCatalogTableWithUniformMetadata(
+          resolvedCurrentTransactionInfo, txnConflictContext.uniformMetadata
+        )
 
       logInfo(logPrefix +
         log"No conflicts with versions " +
@@ -3093,16 +3098,17 @@ trait OptimisticTransactionImpl extends TransactionHelper
   private[delta] def getFirstAttemptVersion: Long = readVersion + 1L
 
   /** Returns the conflicting commit information */
-  protected def getConflictingVersions(previousAttemptVersion: Long): Seq[FileStatus] = {
+  protected def getConflictingVersions(previousAttemptVersion: Long): TxnConflictContext = {
     assert(previousAttemptVersion == preCommitLogSegment.version + 1)
-    val (newPreCommitLogSegment, newCommitFileStatuses) = deltaLog.getUpdatedLogSegment(
-      preCommitLogSegment,
-      readSnapshotTableCommitCoordinatorClientOpt,
-      catalogTable)
-    assert(preCommitLogSegment.version + newCommitFileStatuses.size ==
+    val (newPreCommitLogSegment, txnConflictContext) =
+      deltaLog.getUpdatedLogSegment(
+        preCommitLogSegment,
+        readSnapshotTableCommitCoordinatorClientOpt,
+        catalogTable)
+    assert(preCommitLogSegment.version + txnConflictContext.conflictingCommitFiles.size ==
       newPreCommitLogSegment.version)
     preCommitLogSegment = newPreCommitLogSegment
-    newCommitFileStatuses
+    txnConflictContext
   }
 
   protected def setCommitted(
@@ -3214,6 +3220,31 @@ trait OptimisticTransactionImpl extends TransactionHelper
         throwError("WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED",
           Array("ALTER TABLE"))
       case _ =>
+    }
+  }
+
+  /**
+   * Updates the catalogTable in CurrentTransactionInfo with fresh uniform metadata from
+   * getCommits, so that iceberg incremental conversion on retry uses the correct base version.
+   */
+  protected def updateCatalogTableWithUniformMetadata(
+      txnInfo: CurrentTransactionInfo,
+      uniformMetadataOpt: Option[UniformMetadata]): CurrentTransactionInfo = {
+    uniformMetadataOpt.flatMap(_.getIcebergMetadata.toScala) match {
+      case None => txnInfo
+      case Some(iceberg) =>
+        txnInfo.catalogTable.map { ct =>
+          val newUniFormPropes = Map(
+            IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP ->
+              iceberg.getMetadataLocation,
+            IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_DELTA_VERSION_PROP ->
+              iceberg.getConvertedDeltaVersion.toString,
+            IcebergConstants.CATALOG_TABLE_ICEBERG_CONVERTED_TIMESTAMP_PROP ->
+              iceberg.getConvertedDeltaTimestamp
+          )
+          val newStorage = ct.storage.copy(properties = ct.storage.properties ++ newUniFormPropes)
+          txnInfo.copy(catalogTable = Some(ct.copy(storage = newStorage)))
+        }.getOrElse(txnInfo)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
+import scala.jdk.OptionConverters._
 import scala.util.control.NonFatal
 
 // scalastyle:off import.ordering.noEmptyLine
@@ -39,7 +40,8 @@ import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
 import com.fasterxml.jackson.annotation.JsonIgnore
-import io.delta.storage.commit.{Commit, GetCommitsResponse}
+import io.delta.storage.commit.{Commit, DeltaRESTGetCommitsResponse, GetCommitsResponse}
+import io.delta.storage.commit.uniform.{UniformMetadata => StorageUniformMetadata}
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
 
 import org.apache.spark.{SparkContext, SparkException}
@@ -162,16 +164,16 @@ trait SnapshotManagement { self: DeltaLog =>
    * @param catalogTableOpt the optional catalog table to pass to the commit coordinator client.
    * @param versionToLoad the optional parameter to set the max version we should return. Inclusive.
    * @param includeMinorCompactions Whether to include minor compaction files in the result
-   * @return A tuple where the first element is an array of log files (possibly empty, if no
-   *         usable log files are found), and the second element is the latest checksum file found
-   *         which has a version less than or equal to `versionToLoad`.
+   * @return a [[FullDeltaListingResult]] containing all listed log files, the latest checksum
+   *         file, and any additional metadata fetched during CCv2 commit listing.
    */
   protected def listDeltaCompactedDeltaCheckpointFilesAndLatestChecksumFile(
       startVersion: Long,
       tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient],
       catalogTableOpt: Option[CatalogTable],
       versionToLoad: Option[Long],
-      includeMinorCompactions: Boolean): (Option[Array[FileStatus]], Option[FileStatus]) = {
+      includeMinorCompactions: Boolean)
+  : FullDeltaListingResult = {
     val tableCommitCoordinatorClient = tableCommitCoordinatorClientOpt.getOrElse {
       val (filesOpt, checksumOpt) =
         listFromFileSystemInternal(
@@ -179,7 +181,10 @@ trait SnapshotManagement { self: DeltaLog =>
           versionToLoad,
           includeMinorCompactions
         )
-      return (filesOpt.map(_.map(_._1)), checksumOpt)
+      return FullDeltaListingResult(
+          logFilesOpt = filesOpt.map(_.map(_._1)),
+          latestChecksumFileOpt = checksumOpt,
+          additionalListingMetadata = None)
     }
 
     // Submit a potential async call to get commits from commit coordinator if available
@@ -316,7 +321,14 @@ trait SnapshotManagement { self: DeltaLog =>
       logTuplesFromFsListing.map(_._1) ++ unbackfilledCommitsFiltered
     }
     val latestChecksumOpt = additionalChecksumOpt.orElse(initialChecksumOpt)
-    (logTuplesToReturn, latestChecksumOpt)
+    val uniformMetadataOpt = unbackfilledCommitsResponse match {
+      case r: DeltaRESTGetCommitsResponse => Option(r.getUniformMetadata).flatMap(_.toScala)
+      case _ => None
+    }
+    FullDeltaListingResult(
+      logFilesOpt = logTuplesToReturn,
+      latestChecksumFileOpt = latestChecksumOpt,
+      additionalListingMetadata = uniformMetadataOpt.map(AdditionalListingMetadata(_)))
   }
 
   /**
@@ -334,17 +346,21 @@ trait SnapshotManagement { self: DeltaLog =>
    * @param catalogTableOpt the optional catalog table to pass to the commit coordinator client.
    * @param versionToLoad the optional parameter to set the max version we should return. Inclusive.
    * @param includeMinorCompactions Whether to include minor compaction files in the result
-   * @return Some array of files found (possibly empty, if no usable commit files are present), or
-   *         None if the listing returned no files at all.
+   * @return A tuple of: (1) Some array of files found (possibly empty if no usable commit files
+   *         are present), or None if the listing returned no files at all; and
+   *         (2) an optional [[AdditionalListingMetadata]] which may contain additional metadata
+   *         fetched during CCv2 commit listing (e.g. UniformMetadata when getCommits is backed
+   *         by the delta-rest loadTable API).
    */
   protected final def listDeltaCompactedDeltaAndCheckpointFiles(
       startVersion: Long,
       tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient],
       catalogTableOpt: Option[CatalogTable],
       versionToLoad: Option[Long],
-      includeMinorCompactions: Boolean): Option[Array[FileStatus]] = {
+      includeMinorCompactions: Boolean)
+  : (Option[Array[FileStatus]], Option[AdditionalListingMetadata]) = {
     recordDeltaOperation(self, "delta.deltaLog.listDeltaAndCheckpointFiles") {
-      val (logTuplesOpt, latestChecksumOpt) =
+      val FullDeltaListingResult(logTuplesOpt, latestChecksumOpt, additionalListingMetadata) =
         listDeltaCompactedDeltaCheckpointFilesAndLatestChecksumFile(
           startVersion,
           tableCommitCoordinatorClientOpt,
@@ -352,7 +368,7 @@ trait SnapshotManagement { self: DeltaLog =>
           versionToLoad,
           includeMinorCompactions)
       lastSeenChecksumFileStatusOpt = latestChecksumOpt
-      logTuplesOpt
+      (logTuplesOpt, additionalListingMetadata)
     }
   }
 
@@ -388,7 +404,7 @@ trait SnapshotManagement { self: DeltaLog =>
     val listingStartVersion = Math.max(0L, lastCheckpointVersion)
     val includeMinorCompactions =
       spark.conf.get(DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS)
-    val newFiles = listDeltaCompactedDeltaAndCheckpointFiles(
+    val (newFiles, _) = listDeltaCompactedDeltaAndCheckpointFiles(
       listingStartVersion,
       tableCommitCoordinatorClientOpt,
       catalogTableOpt,
@@ -782,13 +798,14 @@ trait SnapshotManagement { self: DeltaLog =>
       if (upperBoundVersion > 0) findLastCompleteCheckpointBefore(upperBoundVersion) else None
     previousCp match {
       case Some(cp) =>
-        val filesSinceCheckpointVersion = listDeltaCompactedDeltaAndCheckpointFiles(
+        val (filesSinceCheckpointVersionOpt, _) = listDeltaCompactedDeltaAndCheckpointFiles(
           startVersion = cp.version,
           tableCommitCoordinatorClientOpt = tableCommitCoordinatorClientOpt,
           catalogTableOpt = catalogTableOpt,
           versionToLoad = Some(snapshotVersion),
           includeMinorCompactions = false
-        ).getOrElse(Array.empty)
+        )
+        val filesSinceCheckpointVersion = filesSinceCheckpointVersionOpt.getOrElse(Array.empty)
         val (checkpoints, deltas) = filesSinceCheckpointVersion.partition(isCheckpointFile)
         if (deltas.isEmpty) {
           // We cannot find any delta files. Returns None as we cannot construct a `LogSegment` only
@@ -829,7 +846,7 @@ trait SnapshotManagement { self: DeltaLog =>
           Some(checkpointProvider),
           deltas.last.getModificationTime))
       case None =>
-        val listFromResult =
+        val (listFromResultOpt, _) =
           listDeltaCompactedDeltaAndCheckpointFiles(
             startVersion = 0,
             tableCommitCoordinatorClientOpt = tableCommitCoordinatorClientOpt,
@@ -837,7 +854,7 @@ trait SnapshotManagement { self: DeltaLog =>
             versionToLoad = Some(snapshotVersion),
             includeMinorCompactions = false)
         val (deltas, deltaVersions) =
-          listFromResult
+          listFromResultOpt
             .getOrElse(Array.empty)
             .flatMap(DeltaFile.unapply(_))
             .unzip
@@ -983,9 +1000,9 @@ trait SnapshotManagement { self: DeltaLog =>
       oldLogSegment: LogSegment,
       tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient],
       catalogTableOpt: Option[CatalogTable]
-  ): (LogSegment, Seq[FileStatus]) = {
+  ): (LogSegment, TxnConflictContext) = {
     val includeCompactions = spark.conf.get(DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS)
-    val newFilesOpt = listDeltaCompactedDeltaAndCheckpointFiles(
+    val (newFilesOpt, additionalListingMetadata) = listDeltaCompactedDeltaAndCheckpointFiles(
         startVersion = oldLogSegment.version + 1,
         tableCommitCoordinatorClientOpt = tableCommitCoordinatorClientOpt,
         catalogTableOpt = catalogTableOpt,
@@ -999,7 +1016,7 @@ trait SnapshotManagement { self: DeltaLog =>
     val newFiles = newFilesOpt.filter(_.nonEmpty).getOrElse {
       // An empty listing likely implies a list-after-write inconsistency or that somebody clobbered
       // the Delta log.
-      return (oldLogSegment, Nil)
+      return (oldLogSegment, TxnConflictContext(Nil, uniformMetadata = None))
     }
     val allFiles = (
       oldLogSegment.checkpointProvider.topLevelFiles ++
@@ -1019,7 +1036,9 @@ trait SnapshotManagement { self: DeltaLog =>
     val fileStatusesOfConflictingCommits = newFiles.collect {
       case DeltaFile(f, v) if v <= newLogSegment.version => f
     }
-    (newLogSegment, fileStatusesOfConflictingCommits)
+    (newLogSegment, TxnConflictContext(
+      fileStatusesOfConflictingCommits, additionalListingMetadata.map(_.uniformMetadata))
+    )
   }
 
   /**
@@ -1622,6 +1641,40 @@ trait SnapshotManagement { self: DeltaLog =>
   // Visible for testing
   private[delta] def getCapturedSnapshot(): CapturedSnapshot = currentSnapshot
 }
+
+/**
+ * Full result of listing all Delta log files (delta, compacted-delta, checkpoint), the latest
+ * checksum file, and any additional metadata piggybacked on CCv2 commit listing responses.
+ *
+ * @param logFilesOpt an array of log files (possibly empty if no usable log files are found).
+ * @param latestChecksumFileOpt the latest checksum file found with version <= `versionToLoad`.
+ * @param additionalListingMetadata an optional [[AdditionalListingMetadata]] which may contain
+ *        additional metadata fetched during CCv2 commit listing (e.g. UniformMetadata when
+ *        getCommits is backed by the delta-rest loadTable API).
+ */
+case class FullDeltaListingResult(
+    logFilesOpt: Option[Array[FileStatus]],
+    latestChecksumFileOpt: Option[FileStatus],
+    additionalListingMetadata: Option[AdditionalListingMetadata])
+
+/**
+ * Additional metadata piggybacked on CCv2 commit listing responses.
+ *
+ * @param uniformMetadata the latest uniform metadata returned by the CCv2 getCommits call
+ *                        when it is backed by the delta-rest loadTable API.
+ */
+case class AdditionalListingMetadata(uniformMetadata: StorageUniformMetadata)
+
+/**
+ * Context captured during conflict resolution for a retried transaction.
+ *
+ * @param conflictingCommitFiles all conflicting commit files found since the last attempt.
+ * @param uniformMetadata the latest uniform metadata returned by the CCv2 getCommits call
+ *                        when it is backed by the delta-rest loadTable API.
+ */
+case class TxnConflictContext(
+    conflictingCommitFiles: Seq[FileStatus],
+    uniformMetadata: Option[StorageUniformMetadata])
 
 object SnapshotManagement extends DeltaLogging {
   // A thread pool for reading checkpoint files and collecting checkpoint v2 actions like

--- a/storage/src/main/java/io/delta/storage/commit/DeltaRESTGetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/DeltaRESTGetCommitsResponse.java
@@ -16,10 +16,10 @@
 
 package io.delta.storage.commit;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.delta.storage.commit.uniform.UniformMetadata;
 
@@ -29,11 +29,11 @@ import io.delta.storage.commit.uniform.UniformMetadata;
  * Currently, it carries additional {@link UniformMetadata} returned
  * by the loadTable response alongside the standard commits and latest table version.
  */
-public class UCDeltaGetCommitsResponse extends GetCommitsResponse {
+public class DeltaRESTGetCommitsResponse extends GetCommitsResponse {
 
   private final Optional<UniformMetadata> uniformMetadata;
 
-  public UCDeltaGetCommitsResponse(
+  public DeltaRESTGetCommitsResponse(
       List<Commit> commits,
       long latestTableVersion,
       Optional<UniformMetadata> uniformMetadata) {
@@ -46,9 +46,11 @@ public class UCDeltaGetCommitsResponse extends GetCommitsResponse {
   }
 
   @Override
-  public UCDeltaGetCommitsResponse sortCommitsByVersion() {
-    List<Commit> sorted = new ArrayList<>(getCommits());
-    sorted.sort(Comparator.comparingLong(Commit::getVersion));
-    return new UCDeltaGetCommitsResponse(sorted, getLatestTableVersion(), uniformMetadata);
+  public DeltaRESTGetCommitsResponse sortCommitsByVersion() {
+    List<Commit> sorted = getCommits()
+        .stream()
+        .sorted(Comparator.comparingLong(Commit::getVersion))
+        .collect(Collectors.toList());
+    return new DeltaRESTGetCommitsResponse(sorted, getLatestTableVersion(), uniformMetadata);
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
@@ -16,9 +16,9 @@
 
 package io.delta.storage.commit;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 /**
  * Response container for
  * {@link CommitCoordinatorClient#getCommits(TableDescriptor, Long, Long)}.
@@ -44,8 +44,10 @@ public class GetCommitsResponse {
 
   /** Returns a new response with commits sorted by version. */
   public GetCommitsResponse sortCommitsByVersion() {
-    List<Commit> sorted = new ArrayList<>(commits);
-    sorted.sort(Comparator.comparingLong(Commit::getVersion));
+    List<Commit> sorted = commits
+        .stream()
+        .sorted(Comparator.comparingLong(Commit::getVersion))
+        .collect(Collectors.toList());
     return new GetCommitsResponse(sorted, latestTableVersion);
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
-import io.delta.storage.commit.UCDeltaGetCommitsResponse;
+import io.delta.storage.commit.DeltaRESTGetCommitsResponse;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
 import io.delta.storage.commit.actions.AbstractDomainMetadata;
@@ -369,7 +369,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
         ? response.getLatestTableVersion() : -1L;
     Optional<io.delta.storage.commit.uniform.UniformMetadata> storageUniform =
         toStorageUniformMetadata(response.getUniform());
-    return new UCDeltaGetCommitsResponse(commits, latestTableVersion, storageUniform);
+    return new DeltaRESTGetCommitsResponse(commits, latestTableVersion, storageUniform);
   }
 
   /** Converts a UC SDK {@link DeltaCommit} to a Delta {@link Commit}. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Support conflict resolution for UniForm with new Delta-Rest API integration. More specifically,  when a Delta transaction retries after a conflict, the `catalogTable` it carries — which encodes the last converted Iceberg metadataLocation and convertedDeltaVersion — can be stale. Due to external UniForm's concurrency control design, it has to re-fetch latest UniForm information to proceed. 

This PR fixes the problem by threading UniformMetadata from the getCommits response back to the conflict-resolution retry path, so the retry always sees the freshest Iceberg base version. This is possible as `getCommits` is now implemented using Delta-Rest's `loadTable`, which carries UniForm information

## How was this patch tested?
Add UTs
```
build/sbt -DsparkVersion=4.0 "iceberg/testOnly *UniFormE2EIcebergUCSuite"
```