### PR TITLE
[Spark][Kernel] Pass domain metadata intent to UC Delta commits

### DIFF
--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -38,6 +38,7 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -462,6 +463,7 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
                 generateMetadataPayloadOpt(commitMetadata).map(MetadataAdapter::new),
                 Optional.empty() /* oldProtocol */,
                 commitMetadata.getNewProtocolOpt().map(ProtocolAdapter::new),
+                Collections.<AbstractDomainMetadata>emptyList(),
                 uniformMetadataOpt);
             return null;
           } catch (io.delta.storage.commit.CommitFailedException cfe) {

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -18,14 +18,14 @@ package io.delta.kernel.unitycatalog
 
 import java.lang.{Long => JLong}
 import java.net.URI
-import java.util.Optional
+import java.util.{Collections, List => JList, Optional}
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import io.delta.storage.commit.{Commit, CommitFailedException, GetCommitsResponse, TableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{InvalidTargetTableException, UCClient}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
@@ -166,10 +166,12 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata,
       Optional.empty(), // oldProtocol
       newProtocol,
+      Collections.emptyList[AbstractDomainMetadata](), // domainMetadataToCommit
       Optional.empty() // uniform
     )
   }
 
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -180,6 +182,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
+      domainMetadataToCommit: JList[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata]): Unit = {
     forceThrowInCommitMethod()
 
@@ -202,6 +205,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       }
     }
   }
+  // scalastyle:on argcount
 
   override def getCommits(
       tableId: String,

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -166,7 +166,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata,
       Optional.empty(), // oldProtocol
       newProtocol,
-      Collections.emptyList[AbstractDomainMetadata](), // domainMetadataToCommit
+      Collections.emptyList[AbstractDomainMetadata](), // transactionDomainMetadata
       Optional.empty() // uniform
     )
   }
