### PR TITLE
[Spark] Store and use sidecar file schema in V2 Checkpoint metadata tags

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
@@ -564,13 +564,15 @@ object V2CheckpointProvider {
       sidecarFiles: Seq[SidecarFile],
       deltaLog: DeltaLog): V2CheckpointProvider = {
     def getSidecarSchemaFetcher: () => Option[StructType] = {
+      val sidecarSchemaFromMetadata = checkpointMetadata.sidecarFileSchema
       val nonFateSharingSidecarSchemaFuture: NonFateSharingFuture[Option[StructType]] = {
         checkpointV2ThreadPool.submitNonFateSharing { spark: SparkSession =>
           sidecarFiles.headOption.map { sidecarFile =>
             val sidecarFileStatus =
               sidecarFile.toFileStatus(uninitializedV2LikeCheckpointProvider.logPath)
             CheckpointProvider.getParquetSchema(
-              spark, deltaLog, sidecarFileStatus, schemaFromLastCheckpoint = None)
+              spark, deltaLog, sidecarFileStatus,
+              schemaFromLastCheckpoint = sidecarSchemaFromMetadata)
           }
         }
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
@@ -571,7 +571,9 @@ object V2CheckpointProvider {
             val sidecarFileStatus =
               sidecarFile.toFileStatus(uninitializedV2LikeCheckpointProvider.logPath)
             CheckpointProvider.getParquetSchema(
-              spark, deltaLog, sidecarFileStatus,
+              spark,
+              deltaLog,
+              sidecarFileStatus,
               schemaFromLastCheckpoint = sidecarSchemaFromMetadata)
           }
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -983,7 +983,13 @@ object Checkpoints
     // Filter out the sidecar schema if it is too large.
     val sidecarFileSchemaOpt =
       Checkpoints.checkpointSchemaToWriteInLastCheckpointFile(spark, sidecarSchema)
-    val checkpointMetadata = CheckpointMetadata(snapshot.version)
+    val checkpointMetadata = CheckpointMetadata(
+      version = snapshot.version,
+      sidecarNumActions = rowsWrittenInCheckpointJob,
+      sidecarSizeInBytes = parquetFilesSizeInBytes,
+      numOfAddFiles = snapshot.numOfFiles,
+      sidecarFileSchemaOpt = sidecarFileSchemaOpt
+    )
 
     val nonFileActionsToWrite =
       (checkpointMetadata +: sidecarFilesWritten) ++ snapshot.nonFileActions

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1198,6 +1198,16 @@ trait DeltaErrorsBase
     )
   }
 
