### PR TITLE
[Spark][Tests] Add DSv2 repeated table access tests with internal/external changes in Classic/Connect mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,6 +201,12 @@ lazy val connectClient = (project in file("spark-connect/client"))
     commonSettings,
     releaseSettings,
     CrossSparkVersions.sparkDependentSettings(sparkVersion),
+    // Shared refresh test traits compiled into both this module and the `spark`
+    // module. See io.delta.tables.shared.
+    Test / unmanagedSourceDirectories += {
+      (LocalRootProject / baseDirectory).value /
+        "spark-shared-tests" / "src" / "test" / "scala-shared"
+    },
     libraryDependencies ++= Seq(
       "com.google.protobuf" % "protobuf-java" % protoVersion % "protobuf",
       "org.apache.spark" %% "spark-connect-client-jvm" % sparkVersion.value % "provided",
@@ -217,12 +223,16 @@ lazy val connectClient = (project in file("spark-connect/client"))
 
       if (!distributionDir.exists()) {
         IO.createDirectory(jarsDir)
+        // V2/STRICT mode requires the Delta Kernel engine at runtime
+        // (io.delta.kernel.defaults.engine.DefaultEngine), so add the packaged kernel jars.
+        val kernelJars = Seq(
+          (kernelApi / Compile / packageBin).value,
+          (kernelDefaults / Compile / packageBin).value)
         // Create symlinks for all dependencies (filter to only JAR files)
-        serverClassPath.distinct.filter(_.data.isFile).foreach { entry =>
-          val jarFile = entry.data.toPath
-          val linkedJarFile = jarsDir / entry.data.getName
+        (serverClassPath.map(_.data).filter(_.isFile) ++ kernelJars).distinct.foreach { jarFile =>
+          val linkedJarFile = jarsDir / jarFile.getName
           if (!java.nio.file.Files.exists(linkedJarFile.toPath)) {
-            Files.createSymbolicLink(linkedJarFile.toPath, jarFile)
+            Files.createSymbolicLink(linkedJarFile.toPath, jarFile.toPath)
           }
         }
         // Create a symlink for the log4j properties
@@ -565,6 +575,12 @@ lazy val spark = (project in file("spark-unified"))
       (sparkV1 / baseDirectory).value / "src" / "test" / "resources",
       baseDirectory.value / "src" / "test" / "resources"
     ),
+    // Shared refresh test traits compiled into both this module and the
+    // `connectClient` module. See io.delta.tables.shared.
+    Test / unmanagedSourceDirectories += {
+      (LocalRootProject / baseDirectory).value /
+        "spark-shared-tests" / "src" / "test" / "scala-shared"
+    },
 
     CrossSparkVersions.sparkDependentSettings(sparkVersion),
 

--- a/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
+++ b/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables
+
+import io.delta.tables.shared.DeltaRepeatedAccessRefreshTests
+
+import org.apache.spark.sql.test.DeltaQueryTest
+
+/**
+ * Runs the shared [[DeltaRepeatedAccessRefreshTests]] over a remote Spark Connect session. In
+ * Connect the Dataset is re-analyzed on each execution, so repeated reads always see the latest
+ * data and schema.
+ */
+trait DeltaTableRefreshConnectSuiteBase
+  extends DeltaQueryTest
+  with RemoteSparkSession
+  with DeltaRepeatedAccessRefreshTests {
+
+  // The conf key is a literal because the Spark Connect thin client does not depend on Spark
+  // Classic, which is where the Delta SQL configs live, so DeltaSQLConf.V2_ENABLE_MODE.key is
+  // not importable here.
+  override protected def serverConfigs: Map[String, String] =
+    super.serverConfigs + ("spark.databricks.delta.v2.enableMode" -> v2EnableMode)
+}
+
+/**
+ * V2_ENABLE_MODE = AUTO, the product default: the Delta Kernel V2 connector is used only where it
+ * is supported and falls back to the legacy V1 path otherwise.
+ */
+class DeltaTableRefreshConnectAutoModeSuite
+  extends DeltaTableRefreshConnectSuiteBase {
+  override protected def v2EnableMode: String = "AUTO"
+}
+
+/**
+ * V2_ENABLE_MODE = STRICT: always engages the Delta Kernel V2 connector with no V1 fallback. Unlike
+ * AUTO, this surfaces gaps in the V2 connector instead of silently routing around them.
+ *
+ * TODO: full V2 connector support is in progress; ADD COLUMN is not supported in V2 yet.
+ */
+class DeltaTableRefreshConnectStrictModeSuite
+  extends DeltaTableRefreshConnectSuiteBase {
+  override protected def v2EnableMode: String = "STRICT"
+}

--- a/spark-connect/client/src/test/scala/io/delta/connect/tables/RemoteSparkSession.scala
+++ b/spark-connect/client/src/test/scala/io/delta/connect/tables/RemoteSparkSession.scala
@@ -68,6 +68,13 @@ trait RemoteSparkSession extends BeforeAndAfterAll { self: Suite =>
   private val serverPort = 15003
   var spark: SparkSession = _
 
+  /**
+   * Extra Spark configs passed to the server process as `--conf key=value` at startup (the
+   * Connect analog of overriding Spark Classic's `sparkConf`, since the server runs in a separate
+   * JVM).
+   */
+  protected def serverConfigs: Map[String, String] = Map.empty
+
   private val javaHome = System.getProperty("java.home")
 
   private val sparkHome = System.getProperty("delta.spark.home")
@@ -110,6 +117,9 @@ trait RemoteSparkSession extends BeforeAndAfterAll { self: Suite =>
       "org.apache.spark.sql.connect.delta.DeltaRelationPlugin"
     command += "--conf" += "spark.connect.extensions.command.classes=" +
       "org.apache.spark.sql.connect.delta.DeltaCommandPlugin"
+    serverConfigs.foreach { case (confKey, confValue) =>
+      command += "--conf" += s"$confKey=$confValue"
+    }
     // Spark submit requires a jar. We pick one we know exists.
     command += s"$sparkHome/jars/unused-1.0.0.jar"
 

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaRepeatedAccessRefreshTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaRepeatedAccessRefreshTests.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables.shared
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.{AnalysisException, Row}
+
+/**
+ * Repeated `sql()` calls reflect both session and external mutations (data writes, schema changes,
+ * drop/recreate). Shared across classic and Connect.
+ */
+trait DeltaRepeatedAccessRefreshTests
+  extends DeltaTableRefreshSharedBase { self: AnyFunSuite =>
+
+  /** Asserts the full table contents (ordered by id) match `expectedRows`. */
+  private def assertFinalTableState(tableRef: String, expectedRows: Seq[Row]): Unit =
+    checkAnswer(spark.sql(s"SELECT * FROM $tableRef ORDER BY id"), expectedRows)
+
+  // Scenario 1: data changes via writes
+
+  test("scenario 1: repeated sql() reflects session write") {
+    withInitialTable { tableRef =>
+      writerSql(s"INSERT INTO $tableRef VALUES (2, 200)")
+      assertFinalTableState(tableRef, Seq(Row(1, 100), Row(2, 200)))
+    }
+  }
+
+  test("scenario 1 external: repeated sql() reflects external write") {
+    withExternalTable { path =>
+      externalDataWrite(path, Seq((2, 200)))
+      // The default synchronous staleness window re-resolves the snapshot on each read, so the
+      // external commit is already visible before REFRESH; REFRESH then keeps it consistent.
+      assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+      writerSql("REFRESH TABLE t")
+      assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+    }
+  }
+
+  // Scenario 2: schema changes
+
+  test("scenario 2: repeated sql() reflects session schema change") {
+    withInitialTable { tableRef =>
+      writerSql(s"ALTER TABLE $tableRef ADD COLUMN new_column INT")
+      // TODO: STRICT mode does not support schema evolution yet, so the wider INSERT fails with an
+      // arity mismatch; the non-STRICT branch succeeds.
+      if (v2EnableMode == "STRICT") {
+        checkError(
+          exception = intercept[AnalysisException] {
+            writerSql(s"INSERT INTO $tableRef VALUES (2, 200, -1)")
+          },
+          condition = "INSERT_COLUMN_ARITY_MISMATCH")
+      } else {
+        writerSql(s"INSERT INTO $tableRef VALUES (2, 200, -1)")
+        assertFinalTableState(tableRef, Seq(Row(1, 100, null), Row(2, 200, -1)))
+      }
+    }
+  }
+
+  test("scenario 2 external: repeated sql() reflects external schema change") {
+    withExternalTable { path =>
+      externalAddColumnAndWrite(path, Seq((2, 200, -1)))
+      // The default synchronous staleness window re-resolves the snapshot on each read, so the
+      // external schema change is already visible before REFRESH; REFRESH then keeps it consistent.
+      assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+      writerSql("REFRESH TABLE t")
+      assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+    }
+  }
+
+  // Scenario 3: drop and recreate table
+
+  test("scenario 3: repeated sql() reflects session drop/recreate") {
+    withInitialTable { tableRef =>
+      writerSql(s"DROP TABLE $tableRef")
+      writerSql(s"CREATE TABLE $tableRef (id INT, salary INT) USING delta")
+      assertFinalTableState(tableRef, Seq.empty)
+    }
+  }
+
+  test("scenario 3 external: repeated sql() reflects external drop/recreate") {
+    withExternalTable { path =>
+      externalDropAndRecreate(path)
+      // The default synchronous staleness window re-resolves the snapshot on each read, so the
+      // external drop/recreate is already visible before REFRESH; REFRESH then keeps it consistent.
+      assertFinalTableState("t", Seq.empty)
+      writerSql("REFRESH TABLE t")
+      assertFinalTableState("t", Seq.empty)
+    }
+  }
+}

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables.shared
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Paths}
+import java.util.UUID
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
+
+/**
+ * Shared base for the repeated table access refresh tests.
+ *
+ * External writes are simulated by writing commit files directly into the table's `_delta_log` on
+ * the local filesystem, which the Connect client and server share.
+ */
+trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
+
+  protected def spark: SparkSession
+
+  protected def v2EnableMode: String = "NONE"
+
+  protected def checkAnswer(df: => DataFrame, expectedAnswer: Seq[Row]): Unit
+  protected def withTable(tableNames: String*)(f: => Unit): Unit
+
+  /**
+   * Asserts `exception` carries `condition`, tolerating a Connect-wrapped error (the condition may
+   * appear in the message rather than as the error condition) and classic error subclasses.
+   */
+  protected def checkError(exception: SparkThrowable, condition: String): Unit = {
+    val cond = exception.getCondition
+    if (cond != condition) {
+      assert(exception.asInstanceOf[Exception].getMessage.contains(condition),
+        s"Expected error condition '$condition' was not found")
+    }
+  }
+
+  protected def writerSql(sqlText: String): Unit = spark.sql(sqlText)
+
+  protected def createSimpleTable(tableRef: String): Unit =
+    spark.sql(s"CREATE TABLE $tableRef (id INT, salary INT) USING delta")
+
+  protected def insertInitialData(tableRef: String): Unit =
+    spark.sql(s"INSERT INTO $tableRef VALUES (1, 100)")
+
+  /** Inserts the initial `(1, 100)` row into `tableRef` and asserts the first read. */
+  private def seedInitialRow(tableRef: String): Unit = {
+    insertInitialData(tableRef)
+    checkAnswer(spark.sql(s"SELECT * FROM $tableRef"), Seq(Row(1, 100)))
+  }
+
+  /** Runs `body` against a fresh managed catalog table `t` already holding `(1, 100)`. */
+  protected def withInitialTable(body: String => Unit): Unit =
+    withTable("t") {
+      createSimpleTable("t")
+      seedInitialRow("t")
+      body("t")
+    }
+
+  /**
+   * Runs `body` against a fresh external catalog table `t` already holding `(1, 100)`, passing the
+   * table's storage path so the body can stage external commits there before REFRESH TABLE.
+   */
+  protected def withExternalTable(body: String => Unit): Unit = {
+    val dir = Files.createTempDirectory("refresh-ext").toFile
+    try {
+      withTable("t") {
+        spark.sql(
+          s"CREATE TABLE t (id INT, salary INT) USING delta LOCATION '${dir.getAbsolutePath}'")
+        seedInitialRow("t")
+        body(dir.getAbsolutePath)
+      }
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  // External-write simulation: write commit files directly into _delta_log, editing schemas as
+  // StructType values recovered from the stored schemaString.
+
+  private val IdRegex = """"id"\s*:\s*"([^"]+)"""".r
+  private val SchemaStringRegex = """"schemaString"\s*:\s*"((?:[^"\\]|\\.)*)"""".r
+
+  private def deltaLogDir(path: String): File = new File(path, "_delta_log")
+
+  private def commitJsonFiles(path: String): Array[File] =
+    deltaLogDir(path).listFiles().filter(_.getName.endsWith(".json"))
+
+  private def currentVersion(path: String): Long =
+    commitJsonFiles(path).map(_.getName.stripSuffix(".json").toLong).max
+
+  private def latestMetadataLine(path: String): String =
+    commitJsonFiles(path).sortBy(_.getName).flatMap { f =>
+      new String(Files.readAllBytes(f.toPath), UTF_8).split("\n")
+    }.filter(_.contains("\"metaData\"")).lastOption.getOrElse(
+      throw new RuntimeException("No metaData action found in commit files"))
+
+  /** The table's current schema, recovered from the stored schemaString. */
+  private def currentSchema(path: String): StructType = {
+    val escaped = SchemaStringRegex.findFirstMatchIn(latestMetadataLine(path)).map(_.group(1))
+      .getOrElse(throw new RuntimeException("Could not extract schemaString from metadata"))
+    DataType.fromJson(escaped.replace("\\\"", "\"")).asInstanceOf[StructType]
+  }
+
+  /** Returns the metadata line with its schemaString replaced (id and configuration preserved). */
+  private def metadataLineWithSchema(metadataLine: String, schema: StructType): String = {
+    val escaped = schema.json.replace("\"", "\\\"")
+    SchemaStringRegex.replaceFirstIn(
+      metadataLine, java.util.regex.Matcher.quoteReplacement(s""""schemaString":"$escaped""""))
+  }
+
+  /** Returns the metadata line with a fresh table id (simulating a recreated table). */
+  private def metadataLineWithNewId(metadataLine: String): String =
+    IdRegex.replaceFirstIn(
+      metadataLine, java.util.regex.Matcher.quoteReplacement(s""""id":"${UUID.randomUUID()}""""))
+
+  private def addFileJson(name: String, size: Long): String =
+    s"""{"add":{"path":"$name","partitionValues":{},"size":$size,""" +
+    s""""modificationTime":${System.currentTimeMillis()},"dataChange":true}}"""
+
+  private def removeFileJson(name: String): String =
+    s"""{"remove":{"path":"$name","deletionTimestamp":${System.currentTimeMillis()},""" +
+    s""""dataChange":true}}"""
+
+  /** RemoveFile actions for every data file still active in the table. */
+  private def removeActiveFiles(path: String): Seq[String] = {
+    val addRegex = """"add":\{[^}]*"path"\s*:\s*"([^"]+)"""".r
+    val removeRegex = """"remove":\{[^}]*"path"\s*:\s*"([^"]+)"""".r
+    val added = scala.collection.mutable.Set[String]()
+    val removed = scala.collection.mutable.Set[String]()
+    commitJsonFiles(path).sortBy(_.getName).foreach { f =>
+      val content = new String(Files.readAllBytes(f.toPath), UTF_8)
+      addRegex.findAllMatchIn(content).foreach(m => added += m.group(1))
+      removeRegex.findAllMatchIn(content).foreach(m => removed += m.group(1))
+    }
+    (added -- removed).toSeq.map(removeFileJson)
+  }
+
+  /** Writes a parquet file from a DataFrame into the table dir; returns its AddFile action. */
+  private def writeParquetAndGetAddFileAction(path: String, df: DataFrame): String = {
+    val tempDir = Files.createTempDirectory("ext-write").toFile
+    try {
+      df.coalesce(1).write.parquet(s"${tempDir.getAbsolutePath}/out")
+      val parquetFile = new File(tempDir, "out").listFiles()
+        .filter(_.getName.endsWith(".parquet")).head
+      val targetName = s"ext-commit-v${currentVersion(path) + 1}.snappy.parquet"
+      Files.copy(parquetFile.toPath, Paths.get(path).resolve(targetName))
+      addFileJson(targetName, parquetFile.length())
+    } finally {
+      deleteRecursively(tempDir)
+    }
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    Option(file.listFiles()).foreach(_.foreach(deleteRecursively))
+    file.delete()
+  }
+
+  /** Writes a new commit (version + 1) containing the given actions. */
+  private def writeCommit(path: String, actions: Seq[String]): Unit =
+    Files.write(
+      new File(deltaLogDir(path), f"${currentVersion(path) + 1}%020d.json").toPath,
+      actions.mkString("\n").getBytes(UTF_8))
+
+  private def idSalaryRowsToDf(rows: Seq[(Int, Int)]): DataFrame = {
+    val session = spark
+    import session.implicits._
+    rows.toDF("id", "salary")
+  }
+
+  private def idSalaryNewColumnRowsToDf(rows: Seq[(Int, Int, Int)]): DataFrame = {
+    val session = spark
+    import session.implicits._
+    rows.toDF("id", "salary", "new_column")
+  }
+
+  protected def externalDataWrite(path: String, rows: Seq[(Int, Int)]): Unit =
+    writeCommit(path, Seq(writeParquetAndGetAddFileAction(path, idSalaryRowsToDf(rows))))
+
+  protected def externalAddColumnAndWrite(path: String, rows: Seq[(Int, Int, Int)]): Unit = {
+    val newSchema = currentSchema(path).add("new_column", IntegerType, nullable = true)
+    writeCommit(path, Seq(
+      metadataLineWithSchema(latestMetadataLine(path), newSchema),
+      writeParquetAndGetAddFileAction(path, idSalaryNewColumnRowsToDf(rows))))
+  }
+
+  protected def externalDropAndRecreate(path: String): Unit = {
+    val recreatedMeta = metadataLineWithNewId(latestMetadataLine(path))
+    writeCommit(path, removeActiveFiles(path) :+ recreatedMeta)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import io.delta.tables.shared.DeltaRepeatedAccessRefreshTests
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/** Tests repeated table access with external changes. */
+trait DeltaTableRefreshSuiteBase
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaRepeatedAccessRefreshTests {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(DeltaSQLConf.DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED.key, "true")
+      .set(DeltaSQLConf.V2_ENABLE_MODE.key, v2EnableMode)
+  }
+}
+
+/**
+ * V2_ENABLE_MODE = AUTO, the product default: the Delta Kernel V2 connector is used only where it
+ * is supported and falls back to the legacy V1 path otherwise.
+ */
+class DeltaTableRefreshAutoModeSuite
+  extends DeltaTableRefreshSuiteBase {
+  override protected def v2EnableMode: String = "AUTO"
+}
+
+/**
+ * V2_ENABLE_MODE = STRICT: always engages the Delta Kernel V2 connector with no V1 fallback. Unlike
+ * AUTO, this surfaces gaps in the V2 connector instead of silently routing around them.
+ *
+ * TODO: full V2 connector support is in progress; ADD COLUMN is not supported in V2 yet.
+ */
+class DeltaTableRefreshStrictModeSuite
+  extends DeltaTableRefreshSuiteBase {
+  override protected def v2EnableMode: String = "STRICT"
+}


### PR DESCRIPTION
## Description

Add 6 tests verifying that repeated `sql()` calls on Delta tables correctly reflect external changes made via the catalog API, covering both classic and Connect modes (so 24 tests in total: 12 classic + 12 Connect).

Related Spark [PR](https://github.com/apache/spark/pull/55462), tested with an mock Connector.

### Shared external-write simulation
Following Spark's `DSv2ExternalMutationTestBase`, the external-write simulation functions in `DeltaTableRefreshSharedBase` write commit files directly into the table's `_delta_log` on the local filesystem (shared by the Connect client and server) using only `java.io` plus `DataFrame.write`. This bypasses the in-process DeltaLog/snapshot cache in both modes, so a fresh `sql()` re-resolves and observes the change.

### Scenarios
Session writes and external writes, each for: (1) data append, (2) schema change via add-column, (3) drop + recreate. Every scenario verifies repeated `sql()` access reflects the latest snapshot. Concrete suites are parameterized by `V2_ENABLE_MODE` (AUTO, STRICT) in both classic and Connect.

### STRICT behavior
Under STRICT the V2 Kernel connector behaves the same as AUTO, with one exception: `ADD COLUMN` is not supported in V2 yet. After an in-session `ALTER TABLE ADD COLUMN`, the follow-up `INSERT` resolves against the stale cached schema and fails with `INSERT_COLUMN_ARITY_MISMATCH`. This is asserted with a `TODO` to flip once V2 refreshes its schema.

## How was this patch tested?
Tests only. `spark/Test/compile` and `connectClient/Test/compile` pass, and all suites pass locally (12 classic + 12 Connect). They also run in CI in both modes.

## Does this PR introduce _any_ user-facing changes?
No.