### PR TITLE
[Spark] Carry forward existing delta.* properties on managed REPLACE

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -57,7 +57,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=e1f6e52acc39b925fd6a42180d400ca4e0a3895f
+UC_PIN_SHA=ae0a40caa8b2b0627e88b93cb84fe6be255575db
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -187,43 +187,59 @@ trait DeltaConfigsBase extends DeltaLogging {
     val allowArbitraryProperties = SparkSession.active.sessionState.conf
       .getConf(DeltaSQLConf.ALLOW_ARBITRARY_TABLE_PROPERTIES)
 
-    configurations.map { case kv @ (key, value) =>
-      key.toLowerCase(Locale.ROOT) match {
-        case lKey if lKey.startsWith("delta.constraints.") =>
-          // This is a CHECK constraint, we should allow it.
-          kv
-        case lKey if lKey.startsWith(TableFeatureProtocolUtils.FEATURE_PROP_PREFIX) =>
-          // This is a table feature, we should allow it.
-          lKey -> value
-        case lKey if lKey.startsWith("delta.") =>
-          Option(entries.get(lKey.stripPrefix("delta."))) match {
-            case Some(deltaConfig) if (
-              lKey == DeltaConfigs.TOMBSTONE_RETENTION.key.toLowerCase(Locale.ROOT) ||
-              lKey == DeltaConfigs.LOG_RETENTION.key.toLowerCase(Locale.ROOT)) =>
-              val ret = deltaConfig(value) // validate the value
-              validateTombstoneAndLogRetentionDurationCompatibility(configurations)
-              ret
-            case Some(deltaConfig) =>
-              deltaConfig(value) // validate the value
-            case None if lKey.startsWith(DELTA_UNIVERSAL_FORMAT_CONFIG_PREFIX) =>
-              // always allow any delta universal format config with key converted to lower case
-              lKey -> value
-            case None if allowArbitraryProperties =>
-              logConsole(
-                s"You are setting a property: $key that is not recognized by this " +
-                  "version of Delta")
-              kv
-            case None => throw DeltaErrors.unknownConfigurationKeyException(key)
-          }
-        case _ =>
-          if (entries.containsKey(key)) {
-            logConsole(s"""
-              |You are trying to set a property the key of which is the same as Delta config: $key.
-              |If you are trying to set a Delta config, prefix it with "delta.", e.g. 'delta.$key'.
-            """.stripMargin)
-          }
-          kv
-      }
+    configurations.map { case (key, value) =>
+      validateConfiguration(key, value, allowArbitraryProperties, configurations)
+    }
+  }
+
+  /**
+   * Validates a single key-value entry and returns the normalized key -> value pair.
+   * Throws if the key isn't acceptable as a Delta table property.
+   *
+   * @param allConfigurations the full configuration map; used for cross-key checks
+   *                          (e.g. tombstone / log retention compatibility).
+   */
+  def validateConfiguration(
+      key: String,
+      value: String,
+      allowArbitraryProperties: Boolean,
+      allConfigurations: Map[String, String]): (String, String) = {
+    val kv = key -> value
+    key.toLowerCase(Locale.ROOT) match {
+      case lKey if lKey.startsWith("delta.constraints.") =>
+        // This is a CHECK constraint, we should allow it.
+        kv
+      case lKey if lKey.startsWith(TableFeatureProtocolUtils.FEATURE_PROP_PREFIX) =>
+        // This is a table feature, we should allow it.
+        lKey -> value
+      case lKey if lKey.startsWith("delta.") =>
+        Option(entries.get(lKey.stripPrefix("delta."))) match {
+          case Some(deltaConfig) if (
+            lKey == DeltaConfigs.TOMBSTONE_RETENTION.key.toLowerCase(Locale.ROOT) ||
+            lKey == DeltaConfigs.LOG_RETENTION.key.toLowerCase(Locale.ROOT)) =>
+            val ret = deltaConfig(value) // validate the value
+            validateTombstoneAndLogRetentionDurationCompatibility(allConfigurations)
+            ret
+          case Some(deltaConfig) =>
+            deltaConfig(value) // validate the value
+          case None if lKey.startsWith(DELTA_UNIVERSAL_FORMAT_CONFIG_PREFIX) =>
+            // always allow any delta universal format config with key converted to lower case
+            lKey -> value
+          case None if allowArbitraryProperties =>
+            logConsole(
+              s"You are setting a property: $key that is not recognized by this " +
+                "version of Delta")
+            kv
+          case None => throw DeltaErrors.unknownConfigurationKeyException(key)
+        }
+      case _ =>
+        if (entries.containsKey(key)) {
+          logConsole(s"""
+            |You are trying to set a property the key of which is the same as Delta config: $key.
+            |If you are trying to set a Delta config, prefix it with "delta.", e.g. 'delta.$key'.
+          """.stripMargin)
+        }
+        kv
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTableType
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
-import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, ClusteringTableFeature, DeltaConfigs, DeltaErrors, TableFeature}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, ClusteringTableFeature, DeltaConfigs, DeltaErrors, DeltaThrowable, TableFeature}
 import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
@@ -204,8 +204,10 @@ private[catalog] class UCDeltaCatalogClientImpl(
       // Delta's structured-error exceptions for bad keys (DELTA_UNKNOWN_CONFIGURATION,
       // DELTA_CANNOT_MODIFY_TABLE_PROPERTY, etc.), and the raw IllegalArgumentException
       // raised by `require(...)` in the value parser.
-      case _: org.apache.spark.sql.delta.DeltaThrowable => false
-      case _: IllegalArgumentException => false
+      case _: DeltaThrowable | _: IllegalArgumentException =>
+        logDebug(log"Skipping invalid Delta config " +
+          log"'${MDC(DeltaLogKeys.CONFIG_KEY, key)}'='${MDC(DeltaLogKeys.CONFIG, value)}'.")
+        false
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTableType
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
-import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, DeltaErrors, TableFeature}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, ClusteringTableFeature, DeltaConfigs, DeltaErrors, TableFeature}
 import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