+  def tagCouldNotBeParsedException(
+      tagName: String,
+      tags: Map[String, String],
+      cause: Throwable): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_NON_PARSABLE_TAG",
+      messageParameters = Array(tagName, tags.mkString("[", ",", "]")),
+      cause = Some(cause))
+  }
+
   def nonPartitionColumnAbsentException(colsDropped: Boolean): Throwable = {
     val msg = if (colsDropped) {
       " Columns which are of NullType have been dropped."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1626,7 +1626,7 @@ case class CheckpointMetadata(
   def numOfAddFiles: Option[Long] =
     Action.getDeserializedValueForTag[Long](tags, Tags.NUM_OF_ADD_FILES.name)
 
-  /** Number of add file actions in the underlying checkpoint */
+  /** Schema of the [[SidecarFile]]s stored in the checkpoint */
   @JsonIgnore
   def sidecarFileSchema: Option[StructType] = {
     Option(tags)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -181,6 +181,29 @@ object Action extends DeltaLogging {
     }
     StructType(fields)
   }
+
+  /**
+   * Returns the tag value corresponding to a given `key`.
+   * This method throws [[DeltaErrors.tagCouldNotBeParsedException]] exception
+   * if the value is not a valid json or if it cannot be parsed to type `T`.
+   *
+   * @param key key for which we want the extra attribute value
+   * @tparam T value type
+   * @return None if the given key is not present, else returns the corresponding value of type `T`
+   *         from the stored json version of the value for the given key.
+   */
+  def getDeserializedValueForTag[T: Manifest](
+      tags: Map[String, String],
+      key: String): Option[T] = {
+    Option(tags).flatMap(_.get(key)).map { serializedValue =>
+      try {
+        JsonUtils.fromJson[T](serializedValue)
+      } catch {
+        case NonFatal(e) =>
+          throw DeltaErrors.tagCouldNotBeParsedException(key, tags, e)
+      }
+    }
+  }
 }
 
 /**
@@ -1585,8 +1608,61 @@ case class CheckpointMetadata(
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(checkpointMetadata = this)
+
+  import CheckpointMetadata.Tags
+
+  /** Number of actions in the [[SidecarFile]]s */
+  @JsonIgnore
+  def sidecarNumActions: Option[Long] =
+    Action.getDeserializedValueForTag[Long](tags, Tags.SIDECAR_NUM_ACTIONS.name)
+
+  /** Size in bytes across all part files */
+  @JsonIgnore
+  def sidecarSizeInBytes: Option[Long] =
+    Action.getDeserializedValueForTag[Long](tags, Tags.SIDECAR_SIZE_IN_BYTES.name)
+
+  /** Number of add file actions in the underlying checkpoint */
+  @JsonIgnore
+  def numOfAddFiles: Option[Long] =
+    Action.getDeserializedValueForTag[Long](tags, Tags.NUM_OF_ADD_FILES.name)
+
+  /** Number of add file actions in the underlying checkpoint */
+  @JsonIgnore
+  def sidecarFileSchema: Option[StructType] = {
+    Option(tags)
+      .flatMap(_.get(Tags.SIDECAR_FILE_SCHEMA.name))
+      .map(DataType.fromJson(_).asInstanceOf[StructType])
+  }
 }
 
+object CheckpointMetadata {
+
+  def apply(
+      version: Long,
+      sidecarNumActions: Long,
+      sidecarSizeInBytes: Long,
+      numOfAddFiles: Long,
+      sidecarFileSchemaOpt: Option[StructType]): CheckpointMetadata = {
+    val tagMapWithSchema = sidecarFileSchemaOpt.map(Tags.SIDECAR_FILE_SCHEMA.name -> _.json)
+    CheckpointMetadata(
+      version = version,
+      tags = Map(
+        Tags.SIDECAR_NUM_ACTIONS.name -> sidecarNumActions.toString,
+        Tags.SIDECAR_SIZE_IN_BYTES.name -> sidecarSizeInBytes.toString,
+        Tags.NUM_OF_ADD_FILES.name -> numOfAddFiles.toString
+      ) ++ tagMapWithSchema
+    )
+  }
+
+  object Tags {
+    sealed abstract class KeyType(val name: String)
+
+    object SIDECAR_NUM_ACTIONS extends KeyType("sidecarNumActions")
+    object SIDECAR_SIZE_IN_BYTES extends KeyType("sidecarSizeInBytes")
+    object NUM_OF_ADD_FILES extends KeyType("numOfAddFiles")
+    object SIDECAR_FILE_SCHEMA extends KeyType("sidecarFileSchema")
+  }
+}
 
 /** A serialization helper to create a common action envelope. */
 case class SingleAction(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -92,6 +92,19 @@ class CheckpointsSuite
     }
   }
 
+  def getCheckpointFileActions(
+      deltaLog: DeltaLog,
+      checkpoint: FileStatus): Seq[Action] = {
+    if (checkpoint.getPath.toString.endsWith("json")) {
+      deltaLog.store.read(checkpoint.getPath).map(Action.fromJson)
+    } else {
+      val fileIndex =
+        DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Seq(checkpoint)).get
+      deltaLog.loadIndex(fileIndex, Action.logSchema)
+        .as[SingleAction].collect().map(_.unwrap).toSeq
+    }
+  }
+
   protected override def sparkConf = {
     // Set the gs LogStore impl to `LocalLogStore` so that it will work with
     // `FakeGCSFileSystemValidatingCheckpoint`.
@@ -193,17 +206,7 @@ class CheckpointsSuite
           assert(checkpointLiteral == "checkpoint")
       }
 
-      def getCheckpointFileActions(checkpoint: FileStatus) : Seq[Action] = {
-        if (checkpoint.getPath.toString.endsWith("json")) {
-          deltaLog.store.read(checkpoint.getPath).map(Action.fromJson)
-        } else {
-          val fileIndex =
-            DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Seq(checkpoint)).get
-          deltaLog.loadIndex(fileIndex, Action.logSchema)
-            .as[SingleAction].collect().map(_.unwrap).toSeq
-        }
-      }
-      val actions = getCheckpointFileActions(checkpoint)
+      val actions = getCheckpointFileActions(deltaLog, checkpoint)
       // V2 Checkpoints should contain exactly one action each of types
       // Metadata, CheckpointMetadata, and Protocol
       // In this particular case, we should only have one sidecar file
@@ -241,17 +244,7 @@ class CheckpointsSuite
       assert(checkpointFiles.length == 1)
       val checkpoint = checkpointFiles.head
 
