### PR TITLE
[Spark] Fix NoClassDefFoundError for IgnoreCachedData on Spark 4.1.2

### DIFF
--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -276,7 +276,7 @@ object SparkVersionSpec {
   )
 
   private val spark41 = SparkVersionSpec(
-    fullVersion = "4.1.0",
+    fullVersion = "4.1.2",
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.1"),
     supportIceberg = true,

--- a/spark/src/main/scala-shims/spark-4.1/IgnoreCachedDataShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1/IgnoreCachedDataShim.scala
@@ -16,10 +16,18 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 /**
- * Shim for Spark's `IgnoreCachedData` trait. On Spark 4.1 this aliases the real
- * trait so `CacheManager` continues to skip these plans during cache replacement.
- * On Spark 4.2 (SPARK-54812) the trait was removed because `CacheManager` now
- * automatically skips any `Command`-derived plan, so the 4.2 variant of this
- * shim is an empty marker.
+ * Shim for Spark's `IgnoreCachedData` trait. As of Spark 4.1.2 (SPARK-54812,
+ * cherry-picked to branch-4.1) the trait was removed because `CacheManager`
+ * now automatically skips any `Command`-derived plan during cache replacement.
+ * This empty marker trait keeps Delta commands source-compatible across Spark
+ * 4.1.x and 4.2.x without affecting behavior: all Delta commands that
+ * previously mixed in `IgnoreCachedData` already extend
+ * `RunnableCommand`/`Command` and are therefore handled by the new automatic
+ * path.
+ *
+ * Prior to SPARK-54812 (Spark 4.1.0 / 4.1.1) this shim extended the real
+ * `IgnoreCachedData` trait, but doing so on 4.1.2+ triggers
+ * `NoClassDefFoundError` at class-load time because the parent trait no
+ * longer exists in the Spark bytecode.
  */
-trait IgnoreCachedDataShim extends IgnoreCachedData
+trait IgnoreCachedDataShim


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Spark 4.1 variant of `IgnoreCachedDataShim` still extended Spark's
`IgnoreCachedData` trait:

```scala
trait IgnoreCachedDataShim extends IgnoreCachedData
```

SPARK-54812 was cherry-picked into Spark `branch-4.1` and shipped in
**4.1.2**, removing that trait — `CacheManager` now automatically skips any
`Command`-derived plan during cache replacement, so the marker is no longer
needed. Because the shim still referenced the removed parent, every Delta
command that mixes in `IgnoreCachedDataShim` (all the `ALTER TABLE` commands,
`DeltaReorgTableCommand`, etc.) fails to class-load against Spark 4.1.2:

```
java.lang.NoClassDefFoundError: org/apache/spark/sql/catalyst/plans/logical/IgnoreCachedData
```

This makes Delta unusable on Spark 4.1.2 for any DDL path going through those
commands (e.g. `AbstractDeltaCatalog.alterTable`).

This PR makes the 4.1 shim an empty marker trait, matching the existing 4.2
shim. All affected Delta commands already extend `RunnableCommand` / `Command`,
so they continue to be skipped by `CacheManager`'s new automatic path — no
behavior change.

It also bumps `spark41.fullVersion` from `4.1.0` to `4.1.2` in
`project/CrossSparkVersions.scala` so CI compiles and tests against 4.1.2 and
catches this class of branch-4.1 cherry-pick regression going forward.

Resolves #6888

## How was this patch tested?

Compiled and ran the affected DDL path against Spark 4.1.2 locally:

```
build/sbt -DsparkVersion=4.1 \
  'spark/testOnly org.apache.spark.sql.delta.DeltaAlterTableByNameSuite -- -z "ADD COLUMNS"'
```

```
[info] DeltaAlterTableByNameSuite:
[info] - ADD COLUMNS - with positions
[info] - ADD COLUMNS - with positions using an added column
[info] Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

`ADD COLUMNS` instantiates `AlterTableAddColumnsDeltaCommand`, which mixes in
`IgnoreCachedDataShim`; before this fix the suite aborts at class-load with the
`NoClassDefFoundError` above. The bumped CI matrix (`4.1.2`) now exercises this
path on every build.

## Does this PR introduce _any_ user-facing changes?

No. The change restores Delta's ability to load on Spark 4.1.2; there is no
change in behavior on any already-working version.
