### PR TITLE
[Spark][Tests] Add DSv2 CACHE TABLE tests (Classic + Connect)

### DIFF
--- a/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
+++ b/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
@@ -16,19 +16,20 @@
 
 package io.delta.tables
 
-import io.delta.tables.shared.DeltaRepeatedAccessRefreshTests
+import io.delta.tables.shared.{DeltaCacheTableTests, DeltaRepeatedAccessRefreshTests}
 
 import org.apache.spark.sql.test.DeltaQueryTest
 
 /**
- * Runs the shared [[DeltaRepeatedAccessRefreshTests]] over a remote Spark Connect session. In
- * Connect the Dataset is re-analyzed on each execution, so repeated reads always see the latest
- * data and schema.
+ * Runs the shared refresh and cache tests over a remote Spark Connect session. In Connect the
+ * Dataset is re-analyzed on each execution, so repeated reads always see the latest data and
+ * schema.
  */
 trait DeltaTableRefreshConnectSuiteBase
   extends DeltaQueryTest
   with RemoteSparkSession
-  with DeltaRepeatedAccessRefreshTests {
+  with DeltaRepeatedAccessRefreshTests
+  with DeltaCacheTableTests {
 
   // The conf key is a literal because the Spark Connect thin client does not depend on Spark
   // Classic, which is where the Delta SQL configs live, so DeltaSQLConf.V2_ENABLE_MODE.key is

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaCacheTableTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaCacheTableTests.scala
@@ -145,9 +145,9 @@ trait DeltaCacheTableTests
       (sparkVersionBucket, v2EnableMode) match {
         case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") =>
           // 4.1 and 4.2+: the cache is pinned so the drop and recreate is invisible until REFRESH
-          // TABLE. This mirrors SPARK-54022's caching-connector case, not the regular catalog where
-          // the drop and recreate yields a new table identity that makes the cache entry unreachable
-          // and reads empty immediately.
+          // TABLE. This mirrors SPARK-54022's caching-connector case, not the regular catalog
+          // where the drop and recreate yields a new table identity that makes the cache entry
+          // unreachable and reads empty immediately.
           // TODO: once [[DeltaV2Table]] implements [[Table.id]], the recreated table reports a new
           // identity, so Spark treats it as a different table and the cache entry becomes
           // unreachable. STRICT would then read the now empty table immediately ([[Seq.empty]]),

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaCacheTableTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaCacheTableTests.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables.shared
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.Row
+
+/**
+ * CACHE TABLE behavior across session and external mutations, mirroring the DSv2 CACHE scenarios in
+ * apache/spark. An external write (committed straight into `_delta_log`) bypasses the CacheManager.
+ * Shared across classic and Connect.
+ *
+ * The asserted behavior is version and mode dependent, so each scenario branches explicitly on
+ * `spark.version` (4.2+, 4.1, 4.0) and on [[v2EnableMode]] (STRICT vs AUTO):
+ *   - 4.1 and 4.2+: https://github.com/apache/spark/pull/52764 made cached DSv2 tables pin
+ *     their state, so the cache pins and REFRESH TABLE surfaces external changes. A STRICT
+ *     schema change additionally stays pinned out until REFRESH.
+ *   - 4.0 STRICT: there is no pinning, so external changes are visible immediately.
+ *   - 4.0 AUTO: the cache pins but REFRESH TABLE does not surface an external write (a drop and
+ *     recreate is not seen either).
+ */
+trait DeltaCacheTableTests
+  extends DeltaTableRefreshSharedBase { self: AnyFunSuite =>
+
+  /** Runs `body` against an external catalog table `t` holding `(1, 100)` that has been cached. */
+  private def withCachedTable(body: String => Unit): Unit =
+    withExternalTable { path =>
+      writerSql("CACHE TABLE t")
+      try body(path)
+      finally writerSql("UNCACHE TABLE IF EXISTS t")
+    }
+
+  test("cache scenario 1: external data write while cached") {
+    withCachedTable { path =>
+      externalDataWrite(path, Seq((2, 200)))
+      (sparkVersionBucket, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") =>
+          // 4.1 and 4.2+: the cache pins, so the external write is invisible until REFRESH TABLE.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the external write is visible immediately.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+        case ("4.0", "AUTO") =>
+          // 4.0 AUTO: the cache pins and REFRESH TABLE does not surface an external write.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100)))
+      }
+    }
+  }
+
+  test("cache scenario 2: session write then external write while cached") {
+    withCachedTable { path =>
+      writerSql("INSERT INTO t VALUES (2, 200)")
+      assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+      externalDataWrite(path, Seq((3, 300)))
+      (sparkVersionBucket, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") =>
+          // 4.1 and 4.2+: the external write is pinned out of the cache, surfaced by REFRESH TABLE.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200), Row(3, 300)))
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the external write is visible immediately.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200), Row(3, 300)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200), Row(3, 300)))
+        case ("4.0", "AUTO") =>
+          // 4.0 AUTO: the external write is pinned out and REFRESH does not surface it.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+      }
+    }
+  }
+
+  test("cache scenario 3: external schema change while cached") {
+    withCachedTable { path =>
+      externalAddColumnAndWrite(path, Seq((2, 200, -1)))
+      (sparkVersionBucket, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+          // 4.1 and 4.2+ STRICT: the V2 connector pins the cached snapshot, so the change is
+          // invisible.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+        case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "STRICT") | ("4.0", "AUTO") =>
+          // Everywhere else: a schema change breaks cache pinning, so the external change is
+          // visible even before REFRESH.
+          assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+      }
+      writerSql("REFRESH TABLE t")
+      assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+    }
+  }
+
+  test("cache scenario 4: session schema change then external write while cached") {
+    withCachedTable { path =>
+      writerSql("ALTER TABLE t ADD COLUMN new_column INT")
+      externalThreeColumnDataWrite(path, Seq((2, 200, -1)))
+      // TODO: ADD COLUMN is not properly supported in the STRICT V2 connector yet. The connector
+      // caches the schema at table lookup, so the session ADD COLUMN never surfaces and rows read
+      // back as 2 columns. Once STRICT V2 supports ADD COLUMN, new_column should surface (NULL for
+      // the existing row) and these STRICT assertions should expect 3 columns. Under AUTO the
+      // schema change breaks cache pinning, so the ADD COLUMN and external row are both visible.
+      (sparkVersionBucket, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+          // 4.1 and 4.2+ STRICT: the external write is pinned out of the cache until REFRESH.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+        case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+          assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the external write is visible immediately (read as 2 columns).
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+      }
+    }
+  }
+
+  test("cache scenario 5: external drop and recreate while cached") {
+    withCachedTable { path =>
+      externalDropAndRecreate(path)
+      (sparkVersionBucket, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") =>
+          // 4.1 and 4.2+: the cache is pinned so the drop and recreate is invisible until REFRESH
+          // TABLE. This mirrors SPARK-54022's caching-connector case, not the regular catalog where
+          // the drop and recreate yields a new table identity that makes the cache entry unreachable
+          // and reads empty immediately.
+          // TODO: once [[DeltaV2Table]] implements [[Table.id]], the recreated table reports a new
+          // identity, so Spark treats it as a different table and the cache entry becomes
+          // unreachable. STRICT would then read the now empty table immediately ([[Seq.empty]]),
+          // even before REFRESH, instead of serving the cached (1, 100) rows.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq.empty)
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the drop and recreate is visible immediately.
+          assertFinalTableState("t", Seq.empty)
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq.empty)
+        case ("4.0", "AUTO") =>
+          // 4.0 AUTO: the cache pins and REFRESH does not surface the drop and recreate.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100)))
+      }
+    }
+  }
+}

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaRepeatedAccessRefreshTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaRepeatedAccessRefreshTests.scala
@@ -27,10 +27,6 @@ import org.apache.spark.sql.{AnalysisException, Row}
 trait DeltaRepeatedAccessRefreshTests
   extends DeltaTableRefreshSharedBase { self: AnyFunSuite =>
 
-  /** Asserts the full table contents (ordered by id) match `expectedRows`. */
-  private def assertFinalTableState(tableRef: String, expectedRows: Seq[Row]): Unit =
-    checkAnswer(spark.sql(s"SELECT * FROM $tableRef ORDER BY id"), expectedRows)
-
   // Scenario 1: data changes via writes
 
   test("scenario 1: repeated sql() reflects session write") {

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
@@ -39,6 +39,18 @@ trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
 
   protected def v2EnableMode: String = "NONE"
 
+  /** Spark minor version bucket ("4.0", "4.1", "4.2+") that the asserted behavior keys off. */
+  protected def sparkVersionBucket: String = {
+    // Parse major and minor numerically so the bucket stays correct once Spark reaches 4.10,
+    // where a lexicographic string compare would wrongly rank "4.10" below "4.2".
+    val versionParts = spark.version.split('.')
+    val major = versionParts(0).toInt
+    val minor = versionParts(1).toInt
+    if (major > 4 || (major == 4 && minor >= 2)) "4.2+"
+    else if (major == 4 && minor >= 1) "4.1"
+    else "4.0"
+  }
+
   protected def checkAnswer(df: => DataFrame, expectedAnswer: Seq[Row]): Unit
   protected def withTable(tableNames: String*)(f: => Unit): Unit
 
@@ -67,6 +79,10 @@ trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
     insertInitialData(tableRef)
     checkAnswer(spark.sql(s"SELECT * FROM $tableRef"), Seq(Row(1, 100)))
   }
+
+  /** Asserts the full table contents (ordered by id) match `expectedRows`. */
+  protected def assertFinalTableState(tableRef: String, expectedRows: Seq[Row]): Unit =
+    checkAnswer(spark.sql(s"SELECT * FROM $tableRef ORDER BY id"), expectedRows)
 
   /** Runs `body` against a fresh managed catalog table `t` already holding `(1, 100)`. */
   protected def withInitialTable(body: String => Unit): Unit =
@@ -195,6 +211,10 @@ trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
 
   protected def externalDataWrite(path: String, rows: Seq[(Int, Int)]): Unit =
     writeCommit(path, Seq(writeParquetAndGetAddFileAction(path, idSalaryRowsToDf(rows))))
+
+  /** Appends three column rows externally without a schema change (table is already 3 columns). */
+  protected def externalThreeColumnDataWrite(path: String, rows: Seq[(Int, Int, Int)]): Unit =
+    writeCommit(path, Seq(writeParquetAndGetAddFileAction(path, idSalaryNewColumnRowsToDf(rows))))
 
   protected def externalAddColumnAndWrite(path: String, rows: Seq[(Int, Int, Int)]): Unit = {
     val newSchema = currentSchema(path).add("new_column", IntegerType, nullable = true)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta
 
-import io.delta.tables.shared.DeltaRepeatedAccessRefreshTests
+import io.delta.tables.shared.{DeltaCacheTableTests, DeltaRepeatedAccessRefreshTests}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
@@ -29,7 +29,8 @@ trait DeltaTableRefreshSuiteBase
   extends QueryTest
   with SharedSparkSession
   with DeltaSQLCommandTest
-  with DeltaRepeatedAccessRefreshTests {
+  with DeltaRepeatedAccessRefreshTests
+  with DeltaCacheTableTests {
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf


### PR DESCRIPTION
## Description

Add DSv2 `CACHE TABLE` test coverage to the shared refresh suites, mirroring the scenarios in
apache/spark#55577 / #55536. A new shared trait `DeltaCacheTableTests` runs in both classic Spark
and Spark Connect, parameterized by `V2_ENABLE_MODE` (AUTO, STRICT), reusing the external-write
simulation in `DeltaTableRefreshSharedBase` (direct `_delta_log` commit writes that bypass the
`CacheManager`).

Five scenarios (each ends with `REFRESH TABLE`):
1. external data write stays invisible until REFRESH
2. session write invalidates the cache, then an external write stays invisible
3. external schema change
4. session schema change then external write
5. external drop and recreate sees the new empty table

### Behavior documented
- Data-only cases (1, 2, 5): the cache pins state in every mode; the external write is invisible
  until `REFRESH TABLE`.
- Schema-change cases (3, 4) diverge by mode
  - Classic (AUTO): a schema change breaks Spark's plan-shape cache pinning, so the external /
    session schema change is visible even before REFRESH.
  - STRICT (V2 connector): the cached snapshot stays pinned. For scenario 4 the V2 connector does
    not pick up the in-session `ADD COLUMN` (schema cached at table lookup), so the new column never
    surfaces; documented with a TODO, consistent with the refresh suite's scenario 2.

## Stacking
Stacked on #6921 (introduces `DeltaTableRefreshSharedBase`, the refresh suites, and the build.sbt
wiring). Until #6921 merges, this PR's diff includes #6921's commits; it will shrink to just the
cache changes once #6921 lands.

## How was this patch tested?
Tests only. All suites pass locally (Java 17): 11 tests x 4 suites = 44 (6 refresh + 5 cache, each
of classic/Connect x AUTO/STRICT).
- `spark/testOnly org.apache.spark.sql.delta.DeltaTableRefreshAutoModeSuite org.apache.spark.sql.delta.DeltaTableRefreshStrictModeSuite`
- `connectClient/testOnly io.delta.tables.DeltaTableRefreshConnectAutoModeSuite io.delta.tables.DeltaTableRefreshConnectStrictModeSuite`

## Does this PR introduce _any_ user-facing changes?
No.