@@ -156,8 +156,55 @@ private[catalog] class UCDeltaCatalogClientImpl(
     if (suggested == null) return
     // `null` values are engine-generated-at-commit sentinels (e.g. row-tracking materialized
     // column names); Delta rejects them as unknown configs at stage time, so skip and let
-    // the engine substitute them on finalize.
-    suggested.asScala.foreach { case (k, v) => if (v != null) augmented.putIfAbsent(k, v) }
+    // the engine substitute them on finalize. Entries that wouldn't survive Delta config
+    // validation (unknown key, non-editable key, or value that doesn't parse) are also
+    // dropped to keep CREATE from failing later in the staging flow.
+    suggested.asScala.foreach { case (k, v) =>
+      if (v != null && passesDeltaConfigValidation(k, v)) augmented.putIfAbsent(k, v)
+    }
+  }
+
+  /** `delta.feature.clustering`, cached. */
+  private val clusteringFeatureKey =
+    TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature)
+
+  /**
+   * Returns whether `(key, value)` from an existing table's config should be carried forward
+   * when building the REPLACE-augmented property map.
+   */
+  private def isSafeToCarryForwardOnReplace(key: String, value: String): Boolean = {
+    val lKey = key.toLowerCase(java.util.Locale.ROOT)
+    // Only `delta.*` keys are carried; non-`delta.*` user properties (e.g. `Foo=Bar`)
+    // follow normal REPLACE semantics -- the user's new TBLPROPERTIES is authoritative.
+    if (!lKey.startsWith("delta.")) return false
+    // Clustering has DDL-only enablement (`CLUSTER BY`); carrying it as a property would
+    // both throw on REPLACE (`DELTA_CREATE_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED`)
+    // and block legitimate transitions away from a clustered table.
+    if (lKey == clusteringFeatureKey) return false
+    // Defer remaining acceptance to Delta's own per-entry validator -- single source of truth
+    // for "would this survive the next commit". This filters out Delta-internal metadata
+    // like `delta.lastCommitTimestamp` (unregistered) and `delta.columnMapping.maxColumnId`
+    // (non-editable) that `validateConfigurations` would otherwise reject.
+    passesDeltaConfigValidation(key, value)
+  }
+
+  /**
+   * True iff [[DeltaConfigs.validateConfiguration]] would accept `(key, value)` as a Delta
+   * table property. Wraps the validator to convert its throw-on-bad behavior into a
+   * boolean predicate.
+   */
+  private def passesDeltaConfigValidation(key: String, value: String): Boolean = {
+    try {
+      DeltaConfigs.validateConfiguration(
+        key, value, allowArbitraryProperties = false, allConfigurations = Map.empty)
+      true
+    } catch {
+      // Delta's structured-error exceptions for bad keys (DELTA_UNKNOWN_CONFIGURATION,
+      // DELTA_CANNOT_MODIFY_TABLE_PROPERTY, etc.), and the raw IllegalArgumentException
+      // raised by `require(...)` in the value parser.
+      case _: org.apache.spark.sql.delta.DeltaThrowable => false
+      case _: IllegalArgumentException => false
+    }
   }
 
   /**
@@ -284,6 +331,16 @@ private[catalog] class UCDeltaCatalogClientImpl(
       .filterNot(_.equalsIgnoreCase(existingProvider))
       .foreach(_ => throw DeltaErrors.cannotChangeProvider())
     val augmented = new util.HashMap[String, String](properties)
+    // Carry forward the existing table's `delta.*` properties (feature flags, checkpoint
+    // policy, column-mapping mode, row-tracking state, etc.) so REPLACE doesn't silently
+    // strip critical configs that downstream (Table Service / commit validation) would
+    // reject as unsupported changes. Caller-supplied TBLPROPERTIES on the REPLACE win via
+    // `putIfAbsent`. See [[isSafeToCarryForwardOnReplace]] for the carry-forward criteria.
+    Option(info.getMetadata.getConfiguration).foreach { existingConfig =>
+      existingConfig.asScala.foreach { case (k, v) =>
+        if (v != null && isSafeToCarryForwardOnReplace(k, v)) augmented.putIfAbsent(k, v)
+      }
+    }
     // Re-emit the existing provider so downstream sees USING <provider> even if the caller
     // omitted it. Mark the location as system-managed; `PROP_LOCATION` is intentionally not
     // set so downstream Delta resolves the location from the existing table snapshot.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -164,9 +164,13 @@ private[catalog] class UCDeltaCatalogClientImpl(
     }
   }
 
-  /** `delta.feature.clustering`, cached. */
-  private val clusteringFeatureKey =
-    TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature)
+  private val propertiesToSkipCarryForwardOnReplace = Set(
+    // Clustering has DDL-only enablement (`CLUSTER BY`); carrying it as a property would
+    // both throw on REPLACE (`DELTA_CREATE_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED`)
+    // and block legitimate transitions away from a clustered table.
+    TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature),
+    // delta.columnMapping.maxColumnId changes as table schema changes. Not worth carrying forward.
+    DeltaConfigs.COLUMN_MAPPING_MAX_ID.key)
 
   /**
    * Returns whether `(key, value)` from an existing table's config should be carried forward
@@ -177,14 +181,12 @@ private[catalog] class UCDeltaCatalogClientImpl(
     // Only `delta.*` keys are carried; non-`delta.*` user properties (e.g. `Foo=Bar`)
     // follow normal REPLACE semantics -- the user's new TBLPROPERTIES is authoritative.
     if (!lKey.startsWith("delta.")) return false
-    // Clustering has DDL-only enablement (`CLUSTER BY`); carrying it as a property would
-    // both throw on REPLACE (`DELTA_CREATE_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED`)
-    // and block legitimate transitions away from a clustered table.
-    if (lKey == clusteringFeatureKey) return false
+    if (propertiesToSkipCarryForwardOnReplace.contains(key)) return false
     // Defer remaining acceptance to Delta's own per-entry validator -- single source of truth
-    // for "would this survive the next commit". This filters out Delta-internal metadata
+    // for "would this survive the next commit". This would also filter out Delta-internal metadata
     // like `delta.lastCommitTimestamp` (unregistered) and `delta.columnMapping.maxColumnId`
-    // (non-editable) that `validateConfigurations` would otherwise reject.
+    // (non-editable) that `validateConfigurations` would otherwise reject, if they weren't
+    // filtered out by propertiesToSkipCarryForwardOnReplace already.
     passesDeltaConfigValidation(key, value)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -164,24 +164,30 @@ private[catalog] class UCDeltaCatalogClientImpl(
     }
   }
 
+  private def lower(key: String) = key.toLowerCase(java.util.Locale.ROOT)
+
+  /**
+   * Lower case keys of all table properties that should be skipped instead of carrying forward to
+   * the REPLACE-ed table.
+   */
   private val propertiesToSkipCarryForwardOnReplace = Set(
     // Clustering has DDL-only enablement (`CLUSTER BY`); carrying it as a property would
     // both throw on REPLACE (`DELTA_CREATE_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED`)
     // and block legitimate transitions away from a clustered table.
-    TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature),
+    lower(TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature)),
     // delta.columnMapping.maxColumnId changes as table schema changes. Not worth carrying forward.
