### PR TITLE
Clean up Iceberg conversion call sites

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaLog, SerializableFileStatus, Snapshot => DeltaSnapshot}
 import org.apache.spark.sql.delta.DeltaErrors.cloneFromIcebergSourceWithPartitionEvolution
-import org.apache.spark.sql.delta.commands.convert.IcebergTable.ERR_MULTIPLE_PARTITION_SPECS
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -195,7 +195,11 @@ class IcebergTable(
 
   checkConvertible()
 
-  val fileManifest = new IcebergFileManifest(spark, icebergTable, partitionSchema, convertStats)
+  val fileManifest = new IcebergFileManifest(
+    spark,
+    icebergTable,
+    partitionSchema,
+    convertStats)
 
   lazy val numFiles: Long =
     Option(icebergTable.currentSnapshot())

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -298,7 +298,10 @@ case class CloneIcebergSource(
   spark: SparkSession) extends CloneConvertedSource(spark) {
 
   override lazy val convertTargetTable: ConvertTargetTable =
-    ConvertUtils.getIcebergTable(spark, metadataLocation, deltaSnapshotOpt)
+    ConvertUtils.getIcebergTable(
+      spark,
+      metadataLocation,
+      deltaSnapshotOpt = deltaSnapshotOpt)
 
   override def format: String = CloneSourceFormat.ICEBERG
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This removes an unused Iceberg partition-spec import and formats Iceberg conversion call sites so the arguments are easier to read.

## How was this patch tested?

This is a small source cleanup exported by the Delta OSS audit workflow. Existing tests cover the affected clone and Iceberg conversion paths.
