### PR TITLE
[Spark] Deflake ClusteredTableDDLSuite with UUIDs

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -72,11 +72,11 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
   }
 
   // Use a per-suite-instance random suffix to prevent table name collisions across test shards.
-  protected val tableSuffix: String =
+  protected def tableSuffix: String =
     java.util.UUID.randomUUID().toString.replace("-", "").take(8)
-  protected val testTable: String = s"test_ddl_table_$tableSuffix"
-  protected val sourceTable: String = s"test_ddl_source_$tableSuffix"
-  protected val targetTable: String = s"test_ddl_target_$tableSuffix"
+  protected def testTable: String = s"test_ddl_table_$tableSuffix"
+  protected def sourceTable: String = s"test_ddl_source_$tableSuffix"
+  protected def targetTable: String = s"test_ddl_target_$tableSuffix"
 
   protected def isPathBased: Boolean = false
 
@@ -96,6 +96,7 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
         Seq("a.b", "ts"))
     ).foreach { case (testSuffix, columns, clusteringColumns) =>
       test(s"create/replace table$testSuffix") {
+        val testTable = this.testTable
         withTable(testTable) {
           clauses.foreach { clause =>
             createOrReplaceClusteredTable(
@@ -106,6 +107,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
       }
 
       test(s"ctas/rtas$testSuffix") {
+        val sourceTable = this.sourceTable
+        val targetTable = this.targetTable
         withTable(sourceTable, targetTable) {
           sql(s"CREATE TABLE $sourceTable($columns) USING delta")
           withTempDirIfNecessary { location =>
@@ -124,6 +127,7 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
 
       if (clauses.contains("REPLACE")) {
         test(s"Replace from non clustered table$testSuffix") {
+          val targetTable = this.targetTable
           withTable(targetTable) {
             sql(s"CREATE TABLE $targetTable($columns) USING delta")
             createOrReplaceClusteredTable(
@@ -142,7 +146,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
       numIndexedColumns: Int,
       tableSchema: Option[String],
       statsColumns: Seq[String] = Seq.empty,
-      location: Option[String] = None): Unit = {
+      location: Option[String] = None,
+      sourceTable: String = ""): Unit = {
     val clusterSpec = clusterColumns.mkString(",")
     val updatedTableProperties =
       collection.mutable.Map("delta.dataSkippingNumIndexedCols" -> s"$numIndexedColumns")
@@ -174,16 +179,17 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
 
   protected def testStatsCollectionHelper(
       tableSchema: String,
-      numberOfIndexedCols: Int)(cb: => Unit): Unit = {
-    withTable(sourceTable) {
+      numberOfIndexedCols: Int)(cb: String => Unit): Unit = {
+    val src = sourceTable
+    withTable(src) {
       // Create a source table for CTAS.
       sql(
         s"""
-           | CREATE TABLE $sourceTable($tableSchema) USING DELTA
+           | CREATE TABLE $src($tableSchema) USING DELTA
            | TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = '$numberOfIndexedCols')
            |""".stripMargin)
       // Run additional steps.
-      cb
+      cb(src)
     }
   }
 
@@ -304,6 +310,7 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
 
   test("cluster by with more than 4 columns - ctas") {
     val testTable = s"test_table_$tableSuffix"
+    val sourceTable = this.sourceTable
     val schema = "a INT, b INT, c INT, d INT, e INT"
     withTempDirIfNecessary { location =>
       withTable(sourceTable, testTable) {
@@ -349,7 +356,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
         val indexedColumns = 2
         testStatsCollectionHelper(
           tableSchema = tableSchema,
-          numberOfIndexedCols = indexedColumns) {
+          numberOfIndexedCols = indexedColumns) { sourceTable =>
+          val targetTable = this.targetTable
           withTable(targetTable) {
             val deltaLogSrc = DeltaLog.forTable(spark, TableIdentifier(sourceTable))
             // Validate the 3rd column `col1.col12` and 4th column `col2` can not be
@@ -395,7 +403,7 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
         val indexedColumns = 2
         testStatsCollectionHelper(
           tableSchema = tableSchema,
-          numberOfIndexedCols = indexedColumns) {
+          numberOfIndexedCols = indexedColumns) { sourceTable =>
           withTable(table) {
             withTempDir { dir =>
               val deltaLogSrc = DeltaLog.forTable(spark, TableIdentifier(sourceTable))
@@ -417,7 +425,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
                   "col0" :: "col1.col11" :: "col1.col12" :: "col2" :: Nil,
                   indexedColumns,
                   None,
-                  location = Some(dir.getPath)))
+                  location = Some(dir.getPath),
+                  sourceTable = sourceTable))
               checkError(
                 e,
                 "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
@@ -436,7 +445,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
                 table,
                 "col0" :: "col1.col11" :: Nil,
                 indexedColumns,
-                None)
+                None,
+                sourceTable = sourceTable)
             }
           }
         }
@@ -452,7 +462,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
     val nonEligibleTableSchema = s"col0 int, col1 STRUCT<col11: array<int>, col12: string>"
     testStatsCollectionHelper(
       tableSchema = nonEligibleTableSchema,
-      numberOfIndexedCols = indexedColumns) {
+      numberOfIndexedCols = indexedColumns) { sourceTable =>
+      val targetTable = this.targetTable
       withTable(targetTable) {
         val deltaLogSrc = DeltaLog.forTable(spark, TableIdentifier(sourceTable))
         // Validate the 2nd column `col1.col11` cannot be clustering column.
@@ -474,6 +485,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
 
   test("Replace clustered table with non-clustered table") {
     import testImplicits._
+    val sourceTable = this.sourceTable
+    val testTable = this.testTable
     withTable(sourceTable) {
       sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
       spark.range(1000)
@@ -507,6 +520,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
 
   test("Replace clustered table with non-clustered table - dataframe writer") {
     import testImplicits._
+    val sourceTable = this.sourceTable
+    val testTable = this.testTable
     withTable(sourceTable) {
       sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
       spark.range(1000)
@@ -556,6 +571,7 @@ trait ClusteredTableDDLWithColumnMapping
   )
 
   test("validate dropping clustering column is not allowed: single clustering column") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "col1 INT, col2 STRING, col3 LONG", "col1") {
       val e = intercept[DeltaAnalysisException] {
         sql(s"ALTER TABLE $testTable DROP COLUMNS (col1)")
@@ -571,6 +587,7 @@ trait ClusteredTableDDLWithColumnMapping
   }
 
   test("validate dropping clustering column is not allowed: multiple clustering columns") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "col1 INT, col2 STRING, col3 LONG", "col1, col2") {
       val e = intercept[DeltaAnalysisException] {
         sql(s"ALTER TABLE $testTable DROP COLUMNS (col1, col2)")
@@ -585,6 +602,7 @@ trait ClusteredTableDDLWithColumnMapping
 
   test("validate dropping clustering column is not allowed: clustering column + " +
     "non-clustering column") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "col1 INT, col2 STRING, col3 LONG", "col1, col2") {
       val e = intercept[DeltaAnalysisException] {
         sql(s"ALTER TABLE $testTable DROP COLUMNS (col1, col3)")
@@ -600,6 +618,7 @@ trait ClusteredTableDDLWithColumnMapping
 
 trait ClusteredTableDDLWithColumnMappingV2Base extends ClusteredTableDDLWithColumnMapping {
   test("test clustering column names (alter table + create table) with spaces") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "`col1 a` INT, col2 INT, col3 STRUCT<col4 INT, `col5 b` INT>, " +
       "`col6 c` STRUCT<col7 INT, `col8 d.e` INT>, `col9.f` INT", "`col1 a`") {
       val tableIdentifier = TableIdentifier(testTable)
@@ -630,6 +649,7 @@ trait ClusteredTableDDLWithColumnMappingV2Base extends ClusteredTableDDLWithColu
   }
 
   test("validate create table with commas in the column name") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "`col1,a` BIGINT", "`col1,a`") {
       verifyClusteringColumns(TableIdentifier(testTable), Seq("`col1,a`"))
     }
@@ -675,6 +695,7 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("alter table cluster by - valid scenarios") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "id INT, a STRUCT<b INT, c STRING>, name STRING", "id, name") {
       val tableIdentifier = TableIdentifier(testTable)
       verifyClusteringColumns(tableIdentifier, Seq("id", "name"))
@@ -691,6 +712,7 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("alter table cluster by - catalog reflects clustering columns when reordered") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "id INT, a STRUCT<b INT, c STRING>, name STRING", "id, name") {
       val tableIdentifier = TableIdentifier(testTable)
       verifyClusteringColumns(tableIdentifier, Seq("id", "name"))
@@ -702,6 +724,7 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("alter table cluster by - error scenarios") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "id INT, id2 INT, name STRING", "id, name") {
       // Specify non-existing columns.
       val e = intercept[AnalysisException] {
@@ -719,6 +742,7 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("alter table cluster by none") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "id Int", "id") {
       val tableIdentifier = TableIdentifier(testTable)
       verifyClusteringColumns(tableIdentifier, Seq("id"))
@@ -731,6 +755,7 @@ trait ClusteredTableDDLSuiteBase
   test("optimize clustered table and trigger regular compaction") {
     assume(!catalogOwnedDefaultCreationEnabledInTests,
       "OPTIMIZE is blocked on catalog-managed tables")
+    val testTable = this.testTable
     withClusteredTable(testTable, "a INT, b STRING", "a, b") {
       val tableIdentifier = TableIdentifier(testTable)
       verifyClusteringColumns(tableIdentifier, Seq("a", "b"))
@@ -776,6 +801,7 @@ trait ClusteredTableDDLSuiteBase
   test("optimize clustered table - error scenarios") {
     assume(!catalogOwnedDefaultCreationEnabledInTests,
       "OPTIMIZE is blocked on catalog-managed tables")
+    val testTable = this.testTable
     withClusteredTable(testTable, "a INT, b STRING", "a") {
       // Specify partition predicate.
       val e = intercept[DeltaUnsupportedOperationException] {
@@ -805,7 +831,8 @@ trait ClusteredTableDDLSuiteBase
     // Validate ALTER TABLE can not change to a missing stats column.
     testStatsCollectionHelper(
       tableSchema = tableSchema,
-      numberOfIndexedCols = indexedColumns) {
+      numberOfIndexedCols = indexedColumns) { _ =>
+      val testTable = this.testTable
       withTable(testTable) {
         createTableWithStatsColumns(
           "CREATE",
@@ -835,6 +862,7 @@ trait ClusteredTableDDLSuiteBase
 
   Seq("true", "false").foreach { checkEnabled =>
     test(s"Alter column after statement with stats schema update - checkEnabled=$checkEnabled") {
+      val testTable = this.testTable
       withTable(testTable) {
         withSQLConf(
           DeltaSQLConf.DELTA_LIQUID_ALTER_COLUMN_AFTER_STATS_SCHEMA_CHECK.key -> checkEnabled) {
@@ -843,7 +871,7 @@ trait ClusteredTableDDLSuiteBase
 
           testStatsCollectionHelper(
             tableSchema = tableSchema,
-            numberOfIndexedCols = indexedColumns) {
+            numberOfIndexedCols = indexedColumns) { _ =>
 
             createTableWithStatsColumns(
               "CREATE",
@@ -937,6 +965,7 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("alter table cluster by none is a no-op on non-clustered tables") {
+    val testTable = this.testTable
     withTable(testTable) {
       sql(s"CREATE TABLE $testTable (a INT, b STRING) USING delta")
       val tableIdentifier = TableIdentifier(testTable)
@@ -963,6 +992,7 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("alter table set tbl properties not allowed for clusteringColumns") {
+    val testTable = this.testTable
     withClusteredTable(testTable, "a INT, b STRING", "a") {
       val e = intercept[DeltaUnsupportedOperationException] {
         sql(s"""
@@ -978,6 +1008,7 @@ trait ClusteredTableDDLSuiteBase
   }
 
   test("validate RESTORE on clustered table") {
+    val testTable = this.testTable
     val tableIdentifier = TableIdentifier(testTable)
     // Scenario 1: restore clustered table to unclustered version.
     withTable(testTable) {
@@ -1090,6 +1121,8 @@ trait ClusteredTableDDLWithV2Base
   testColTypeValidation("REPLACE")
 
   test("replace with different clustering columns") {
+    val sourceTable = this.sourceTable
+    val testTable = this.testTable
     withTable(sourceTable) {
       sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
       // Validate REPLACE TABLE (AS SELECT).
@@ -1113,6 +1146,8 @@ trait ClusteredTableDDLWithV2Base
   }
 
   test("Validate replacing clustered tables with partitioned tables is not allowed") {
+    val sourceTable = this.sourceTable
+    val testTable = this.testTable
     withTable(sourceTable) {
       sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
 
@@ -1142,6 +1177,8 @@ trait ClusteredTableDDLWithV2Base
   }
 
   test("Validate replacing partitioned tables with clustered tables is allowed") {
+    val sourceTable = this.sourceTable
+    val testTable = this.testTable
     withTable(sourceTable) {
       sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
 
@@ -1179,6 +1216,7 @@ trait ClusteredTableDDLWithV2Base
       Seq("a.b", "ts"))
   ).foreach { case (testSuffix, columns, clusteringColumns) =>
     test(s"create/replace table createOrReplace$testSuffix") {
+      val testTable = this.testTable
       withTable(testTable) {
         // Repeat two times to test both create and replace cases.
         (1 to 2).foreach { _ =>
@@ -1190,6 +1228,8 @@ trait ClusteredTableDDLWithV2Base
     }
 
     test(s"ctas/rtas createOrReplace$testSuffix") {
+      val sourceTable = this.sourceTable
+      val targetTable = this.targetTable
       withTable(sourceTable, targetTable) {
         sql(s"CREATE TABLE $sourceTable($columns) USING delta")
         withTempDirIfNecessary { location =>


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Previously, we changed table names in ClusteredTableDDLSuite to work better with concurrently-run test cases, but the use of `val` instead of `def` meant that we were reusing the same UUID across tests. This change fixes this to generate a new test table each time and updates tests to store the value they use

## How was this patch tested?

test only

## Does this PR introduce _any_ user-facing changes?

No