### PR TITLE
[Flink][Upsert Step 5] Surface write.mode='upsert' through Flink SQL DDL

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/sql/DeltaDynamicTableSink.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/DeltaDynamicTableSink.java
@@ -19,11 +19,14 @@ package io.delta.flink.sink.sql;
 import static io.delta.flink.sink.sql.DeltaDynamicTableSinkFactory.*;
 
 import io.delta.flink.sink.DeltaSink;
+import io.delta.flink.sink.DeltaSinkConf;
 import io.delta.kernel.internal.util.Preconditions;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.api.ValidationException;
@@ -37,6 +40,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 
 /**
  * Flink {@link DynamicTableSink} implementation that writes data to a Delta table via {@link
@@ -62,7 +66,21 @@ public class DeltaDynamicTableSink implements DynamicTableSink, SupportsPartitio
 
   @Override
   public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+    if (getWriteMode() == DeltaSinkConf.WriteMode.UPSERT) {
+      // Use Flink's standard upsert mode: INSERT, UPDATE_AFTER, DELETE. UPDATE_BEFORE is elided
+      // by Flink when the sink declares a primary key.
+      return ChangelogMode.newBuilder()
+          .addContainedKind(RowKind.INSERT)
+          .addContainedKind(RowKind.UPDATE_AFTER)
+          .addContainedKind(RowKind.DELETE)
+          .build();
+    }
     return ChangelogMode.insertOnly();
+  }
+
+  /** Reads {@link DeltaSinkConf#WRITE_MODE} from the options map as a typed enum. */
+  private DeltaSinkConf.WriteMode getWriteMode() {
+    return Configuration.fromMap(options).get(DeltaSinkConf.WRITE_MODE);
   }
 
   @Override
@@ -71,6 +89,18 @@ public class DeltaDynamicTableSink implements DynamicTableSink, SupportsPartitio
 
     Preconditions.checkArgument(
         options.get(FactoryUtil.CONNECTOR.key()).equals(IDENTIFIER), "Target table must be delta");
+
+    DeltaSinkConf.WriteMode writeMode = getWriteMode();
+    // The factory already resolved column names to ordinals when building the options map.
+    // Here we just parse them back into Integers and hand them to DeltaSink.Builder.
+    List<Integer> primaryKeyOrdinals =
+        writeMode == DeltaSinkConf.WriteMode.UPSERT
+            ? Arrays.stream(options.getOrDefault(DeltaSinkConf.PRIMARY_KEY.key(), "").split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Integer::parseInt)
+                .collect(java.util.stream.Collectors.toList())
+            : java.util.Collections.emptyList();
 
     DeltaSink deltaSink;
     if (options.containsKey(TABLE_PATH.key())) {
@@ -82,6 +112,8 @@ public class DeltaDynamicTableSink implements DynamicTableSink, SupportsPartitio
               .withTablePath(options.get(TABLE_PATH.key()))
               .withPartitionColNames(
                   Arrays.asList(options.getOrDefault(PARTITIONS.key(), "").split(",")))
+              .withWriteMode(writeMode)
+              .withPrimaryKey(primaryKeyOrdinals)
               .build();
     } else {
       // Fetch catalog and configs
@@ -97,6 +129,8 @@ public class DeltaDynamicTableSink implements DynamicTableSink, SupportsPartitio
                       "unitycatalog.table_name", tableId.asSummaryString()))
               .withEndpoint(options.get(FlinkUnityCatalogFactory.ENDPOINT.key()))
               .withToken(options.get(FlinkUnityCatalogFactory.TOKEN.key()))
+              .withWriteMode(writeMode)
+              .withPrimaryKey(primaryKeyOrdinals)
               .build();
     }
 

--- a/flink/src/main/java/io/delta/flink/sink/sql/DeltaDynamicTableSinkFactory.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/DeltaDynamicTableSinkFactory.java
@@ -17,11 +17,19 @@
 package io.delta.flink.sink.sql;
 
 import io.delta.flink.sink.DeltaSinkConf;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.FactoryUtil;
