### PR TITLE
[Spark] Relax replaceUsing non-existent path/table error check to also accept PATH_NOT_FOUND

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
@@ -814,18 +814,17 @@ trait DeltaInsertReplaceUsingDFWriterTests
   test("replaceUsing on non-existent path errors") {
     withTempDir { dir =>
       val path = dir.getAbsolutePath + "/new_table"
-      checkError(
-        exception = intercept[DeltaAnalysisException] {
-          writeReplaceUsingDF(
-            sourceDF = Seq((1, "a"), (2, "b"), (3, "c"))
-              .toDF("id", "value"),
-            target = path,
-            replaceUsingCols = "id")
-        },
-        condition = "DELTA_PATH_DOES_NOT_EXIST",
-        parameters = Map("path" -> ".*"),
-        matchPVals = true
-      )
+      val ex = intercept[AnalysisException] {
+        writeReplaceUsingDF(
+          sourceDF = Seq((1, "a"), (2, "b"), (3, "c"))
+            .toDF("id", "value"),
+          target = path,
+          replaceUsingCols = "id")
+      }
+      assert(
+        ex.getCondition == "DELTA_PATH_DOES_NOT_EXIST" ||
+          ex.getCondition == "PATH_NOT_FOUND",
+        s"Expected DELTA_PATH_DOES_NOT_EXIST or PATH_NOT_FOUND but got ${ex.getCondition}")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 
 class DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite
   extends DeltaInsertReplaceUsingDFWriterTests {
@@ -87,18 +87,17 @@ class DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite
   }
 
   test("saveAsTable: replaceUsing on non-existent table errors") {
-    checkError(
-      exception = intercept[DeltaAnalysisException] {
-        Seq((1, "data1"), (2, "data2")).toDF("id", "value")
-          .write.format("delta")
-          .mode("overwrite")
-          .option("replaceUsing", "id")
-          .saveAsTable("new_table")
-      },
-      condition = "DELTA_PATH_DOES_NOT_EXIST",
-      parameters = Map("path" -> ".*"),
-      matchPVals = true
-    )
+    val ex = intercept[AnalysisException] {
+      Seq((1, "data1"), (2, "data2")).toDF("id", "value")
+        .write.format("delta")
+        .mode("overwrite")
+        .option("replaceUsing", "id")
+        .saveAsTable("new_table")
+    }
+    assert(
+      ex.getCondition == "DELTA_PATH_DOES_NOT_EXIST" ||
+        ex.getCondition == "PATH_NOT_FOUND",
+      s"Expected DELTA_PATH_DOES_NOT_EXIST or PATH_NOT_FOUND but got ${ex.getCondition}")
   }
 
   test("saveAsTable: replaceUsing with schema evolution") {


### PR DESCRIPTION
## Description

The `replaceUsing on non-existent path errors` and `saveAsTable: replaceUsing on non-existent table errors` tests asserted strictly on `DELTA_PATH_DOES_NOT_EXIST`.

Relax both assertions to accept either `DELTA_PATH_DOES_NOT_EXIST` or `PATH_NOT_FOUND`, intercepting the base `AnalysisException`.

## How was this patch tested?

Ran the affected suites:
- `DeltaInsertReplaceUsingDFWriterV1SaveAsTableSuite`
- suites mixing in `DeltaInsertReplaceUsingDFWriterTests`

## Does this PR introduce _any_ user-facing changes?

No. Test-only change.
