### PR TITLE
fix: case-insensitive column lookup in StatsSchemaHelper

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -166,14 +166,18 @@ public class StatsSchemaHelper {
         logicalToPhysicalColumnAndDataType.entrySet().stream()
             .collect(
                 Collectors.toMap(
-                    Map.Entry::getKey, e -> e.getValue()._1 // map to just the column
-                    ));
+                    Map.Entry::getKey,
+                    e -> e.getValue()._1, // map to just the column
+                    (v1, v2) -> v1,
+                    () -> new TreeMap<>(CASE_INSENSITIVE_COLUMN_COMPARATOR)));
     this.logicalToDataType =
         logicalToPhysicalColumnAndDataType.entrySet().stream()
             .collect(
                 Collectors.toMap(
-                    Map.Entry::getKey, e -> e.getValue()._2 // map to just the data type
-                    ));
+                    Map.Entry::getKey,
+                    e -> e.getValue()._2, // map to just the data type
+                    (v1, v2) -> v1,
+                    () -> new TreeMap<>(CASE_INSENSITIVE_COLUMN_COMPARATOR)));
   }
 
   /**
@@ -269,6 +273,28 @@ public class StatsSchemaHelper {
   //////////////////////////////////////////////////////////////////////////////////
   // Private static fields and methods
   //////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Comparator for {@link Column} keys that compares each name component case-insensitively. This
+   * allows data-skipping lookups to find a schema column regardless of the case used in the query
+   * predicate (e.g. a filter on {@code "value"} correctly matches a schema column named {@code
+   * "Value"}).
+   */
+  private static final Comparator<Column> CASE_INSENSITIVE_COLUMN_COMPARATOR =
+      (a, b) -> {
+        String[] aNames = a.getNames();
+        String[] bNames = b.getNames();
+        if (aNames.length != bNames.length) {
+          return aNames.length - bNames.length;
+        }
+        for (int i = 0; i < aNames.length; i++) {
+          int cmp = aNames[i].compareToIgnoreCase(bNames[i]);
+          if (cmp != 0) {
+            return cmp;
+          }
+        }
+        return 0;
+      };
 
   private static final Set<String> SKIPPING_ELIGIBLE_TYPE_NAMES =
       new HashSet<String>() {
@@ -414,7 +440,7 @@ public class StatsSchemaHelper {
    */
   private Map<Column, Tuple2<Column, DataType>> getLogicalToPhysicalColumnAndDataType(
       StructType dataSchema) {
-    Map<Column, Tuple2<Column, DataType>> result = new HashMap<>();
+    Map<Column, Tuple2<Column, DataType>> result = new TreeMap<>(CASE_INSENSITIVE_COLUMN_COMPARATOR);
     for (StructField field : dataSchema.fields()) {
       if (field.getDataType() instanceof StructType) {
         Map<Column, Tuple2<Column, DataType>> nestedCols =

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
@@ -393,6 +393,48 @@ class StatsSchemaHelperSuite extends AnyFunSuite {
     assert(statsSchema == expectedStatsSchema)
   }
 
+  test("column lookups are case-insensitive when schema has mixed-case column names") {
+    // Schema columns use upper-case names; predicates typically arrive in lower-case.
+    // Without case-insensitive map keys the lookup silently misses and data skipping is disabled.
+    val dataSchema = new StructType()
+      .add("Value", IntegerType.INTEGER)
+      .add("Count", LongType.LONG)
+      .add("Label", StringType.STRING)
+
+    val helper = new StatsSchemaHelper(dataSchema)
+
+    // Lower-case lookups must succeed (the common failure mode from the bug)
+    assert(helper.isSkippingEligibleMinMaxColumn(new io.delta.kernel.expressions.Column("value")))
+    assert(helper.isSkippingEligibleNullCountColumn(new io.delta.kernel.expressions.Column("value")))
+    assert(helper.isSkippingEligibleMinMaxColumn(new io.delta.kernel.expressions.Column("count")))
+    assert(helper.isSkippingEligibleNullCountColumn(new io.delta.kernel.expressions.Column("count")))
+    assert(helper.isSkippingEligibleMinMaxColumn(new io.delta.kernel.expressions.Column("label")))
+    assert(helper.isSkippingEligibleNullCountColumn(new io.delta.kernel.expressions.Column("label")))
+
+    // Upper-case (original schema case) must still work
+    assert(helper.isSkippingEligibleMinMaxColumn(new io.delta.kernel.expressions.Column("Value")))
+    assert(helper.isSkippingEligibleNullCountColumn(new io.delta.kernel.expressions.Column("Value")))
+
+    // Mixed-case must also work
+    assert(helper.isSkippingEligibleMinMaxColumn(new io.delta.kernel.expressions.Column("VALUE")))
+    assert(helper.isSkippingEligibleNullCountColumn(new io.delta.kernel.expressions.Column("COUNT")))
+  }
+
+  test("case-insensitive column lookups work for nested struct columns") {
+    val dataSchema = new StructType()
+      .add("Parent", new StructType().add("Child", LongType.LONG))
+
+    val helper = new StatsSchemaHelper(dataSchema)
+
+    // All case variants of the nested path must resolve correctly
+    assert(helper.isSkippingEligibleMinMaxColumn(
+      new io.delta.kernel.expressions.Column(Array("parent", "child"))))
+    assert(helper.isSkippingEligibleMinMaxColumn(
+      new io.delta.kernel.expressions.Column(Array("PARENT", "CHILD"))))
+    assert(helper.isSkippingEligibleMinMaxColumn(
+      new io.delta.kernel.expressions.Column(Array("Parent", "Child"))))
+  }
+
   test("check getStatsSchema with collations - no eligible string columns") {
     val dataSchema = new StructType()
       .add("a", IntegerType.INTEGER)


### PR DESCRIPTION
## What does this PR do?

Fixes #6247 — data skipping is silently disabled when a query predicate references a column name that differs in case from the schema definition (e.g. filter on `value` when the column is named `Value`).

## Root cause

`StatsSchemaHelper` builds two lookup maps (`logicalToPhysicalColumn`, `logicalToDataType`) using `HashMap`. All lookups go through `Column.equals()`, which compares name components with `Arrays.equals()` — an exact, case-sensitive comparison.

If the schema has `Value` but the predicate arrives as `value`, `containsKey` returns `false`, `isSkippingEligibleMinMaxColumn` returns `false`, and data skipping is skipped entirely for that column.

## Fix

Replaced `HashMap` with `TreeMap` backed by a `Comparator<Column>` that compares each name part with `String.compareToIgnoreCase`. This means lookups succeed regardless of the case of the incoming column name, matching how Delta Spark handles case-insensitive column resolution.

The fix is contained entirely within `StatsSchemaHelper` — no changes to the public `Column` API.

## Tests

Added two new tests to `StatsSchemaHelperSuite`:
- `column lookups are case-insensitive when schema has mixed-case column names` — verifies flat columns
- `case-insensitive column lookups work for nested struct columns` — verifies nested column paths

## Notes

- The `(v1, v2) -> v1` merge function in `Collectors.toMap` is a no-op safety guard; duplicate keys cannot occur here since each schema field name is unique within a struct.
- cc @DrakeLin