-    DeltaConfigs.COLUMN_MAPPING_MAX_ID.key)
+    lower(DeltaConfigs.COLUMN_MAPPING_MAX_ID.key))
 
   /**
    * Returns whether `(key, value)` from an existing table's config should be carried forward
    * when building the REPLACE-augmented property map.
    */
   private def isSafeToCarryForwardOnReplace(key: String, value: String): Boolean = {
-    val lKey = key.toLowerCase(java.util.Locale.ROOT)
+    val lKey = lower(key)
     // Only `delta.*` keys are carried; non-`delta.*` user properties (e.g. `Foo=Bar`)
     // follow normal REPLACE semantics -- the user's new TBLPROPERTIES is authoritative.
     if (!lKey.startsWith("delta.")) return false
-    if (propertiesToSkipCarryForwardOnReplace.contains(key)) return false
+    if (propertiesToSkipCarryForwardOnReplace.contains(lKey)) return false
     // Defer remaining acceptance to Delta's own per-entry validator -- single source of truth
     // for "would this survive the next commit". This would also filter out Delta-internal metadata
     // like `delta.lastCommitTimestamp` (unregistered) and `delta.columnMapping.maxColumnId`
@@ -328,7 +334,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
     requireCatalogManagedDeltaTable(info, qualifiedName)
     val existingProvider =
       Option(info.getMetadata.getProvider)
-        .map(_.toLowerCase(java.util.Locale.ROOT))
+        .map(lower)
         .get
     // REPLACE cannot change the table's storage format.
     Option(properties.get(TableCatalog.PROP_PROVIDER))
@@ -394,7 +400,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
         s"REPLACE TABLE is only supported for catalog-managed UC Delta tables; " +
           s"$qualified is ${info.getTableType}.")
     }