-      def getCheckpointFileActions(checkpoint: FileStatus): Seq[Action] = {
-        if (checkpoint.getPath.toString.endsWith("json")) {
-          deltaLog.store.read(checkpoint.getPath).map(Action.fromJson)
-        } else {
-          val fileIndex =
-            DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Seq(checkpoint)).get
-          deltaLog.loadIndex(fileIndex, Action.logSchema)
-            .as[SingleAction].collect().map(_.unwrap).toSeq
-        }
-      }
-      val actions = getCheckpointFileActions(checkpoint)
+      val actions = getCheckpointFileActions(deltaLog, checkpoint)
       val cmActions = actions.collect { case cm: CheckpointMetadata => cm }
       assert(cmActions.length == 1)
       val cm = cmActions.head
@@ -284,15 +277,15 @@ class CheckpointsSuite
       assert(sidecarSchema.fieldNames.contains("remove"),
         s"sidecar schema should contain 'remove' field, got: ${sidecarSchema.fieldNames.toSeq}")
 
-      val v2Provider = getV2CheckpointProvider(deltaLog, update = true)
-      val resolvedSchema = v2Provider.allActionsFileIndexesAndSchemas(spark, deltaLog)
-        .filter(_._1.files.exists(f => f.getPath.toString.contains("_sidecars")))
-        .map(_._2)
-      assert(resolvedSchema.nonEmpty, "Should have at least one sidecar file index")
-      assert(resolvedSchema.head == sidecarSchema,
-        s"Schema from tags should match resolved sidecar schema.\n" +
+      val sidecarActions = actions.collect { case s: SidecarFile => s }
+      assert(sidecarActions.nonEmpty, "Should have at least one sidecar file")
+      val sidecarFileStatus = sidecarActions.head.toFileStatus(deltaLog.logPath)
+      val footerSchema = Snapshot.getParquetFileSchemaAndRowCount(
+        spark, deltaLog, sidecarFileStatus)._1
+      assert(footerSchema == sidecarSchema,
+        s"Schema from tags should match schema read from sidecar Parquet footer.\n" +
         s"From tags: ${sidecarSchema.treeString}\n" +
-        s"Resolved: ${resolvedSchema.head.treeString}")
+        s"From footer: ${footerSchema.treeString}")
 
       val roundTripped = JsonUtils.fromJson[SingleAction](cm.json).unwrap
         .asInstanceOf[CheckpointMetadata]

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -229,6 +229,80 @@ class CheckpointsSuite
     }
   }
 
