### PR TITLE
[Spark] Allow concurrent DML transactions during ICT enablement

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -755,8 +755,15 @@ private[delta] class ConflictChecker(
     val v2CheckpointAllowList =
         Set(DeltaConfigs.CHECKPOINT_POLICY.key)
 
+    // Resolving an inCommitTimestamps enablement conflict with another transaction is valid
+    // since a transaction that was prepared before ICT was enabled can be safely rebased:
+    // resolveTimestampOrderingConflicts() will assign it a valid ICT timestamp on the fly.
+    val ictAllowList =
+        InCommitTimestampUtils.TABLE_PROPERTY_KEYS.toSet
+
     rowTrackingAllowList ++ columnMappingAllowList ++ dvsAllowList
       .++(v2CheckpointAllowList)
+      .++(ictAllowList)
   }
 
   /**
@@ -824,6 +831,12 @@ private[delta] class ConflictChecker(
         case DeltaConfigs.CHECKPOINT_POLICY.key =>
           currentTransactionInfo.protocol.isFeatureSupported(V2CheckpointTableFeature) &&
             value == CheckpointPolicy.V2.name
+        // ICT enablement configurations.
+        case DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key =>
+          currentTransactionInfo.protocol.isFeatureSupported(InCommitTimestampTableFeature) &&
+            value.toBoolean // only allow enabling, not disabling
+        case DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key => isNew
+        case DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key => isNew
         case _ => true
       }
     }
@@ -1355,42 +1368,90 @@ private[delta] class ConflictChecker(
     if (!DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(currentTransactionInfo.metadata)) {
       return
     }
+      resolveTimestampOrderingConflictsWithICTEnablementResolution()
+  }
 
+
+  /**
+   * Implements [[resolveTimestampOrderingConflicts]], handling the case where a DML transaction
+   * retries over a concurrent ICT enablement commit, using graceful fallbacks instead of
+   * throwing when inCommitTimestamp is absent.
+   */
+  private def resolveTimestampOrderingConflictsWithICTEnablementResolution(): Unit = {
+    // There are three possible cases at this point based on which commits have an ICT timestamp:
+    //   (1) Both winning and current have ICT: ICT was enabled before both transactions started.
+    //       Note: two racing ICT enablements cannot both reach this point -- the losing one would
+    //       fail with a protocolChangedException in checkProtocolCompatibility().
+    //   (2) Winning has no ICT, current has ICT: the current transaction is the ICT enablement.
+    //       The winning commit predates ICT, so we fall back to its file modification timestamp.
+    //   (3) Winning has ICT, current has no ICT: the current transaction was prepared before ICT
+    //       was enabled. A concurrent ICT enablement won the race, so the current transaction's
+    //       commitInfo has no inCommitTimestamp; we fall back to its wall-clock timestamp.
+    //
+    // A fourth case -- neither has ICT -- is impossible. The guard above ensures ICT is enabled
+    // in the current transaction's metadata, which is either the transaction's own or was
+    // adopted from a winning commit by attemptToResolveMetadataConflicts(). In either case,
+    // at least one of the two commits must carry an inCommitTimestamp.
+
+    // Use the winning commit's ICT timestamp if available. If the winning commit predates ICT
+    // (i.e. it has no inCommitTimestamp), fall back to its file timestamp as an approximation.
     val winningCommitTimestamp =
-      if (InCommitTimestampUtils.didCurrentTransactionEnableICT(
-              currentTransactionInfo.metadata, currentTransactionInfo.readSnapshot)) {
-        // Since the current transaction enabled inCommitTimestamps, we should use the file
-        // timestamp from the winning transaction as its commit timestamp.
-        winningCommitSummary.commitFileTimestamp
-    } else {
-      // Get the inCommitTimestamp from the winning transaction.
-      CommitInfo.getRequiredInCommitTimestamp(
-        winningCommitSummary.commitInfo, winningCommitVersion.toString)
-    }
-    val currentTransactionTimestamp = CommitInfo.getRequiredInCommitTimestamp(
-      currentTransactionInfo.commitInfo, "NEW_COMMIT")
-    // getRequiredInCommitTimestamp will throw an exception if commitInfo is None.
+      winningCommitSummary.commitInfo
+        .flatMap(_.inCommitTimestamp)
+        .getOrElse(winningCommitSummary.commitFileTimestamp)
+    // Use the ICT timestamp from CommitInfo if present. If the transaction was prepared before
+    // ICT was enabled (e.g. a DML concurrent with an ICT enablement), fall back to the
+    // wall-clock time recorded in CommitInfo. Math.max below ensures monotonicity regardless.
+    val currentTransactionTimestamp =
+      currentTransactionInfo.commitInfo.flatMap(_.inCommitTimestamp).getOrElse {
+        currentTransactionInfo.commitInfo.map(_.getTimestamp).getOrElse {
+          throw DeltaErrors.missingCommitInfo(InCommitTimestampTableFeature.name, "NEW_COMMIT")
+        }
+      }
     val currentTransactionCommitInfo = currentTransactionInfo.commitInfo.get
     val updatedCommitTimestamp = Math.max(currentTransactionTimestamp, winningCommitTimestamp + 1)
     val updatedCommitInfo =
       currentTransactionCommitInfo.copy(inCommitTimestamp = Some(updatedCommitTimestamp))
     currentTransactionInfo = currentTransactionInfo.copy(commitInfo = Some(updatedCommitInfo))
     val nextAvailableVersion = winningCommitVersion + 1L
-    val updatedMetadata =
-      InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
-        spark,
-        updatedCommitTimestamp,
-        currentTransactionInfo.readSnapshot,
-        currentTransactionInfo.metadata,
-        nextAvailableVersion)
-    updatedMetadata.foreach { updatedMetadata =>
-      currentTransactionInfo = currentTransactionInfo.copy(
-        metadata = updatedMetadata,
-        actions = currentTransactionInfo.actions.map {
-          case _: Metadata => updatedMetadata
-          case other => other
+    // The winning commit's Metadata action if present, otherwise the read snapshot's metadata.
+    // This is an approximation of the metadata at winningCommitVersion: when the winning commit
+    // has no metadata update, the read snapshot's metadata may be stale in multi-winner scenarios
+    // where a prior winner updated metadata without this winning commit doing so.
+    val priorMetadata = winningCommitSummary.metadataUpdates.headOption
+      .getOrElse(currentTransactionInfo.readSnapshot.metadata)
+    currentTransactionInfo.actions.collectFirst { case m: Metadata => m }
+        .foreach { currentMetadata =>
+      val updatedMetadataOpt = InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
+        spark = spark,
+        inCommitTimestamp = updatedCommitTimestamp,
+        currentMetadataWithVersion =
+          InCommitTimestampUtils.MetadataWithVersion(nextAvailableVersion, currentMetadata),
+        priorMetadataWithVersion =
+          InCommitTimestampUtils.MetadataWithVersion(winningCommitVersion, priorMetadata))
+      updatedMetadataOpt.foreach { updatedMetadata =>
+        currentTransactionInfo = currentTransactionInfo.copy(
+          metadata = updatedMetadata,
+          actions = currentTransactionInfo.actions.map {
+            case _: Metadata => updatedMetadata
+            case other => other
+          })
+      }
+      val finalMetadata = updatedMetadataOpt.getOrElse(currentMetadata)
+      if (DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(finalMetadata)
+          .contains(nextAvailableVersion)) {
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(finalMetadata)
+            .foreach { ts =>
+          // Post-condition: CommitInfo.inCommitTimestamp and Metadata.enablementTimestamp are
+          // updated through separate code paths above; this assert verifies they agree for the
+          // ICT enablement commit. The guard `contains(nextAvailableVersion)` restricts the
+          // check to the enablement commit itself -- any other transaction that writes a Metadata
+          // action on an already-ICT-enabled table carries a historical enablementTimestamp from
+          // a prior commit, which would make the assertion fail incorrectly without the guard.
+          assert(ts == updatedCommitTimestamp,
+            s"ICT enablementTimestamp $ts must equal inCommitTimestamp $updatedCommitTimestamp")
         }
-      )
+      }
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1923,7 +1923,12 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val metadataWithIctInfo = commitInfo.inCommitTimestamp
       .flatMap { inCommitTimestamp =>
         InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
-          spark, inCommitTimestamp, snapshot, metadata, firstAttemptVersion)
+          spark = spark,
+          inCommitTimestamp = inCommitTimestamp,
+          currentMetadataWithVersion =
+            InCommitTimestampUtils.MetadataWithVersion(firstAttemptVersion, metadata),
+          priorMetadataWithVersion =
+            InCommitTimestampUtils.MetadataWithVersion(snapshot.version, snapshot.metadata))
       }.getOrElse { return false }
     newMetadata = Some(metadataWithIctInfo)
     true

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/InCommitTimestampUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/InCommitTimestampUtils.scala
@@ -16,13 +16,16 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata}
+import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.util.ScalaExtensions._
 
 import org.apache.spark.sql.SparkSession
 
 object InCommitTimestampUtils {
+
+  /** Pairs a commit version with the [[Metadata]] that was written at that version. */
+  case class MetadataWithVersion(version: Long, metadata: Metadata)
 
   final val TABLE_PROPERTY_CONFS = Seq(
     DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED,
@@ -31,25 +34,30 @@ object InCommitTimestampUtils {
 
   final val TABLE_PROPERTY_KEYS: Seq[String] = TABLE_PROPERTY_CONFS.map(_.key)
 
-  /** Returns true if the current transaction implicitly/explicitly enables ICT. */
+  /**
+   * Returns true if ICT was newly enabled by the commit at [[currentMetadataWithVersion.version]],
+   * i.e. it is enabled there but was not enabled in the immediately preceding version.
+   *
+   * WARNING: The Metadata() of InitialSnapshot can have ICT=true from the default table
+   * property. When priorMetadataWithVersion.version is -1 (no prior commit exists),
+   * we treat ICT as not previously enabled so that a genuine first-commit enablement
+   * returns true.
+   *
+   * Note: [[priorMetadataWithVersion]] may be an approximation of the metadata at the
+   * preceding version (e.g. the read snapshot's metadata when the winning commit had no
+   * metadata update). Callers are responsible for ensuring the value correctly reflects
+   * the ICT state at the preceding version for their use case.
+   */
   def didCurrentTransactionEnableICT(
-      currentTransactionMetadata: Metadata,
-      readSnapshot: Snapshot): Boolean = {
-    // If ICT is currently enabled, and the read snapshot did not have ICT enabled,
-    // then the current transaction must have enabled it.
-    // In case of a conflict, any winning transaction that enabled it after
-    // our read snapshot would have caused a metadata conflict abort
-    // (see [[ConflictChecker.checkNoMetadataUpdates]]), so we know that
-    // all winning transactions' ICT enablement status must match the read snapshot.
-    //
-    // WARNING: The Metadata() of InitialSnapshot can enable ICT by default. To ensure that
-    // this function returns true if ICT is enabled during the first commit, we explicitly handle
-    // the case where the readSnapshot.version is -1.
+      currentMetadataWithVersion: MetadataWithVersion,
+      priorMetadataWithVersion: MetadataWithVersion): Boolean = {
+    assert(currentMetadataWithVersion.version == priorMetadataWithVersion.version + 1)
     val isICTCurrentlyEnabled =
-      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(currentTransactionMetadata)
-    val wasICTEnabledInReadSnapshot = readSnapshot.version != -1 &&
-      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(readSnapshot.metadata)
-    isICTCurrentlyEnabled && !wasICTEnabledInReadSnapshot
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(currentMetadataWithVersion.metadata)
+    val wasICTPreviouslyEnabled = priorMetadataWithVersion.version != -1 &&
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(
+        priorMetadataWithVersion.metadata)
+    isICTCurrentlyEnabled && !wasICTPreviouslyEnabled
   }
 
   /**
@@ -59,35 +67,47 @@ object InCommitTimestampUtils {
    * 1. If this transaction enables inCommitTimestamp.
    * 2. If the commit version is not 0. This is because we only need to persist
    *  the enablement info if there are non-ICT commits in the Delta log.
-   * For cases where ICT is enabled in both the current transaction and the read snapshot,
-   * we will retain the enablement info from the read snapshot. Note that this can
+   * For cases where ICT is enabled in both the current transaction and the preceding version,
+   * we will retain the enablement info from the preceding version. Note that this can
    * happen for commands like REPLACE or CLONE, where we can end up dropping the enablement
    * info due to the belief that ICT was just enabled.
    * Note: This function must only be called after transaction conflicts have been resolved.
+   *
+   * @param currentMetadataWithVersion the version and metadata being committed.
+   * @param priorMetadataWithVersion the version and metadata of the immediately preceding
+   *   committed version. This can be from the read snapshot of the current transaction or from a
+   *   winning commit on top of which the current transaction is rebased.
    */
   def getUpdatedMetadataWithICTEnablementInfo(
       spark: SparkSession,
       inCommitTimestamp: Long,
-      readSnapshot: Snapshot,
-      metadata: Metadata,
-      commitVersion: Long): Option[Metadata] = {
-    if (didCurrentTransactionEnableICT(metadata, readSnapshot) && commitVersion != 0) {
+      currentMetadataWithVersion: MetadataWithVersion,
+      priorMetadataWithVersion: MetadataWithVersion): Option[Metadata] = {
+    val commitVersion = currentMetadataWithVersion.version
+    val metadata = currentMetadataWithVersion.metadata
+    assert(
+      commitVersion == priorMetadataWithVersion.version + 1,
+      s"In-commit timestamp enablement tracking requires consecutive versions " +
+      s"(got commitVersion=$commitVersion, priorVersion=" +
+      s"${priorMetadataWithVersion.version})")
+    val currentTxnEnabledICT =
+      didCurrentTransactionEnableICT(currentMetadataWithVersion, priorMetadataWithVersion)
+    if (currentTxnEnabledICT && commitVersion != 0) {
       val enablementTrackingProperties = Map(
         DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key -> commitVersion.toString,
         DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key -> inCommitTimestamp.toString)
       Some(metadata.copy(configuration = metadata.configuration ++ enablementTrackingProperties))
     } else if (DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata) &&
-        !didCurrentTransactionEnableICT(metadata, readSnapshot) &&
+        !currentTxnEnabledICT &&
         // This check ensures that we don't make an unnecessary metadata update
         // even when ICT enablement properties are not being dropped.
-        getValidatedICTEnablementInfo(readSnapshot.metadata).isDefined &&
+        getValidatedICTEnablementInfo(priorMetadataWithVersion.metadata).isDefined &&
         getValidatedICTEnablementInfo(metadata).isEmpty &&
         spark.conf.get(DeltaSQLConf.IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED)
     ) {
-      // If ICT was enabled in the readSnapshot and is still enabled, we should
-      // retain the enablement info from the read snapshot.
-      // This prevents enablement info from being dropped during REPLACE/CLONE.
-      val existingICTConfigs = readSnapshot.metadata.configuration
+      // If ICT was enabled in the preceding version and is still enabled, retain the
+      // enablement info. This prevents it from being dropped during REPLACE/CLONE.
+      val existingICTConfigs = priorMetadataWithVersion.metadata.configuration
         .filter { case (k, _) => TABLE_PROPERTY_KEYS.contains(k) }
       Some(metadata.copy(configuration = metadata.configuration ++ existingICTConfigs))
     } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/FeatureEnablementConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/FeatureEnablementConcurrencySuite.scala
@@ -288,6 +288,75 @@ class FeatureEnablementConcurrencySuite
       allowList = Set(DeltaConfigs.CHECKPOINT_POLICY.key))
     assert(!result6.areValid)
 
+    // Tests 7-13: ICT per-key validators.
+    val ictProtocol = Protocol.forTableFeature(InCommitTimestampTableFeature)
+    val conflictCheckerWithICT = new ConflictChecker(
+      spark,
+      initialCurrentTransactionInfo = dummyTransactionInfo.copy(protocol = ictProtocol),
+      winningCommitSummary = dummySummary,
+      isolationLevel = WriteSerializable)
+    val ictAllowList = InCommitTimestampUtils.TABLE_PROPERTY_KEYS.toSet
+
+    // Test 7: Enabling ICT is valid when the protocol supports InCommitTimestampTableFeature.
+    val result7 = conflictCheckerWithICT.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration = Map.empty),
+      winningMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")),
+      allowList = ictAllowList)
+    assert(result7.areValid)
+
+    // Test 8: Enabling ICT is invalid when the protocol does not support
+    // InCommitTimestampTableFeature.
+    val result8 = conflictChecker.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration = Map.empty),
+      winningMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")),
+      allowList = ictAllowList)
+    assert(!result8.areValid)
+
+    // Test 9: Disabling ICT (value = false) is invalid -- validator only permits enablement.
+    val result9 = conflictCheckerWithICT.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration = Map.empty),
+      winningMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "false")),
+      allowList = ictAllowList)
+    assert(!result9.areValid)
+
+    // Test 10: Adding enablementVersion is valid (isNew = true).
+    val result10 = conflictCheckerWithICT.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration = Map.empty),
+      winningMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key -> "5")),
+      allowList = ictAllowList)
+    assert(result10.areValid)
+
+    // Test 11: Changing enablementVersion is invalid -- the add-only validator rejects overwrites.
+    val result11 = conflictCheckerWithICT.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key -> "3")),
+      winningMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key -> "5")),
+      allowList = ictAllowList)
+    assert(!result11.areValid)
+
+    // Test 12: Adding enablementTimestamp is valid (isNew = true).
+    val result12 = conflictCheckerWithICT.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration = Map.empty),
+      winningMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key -> "1000")),
+      allowList = ictAllowList)
+    assert(result12.areValid)
+
+    // Test 13: Changing enablementTimestamp is invalid -- the add-only validator rejects
+    // overwrites.
+    val result13 = conflictCheckerWithICT.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key -> "500")),
+      winningMetadata = Metadata(configuration =
+        Map(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key -> "1000")),
+      allowList = ictAllowList)
+    assert(!result13.areValid)
+
   }
 
   def testFeatureDisablement(property: String, withUnset: Boolean): Unit = {
@@ -638,4 +707,298 @@ class FeatureEnablementConcurrencySuite
   test(s"Disable Deletion Vectors feature - withUnset: $withUnset") {
     testFeatureDisablement(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key, withUnset)
   }
+  ///////////////////////////////////////////////////////////////////
+  // ICT enablement: end-to-end conflict resolution. Positive cases//
+  // verify DML rebases over ICT enablement; negative cases        //
+  // verify unresolvable conflicts still fail.                     //
+  ///////////////////////////////////////////////////////////////////
+  test("Enable ICT feature - DML succeeds when interleaved with ICT enablement") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val ictEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val businessTxn = Delete(rows = Seq(90L))
+
+        businessTxn.interleave(ctx) {
+          ictEnablementTxn.execute(ctx)
+        }
+
+      val snapshot = deltaLog.update()
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata))
+      // The DML must have conflicted and retried.
+      val dmlVersion = snapshot.version
+      val enablementVersion = dmlVersion - 1
+      // ICT timestamps must be strictly monotone across the enablement boundary (Fix 2 + Fix 3).
+      assert(InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, dmlVersion) >
+          InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, enablementVersion))
+      // Provenance written by the enablement commit must not be overwritten by the rebased
+      // DML commit (Fix 4).
+      val observedEnablementVersion =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(snapshot.metadata)
+      val observedEnablementTimestamp =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(snapshot.metadata)
+      assert(observedEnablementVersion.contains(enablementVersion))
+      assert(observedEnablementTimestamp.contains(
+        InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, enablementVersion)))
+    }
+  }
+
+
+  for (withUnset <- BOOLEAN_DOMAIN)
+  test(s"Disable ICT feature - withUnset: $withUnset") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+      AlterTableProperty(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+        .execute(ctx)
+
+      val businessTxn = Delete(rows = Seq(90L))
+      val disableTxn = if (withUnset) {
+        UnsetTableProperty(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key)
+      } else {
+        AlterTableProperty(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "false")
+      }
+
+      businessTxn.start(ctx)
+      disableTxn.execute(ctx)
+      val e = intercept[org.apache.spark.SparkException] {
+        businessTxn.commit(ctx)
+      }
+      assert(e.getCause.asInstanceOf[DeltaThrowable].getErrorClass() === "DELTA_METADATA_CHANGED")
+    }
+  }
+
+  // Unit test for the ICT-enablement detection predicate.
+  test("didCurrentTransactionEnableICT - MetadataWithVersion consecutive-version pairs") {
+    val ictOn = Metadata(configuration =
+      Map(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+    val ictOff = Metadata(configuration = Map.empty)
+
+    // Core of Fix 4: ICT enabled at both N and N+1 -> false.
+    // This is the shape ConflictChecker passes after copying the winning commit's metadata:
+    // both positions carry the same ICT-enabled metadata, so the DML did not enable ICT.
+    assert(!InCommitTimestampUtils.didCurrentTransactionEnableICT(
+      InCommitTimestampUtils.MetadataWithVersion(5, ictOn),
+      InCommitTimestampUtils.MetadataWithVersion(4, ictOn)))
+
+    // Normal enablement: ICT enabled at N+1, disabled at N -> true.
+    assert(InCommitTimestampUtils.didCurrentTransactionEnableICT(
+      InCommitTimestampUtils.MetadataWithVersion(5, ictOn),
+      InCommitTimestampUtils.MetadataWithVersion(4, ictOff)))
+
+    // ICT not enabled at either version -> false.
+    assert(!InCommitTimestampUtils.didCurrentTransactionEnableICT(
+      InCommitTimestampUtils.MetadataWithVersion(5, ictOff),
+      InCommitTimestampUtils.MetadataWithVersion(4, ictOff)))
+
+    // version = -1 (InitialSnapshot sentinel): treated as not previously enabled regardless
+    // of metadata content, so a first-commit enablement returns true.
+    assert(InCommitTimestampUtils.didCurrentTransactionEnableICT(
+      InCommitTimestampUtils.MetadataWithVersion(0, ictOn),
+      InCommitTimestampUtils.MetadataWithVersion(-1, ictOn)))
+  }
+
+  // A blind-append Insert started before ICT is enabled must receive a valid ICT after
+  // rebasing over the enablement commit, even though it has no metadata conflict.
+  test("Enable ICT feature - Insert (blind append) interleaved with ICT enablement") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val ictEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val insertTxn = Insert(rows = Seq.range(100, 110), partitionColumn = None)
+
+      insertTxn.interleave(ctx) {
+        ictEnablementTxn.execute(ctx)
+      }
+
+      val snapshot = deltaLog.update()
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata))
+      val insertVersion = snapshot.version
+      val enablementVersion = insertVersion - 1
+      assert(InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, insertVersion) >
+          InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, enablementVersion))
+    }
+  }
+
+  // Same as the Delete variant ("Enable ICT feature - DML succeeds when interleaved with ICT
+  // enablement") but exercises the Update code path.
+  test("Enable ICT feature - Update DML interleaved with ICT enablement") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val ictEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val businessTxn = Update(rows = Seq(90L), setValue = -1L)
+
+        businessTxn.interleave(ctx) {
+          ictEnablementTxn.execute(ctx)
+        }
+
+      val snapshot = deltaLog.update()
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata))
+      val dmlVersion = snapshot.version
+      val enablementVersion = dmlVersion - 1
+      assert(InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, dmlVersion) >
+          InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, enablementVersion))
+      val observedEnablementVersion =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(snapshot.metadata)
+      val observedEnablementTimestamp =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(snapshot.metadata)
+      assert(observedEnablementVersion.contains(enablementVersion))
+      assert(observedEnablementTimestamp.contains(
+        InCommitTimestampTestUtils.getInCommitTimestamp(deltaLog, enablementVersion)))
+    }
+  }
+
+  // Both ICT and DV enablement carry a Protocol change. Whichever loses gets
+  // ProtocolChangedException; the ICT enablement does not override protocol-conflict abort.
+  test("ICT enablement aborted by concurrent DV enablement: ProtocolChangedException") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val ictEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val dvEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key, value = "true")
+
+      ictEnablementTxn.start(ctx)
+      dvEnablementTxn.execute(ctx)
+      val e = intercept[org.apache.spark.SparkException] {
+        ictEnablementTxn.commit(ctx)
+      }
+      assert(e.getCause.isInstanceOf[io.delta.exceptions.ProtocolChangedException])
+    }
+  }
+
+  // The ICT enablement conflict resolver only allows rebasing over ICT-only metadata changes.
+  // When the winning commit also changes a non-allowlisted config key, the DML must still
+  // fail with DELTA_METADATA_CHANGED.
+  test("Enable ICT feature - DML fails when ICT enablement also modifies non-allowlisted config") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+      val businessTxn = Delete(rows = Seq(90L))
+
+      businessTxn.start(ctx)
+      // The winning commit enables ICT together with a non-ICT config change.
+      sql(s"""ALTER TABLE $testTableName SET TBLPROPERTIES (
+             |  '${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true',
+             |  '${DeltaConfigs.CHECKPOINT_INTERVAL.key}' = '20'
+             |)""".stripMargin)
+      val e = intercept[org.apache.spark.SparkException] {
+        businessTxn.commit(ctx)
+      }
+      assert(e.getCause.asInstanceOf[DeltaThrowable].getErrorClass() === "DELTA_METADATA_CHANGED")
+    }
+  }
+
+  // After the DML retries and commits over the ICT enablement, the data change must be
+  // correctly applied: no rows double-deleted or silently dropped.
+  test("Enable ICT feature - data integrity preserved after DML retries over ICT enablement") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val ictEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val deleteTxn = Delete(rows = Seq(42L))
+
+        deleteTxn.interleave(ctx) {
+          ictEnablementTxn.execute(ctx)
+        }
+
+      val remaining = spark.table(testTableName).collect().map(_.getLong(0)).toSet
+      assert(!remaining.contains(42L), "deleted row 42 must not appear after retry")
+      assert((0L until 100L).filterNot(_ == 42L).forall(remaining.contains),
+        "all other rows 0-99 (except 42) must still be present")
+    }
+  }
+
+  // Both the loser and winner have metadata updates, so attemptToResolveMetadataConflicts
+  // rejects the loser immediately before the ICT allowlist check runs.
+  test("Enable ICT feature - metadata-changing loser fails with DELTA_METADATA_CHANGED") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val ictEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val metadataLoserTxn = AlterTableProperty(
+        property = DeltaConfigs.CHECKPOINT_INTERVAL.key, value = "20")
+
+      metadataLoserTxn.start(ctx)
+      ictEnablementTxn.execute(ctx)
+      val e = intercept[org.apache.spark.SparkException] {
+        metadataLoserTxn.commit(ctx)
+      }
+      assert(e.getCause.asInstanceOf[DeltaThrowable].getErrorClass() === "DELTA_METADATA_CHANGED")
+    }
+  }
+
+  // Both the loser and winner carry Protocol actions; ProtocolChangedException fires before
+  // the ICT metadata allowlist is consulted.
+  test("Enable ICT feature - protocol-changing loser fails with ProtocolChangedException") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val ictEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val dvEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key, value = "true")
+
+      dvEnablementTxn.start(ctx)
+      ictEnablementTxn.execute(ctx)
+      val e = intercept[org.apache.spark.SparkException] {
+        dvEnablementTxn.commit(ctx)
+      }
+      assert(e.getCause.isInstanceOf[io.delta.exceptions.ProtocolChangedException])
+    }
+  }
+
+  test("Enable ICT feature - concurrent enablements: loser fails with ProtocolChangedException") {
+    withSQLConf(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "false") {
+      val (deltaLog, _) = createTestTable()
+      val ctx = new TestContext(deltaLog)
+
+      val userEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+      val afeEnablementTxn = AlterTableProperty(
+        property = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key, value = "true")
+
+      userEnablementTxn.start(ctx)
+      afeEnablementTxn.execute(ctx) // enablement wins at N+1
+      val e = intercept[org.apache.spark.SparkException] {
+        userEnablementTxn.commit(ctx)
+      }
+      // Both loser and winner carry a Protocol action -> checkProtocolCompatibility throws
+      // before failConcurrentTransactionsAtUpgrade or the ICT allowlist is consulted.
+      assert(e.getCause.isInstanceOf[io.delta.exceptions.ProtocolChangedException])
+
+      // Winner's commit stands: ICT is correctly enabled with provenance intact.
+      val snapshot = deltaLog.update()
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata))
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+        .fromMetaData(snapshot.metadata).isDefined)
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+        .fromMetaData(snapshot.metadata).isDefined)
+    }
+  }
+
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -23,8 +23,10 @@ import scala.collection.JavaConverters._
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
-import org.apache.spark.sql.delta.actions.{Action, CommitInfo}
-import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedCommitCoordinatorProvider, CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite, CommitCoordinatorProvider, CommitCoordinatorUtilBase, TrackingInMemoryCommitCoordinatorBuilder}
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata}
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedCommitCoordinatorProvider,
+  CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite, CommitCoordinatorProvider,
+  CommitCoordinatorUtilBase, TrackingInMemoryCommitCoordinatorBuilder}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -308,6 +310,10 @@ class InCommitTimestampSuite
     }
   }
 