-    val provider = Option(info.getMetadata.getProvider).map(_.toLowerCase(java.util.Locale.ROOT))
+    val provider = Option(info.getMetadata.getProvider).map(lower)
     if (!provider.contains("delta")) {
       throw DeltaErrors.notADeltaTableException("REPLACE TABLE", qualified)
     }
@@ -547,7 +553,7 @@ private[catalog] class UCDeltaCatalogClientImpl(
       tableType = fromUcTableType(info.getTableType),
       storage = storage,
       schema = schema,
-      provider = Option(m.getProvider).map(_.toLowerCase(java.util.Locale.ROOT)),
+      provider = Option(m.getProvider).map(lower),
       partitionColumnNames = partitionColumns,
       comment = Option(m.getDescription),
       createTime = if (m.getCreatedTime != null) m.getCreatedTime else 0L,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -252,7 +252,7 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
 
   test("createStagingTable: suggested property is applied when caller hasn't set it") {
     // `delta.checkpointInterval` is a real, editable Delta config so it survives the
-    // `isAllowedSuggestedProperty` filter.
+    // `passesDeltaConfigValidation` filter.
     val (client, _) = newRecordingClient(
       suggestedProperties = javaMap("delta.checkpointInterval" -> "20"))
     val out = client.createStagingTable(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -552,7 +552,8 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
   // post-REPLACE commits for stripping required features.
   // -------------------------------------------------------------------------
 
-  test("loadTableAndBuildReplaceProps: carries forward existing delta.feature.* + editable configs") {
+  test(
+    "loadTableAndBuildReplaceProps: carries forward existing delta.feature.* + editable configs") {
     val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
       "delta.feature.deletionVectors" -> "supported",
       "delta.enableDeletionVectors" -> "true",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -251,24 +251,39 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
   }
 
   test("createStagingTable: suggested property is applied when caller hasn't set it") {
+    // `delta.checkpointInterval` is a real, editable Delta config so it survives the
+    // `isAllowedSuggestedProperty` filter.
     val (client, _) = newRecordingClient(
-      suggestedProperties = javaMap("delta.someSuggested" -> "ucs-val"))
+      suggestedProperties = javaMap("delta.checkpointInterval" -> "20"))
     val out = client.createStagingTable(
       Identifier.of(Array("sch"), "tbl"),
       stageProps("delta.catalogManaged" -> "supported"))
-    assert(out.get("delta.someSuggested") === "ucs-val")
+    assert(out.get("delta.checkpointInterval") === "20")
   }
 
   test("createStagingTable: suggested property defers to caller when both set") {
     val (client, _) = newRecordingClient(
-      suggestedProperties = javaMap("delta.someSuggested" -> "ucs-val"))
+      suggestedProperties = javaMap("delta.checkpointInterval" -> "20"))
     val out = client.createStagingTable(
       Identifier.of(Array("sch"), "tbl"),
       stageProps(
         "delta.catalogManaged" -> "supported",
-        "delta.someSuggested" -> "caller-val"))
-    assert(out.get("delta.someSuggested") === "caller-val",
+        "delta.checkpointInterval" -> "50"))
+    assert(out.get("delta.checkpointInterval") === "50",
       "user TBLPROPERTIES must win over a suggested value")
+  }
+
+  test("createStagingTable: suggested property unknown to Delta Spark is silently dropped") {
+    // UC may suggest Kernel-only properties (e.g. `delta.parquet.compression.codec`) that
+    // this Delta Spark build doesn't recognize. The suggested-properties path drops them
+    // instead of letting `DeltaConfigs.validateConfigurations` throw downstream.
+    val (client, _) = newRecordingClient(
+      suggestedProperties = javaMap("delta.parquet.compression.codec" -> "snappy"))
+    val out = client.createStagingTable(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.catalogManaged" -> "supported"))
+    assert(!out.containsKey("delta.parquet.compression.codec"),
+      "unknown delta.* suggested keys must not flow through")
   }
 
   test("createStagingTable: required protocol features are encoded as delta.feature.*") {
@@ -401,9 +416,11 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       provider: String = "DELTA",
       catalogManaged: Boolean = true,
       storageProperties: util.Map[String, String] =
-        util.Map.of("fs.s3a.access.key", "existing-key")): TableInfo = {
+        util.Map.of("fs.s3a.access.key", "existing-key"),
+      additionalConfig: Map[String, String] = Map.empty): TableInfo = {
     val config = new util.HashMap[String, String]()
     if (catalogManaged) config.put("delta.feature.catalogManaged", "supported")
+    additionalConfig.foreach { case (k, v) => config.put(k, v) }
     val metadata = new TestMetadata(provider = provider, configuration = config)
     new TableInfo(
       UUID.fromString("00000000-0000-0000-0000-000000000002"),
@@ -527,6 +544,71 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
         Identifier.of(Array("sch"), "tbl"),
         stageProps("delta.feature.catalogManaged" -> "supported"))
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // loadTableAndBuildReplaceProps: existing-table `delta.*` carry-forward.
+  // Pin which keys survive REPLACE so Table Service / commit validation doesn't reject
+  // post-REPLACE commits for stripping required features.
+  // -------------------------------------------------------------------------
+
+  test("loadTableAndBuildReplaceProps: carries forward existing delta.feature.* + editable configs") {
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      "delta.feature.deletionVectors" -> "supported",
+      "delta.enableDeletionVectors" -> "true",
+      "delta.checkpointInterval" -> "20")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.feature.catalogManaged" -> "supported"))
+    assert(out.get("delta.feature.deletionVectors") === "supported")
+    assert(out.get("delta.enableDeletionVectors") === "true")
+    assert(out.get("delta.checkpointInterval") === "20")
+  }
+
+  test("loadTableAndBuildReplaceProps: does NOT carry delta.feature.clustering") {
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      "delta.feature.clustering" -> "supported")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.feature.catalogManaged" -> "supported"))
+    assert(!out.containsKey("delta.feature.clustering"),
+      "clustering must NOT carry forward; only CLUSTER BY DDL can enable it, and " +
+        "carrying it would also block REPLACE transitions away from a clustered table")
+  }
+
+  test("loadTableAndBuildReplaceProps: does NOT carry Delta-internal / non-editable keys") {
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      // Delta-internal metadata that's not in DeltaConfigs.entries.
+      "delta.lastCommitTimestamp" -> "1234567890",
+      // Registered but non-editable; rejected by `DELTA_CANNOT_MODIFY_TABLE_PROPERTY`.
+      "delta.columnMapping.maxColumnId" -> "5")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.feature.catalogManaged" -> "supported"))
+    assert(!out.containsKey("delta.lastCommitTimestamp"))
+    assert(!out.containsKey("delta.columnMapping.maxColumnId"))
+  }
+
+  test("loadTableAndBuildReplaceProps: caller TBLPROPERTIES wins over carried-forward value") {
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      "delta.checkpointInterval" -> "10")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps(
+        "delta.feature.catalogManaged" -> "supported",
+        "delta.checkpointInterval" -> "50"))
+    assert(out.get("delta.checkpointInterval") === "50",
+      "caller-supplied TBLPROPERTIES on the REPLACE must override the existing value")
+  }
+
+  test("loadTableAndBuildReplaceProps: does NOT carry non-delta.* user properties") {
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      "Foo" -> "Bar")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.feature.catalogManaged" -> "supported"))
+    assert(!out.containsKey("Foo"),
+      "non-delta.* user keys follow normal REPLACE semantics: dropped unless re-supplied")
   }
 
   test("loadTable converts TableInfo to V1Table with catalog-supplied fields") {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -860,23 +860,37 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       final Map<String, String> expectedOtherProperties =
           ImmutableMap.<String, String>builder()
               .put("delta.checkpointPolicy", "v2")
+              .put("delta.checkpoint.writeStatsAsJson", "true")
+              .put("delta.checkpoint.writeStatsAsStruct", "true")
+              .put("delta.columnMapping.mode", "name")
               .put("delta.enableDeletionVectors", "true")
               .put("delta.enableInCommitTimestamps", "true")
               .put("delta.enableRowTracking", "true")
               .put("delta.lastUpdateVersion", expectedLastUpdateVersion)
               .put("delta.minReaderVersion", "3")
               .put("delta.minWriterVersion", "7")
+              .put("delta.randomizeFilePrefixes", "true")
               .put(UC_TABLE_ID_KEY, tableInfo.getTableId())
               // User specified custom table property is also sent.
               .putAll(customizedProps)
               .putAll(expectedClusteringProperties)
               .build();
-      // The value of these properties aren't predictable. But at least we confirm their existence.
+      // The value of these properties aren't predictable. But at least we confirm their
+      // existence. Column-mapping rewrites the logical CLUSTER BY column to a physical
+      // `col-<UUID>` reference, so `clusteringColumns` is verified by existence only when
+      // present.
       final Set<String> expectedPropertiesWithVariableValue =
-          Set.of(
-              "delta.lastCommitTimestamp",
-              "delta.rowTracking.materializedRowCommitVersionColumnName",
-              "delta.rowTracking.materializedRowIdColumnName");
+          Stream.concat(
+                  Stream.of(
+                      "delta.lastCommitTimestamp",
+                      // Schema-dependent; value is the largest column id assigned by Delta.
+                      "delta.columnMapping.maxColumnId",
+                      "delta.rowTracking.materializedRowCommitVersionColumnName",
+                      "delta.rowTracking.materializedRowIdColumnName"),
+                  withCluster && expectClusteringColumnsProperty
+                      ? Stream.of("clusteringColumns")
+                      : Stream.empty())
+              .collect(Collectors.toUnmodifiableSet());
 
       // `delta.rowTracking.rowIdHighWaterMark` is emitted when using UC Delta API only.
       // Difference servers may or may not persist it as a table property.

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -831,12 +831,13 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       Map<String, String> tablePropertiesFromServer = tableInfo.getProperties();
       tablePropertiesFromServer.remove("table_type", "MANAGED"); // New property by Spark 4.1
 
-      // CLUSTER BY has two extra properties.
+      // CLUSTER BY adds `delta.feature.clustering`. The accompanying `clusteringColumns` property
+      // holds the physical (column-mapped) column reference, whose value isn't predictable, so it
+      // is verified by existence only via `expectedPropertiesWithVariableValue` below.
       final Map<String, String> expectedClusteringProperties =
           withCluster
               ? ImmutableMap.<String, String>builder()
                   .put("delta.feature.clustering", SUPPORTED)
-                  .put("clusteringColumns", "[[\"" + clusterColumn.get() + "\"]]")
                   .build()
               : ImmutableMap.of();
       final Map<String, String> expectedOtherProperties =
@@ -857,10 +858,11 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
               .putAll(customizedProps)
               .putAll(expectedClusteringProperties)
               .build();
-      // The value of these properties aren't predictable. But at least we confirm their
-      // existence. Column-mapping rewrites the logical CLUSTER BY column to a physical
-      // `col-<UUID>` reference, so `clusteringColumns` is verified by existence only when
-      // present.
+      // The value of these properties aren't predictable, so they are listed here to keep the
+      // unexpected-property check below from flagging them; their values are asserted separately.
+      // Column-mapping rewrites the logical CLUSTER BY column to a physical `col-<UUID>` reference,
+      // so `clusteringColumns` can't be matched against the logical name -- its shape is validated
+      // explicitly below instead.
       final Set<String> expectedPropertiesWithVariableValue =
           Stream.concat(
                   Stream.of(
@@ -869,9 +871,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
                       "delta.columnMapping.maxColumnId",
                       "delta.rowTracking.materializedRowCommitVersionColumnName",
                       "delta.rowTracking.materializedRowIdColumnName"),
-                  withCluster && expectClusteringColumnsProperty
-                      ? Stream.of("clusteringColumns")
-                      : Stream.empty())
+                  withCluster ? Stream.of("clusteringColumns") : Stream.empty())
               .collect(Collectors.toUnmodifiableSet());
 
       // `delta.rowTracking.rowIdHighWaterMark` is emitted when using UC Delta API only.
