### PR TITLE
[Spark][Tests] Add DSv2 stored-plan temp view refresh tests in Classic/Connect mode

### DIFF
--- a/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
+++ b/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
@@ -16,7 +16,8 @@
 
 package io.delta.tables
 
-import io.delta.tables.shared.{DeltaCacheTableTests, DeltaRepeatedAccessRefreshTests}
+import io.delta.tables.shared.{
+  DeltaCacheTableTests, DeltaRepeatedAccessRefreshTests, DeltaTempViewStoredPlanRefreshTests}
 
 import org.apache.spark.sql.test.DeltaQueryTest
 
@@ -29,7 +30,8 @@ trait DeltaTableRefreshConnectSuiteBase
   extends DeltaQueryTest
   with RemoteSparkSession
   with DeltaRepeatedAccessRefreshTests
-  with DeltaCacheTableTests {
+  with DeltaCacheTableTests
+  with DeltaTempViewStoredPlanRefreshTests {
 
   // The conf key is a literal because the Spark Connect thin client does not depend on Spark
   // Classic, which is where the Delta SQL configs live, so DeltaSQLConf.V2_ENABLE_MODE.key is

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
@@ -25,7 +25,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
+import org.apache.spark.sql.types.{DataType, IntegerType, MetadataBuilder, StructField, StructType}
 
 /**
  * Shared base for the repeated table access refresh tests.
@@ -104,6 +104,85 @@ trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
           s"CREATE TABLE t (id INT, salary INT) USING delta LOCATION '${dir.getAbsolutePath}'")
         seedInitialRow("t")
         body(dir.getAbsolutePath)
+      }
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  /**
+   * TBLPROPERTIES clause enabling the requested table features. Column mapping is required before a
+   * column can be dropped or re-added; type widening allows an ALTER COLUMN to a wider type.
+   */
+  private def tableProperties(columnMapping: Boolean, typeWidening: Boolean): String = {
+    val props =
+      (if (columnMapping) Seq("'delta.columnMapping.mode' = 'name'") else Nil) ++
+      (if (typeWidening) Seq("'delta.enableTypeWidening' = 'true'") else Nil)
+    if (props.isEmpty) "" else s" TBLPROPERTIES (${props.mkString(", ")})"
+  }
+
+  /**
+   * Seeds the initial `(1, 100)` row, returning true when the table was seeded. Under STRICT the
+   * DSv2 write path rejects writes to column-mapped tables (master's DeltaV2WriteBuilder guard), so
+   * such a table can never be seeded; in that case assert the rejection (an
+   * UnsupportedOperationException, or its SparkUnsupportedOperationException subclass over Connect)
+   * and return false so the caller skips the scenario body.
+   */
+  private def seedInitialRow(columnMapping: Boolean): Boolean = {
+    if (columnMapping && v2EnableMode == "STRICT") {
+      val expectedError = "DSv2 writes are not supported on column-mapped Delta tables"
+      val seedError =
+        try {
+          insertInitialData("t")
+          None
+        } catch {
+          case e: UnsupportedOperationException => Option(e.getMessage)
+        }
+      assert(
+        seedError.exists(_.contains(expectedError)),
+        s"expected '$expectedError', got: $seedError")
+      false
+    } else {
+      insertInitialData("t")
+      true
+    }
+  }
+
+  /**
+   * Runs `body` against a fresh managed catalog table `t` already holding `(1, 100)`, optionally
+   * enabling column mapping or type widening. Returns without running `body` when STRICT rejects
+   * the seed write to a column-mapped table.
+   */
+  protected def withInitialTable(
+      columnMapping: Boolean = false,
+      typeWidening: Boolean = false)(body: String => Unit): Unit =
+    withTable("t") {
+      spark.sql(
+        "CREATE TABLE t (id INT, salary INT) USING delta" +
+        tableProperties(columnMapping, typeWidening))
+      if (seedInitialRow(columnMapping)) {
+        body("t")
+      }
+    }
+
+  /**
+   * Runs `body` against a fresh external catalog table `t` already holding `(1, 100)`, optionally
+   * enabling column mapping or type widening, passing the table's storage path so the body can
+   * stage external commits there before re-reading. Returns without running `body` when STRICT
+   * rejects the seed write to a column-mapped table.
+   */
+  protected def withExternalTable(
+      columnMapping: Boolean = false,
+      typeWidening: Boolean = false)(body: String => Unit): Unit = {
+    val dir = Files.createTempDirectory("refresh-ext").toFile
+    try {
+      withTable("t") {
+        spark.sql(
+          s"CREATE TABLE t (id INT, salary INT) USING delta LOCATION '${dir.getAbsolutePath}'" +
+          tableProperties(columnMapping, typeWidening))
+        if (seedInitialRow(columnMapping)) {
+          body(dir.getAbsolutePath)
+        }
       }
     } finally {
       deleteRecursively(dir)
@@ -226,5 +305,48 @@ trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
   protected def externalDropAndRecreate(path: String): Unit = {
     val recreatedMeta = metadataLineWithNewId(latestMetadataLine(path))
     writeCommit(path, removeActiveFiles(path) :+ recreatedMeta)
+  }
+
+  private val MaxColumnIdRegex =
+    """"delta\.columnMapping\.maxColumnId"\s*:\s*"(\d+)"""".r
+
+  /** Drops a top level column by rewriting the metadata schema with the column removed. */
+  protected def externalDropColumn(path: String, col: String): Unit = {
+    val newSchema = StructType(currentSchema(path).filterNot(_.name == col))
+    writeCommit(path, Seq(metadataLineWithSchema(latestMetadataLine(path), newSchema)))
+  }
+
+  /** Changes a column's type by rewriting the metadata schema (e.g. INT widened to BIGINT). */
+  protected def externalChangeColumnType(path: String, col: String, newType: DataType): Unit = {
+    val newSchema = StructType(currentSchema(path).map { f =>
+      if (f.name == col) f.copy(dataType = newType) else f
+    })
+    writeCommit(path, Seq(metadataLineWithSchema(latestMetadataLine(path), newSchema)))
+  }
+
+  /**
+   * Drops `col` then re-adds it with the same name and `newType`. The re-added column gets a fresh
+   * column-mapping id and physical name (and bumps `maxColumnId`), mirroring what Delta does for a
+   * real DROP then ADD COLUMN on a column-mapping table.
+   */
+  protected def externalDropAndReAddColumn(path: String, col: String, newType: DataType): Unit = {
+    val meta = latestMetadataLine(path)
+    val maxId = MaxColumnIdRegex.findFirstMatchIn(meta).map(_.group(1).toInt).getOrElse(
+      throw new RuntimeException("Table is not column-mapping enabled"))
+    val newId = maxId + 1
+    val reAdded = new StructField(
+      col,
+      newType,
+      nullable = true,
+      new MetadataBuilder()
+        .putLong("delta.columnMapping.id", newId)
+        .putString("delta.columnMapping.physicalName", s"col-${UUID.randomUUID()}")
+        .build())
+    val newSchema = StructType(currentSchema(path).fields.filterNot(_.name == col) :+ reAdded)
+    val withSchema = metadataLineWithSchema(meta, newSchema)
+    val withBumpedMaxId = MaxColumnIdRegex.replaceFirstIn(
+      withSchema,
+      java.util.regex.Matcher.quoteReplacement(s""""delta.columnMapping.maxColumnId":"$newId""""))
+    writeCommit(path, Seq(withBumpedMaxId))
   }
 }

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTempViewStoredPlanRefreshTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTempViewStoredPlanRefreshTests.scala
@@ -1,0 +1,477 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables.shared
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType}
+
+/**
+ * Stored-plan temp view refresh tests for Delta tables, shared across classic and Connect.
+ *
+ * A temp view created from a Dataset (`spark.table(t).filter(...)`) captures the analyzed plan
+ * rather than SQL text. These tests verify how such a view reacts when the underlying Delta table
+ * changes, both via session SQL and via external writes (commits staged directly into the
+ * `_delta_log`).
+ *
+ * Behavior depends on the V2 enable mode. Under AUTO the legacy V1 path picks up data and additive
+ * schema changes on the next access and raises a Delta error on incompatible changes. Under STRICT
+ * the Kernel V2 connector instead enforces the stored plan's schema and raises Spark's
+ * [[INCOMPATIBLE_COLUMN_CHANGES_AFTER_VIEW_WITH_PLAN_CREATION]] on any column change. The two modes
+ * are gated below.
+ */
+trait DeltaTempViewStoredPlanRefreshTests
+  extends DeltaTableRefreshSharedBase { self: AnyFunSuite =>
+
+  // Creates the stored-plan temp view `v` = `tableRef` filtered to `salary < 999`, runs `body`,
+  // then drops the view. Does not assert the baseline; each test asserts the version and mode
+  // specific initial contents itself.
+  private def withStoredPlanView(tableRef: String)(body: => Unit): Unit =
+    try {
+      spark.table(tableRef).filter("salary < 999").createOrReplaceTempView("v")
+      body
+    } finally {
+      spark.sql("DROP VIEW IF EXISTS v")
+    }
+
+  test("scenario 1 session: view reflects session write") {
+    withInitialTable() { t =>
+      withStoredPlanView(t) {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        writerSql(s"INSERT INTO $t VALUES (2, 200)")
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") |
+              ("4.0", "AUTO") =>
+            // STRICT 4.1+ and AUTO (all versions) refresh: the new row shows through the filter.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100), Row(2, 200)))
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the snapshot captured when the view plan was built, so the session
+            // write is invisible.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        }
+      }
+    }
+  }
+
+  test("scenario 1 external: view reflects external write") {
+    withExternalTable() { path =>
+      withStoredPlanView("t") {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        externalDataWrite(path, Seq((2, 200)))
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") |
+              ("4.0", "AUTO") =>
+            // STRICT 4.1+ and AUTO (all versions) refresh: the new row shows through the filter.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100), Row(2, 200)))
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot, so the external write is invisible.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        }
+      }
+    }
+  }
+
+  test("scenario 2 session: view preserves schema after session ADD COLUMN") {
+    withInitialTable() { t =>
+      withStoredPlanView(t) {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        writerSql(s"ALTER TABLE $t ADD COLUMN new_column INT")
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
+            // TODO: schema evolution is not fully supported in V2 STRICT yet, so the wider INSERT
+            // fails with an arity mismatch.
+            checkError(
+              exception = intercept[AnalysisException] {
+                writerSql(s"INSERT INTO $t VALUES (2, 200, -1)")
+              },
+              condition = "INSERT_COLUMN_ARITY_MISMATCH")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view keeps its original two columns, so the wider INSERT succeeds and the
+            // new row shows through projected to id and salary.
+            writerSql(s"INSERT INTO $t VALUES (2, 200, -1)")
+            checkAnswer(spark.table("v"), Seq(Row(1, 100), Row(2, 200)))
+        }
+      }
+    }
+  }
+
+  test("scenario 2 external: view preserves schema after external ADD COLUMN") {
+    withExternalTable() { path =>
+      withStoredPlanView("t") {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        externalAddColumnAndWrite(path, Seq((2, 200, -1)))
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // STRICT 4.2+ and AUTO (all versions) refresh preserving the original two columns; the
+            // new row shows through projected to id and salary.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100), Row(2, 200)))
+          case ("4.1", "STRICT") =>
+            // 4.1 STRICT rejects the additive column change against the stored plan.
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "INCOMPATIBLE_COLUMN_CHANGES_AFTER_VIEW_WITH_PLAN_CREATION")
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot, so the external change is invisible.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        }
+      }
+    }
+  }
+
+  test("scenario 3 session: view detects session column removal") {
+    withInitialTable(columnMapping = true) { t =>
+      withStoredPlanView(t) {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet. A Kernel V2 scan of a
+            // column-mapping table with a pushed filter returns no rows, so the view is empty, and
+            // the V2 session catalog reads the table schema as empty, so the DROP COLUMN itself
+            // fails with FIELD_NOT_FOUND.
+            checkAnswer(spark.table("v"), Seq.empty)
+            checkError(
+              exception = intercept[SparkThrowable] {
+                writerSql(s"ALTER TABLE $t DROP COLUMN salary")
+              },
+              condition = "FIELD_NOT_FOUND")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view starts as the filtered [1, 100] and dropping the referenced column
+            // raises the Delta schema-change error on the next read.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            writerSql(s"ALTER TABLE $t DROP COLUMN salary")
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+        }
+      }
+    }
+  }
+
+  test("scenario 3 external: view detects external column removal") {
+    withExternalTable(columnMapping = true) { path =>
+      withStoredPlanView("t") {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet. The filter-pushdown gap
+            // makes the view empty, but the external column removal is still detected against the
+            // stored plan and rejected on read.
+            checkAnswer(spark.table("v"), Seq.empty)
+            externalDropColumn(path, "salary")
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "INCOMPATIBLE_COLUMN_CHANGES_AFTER_VIEW_WITH_PLAN_CREATION")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view starts as the filtered [1, 100] and the external column removal raises
+            // the Delta schema-change error on the next read.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            externalDropColumn(path, "salary")
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot, so the external removal is invisible; the
+            // filter-pushdown gap keeps the view empty. TODO: column mapping is not fully supported
+            // in V2 STRICT yet.
+            checkAnswer(spark.table("v"), Seq.empty)
+            externalDropColumn(path, "salary")
+            checkAnswer(spark.table("v"), Seq.empty)
+        }
+      }
+    }
+  }
+
+  test("scenario 4 session: view resolves to session-recreated table") {
+    withInitialTable() { t =>
+      withStoredPlanView(t) {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        writerSql(s"DROP TABLE $t")
+        writerSql(s"CREATE TABLE $t (id INT, salary INT) USING delta")
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") |
+              ("4.0", "AUTO") =>
+            // STRICT 4.1+ and AUTO (all versions) re-resolve the table by name, reflecting the new
+            // empty table.
+            checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view to the dropped table's commit, whose files the session DROP
+            // physically removed, so the read fails. Classic raises a raw Kernel exception (not a
+            // SparkThrowable) and Connect wraps it; both messages contain "does not exist".
+            val message =
+              try {
+                spark.table("v").collect()
+                ""
+              } catch {
+                case t: Throwable => Option(t.getMessage).getOrElse("")
+              }
+            assert(message.contains("does not exist"),
+              s"Expected a missing pinned-file error but got: '$message'")
+        }
+      }
+    }
+  }
+
+  test("scenario 4 external: view resolves to externally recreated table") {
+    withExternalTable() { path =>
+      withStoredPlanView("t") {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        externalDropAndRecreate(path)
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") |
+              ("4.0", "AUTO") =>
+            // STRICT 4.1+ and AUTO (all versions) re-resolve the table by name, reflecting the new
+            // empty table.
+            checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot (the external recreate keeps the old files), so
+            // the view still returns its original rows.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        }
+      }
+    }
+  }
+
+  test("scenario 4 session column mapping: view resolves to session-recreated table") {
+    withInitialTable(columnMapping = true) { t =>
+      withStoredPlanView(t) {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet (filter-pushdown gap),
+            // so the view is empty before and after the drop and recreate.
+            checkAnswer(spark.table("v"), Seq.empty)
+            writerSql(s"DROP TABLE $t")
+            writerSql(
+              s"CREATE TABLE $t (id INT, salary INT) USING delta " +
+              "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')")
+            checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: recreating a column-mapping table assigns fresh column ids, breaking the stored
+            // plan, so the view read raises the Delta schema-change error.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            writerSql(s"DROP TABLE $t")
+            writerSql(
+              s"CREATE TABLE $t (id INT, salary INT) USING delta " +
+              "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')")
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view to the dropped table's commit, whose files the session DROP
+            // physically removed, so the read fails (raw Kernel exception whose message contains
+            // "does not exist"). TODO: column mapping is not fully supported in V2 STRICT yet.
+            checkAnswer(spark.table("v"), Seq.empty)
+            writerSql(s"DROP TABLE $t")
+            writerSql(
+              s"CREATE TABLE $t (id INT, salary INT) USING delta " +
+              "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')")
+            val message =
+              try {
+                spark.table("v").collect()
+                ""
+              } catch {
+                case t: Throwable => Option(t.getMessage).getOrElse("")
+              }
+            assert(message.contains("does not exist"),
+              s"Expected a missing pinned-file error but got: '$message'")
+        }
+      }
+    }
+  }
+
+  test("scenario 4 external column mapping: view resolves to externally recreated table") {
+    withExternalTable(columnMapping = true) { path =>
+      withStoredPlanView("t") {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet (filter-pushdown gap),
+            // so the view is empty before and after the external drop and recreate.
+            checkAnswer(spark.table("v"), Seq.empty)
+            externalDropAndRecreate(path)
+            checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view re-resolves the table by name, reflecting the new empty table.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            externalDropAndRecreate(path)
+            checkAnswer(spark.table("v"), Seq.empty)
+        }
+      }
+    }
+  }
+
+  test("scenario 5 session: view detects session drop and re-add column same type") {
+    withInitialTable(columnMapping = true) { t =>
+      withStoredPlanView(t) {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet. The view is empty (the
+            // filter-pushdown gap) and the V2 session catalog reads the table schema as empty, so
+            // the DROP COLUMN fails with FIELD_NOT_FOUND before the column can be re-added.
+            checkAnswer(spark.table("v"), Seq.empty)
+            checkError(
+              exception = intercept[SparkThrowable] {
+                writerSql(s"ALTER TABLE $t DROP COLUMN salary")
+              },
+              condition = "FIELD_NOT_FOUND")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view starts as the filtered [1, 100]; re-adding the column with a fresh
+            // column id breaks the stored plan, raising the Delta schema-change error.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            writerSql(s"ALTER TABLE $t DROP COLUMN salary")
+            writerSql(s"ALTER TABLE $t ADD COLUMN salary INT")
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+        }
+      }
+    }
+  }
+
+  test("scenario 5 external: view detects external drop and re-add column same type") {
+    withExternalTable(columnMapping = true) { path =>
+      withStoredPlanView("t") {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet. The filter-pushdown gap
+            // makes the view empty; re-adding the column with the same name and type is not an
+            // incompatible change, so the view stays empty.
+            checkAnswer(spark.table("v"), Seq.empty)
+            externalDropAndReAddColumn(path, "salary", IntegerType)
+            checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view starts as the filtered [1, 100]; re-adding the column with a fresh
+            // column id breaks the stored plan, raising the Delta schema-change error.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            externalDropAndReAddColumn(path, "salary", IntegerType)
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+        }
+      }
+    }
+  }
+
+  test("scenario 6 session: view detects session column type change") {
+    withInitialTable(columnMapping = true) { t =>
+      withStoredPlanView(t) {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet. The view is empty (the
+            // filter-pushdown gap) and the V2 session catalog reads the table schema as empty, so
+            // the DROP COLUMN fails with FIELD_NOT_FOUND before the column can be re-added.
+            checkAnswer(spark.table("v"), Seq.empty)
+            checkError(
+              exception = intercept[SparkThrowable] {
+                writerSql(s"ALTER TABLE $t DROP COLUMN salary")
+              },
+              condition = "FIELD_NOT_FOUND")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view starts as the filtered [1, 100]; re-adding the column with a different
+            // type breaks the stored plan, raising the Delta schema-change error.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            writerSql(s"ALTER TABLE $t DROP COLUMN salary")
+            writerSql(s"ALTER TABLE $t ADD COLUMN salary STRING")
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+        }
+      }
+    }
+  }
+
+  test("scenario 6 external: view detects external column type change") {
+    withExternalTable(columnMapping = true) { path =>
+      withStoredPlanView("t") {
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+            // TODO: column mapping is not fully supported in V2 STRICT yet. The filter-pushdown gap
+            // makes the view empty, but the external type change is still detected against the
+            // stored plan and rejected on read.
+            checkAnswer(spark.table("v"), Seq.empty)
+            externalDropAndReAddColumn(path, "salary", StringType)
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "INCOMPATIBLE_COLUMN_CHANGES_AFTER_VIEW_WITH_PLAN_CREATION")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the view starts as the filtered [1, 100]; re-adding the column with a different
+            // type breaks the stored plan, raising the Delta schema-change error.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            externalDropAndReAddColumn(path, "salary", StringType)
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot, so the external type change is invisible; the
+            // filter-pushdown gap keeps the view empty. TODO: column mapping is not fully supported
+            // in V2 STRICT yet.
+            checkAnswer(spark.table("v"), Seq.empty)
+            externalDropAndReAddColumn(path, "salary", StringType)
+            checkAnswer(spark.table("v"), Seq.empty)
+        }
+      }
+    }
+  }
+
+  test("scenario 7 session: view reflects session type widening") {
+    withInitialTable(typeWidening = true) { t =>
+      withStoredPlanView(t) {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
+            // TODO: the V2 STRICT ALTER COLUMN path reports the column as missing rather than
+            // applying the type change.
+            checkError(
+              exception = intercept[SparkThrowable] {
+                writerSql(s"ALTER TABLE $t ALTER COLUMN salary TYPE BIGINT")
+              },
+              condition = "FIELD_NOT_FOUND")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: type widening lets the ALTER succeed, but the widened column type breaks the
+            // stored plan, so the view read raises the Delta schema-change error.
+            writerSql(s"ALTER TABLE $t ALTER COLUMN salary TYPE BIGINT")
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+        }
+      }
+    }
+  }
+
+  test("scenario 7 external: view reflects external type widening") {
+    withExternalTable(typeWidening = true) { path =>
+      withStoredPlanView("t") {
+        checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        externalChangeColumnType(path, "salary", LongType)
+        (sparkVersionBucket, v2EnableMode) match {
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+            // STRICT 4.1+ rejects the incompatible column change against the stored plan.
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "INCOMPATIBLE_COLUMN_CHANGES_AFTER_VIEW_WITH_PLAN_CREATION")
+          case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+            // AUTO: the widened column type is incompatible with the stored plan, surfacing the
+            // Delta schema-change error.
+            checkError(
+              exception = intercept[SparkThrowable] { spark.table("v").collect() },
+              condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot, so the external change is invisible.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+        }
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
@@ -16,7 +16,8 @@
 
 package org.apache.spark.sql.delta
 
-import io.delta.tables.shared.{DeltaCacheTableTests, DeltaRepeatedAccessRefreshTests}
+import io.delta.tables.shared.{
+  DeltaCacheTableTests, DeltaRepeatedAccessRefreshTests, DeltaTempViewStoredPlanRefreshTests}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
@@ -30,7 +31,8 @@ trait DeltaTableRefreshSuiteBase
   with SharedSparkSession
   with DeltaSQLCommandTest
   with DeltaRepeatedAccessRefreshTests
-  with DeltaCacheTableTests {
+  with DeltaCacheTableTests
+  with DeltaTempViewStoredPlanRefreshTests {
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf


### PR DESCRIPTION
## Description

Ports apache/spark's `DSv2TempViewWithStoredPlanTests` (apache/spark#55540, apache/spark#55571) to Delta. A temp view created from a Dataset (`spark.table(t).filter("salary < 999").createOrReplaceTempView("v")`) captures the analyzed plan rather than SQL text. These tests verify how such a view reacts when the underlying Delta table changes, via both session SQL and external `_delta_log` commits, across V2 enable modes AUTO and STRICT in both Classic and Connect.

Scenarios (each with a session and an external sub-case):
1. Insert new data — view reflects it.
2. ADD COLUMN — AUTO preserves the 2-column view; STRICT rejects the change.
3. DROP COLUMN — view detects the removal.
4. Drop and recreate the table — view re-resolves to the new empty table (with and without column mapping).
5. Drop and re-add a column with the same type — view detects fresh column ids.
6. Drop and re-add a column with a different type — view detects the type change.
7. Type widening INT -> BIGINT — rejected.

Behavior is gated by mode and Spark minor version: AUTO follows the legacy V1 path (`DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS`); STRICT engages the Kernel V2 connector (`INCOMPATIBLE_COLUMN_CHANGES_AFTER_VIEW_WITH_PLAN_CREATION`). A number of STRICT cases are placeholders that assert the current (not-yet-supported) DSv2 behavior, e.g. the column-mapping DROP/ADD COLUMN cases assert `FIELD_NOT_FOUND` and the V2 filter-pushdown gap on column-mapping tables (with TODOs). As DSv2 closes these gaps the assertions will start failing and we will update them.

## How was this patch tested?

New tests only. This PR adds 16 stored-plan temp view tests, mixed into each of the existing refresh suites alongside the 6 repeated-access and 5 cache-table tests (27 per suite). Local results on Spark 4.1+:
- `DeltaTableRefreshAutoModeSuite`: 27 passed (16 new)
- `DeltaTableRefreshStrictModeSuite`: 27 passed (16 new)
- `DeltaTableRefreshConnectAutoModeSuite`: 27 passed (16 new)
- `DeltaTableRefreshConnectStrictModeSuite`: 27 passed (16 new)

## Does this PR introduce _any_ user-facing change?

No. Tests and test build wiring only.


