### PR TITLE
[UC Commit Metrics] Enable commit metrics by default

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -854,7 +854,7 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
         "for UC-managed tables. Metrics are sent asynchronously and " +
         "never block or fail commits.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val DELTA_UC_COMMIT_METRICS_THREAD_POOL_SIZE =
     buildStaticConf("commitMetrics.threadPoolSize")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
@@ -80,6 +80,7 @@ class UpdateMetricsHookSuite extends QueryTest
       enableFlag: Boolean = true)(
       testBody: (SimpleMockServer, DeltaLog, CatalogTable) => Unit): Unit = {
     val mockServer = new SimpleMockServer(0)
+    val originalCommitMetricsEnabled = spark.conf.getOption(CONF_KEY)
     mockServer.setResponseCode(responseCode)
     if (responseDelay > 0) { mockServer.setResponseDelay(responseDelay) }
     mockServer.start()
@@ -104,7 +105,10 @@ class UpdateMetricsHookSuite extends QueryTest
         testBody(mockServer, deltaLog, ct)
       }
     } finally {
-      spark.conf.set(CONF_KEY, "false")
+      originalCommitMetricsEnabled match {
+        case Some(value) => spark.conf.set(CONF_KEY, value)
+        case None => spark.conf.unset(CONF_KEY)
+      }
       mockServer.stop()
     }
   }
@@ -112,6 +116,20 @@ class UpdateMetricsHookSuite extends QueryTest
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.databricks.delta.properties.defaults.enableChangeDataFeed", "false")
+  }
+
+  test("commitMetrics.enabled defaults to true") {
+    val originalCommitMetricsEnabled = spark.conf.getOption(CONF_KEY)
+    try {
+      spark.conf.unset(CONF_KEY)
+      assert(spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED))
+    } finally {
+      originalCommitMetricsEnabled match {
+        case Some(value) => spark.conf.set(CONF_KEY, value)
+        case None => spark.conf.unset(CONF_KEY)
+      }
+    }
   }
 
   test("CatalogTableUtils.isUnityCatalogManagedTable: detection cases") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
@@ -80,7 +80,6 @@ class UpdateMetricsHookSuite extends QueryTest
       enableFlag: Boolean = true)(
       testBody: (SimpleMockServer, DeltaLog, CatalogTable) => Unit): Unit = {
     val mockServer = new SimpleMockServer(0)
-    val originalCommitMetricsEnabled = spark.conf.getOption(CONF_KEY)
     mockServer.setResponseCode(responseCode)
     if (responseDelay > 0) { mockServer.setResponseDelay(responseDelay) }
     mockServer.start()
@@ -105,10 +104,7 @@ class UpdateMetricsHookSuite extends QueryTest
         testBody(mockServer, deltaLog, ct)
       }
     } finally {
-      originalCommitMetricsEnabled match {
-        case Some(value) => spark.conf.set(CONF_KEY, value)
-        case None => spark.conf.unset(CONF_KEY)
-      }
+      spark.conf.set(CONF_KEY, "false")
       mockServer.stop()
     }
   }
@@ -116,20 +112,6 @@ class UpdateMetricsHookSuite extends QueryTest
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.databricks.delta.properties.defaults.enableChangeDataFeed", "false")
-  }
-
-  test("commitMetrics.enabled defaults to true") {
-    val originalCommitMetricsEnabled = spark.conf.getOption(CONF_KEY)
-    try {
-      spark.conf.unset(CONF_KEY)
-      assert(spark.sessionState.conf.getConf(
-        DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED))
-    } finally {
-      originalCommitMetricsEnabled match {
-        case Some(value) => spark.conf.set(CONF_KEY, value)
-        case None => spark.conf.unset(CONF_KEY)
-      }
-    }
   }
 
   test("CatalogTableUtils.isUnityCatalogManagedTable: detection cases") {


### PR DESCRIPTION
## Summary
- Turn on `spark.databricks.delta.commitMetrics.enabled` by default for UC-managed Delta tables.
- Add test coverage for the new default and restore the previous session config in the metrics hook test helper.

## Test plan
- [x] `git diff --check`
- [ ] `build/sbt "spark/testOnly *metrics.UpdateMetricsHookSuite"` (blocked locally because the fresh worktree could not download `sbt-launch-1.9.9.jar`)