@@ -891,6 +891,14 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
           (key, value) -> assertThat(tablePropertiesFromServer).containsEntry(key, value));
       expectedPropertiesWithVariableValue.forEach(
           key -> assertThat(tablePropertiesFromServer).containsKey(key));
+
+      // CLUSTER BY (col) persists the column as a column-mapped physical `col-<UUID>` reference.
+      // The UUID is unpredictable, so validate the shape: exactly one column-mapped clustering
+      // column.
+      if (withCluster) {
+        assertThat(tablePropertiesFromServer.get("clusteringColumns"))
+            .matches("\\[\\[\"col-[0-9a-f-]+\"\\]\\]");
+      }
 
       // Server doesn't have any unexpected table properties. If anyone introduces a new table
       // property and this fails, update the list of expected properties.

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -60,14 +60,11 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
   private static final String UC_TABLE_ID_KEY = "io.unitycatalog.tableId";
   private static final String DELTA_CATALOG_MANAGED_KEY = "delta.feature.catalogManaged";
   private static final String SUPPORTED = "supported";
-  private static final String MANAGED_TBLPROPERTIES_CLAUSE =
-      String.format("TBLPROPERTIES ('%s'='%s', 'Foo'='Bar')", DELTA_CATALOG_MANAGED_KEY, SUPPORTED);
+  private static final String CUSTOM_TBLPROPERTIES_CLAUSE = "TBLPROPERTIES ('Foo'='Bar')";
   // In the table REPLACE test, a slightly different table property clause will be used to create
   // the first table. Then the REPLACE command would use TBLPROPERTIES_CLAUSE. This is to make sure
   // that the table properties are properly updated in the REPLACE command.