@@ -182,7 +182,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
-      domainMetadataToCommit: JList[AbstractDomainMetadata],
+      transactionDomainMetadata: JList[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata]): Unit = {
     forceThrowInCommitMethod()
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2925,10 +2925,6 @@ trait OptimisticTransactionImpl extends TransactionHelper
   ): Commit = {
     val updatedActions =
       currentTransactionInfo.getUpdatedActions(snapshot.metadata, snapshot.protocol)
-    val domainMetadataToCommit =
-      DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(
-        currentTransactionInfo.actions,
-        currentTransactionInfo.protocol)
     val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
       tableCommitCoordinatorClient.commit(
         attemptVersion,
@@ -2937,7 +2933,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         catalogTable.map(_.identifier),
         new CatalogTrackedInfo(
           currentTransactionInfo.convertedIcebergMetadata.toJava,
-          domainMetadataToCommit.map(dm => dm: AbstractDomainMetadata).asJava)
+          currentTransactionInfo.domainMetadata.map(dm => dm: AbstractDomainMetadata).asJava)
       )
     }
     if (attemptVersion == 0L) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2925,10 +2925,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
   ): Commit = {
     val updatedActions =
       currentTransactionInfo.getUpdatedActions(snapshot.metadata, snapshot.protocol)
-    val domainMetadataActions = currentTransactionInfo.actions
     val domainMetadataToCommit =
       DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(
-        domainMetadataActions,
+        currentTransactionInfo.actions,
         currentTransactionInfo.protocol)
     val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
       tableCommitCoordinatorClient.commit(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -58,7 +58,7 @@ import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils, PartitionUtils, TransactionHelper}
 import org.apache.spark.sql.util.ScalaExtensions._
 import io.delta.storage.commit._
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 import org.apache.commons.lang3.NotImplementedException
@@ -2925,13 +2925,19 @@ trait OptimisticTransactionImpl extends TransactionHelper
   ): Commit = {
     val updatedActions =
       currentTransactionInfo.getUpdatedActions(snapshot.metadata, snapshot.protocol)
+    val domainMetadataToCommit =
+      DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(
+        currentTransactionInfo.actions,
+        currentTransactionInfo.protocol)
     val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
       tableCommitCoordinatorClient.commit(
         attemptVersion,
         jsonActions,
         updatedActions,
         catalogTable.map(_.identifier),
-        new CatalogTrackedInfo(currentTransactionInfo.convertedIcebergMetadata.toJava)
+        new CatalogTrackedInfo(
+          currentTransactionInfo.convertedIcebergMetadata.toJava,
+          domainMetadataToCommit.map(dm => dm: AbstractDomainMetadata).asJava)
       )
     }
     if (attemptVersion == 0L) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2925,9 +2925,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
   ): Commit = {
     val updatedActions =
       currentTransactionInfo.getUpdatedActions(snapshot.metadata, snapshot.protocol)
+    val domainMetadataActions = currentTransactionInfo.actions
     val domainMetadataToCommit =
       DomainMetadataUtils.validateDomainMetadataSupportedAndNoDuplicate(
-        currentTransactionInfo.actions,
+        domainMetadataActions,
         currentTransactionInfo.protocol)
     val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
       tableCommitCoordinatorClient.commit(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -69,7 +69,7 @@ class InMemoryUCClient(
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
-      domainMetadataToCommit: JList[AbstractDomainMetadata],
+      transactionDomainMetadata: JList[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata] = Optional.empty()): Unit = {
     ucCommitCoordinator.commitToCoordinator(
       tableId,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -18,11 +18,11 @@ package org.apache.spark.sql.delta.coordinatedcommits
 
 import java.lang.{Long => JLong}
 import java.net.URI
-import java.util.Optional
+import java.util.{List => JList, Optional}
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import io.delta.storage.commit.{Commit => JCommit, GetCommitsResponse => JGetCommitsResponse, TableIdentifier}
-import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCClient
 import io.delta.storage.commit.uniform.UniformMetadata
 
@@ -58,6 +58,7 @@ class InMemoryUCClient(
 
   override def getMetastoreId: String = metastoreId
 
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -68,6 +69,7 @@ class InMemoryUCClient(
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
+      domainMetadataToCommit: JList[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata] = Optional.empty()): Unit = {
     ucCommitCoordinator.commitToCoordinator(
       tableId,
@@ -84,6 +86,7 @@ class InMemoryUCClient(
       Option(uniform.orElse(null))
     )
   }
+  // scalastyle:on argcount
 
   override def getCommits(
       tableId: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -726,6 +726,7 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       domainMetadata: util.List[AbstractDomainMetadata],
       lastCommitTimestampMs: Long): TableInfo =
     throw new UnsupportedOperationException
+  // scalastyle:off argcount
   override def commit(
       tableId: String,
       tableUri: URI,
@@ -739,6 +740,7 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       domainMetadataToCommit: util.List[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata]): Unit =
     throw new UnsupportedOperationException
+  // scalastyle:on argcount
   override def getCommits(
       tableId: String,
       tableUri: URI,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -736,6 +736,7 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
+      domainMetadataToCommit: util.List[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata]): Unit =
     throw new UnsupportedOperationException
   override def getCommits(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -737,7 +737,7 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       newMetadata: Optional[AbstractMetadata],
       oldProtocol: Optional[AbstractProtocol],
       newProtocol: Optional[AbstractProtocol],
-      domainMetadataToCommit: util.List[AbstractDomainMetadata],
+      transactionDomainMetadata: util.List[AbstractDomainMetadata],
       uniform: Optional[UniformMetadata]): Unit =
     throw new UnsupportedOperationException
   // scalastyle:on argcount

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -139,9 +139,9 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
             newMetadata: Optional[AbstractMetadata],
             oldProtocol: Optional[AbstractProtocol],
             newProtocol: Optional[AbstractProtocol],
-            domainMetadataToCommit: JList[AbstractDomainMetadata],
+            transactionDomainMetadata: JList[AbstractDomainMetadata],
             uniform: Optional[UniformMetadata]): Unit = {
-          capturedDomainMetadata = domainMetadataToCommit
+          capturedDomainMetadata = transactionDomainMetadata
         }
         // scalastyle:on argcount
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalArgumentException, 
 import org.apache.spark.sql.delta.CommitCoordinatorGetCommitsFailedException
 import org.apache.spark.sql.delta.DeltaConfigs.{COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
-import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{CommitInfo, DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogTrackedInfo
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -47,6 +47,7 @@ import io.delta.storage.commit.{
   TableIdentifier => JTableIdentifier,
   UpdatedActions
 }
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{
   UCCommitCoordinatorClient,
   UCCoordinatedCommitsUsageLogs}
@@ -118,6 +119,65 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
       assert(capturedTableIdentifier != null)
       assert(capturedTableIdentifier.getNamespace.toSeq == Seq("main", "default"))
       assert(capturedTableIdentifier.getName == "tbl")
+    }
+  }
+
+  test("direct UC commit forwards raw domain metadata intent from CatalogTrackedInfo") {
+    withTempTableDir { tempDir =>
+      val log = DeltaLog.forTable(spark, tempDir.toString)
+      val logPath = log.logPath
+      var capturedDomainMetadata: JList[AbstractDomainMetadata] = null
+      val capturingUCClient = new InMemoryUCClient(metastoreId.toString, ucCommitCoordinator) {
+        // scalastyle:off argcount
+        override def commit(
+            tableId: String,
+            tableUri: java.net.URI,
+            tableIdentifier: JTableIdentifier,
+            commit: Optional[JCommit],
+            lastKnownBackfilledVersion: Optional[JLong],
+            oldMetadata: Optional[AbstractMetadata],
+            newMetadata: Optional[AbstractMetadata],
+            oldProtocol: Optional[AbstractProtocol],
+            newProtocol: Optional[AbstractProtocol],
+            domainMetadataToCommit: JList[AbstractDomainMetadata],
+            uniform: Optional[UniformMetadata]): Unit = {
+          capturedDomainMetadata = domainMetadataToCommit
+        }
+        // scalastyle:on argcount
+      }
+      val commitCoordinatorClient =
+        new UCCommitCoordinatorClient(Map.empty[String, String].asJava, capturingUCClient)
+      commitCoordinatorClient.registerTable(
+        logPath, Optional.empty(), -1L, initMetadata(), Protocol(1, 1))
+      writeCommitZero(logPath)
+      val tableDesc = new TableDescriptor(
+        logPath,
+        Optional.empty(),
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableUUID.toString).asJava)
+      val commitInfo = CommitInfo.empty(version = Some(1)).withTimestamp(1)
+        .copy(inCommitTimestamp = Some(1))
+      val updatedActions = getUpdatedActionsForNonZerothCommit(commitInfo)
+      val setDomainMetadata =
+        DomainMetadata("delta.clustering", """{"clusteringColumns":[["id"]]}""", removed = false)
+      val removeDomainMetadata = DomainMetadata("delta.rowTracking", "{}", removed = true)
+      val catalogTrackedInfo = new CatalogTrackedInfo(
+        Optional.empty(),
+        Seq(setDomainMetadata, removeDomainMetadata)
+          .map(dm => dm: AbstractDomainMetadata)
+          .asJava)
+
+      commitCoordinatorClient.commit(
+        LogStoreInverseAdaptor(log.store, log.newDeltaHadoopConf()),
+        log.newDeltaHadoopConf(),
+        tableDesc,
+        1L,
+        Iterator(commitInfo.json).asJava,
+        catalogTrackedInfo,
+        updatedActions)
+
+      assert(capturedDomainMetadata.asScala.map(_.getDomain) ===
+        Seq("delta.clustering", "delta.rowTracking"))
+      assert(capturedDomainMetadata.asScala.map(_.isRemoved) === Seq(false, true))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -147,8 +147,6 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
       }
       val commitCoordinatorClient =
         new UCCommitCoordinatorClient(Map.empty[String, String].asJava, capturingUCClient)
-      commitCoordinatorClient.registerTable(
-        logPath, Optional.empty(), -1L, initMetadata(), Protocol(1, 1))
       writeCommitZero(logPath)
       val tableDesc = new TableDescriptor(
         logPath,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
@@ -127,7 +127,7 @@ trait UCCommitCoordinatorClientSuiteBase extends CommitCoordinatorClientImplSuit
       Optional.empty(), // newMetadata
       Optional.empty(), // oldProtocol
       Optional.empty(), // newProtocol
-      java.util.Collections.emptyList[AbstractDomainMetadata](), // domainMetadataToCommit
+      java.util.Collections.emptyList[AbstractDomainMetadata](), // transactionDomainMetadata
       Optional.empty() /* uniform */)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
@@ -32,6 +32,7 @@ import io.delta.storage.commit.{
   CoordinatedCommitsUtils => JCoordinatedCommitsUtils,
   GetCommitsResponse => JGetCommitsResponse
 }
+import io.delta.storage.commit.actions.AbstractDomainMetadata
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient}
 import org.apache.hadoop.fs.Path
 import org.mockito.ArgumentMatchers.any
@@ -126,6 +127,7 @@ trait UCCommitCoordinatorClientSuiteBase extends CommitCoordinatorClientImplSuit
       Optional.empty(), // newMetadata
       Optional.empty(), // oldProtocol
       Optional.empty(), // newProtocol
+      java.util.Collections.emptyList[AbstractDomainMetadata](), // domainMetadataToCommit
       Optional.empty() /* uniform */)
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
@@ -375,14 +375,10 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
   }
 
   // Replacing a clustered managed Delta table with a non-clustered, non-partitioned one
-  // succeeds at the data plane (the table is queryable with the new schema, INSERTs land
-  // correctly), but UC's metastore retains the seed's `clusteringColumns` and
-  // `delta.feature.clustering` properties. The REPLACE does not propagate the cluster
-  // removal to UC's domain metadata. Pinned so we notice if the behavior changes; when
-  // fixed, update the assertion to reflect the cleared state.
-  // TODO: fix this issue https://github.com/delta-io/delta/issues/6915
+  // succeeds at the data plane and forwards the clustering domain metadata intent to UC.
+  // UC clears the clustering columns while keeping the clustering table feature supported.
   @Test
-  public void testReplaceClusteredManagedTableWithNoneRetainsStaleUcClustering() throws Exception {
+  public void testReplaceClusteredManagedTableWithNoneClearsUcClusteringColumns() throws Exception {
     String tableName = "cluster_to_none_" + UUID.randomUUID().toString().replace("-", "");
     String fullTableName = fullTableName(tableName);
     try {
@@ -402,7 +398,7 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
       TablesApi tablesApi = new TablesApi(unityCatalogInfo().createApiClient());
       TableInfo info = tablesApi.getTable(fullTableName, false, false);
       assertThat(info.getProperties())
-          .containsEntry("clusteringColumns", "[[\"col1\"]]")
+          .containsEntry("clusteringColumns", "[]")
           .containsEntry("delta.feature.clustering", "supported");
     } finally {
       sql("DROP TABLE IF EXISTS %s", fullTableName);

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -452,8 +452,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         options.getClusterColumn(),
         options.getPartitionColumn(),
         // For MANAGED+REPLACE: seed CREATE=v0, seed INSERT=v1, REPLACE=v2.
-        isManagedReplace ? "2" : "0",
-        !isManagedReplace);
+        isManagedReplace ? "2" : "0");
   }
 
   @Test
@@ -588,8 +587,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         withCluster,
         options.getClusterColumn(),
         options.getPartitionColumn(),
-        "0",
-        true);
+        "0");
 
     // Second CREATE OR REPLACE: identical metadata; goes through
     // `loadTableAndBuildReplaceProps`. Identity must survive and the post-create INSERT
