### PR TITLE
Auto-resolve responseFormat for CDF queries

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -348,8 +348,10 @@ private[sharing] class DeltaSharingDataSource
     val options = new DeltaSharingOptions(parameters)
 
     val userInputResponseFormat = options.options.get(DeltaSharingOptions.RESPONSE_FORMAT)
-    if (userInputResponseFormat.isEmpty && !options.readChangeFeed) {
-      return autoResolveBaseRelationForSnapshotQuery(options, sqlContext)
+
+    if (userInputResponseFormat.isEmpty &&
+      (!options.readChangeFeed || shouldAutoResolveCDF(options, sqlContext))) {
+      return autoResolveBaseRelation(options, sqlContext)
     }
 
     val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
@@ -423,6 +425,20 @@ private[sharing] class DeltaSharingDataSource
   }
 
   /**
+   * Whether a CDF query should auto-resolve its response format (parquet vs delta) by asking the
+   * server, rather than falling back to the legacy parquet path. True only for change-feed reads
+   * with the CDF auto-resolve flag enabled.
+   */
+  private def shouldAutoResolveCDF(
+      options: DeltaSharingOptions,
+      sqlContext: SQLContext): Boolean = {
+    options.readChangeFeed && sqlContext.sparkSession.sessionState.conf.getConf(
+      DeltaSQLConf.DELTA_SHARING_ENABLE_AUTO_RESOLVE_FOR_CDF
+    )
+  }
+
+  /**
+   * Auto-resolves the response format for a batch query (snapshot or CDF).
    * "parquet format sharing" leverages the existing set of remote classes to directly handle the
    * list of presigned urls and read data.
    * "delta format sharing" instead constructs a local delta log and leverages the delta library to
@@ -431,27 +447,44 @@ private[sharing] class DeltaSharingDataSource
    * of the shared table by the server (based on whether there are advanced delta features in the
    * shared table), and then decide the code path on the client side.
    */