-  private static final String MANAGED_TBLPROPERTIES_CLAUSE_OTHER =
-      String.format(
-          "TBLPROPERTIES ('%s'='%s', 'Foo2'='Bar2')", DELTA_CATALOG_MANAGED_KEY, SUPPORTED);
+  private static final String CUSTOM_TBLPROPERTIES_CLAUSE_OTHER = "TBLPROPERTIES ('Foo2'='Bar2')";
 
   // Expected table features to be enabled for managed tables
   private static final List<String> EXPECTED_MANAGED_TABLE_FEATURES =
@@ -211,7 +208,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
           columnsClause(),
           partitionClause(),
           clusterClause(),
-          MANAGED_TBLPROPERTIES_CLAUSE,
+          CUSTOM_TBLPROPERTIES_CLAUSE,
           commentClause(),
           asSelectClause());
     }
@@ -409,10 +406,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       String seedClusterClause = withClusterBeforeReplace ? "CLUSTER BY (col1)" : "";
       sql(
           "CREATE TABLE %s (col1 STRING, col2 STRING) USING DELTA %s %s %s",
-          fullTableName,
-          MANAGED_TBLPROPERTIES_CLAUSE_OTHER,
-          seedPartitionClause,
-          seedClusterClause);
+          fullTableName, CUSTOM_TBLPROPERTIES_CLAUSE_OTHER, seedPartitionClause, seedClusterClause);
       sql("INSERT INTO %s VALUES ('seed_col1', 'seed_col2')", fullTableName);
       tablesToCleanUp.add(fullTableName);
     }