@@ -618,8 +616,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         withCluster,
         options.getClusterColumn(),
         options.getPartitionColumn(),
-        withCluster ? "2" : "0",
-        true);
+        withCluster ? "2" : "0");
   }
 
   /**
@@ -798,8 +795,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         false,
         Optional.empty(),
         Optional.empty(),
-        "0",
-        true);
+        "0");
   }
 
   private void assertUCTableInfo(
@@ -812,8 +808,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       boolean withCluster,
       Optional<String> clusterColumn,
       Optional<String> partitionColumn,
-      String expectedLastUpdateVersion,
-      boolean expectClusteringColumnsProperty)
+      String expectedLastUpdateVersion)
       throws ApiException {
     UnityCatalogInfo uc = unityCatalogInfo();
     String catalogName = uc.catalogName();
@@ -859,10 +854,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
           withCluster
               ? ImmutableMap.<String, String>builder()
                   .put("delta.feature.clustering", SUPPORTED)
-                  .putAll(
-                      expectClusteringColumnsProperty
-                          ? Map.of("clusteringColumns", "[[\"" + clusterColumn.get() + "\"]]")
-                          : Map.of())
+                  .put("clusteringColumns", "[[\"" + clusterColumn.get() + "\"]]")
                   .build()
               : ImmutableMap.of();
       final Map<String, String> expectedOtherProperties =

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -323,7 +323,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     // Matrix 3: MANAGED REPLACE — partition / cluster shape transitions on existing
     // tables. Only the transitions exercised through the standard runner live here:
     //   - partition->cluster, partition->none
-    // The other two (`cluster->none` pins a known UC-side stale-metadata issue; and
+    // The other two (`cluster->none` has its own UC clearing assertion; and
     // `cluster->partition` is unconditionally rejected by Delta) are in
     // UCDeltaManagedReplaceSemanticsTest because they don't use this runner.
     counter++;
@@ -606,8 +606,8 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     } else {
       check(fullTableName, List.of(List.of("3", "c")));
     }
-    // Identical metadata: UC's view of `lastUpdateVersion` and `clusteringColumns` is
-    // unchanged from the first COR.
+    // Identical clustered metadata still sends clustering domain metadata intent to UC, so UC's
+    // lastUpdateVersion advances to the replacement commit version.
     assertUCTableInfo(
         TableType.MANAGED,
         fullTableName,
@@ -618,7 +618,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
         withCluster,
         options.getClusterColumn(),
         options.getPartitionColumn(),
-        "0",
+        withCluster ? "2" : "0",
         true);
   }
 
@@ -854,8 +854,7 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       Map<String, String> tablePropertiesFromServer = tableInfo.getProperties();
       tablePropertiesFromServer.remove("table_type", "MANAGED"); // New property by Spark 4.1
 
-      // CLUSTER BY has two extra properties, except managed REPLACE does not send clustering
-      // domain metadata to UC yet.
+      // CLUSTER BY has two extra properties.
       final Map<String, String> expectedClusteringProperties =
           withCluster
               ? ImmutableMap.<String, String>builder()

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
@@ -113,19 +113,19 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
         "id INT, name STRING",
         TableType.MANAGED,
         tableName -> {
-          assertThat(loadTableViaDeltaRest(tableName).getMetadata().getProperties())
+          assertThat(loadTable(tableName).getMetadata().getProperties())
               .doesNotContainKey("clusteringColumns");
 
           sql("ALTER TABLE %s CLUSTER BY (id)", tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          LoadTableResponse response = loadTable(tableName);
           assertThat(response.getMetadata().getProperties())
               .containsEntry("delta.feature.clustering", "supported")
               .containsEntry("clusteringColumns", "[[\"id\"]]");
 
           sql("ALTER TABLE %s CLUSTER BY NONE", tableName);
 
-          response = loadTableViaDeltaRest(tableName);
+          response = loadTable(tableName);
           assertThat(response.getMetadata().getProperties())
               .containsEntry("delta.feature.clustering", "supported")
               .containsEntry("clusteringColumns", "[]");
@@ -251,7 +251,7 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
         });
   }
 
-  private LoadTableResponse loadTableViaDeltaRest(String tableName) throws Exception {
+  private LoadTableResponse loadTableRest(String tableName) throws Exception {
     String[] parts = tableName.split("\\.", 3);
     return new TablesApi(unityCatalogInfo().createApiClient())
         .loadTable(parts[0], parts[1], parts[2]);

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
@@ -251,7 +251,7 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
         });
   }
 
-  private LoadTableResponse loadTableRest(String tableName) throws Exception {
+  private LoadTableResponse loadTable(String tableName) throws Exception {
     String[] parts = tableName.split("\\.", 3);
     return new TablesApi(unityCatalogInfo().createApiClient())
         .loadTable(parts[0], parts[1], parts[2]);

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
@@ -16,6 +16,10 @@
 
 package io.sparkuctest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.unitycatalog.client.delta.api.TablesApi;
+import io.unitycatalog.client.delta.model.LoadTableResponse;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -99,6 +103,32 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
           check(
               sql("SELECT id, name, extra FROM %s ORDER BY id", tableName),
               List.of(row("1", "initial", "null"), row("2", "new", "extra_value")));
+        });
+  }
+
+  @Test
+  public void testAlterTableClusterByUpdatesUcDomainMetadata() throws Exception {
+    withNewTable(
+        "alter_cluster_by_domain_metadata_test",
+        "id INT, name STRING",
+        TableType.MANAGED,
+        tableName -> {
+          assertThat(loadTableViaDeltaRest(tableName).getMetadata().getProperties())
+              .doesNotContainKey("clusteringColumns");
+
+          sql("ALTER TABLE %s CLUSTER BY (id)", tableName);
+
+          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          assertThat(response.getMetadata().getProperties())
+              .containsEntry("delta.feature.clustering", "supported")
+              .containsEntry("clusteringColumns", "[[\"id\"]]");
+
+          sql("ALTER TABLE %s CLUSTER BY NONE", tableName);
+
+          response = loadTableViaDeltaRest(tableName);
+          assertThat(response.getMetadata().getProperties())
+              .containsEntry("delta.feature.clustering", "supported")
+              .containsEntry("clusteringColumns", "[]");
         });
   }
 
@@ -219,6 +249,12 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
           sql("INSERT INTO %s VALUES (1, 'foo'), (2, 'bar')", tableName);
           check(tableName, List.of(List.of("1", "foo"), List.of("2", "bar")));
         });
+  }
+
+  private LoadTableResponse loadTableViaDeltaRest(String tableName) throws Exception {
+    String[] parts = tableName.split("\\.", 3);
+    return new TablesApi(unityCatalogInfo().createApiClient())
+        .loadTable(parts[0], parts[1], parts[2]);
   }
 
   /**

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
@@ -12,7 +12,7 @@ public class CatalogTrackedInfo {
         new CatalogTrackedInfo(Optional.empty(), Collections.emptyList());
 
     private final Optional<UniformMetadata> deltaUniformIceberg;
-    private final List<AbstractDomainMetadata> domainMetadataToCommit;
+    private final List<AbstractDomainMetadata> transactionDomainMetadata;
 
     public CatalogTrackedInfo(Optional<UniformMetadata> deltaUniformIceberg) {
         this(deltaUniformIceberg, Collections.emptyList());
@@ -20,16 +20,16 @@ public class CatalogTrackedInfo {
 
     public CatalogTrackedInfo(
             Optional<UniformMetadata> deltaUniformIceberg,
-            List<AbstractDomainMetadata> domainMetadataToCommit) {
+            List<AbstractDomainMetadata> transactionDomainMetadata) {
         this.deltaUniformIceberg = deltaUniformIceberg;
-        this.domainMetadataToCommit = domainMetadataToCommit;
+        this.transactionDomainMetadata = transactionDomainMetadata;
     }
 
     public Optional<UniformMetadata> deltaUniformIceberg() {
         return deltaUniformIceberg;
     }
 
-    public List<AbstractDomainMetadata> domainMetadataToCommit() {
-        return domainMetadataToCommit;
+    public List<AbstractDomainMetadata> transactionDomainMetadata() {
+        return transactionDomainMetadata;
     }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CatalogTrackedInfo.java
@@ -1,19 +1,35 @@
 package org.apache.spark.sql.delta.coordinatedcommits;
 
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.uniform.UniformMetadata;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 public class CatalogTrackedInfo {
-    public static final CatalogTrackedInfo EMPTY = new CatalogTrackedInfo(Optional.empty());
+    public static final CatalogTrackedInfo EMPTY =
+        new CatalogTrackedInfo(Optional.empty(), Collections.emptyList());
 
     private final Optional<UniformMetadata> deltaUniformIceberg;
+    private final List<AbstractDomainMetadata> domainMetadataToCommit;
 
     public CatalogTrackedInfo(Optional<UniformMetadata> deltaUniformIceberg) {
+        this(deltaUniformIceberg, Collections.emptyList());
+    }
+
+    public CatalogTrackedInfo(
+            Optional<UniformMetadata> deltaUniformIceberg,
+            List<AbstractDomainMetadata> domainMetadataToCommit) {
         this.deltaUniformIceberg = deltaUniformIceberg;
+        this.domainMetadataToCommit = domainMetadataToCommit;
     }
 
     public Optional<UniformMetadata> deltaUniformIceberg() {
         return deltaUniformIceberg;
+    }
+
+    public List<AbstractDomainMetadata> domainMetadataToCommit() {
+        return domainMetadataToCommit;
     }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -20,6 +20,7 @@ import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
@@ -83,6 +84,9 @@ public interface UCClient extends AutoCloseable {
    *                    If present, UC can validate the current protocol state.
    * @param newProtocol An Optional containing a new protocol version to be applied to the table.
    *                    If present, the table's protocol will be updated atomically with the commit.
+   * @param domainMetadataToCommit The raw domain metadata actions in this commit.
+   *                               A non-removed action sets domain metadata, and a removed action
+   *                               removes the domain metadata.
    * @param uniform An Optional containing UniForm metadata for Delta Universal Format support.
    *                If present, this metadata will be used by UC to manage format conversions
    *                (e.g., Iceberg, Hudi).
@@ -101,6 +105,7 @@ public interface UCClient extends AutoCloseable {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
+      List<AbstractDomainMetadata> domainMetadataToCommit,
       Optional<UniformMetadata> uniform
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException;
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -84,9 +84,9 @@ public interface UCClient extends AutoCloseable {
    *                    If present, UC can validate the current protocol state.
    * @param newProtocol An Optional containing a new protocol version to be applied to the table.
    *                    If present, the table's protocol will be updated atomically with the commit.
-   * @param domainMetadataToCommit The raw domain metadata actions in this commit.
-   *                               A non-removed action sets domain metadata, and a removed action
-   *                               removes the domain metadata.
+   * @param transactionDomainMetadata The raw domain metadata actions from this transaction.
+   *                                  A non-removed action sets domain metadata, and a removed action
+   *                                  removes the domain metadata.
    * @param uniform An Optional containing UniForm metadata for Delta Universal Format support.
    *                If present, this metadata will be used by UC to manage format conversions
    *                (e.g., Iceberg, Hudi).
@@ -105,7 +105,7 @@ public interface UCClient extends AutoCloseable {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
-      List<AbstractDomainMetadata> domainMetadataToCommit,
+      List<AbstractDomainMetadata> transactionDomainMetadata,
       Optional<UniformMetadata> uniform
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException;
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -725,7 +725,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       newMetadata,
       oldProtocol,
       newProtocol,
-      catalogTrackedInfo.domainMetadataToCommit(),
+      catalogTrackedInfo.transactionDomainMetadata(),
       catalogTrackedInfo.deltaUniformIceberg()
     );
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -725,6 +725,7 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
       newMetadata,
       oldProtocol,
       newProtocol,
+      catalogTrackedInfo.domainMetadataToCommit(),
       catalogTrackedInfo.deltaUniformIceberg()
     );
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -262,12 +262,12 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
-      List<AbstractDomainMetadata> domainMetadataToCommit,
+      List<AbstractDomainMetadata> transactionDomainMetadata,
       Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform)
       throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
-    Objects.requireNonNull(domainMetadataToCommit, "domainMetadataToCommit must not be null");
+    Objects.requireNonNull(transactionDomainMetadata, "transactionDomainMetadata must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     UpdateTableRequest request = new UpdateTableRequest();
@@ -300,7 +300,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .action("set-protocol")
           .protocol(toSDKDeltaProtocol(newProtocol.get())));
     }
-    addDomainMetadataUpdateActions(request, domainMetadataToCommit);
+    addDomainMetadataUpdateActions(request, transactionDomainMetadata);
 
     try {
       deltaTablesApi.updateTable(name.catalog, name.schema, name.table, request);
@@ -694,10 +694,10 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
   private static void addDomainMetadataUpdateActions(
       UpdateTableRequest request,
-      List<AbstractDomainMetadata> domainMetadataToCommit) throws IOException {
+      List<AbstractDomainMetadata> transactionDomainMetadata) throws IOException {
     List<AbstractDomainMetadata> setDomainMetadata = new ArrayList<>();
     List<String> removeDomains = new ArrayList<>();
-    for (AbstractDomainMetadata domainMetadata : domainMetadataToCommit) {
+    for (AbstractDomainMetadata domainMetadata : transactionDomainMetadata) {
       if (domainMetadata.isRemoved()) {
         removeDomains.add(domainMetadata.getDomain());
       } else {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -47,8 +47,10 @@ import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.client.delta.model.DeltaCommit;
 import io.unitycatalog.client.delta.model.DeltaProtocol;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.RemoveDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.RemovePropertiesUpdate;
 import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
+import io.unitycatalog.client.delta.model.SetDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.SetLatestBackfilledVersionUpdate;
 import io.unitycatalog.client.delta.model.SetPartitionColumnsUpdate;
 import io.unitycatalog.client.delta.model.SetPropertiesUpdate;
@@ -260,10 +262,12 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
+      List<AbstractDomainMetadata> domainMetadataToCommit,
       Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform)
       throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
+    Objects.requireNonNull(domainMetadataToCommit, "domainMetadataToCommit must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     UpdateTableRequest request = new UpdateTableRequest();
@@ -296,6 +300,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .action("set-protocol")
           .protocol(toSDKDeltaProtocol(newProtocol.get())));
     }
+    addDomainMetadataUpdateActions(request, domainMetadataToCommit);
 
     try {
       deltaTablesApi.updateTable(name.catalog, name.schema, name.table, request);
@@ -687,11 +692,37 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return protocol;
   }
 
+  private static void addDomainMetadataUpdateActions(
+      UpdateTableRequest request,
+      List<AbstractDomainMetadata> domainMetadataToCommit) throws IOException {
+    List<AbstractDomainMetadata> setDomainMetadata = new ArrayList<>();
+    List<String> removeDomains = new ArrayList<>();
+    for (AbstractDomainMetadata domainMetadata : domainMetadataToCommit) {
+      if (domainMetadata.isRemoved()) {
+        removeDomains.add(domainMetadata.getDomain());
+      } else {
+        setDomainMetadata.add(domainMetadata);
+      }
+    }
+
+    DomainMetadataUpdates setUpdates = toSDKDomainMetadataUpdates(setDomainMetadata);
+    if (setUpdates != null) {
+      request.addUpdatesItem(new SetDomainMetadataUpdate()
+          .action("set-domain-metadata")
+          .updates(setUpdates));
+    }
+    if (!removeDomains.isEmpty()) {
+      request.addUpdatesItem(new RemoveDomainMetadataUpdate()
+          .action("remove-domain-metadata")
+          .domains(removeDomains));
+    }
+  }
+
   /**
    * Maps Delta {@link AbstractDomainMetadata} entries onto the UC SDK's typed {@link
    * DomainMetadataUpdates}. UC models only {@code delta.clustering} and {@code
-   * delta.rowTracking}; entries for unknown domains are dropped silently. Returns {@code null}
-   * when no known-domain entries were produced.
+   * delta.rowTracking}; entries for unknown domains fail fast. Returns {@code null} when no
+   * known-domain entries were produced.
    *
    * <p>Each {@code configuration} JSON is parsed into a typed DTO so a shape mismatch fails at
    * parse time with a Jackson error rather than at first use after an unchecked cast.
@@ -703,7 +734,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     DomainMetadataUpdates updates = new DomainMetadataUpdates();
     boolean any = false;
     for (AbstractDomainMetadata dm : entries) {
-      // This function is for createTable only for now.
+      // Remove intents are carried separately by remove-domain-metadata commit updates.
       if (dm.isRemoved()) {
         continue;
       }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -180,7 +180,7 @@ public class UCTokenBasedRestClient implements UCClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
-      List<AbstractDomainMetadata> domainMetadataToCommit,
+      List<AbstractDomainMetadata> transactionDomainMetadata,
       Optional<UniformMetadata> uniform
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -21,6 +21,7 @@ import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.IcebergMetadata;
@@ -179,6 +180,7 @@ public class UCTokenBasedRestClient implements UCClient {
       Optional<AbstractMetadata> newMetadata,
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
+      List<AbstractDomainMetadata> domainMetadataToCommit,
       Optional<UniformMetadata> uniform
   ) throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -306,7 +306,8 @@ class UCDeltaTokenBasedRestClientSuite
     withClient { c =>
       c.commit(testTableId.toString, new URI("s3://bucket/table"), testIdentifier,
         Optional.of(createCommit(5L)), Optional.of(java.lang.Long.valueOf(3L)),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
     }
 
     val json = objectMapper.readTree(captured)
@@ -348,7 +349,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.of(oldMeta), Optional.of(newMeta),
-        Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
     }
 
     val actions = {
@@ -377,7 +379,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(),
-        Optional.of(oldProto), Optional.of(newProto), Optional.empty())
+        Optional.of(oldProto), Optional.of(newProto),
+        Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -385,6 +388,37 @@ class UCDeltaTokenBasedRestClientSuite
       .find(_.get("action").asText() == "set-protocol").get.get("protocol")
     assert(proto.get("min-reader-version").asInt() === 3)
     assert(proto.get("min-writer-version").asInt() === 7)
+  }
+
+  test("commit sends domain metadata intent updates") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      if (exchange.getRequestMethod == "POST") {
+        captured = body
+      }
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    withClient { c =>
+      c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+        Optional.of(createCommit(1L)), Optional.empty(),
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        java.util.List.of(
+          dm("delta.clustering", """{"clusteringColumns":[["c1"]]}"""),
+          dm("delta.rowTracking", "{}", removed = true)),
+        Optional.empty())
+    }
+
+    val updates = objectMapper.readTree(captured).get("updates")
+    val setDomainMetadata = (0 until updates.size()).map(updates.get)
+      .find(_.get("action").asText() == "set-domain-metadata").get
+    val removeDomainMetadata = (0 until updates.size()).map(updates.get)
+      .find(_.get("action").asText() == "remove-domain-metadata").get
+
+    val clusteringColumns =
+      setDomainMetadata.get("updates").get("delta.clustering").get("clusteringColumns")
+    assert(clusteringColumns.get(0).get(0).asText() === "c1")
+    assert(removeDomainMetadata.get("domains").get(0).asText() === "delta.rowTracking")
   }
 
   test("commit skips metadata updates when old and new are equal") {
@@ -404,7 +438,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.of(m1), Optional.of(m2),
-        Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -430,7 +465,8 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(),
-        Optional.of(p1), Optional.of(p2), Optional.empty())
+        Optional.of(p1), Optional.of(p2),
+        Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
     }
 
     val updates = objectMapper.readTree(captured).get("updates")
@@ -454,6 +490,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](),
         Optional.of(uniform))
     }
 
@@ -484,6 +521,7 @@ class UCDeltaTokenBasedRestClientSuite
       c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
         Optional.of(createCommit(1L)), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](),
         Optional.of(uniform))
     }
 
@@ -511,7 +549,8 @@ class UCDeltaTokenBasedRestClientSuite
       val e = intercept[CommitFailedException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
       }
       assert(e.getRetryable && e.getConflict)
     }
@@ -530,7 +569,8 @@ class UCDeltaTokenBasedRestClientSuite
       val e = intercept[CommitFailedException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
       }
       assert(!e.getRetryable && !e.getConflict)
       assert(e.getMessage.contains("Invalid updateTable request"))
@@ -550,7 +590,8 @@ class UCDeltaTokenBasedRestClientSuite
       intercept[InvalidTargetTableException] {
         c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
       }
     }
   }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -23,7 +23,7 @@ import java.util.{Collections, Optional}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
 import io.delta.storage.commit.{Commit, CommitFailedException}
-import io.delta.storage.commit.actions.AbstractMetadata
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 import io.unitycatalog.client.auth.TokenProvider
 
@@ -155,7 +155,8 @@ class UCTokenBasedRestClientSuite
     withClient { client =>
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
     }
   }
 
@@ -171,6 +172,7 @@ class UCTokenBasedRestClientSuite
         Optional.of(createMetadata()),
         Optional.empty(),
         Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](),
         Optional.empty())
     }
   }
@@ -180,12 +182,12 @@ class UCTokenBasedRestClientSuite
       intercept[NullPointerException] {
         client.commit(null, testTableUri, null, Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty())
+          Optional.empty(), Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
       }
       intercept[NullPointerException] {
         client.commit(testTableId, null, null, Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty())
+          Optional.empty(), Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
       }
     }
   }
@@ -196,7 +198,8 @@ class UCTokenBasedRestClientSuite
       withClient { client =>
         client.commit(testTableId, testTableUri, null,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-          Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+          Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
       }
     }
 
@@ -301,6 +304,7 @@ class UCTokenBasedRestClientSuite
         client.commit(testTableId, testTableUri, null,
           Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
           Optional.empty(), Optional.empty(), Optional.empty(),
+          Collections.emptyList[AbstractDomainMetadata](),
           Optional.of(new UniformMetadata(icebergMeta)))
       }
 
@@ -334,7 +338,8 @@ class UCTokenBasedRestClientSuite
     withClient { client =>
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())
+        Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](), Optional.empty())
     }
 
     val json = objectMapper.readTree(capturedBody)
@@ -352,6 +357,7 @@ class UCTokenBasedRestClientSuite
       client.commit(testTableId, testTableUri, null,
         Optional.of(createCommit(1L)), Optional.empty(), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(),
+        Collections.emptyList[AbstractDomainMetadata](),
         Optional.of(new UniformMetadata(null)))
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR wires Delta domain metadata actions through the UC commit path.

The main design decision is to use the `DomainMetadata` actions in the Delta commit as the source of truth for UC domain metadata intent. A normal `DomainMetadata` action means “set this domain metadata”. A `DomainMetadata` action with `removed=true` means “remove this domain”.

For example, a commit can contain these actions:

```json
{"domainMetadata":{"domain":"delta.clustering","configuration":"{\"clusteringColumns\":[[\"id\"]]}","removed":false}}

{"domainMetadata":{"domain":"delta.rowTracking","configuration":"{}","removed":true}}
```

The first action means “set `delta.clustering` domain metadata”. The second action means “remove `delta.rowTracking` domain metadata”.

This means Delta does not compute an old-to-new domain metadata diff for this API. The commit already contains the exact intent that the UC Delta REST API needs.

This keeps the change narrow. `CatalogTrackedInfo` carries the commit’s domain metadata actions, and `UCClient.commit(...)` receives them. `UCCommitCoordinatorClient.commitToUC(...)` stays unchanged. The UC Delta REST client converts the actions into `set-domain-metadata` and `remove-domain-metadata` requests.

Kernel call sites pass an empty domain metadata list for now, so this PR does not change Kernel commit behavior.

## How was this patch tested?
Integration tests and unit tests.

## Does this PR introduce _any_ user-facing changes?
Yes. Adds DomainMetadata support.