+  ///////////////////////////////////////////////////////////////////
+  // Recording when ICT was first enabled: the enablement commit   //
+  // stamps its own version and timestamp into the table metadata. //
+  ///////////////////////////////////////////////////////////////////
   test("Enablement tracking properties should not be added if ICT is enabled on commit 0") {
     withTempTable(createTable = false) { tableName =>
       spark.range(10).write.format("delta").saveAsTable(tableName)
@@ -383,6 +389,525 @@ class InCommitTimestampSuite
         assert(observedEnablementTimestamp.get == getInCommitTimestamp(deltaLog, version = 3))
         assert(observedEnablementVersion.get == 3)
       }
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////
+  // Provenance survives subsequent commits: the enablementVersion //
+  // and enablementTimestamp must not be overwritten by conflict   //
+  // resolution or later transactions rebasing over enablement.   //
+  ///////////////////////////////////////////////////////////////////
+  // Both transactions carry a Protocol action, so ConflictChecker aborts the loser before
+  // resolveTimestampOrderingConflicts is reached.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: concurrent ICT enablements abort the loser") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshot = deltaLog.snapshot
+        val ictEnablementMetadata = snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration ++ Map(
+            DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+
+        val txn1 = deltaLog.startTransaction()
+        deltaLog.startTransaction().commit(Seq(ictEnablementMetadata), ManualUpdate)
+        intercept[io.delta.exceptions.ProtocolChangedException] {
+          txn1.commit(Seq(ictEnablementMetadata), ManualUpdate)
+        }
+      }
+    }
+  }
+
+  // An ALTER TABLE on an ICT-enabled table carries a Metadata action with the historical
+  // enablementTimestamp already present. When such a transaction loses a conflict to a plain DML,
+  // resolveTimestampOrderingConflicts must not compare that historical timestamp against the
+  // current commit's inCommitTimestamp (which would assert-fail). The enablement provenance
+  // must remain unchanged after the retry.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: " +
+      "ALTER TABLE on ICT-enabled table preserves enablementTimestamp") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempTable(createTable = false) { tableName =>
+        // Create the table with ICT off and make a non-ICT commit so that when ICT is later
+        // enabled the enablement tracking properties (timestamp + version) are actually written.
+        // (When ICT is enabled on commit 0 those properties are intentionally omitted.)
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        spark.sql(s"INSERT INTO $tableName VALUES 10")
+        spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+          s"('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshot = deltaLog.snapshot
+        val origEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(snapshot.metadata)
+        val origEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(snapshot.metadata)
+        assert(origEnablementTimestamp.isDefined)
+        assert(origEnablementVersion.isDefined)
+
+        // Simulate ALTER TABLE adding a property -- carries a Metadata action that includes
+        // the existing enablementTimestamp/Version from the snapshot.
+        val alterTableMetadata = snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration ++ Map("delta.testProp" -> "testValue"))
+        val alterTxn = deltaLog.startTransaction()
+        deltaLog.startTransaction().commit(Seq(createTestAddFile("dml_winner")), ManualUpdate)
+        val usageRecords = Log4jUsageLogger.track {
+          alterTxn.commit(Seq(alterTableMetadata), ManualUpdate)
+        }
+        assert(filterUsageRecords(usageRecords, "delta.commit.retry").length == 1)
+
+        val finalSnapshot = deltaLog.update()
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+            .fromMetaData(finalSnapshot.metadata) == origEnablementTimestamp)
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+            .fromMetaData(finalSnapshot.metadata) == origEnablementVersion)
+      }
+    }
+  }
+
+  // A REPLACE/CLONE that drops the ICT enablement provenance keys (while keeping ICT enabled)
+  // and loses a conflict to a plain DML must have those keys restored by the retention fix.
+  // The restored keys must equal the originals -- not the current commit's timestamp.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: " +
+      "REPLACE on ICT-enabled table retains enablementTimestamp") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        spark.sql(s"INSERT INTO $tableName VALUES 10")
+        spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+          s"('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshot = deltaLog.snapshot
+        val origEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(snapshot.metadata)
+        val origEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(snapshot.metadata)
+        assert(origEnablementTimestamp.isDefined)
+        assert(origEnablementVersion.isDefined)
+
+        // Simulate a REPLACE that keeps ICT enabled but drops the provenance keys.
+        val replaceMetadata = snapshot.metadata.copy(
+          configuration = Map(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+        val replaceTxn = deltaLog.startTransaction()
+        deltaLog.startTransaction().commit(Seq(createTestAddFile("dml_winner")), ManualUpdate)
+        val usageRecords = Log4jUsageLogger.track {
+          replaceTxn.commit(Seq(replaceMetadata), ManualUpdate)
+        }
+        assert(filterUsageRecords(usageRecords, "delta.commit.retry").length == 1)
+
+        val finalSnapshot = deltaLog.update()
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+            .fromMetaData(finalSnapshot.metadata) == origEnablementTimestamp)
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+            .fromMetaData(finalSnapshot.metadata) == origEnablementVersion)
+      }
+    }
+  }
+
+  // When the ICT-enablement txn loses a conflict, enablementTimestamp must be updated to match
+  // the inCommitTimestamp actually assigned at commit time, not the one from the first attempt.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: " +
+      "ICT-enablement loser updates enablementTimestamp after rebase") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshot = deltaLog.snapshot
+        val ictEnablementMetadata = snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration ++ Map(
+            DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+
+        val ictTxn = deltaLog.startTransaction()
+        deltaLog.startTransaction().commit(Seq(createTestAddFile("dml_winner")), ManualUpdate)
+        val usageRecords = Log4jUsageLogger.track {
+          ictTxn.commit(Seq(ictEnablementMetadata), ManualUpdate)
+        }
+        assert(filterUsageRecords(usageRecords, "delta.commit.retry").length == 1)
+
+        val finalSnapshot = deltaLog.update()
+        val observedEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+            .fromMetaData(finalSnapshot.metadata)
+        val observedEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+            .fromMetaData(finalSnapshot.metadata)
+        assert(observedEnablementTimestamp.get ==
+          getInCommitTimestamp(deltaLog, finalSnapshot.version))
+        assert(observedEnablementVersion.get == finalSnapshot.version)
+      }
+    }
+  }
+
+  // When the ICT-enablement txn loses conflicts against multiple consecutive DML winners,
+  // resolveTimestampOrderingConflicts is called once per winning commit. The final
+  // enablementVersion and enablementTimestamp must reflect the version and inCommitTimestamp
+  // actually written, not an intermediate value from an earlier winning commit.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: ICT-enablement loser updates " +
+      "enablementTimestamp across multiple winning commits") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshot = deltaLog.snapshot
+        val ictEnablementMetadata = snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration ++ Map(
+            DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+
+        val ictTxn = deltaLog.startTransaction()
+        // Two DML winners committed before the enablement txn tries to commit; both are
+        // processed by checkAndRetry in a single retry, so resolveTimestampOrderingConflicts
+        // runs twice -- once per winning commit.
+        deltaLog.startTransaction().commit(Seq(createTestAddFile("dml_winner_1")), ManualUpdate)
+        deltaLog.startTransaction().commit(Seq(createTestAddFile("dml_winner_2")), ManualUpdate)
+        val usageRecords = Log4jUsageLogger.track {
+          ictTxn.commit(Seq(ictEnablementMetadata), ManualUpdate)
+        }
+        assert(filterUsageRecords(usageRecords, "delta.commit.retry").length == 1)
+
+        val finalSnapshot = deltaLog.update()
+        val observedEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+            .fromMetaData(finalSnapshot.metadata)
+        val observedEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+            .fromMetaData(finalSnapshot.metadata)
+        assert(observedEnablementTimestamp.get ==
+          getInCommitTimestamp(deltaLog, finalSnapshot.version))
+        assert(observedEnablementVersion.get == finalSnapshot.version)
+      }
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////
+  // Timestamps stay in order across the enablement boundary:      //
+  // DML transactions rebased over ICT enablement must receive an  //
+  // inCommitTimestamp strictly greater than the enabling commit.  //
+  ///////////////////////////////////////////////////////////////////
+  // Fix 2: DML prepared before ICT was enabled (inCommitTimestamp=None in CommitInfo)
+  // must fall back to wall-clock time rather than throwing missingCommitTimestamp.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: pre-ICT DML gets ICT via wall-clock fallback") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        val startTime = System.currentTimeMillis()
+        val clock = new ManualClock(startTime)
+        val deltaLog = getDeltaLogWithClock(tableName, clock)
+        val snapshot = deltaLog.snapshot
+
+        // Start a DML transaction against the pre-ICT snapshot.
+        // When commit() is called later, CommitInfo.inCommitTimestamp will be None
+        // because ICT is not enabled in the transaction's read snapshot.
+        val dmlTxn = deltaLog.startTransaction()
+
+        // ICT enablement wins concurrently. Move clock forward slightly.
+        clock.setTime(startTime + 1000)
+        val ictEnablementMetadataConfig = snapshot.metadata.configuration ++ Map(
+          DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")
+        val ictEnablementMetadata =
+          snapshot.metadata.copy(configuration = ictEnablementMetadataConfig)
+        deltaLog.startTransaction().commit(Seq(ictEnablementMetadata), ManualUpdate)
+        val enablementVersion = deltaLog.update().version
+
+        // Move clock backward to exercise the Fix 2 fallback path:
+        // resolveTimestampOrderingConflicts falls back to CommitInfo.getTimestamp(),
+        // then Math.max(backwardTime, enablementICT + 1) restores monotonicity.
+        clock.setTime(startTime - 10000)
+        val usageRecords = Log4jUsageLogger.track {
+          dmlTxn.commit(Seq(createTestAddFile("dml")), ManualUpdate)
+        }
+        val dmlVersion = deltaLog.update().version
+
+        assert(filterUsageRecords(usageRecords, "delta.commit.retry").length == 1)
+        // DML must have received a valid ICT despite inCommitTimestamp=None at prepare time.
+        assert(getInCommitTimestamp(deltaLog, dmlVersion) >
+          getInCommitTimestamp(deltaLog, enablementVersion))
+      }
+    }
+  }
+
+  // Fix 3: winningCommitTimestamp must be read from CommitInfo.inCommitTimestamp, not from the
+  // log file's mtime. When rapid commits drive ICT above wall clock, file mtime <
+  // inCommitTimestamp, so using file mtime as the reference produces a DML ICT less than
+  // the winning commit's ICT.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: DML uses winning commit ICT, not file mtime") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        val startTime = System.currentTimeMillis()
+        // Set the clock far into the future so the enablement commit's ICT will be
+        // well above the file's actual mtime on disk, simulating a table where rapid
+        // commits have driven ICT far above wall clock.
+        val futureTime = startTime + 100000000L
+        val clock = new ManualClock(startTime)
+        val deltaLog = getDeltaLogWithClock(tableName, clock)
+        val snapshot = deltaLog.snapshot
+
+        // DML starts at startTime. CommitInfo.inCommitTimestamp = None (pre-ICT).
+        val dmlTxn = deltaLog.startTransaction()
+
+        // Enablement commit with ICT = futureTime, but file mtime on disk ~= startTime.
+        clock.setTime(futureTime)
+        val ictEnablementMetadataConfig = snapshot.metadata.configuration ++ Map(
+          DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")
+        val ictEnablementMetadata =
+          snapshot.metadata.copy(configuration = ictEnablementMetadataConfig)
+        deltaLog.startTransaction().commit(Seq(ictEnablementMetadata), ManualUpdate)
+        val enablementVersion = deltaLog.update().version
+        val enablementICT = getInCommitTimestamp(deltaLog, enablementVersion)
+
+        // Verify the test setup: ICT must be well above file mtime.
+        val fs = deltaLog.logPath.getFileSystem(deltaLog.newDeltaHadoopConf())
+        val enablementFileMtime = fs
+          .getFileStatus(FileNames.unsafeDeltaFile(deltaLog.logPath, enablementVersion))
+          .getModificationTime
+        assert(enablementICT > enablementFileMtime,
+          s"Setup: enablementICT $enablementICT must be > file mtime $enablementFileMtime")
+
+        // DML retries with clock back at startTime.
+        clock.setTime(startTime)
+        dmlTxn.commit(Seq(createTestAddFile("dml")), ManualUpdate)
+        val dmlVersion = deltaLog.update().version
+
+        // Without Fix 3: winningCommitTimestamp = commitFileTimestamp ~= startTime, so
+        // updatedTimestamp = max(startTime, startTime+1) = startTime+1 << enablementICT.
+        // With Fix 3: winningCommitTimestamp = enablementICT, so
+        // updatedTimestamp = max(startTime, enablementICT+1) = enablementICT+1 > enablementICT.
+        assert(getInCommitTimestamp(deltaLog, dmlVersion) > enablementICT)
+      }
+    }
+  }
+
+  // Two DML transactions both started before ICT was enabled.  Both rebase over the same
+  // enablement commit and commit sequentially; each must receive an ICT strictly greater than
+  // the previous commit.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: two pre-ICT DML losers get monotone ICTs") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshot = deltaLog.snapshot
+        val ictEnablementMetadata = snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration ++ Map(
+            DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+
+        val dmlTxn1 = deltaLog.startTransaction()
+        val dmlTxn2 = deltaLog.startTransaction()
+
+        deltaLog.startTransaction().commit(Seq(ictEnablementMetadata), ManualUpdate)
+        val enablementVersion = deltaLog.update().version
+
+        dmlTxn1.commit(Seq(createTestAddFile("dml1")), ManualUpdate)
+        val dml1Version = deltaLog.update().version
+        dmlTxn2.commit(Seq(createTestAddFile("dml2")), ManualUpdate)
+        val dml2Version = deltaLog.update().version
+
+        val enablementICT = getInCommitTimestamp(deltaLog, enablementVersion)
+        val dml1ICT = getInCommitTimestamp(deltaLog, dml1Version)
+        val dml2ICT = getInCommitTimestamp(deltaLog, dml2Version)
+        assert(dml1ICT > enablementICT,
+          s"DML1 ICT $dml1ICT must be > enablement ICT $enablementICT")
+        assert(dml2ICT > dml1ICT, s"DML2 ICT $dml2ICT must be > DML1 ICT $dml1ICT")
+      }
+    }
+  }
+
+  // Complement to "DML prepared pre-ICT gets ICT via wall-clock fallback":
+  // when the DML's wall-clock time is already ABOVE the enabling commit's ICT,
+  // Math.max takes the left (wall-clock) branch and the DML's ICT equals the wall clock.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: " +
+      "DML wall-clock above enabling ICT uses wall-clock branch") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        val highTime = System.currentTimeMillis() + 500000L
+        val lowTime = highTime - 100000L
+        val clock = new ManualClock(highTime)
+        val deltaLog = getDeltaLogWithClock(tableName, clock)
+        val snapshot = deltaLog.snapshot
+
+        // DML starts while clock is at highTime (pre-ICT, no inCommitTimestamp in CommitInfo).
+        val dmlTxn = deltaLog.startTransaction()
+
+        // ICT enablement commits at lowTime < highTime.
+        clock.setTime(lowTime)
+        val ictEnablementMetadata = snapshot.metadata.copy(
+          configuration = snapshot.metadata.configuration ++ Map(
+            DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+        deltaLog.startTransaction().commit(Seq(ictEnablementMetadata), ManualUpdate)
+        val enablementVersion = deltaLog.update().version
+        val enablementICT = getInCommitTimestamp(deltaLog, enablementVersion)
+
+        // DML commits with clock back at highTime.
+        clock.setTime(highTime)
+        dmlTxn.commit(Seq(createTestAddFile("dml")), ManualUpdate)
+        val dmlVersion = deltaLog.update().version
+        val dmlICT = getInCommitTimestamp(deltaLog, dmlVersion)
+
+        // Math.max(highTime, enablementICT + 1) = highTime since highTime > enablementICT + 1.
+        assert(dmlICT >= highTime,
+          s"DML ICT $dmlICT must be >= wall-clock $highTime (left branch of Math.max)")
+        assert(dmlICT > enablementICT,
+          s"DML ICT $dmlICT must be > enablement ICT $enablementICT")
+      }
+    }
+  }
+
+  // Regression guard: a plain DML-vs-DML conflict on an already-ICT-enabled table must
+  // still produce strictly monotone ICTs and must not disturb the enablement provenance.
+  testWithDefaultCommitCoordinatorUnset(
+      "Conflict resolution with ICT enablement: concurrent DML preserves ICT provenance") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString) {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+          s"('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshot = deltaLog.snapshot
+        val origEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(snapshot.metadata)
+        val origEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(snapshot.metadata)
+        assert(origEnablementVersion.isDefined && origEnablementTimestamp.isDefined)
+
+        val dmlTxn1 = deltaLog.startTransaction()
+        val dmlTxn2 = deltaLog.startTransaction()
+
+        dmlTxn1.commit(Seq(createTestAddFile("dml1")), ManualUpdate)
+        val dml1Version = deltaLog.update().version
+        dmlTxn2.commit(Seq(createTestAddFile("dml2")), ManualUpdate)
+        val dml2Version = deltaLog.update().version
+
+        assert(getInCommitTimestamp(deltaLog, dml2Version) >
+          getInCommitTimestamp(deltaLog, dml1Version))
+        val finalSnapshot = deltaLog.update()
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+            .fromMetaData(finalSnapshot.metadata) == origEnablementVersion)
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+            .fromMetaData(finalSnapshot.metadata) == origEnablementTimestamp)
+      }
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////
+  // Recovering dropped provenance (Branch 2 fix): REPLACE/CLONE   //
+  // drops provenance keys while keeping ICT enabled; the fix      //
+  // must restore them from the last committed snapshot.           //
+  ///////////////////////////////////////////////////////////////////
+  // Covers the case where the snapshot that REPLACE reads is NOT the ICT-enablement commit
+  // but a later metadata-changing commit that carried provenance forward. Branch 2 of
+  // getUpdatedMetadataWithICTEnablementInfo must still restore provenance from that
+  // intermediate snapshot, not skip it.
+  testWithDefaultCommitCoordinatorUnset(
+      "REPLACE retains ICT provenance when last committed metadata " +
+      "is from a non-enablement commit") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString,
+      DeltaSQLConf.IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED.key -> "true") {
+      withTempTable(createTable = false) { tableName =>
+        spark.range(10).write.format("delta").saveAsTable(tableName)
+        spark.sql(s"INSERT INTO $tableName VALUES 10")
+        spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+          s"('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val enablementSnapshot = deltaLog.snapshot
+        val origEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+            .fromMetaData(enablementSnapshot.metadata)
+        val origEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+            .fromMetaData(enablementSnapshot.metadata)
+        assert(origEnablementTimestamp.isDefined && origEnablementVersion.isDefined)
+
+        // A metadata-changing commit after enablement makes this the snapshot the REPLACE
+        // will read, not the ICT-enablement commit itself. Provenance is carried forward.
+        spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+          s"('${DeltaConfigs.CHECKPOINT_INTERVAL.key}' = '20')")
+        val intermediateSnapshot = deltaLog.update()
+        assert(intermediateSnapshot.version > enablementSnapshot.version)
+        assert(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+          .fromMetaData(intermediateSnapshot.metadata) == origEnablementTimestamp,
+          "intermediate commit must carry provenance forward")
+
+        // Simulate a REPLACE that keeps ICT enabled but drops provenance keys.
+        val replaceMetadata = intermediateSnapshot.metadata.copy(
+          configuration = Map(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+        deltaLog.startTransaction().commit(Seq(replaceMetadata), ManualUpdate)
+
+        val finalSnapshot = deltaLog.update()
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+            .fromMetaData(finalSnapshot.metadata) == origEnablementTimestamp)
+        assert(
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+            .fromMetaData(finalSnapshot.metadata) == origEnablementVersion)
+      }
+    }
+  }
+
+  // Direct unit test of Branch 2 of getUpdatedMetadataWithICTEnablementInfo:
+  // when ICT is still enabled but provenance was dropped (REPLACE/CLONE pattern),
+  // the fix must copy provenance from lastCommittedMetadata; kill switch disables it.
+  testWithDefaultCommitCoordinatorUnset(
+      "getUpdatedMetadataWithICTEnablementInfo Branch 2 restores dropped provenance") {
+    val enablementVersion = 5L
+    val enablementTimestamp = 12345678L
+    val lastCommittedMetadata = Metadata(configuration = Map(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true",
+      DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key -> enablementVersion.toString,
+      DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key -> enablementTimestamp.toString))
+    val currentMetadata = Metadata(configuration = Map(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+
+    withSQLConf(
+        DeltaSQLConf.IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED.key -> "true") {
+      val result = InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
+        spark,
+        inCommitTimestamp = 99999999L,
+        InCommitTimestampUtils.MetadataWithVersion(6, currentMetadata),
+        InCommitTimestampUtils.MetadataWithVersion(5, lastCommittedMetadata))
+      assert(result.isDefined)
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+        .fromMetaData(result.get).contains(enablementVersion))
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+        .fromMetaData(result.get).contains(enablementTimestamp))
+    }
+
+    withSQLConf(
+        DeltaSQLConf.IN_COMMIT_TIMESTAMP_RETAIN_ENABLEMENT_INFO_FIX_ENABLED.key -> "false") {
+      val result = InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
+        spark,
+        inCommitTimestamp = 99999999L,
+        InCommitTimestampUtils.MetadataWithVersion(6, currentMetadata),
+        InCommitTimestampUtils.MetadataWithVersion(5, lastCommittedMetadata))
+      assert(result.isEmpty)
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark

## Description

DML transactions (UPDATE/DELETE/MERGE) that start before InCommitTimestamp (ICT) is enabled on a table can fail spuriously if a concurrent ICT-enablement commit wins the race. The existing conflict resolution throws when `inCommitTimestamp` is absent from the losing transaction's `CommitInfo`, but that timestamp is legitimately missing for transactions prepared before ICT was enabled.

This PR makes ICT enablement conflict-free for concurrent DML by:
- Adding ICT-related metadata keys to the conflict resolution allow-list
- Falling back to wall-clock time when `inCommitTimestamp` is absent from the current transaction
- Using `CommitInfo.inCommitTimestamp` (not file mtime) as the reference timestamp from the winning commit
- Refactoring `getUpdatedMetadataWithICTEnablementInfo` to use explicit `MetadataWithVersion` pairs to avoid incorrectly overwriting ICT enablement provenance on rebasing DML

## How was this patch tested?

New tests in `FeatureEnablementConcurrencySuite` covering DML interleaved with ICT enablement, and extended `InCommitTimestampSuite` tests verifying correct provenance metadata under concurrency.

## Does this PR introduce _any_ user-facing changes?

Yes. DML transactions that previously failed with an exception when racing against ICT enablement will now retry successfully.