### PR TITLE
[Spark] Expose dataPath on SnapshotDescriptor

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -239,7 +239,7 @@ class IcebergConversionTransaction(
   // Member variables //
   //////////////////////
 
-  protected val tablePath = postCommitSnapshot.deltaLog.dataPath
+  protected val tablePath = postCommitSnapshot.dataPath
 
   protected val convert = new DeltaToIcebergConverter(postCommitSnapshot, catalogTable)
 
@@ -505,7 +505,7 @@ class IcebergConversionTransaction(
     val tableExists = ucTable.tableExists(icebergIdentifier)
 
     def tableBuilder = {
-      val tableLocation = postCommitSnapshot.deltaLog.dataPath.toString
+      val tableLocation = postCommitSnapshot.dataPath.toString
       ucTable
         .buildTable(icebergIdentifier, icebergSchema)
         .withPartitionSpec(partitionSpec)

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -29,6 +29,8 @@ import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
 import io.delta.sharing.client.model.{DeltaTableFiles, DeltaTableMetadata, Table}
 import io.delta.sharing.client.util.JsonUtils
 
+import org.apache.hadoop.fs.Path
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.delta.sharing.TableRefreshResult
 import org.apache.spark.internal.Logging
@@ -302,6 +304,7 @@ object DeltaSharingUtils extends Logging {
       localDeltaLog,
       new SnapshotDescriptor {
         val deltaLog: DeltaLog = localDeltaLog
+        val dataPath: Path = localDeltaLog.dataPath
         val metadata: Metadata = deltaSharingTableMetadata.metadata.deltaMetadata
         val protocol: Protocol = deltaSharingTableMetadata.protocol.deltaProtocol
         val version = deltaSharingTableMetadata.version

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1419,7 +1419,7 @@ private[delta] class ConflictChecker(
     if (tableName != null) {
       tableName
     } else {
-      s"delta.`${currentTransactionInfo.readSnapshot.deltaLog.dataPath}`"
+      s"delta.`${currentTransactionInfo.readSnapshot.dataPath}`"
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1695,7 +1695,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // If this transaction commits to the redirect destination location, then there is no
     // need to validate the subsequent no-redirect rules.
     val configuration = deltaLog.newDeltaHadoopConf()
-    val dataPath = snapshot.deltaLog.dataPath.toUri.getPath
+    val dataPath = snapshot.dataPath.toUri.getPath
     val catalog = spark.sessionState.catalog
     val isRedirectDest = redirectConfig.spec.isRedirectDest(catalog, configuration, dataPath)
     if (isRedirectDest) return

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -67,6 +67,8 @@ trait SnapshotDescriptor extends DeltaLoggingProvider {
 
   def schema: StructType = metadata.schema
 
+  def dataPath: Path
+
   protected[delta] def numOfFilesIfKnown: Option[Long]
   protected[delta] def sizeInBytesIfKnown: Option[Long]
 
@@ -120,6 +122,8 @@ class Snapshot(
   import DeltaLogFileIndex.COMMIT_VERSION_COLUMN
   // For implicits which re-use Encoder:
   import org.apache.spark.sql.delta.implicits._
+
+  override def dataPath: Path = deltaLog.dataPath
 
   protected def spark = SparkSession.active
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -785,6 +785,14 @@ sealed trait FileAction extends Action {
   def toPath: Path = sparkPath.toPath
 
   /** Returns the absolute [[Path]] for this file action (not URL-encoded). */
+  def absolutePath(snapshot: SnapshotDescriptor): Path = {
+    // dataPath is not URL-encoded.
+    val dataPath: Path = snapshot.dataPath
+    // this.path is a URL-encoded String, that is either the relative or absolute path.
+    DeltaFileOperations.absolutePath(dataPath.toString, path)
+  }
+
+  /** Returns the absolute [[Path]] for this file action (not URL-encoded). */
   def absolutePath(deltaLog: DeltaLog): Path = {
     // dataPath is not URL-encoded.
     val dataPath: Path = deltaLog.dataPath

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -369,7 +369,7 @@ class OptimizeExecutor(
 
       optimizeStrategy.updateOptimizeStats(optimizeStats, removedFiles, jobs)
 
-      return Seq(Row(snapshot.deltaLog.dataPath.toString, optimizeStats.toOptimizeMetrics))
+      return Seq(Row(snapshot.dataPath.toString, optimizeStats.toOptimizeMetrics))
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
@@ -108,7 +108,7 @@ trait ReorgTableHelper extends Serializable {
       filterFileFn: StructType => Boolean): Seq[AddFile] = {
 
     val serializedConf = new SerializableConfiguration(snapshot.deltaLog.newDeltaHadoopConf())
-    val dataPath = new Path(snapshot.deltaLog.dataPath.toString)
+    val dataPath = new Path(snapshot.dataPath.toString)
 
     import org.apache.spark.sql.delta.implicits._
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -58,6 +58,7 @@ abstract class TahoeFileIndex(
   with SupportsRowIndexFilters
   with SnapshotDescriptor {
 
+
   override def rootPaths: Seq[Path] = path :: Nil
 
   /**
@@ -211,6 +212,7 @@ abstract class TahoeFileIndexWithSnapshotDescriptor(
   override def version: Long = snapshot.version
   override def metadata: Metadata = snapshot.metadata
   override def protocol: Protocol = snapshot.protocol
+  override def dataPath: Path = snapshot.dataPath
 
 
   protected[delta] def numOfFilesIfKnown: Option[Long] = snapshot.numOfFilesIfKnown
@@ -229,6 +231,7 @@ class ShallowSnapshotDescriptor(
   override val version: Long = snapshot.version
   override val metadata: Metadata = snapshot.metadata
   override val protocol: Protocol = snapshot.protocol
+  override val dataPath: Path = snapshot.dataPath
   // Avoid eager state reconstruction
   override protected[delta] def numOfFilesIfKnown: Option[Long] =
     deltaLog.getSnapshotAt(version, catalogTableOpt = catalogTableOpt).numOfFilesIfKnown
@@ -282,6 +285,7 @@ case class TahoeLogFileIndex(
   // from the one returned by [[getSnapshot]] that we will eventually scan.
   override def metadata: Metadata = snapshotAtAnalysis.metadata
   override def protocol: Protocol = snapshotAtAnalysis.protocol
+  override def dataPath: Path = deltaLog.dataPath
 
   private def checkSchemaOnRead: Boolean = {
     spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_SCHEMA_ON_READ_CHECK_ENABLED)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -535,7 +535,7 @@ object DeltaDataSource extends DatabricksLogging {
           spark,
           schemaTrackingLocation,
           sourceSnapshot.deltaLog.unsafeVolatileTableId,
-          sourceSnapshot.deltaLog.dataPath.toString,
+          sourceSnapshot.dataPath.toString,
           parameters,
           sourceMetadataPathOpt,
           mergeConsecutiveSchemaChanges,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.delta.storage.{ClosableIterator, SupportsRewinding}
 import org.apache.spark.sql.delta.storage.ClosableIterator._
 import org.apache.spark.sql.delta.util.{DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.util.ScalaExtensions._
-import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -153,6 +153,7 @@ trait DeltaSourceBase extends Source
       // Construct a snapshot descriptor with custom schema inline
       new SnapshotDescriptor {
         val deltaLog: DeltaLog = snapshotAtSourceInit.deltaLog
+        val dataPath: Path = snapshotAtSourceInit.dataPath
         val metadata: Metadata =
           snapshotAtSourceInit.metadata.copy(
             schemaString = customMetadata.dataSchemaJson,


### PR DESCRIPTION
## Description

Expose `dataPath` on `SnapshotDescriptor` and migrate production callers from `snapshot.deltaLog.dataPath` to `snapshot.dataPath`.

This is the first step of removing `snapshotDescriptor.deltaLog`.

## How was this patch tested?

Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

No.