@@ -63,11 +71,66 @@ public class DeltaDynamicTableSinkFactory implements DynamicTableSinkFactory {
 
     ReadableConfig options = helper.getOptions();
     ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
+
+    // The Delta sink only writes physical columns. Computed and metadata columns are not
+    // supported: they are silently dropped from the written data, and they shift the ordinals of
+    // the physical columns that the writer (and the upsert primary key) operate on. Reject them
+    // up front rather than produce surprising results.
+    List<String> nonPhysicalColumns =
+        schema.getColumns().stream()
+            .filter(column -> !column.isPhysical())
+            .map(Column::getName)
+            .collect(Collectors.toList());
+    if (!nonPhysicalColumns.isEmpty()) {
+      throw new ValidationException(
+          "The Delta sink does not support computed or metadata columns; all columns must be "
+              + "physical. Offending columns: "
+              + nonPhysicalColumns
+              + ".");
+    }
+
     DataType consumedDataType = schema.toPhysicalRowDataType();
 
     Integer sinkParallelism = options.getOptional(FactoryUtil.SINK_PARALLELISM).orElse(null);
+
+    Map<String, String> resolvedOptions = new HashMap<>(options.toMap());
+    DeltaSinkConf.WriteMode writeMode = options.get(DeltaSinkConf.WRITE_MODE);
+
+    if (writeMode == DeltaSinkConf.WriteMode.UPSERT) {
+      Optional<UniqueConstraint> pkConstraint = schema.getPrimaryKey();
+      if (pkConstraint.isEmpty()) {
+        throw new ValidationException(
+            "write.mode = 'upsert' requires a 'PRIMARY KEY (...) NOT ENFORCED' clause on the "
+                + "table definition.");
+      }
+      // Resolve PK column names to 0-based ordinals against the physical schema. Lower layers
+      // operate on RowData ordinals; doing the lookup here lets us surface "unknown column"
+      // failures as ValidationException at planning time instead of as a writer-construction
+      // RuntimeException at job startup.
+      List<String> physicalNames = schema.getColumnNames();
+      String ordinals =
+          pkConstraint.get().getColumns().stream()
+              .map(
+                  name -> {
+                    int idx = physicalNames.indexOf(name);
+                    if (idx < 0) {
+                      throw new ValidationException(
+                          "Primary-key column '"
+                              + name
+                              + "' does not exist in the table schema "
+                              + physicalNames
+                              + ".");
+                    }
+                    return Integer.toString(idx);
+                  })
+              .collect(Collectors.joining(","));
+      // PRIMARY_KEY is an internal wire-format option carrying the resolved ordinals to
+      // TaskManagers; it is intentionally not in optionalOptions().
+      resolvedOptions.put(DeltaSinkConf.PRIMARY_KEY.key(), ordinals);
+    }
+
     return new DeltaDynamicTableSink(
-        context.getObjectIdentifier(), consumedDataType, sinkParallelism, options.toMap());
+        context.getObjectIdentifier(), consumedDataType, sinkParallelism, resolvedOptions);
   }
 
   public static final String IDENTIFIER = "delta";
@@ -95,6 +158,7 @@ public class DeltaDynamicTableSinkFactory implements DynamicTableSinkFactory {
         DeltaSinkConf.SCHEMA_EVOLUTION_MODE,
         DeltaSinkConf.FILE_ROLLING_STRATEGY,
         DeltaSinkConf.FILE_ROLLING_SIZE,
-        DeltaSinkConf.FILE_ROLLING_COUNT);
+        DeltaSinkConf.FILE_ROLLING_COUNT,
+        DeltaSinkConf.WRITE_MODE);
   }
 }

--- a/flink/src/test/java/io/delta/flink/sink/sql/DeltaDynamicTableSinkTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/sql/DeltaDynamicTableSinkTest.java
@@ -16,16 +16,27 @@
 
 package io.delta.flink.sink.sql;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.flink.TestHelper;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.types.RowKind;
 import org.junit.jupiter.api.Test;
 
 /** Test suite for {@link DeltaDynamicTableSink}. */