@@ -466,7 +460,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
             () ->
                 sql(
                     "CREATE TABLE %s(name STRING) USING parquet %s",
-                    fullTableName, MANAGED_TBLPROPERTIES_CLAUSE))
+                    fullTableName, CUSTOM_TBLPROPERTIES_CLAUSE))
         .hasMessageContaining("not support non-Delta managed table");
 
     // Test 2: Invalid property value 'disabled' for catalogManaged feature
@@ -488,24 +482,12 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         .hasMessageContaining(UC_TABLE_ID_KEY);
 
     // Test 4: Cannot set is_managed_location to false for managed tables.
-    // catalogManaged must be included so the statement passes managed-table validation (Test 5)
-    // and actually reaches the is_managed_location check.
     assertThatThrownBy(
             () ->
                 sql(
-                    "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = '%s', '%s' = 'false')",
-                    fullTableName,
-                    DELTA_CATALOG_MANAGED_KEY,
-                    SUPPORTED,
-                    TableCatalog.PROP_IS_MANAGED_LOCATION))
+                    "CREATE TABLE %s(name STRING) USING delta TBLPROPERTIES ('%s' = 'false')",
+                    fullTableName, TableCatalog.PROP_IS_MANAGED_LOCATION))
         .hasMessageContaining("is_managed_location");
-
-    // Test 5: Managed table creation requires catalogManaged property
-    assertThatThrownBy(() -> sql("CREATE TABLE %s(name STRING) USING delta", fullTableName))
-        .hasMessageContaining(
-            String.format(
-                "Managed table creation requires table property '%s'='%s' to be set",
-                DELTA_CATALOG_MANAGED_KEY, SUPPORTED));
   }
 
   // EXTERNAL is intentionally excluded: CREATE OR REPLACE is not supported yet.

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
@@ -120,8 +120,13 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
 
           LoadTableResponse response = loadTable(tableName);
           assertThat(response.getMetadata().getProperties())
-              .containsEntry("delta.feature.clustering", "supported")
-              .containsEntry("clusteringColumns", "[[\"id\"]]");
+              .containsEntry("delta.feature.clustering", "supported");
+          // Column mapping rewrites the logical `id` to a physical `col-<UUID>` reference. The UC
+          // API exposes only the logical schema, so the exact physical name can't be resolved to
+          // assert here; validate instead that the persisted clustering set is exactly one
+          // column-mapped physical reference (one column, in `col-<UUID>` form).
+          assertThat(response.getMetadata().getProperties().get("clusteringColumns"))
+              .matches("\\[\\[\"col-[0-9a-f-]+\"\\]\\]");
 
           sql("ALTER TABLE %s CLUSTER BY NONE", tableName);
 

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverterSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverterSuite.scala
@@ -16,11 +16,11 @@
 
 package io.delta.storage.commit.uccommitcoordinator
 