+  testDifferentV2Checkpoints("V2 Checkpoint - CheckpointMetadata tags contain" +
+      " sidecar stats and schema") {
+    withTempDir { tempDir =>
+      val path = tempDir.getAbsolutePath
+      spark.range(10).write.format("delta").save(path)
+      val deltaLog = DeltaLog.forTable(spark, path)
+      deltaLog.checkpoint()
+
+      val checkpointFiles = deltaLog.listFrom(0).filter(FileNames.isCheckpointFile).toList
+      assert(checkpointFiles.length == 1)
+      val checkpoint = checkpointFiles.head
+
+      def getCheckpointFileActions(checkpoint: FileStatus): Seq[Action] = {
+        if (checkpoint.getPath.toString.endsWith("json")) {
+          deltaLog.store.read(checkpoint.getPath).map(Action.fromJson)
+        } else {
+          val fileIndex =
+            DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Seq(checkpoint)).get
+          deltaLog.loadIndex(fileIndex, Action.logSchema)
+            .as[SingleAction].collect().map(_.unwrap).toSeq
+        }
+      }
+      val actions = getCheckpointFileActions(checkpoint)
+      val cmActions = actions.collect { case cm: CheckpointMetadata => cm }
+      assert(cmActions.length == 1)
+      val cm = cmActions.head
+
+      assert(cm.tags != null, "CheckpointMetadata.tags should not be null")
+      val expectedKeys = Set(
+        "sidecarNumActions",
+        "sidecarSizeInBytes",
+        "numOfAddFiles",
+        "sidecarFileSchema"
+      )
+      assert(expectedKeys.subsetOf(cm.tags.keySet),
+        s"tags keys ${cm.tags.keySet} should contain all of $expectedKeys")
+
+      val numActions = cm.tags("sidecarNumActions").toLong
+      assert(numActions > 0, s"sidecarNumActions should be > 0, got $numActions")
+      val sizeInBytes = cm.tags("sidecarSizeInBytes").toLong
+      assert(sizeInBytes > 0, s"sidecarSizeInBytes should be > 0, got $sizeInBytes")
+      val numOfAddFiles = cm.tags("numOfAddFiles").toLong
+      assert(numOfAddFiles > 0, s"numOfAddFiles should be > 0, got $numOfAddFiles")
+
+      val schemaJson = cm.tags("sidecarFileSchema")
+      assert(schemaJson != null && schemaJson.nonEmpty,
+        "sidecarFileSchema should be a non-empty JSON string")
+      val schema = cm.sidecarFileSchema
+      assert(schema.isDefined, "sidecarFileSchema should deserialize to Some(StructType)")
+      val sidecarSchema = schema.get
+      assert(sidecarSchema.fieldNames.contains("add"),
+        s"sidecar schema should contain 'add' field, got: ${sidecarSchema.fieldNames.toSeq}")
+      assert(sidecarSchema.fieldNames.contains("remove"),
+        s"sidecar schema should contain 'remove' field, got: ${sidecarSchema.fieldNames.toSeq}")
+
+      val v2Provider = getV2CheckpointProvider(deltaLog, update = true)
+      val resolvedSchema = v2Provider.allActionsFileIndexesAndSchemas(spark, deltaLog)
+        .filter(_._1.files.exists(f => f.getPath.toString.contains("_sidecars")))
+        .map(_._2)
+      assert(resolvedSchema.nonEmpty, "Should have at least one sidecar file index")
+      assert(resolvedSchema.head == sidecarSchema,
+        s"Schema from tags should match resolved sidecar schema.\n" +
+        s"From tags: ${sidecarSchema.treeString}\n" +
+        s"Resolved: ${resolvedSchema.head.treeString}")
+
+      val roundTripped = JsonUtils.fromJson[SingleAction](cm.json).unwrap
+        .asInstanceOf[CheckpointMetadata]
+      assert(roundTripped.tags == cm.tags,
+        "Tags should survive JSON round-trip serialization")
+      assert(roundTripped.sidecarFileSchema == cm.sidecarFileSchema,
+        "sidecarFileSchema should survive JSON round-trip")
+    }
+  }
+
   test("SC-86940: isGCSPath") {
     val conf = new Configuration()
     assert(Checkpoints.isGCSPath(conf, new Path("gs://foo/bar")))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/ActionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/ActionSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.actions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{BooleanType, StructField, StructType}
+
+class ActionSuite extends SparkFunSuite with SharedSparkSession {
+
+  test("CheckpointMetadata - extract from tags") {
+    val metadata1 = CheckpointMetadata(version = 1, tags = null)
+    assert(metadata1.numOfAddFiles.isEmpty)
+    assert(metadata1.sidecarSizeInBytes.isEmpty)
+    assert(metadata1.sidecarNumActions.isEmpty)
+    assert(metadata1.sidecarFileSchema.isEmpty)
+
+    import CheckpointMetadata.Tags
+    val metadata2 = CheckpointMetadata(
+      version = 1,
+      tags = Map(Tags.NUM_OF_ADD_FILES.name -> "2", Tags.SIDECAR_SIZE_IN_BYTES.name -> "3"))
+    assert(metadata2.numOfAddFiles.contains(2))
+    assert(metadata2.sidecarSizeInBytes.contains(3))
+    assert(metadata2.sidecarNumActions.isEmpty)
+    assert(metadata2.sidecarFileSchema.isEmpty)
+
+    val schemaForMetadata = StructType(Seq(StructField("a", dataType = BooleanType)))
+    val metadata3 = CheckpointMetadata(
+      version = 1,
+      tags = Map(
+        Tags.SIDECAR_NUM_ACTIONS.name -> "2",
+        Tags.SIDECAR_FILE_SCHEMA.name -> schemaForMetadata.json)
+    )
+    assert(metadata3.numOfAddFiles.isEmpty)
+    assert(metadata3.sidecarSizeInBytes.isEmpty)
+    assert(metadata3.sidecarNumActions.contains(2))
+    assert(metadata3.sidecarFileSchema.contains(schemaForMetadata))
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This change enables V2 Checkpoints to store the sidecar file schema in CheckpointMetadata tags. When reading a V2 Checkpoint, the schema can be retrieved from the metadata tags instead of requiring a full Parquet footer read of sidecar files.

Changes:
- Add `sidecarFileSchema`, `sidecarNumActions`, `sidecarSizeInBytes`, and `numOfAddFiles` accessors to `CheckpointMetadata`
- Add `CheckpointMetadata.apply` factory method that populates tags with sidecar stats and file schema
- Add `CheckpointMetadata.Tags` object with typed key definitions
- Add `Action.getDeserializedValueForTag` utility for type-safe tag parsing
- Add `DeltaErrors.tagCouldNotBeParsedException` for tag parse failures
- Update `Checkpoints.writeV2Checkpoint` to use full `CheckpointMetadata` constructor with sidecar stats and schema
- Update `V2CheckpointProvider.apply` to pass the stored sidecar schema to `getParquetSchema` for schema resolution


## How was this patch tested?

Unit tests. 

## Does this PR introduce _any_ user-facing changes?

No.
