### PR TITLE
[CI] Use Temurin instead of Zulu for JDK setup in kernel_test workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Java 17
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
 
       - name: Set up Python

--- a/.github/workflows/changelog_tests_spark42.yaml
+++ b/.github/workflows/changelog_tests_spark42.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Restore SBT cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/disabled_publish_docs.yaml
+++ b/.github/workflows/disabled_publish_docs.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: ${{ matrix.version.java }}
 
       - name: Setup python environment

--- a/.github/workflows/disabled_spark_test_uc_master.yaml
+++ b/.github/workflows/disabled_spark_test_uc_master.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Cache Scala, SBT, Maven local
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3

--- a/.github/workflows/flink_test.yaml
+++ b/.github/workflows/flink_test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Restore SBT cache
         id: cache-sbt

--- a/.github/workflows/iceberg_test.yaml
+++ b/.github/workflows/iceberg_test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Cache Scala, SBT
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0

--- a/.github/workflows/kernel_docs.yaml
+++ b/.github/workflows/kernel_docs.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "11"
       - name: Generate docs
         run: |

--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Restore SBT cache
         id: cache-sbt
@@ -98,14 +98,14 @@ jobs:
       - name: install java 17 for UC build
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Set up pinned Unity Catalog
         uses: ./.github/actions/setup-unitycatalog
       - name: install java 11 for integration test
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "11"
       - name: Run integration tests
         run: |

--- a/.github/workflows/kernel_unitycatalog_test.yaml
+++ b/.github/workflows/kernel_unitycatalog_test.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       # kernelUnityCatalog depends on unreleased UC APIs; publish the pinned UC build locally before
       # sbt tries to resolve the dependency.

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Generate released Spark versions matrix
         id: generate
@@ -63,7 +63,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: ${{ steps.spark-details.outputs.jvm_version }}
       - name: Restore SBT cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Generate released Spark versions matrix
         id: generate
@@ -64,7 +64,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: ${{ steps.spark-details.outputs.jvm_version }}
       - name: Cache Scala, SBT
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
       - name: Generate Spark versions matrix
         id: generate
@@ -67,7 +67,7 @@ jobs:
       - name: install java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: ${{ steps.spark-details.outputs.jvm_version }}
       - name: Restore SBT cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -16,7 +16,7 @@
         - name: install java
           uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
           with:
-            distribution: "zulu"
+            distribution: "temurin"
             java-version: "17"
         - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         - name: generate unidoc


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

```
Installed distributions
  Trying to resolve the latest version from remote
  Error: error code: 520
```
This PR switches the three `setup-java` steps in `kernel_test.yaml` and other workflows from `zulu` to `temurin`. Temurin resolves the JDK from the GitHub-hosted version manifest and the JDKs preinstalled on the ubuntu runners, so it does not depend on Azul's API being reachable. This removes a class of transient CI failures.


## How was this patch tested?

CI on this PR runs the modified `kernel_test` workflow, which exercises the
`temurin` JDK setup directly. No product code is changed.

## Does this PR introduce _any_ user-facing changes?

No.
