### PR TITLE
[DSv2] Reject DSv2 batch writes to column-mapped Delta tables

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
@@ -91,23 +91,6 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
     Row txnState = transaction.getTransactionState(this.engine);
     this.serializedTxnState = new SerializableKernelRowWrapper(txnState);
 
-    // Reject writes to column-mapped tables: the V2 write path writes Parquet with logical
-    // column names, but column-mapped tables store data under physical UUID-based names.
-    // The mismatch causes reads to return null for every value. Fail fast here rather than
-    // silently producing corrupt data.
-    String cmMode =
-        ((io.delta.kernel.internal.SnapshotImpl) initialSnapshot)
-            .getMetadata()
-            .getConfiguration()
-            .getOrDefault("delta.columnMapping.mode", "none");
-    if (!"none".equalsIgnoreCase(cmMode)) {
-      throw new UnsupportedOperationException(
-          "DeltaV2BatchWrite does not support column-mapped Delta tables "
-              + "(delta.columnMapping.mode = "
-              + cmMode
-              + "). Use the V1 write path (format(\"delta\").write()) instead.");
-    }
-
     this.targetDirectory =
         Transaction.getWriteContext(this.engine, txnState, Collections.emptyMap())
             .getTargetDirectory();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
@@ -91,6 +91,23 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
     Row txnState = transaction.getTransactionState(this.engine);
     this.serializedTxnState = new SerializableKernelRowWrapper(txnState);
 
+    // Reject writes to column-mapped tables: the V2 write path writes Parquet with logical
+    // column names, but column-mapped tables store data under physical UUID-based names.
+    // The mismatch causes reads to return null for every value. Fail fast here rather than
+    // silently producing corrupt data.
+    String cmMode =
+        ((io.delta.kernel.internal.SnapshotImpl) initialSnapshot)
+            .getMetadata()
+            .getConfiguration()
+            .getOrDefault("delta.columnMapping.mode", "none");
+    if (!"none".equalsIgnoreCase(cmMode)) {
+      throw new UnsupportedOperationException(
+          "DeltaV2BatchWrite does not support column-mapped Delta tables "
+              + "(delta.columnMapping.mode = "
+              + cmMode
+              + "). Use the V1 write path (format(\"delta\").write()) instead.");
+    }
+
     this.targetDirectory =
         Transaction.getWriteContext(this.engine, txnState, Collections.emptyMap())
             .getTargetDirectory();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
@@ -67,6 +68,19 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
 
   @Override
   public Write build() {
+    // Reject writes to column-mapped tables: the V2 write path writes Parquet with logical
+    // column names, but column-mapped tables store data under physical UUID-based names.
+    // The mismatch causes reads to return null for every value.
+    ColumnMapping.ColumnMappingMode cmMode =
+        ColumnMapping.getColumnMappingMode(initialSnapshot.getTableProperties());
+    if (ColumnMapping.isColumnMappingModeEnabled(cmMode)) {
+      throw new UnsupportedOperationException(
+          "DSv2 writes are not supported on column-mapped Delta tables "
+              + "(delta.columnMapping.mode = "
+              + cmMode.toString()
+              + "). Use the V1 write path (format(\"delta\").write()) instead.");
+    }
+
     StructType tableSchema =
         SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
     // Strip column mapping metadata (physical names, IDs) so mergeSchemas compares

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -531,6 +531,86 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
   }
 
   @Test
+  public void testWriteBuilderRejectsColumnMappedTable(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE test_cm_write (id INT, name STRING) USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode'='name') "
+                + "LOCATION '%s'",
+            path));
+
+    DeltaV2Table table =
+        new DeltaV2Table(Identifier.of(new String[] {"default"}, "test_cm_write"), path);
+    LogicalWriteInfo writeInfo =
+        new LogicalWriteInfo() {
+          @Override
+          public String queryId() {
+            return "test-query-id";
+          }
+
+          @Override
+          public StructType schema() {
+            return new StructType()
+                .add("id", DataTypes.IntegerType)
+                .add("name", DataTypes.StringType);
+          }
+
+          @Override
+          public CaseInsensitiveStringMap options() {
+            return new CaseInsensitiveStringMap(Collections.emptyMap());
+          }
+        };
+
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class, () -> table.newWriteBuilder(writeInfo).build());
+    assertTrue(
+        e.getMessage().contains("not supported on column-mapped"),
+        "exception message should mention column-mapped; was: " + e.getMessage());
+  }
+
+  @Test
+  public void testWriteBuilderRejectsIdMappedTable(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE test_id_write (id INT, name STRING) USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode'='id') "
+                + "LOCATION '%s'",
+            path));
+
+    DeltaV2Table table =
+        new DeltaV2Table(Identifier.of(new String[] {"default"}, "test_id_write"), path);
+    LogicalWriteInfo writeInfo =
+        new LogicalWriteInfo() {
+          @Override
+          public String queryId() {
+            return "test-query-id";
+          }
+
+          @Override
+          public StructType schema() {
+            return new StructType()
+                .add("id", DataTypes.IntegerType)
+                .add("name", DataTypes.StringType);
+          }
+
+          @Override
+          public CaseInsensitiveStringMap options() {
+            return new CaseInsensitiveStringMap(Collections.emptyMap());
+          }
+        };
+
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class, () -> table.newWriteBuilder(writeInfo).build());
+    assertTrue(
+        e.getMessage().contains("not supported on column-mapped"),
+        "exception message should mention column-mapped; was: " + e.getMessage());
+  }
+
+  @Test
   public void testSchemaWithReadChangeFeedIncludesCDCColumns(@TempDir File tempDir) {
     String path = tempDir.getAbsolutePath();
     spark.sql(String.format("CREATE TABLE test_cdc_on (id INT) USING delta LOCATION '%s'", path));


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark

## Description

`DeltaV2WriteBuilder.build()` now rejects batch writes to column-mapped Delta tables
before creating a Kernel `Transaction`.

The DSv2 write path writes Parquet files using logical column names, but column-mapped
tables store data under physical UUID-based names. Any data written by the V2 path is
permanently unreadable — every column reads back as `null`. This guard prevents silent
data corruption.

## How was this patch tested?

Unit test added in `SparkTableTest.testWriteBuilderRejectsColumnMappedTable`.

## Does this PR introduce _any_ user-facing changes?

Yes: attempting to write to a column-mapped Delta table via the DSv2 connector now throws
`UnsupportedOperationException` instead of silently writing corrupt data. The error message
directs users to the V1 write path (`format("delta").write()`).