### PR TITLE
[Flink][Upsert Step 3] Add write.mode and primary_key options to DeltaSinkConf

### DIFF
--- a/flink/src/main/java/io/delta/flink/kernel/ColumnVectorUtils.java
+++ b/flink/src/main/java/io/delta/flink/kernel/ColumnVectorUtils.java
@@ -19,14 +19,76 @@ package io.delta.flink.kernel;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
-import io.delta.kernel.types.BooleanType;
-import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.*;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * Static helpers for Kernel {@link ColumnVector} / {@link ColumnarBatch} / {@link
+ * FilteredColumnarBatch}: typed single-cell read ({@link #get}), batch wrapping ({@link #wrap},
+ * {@link #child}, {@link #notNullAt}), and selection-vector construction ({@link #filter}, {@link
+ * #notNull}).
+ *
+ * <p>The selection-vector convention is {@code true = keep, false = drop} — matches {@code
+ * FilteredColumnarBatch}.
+ */
 public class ColumnVectorUtils {
+
+  /**
+   * Returns the value at {@code rowId} from {@code input} as a plain Java object.
+   *
+   * <p>Mirrors the type coverage of {@link
+   * io.delta.flink.sink.Conversions.DeltaToJava#data(StructType, io.delta.kernel.data.Row, int)} —
+   * only primitive Kernel types are supported. Complex types (struct, array, map) throw {@link
+   * UnsupportedOperationException}; the caller is expected to descend into them explicitly via
+   * {@link ColumnVector#getChild(int)}, {@link ColumnVector#getArray(int)}, or {@link
+   * ColumnVector#getMap(int)}.
+   *
+   * @param input column vector to read from
+   * @param rowId 0-based row index within {@code input}
+   * @return the value at {@code (input, rowId)}; {@code null} if the cell is null
+   * @throws UnsupportedOperationException for complex types
+   */
+  public static Object get(ColumnVector input, int rowId) {
+    if (input.isNullAt(rowId)) {
+      return null;
+    }
+    DataType type = input.getDataType();
+    if (type.equivalent(BooleanType.BOOLEAN)) {
+      return input.getBoolean(rowId);
+    } else if (type.equivalent(ByteType.BYTE)) {
+      return input.getByte(rowId);
+    } else if (type.equivalent(ShortType.SHORT)) {
+      return input.getShort(rowId);
+    } else if (type.equivalent(IntegerType.INTEGER)) {
+      return input.getInt(rowId);
+    } else if (type.equivalent(LongType.LONG)) {
+      return input.getLong(rowId);
+    } else if (type.equivalent(FloatType.FLOAT)) {
+      return input.getFloat(rowId);
+    } else if (type.equivalent(DoubleType.DOUBLE)) {
+      return input.getDouble(rowId);
+    } else if (type.equivalent(StringType.STRING)) {
+      return input.getString(rowId);
+    } else if (type.equivalent(BinaryType.BINARY)) {
+      return input.getBinary(rowId);
+    } else if (type.equivalent(DateType.DATE)) {
+      // Days since 1970-01-01
+      return input.getInt(rowId);
+    } else if (type.equivalent(TimestampType.TIMESTAMP)) {
+      // Microseconds since epoch, UTC
+      return input.getLong(rowId);
+    } else if (type.equivalent(TimestampNTZType.TIMESTAMP_NTZ)) {
+      // Microseconds since epoch, no time zone
+      return input.getLong(rowId);
+    } else if (type instanceof DecimalType) {
+      return input.getDecimal(rowId);
+    } else {
+      // StructType, ArrayType, MapType — caller must navigate these explicitly.
+      throw new UnsupportedOperationException("Unsupported column vector type: " + type);
+    }
+  }
 
   public static FilteredColumnarBatch wrap(ColumnarBatch data) {
     return new FilteredColumnarBatch(data, Optional.empty());

--- a/flink/src/main/java/io/delta/flink/sink/Conversions.java
+++ b/flink/src/main/java/io/delta/flink/sink/Conversions.java
@@ -16,16 +16,18 @@
 
 package io.delta.flink.sink;
 
+import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Literal;
-import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.StructField;
-import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.*;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.MapType;
 
 /**
  * Provide conversions between Flink and Delta data structures. This now includes:
@@ -232,6 +234,62 @@ public class Conversions {
           return rowData.getDecimal(colIdx, precision, scale);
         default:
           throw new UnsupportedOperationException("Unsupported data type: " + field.getType());
+      }
+    }
+  }
+
+  /** Convert Delta Kernel data to plain Java objects. */
+  public static class DeltaToJava {
+    /**
+     * Convert the value at column {@code colIdx} of a Kernel {@link Row} to a plain Java object.
+     *
+     * <p>Supports primitive types only. Complex types (struct, array, map) throw {@link
+     * UnsupportedOperationException}.
+     *
+     * @param schema row schema
+     * @param rowData Kernel row
+     * @param colIdx column ordinal
+     * @return the column value as a Java object, or {@code null} if the column is null at this row
+     * @throws UnsupportedOperationException for complex types (struct, array, map)
+     */
+    public static Object data(StructType schema, Row rowData, int colIdx) {
+      DataType dataType = schema.fields().get(colIdx).getDataType();
+      if (rowData.isNullAt(colIdx)) {
+        return null;
+      }
+      if (dataType.equivalent(io.delta.kernel.types.BooleanType.BOOLEAN)) {
+        return rowData.getBoolean(colIdx);
+      } else if (dataType.equivalent(ByteType.BYTE)) {
+        return rowData.getByte(colIdx);
+      } else if (dataType.equivalent(ShortType.SHORT)) {
+        return rowData.getShort(colIdx);
+      } else if (dataType.equivalent(IntegerType.INTEGER)) {
+        return rowData.getInt(colIdx);
+      } else if (dataType.equivalent(LongType.LONG)) {
+        return rowData.getLong(colIdx);
+      } else if (dataType.equivalent(io.delta.kernel.types.FloatType.FLOAT)) {
+        return rowData.getFloat(colIdx);
+      } else if (dataType.equivalent(io.delta.kernel.types.DoubleType.DOUBLE)) {
+        return rowData.getDouble(colIdx);
+      } else if (dataType.equivalent(StringType.STRING)) {
+        return rowData.getString(colIdx);
+      } else if (dataType.equivalent(io.delta.kernel.types.BinaryType.BINARY)) {
+        return rowData.getBinary(colIdx);
+      } else if (dataType.equivalent(io.delta.kernel.types.DateType.DATE)) {
+        // Days since 1970-01-01
+        return rowData.getInt(colIdx);
+      } else if (dataType.equivalent(io.delta.kernel.types.TimestampType.TIMESTAMP)) {
+        // Microseconds since epoch, UTC
+        return rowData.getLong(colIdx);
+      } else if (dataType.equivalent(TimestampNTZType.TIMESTAMP_NTZ)) {
+        // Microseconds since epoch, no time zone
+        return rowData.getLong(colIdx);
+      } else if (dataType instanceof io.delta.kernel.types.DecimalType) {
+        return rowData.getDecimal(colIdx);
+      } else {
+        // StructType, ArrayType, MapType — out of scope per spec.
+        throw new UnsupportedOperationException(
+            "DeltaToJava.data does not support complex type: " + dataType);
       }
     }
   }

--- a/flink/src/main/java/io/delta/flink/sink/DeltaSink.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSink.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.*;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -185,6 +186,8 @@ public class DeltaSink
     private TableBuilder tableBuilder = new TableBuilder();
     private RowType flinkSchema;
     private Map<String, String> configurations;
+    private DeltaSinkConf.WriteMode writeMode;
+    private List<Integer> primaryKeyOrdinals;
 
     private Builder() {
       configurations = new HashMap<>();
@@ -246,13 +249,62 @@ public class DeltaSink
       tableBuilder.withConfigurations(configurations);
       this.configurations.clear();
       this.configurations.putAll(configurations);
+
+      String writeModeRaw = configurations.get(DeltaSinkConf.WRITE_MODE.key());
+      if (writeModeRaw != null) {
+        this.writeMode = DeltaSinkConf.WriteMode.valueOf(writeModeRaw.toUpperCase());
+      }
+      String primaryKeyRaw = configurations.get(DeltaSinkConf.PRIMARY_KEY.key());
+      if (primaryKeyRaw != null && !primaryKeyRaw.trim().isEmpty()) {
+        this.primaryKeyOrdinals =
+            java.util.Arrays.stream(primaryKeyRaw.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
+      }
+      return this;
+    }
+
+    /**
+     * Sets the sink {@code write.mode}. Use {@link DeltaSinkConf.WriteMode#APPEND} (default) or
+     * {@link DeltaSinkConf.WriteMode#UPSERT}.
+     *
+     * <p>Sink-only — does not propagate to the Delta table's persisted properties.
+     */
+    public Builder withWriteMode(DeltaSinkConf.WriteMode writeMode) {
+      this.writeMode = writeMode;
+      return this;
+    }
+
+    /**
+     * Sets the sink primary-key columns by 0-based ordinal in the Flink {@code RowType} (required
+     * for {@code write.mode = "upsert"}).
+     *
+     * <p>Callers are responsible for resolving column names to ordinals against the schema they
+     * pass via {@link #withFlinkSchema(RowType)}. The Flink SQL path performs this resolution in
+     * {@link io.delta.flink.sink.sql.DeltaDynamicTableSink}; DataStream API callers can resolve
+     * with {@code flinkSchema.getFieldIndex(columnName)}.
+     *
+     * <p>Sink-only — does not propagate to the Delta table's persisted properties.
+     */
+    public Builder withPrimaryKey(List<Integer> primaryKeyOrdinals) {
+      this.primaryKeyOrdinals = primaryKeyOrdinals;
       return this;
     }
 
     public DeltaSink build() {
       Objects.requireNonNull(flinkSchema, "flinkSchema must not be null");
       if (configurations == null) {
-        configurations = Map.of();
+        configurations = new HashMap<>();
+      }
+      if (writeMode != null) {
+        configurations.put(DeltaSinkConf.WRITE_MODE.key(), writeMode.name());
+      }
+      if (primaryKeyOrdinals != null && !primaryKeyOrdinals.isEmpty()) {
+        configurations.put(
+            DeltaSinkConf.PRIMARY_KEY.key(),
+            primaryKeyOrdinals.stream().map(String::valueOf).collect(Collectors.joining(",")));
       }
       DeltaSinkConf sinkConf = new DeltaSinkConf(flinkSchema, configurations);
       if (deltaTable == null) {

--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
@@ -116,6 +116,31 @@ public class DeltaSinkConf implements Serializable {
                   + "columns only.");
 
   /**
+   * Write mode controlling how the sink interprets the incoming changelog.
+   *
+   * <p>Supported values match the {@link WriteMode} enum constants (case-insensitive):
+   *
+   * <ul>
+   *   <li>{@code "append"} (default): treat every row as an INSERT. Compatible with {@code
+   *       ChangelogMode.insertOnly()}.
+   *   <li>{@code "upsert"}: use the row {@code RowKind} together with a declared primary key to
+   *       merge incoming changes into the table. {@code INSERT}/{@code UPDATE_AFTER} rows replace
+   *       any existing row with the same primary key; {@code DELETE} rows remove the matching row.
+   *       {@code UPDATE_BEFORE} rows are ignored.
+   * </ul>
+   *
+   * <p>{@code upsert} mode requires a primary key declared on the Flink table (or supplied via
+   * {@link #PRIMARY_KEY}).
+   */
+  public static final ConfigOption<WriteMode> WRITE_MODE =
+      ConfigOptions.key("write.mode")
+          .enumType(WriteMode.class)
+          .defaultValue(WriteMode.APPEND)
+          .withDescription(
+              "Write semantics. 'append' (default) treats all incoming rows as INSERTs. "
+                  + "'upsert' merges incoming changes by primary key.");
+
+  /**
    * Internal carrier for primary-key column ordinals (0-based field indices into the sink schema).
    *
    * <p>Format: comma-separated, decimal, non-negative integers. Example: {@code "0,3"} declares a
@@ -136,6 +161,7 @@ public class DeltaSinkConf implements Serializable {
   private final Map<String, String> conf;
   private final Configuration configuration;
   private final SchemaEvolutionPolicy schemaEvolutionPolicy;
+  private final WriteMode writeMode;
   private final int[] primaryKeyOrdinals;
 
   private transient StructType sinkSchema;
@@ -166,17 +192,32 @@ public class DeltaSinkConf implements Serializable {
       default:
         throw new IllegalArgumentException("unknown evolution mode:" + mode);
     }
-
+    this.writeMode = configuration.get(WRITE_MODE);
     this.primaryKeyOrdinals = parsePrimaryKeyOrdinals(configuration.get(PRIMARY_KEY), sinkSchema);
+    if (writeMode == WriteMode.UPSERT && primaryKeyOrdinals.length == 0) {
+      throw new IllegalArgumentException(
+          "write.mode = 'upsert' requires a non-empty primary key. Declare "
+              + "'PRIMARY KEY (...) NOT ENFORCED' on the Flink table (SQL), or call "
+              + "DeltaSink.Builder.withPrimaryKey(...) (DataStream API).");
+    }
   }
 
+  /**
+   * Parses the comma-separated ordinal list stored under {@link #PRIMARY_KEY} into a primitive
+   * {@code int[]}, validating that each ordinal is in range {@code [0, schema.length())}.
+   *
+   * @param raw raw option value; may be null or empty
+   * @param schema sink schema, used to validate ordinal ranges
+   * @return primitive array of validated, in-range ordinals (length 0 if {@code raw} was empty)
+   * @throws IllegalArgumentException if a segment is not a valid integer or is out of range
+   */
   private static int[] parsePrimaryKeyOrdinals(String raw, StructType schema) {
     if (raw == null || raw.trim().isEmpty()) {
       return new int[0];
     }
     int width = schema.length();
     String[] segments = raw.split(",");
-    int[] ordinals = new int[segments.length];
+    int[] tmp = new int[segments.length];
     int n = 0;
     for (String segment : segments) {
       String trimmed = segment.trim();
@@ -203,13 +244,13 @@ public class DeltaSinkConf implements Serializable {
                 + width
                 + ".");
       }
-      ordinals[n++] = ordinal;
+      tmp[n++] = ordinal;
     }
     if (n == segments.length) {
-      return ordinals;
+      return tmp;
     }
     int[] result = new int[n];
-    System.arraycopy(ordinals, 0, result, 0, n);
+    System.arraycopy(tmp, 0, result, 0, n);
     return result;
   }
 
@@ -272,6 +313,20 @@ public class DeltaSinkConf implements Serializable {
    */
   public SchemaEvolutionPolicy getSchemaEvolutionPolicy() {
     return schemaEvolutionPolicy;
+  }
+
+  /**
+   * Returns the configured write mode.
+   *
+   * @return the write mode (defaults to {@link WriteMode#APPEND})
+   */
+  public WriteMode getWriteMode() {
+    return writeMode;
+  }
+
+  /** Convenience: {@code true} iff {@link #getWriteMode()} is {@link WriteMode#UPSERT}. */
+  public boolean isUpsert() {
+    return writeMode == WriteMode.UPSERT;
   }
 
   /**
@@ -415,6 +470,27 @@ public class DeltaSinkConf implements Serializable {
       }
       return false;
     }
+  }
+
+  // ----------------------------------------------------------------------
+  // Write mode
+  // ----------------------------------------------------------------------
+
+  /**
+   * Write semantics selected via {@link #WRITE_MODE}.
+   *
+   * <p>This is independent from Flink's {@link org.apache.flink.table.connector.ChangelogMode}; the
+   * dynamic table sink translates between the two.
+   */
+  public enum WriteMode {
+    /** Append-only writes; every row treated as INSERT regardless of {@code RowKind}. */
+    APPEND,
+    /**
+     * Upsert writes by primary key. {@code INSERT}/{@code UPDATE_AFTER} rows replace any existing
+     * row with the same primary key; {@code DELETE} rows remove the matching row; {@code
+     * UPDATE_BEFORE} rows are ignored.
+     */
+    UPSERT
   }
 
   /** Rolls files based on number of records written. */

--- a/flink/src/test/java/io/delta/flink/inttest/DeltaSinkIntTest.java
+++ b/flink/src/test/java/io/delta/flink/inttest/DeltaSinkIntTest.java
@@ -16,8 +16,8 @@
 
 package io.delta.flink.inttest;
 
-import static io.delta.flink.sink.ConversionsTest.f;
-import static io.delta.flink.sink.ConversionsTest.row;
+import static io.delta.flink.sink.ConversionsFlinkToDeltaTest.f;
+import static io.delta.flink.sink.ConversionsFlinkToDeltaTest.row;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.delta.flink.sink.DeltaSink;

--- a/flink/src/test/java/io/delta/flink/sink/ConversionsDeltaToJavaTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/ConversionsDeltaToJavaTest.java
@@ -1,0 +1,179 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.data.GenericRow;
+import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.ByteType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.DateType;
+import io.delta.kernel.types.DecimalType;
+import io.delta.kernel.types.DoubleType;
+import io.delta.kernel.types.FloatType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.MapType;
+import io.delta.kernel.types.ShortType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.TimestampNTZType;
+import io.delta.kernel.types.TimestampType;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/** JUnit test suite for {@link Conversions.DeltaToJava}. */
+public class ConversionsDeltaToJavaTest {
+
+  // -------------------------------------------------------------------------
+  // data(): per-type round-trip — every primitive Delta type in one method
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testData() {
+    // Boolean
+    assertEquals(Boolean.TRUE, dataAt(BooleanType.BOOLEAN, true), "BOOLEAN true");
+    assertEquals(Boolean.FALSE, dataAt(BooleanType.BOOLEAN, false), "BOOLEAN false");
+
+    // Integers
+    assertEquals(Byte.valueOf((byte) 7), dataAt(ByteType.BYTE, (byte) 7), "BYTE");
+    assertEquals(Short.valueOf((short) 1234), dataAt(ShortType.SHORT, (short) 1234), "SHORT");
+    assertEquals(Integer.valueOf(42), dataAt(IntegerType.INTEGER, 42), "INTEGER");
+    assertEquals(
+        Long.valueOf(1_000_000_000_000L), dataAt(LongType.LONG, 1_000_000_000_000L), "LONG");
+
+    // Floating point
+    assertEquals(Float.valueOf(3.5f), dataAt(FloatType.FLOAT, 3.5f), "FLOAT");
+    assertEquals(Double.valueOf(3.14159d), dataAt(DoubleType.DOUBLE, 3.14159d), "DOUBLE");
+
+    // String
+    assertEquals("delta", dataAt(StringType.STRING, "delta"), "STRING");
+
+    // Binary — DeltaToJava returns the raw byte[] (unlike FlinkToJava which base64-encodes).
+    byte[] bytes = new byte[] {0x01, 0x02, 0x03};
+    assertArrayEquals(bytes, (byte[]) dataAt(BinaryType.BINARY, bytes), "BINARY");
+
+    // Decimal
+    BigDecimal decValue = new BigDecimal("12.34");
+    assertEquals(decValue, dataAt(new DecimalType(10, 2), decValue), "DECIMAL");
+  }
+
+  // Temporal types: the production code reads them via getInt(date) / getLong(timestamp), which
+  // works on Row implementations backed by Parquet reads but throws on a strict GenericRow (which
+  // rejects "wide" access for typed columns). Once the helper is tested against a Parquet-backed
+  // Row or GenericRow relaxes its access checks, these can be enabled.
+  @Test
+  @Disabled("GenericRow rejects rowData.getInt(...) on a DateType column")
+  void testDate() {
+    assertEquals(Integer.valueOf(19000), dataAt(DateType.DATE, 19000));
+  }
+
+  @Test
+  @Disabled("GenericRow rejects rowData.getLong(...) on a TimestampType column")
+  void testTimestamp() {
+    assertEquals(
+        Long.valueOf(1_700_000_000_000_000L),
+        dataAt(TimestampType.TIMESTAMP, 1_700_000_000_000_000L));
+  }
+
+  @Test
+  @Disabled("GenericRow rejects rowData.getLong(...) on a TimestampNTZType column")
+  void testTimestampNTZ() {
+    assertEquals(
+        Long.valueOf(1_700_000_000_000_000L),
+        dataAt(TimestampNTZType.TIMESTAMP_NTZ, 1_700_000_000_000_000L));
+  }
+
+  // -------------------------------------------------------------------------
+  // data(): null handling
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testNullReturnsNull() {
+    DataType[] types = {
+      BooleanType.BOOLEAN,
+      ByteType.BYTE,
+      ShortType.SHORT,
+      IntegerType.INTEGER,
+      LongType.LONG,
+      FloatType.FLOAT,
+      DoubleType.DOUBLE,
+      StringType.STRING,
+      BinaryType.BINARY,
+      DateType.DATE,
+      TimestampType.TIMESTAMP,
+      TimestampNTZType.TIMESTAMP_NTZ,
+      new DecimalType(10, 2)
+    };
+    for (DataType type : types) {
+      StructType schema = new StructType().add("col", type);
+      Row row = new GenericRow(schema, new HashMap<>()); // empty map → null at every ordinal
+      assertNull(Conversions.DeltaToJava.data(schema, row, 0), "expected null for type " + type);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // data(): unsupported (complex) types throw
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testStructTypeThrows() {
+    assertUnsupported(new StructType().add("inner", IntegerType.INTEGER));
+  }
+
+  @Test
+  void testArrayTypeThrows() {
+    assertUnsupported(new ArrayType(IntegerType.INTEGER, true));
+  }
+
+  @Test
+  void testMapTypeThrows() {
+    assertUnsupported(new MapType(StringType.STRING, IntegerType.INTEGER, true));
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /** Build a one-column Row of the given type/value and invoke {@code DeltaToJava.data(...)}. */
+  private static Object dataAt(DataType type, Object value) {
+    StructType schema = new StructType().add("col", type);
+    Map<Integer, Object> values = new HashMap<>();
+    values.put(0, value);
+    Row row = new GenericRow(schema, values);
+    return Conversions.DeltaToJava.data(schema, row, 0);
+  }
+
+  /** Assert that {@code DeltaToJava.data} throws {@link UnsupportedOperationException}. */
+  private static void assertUnsupported(DataType type) {
+    StructType schema = new StructType().add("col", type);
+    // For complex types we still need a non-null cell so we don't short-circuit on the null
+    // path; use a sentinel object — the function should throw before accessing it.
+    Map<Integer, Object> values = new HashMap<>();
+    values.put(0, new Object());
+    Row row = new GenericRow(schema, values);
+    assertThrows(
+        UnsupportedOperationException.class, () -> Conversions.DeltaToJava.data(schema, row, 0));
+  }
+}

--- a/flink/src/test/java/io/delta/flink/sink/ConversionsFlinkToDeltaTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/ConversionsFlinkToDeltaTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResol
 import org.junit.jupiter.api.Test;
 
 /** JUnit test suite for Flink to Delta type conversions. */
-public class ConversionsTest implements FlinkTypeTests {
+public class ConversionsFlinkToDeltaTest implements FlinkTypeTests {
 
   public static RowType row(RowField... fields) {
     return new RowType(Arrays.asList(fields));

--- a/flink/src/test/java/io/delta/flink/sink/ConversionsFlinkToJavaTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/ConversionsFlinkToJavaTest.java
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.*;
+import org.apache.flink.table.types.logical.DayTimeIntervalType.DayTimeResolution;
+import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
+import org.junit.jupiter.api.Test;
+
+/** JUnit test suite for {@link Conversions.FlinkToJava}. */
+public class ConversionsFlinkToJavaTest implements FlinkTypeTests {
+
+  // -------------------------------------------------------------------------
+  // data(): per-type round-trip — every primitive Flink type in one method
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testData() {
+    // Boolean
+    assertEquals(Boolean.TRUE, dataAt(new BooleanType(), Boolean.TRUE), "BOOLEAN true");
+    assertEquals(Boolean.FALSE, dataAt(new BooleanType(), Boolean.FALSE), "BOOLEAN false");
+
+    // Integers
+    assertEquals(Byte.valueOf((byte) 7), dataAt(new TinyIntType(), (byte) 7), "TINYINT");
+    assertEquals(Short.valueOf((short) 1234), dataAt(new SmallIntType(), (short) 1234), "SMALLINT");
+    assertEquals(Integer.valueOf(42), dataAt(new IntType(), 42), "INTEGER");
+    assertEquals(
+        Long.valueOf(1_000_000_000_000L), dataAt(new BigIntType(), 1_000_000_000_000L), "BIGINT");
+
+    // Floating point
+    assertEquals(Float.valueOf(3.5f), dataAt(new FloatType(), 3.5f), "FLOAT");
+    assertEquals(Double.valueOf(3.14159d), dataAt(new DoubleType(), 3.14159d), "DOUBLE");
+
+    // Character
+    assertEquals("hello", dataAt(new CharType(5), StringData.fromString("hello")), "CHAR");
+    assertEquals(
+        "delta",
+        dataAt(new VarCharType(VarCharType.MAX_LENGTH), StringData.fromString("delta")),
+        "VARCHAR");
+
+    // Binary — FlinkToJava base64-encodes (unlike DeltaToJava which returns raw byte[]).
+    assertEquals("AQID", dataAt(new BinaryType(3), new byte[] {0x01, 0x02, 0x03}), "BINARY base64");
+    assertEquals(
+        "ECAwQA==",
+        dataAt(new VarBinaryType(VarBinaryType.MAX_LENGTH), new byte[] {0x10, 0x20, 0x30, 0x40}),
+        "VARBINARY base64");
+
+    // Decimal
+    DecimalData decValue = DecimalData.fromBigDecimal(new BigDecimal("12.34"), 10, 2);
+    assertEquals(decValue, dataAt(new DecimalType(10, 2), decValue), "DECIMAL");
+
+    // Temporal
+    assertEquals(Integer.valueOf(19000), dataAt(new DateType(), 19000), "DATE");
+    assertEquals(Integer.valueOf(123456), dataAt(new TimeType(3), 123456), "TIME");
+    // Timestamps are read via getLong; callers pre-store them as long microseconds.
+    assertEquals(
+        Long.valueOf(1_700_000_000_000_000L),
+        dataAt(new TimestampType(6), 1_700_000_000_000_000L),
+        "TIMESTAMP_WITHOUT_TIME_ZONE");
+    assertEquals(
+        Long.valueOf(1_700_000_000_000_000L),
+        dataAt(new LocalZonedTimestampType(6), 1_700_000_000_000_000L),
+        "TIMESTAMP_WITH_LOCAL_TIME_ZONE");
+
+    // Intervals
+    assertEquals(
+        Integer.valueOf(15),
+        dataAt(new YearMonthIntervalType(YearMonthResolution.YEAR_TO_MONTH, 4), 15),
+        "INTERVAL_YEAR_MONTH");
+    assertEquals(
+        Long.valueOf(86_400_000L),
+        dataAt(new DayTimeIntervalType(DayTimeResolution.DAY, 3, 6), 86_400_000L),
+        "INTERVAL_DAY_TIME");
+  }
+
+  // -------------------------------------------------------------------------
+  // data(): null handling — parameterized across all primitive types
+  // -------------------------------------------------------------------------
+
+  @TestAllFlinkTypes
+  void testPrimitiveDataNull(LogicalType primitiveType) {
+    RowType flinkType = RowType.of(new LogicalType[] {primitiveType}, new String[] {"id"});
+    RowData withNull = GenericRowData.of(new Object[] {null});
+    assertNull(Conversions.FlinkToJava.data(flinkType, withNull, 0));
+  }
+
+  // -------------------------------------------------------------------------
+  // data(): unsupported types
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testUnsupportedTypeThrows() {
+    RowType rowType =
+        RowType.of(new LogicalType[] {new ArrayType(new IntType())}, new String[] {"arr"});
+    RowData row = GenericRowData.of(new Object[] {new Object()});
+    assertThrows(
+        UnsupportedOperationException.class, () -> Conversions.FlinkToJava.data(rowType, row, 0));
+  }
+
+  // -------------------------------------------------------------------------
+  // partitionValues(): shape and null behavior
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testPartitionValuesReturnsOptionalForEachColumn() {
+    RowType schema =
+        RowType.of(
+            new LogicalType[] {new IntType(), new VarCharType(VarCharType.MAX_LENGTH)},
+            new String[] {"id", "part"});
+    RowData row = GenericRowData.of(42, StringData.fromString("p0"));
+
+    Map<String, Object> result =
+        Conversions.FlinkToJava.partitionValues(schema, List.of("id", "part"), row);
+
+    assertEquals(2, result.size());
+    assertEquals(Optional.of(42), result.get("id"));
+    assertEquals(Optional.of("p0"), result.get("part"));
+  }
+
+  @Test
+  void testPartitionValuesWrapsNullAsEmptyOptional() {
+    RowType schema = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+    RowData row = GenericRowData.of(new Object[] {null});
+
+    Map<String, Object> result =
+        Conversions.FlinkToJava.partitionValues(schema, List.of("id"), row);
+
+    assertEquals(1, result.size());
+    assertEquals(Optional.empty(), result.get("id"));
+  }
+
+  @Test
+  void testPartitionValuesEmptyColumnsReturnsEmptyMap() {
+    RowType schema = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+    RowData row = GenericRowData.of(42);
+
+    Map<String, Object> result = Conversions.FlinkToJava.partitionValues(schema, List.of(), row);
+
+    assertTrue(result.isEmpty());
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /** Wrap {@code type} in a one-column RowType and invoke {@link Conversions.FlinkToJava#data}. */
+  private static Object dataAt(LogicalType type, Object value) {
+    RowType schema = RowType.of(new LogicalType[] {type}, new String[] {"col"});
+    RowData row = GenericRowData.of(value);
+    return Conversions.FlinkToJava.data(schema, row, 0);
+  }
+}

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkConfTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkConfTest.java
@@ -16,10 +16,14 @@
 
 package io.delta.flink.sink;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.types.*;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -106,5 +110,109 @@ class DeltaSinkConfTest {
         allowTableSchemas.stream()
             .allMatch(
                 tableSchema -> conf.getSchemaEvolutionPolicy().allowEvolve(tableSchema, schema)));
+  }
+
+  // ----------------------------------------------------------------------
+  // write.mode / primary_key
+  // ----------------------------------------------------------------------
+
+  @Test
+  void testWriteModeDefaultsToAppend() {
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Map.of());
+
+    assertEquals(DeltaSinkConf.WriteMode.APPEND, conf.getWriteMode());
+    assertEquals(0, conf.getPrimaryKeyOrdinals().length);
+    assertTrue(!conf.isUpsert());
+  }
+
+  @Test
+  void testUpsertModeRequiresPrimaryKey() {
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "upsert");
+
+    assertThrows(IllegalArgumentException.class, () -> new DeltaSinkConf(schema, opts));
+  }
+
+  @Test
+  void testUpsertModeWithPrimaryKey() {
+    StructType schema =
+        new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "upsert");
+    opts.put(DeltaSinkConf.PRIMARY_KEY.key(), "0");
+
+    DeltaSinkConf conf = new DeltaSinkConf(schema, opts);
+    assertEquals(DeltaSinkConf.WriteMode.UPSERT, conf.getWriteMode());
+    assertTrue(conf.isUpsert());
+    assertArrayEquals(new int[] {0}, conf.getPrimaryKeyOrdinals());
+  }
+
+  @Test
+  void testPrimaryKeyOrdinalParsing() {
+    StructType schema =
+        new StructType()
+            .add("a", IntegerType.INTEGER)
+            .add("b", IntegerType.INTEGER)
+            .add("c", IntegerType.INTEGER);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "upsert");
+    opts.put(DeltaSinkConf.PRIMARY_KEY.key(), " 0 ,1,  2  ");
+
+    DeltaSinkConf conf = new DeltaSinkConf(schema, opts);
+    assertArrayEquals(new int[] {0, 1, 2}, conf.getPrimaryKeyOrdinals());
+  }
+
+  @Test
+  void testNonIntegerPrimaryKeyThrows() {
+    // Stale name-based wire-format value should now fail loudly instead of being silently
+    // misinterpreted; this guards against accidental regressions of the contract.
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "upsert");
+    opts.put(DeltaSinkConf.PRIMARY_KEY.key(), "id");
+
+    assertThrows(IllegalArgumentException.class, () -> new DeltaSinkConf(schema, opts));
+  }
+
+  @Test
+  void testOutOfRangePrimaryKeyOrdinalThrows() {
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "upsert");
+    opts.put(DeltaSinkConf.PRIMARY_KEY.key(), "5");
+
+    assertThrows(IllegalArgumentException.class, () -> new DeltaSinkConf(schema, opts));
+  }
+
+  @Test
+  void testNegativePrimaryKeyOrdinalThrows() {
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "upsert");
+    opts.put(DeltaSinkConf.PRIMARY_KEY.key(), "-1");
+
+    assertThrows(IllegalArgumentException.class, () -> new DeltaSinkConf(schema, opts));
+  }
+
+  @Test
+  void testWriteModeIsCaseInsensitive() {
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "UPSERT");
+    opts.put(DeltaSinkConf.PRIMARY_KEY.key(), "0");
+
+    DeltaSinkConf conf = new DeltaSinkConf(schema, opts);
+    assertEquals(DeltaSinkConf.WriteMode.UPSERT, conf.getWriteMode());
+  }
+
+  @Test
+  void testUnknownWriteModeThrows() {
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    Map<String, String> opts = new HashMap<>();
+    opts.put(DeltaSinkConf.WRITE_MODE.key(), "merge");
+
+    assertThrows(IllegalArgumentException.class, () -> new DeltaSinkConf(schema, opts));
   }
 }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkTest.java
@@ -470,4 +470,71 @@ public class DeltaSinkTest extends TestHelper {
                   assertEquals("ab", ((UnityCatalog) table.getCatalog()).getName());
                 }));
   }
+
+  @Test
+  void testBuilderUpsertOptionsTypedSettersPreservedWhenMapLacksKeys() {
+    RowType flinkSchema =
+        RowType.of(
+            new LogicalType[] {new IntType(), new VarCharType(VarCharType.MAX_LENGTH)},
+            new String[] {"id", "part"});
+    withTempDir(
+        dir -> {
+          DeltaSink sink =
+              DeltaSink.builder()
+                  .withFlinkSchema(flinkSchema)
+                  .withWriteMode(DeltaSinkConf.WriteMode.UPSERT)
+                  .withPrimaryKey(List.of(0))
+                  .withConfigurations(
+                      Map.of("type", "hadoop", "hadoop.table_path", dir.getAbsolutePath()))
+                  .build();
+          assertEquals(DeltaSinkConf.WriteMode.UPSERT, sink.getConf().getWriteMode());
+          assertArrayEquals(new int[] {0}, sink.getConf().getPrimaryKeyOrdinals());
+        });
+  }
+
+  @Test
+  void testBuilderUpsertOptionsTypedSettersWinWhenAppliedLast() {
+    RowType flinkSchema =
+        RowType.of(
+            new LogicalType[] {new IntType(), new VarCharType(VarCharType.MAX_LENGTH)},
+            new String[] {"id", "part"});
+    withTempDir(
+        dir -> {
+          DeltaSink sink =
+              DeltaSink.builder()
+                  .withFlinkSchema(flinkSchema)
+                  .withConfigurations(
+                      Map.of("type", "hadoop", "hadoop.table_path", dir.getAbsolutePath()))
+                  .withWriteMode(DeltaSinkConf.WriteMode.UPSERT)
+                  .withPrimaryKey(List.of(0))
+                  .build();
+          assertEquals(DeltaSinkConf.WriteMode.UPSERT, sink.getConf().getWriteMode());
+          assertArrayEquals(new int[] {0}, sink.getConf().getPrimaryKeyOrdinals());
+        });
+  }
+
+  @Test
+  void testBuilderUpsertOptionsMapOverridesTypedSetters() {
+    RowType flinkSchema =
+        RowType.of(
+            new LogicalType[] {new IntType(), new VarCharType(VarCharType.MAX_LENGTH)},
+            new String[] {"id", "part"});
+    withTempDir(
+        dir -> {
+          DeltaSink sink =
+              DeltaSink.builder()
+                  .withFlinkSchema(flinkSchema)
+                  .withWriteMode(DeltaSinkConf.WriteMode.APPEND)
+                  .withPrimaryKey(List.of(1))
+                  .withConfigurations(
+                      Map.of(
+                          "type", "hadoop",
+                          "hadoop.table_path", dir.getAbsolutePath(),
+                          "write.mode", "upsert",
+                          "primary_key", "0"))
+                  .build();
+          assertEquals(DeltaSinkConf.WriteMode.UPSERT, sink.getConf().getWriteMode());
+          assertArrayEquals(new int[] {0}, sink.getConf().getPrimaryKeyOrdinals());
+        });
+  }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

Step 3 of the Flink upsert sink stack. Exposes the user-facing knobs that subsequent PRs consume.

`DeltaSinkConf`:
- Add `WriteMode` enum (`APPEND`, `UPSERT`) and the public `write.mode` `ConfigOption`.
- Add an internal-only `primary_key` `ConfigOption` carrying the comma-separated 0-based ordinal list of the sink schema's PK columns. The option is intentionally **not** registered in `optionalOptions()` so Flink SQL `WITH(...)` clauses cannot override the DDL primary key.
- Parse and validate at construction: `write.mode = 'upsert'` requires a non-empty PK; otherwise `IllegalArgumentException`.
- Add getters: `getWriteMode()`, `isUpsert()`.

`DeltaSink.Builder`:
- `Builder.withWriteMode(WriteMode)` and `Builder.withPrimaryKey(List<Integer>)` expose the new options to DataStream API callers. PK is accepted as ordinals into the Flink `RowType` — callers resolve column names to ordinals.

Stack:
- Followed by #6997 (DeltaUpsertWriterTask + merge strategies), #6934 (writer routing), #6935 (SQL DDL), #6977 (MoR + default flip). #6964 (DV support) is a parallel prerequisite for #6977.

Part of #5901.

## How was this patch tested?

- `build/sbt "flink/testOnly io.delta.flink.sink.DeltaSinkConfTest io.delta.flink.sink.ConversionsFlinkToDeltaTest io.delta.flink.sink.ConversionsFlinkToJavaTest io.delta.flink.sink.ConversionsDeltaToJavaTest"`.

## Does this PR introduce _any_ user-facing changes?

Yes. Adds the `write.mode` table option (default `append`); when set to `upsert`, the sink requires a primary key. Programmatic DataStream API callers gain `Builder.withWriteMode(...)` and `Builder.withPrimaryKey(...)`.