### PR TITLE
[Spark] Enforce UC Delta API usage and clean up legacy-endpoint calls

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -1333,7 +1333,9 @@ trait SupportsPathIdentifier extends TableCatalog { self: AbstractDeltaCatalog =
       // scalastyle:on deltahadoopconfiguration
       fs.exists(path) && fs.listStatus(path).nonEmpty
     } else {
-      super.tableExists(ident)
+      deltaCatalogClient
+        .map(_.tableExists(ident))
+        .getOrElse(super.tableExists(ident))
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -39,6 +39,14 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 private[catalog] trait AbstractDeltaCatalogClient {
 
   /**
+   * Returns whether a table with `ident` exists in the catalog.
+   *
+   * @param ident identifier of the table to check.
+   * @return `true` if the table exists in the catalog; `false` otherwise.
+   */
+  def tableExists(ident: Identifier): Boolean
+
+  /**
    * Loads the table identified by `ident` from the catalog.
    *
    * @param ident identifier of the table to load.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -69,6 +69,22 @@ private[catalog] class UCDeltaCatalogClientImpl(
   extends AbstractDeltaCatalogClient with Logging {
 
   // -------------------------------------------------------------------------
+  // DeltaCatalogClient: tableExists
+  // -------------------------------------------------------------------------
+
+  override def tableExists(ident: Identifier): Boolean = {
+    try {
+      ucClient.loadTable(toStorageTableIdent(ident))
+      true
+    } catch {
+      case _: StorageNoSuchTableException => false
+      // UC acknowledged the table; we just couldn't process it further (non-Delta format or
+      // credential fetch failed). The table still exists in the catalog.
+      case _: UnsupportedTableFormatException | _: CredentialFetchFailedException => true
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // DeltaCatalogClient: loadTable
   // -------------------------------------------------------------------------
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -26,7 +26,7 @@ import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier => S
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{DeltaProtocol, StagingTableInfo, TableInfo, TableType => UcTableType}
-import io.delta.storage.commit.uccommitcoordinator.exceptions.{CredentialFetchFailedException, NoSuchTableException => StorageNoSuchTableException}
+import io.delta.storage.commit.uccommitcoordinator.exceptions.{CredentialFetchFailedException, UnsupportedTableFormatException, NoSuchTableException => StorageNoSuchTableException}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
 import org.apache.spark.sql.QueryTest
@@ -676,6 +676,48 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       client.loadTable(Identifier.of(Array("sch"), "tbl"))
     }
     assert(thrown eq ex)
+  }
+
+  // -------------------------------------------------------------------------
+  // tableExists: maps `StorageNoSuchTableException` to `false`; treats UC-side
+  // "exists but not Delta-readable" / "exists but creds failed" responses as `true`
+  // since the table still exists in the catalog. Other failures propagate.
+  // -------------------------------------------------------------------------
+
+  private def tableExistsClient(loadResult: => TableInfo): UCDeltaCatalogClientImpl =
+    new UCDeltaCatalogClientImpl(catalogName = "main", ucClient = new StubUCDeltaClient(loadResult))
+
+  test("tableExists: returns true when UC returns table info") {
+    val client = tableExistsClient(existingDeltaTableInfo())
+    assert(client.tableExists(Identifier.of(Array("sch"), "tbl")))
+  }
+
+  test("tableExists: returns false on StorageNoSuchTableException") {
+    val client = tableExistsClient(throw new StorageNoSuchTableException("no such table"))
+    assert(!client.tableExists(Identifier.of(Array("sch"), "tbl")))
+  }
+
+  test("tableExists: returns true on UnsupportedTableFormatException (table exists, " +
+      "just not Delta-readable)") {
+    val client = tableExistsClient(throw new UnsupportedTableFormatException(
+      "not delta", new RuntimeException("simulated")))
+    assert(client.tableExists(Identifier.of(Array("sch"), "tbl")))
+  }
+
+  test("tableExists: returns true on CredentialFetchFailedException (table exists, " +
+      "credentials unavailable)") {
+    val client = tableExistsClient(throw new CredentialFetchFailedException(
+      "creds exhausted", new RuntimeException("simulated"), null))
+    assert(client.tableExists(Identifier.of(Array("sch"), "tbl")))
+  }
+
+  test("tableExists: propagates unrelated IOExceptions instead of masking as not-exists") {
+    val ioe = new java.io.IOException("network blip")
+    val client = tableExistsClient(throw ioe)
+    val thrown = intercept[java.io.IOException] {
+      client.tableExists(Identifier.of(Array("sch"), "tbl"))
+    }
+    assert(thrown eq ioe)
   }
 }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaStreamingTest.java
@@ -20,11 +20,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiException;
-import io.unitycatalog.client.api.DeltaCommitsApi;
-import io.unitycatalog.client.api.TablesApi;
-import io.unitycatalog.client.model.DeltaGetCommits;
-import io.unitycatalog.client.model.DeltaGetCommitsResponse;
-import io.unitycatalog.client.model.TableInfo;
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -193,21 +190,17 @@ public class UCDeltaStreamingTest extends UCDeltaTableIntegrationBaseTest {
         });
   }
 
-  private void assertUCManagedTableVersion(long expectedVersion, String tableName, ApiClient client)
-      throws ApiException {
-    // Get the table info.
-    TablesApi tablesApi = new TablesApi(client);
-    TableInfo tableInfo = tablesApi.getTable(tableName, false, false);
-
-    // Get the latest UC commit version.
-    DeltaCommitsApi deltaCommitsApi = new DeltaCommitsApi(client);
-    DeltaGetCommitsResponse resp =
-        deltaCommitsApi.getCommits(
-            new DeltaGetCommits().tableId(tableInfo.getTableId()).startVersion(0L));
-    assertNotNull(resp, "DeltaGetCommits response should not be null");
+  private void assertUCManagedTableVersion(
+      long expectedVersion, String fullTableName, ApiClient client) throws ApiException {
+    // The UC Delta API's `loadTable` returns the table metadata and the latest committed
+    // version in a single response, replacing the previous two-step lookup (TablesApi.getTable
+    // followed by DeltaCommitsApi.getCommits).
+    String[] parts = fullTableName.split("\\.");
+    assertEquals(3, parts.length, "Full table name must be catalog.schema.table");
+    TablesApi deltaTablesApi = new TablesApi(client);
+    LoadTableResponse resp = deltaTablesApi.loadTable(parts[0], parts[1], parts[2]);
+    assertNotNull(resp, "LoadTableResponse should not be null");
     assertNotNull(resp.getLatestTableVersion(), "Latest table version should not be null");
-
-    // The UC server should have the latest version.
     assertEquals(expectedVersion, resp.getLatestTableVersion());
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -181,11 +181,6 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     return conf;
   }
 
-  /** Subclasses can override to false for A/B comparison with the legacy path. */
-  protected boolean useDeltaRestApiForTests() {
-    return true;
-  }
-
   /**
    * Whether the class-level @AfterAll should assert that the UC Delta API actually served at least
    * one load. Override to false in classes that intentionally exercise only the fallback path

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
@@ -135,6 +135,11 @@ public abstract class UnityCatalogSupport {
     return ucRemote != null && ucRemote.equalsIgnoreCase("true");
   }
 
+  /** Subclasses can override to false for A/B comparison with the legacy path. */
+  protected boolean useDeltaRestApiForTests() {
+    return true;
+  }
+
   /** The Unity Catalog info instance for subclasses access */
   private UnityCatalogInfo ucInfo = null;
 
@@ -250,6 +255,9 @@ public abstract class UnityCatalogSupport {
     serverProps.setProperty("server.managed-table.enabled", "true");
     serverProps.setProperty(
         "storage-root.tables", new File(ucServerDir, "ucroot").getAbsolutePath());
+    if (useDeltaRestApiForTests()) {
+      serverProps.setProperty("server.managed-table.use-delta-api-only", "true");
+    }
 
     // Configure S3 credentials for the fake bucket (mirrors UC OSS BaseSparkIntegrationTest).
     serverProps.setProperty("s3.bucketPath.0", "s3://" + FAKE_S3_BUCKET);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfo.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfo.java
@@ -30,11 +30,19 @@ import java.util.Map;
  */
 public final class UCTableInfo {
 
+  // Per-catalog opt-in flag keys whose values must flow from the Spark catalog config into the UC
+  // client factory so the right client implementation is constructed. Mirrors the keys recognized
+  // by UCTokenBasedRestClientFactory.createUCClient.
+  public static final String DELTA_REST_API_ENABLED_KEY = "deltaRestApi.enabled";
+  public static final String RENEW_CREDENTIAL_ENABLED_KEY = "renewCredential.enabled";
+  public static final String CRED_SCOPED_FS_ENABLED_KEY = "credScopedFs.enabled";
+
   private final String tableId;
   private final String tablePath;
   private final UCTableIdentifier tableIdentifier;
   private final String ucUri;
   private final Map<String, String> authConfig;
+  private final Map<String, String> optInFlags;
 
   public UCTableInfo(
       String tableId,
@@ -42,11 +50,22 @@ public final class UCTableInfo {
       UCTableIdentifier tableIdentifier,
       String ucUri,
       Map<String, String> authConfig) {
+    this(tableId, tablePath, tableIdentifier, ucUri, authConfig, Collections.emptyMap());
+  }
+
+  public UCTableInfo(
+      String tableId,
+      String tablePath,
+      UCTableIdentifier tableIdentifier,
+      String ucUri,
+      Map<String, String> authConfig,
+      Map<String, String> optInFlags) {
     this.tableId = requireNonNull(tableId, "tableId is null");
     this.tablePath = requireNonNull(tablePath, "tablePath is null");
     this.tableIdentifier = requireNonNull(tableIdentifier, "tableIdentifier is null");
     this.ucUri = requireNonNull(ucUri, "ucUri is null");
     this.authConfig = Collections.unmodifiableMap(requireNonNull(authConfig, "authConfig is null"));
+    this.optInFlags = Collections.unmodifiableMap(requireNonNull(optInFlags, "optInFlags is null"));
   }
 
   public String getTableId() {
@@ -69,14 +88,21 @@ public final class UCTableInfo {
     return authConfig;
   }
 
+  public Map<String, String> getOptInFlags() {
+    return optInFlags;
+  }
+
   /**
    * Builds a flat config map suitable for {@code UCTokenBasedRestClientFactory.createUCClient}.
-   * Re-adds the {@code auth.} prefix to auth config keys and includes {@code uri}.
+   * Re-adds the {@code auth.} prefix to auth config keys, includes {@code uri}, and forwards any
+   * per-catalog opt-in flags ({@link #DELTA_REST_API_ENABLED_KEY} etc.) so the factory picks the
+   * correct client implementation.
    */
   public Map<String, String> toUcConfig() {
     Map<String, String> ucConfig = new HashMap<>();
     ucConfig.put("uri", ucUri);
     authConfig.forEach((k, v) -> ucConfig.put("auth." + k, v));
+    ucConfig.putAll(optInFlags);
     return ucConfig;
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
@@ -20,6 +20,7 @@ import static scala.jdk.javaapi.CollectionConverters.asJava;
 
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.spark.sql.SparkSession;
@@ -94,7 +95,31 @@ public final class UCUtils {
             tablePath,
             extractTableIdentifier(catalogTable),
             ucUri,
-            asJava(config.authConfig())));
+            asJava(config.authConfig()),
+            extractOptInFlags(asJava(config.ucConfig()))));
+  }
+
+  /**
+   * Selects the per-catalog opt-in flag keys recognized by {@code
+   * UCTokenBasedRestClientFactory.createUCClient} (e.g. {@code deltaRestApi.enabled}) so they
+   * propagate through {@link UCTableInfo#toUcConfig()} into the V2 connector's UC client
+   * construction. Without this, the factory falls back to the legacy client even when the catalog
+   * has opted into the new Delta API path.
+   */
+  private static Map<String, String> extractOptInFlags(Map<String, String> ucConfig) {
+    Map<String, String> flags = new HashMap<>();
+    for (String key :
+        new String[] {
+          UCTableInfo.DELTA_REST_API_ENABLED_KEY,
+          UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY,
+          UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY
+        }) {
+      String value = ucConfig.get(key);
+      if (value != null) {
+        flags.put(key, value);
+      }
+    }
+    return flags;
   }
 
   private static String extractUCTableId(CatalogTable catalogTable) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfoTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCTableInfoTest.java
@@ -70,4 +70,59 @@ class UCTableInfoTest {
 
     assertEquals("tableIdentifier is null", ex.getMessage());
   }
+
+  @Test
+  void testToUcConfigForwardsOptInFlags() {
+    // The opt-in flags must reach `toUcConfig`'s output verbatim; otherwise
+    // `UCTokenBasedRestClientFactory.createUCClient` falls back to the legacy client
+    // even when the catalog has opted into the new Delta API.
+    Map<String, String> authConfig = new HashMap<>();
+    authConfig.put("type", "static");
+    authConfig.put("token", "tok");
+
+    Map<String, String> optInFlags = new HashMap<>();
+    optInFlags.put(UCTableInfo.DELTA_REST_API_ENABLED_KEY, "true");
+    optInFlags.put(UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY, "true");
+    optInFlags.put(UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY, "false");
+
+    UCTableInfo info =
+        new UCTableInfo(
+            "uc_tbl_1",
+            "s3://bucket/tbl",
+            new UCTableIdentifier("cat", "sch", "tbl"),
+            "https://uc.example.net",
+            authConfig,
+            optInFlags);
+
+    Map<String, String> ucConfig = info.toUcConfig();
+    assertEquals("https://uc.example.net", ucConfig.get("uri"));
+    assertEquals("static", ucConfig.get("auth.type"));
+    assertEquals("tok", ucConfig.get("auth.token"));
+    assertEquals("true", ucConfig.get(UCTableInfo.DELTA_REST_API_ENABLED_KEY));
+    assertEquals("true", ucConfig.get(UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY));
+    assertEquals("false", ucConfig.get(UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY));
+  }
+
+  @Test
+  void testLegacyConstructorDefaultsOptInFlagsToEmpty() {
+    // Callers that don't pass optInFlags get the legacy behavior: no flags emitted into
+    // `toUcConfig`. The factory falls back to the default UC client, preserving prior
+    // semantics for code paths that haven't migrated.
+    Map<String, String> authConfig = new HashMap<>();
+    authConfig.put("token", "tok");
+
+    UCTableInfo info =
+        new UCTableInfo(
+            "uc_tbl_1",
+            "s3://bucket/tbl",
+            new UCTableIdentifier("cat", "sch", "tbl"),
+            "https://uc.example.net",
+            authConfig);
+
+    assertEquals(true, info.getOptInFlags().isEmpty(), "Default optInFlags should be empty");
+    Map<String, String> ucConfig = info.toUcConfig();
+    assertEquals(null, ucConfig.get(UCTableInfo.DELTA_REST_API_ENABLED_KEY));
+    assertEquals(null, ucConfig.get(UCTableInfo.RENEW_CREDENTIAL_ENABLED_KEY));
+    assertEquals(null, ucConfig.get(UCTableInfo.CRED_SCOPED_FS_ENABLED_KEY));
+  }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6920/files) to review incremental changes.
- [**stack/delta_api_only**](https://github.com/delta-io/delta/pull/6920) [[Files changed](https://github.com/delta-io/delta/pull/6920/files)]
  - [stack/replace_table_property](https://github.com/delta-io/delta/pull/6923) [[Files changed](https://github.com/delta-io/delta/pull/6923/files/c058afe86312127fb12301ad2f4903de14693e48..2647fa52b769a65fdb87d88f448639aa737ce974)]
    - [stack/delta_api_default](https://github.com/delta-io/delta/pull/6951) [[Files changed](https://github.com/delta-io/delta/pull/6951/files/2647fa52b769a65fdb87d88f448639aa737ce974..832452880c757c2d2667096f474c36b1846e22d3)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Enforce UC Delta API usage and clean up legacy-endpoint calls

- Test infra:
  - Test fixture sets `server.managed-table.use-delta-api-only=true` so any leftover legacy-endpoint call fails loudly.
  - `UCDeltaStreamingTest.assertUCManagedTableVersion` migrates off `DeltaCommitsApi.getCommits` to `TablesApi.loadTable` (single call, returns latest version).
- `tableExists` hook on `AbstractDeltaCatalogClient`:
  - `UCDeltaCatalogClientImpl` implements it via `ucClient.loadTable`; `NoSuchTable` → `false`, unsupported-format / cred-fetch failures → `true` (table still exists in the catalog).
  - `AbstractDeltaCatalog.tableExists` consults the client for non-path identifiers when wired.
- V2 connector opt-in flag propagation:
  - `UCTableInfo` gains an `optInFlags` field forwarded by `toUcConfig()`.
  - `UCUtils.extractTableInfo` filters `deltaRestApi.enabled` / `renewCredential.enabled` / `credScopedFs.enabled` from `UCCatalogConfig` into it.
  - Fixes the V2 connector falling back to the legacy UC client even when the catalog opted into the new Delta API.

## How was this patch tested?
- New tests:
  - `AbstractDeltaCatalogClientRoutingSuite`: `tableExists` happy path + `NoSuchTable` / unsupported / cred-fetch / propagated-`IOException`.
  - `UCTableInfoTest`: opt-in flag round-trip through `toUcConfig`.
  - `UCDeltaManagedReplaceSemanticsTest.testReplaceOnPathBasedIdentifierIsRejected`: pins path-based REPLACE → `CannotReplaceMissingTableException`.

## Does this PR introduce _any_ user-facing changes?
No.
