### PR TITLE
[Spark] Use isPathIdentifier in UC routing predicates; pin path-based REPLACE outcomes

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -545,8 +545,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         properties.containsKey(TableCatalog.PROP_EXTERNAL)) {
       return false
     }
-    val ns = ident.namespace()
-    !(ns.length == 1 && new Path(ident.name()).isAbsolute)
+    !isPathIdentifier(ident)
   }
 
   /**
@@ -583,8 +582,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           s"'${TableCatalog.PROP_EXTERNAL}': only catalog-managed Delta tables can " +
           "be replaced on this path.")
     }
-    val ns = ident.namespace()
-    !(ns.length == 1 && new Path(ident.name()).isAbsolute)
+    !isPathIdentifier(ident)
   }
 
   /**

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.model.TableInfo;
+import java.nio.file.AccessDeniedException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -431,11 +432,17 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
   }
 
   // Path-based identifiers (e.g. `delta.`/tmp/foo``) are not valid UC table references --
-  // UC has no entry for them. `shouldRouteReplaceThroughDeltaCatalogClient` skips routing on
-  // those, so the request falls through to the standard Spark V2 REPLACE flow, which surfaces
-  // `CannotReplaceMissingTableException` for the unresolved identifier. Pinned so that any
-  // future change to the routing gate's path-based predicate (or the fall-through behavior)
-  // is caught here instead of silently regressing.
+  // UC has no entry for them. Spark V2's `AtomicReplaceTableExec` calls
+  // `catalog.tableExists(ident)` before `stageReplace`, and `AbstractDeltaCatalog.tableExists`
+  // probes the filesystem (`fs.exists(path)`) for path-based identifiers. The end-user-visible
+  // exception therefore depends on whether the underlying filesystem is reachable:
+  //   - filesystem reachable, path missing -> `tableExists` returns false ->
+  //     Spark V2 throws `CannotReplaceMissingTableException` (errorClass TABLE_OR_VIEW_NOT_FOUND).
+  //   - filesystem unreachable (e.g. S3 403 when the UC server's federated credentials are
+  //     not loaded into the Spark session) -> `fs.exists` throws `AccessDeniedException`,
+  //     which bubbles up out of `AtomicReplaceTableExec.run`.
+  // Either outcome is an acceptable rejection of path-based REPLACE on a UC catalog; this
+  // test pins both as the only outcomes (no silent success, no surprise new exception class).
   @Test
   public void testReplaceOnPathBasedIdentifierIsRejected() throws Exception {
     withTempDir(
@@ -446,9 +453,13 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
                           "REPLACE TABLE delta.`%s` (i INT, s STRING) USING DELTA "
                               + "TBLPROPERTIES ('delta.feature.catalogManaged'='supported')",
                           location.toString()))
-              .isInstanceOf(CannotReplaceMissingTableException.class)
-              .hasMessageContaining("TABLE_OR_VIEW_NOT_FOUND")
-              .hasMessageContaining(location.toString());
+              .satisfiesAnyOf(
+                  t ->
+                      assertThat(t)
+                          .isInstanceOf(CannotReplaceMissingTableException.class)
+                          .hasMessageContaining("TABLE_OR_VIEW_NOT_FOUND")
+                          .hasMessageContaining(location.toString()),
+                  t -> assertThat(t).isInstanceOf(AccessDeniedException.class));
         });
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6924/files) to review incremental changes.
- [**stack/replace_path_table_fail**](https://github.com/delta-io/delta/pull/6924) [[Files changed](https://github.com/delta-io/delta/pull/6924/files)]

---------
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Use isPathIdentifier in UC routing predicates; pin path-based REPLACE outcomes

Changes:
- `shouldRouteCreateThroughDeltaCatalogClient` / `shouldRouteReplaceThroughDeltaCatalogClient`: replace inline `ns.length == 1 && new Path(ident.name()).isAbsolute` with `isPathIdentifier(ident)`.
- `testReplaceOnPathBasedIdentifierIsRejected`: accept either `CannotReplaceMissingTableException` or `java.nio.file.AccessDeniedException`.

Why:
- `isPathIdentifier` adds `hasDeltaNamespace` narrowing, the `supportSQLOnFile` gate, and an `IllegalArgumentException` guard.
- Plain REPLACE never reaches the routing gate on a path-based identifier (Spark V2's `AtomicReplaceTableExec` pre-checks `tableExists`); the check is kept as defense-in-depth for CREATE OR REPLACE.
- The two-outcome test pins both environments: filesystem reachable (missing-table) and S3 403 (e.g. Table Service without UC federated creds in the Spark session).

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
No