@@ -37,26 +48,7 @@ class DeltaDynamicTableSinkTest extends TestHelper {
         dir -> {
           Map<String, String> options = Map.of("connector", "delta", "table_path", dir.getPath());
 
-          CatalogTable table =
-              CatalogTable.newBuilder()
-                  .schema(
-                      Schema.newBuilder()
-                          .column("id", DataTypes.BIGINT())
-                          .column("dt", DataTypes.STRING())
-                          .build())
-                  .comment("test table")
-                  .partitionKeys(List.of())
-                  .options(options)
-                  .build();
-
-          ResolvedCatalogTable resolvedTable =
-              new ResolvedCatalogTable(
-                  table,
-                  ResolvedSchema.physical(
-                      new String[] {"id", "dt"},
-                      new org.apache.flink.table.types.DataType[] {
-                        DataTypes.BIGINT(), DataTypes.STRING()
-                      }));
+          ResolvedCatalogTable resolvedTable = simpleTable(options, /* pk = */ null);
 
           TestDynamicTableSinkContext context = new TestDynamicTableSinkContext(resolvedTable);
 
@@ -64,6 +56,158 @@ class DeltaDynamicTableSinkTest extends TestHelper {
           var sink = factory.createDynamicTableSink(context);
 
           assertTrue(sink instanceof DeltaDynamicTableSink);
+          // Default is append mode → insert-only changelog.
+          assertEquals(
+              ChangelogMode.insertOnly(), sink.getChangelogMode(ChangelogMode.insertOnly()));
         });
+  }
+
+  @Test
+  void testUpsertModeAdvertisesUpsertChangelogMode() {
+    withTempDir(
+        dir -> {
+          Map<String, String> options = new HashMap<>();
+          options.put("connector", "delta");
+          options.put("table_path", dir.getPath());
+          options.put("write.mode", "upsert");
+
+          ResolvedCatalogTable resolvedTable = simpleTable(options, List.of("id"));
+
+          DynamicTableSink sink =
+              new DeltaDynamicTableSinkFactory()
+                  .createDynamicTableSink(new TestDynamicTableSinkContext(resolvedTable));
+
+          ChangelogMode mode = sink.getChangelogMode(ChangelogMode.upsert());
+          assertTrue(mode.contains(RowKind.INSERT), "upsert mode must allow INSERT");
+          assertTrue(mode.contains(RowKind.UPDATE_AFTER), "upsert mode must allow UPDATE_AFTER");
+          assertTrue(mode.contains(RowKind.DELETE), "upsert mode must allow DELETE");
+          // UPDATE_BEFORE is elided by Flink for PK sinks.
+          assertTrue(
+              !mode.contains(RowKind.UPDATE_BEFORE),
+              "upsert mode should not request UPDATE_BEFORE");
+        });
+  }
+
+  @Test
+  void testUpsertModeWithoutPrimaryKeyThrows() {
+    withTempDir(
+        dir -> {
+          Map<String, String> options = new HashMap<>();
+          options.put("connector", "delta");
+          options.put("table_path", dir.getPath());
+          options.put("write.mode", "upsert");
+
+          ResolvedCatalogTable resolvedTable = simpleTable(options, /* pk = */ null);
+
+          assertThrows(
+              ValidationException.class,
+              () ->
+                  new DeltaDynamicTableSinkFactory()
+                      .createDynamicTableSink(new TestDynamicTableSinkContext(resolvedTable)));
+        });
+  }
+
+  @Test
+  void testUpsertModeRejectsUnknownPrimaryKeyOption() {
+    withTempDir(
+        dir -> {
+          // The 'primary_key' option is NOT a public option; the factory's `validate()` call
+          // should reject it as an unknown option.
+          Map<String, String> options = new HashMap<>();
+          options.put("connector", "delta");
+          options.put("table_path", dir.getPath());
+          options.put("write.mode", "upsert");
+          options.put("primary_key", "id");
+
+          ResolvedCatalogTable resolvedTable = simpleTable(options, List.of("id"));
+
+          assertThrows(
+              ValidationException.class,
+              () ->
+                  new DeltaDynamicTableSinkFactory()
+                      .createDynamicTableSink(new TestDynamicTableSinkContext(resolvedTable)));
+        });
+  }
+
+  @Test
+  void testNonPhysicalColumnsAreRejected() {
+    withTempDir(
+        dir -> {
+          Map<String, String> options = new HashMap<>();
+          options.put("connector", "delta");
+          options.put("table_path", dir.getPath());
+          options.put("write.mode", "upsert");
+
+          // A virtual (non-physical) metadata column "m" precedes the physical PK column "id".
+          // The Delta sink only writes physical columns, and a non-physical column shifts the
+          // ordinals the writer/primary-key operate on, so the factory must reject it.
+          ResolvedSchema resolvedSchema =
+              new ResolvedSchema(
+                  Arrays.asList(
+                      Column.metadata("m", DataTypes.BIGINT(), null, /* isVirtual = */ true),
+                      Column.physical("id", DataTypes.BIGINT().notNull()),
+                      Column.physical("dt", DataTypes.STRING())),
+                  Collections.emptyList(),
+                  UniqueConstraint.primaryKey("pk", List.of("id")));
+
+          CatalogTable table =
+              CatalogTable.newBuilder()
+                  .schema(
+                      Schema.newBuilder()
+                          .columnByMetadata("m", DataTypes.BIGINT(), null, /* isVirtual = */ true)
+                          .column("id", DataTypes.BIGINT().notNull())
+                          .column("dt", DataTypes.STRING())
+                          .primaryKey("id")
+                          .build())
+                  .comment("test table")
+                  .partitionKeys(Collections.emptyList())
+                  .options(options)
+                  .build();
+
+          ResolvedCatalogTable resolvedTable = new ResolvedCatalogTable(table, resolvedSchema);
+
+          assertThrows(
+              ValidationException.class,
+              () ->
+                  new DeltaDynamicTableSinkFactory()
+                      .createDynamicTableSink(new TestDynamicTableSinkContext(resolvedTable)));
+        });
+  }
+
+  /**
+   * Build a {@link ResolvedCatalogTable} with two columns {@code (id BIGINT, dt STRING)} and the
+   * given options + optional primary-key columns.
+   */
+  private static ResolvedCatalogTable simpleTable(Map<String, String> options, List<String> pk) {
+    Schema.Builder schemaBuilder =
+        Schema.newBuilder()
+            .column("id", DataTypes.BIGINT().notNull())
+            .column("dt", DataTypes.STRING());
+    if (pk != null && !pk.isEmpty()) {
+      schemaBuilder.primaryKey(pk);
+    }
+
+    CatalogTable table =
+        CatalogTable.newBuilder()
+            .schema(schemaBuilder.build())
+            .comment("test table")
+            .partitionKeys(Collections.emptyList())
+            .options(options)
+            .build();
+
+    ResolvedSchema resolvedSchema =
+        pk == null || pk.isEmpty()
+            ? ResolvedSchema.physical(
+                new String[] {"id", "dt"},
+                new org.apache.flink.table.types.DataType[] {
+                  DataTypes.BIGINT().notNull(), DataTypes.STRING()
+                })
+            : new ResolvedSchema(
+                Arrays.asList(
+                    Column.physical("id", DataTypes.BIGINT().notNull()),
+                    Column.physical("dt", DataTypes.STRING())),
+                Collections.emptyList(),
+                UniqueConstraint.primaryKey("pk", pk));
+    return new ResolvedCatalogTable(table, resolvedSchema);
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

Step 6 of the Flink upsert sink stack. Plumbs the upsert option (introduced in Step 3) through Flink SQL's `DynamicTableSink`/`DynamicTableSinkFactory` so table DDL can opt into upsert semantics declaratively.

`DeltaDynamicTableSink`:
- `getChangelogMode()` returns Flink's standard upsert `ChangelogMode` (`INSERT`, `UPDATE_AFTER`, `DELETE`) when `write.mode='upsert'`; `insertOnly()` otherwise.
- `getSinkRuntimeProvider()` reads the `write.mode` enum, parses the resolved PK ordinal list from the option map, and passes both to `DeltaSink.Builder` via `withWriteMode(...)` / `withPrimaryKey(...)` on both the Hadoop and Catalog paths.

`DeltaDynamicTableSinkFactory`:
- Register `write.mode` as an optional option. `primary_key` stays internal (unregistered) so SQL `WITH(...)` clauses cannot override the DDL primary key.
- In `createDynamicTableSink()`: when `write.mode='upsert'`, require `ResolvedSchema.getPrimaryKey()` (else `ValidationException`), translate each PK column name → 0-based ordinal against the resolved schema (unknown column → `ValidationException`), and stamp the comma-separated list into the internal `primary_key` option carried to the sink.

`DeltaDynamicTableSinkTest` covers the upsert-mode changelog, missing-PK validation, and unknown-PK rejection.

Stack:
- Built on the writer-routing PR (#6934).
- Followed by the MoR PR (#6977) which depends on the DV-support PR (#6964) in parallel.

Part of #5901.

## How was this patch tested?

- `build/sbt "flink/testOnly io.delta.flink.sink.sql.DeltaDynamicTableSinkTest"`.

## Does this PR introduce _any_ user-facing changes?

Yes. Flink SQL `CREATE TABLE ... WITH ('write.mode' = 'upsert')` is honored end-to-end. The declared `PRIMARY KEY` becomes the dedup key; `write.mode='upsert'` without a PK fails at validation time with a clear message.