-import java.util.{Arrays, Collections, HashMap => JHashMap}
+import java.util.{Arrays, Collections}
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.unitycatalog.client.delta.model.{ArrayType, DecimalType, DeltaType, MapType}
-import io.unitycatalog.client.delta.model.{PrimitiveType, StructField, StructType}
+import io.unitycatalog.client.delta.model.{PrimitiveType, StructField, StructFieldMetadata, StructType}
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -29,8 +29,12 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
   private val objectMapper = new ObjectMapper()
 
   private def prim(t: String): PrimitiveType = new PrimitiveType().`type`(t)
+  // Delta's wire format requires `metadata` to always be present (even if empty); a real
+  // schema parsed from the wire never has a null metadata, so the helper mirrors that
+  // shape with an empty StructFieldMetadata by default.
   private def field(name: String, t: DeltaType, nullable: Boolean = true): StructField =
-    new StructField().name(name).nullable(nullable).`type`(t)
+    new StructField()
+      .name(name).nullable(nullable).`type`(t).metadata(new StructFieldMetadata())
 
   /**
    * One example per primitive: (UC `ColumnTypeName`, catalog-side DDL form, Delta wire form).
@@ -159,7 +163,7 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
   }
 
   test("serializeSchema: per-field metadata round-trips; empty metadata emits {} (not omitted)") {
-    val metadata = new JHashMap[String, Object]()
+    val metadata = new StructFieldMetadata()
     metadata.put("comment", "user-facing column doc")
     metadata.put("delta.columnMapping.id", java.lang.Long.valueOf(42L))
     val annotated = new StructField()
@@ -174,20 +178,6 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
     // Empty metadata must still be present as `{}`; Delta's reader treats omission as ambiguous.
     val plainMeta = parsed.get("fields").get(1).get("metadata")
     assert(plainMeta != null && plainMeta.isObject && plainMeta.size() === 0)
-  }
-
-  test("serializeSchema: null containsNull / valueContainsNull are omitted from JSON output") {
-    // Delta's reader rejects literal "containsNull":null, so the mapper must omit the key.
-    val arr = new ArrayType().elementType(prim("string")) // containsNull deliberately unset
-    val m = new MapType().keyType(prim("string")).valueType(prim("integer")) // and here too
-    val s = new StructType().addFieldsItem(field("a", arr)).addFieldsItem(field("m", m))
-    val parsed = objectMapper.readTree(UCDeltaSchemaConverter.serializeSchema(s))
-    val arrJson = parsed.get("fields").get(0).get("type")
-    val arrNode = arrJson.get("containsNull")
-    assert(arrNode == null || !arrNode.isNull, s"unexpected null containsNull in: $arrJson")
-    val mapJson = parsed.get("fields").get(1).get("type")
-    val mapNode = mapJson.get("valueContainsNull")
-    assert(mapNode == null || !mapNode.isNull, s"unexpected null valueContainsNull in: $mapJson")
   }
 
   // ----------------------------------------


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6923/files) to review incremental changes.
- [**stack/replace_table_property**](https://github.com/delta-io/delta/pull/6923) [[Files changed](https://github.com/delta-io/delta/pull/6923/files)]
  - [stack/delta_api_default](https://github.com/delta-io/delta/pull/6951) [[Files changed](https://github.com/delta-io/delta/pull/6951/files/8677f8070f5b243088401cefc41b13527c433032..f667dd6b0904cf2244b2851fd35611a965cbcb44)]

---------
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Carry forward existing delta.* properties on managed REPLACE

When the UC Delta API routes REPLACE through `loadTableAndBuildReplaceProps`, preserve the existing table's `delta.*` configuration so the follow-up commit doesn't strip required features (and get rejected by commit-side validation).

Carry forward only keys that:
- start with `delta.`
- are not `delta.feature.clustering` (DDL-only via `CLUSTER BY`)
- pass `DeltaConfigs.validateConfiguration` (registered + editable + valid value)

Caller-supplied TBLPROPERTIES still win via `putIfAbsent`. Unknown/Kernel-only suggested properties from UC are filtered through the same validator so REPLACE doesn't fail on `DELTA_UNKNOWN_CONFIGURATION`.

Refactor `DeltaConfigs.validateConfigurations` to expose a single-key `validateConfiguration` entry point, reused by the carry-forward filter and the suggested-property filter.

## How was this patch tested?
- `AbstractDeltaCatalogClientRoutingSuite`: 5 focused unit tests pinning the carry-forward contract (feature flags + editable configs survive; clustering / non-editable / Delta-internal / non-delta keys are dropped; caller wins).
- `UCDeltaTableCreationTest` and `UCDeltaManagedReplaceSemanticsTest`: update expected property sets / version assertions for the new UC server defaults.

## Does this PR introduce _any_ user-facing changes?
No