-  private def autoResolveBaseRelationForSnapshotQuery(
+  private def autoResolveBaseRelation(
       options: DeltaSharingOptions,
       sqlContext: SQLContext): BaseRelation = {
     val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
-    logInfo(s"autoResolving BaseRelation for path:${path}, " +
+    val queryKind = if (options.readChangeFeed) "cdf query" else "snapshot query"
+    logInfo(s"autoResolving BaseRelation for $queryKind, path:${path}, " +
       s"with options:${DeltaSharingDataSource.redactOptions(options.options)}.")
     val parsedPath =
       DeltaSharingRestClient.parsePath(path, options.shareCredentialsOptions)
+
+    // For a CDF query, pin getMetadata to the end of the CDF range so the returned
+    // schema/protocol matches what the downstream CDF reader will see. Fall back to None
+    // (= latest) when no ending boundary is given.
+    val (pinnedMetadataVersion, pinnedMetadataTimestamp) = if (options.readChangeFeed) {
+      val endingVersion = options.cdfOptions.get(DeltaDataSource.CDC_END_VERSION_KEY).map(_.toLong)
+      val endingTimestamp = options.cdfOptions.get(DeltaDataSource.CDC_END_TIMESTAMP_KEY)
+      if (endingVersion.isDefined) (endingVersion, None)
+      else if (endingTimestamp.isDefined) (None, endingTimestamp)
+      else (None, None)
+    } else {
+      (options.versionAsOf, options.timestampAsOf)
+    }
+    logInfo(s"Pinning getMetadata for $queryKind to " +
+      s"pinnedMetadataVersion:$pinnedMetadataVersion, " +
+      s"pinnedMetadataTimestamp:$pinnedMetadataTimestamp.")
 
     val (dsTable, deltaTableMetadata) = createClientAndQueryMetadata(
       sqlContext = sqlContext,
       parsedPath = parsedPath,
       shareCredentialsOptions = options.shareCredentialsOptions,
       forStreaming = false,
-      versionAsOf = options.versionAsOf,
-      timestampAsOf = options.timestampAsOf,
+      versionAsOf = pinnedMetadataVersion,
+      timestampAsOf = pinnedMetadataTimestamp,
       callerOrg = options.callerOrg
     )
 
     if (deltaTableMetadata.respondedFormat == DeltaSharingOptions.RESPONSE_FORMAT_PARQUET) {
-      logInfo(s"Resolved as parquet format for table path:$path, " +
+      logInfo(s"Resolved $queryKind as parquet format for table path:$path, " +
         s"parameters:${DeltaSharingDataSource.redactOptions(options.options)}")
       val deltaLog = RemoteDeltaLog(
         path = path,
@@ -463,12 +496,8 @@ private[sharing] class DeltaSharingDataSource
       )
       deltaLog.createRelation(options.versionAsOf, options.timestampAsOf, options.cdfOptions)
     } else if (deltaTableMetadata.respondedFormat == DeltaSharingOptions.RESPONSE_FORMAT_DELTA) {
-      logInfo(s"Resolved as delta format for table path:$path, " +
+      logInfo(s"Resolved $queryKind as delta format for table path:$path, " +
         s"parameters:${DeltaSharingDataSource.redactOptions(options.options)}")
-      val deltaSharingTableMetadata = DeltaSharingUtils.getDeltaSharingTableMetadata(
-        table = dsTable,
-        deltaTableMetadata = deltaTableMetadata
-      )
       val deltaOnlyClient = DeltaSharingRestClient(
         profileFile = parsedPath.profileFile,
         shareCredentialsOptions = options.shareCredentialsOptions,
@@ -480,13 +509,21 @@ private[sharing] class DeltaSharingDataSource
         readerFeatures = DeltaSharingUtils.SUPPORTED_READER_FEATURES.mkString(","),
         callerOrg = options.callerOrg
       )
-      getHadoopFsRelationForDeltaSnapshotQuery(
-        path = path,
-        options = options,
-        dsTable = dsTable,
-        client = deltaOnlyClient,
-        deltaSharingTableMetadata = deltaSharingTableMetadata
-      )
+      if (options.readChangeFeed) {
+        DeltaSharingCDFUtils.prepareCDFRelation(sqlContext, options, dsTable, deltaOnlyClient)
+      } else {
+        val deltaSharingTableMetadata = DeltaSharingUtils.getDeltaSharingTableMetadata(
+          table = dsTable,
+          deltaTableMetadata = deltaTableMetadata
+        )
+        getHadoopFsRelationForDeltaSnapshotQuery(
+          path = path,
+          options = options,
+          dsTable = dsTable,
+          client = deltaOnlyClient,
+          deltaSharingTableMetadata = deltaSharingTableMetadata
+        )
+      }
     } else {
       throw new UnsupportedOperationException(
         s"Unexpected respondedFormat for getMetadata rpc:${deltaTableMetadata.respondedFormat}."

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -1038,6 +1038,250 @@ trait DeltaSharingDataSourceDeltaSuiteBase
     }
   }
 
+  test("DeltaSharingDataSource auto-resolves responseFormat for cdf query gated by flag") {
+    withTempDir { tempDir =>
+      for (autoResolveEnabled <- Seq(true, false)) {
+        val suffix = if (autoResolveEnabled) "on" else "off"
+        val deltaTableName = s"delta_table_cdf_autoresolve_$suffix"
+        withTable(deltaTableName) {
+          sql(s"""
+                 |CREATE TABLE $deltaTableName (c1 INT, c2 STRING) USING DELTA PARTITIONED BY (c2)
+                 |TBLPROPERTIES (
+                 |  delta.enableChangeDataFeed = true,
+                 |  delta.enableDeletionVectors = true
+                 |)
+                 |""".stripMargin)
+          sql(s"""INSERT INTO $deltaTableName VALUES (1, "one"), (2, "two")""")
+          sql(s"""INSERT INTO $deltaTableName VALUES (3, "two")""")
+          sql(s"""UPDATE $deltaTableName SET c2="new two" where c1=2""")
+          sql(s"""DELETE FROM $deltaTableName WHERE c1 = 2""")
+
+          val sharedTableName = s"shared_cdf_autoresolve_$suffix"
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+          val autoResolveConf = Map(
+            DeltaSQLConf.DELTA_SHARING_ENABLE_AUTO_RESOLVE_FOR_CDF.key ->
+              autoResolveEnabled.toString
+          )
+
+          val expectedSchema: StructType = new StructType()
+            .add("c1", IntegerType)
+            .add("c2", StringType)
+            .add("_change_type", StringType)
+            .add("_commit_version", LongType)
+            .add("_commit_timestamp", TimestampType)
+
+          // Versions: v0 CREATE, v1/v2 INSERT, v3 UPDATE, v4 DELETE. Read CDF from v1, and use v3
+          // as the (inclusive) end bound for the bounded cases so it excludes the v4 delete.
+          val startVersion = 1L
+          val endVersion = 3L
+          def isoTimestampForVersion(version: Long): String =
+            DateTimeUtils
+              .toJavaTimestamp(getTimeStampForVersion(deltaTableName, version) * 1000)
+              .toInstant
+              .toString
+          val startTimestamp = isoTimestampForVersion(startVersion)
+          val endTimestamp = isoTimestampForVersion(endVersion)
+
+          // Auto-resolve calls getMetadata to learn the server's preferred format, pinned to the
+          // end of the CDF range (latest when unbounded), and the legacy parquet RemoteDeltaLog
+          // also calls getMetadata on init. Mock every boundary the cases below exercise.
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          prepareMockedClientMetadata(
+            deltaTableName,
+            sharedTableName,
+            versionAsOf = Some(endVersion)
+          )
+          prepareMockedClientMetadata(
+            deltaTableName,
+            sharedTableName,
+            timestampAsOf = Some(endTimestamp)
+          )
+
+          // Flatten an exception and its causes into the concatenated message text, so assertions
+          // can look for a marker anywhere in the chain regardless of wrapping.
+          def causeChain(ex: Throwable): String =
+            Iterator
+              .iterate[Throwable](ex)(t => if (t == null) null else t.getCause)
+              .takeWhile(_ != null)
+              .map(t => Option(t.getMessage).getOrElse(""))
+              .mkString("\n")
+
+          val versionOnlyOpts = Seq("startingVersion" -> startVersion.toString)
+          val versionRangeOpts =
+            Seq("startingVersion" -> startVersion.toString, "endingVersion" -> endVersion.toString)
+          val timestampOnlyOpts = Seq("startingTimestamp" -> startTimestamp)
+          val timestampRangeOpts =
+            Seq("startingTimestamp" -> startTimestamp, "endingTimestamp" -> endTimestamp)
+
+          // (label, options applied to the sharing read, options applied to the expected delta
+          // read). Timestamp-based sharing reads are compared against the equivalent version
+          // bounds on the delta side to avoid depending on delta's timestamp-resolution edges.
+          val cdfCases = Seq(
+            ("startingVersion, no end", versionOnlyOpts, versionOnlyOpts),
+            ("startingVersion, endingVersion", versionRangeOpts, versionRangeOpts),
+            ("startingTimestamp, no end", timestampOnlyOpts, versionOnlyOpts),
+            ("startingTimestamp, endingTimestamp", timestampRangeOpts, versionRangeOpts)
+          )
+
+          for ((label, sharingOptions, deltaOptions) <- cdfCases) {
+            // The test client keys getCDFFiles on the starting bound only, so register the
+            // starting timestamp block when needed, and bound the mocked files by endingVersion
+            // so an ending bound is reflected in what the server returns (the local delta CDF read
+            // derives its end from those files, not from the request option).
+            val mockStartTimestamp =
+              sharingOptions.collectFirst { case ("startingTimestamp", value) => value }
+            val mockEndingVersion =
+              if (deltaOptions.exists(_._1 == "endingVersion")) Some(endVersion) else None
+            prepareMockedClientAndFileSystemResultForCdf(
+              deltaTableName,
+              sharedTableName,
+              startVersion,
+              startingTimestamp = mockStartTimestamp,
+              endingVersion = mockEndingVersion
+            )
+
+            if (autoResolveEnabled) {
+              def testAutoResolveCdf(tablePath: String): Unit = {
+                val sharingDf = spark.read
+                  .format("deltaSharing")
+                  .option("readChangeFeed", "true")
+                  .options(sharingOptions.toMap)
+                  .load(tablePath)
+                assert(sharingDf.schema == expectedSchema, s"schema mismatch for case: $label")
+
+                val expected = spark.read
+                  .format("delta")
+                  .option("readChangeFeed", "true")
+                  .options(deltaOptions.toMap)
+                  .table(deltaTableName)
+                checkAnswer(sharingDf, expected)
+                assert(sharingDf.count() > 0, s"expected non-empty result for case: $label")
+              }
+
+              withSQLConf((autoResolveConf ++ getDeltaSharingClassesSQLConf).toSeq: _*) {
+                val profileFile = prepareProfileFile(tempDir)
+                testAutoResolveCdf(
+                  profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+                )
+              }
+            } else {
+              withSQLConf((autoResolveConf ++ getDeltaSharingClassesSQLConf).toSeq: _*) {
+                val profileFile = prepareProfileFile(tempDir)
+                val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+                // With flag off + no responseFormat, the query falls through to the legacy parquet
+                // path. The OSS parquet RemoteDeltaLog receives the delta-format response from
+                // TestClientForDeltaFormatSharing (the test client always responds delta) and dies
+                // initializing its RemoteSnapshot. That failure proves the auto-resolve gate did
+                // NOT fire: had it fired, the request would have succeeded via the delta CDF path
+                // (as the flag-on branch demonstrates).
+                val ex = intercept[Exception] {
+                  spark.read
+                    .format("deltaSharing")
+                    .option("readChangeFeed", "true")
+                    .options(sharingOptions.toMap)
+                    .load(tablePath)
+                    .collect()
+                }
+                val chain = causeChain(ex)
+                assert(
+                  chain.contains("RemoteSnapshot"),
+                  s"Expected the legacy parquet path (RemoteSnapshot) to surface for case " +
+                    s"$label; got:\n$chain"
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("DeltaSharingDataSource reads cdf from a parquet-format shared table " +
+    "regardless of auto-resolve flag") {
+    withTempDir { tempDir =>
+      // A parquet-format shared table has no advanced delta features, so a CDF read lands on the
+      // legacy parquet path either way: with the flag on it is resolved to parquet via getMetadata,
+      // and with the flag off it is the default parquet fall-through. Both should read the
+      // parquet-format CDF response end-to-end and match a direct Delta CDF read.
+      for (autoResolveEnabled <- Seq(true, false)) {
+        val suffix = if (autoResolveEnabled) "on" else "off"
+        val deltaTableName = s"delta_table_cdf_parquet_$suffix"
+        withTable(deltaTableName) {
+          // Mimic a parquet-format table: change data feed on, deletion vectors off (a real
+          // parquet-format share cannot carry advanced features like deletion vectors).
+          sql(s"""
+                 |CREATE TABLE $deltaTableName (c1 INT, c2 STRING) USING DELTA PARTITIONED BY (c2)
+                 |TBLPROPERTIES (
+                 |  delta.enableChangeDataFeed = true,
+                 |  delta.enableDeletionVectors = false
+                 |)
+                 |""".stripMargin)
+          sql(s"""INSERT INTO $deltaTableName VALUES (1, "one"), (2, "two")""")
+          sql(s"""INSERT INTO $deltaTableName VALUES (3, "two")""")
+          sql(s"""UPDATE $deltaTableName SET c2="new two" where c1=2""")
+          sql(s"""DELETE FROM $deltaTableName WHERE c1 = 2""")
+
+          val startVersion = 1L
+          val parquetSharedTable = s"shared_parquet_table_cdf_$suffix"
+          prepareMockedClientGetTableVersion(deltaTableName, parquetSharedTable)
+          // getMetadata responds parquet (SingleAction-shaped) -- used by the auto-resolve probe
+          // (flag on) and by the legacy parquet RemoteSnapshot init (flag off).
+          prepareMockedClientAndFileSystemResultForParquet(deltaTableName, parquetSharedTable)
+          // Parquet-format CDF response so the parquet CDF reader can read it end-to-end.
+          prepareMockedClientAndFileSystemResultForCdf(
+            deltaTableName,
+            parquetSharedTable,
+            startVersion,
+            responseFormat = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET
+          )
+
+          val autoResolveConf = Map(
+            DeltaSQLConf.DELTA_SHARING_ENABLE_AUTO_RESOLVE_FOR_CDF.key ->
+              autoResolveEnabled.toString
+          )
+
+          // The legacy parquet CDF reader surfaces the same CDF columns but orders them differently
+          // and emits _commit_timestamp as epoch-millis (LongType) rather than delta's
+          // TimestampType, so compare on the columns whose representation is identical, and assert
+          // on the column set rather than strict schema equality.
+          val cdfColumns = Seq("c1", "c2", "_change_type", "_commit_version")
+          val expectedColumns =
+            Set("c1", "c2", "_change_type", "_commit_version", "_commit_timestamp")
+
+          def testParquetCdf(tablePath: String): Unit = {
+            val sharingDf = spark.read
+              .format("deltaSharing")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", startVersion)
+              .load(tablePath)
+            assert(
+              sharingDf.columns.toSet == expectedColumns,
+              s"unexpected columns for parquet cdf read: ${sharingDf.columns.mkString(",")}"
+            )
+
+            val expected = spark.read
+              .format("delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", startVersion)
+              .table(deltaTableName)
+              .select(cdfColumns.map(col): _*)
+            val sharingCdf = sharingDf.select(cdfColumns.map(col): _*)
+            checkAnswer(sharingCdf, expected)
+            assert(sharingCdf.count() > 0, "expected non-empty result for parquet cdf read")
+          }
+
+          withSQLConf((autoResolveConf ++ getDeltaSharingClassesSQLConf).toSeq: _*) {
+            val profileFile = prepareProfileFile(tempDir)
+            testParquetCdf(
+              profileFile.getCanonicalPath + s"#share1.default.$parquetSharedTable"
+            )
+          }
+        }
+      }
+    }
+  }
+
   test("DeltaSharingDataSource able to read data for cdf query with more entries") {
     withTempDir { tempDir =>
       val deltaTableName = "delta_table_cdf_more"

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -38,9 +38,12 @@ import org.apache.spark.sql.delta.deletionvectors.{
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import com.google.common.hash.Hashing
 import io.delta.sharing.client.model.{
+  AddCDCFile => ClientAddCDCFile,
   AddFile => ClientAddFile,
+  AddFileForCDF => ClientAddFileForCDF,
   Metadata => ClientMetadata,
-  Protocol => ClientProtocol
+  Protocol => ClientProtocol,
+  RemoveFile => ClientRemoveFile
 }
 import io.delta.sharing.spark.model.{
   DeltaSharingFileAction,
@@ -183,17 +186,20 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
   private[spark] def prepareMockedClientMetadata(
       deltaTable: String,
       sharedTable: String,
-      versionAsOf: Option[Long] = None): Unit = {
+      versionAsOf: Option[Long] = None,
+      timestampAsOf: Option[String] = None): Unit = {
     val snapshotToUse = getSnapshotToUse(deltaTable, versionAsOf)
     val dsProtocol: DeltaSharingProtocol = DeltaSharingProtocol(snapshotToUse.protocol)
     val dsMetadata: DeltaSharingMetadata = DeltaSharingMetadata(
       deltaMetadata = snapshotToUse.metadata
     )
 
-    // Put the metadata in blockManager for DeltaSharingClient to return for getMetadata.
+    // Put the metadata in blockManager for DeltaSharingClient to return for getMetadata. The block
+    // is keyed by versionAsOf/timestampAsOf so callers can mock the getMetadata pinned to a
+    // specific boundary (e.g. the end of a CDF range).
     DeltaSharingUtils.overrideIteratorBlock[String](
       blockId = TestClientForDeltaFormatSharing.getBlockId(
-        sharedTable, "getMetadata", versionAsOf = versionAsOf),
+        sharedTable, "getMetadata", versionAsOf = versionAsOf, timestampAsOf = timestampAsOf),
       values = Seq(dsProtocol.json, dsMetadata.json).toIterator
     )
   }
@@ -548,13 +554,34 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
     )
   }
 
+  // Convert a delta Metadata to the parquet-wire client Metadata used in parquet-format responses.
+  private def getClientMetadataForParquet(
+      deltaMetadata: Metadata,
+      size: java.lang.Long = null): ClientMetadata = {
+    ClientMetadata(
+      id = deltaMetadata.id,
+      name = deltaMetadata.name,
+      description = deltaMetadata.description,
+      schemaString = deltaMetadata.schemaString,
+      configuration = deltaMetadata.configuration,
+      partitionColumns = deltaMetadata.partitionColumns,
+      size = size
+    )
+  }
+
   private[spark] def prepareMockedClientAndFileSystemResultForCdf(
       deltaTable: String,
       sharedTable: String,
       startingVersion: Long,
       startingTimestamp: Option[String] = None,
       inlineDvFormat: Option[RoaringBitmapArrayFormat.Value] = None,
-      assertMultipleDvsInOneFile: Boolean = false): Unit = {
+      assertMultipleDvsInOneFile: Boolean = false,
+      endingVersion: Option[Long] = None,
+      responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_DELTA): Unit = {
+    val parquetFormat = responseFormat == DeltaSharingOptions.RESPONSE_FORMAT_PARQUET
+    // File action lines (plus any mid-range metadata changes), in commit order. The protocol and
+    // metadata header is prepended after the walk because the parquet metadata carries the
+    // accumulated table size, which is only known once all file actions are seen.
     val actionLines = Seq.newBuilder[String]
 
     var maxVersion = -1L
@@ -562,11 +589,6 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
 
     val deltaLog = DeltaLog.forTable(spark, new TableIdentifier(deltaTable))
     val startingSnapshot = deltaLog.getSnapshotAt(startingVersion)
-    actionLines += DeltaSharingProtocol(deltaProtocol = startingSnapshot.protocol).json
-    actionLines += DeltaSharingMetadata(
-      deltaMetadata = startingSnapshot.metadata,
-      version = startingVersion
-    ).json
 
     val dvPathToCount = scala.collection.mutable.Map[String, Int]()
     val files =
@@ -574,19 +596,32 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
     files.foreach { f =>
       if (FileNames.isDeltaFile(new Path(f.getName))) {
         val version = FileNames.getFileVersion(new Path(f.getName))
-        if (version >= startingVersion) {
+        if (version >= startingVersion && endingVersion.forall(version <= _)) {
           // protocol/metadata are processed from startingSnapshot, only process versions greater
-          // than startingVersion for real actions and possible metadata changes.
+          // than startingVersion for real actions and possible metadata changes. When endingVersion
+          // is set, skip versions past it so the mocked response is bounded like a server that
+          // honors the endingVersion/endingTimestamp request bound.
           maxVersion = maxVersion.max(version)
           val timestamp = f.lastModified
-          FileUtils.readLines(f).asScala.foreach { l =>
-            val action = Action.fromJson(l)
+          val versionActions = FileUtils.readLines(f).asScala.toSeq.map(Action.fromJson)
+          // A commit that produced CDC files (_change_data) is authoritative for CDF via those
+          // files; delta's CDF reader then ignores the data-rewrite add/remove of that commit (e.g.
+          // a partition-changing UPDATE rewrites files AND writes update_pre/postimage CDC). The
+          // delta-format response carries everything and lets the delta reader sort it out, but the
+          // parquet CDF reader has no such logic, so for parquet we skip those add/remove files to
+          // avoid double-counting them as insert/delete.
+          val versionHasCdc = versionActions.exists(_.isInstanceOf[AddCDCFile])
+          versionActions.foreach { action =>
             action match {
               case m: Metadata =>
-                actionLines += DeltaSharingMetadata(
-                  deltaMetadata = m,
-                  version = version
-                ).json
+                if (parquetFormat) {
+                  actionLines += JsonUtils.toJson(getClientMetadataForParquet(m).wrap)
+                } else {
+                  actionLines += DeltaSharingMetadata(
+                    deltaMetadata = m,
+                    version = version
+                  ).json
+                }
               case addFile: AddFile if addFile.dataChange =>
                 if (assertMultipleDvsInOneFile) {
                   updateDvPathToCount(addFile, dvPathToCount)
@@ -597,37 +632,84 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
                 } else {
                   addFile
                 }
-                val dsAddFile =
-                  getDeltaSharingFileActionForAddFile(updatedAdd, sharedTable, version, timestamp)
                 totalSize = totalSize + updatedAdd.size
-                actionLines += dsAddFile.json
+                if (parquetFormat) {
+                  // Skip data-rewrite adds when the commit's change is captured by CDC files.
+                  if (!versionHasCdc) {
+                    val parquetFile = removePartitionPrefix(updatedAdd.path)
+                    actionLines += JsonUtils.toJson(
+                      ClientAddFileForCDF(
+                        url = TestDeltaSharingFileSystem.encode(sharedTable, parquetFile),
+                        id = Hashing.md5().hashString(parquetFile, UTF_8).toString,
+                        partitionValues = updatedAdd.partitionValues,
+                        size = updatedAdd.size,
+                        version = version,
+                        timestamp = timestamp
+                      ).wrap
+                    )
+                  }
+                } else {
+                  val dsAddFile =
+                    getDeltaSharingFileActionForAddFile(updatedAdd, sharedTable, version, timestamp)
+                  actionLines += dsAddFile.json
+                }
               case removeFile: RemoveFile if removeFile.dataChange =>
                 // scalastyle:off removeFile
-                val dsRemoveFile = getDeltaSharingFileActionForRemoveFile(
-                  removeFile,
-                  sharedTable,
-                  version,
-                  timestamp
-                )
-                // scalastyle:on removeFile
                 totalSize = totalSize + removeFile.size.getOrElse(0L)
-                actionLines += dsRemoveFile.json
+                if (parquetFormat) {
+                  // Skip data-rewrite removes when the commit's change is captured by CDC files.
+                  if (!versionHasCdc) {
+                    val parquetFile = removePartitionPrefix(removeFile.path)
+                    actionLines += JsonUtils.toJson(
+                      ClientRemoveFile(
+                        url = TestDeltaSharingFileSystem.encode(sharedTable, parquetFile),
+                        id = Hashing.md5().hashString(parquetFile, UTF_8).toString,
+                        partitionValues =
+                          Option(removeFile.partitionValues).getOrElse(Map.empty[String, String]),
+                        size = removeFile.size.getOrElse(0L),
+                        version = version,
+                        timestamp = timestamp
+                      ).wrap
+                    )
+                  }
+                } else {
+                  val dsRemoveFile = getDeltaSharingFileActionForRemoveFile(
+                    removeFile,
+                    sharedTable,
+                    version,
+                    timestamp
+                  )
+                  actionLines += dsRemoveFile.json
+                }
+                // scalastyle:on removeFile
               case cdcFile: AddCDCFile =>
                 val parquetFile = removePartitionPrefix(cdcFile.path)
-
-                // Convert from delta AddCDCFile to DeltaSharingFileAction to serialize to json.
-                val dsCDCFile = DeltaSharingFileAction(
-                  id = Hashing.sha256().hashString(parquetFile, UTF_8).toString,
-                  version = version,
-                  timestamp = timestamp,
-                  deltaSingleAction = cdcFile
-                    .copy(
-                      path = TestDeltaSharingFileSystem.encode(sharedTable, parquetFile)
-                    )
-                    .wrap
-                )
                 totalSize = totalSize + cdcFile.size
-                actionLines += dsCDCFile.json
+                if (parquetFormat) {
+                  actionLines += JsonUtils.toJson(
+                    ClientAddCDCFile(
+                      url = TestDeltaSharingFileSystem.encode(sharedTable, parquetFile),
+                      id = Hashing.md5().hashString(parquetFile, UTF_8).toString,
+                      partitionValues = cdcFile.partitionValues,
+                      size = cdcFile.size,
+                      version = version,
+                      timestamp = timestamp
+                    ).wrap
+                  )
+                } else {
+                  // Convert from delta AddCDCFile to DeltaSharingFileAction to serialize to json.
+                  val dsCDCFile = DeltaSharingFileAction(
+                    id = Hashing.sha256().hashString(parquetFile, UTF_8).toString,
+                    version = version,
+                    timestamp = timestamp,
+                    deltaSingleAction = cdcFile
+                      .copy(
+                        path = TestDeltaSharingFileSystem.encode(sharedTable, parquetFile)
+                      )
+                      .wrap
+                  )
+                  actionLines += dsCDCFile.json
+                }
               case _ => // ignore other lines
             }
           }
@@ -651,10 +733,28 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
       assert(dvPathToCount.max._2 > 1)
     }
 
+    // Prepend the protocol/metadata header. For parquet the metadata carries the table size, which
+    // is only known after walking the file actions above; for delta it mirrors the prior behavior.
+    val headerLines = if (parquetFormat) {
+      Seq(
+        JsonUtils.toJson(ClientProtocol(minReaderVersion = 1).wrap),
+        JsonUtils.toJson(getClientMetadataForParquet(startingSnapshot.metadata, totalSize).wrap)
+      )
+    } else {
+      Seq(
+        DeltaSharingProtocol(deltaProtocol = startingSnapshot.protocol).json,
+        DeltaSharingMetadata(
+          deltaMetadata = startingSnapshot.metadata,
+          version = startingVersion
+        ).json
+      )
+    }
+    val resultLines = headerLines ++ actionLines.result()
+
     DeltaSharingUtils.overrideIteratorBlock[String](
       blockId =
         TestClientForDeltaFormatSharing.getBlockId(sharedTable, s"getCDFFiles_$startingVersion"),
-      values = actionLines.result().toIterator
+      values = resultLines.toIterator
     )
     if (startingTimestamp.isDefined) {
       DeltaSharingUtils.overrideIteratorBlock[String](
@@ -662,7 +762,7 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
           sharedTable,
           s"getCDFFiles_${startingTimestamp.get}"
         ),
-        values = actionLines.result().toIterator
+        values = resultLines.toIterator
       )
     }
   }

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -26,9 +26,13 @@ import io.delta.sharing.client.{
   DeltaSharingRestClient
 }
 import io.delta.sharing.client.model.{
+  AddCDCFile => ClientAddCDCFile,
   AddFile => ClientAddFile,
+  AddFileForCDF => ClientAddFileForCDF,
   DeltaTableFiles,
   DeltaTableMetadata,
+  Metadata => ClientMetadata,
+  RemoveFile => ClientRemoveFile,
   SingleAction,
   Table,
   TemporaryCredentials
@@ -289,11 +293,41 @@ private[spark] class TestClientForDeltaFormatSharing(
     while (iterator.hasNext) {
       linesBuilder += iterator.next()
     }
-    DeltaTableFiles(
-      version = getTableVersion(table),
-      lines = linesBuilder.result(),
-      respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA
-    )
+    if (table.name.contains("shared_parquet_table") &&
+      responseFormat.contains(DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET)) {
+      val lines = linesBuilder.result()
+      val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
+      val metadata = JsonUtils.fromJson[SingleAction](lines(1)).metaData
+      val addFiles = ArrayBuffer[ClientAddFileForCDF]()
+      val cdfFiles = ArrayBuffer[ClientAddCDCFile]()
+      val removeFiles = ArrayBuffer[ClientRemoveFile]()
+      val additionalMetadatas = ArrayBuffer[ClientMetadata]()
+      lines.drop(2).foreach { line =>
+        JsonUtils.fromJson[SingleAction](line).unwrap match {
+          case c: ClientAddCDCFile => cdfFiles.append(c)
+          case a: ClientAddFileForCDF => addFiles.append(a)
+          case r: ClientRemoveFile => removeFiles.append(r)
+          case m: ClientMetadata => additionalMetadatas.append(m)
+          case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
+        }
+      }
+      DeltaTableFiles(
+        version = getTableVersion(table),
+        protocol = protocol,
+        metadata = metadata,
+        addFiles = addFiles.toSeq,
+        cdfFiles = cdfFiles.toSeq,
+        removeFiles = removeFiles.toSeq,
+        additionalMetadatas = additionalMetadatas.toSeq,
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET
+      )
+    } else {
+      DeltaTableFiles(
+        version = getTableVersion(table),
+        lines = linesBuilder.result(),
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA
+      )
+    }
   }
 
   override def generateTemporaryTableCredential(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3140,6 +3140,16 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_SHARING_ENABLE_AUTO_RESOLVE_FOR_CDF =
+    buildConf("spark.sql.delta.sharing.enableAutoResolveForCdf")
+      .doc("When true, Delta Sharing CDF queries without an explicit responseFormat will " +
+        "call getMetadata on the sharing server and pick the parquet or delta CDF code path " +
+        "based on the server's responded format. When false, CDF queries without a response " +
+        "format fall back to the legacy parquet path.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   ///////////////////
   // IDENTITY COLUMN
   ///////////////////


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DeltaSharingDataSource.createRelation` currently auto-resolves the `responseFormat` (parquet vs delta) only for snapshot queries; CDF queries are explicitly excluded. As a result, a CDF read without an explicit `responseFormat` (e.g. `spark.read.option("readChangeFeed", "true").table(...)`) always falls into the legacy parquet path. For shared tables that require delta-format responses (deletion vectors, column mapping, ...), this picks the wrong path and the query fails or returns an incorrect schema.

This PR extends auto-resolve to CDF queries:

- Adds `spark.sql.delta.sharing.enableAutoResolveForCdf` (internal, default `false`) in `DeltaSQLConf`. When enabled, a CDF query without an explicit response format calls `getMetadata` on the sharing server and selects the parquet or delta CDF code path based on the server's responded format.
- Generalizes `autoResolveBaseRelationForSnapshotQuery` into `autoResolveBaseRelation`, covering both snapshot and CDF queries. For CDF, `getMetadata` is pinned to the end of the CDF range (ending version, else ending timestamp, else latest) so the resolved schema/protocol matches what the CDF reader will see; the delta path routes through `DeltaSharingCDFUtils.prepareCDFRelation`.

## How was this patch tested?

New tests in `DeltaSharingDataSourceDeltaSuite` exercise the CDF auto-resolve path end-to-end for both parquet-resolved and delta-resolved responses, with supporting helpers in `DeltaSharingDataSourceDeltaTestUtils` and `TestClientForDeltaFormatSharing`.
