### PR TITLE
[Spark] Migrate UpdateMetricsHook to the Delta API /metrics endpoint

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -21,8 +21,9 @@ import java.util
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
-import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{Action, DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
+import org.apache.spark.sql.delta.stats.FileSizeHistogram
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -36,7 +37,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * storage credentials on the returned [[Table]]. Keeping these behind a client interface
  * isolates that plumbing from `AbstractDeltaCatalog`.
  */
-private[catalog] trait AbstractDeltaCatalogClient {
+private[delta] trait AbstractDeltaCatalogClient {
 
   /**
    * Returns whether a table with `ident` exists in the catalog.
@@ -120,6 +121,26 @@ private[catalog] trait AbstractDeltaCatalogClient {
       domainMetadata: Seq[DomainMetadata],
       protocol: Protocol,
       lastCommitTimestampMs: Long): Unit
+
+  /**
+   * Reports post-commit telemetry for the table to the catalog. Implementations build
+   * whatever payload their catalog expects from the per-commit fields and the
+   * `CatalogTable`'s storage properties (e.g. the catalog-side table id), then ship it.
+   *
+   * Exceptions bubble out; implementations must not swallow failures internally.
+   *
+   * @param ct                catalog metadata for the committed table.
+   * @param committedActions  actions written in this commit (used to derive file/row counts).
+   * @param committedVersion  the commit version (used as the histogram's commit version).
+   * @param snapshotHistogram post-commit file-size distribution read from the CRC; `None`
+   *                          when the CRC is unavailable. Read from the CRC only to avoid
+   *                          triggering state reconstruction.
+   */
+  def reportMetrics(
+      ct: CatalogTable,
+      committedActions: Seq[Action],
+      committedVersion: Long,
+      snapshotHistogram: Option[FileSizeHistogram]): Unit
 }
 
 /** Builds a [[AbstractDeltaCatalogClient]] from catalog options. */
@@ -130,7 +151,13 @@ private[catalog] trait AbstractDeltaCatalogClientFactory {
       fallbackLoadTableFunc: Identifier => Table): AbstractDeltaCatalogClient
 }
 
-private[catalog] object AbstractDeltaCatalogClient extends Logging {
+/**
+ * Factory entry point for [[AbstractDeltaCatalogClient]] instances. Used both by
+ * `AbstractDeltaCatalog.initialize` (to wire the catalog's own client at construction
+ * time) and by the post-commit metrics hook (to build a fresh per-commit client without
+ * caching state across commits).
+ */
+private[delta] object AbstractDeltaCatalogClient extends Logging {
 
   private val UC_DELTA_CATALOG_CLIENT_IMPL_CLASS_NAME: String =
     "org.apache.spark.sql.delta.catalog.UCDeltaCatalogClientImpl"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -46,12 +46,13 @@ import org.apache.spark.sql.catalyst.catalog.{
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
 import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, ClusteringTableFeature, DeltaConfigs, DeltaErrors, DeltaThrowable, TableFeature}
-import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, DomainMetadata, Metadata, Protocol, RemoveFile, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.IcebergConstants
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.FileSizeHistogram
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -453,6 +454,25 @@ private[catalog] class UCDeltaCatalogClientImpl(
   }
 
   // -------------------------------------------------------------------------
+  // DeltaCatalogClient: reportMetrics
+  // -------------------------------------------------------------------------
+
+  override def reportMetrics(
+      ct: CatalogTable,
+      committedActions: Seq[Action],
+      committedVersion: Long,
+      snapshotHistogram: Option[FileSizeHistogram]): Unit = {
+    val tableId = ct.storage.properties(UC_TABLE_ID_KEY)
+    val ident = identifierFromCatalogTable(ct)
+    val report = UCDeltaCatalogClientImpl.buildCommitReport(
+      committedActions, committedVersion, snapshotHistogram)
+    ucClient.reportMetrics(tableId, toStorageTableIdent(ident), report)
+  }
+
+  private def identifierFromCatalogTable(ct: CatalogTable): Identifier =
+    Identifier.of(ct.identifier.database.toArray, ct.identifier.table)
+
+  // -------------------------------------------------------------------------
   // Internal helpers
   // -------------------------------------------------------------------------
 
@@ -669,4 +689,83 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
           s"$AuthPrefix* keys) or the legacy '$LegacyTokenKey' option.")
     }
   }
+
+  // -------------------------------------------------------------------------
+  // reportMetrics helpers (UC payload shaping)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds the UC Delta API commit-report payload. Visible for targeted unit testing;
+   * production callers should go through the instance `reportMetrics` method.
+   */
+  private[catalog] def buildCommitReport(
+      committedActions: Seq[Action],
+      committedVersion: Long,
+      snapshotHistogram: Option[FileSizeHistogram]
+      ): UCDeltaModels.CommitReport = {
+    val commitInfo =
+      committedActions.collectFirst { case ci: CommitInfo => ci }
+    val opMetrics =
+      commitInfo.flatMap(_.operationMetrics).getOrElse(Map.empty)
+    val addFiles = committedActions.collect { case a: AddFile => a }
+    val removeFiles = committedActions.collect { case r: RemoveFile => r }
+
+    val histogramPayload = snapshotHistogram.map { h =>
+      new UCDeltaModels.FileSizeHistogram(
+        h.sortedBinBoundaries.map(Long.box).asJava,
+        h.fileCounts.toSeq.map(Long.box).asJava,
+        h.totalBytes.toSeq.map(Long.box).asJava,
+        committedVersion)
+    }.toJava
+
+    new UCDeltaModels.CommitReport(
+      addFiles.size.toLong,
+      removeFiles.size.toLong,
+      addFiles.map(_.size).sum,
+      removeFiles.flatMap(_.size).sum,
+      extractRowsInserted(opMetrics, addFiles).map(Long.box).toJava,
+      extractRowsRemoved(opMetrics, removeFiles).map(Long.box).toJava,
+      extractRowsUpdated(opMetrics).map(Long.box).toJava,
+      histogramPayload)
+  }
+
+  // operationMetrics keys vary by operation: MERGE writes numTargetRowsInserted, WRITE
+  // writes numOutputRows. Falls back to per-file numLogicalRecords stats when no
+  // operationMetrics are present.
+  private def extractRowsInserted(
+      opMetrics: Map[String, String],
+      addFiles: Seq[AddFile]): Option[Long] = {
+    opMetrics.get("numTargetRowsInserted")
+      .orElse(opMetrics.get("numOutputRows"))
+      .flatMap(toLong)
+      .orElse {
+        val fromStats = addFiles.flatMap(_.numLogicalRecords)
+        if (fromStats.nonEmpty) Some(fromStats.sum) else None
+      }
+  }
+
+  // MERGE writes numTargetRowsDeleted, DELETE writes numDeletedRows.
+  private def extractRowsRemoved(
+      opMetrics: Map[String, String],
+      removeFiles: Seq[RemoveFile]): Option[Long] = {
+    opMetrics.get("numTargetRowsDeleted")
+      .orElse(opMetrics.get("numDeletedRows"))
+      .flatMap(toLong)
+      .orElse {
+        val fromStats = removeFiles.flatMap(_.numLogicalRecords)
+        if (fromStats.nonEmpty) Some(fromStats.sum) else None
+      }
+  }
+
+  // MERGE writes numTargetRowsUpdated, UPDATE writes numUpdatedRows. No file-stats
+  // fallback: per-file stats can't distinguish updated rows from inserted/removed rows.
+  private def extractRowsUpdated(opMetrics: Map[String, String]): Option[Long] = {
+    opMetrics.get("numTargetRowsUpdated")
+      .orElse(opMetrics.get("numUpdatedRows"))
+      .flatMap(toLong)
+  }
+
+  private def toLong(s: String): Option[Long] =
+    try Some(s.toLong)
+    catch { case _: NumberFormatException => None }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
@@ -22,71 +22,40 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
-
 import org.apache.spark.sql.delta.CommittedTransaction
-import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
-import org.apache.spark.sql.delta.coordinatedcommits.UCCommitCoordinatorBuilder
+import org.apache.spark.sql.delta.catalog.AbstractDeltaCatalogClient
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.stats.FileSizeHistogram
-import org.apache.spark.sql.delta.util.{CatalogTableUtils, JsonUtils}
+import org.apache.spark.sql.delta.util.CatalogTableUtils
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
 
-import io.unitycatalog.client.auth.TokenProvider
-import org.apache.http.HttpHeaders
-import org.apache.http.client.config.RequestConfig
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.entity.{ContentType, StringEntity}
-import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
-import org.apache.http.util.EntityUtils
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-
-// Payload case classes
-
-case class ReportDeltaMetricsRequest(
-    @JsonProperty("table_id") tableId: String,
-    @JsonProperty("report") report: CommitReportEnvelope)
-
-case class CommitReportEnvelope(
-    @JsonProperty("commit_report") commitReport: CommitReport)
-
-case class CommitReport(
-    @JsonProperty("num_files_added") numFilesAdded: Long,
-    @JsonProperty("num_files_removed") numFilesRemoved: Long,
-    @JsonProperty("num_bytes_added") numBytesAdded: Long,
-    @JsonProperty("num_bytes_removed") numBytesRemoved: Long,
-    @JsonProperty("num_rows_inserted")
-      numRowsInserted: Option[Long] = None,
-    @JsonProperty("num_rows_removed")
-      numRowsRemoved: Option[Long] = None,
-    @JsonProperty("num_rows_updated")
-      numRowsUpdated: Option[Long] = None,
-    @JsonProperty("file_size_histogram")
-      fileSizeHistogram: Option[FileSizeHistogramPayload] = None)
-
-case class FileSizeHistogramPayload(
-    @JsonProperty("sorted_bin_boundaries")
-      sortedBinBoundaries: Seq[Long],
-    @JsonProperty("file_counts") fileCounts: Seq[Long],
-    @JsonProperty("total_bytes") totalBytes: Seq[Long],
-    @JsonProperty("commit_version")
-      commitVersion: Long)
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * Post-commit hook that sends commit metrics to Unity Catalog
  * for UC-managed Delta tables.
  *
- * Metrics are dispatched asynchronously to a background thread
- * pool and never block or fail the commit. Gated by
- * [[DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED]].
+ * The hook reads the catalog's options out of `spark.conf` for the table's V2 catalog name
+ * and builds a fresh [[AbstractDeltaCatalogClient]] per commit (inside the async dispatch),
+ * then forwards the per-commit telemetry to it. The client knows how to shape and ship the
+ * payload; the hook itself never sees the wire types.
  *
- * @param catalogTable catalog metadata for UC-managed detection
+ * Building a client per commit avoids caching anything that would transitively pin the
+ * [[SparkSession]] in a long-lived map. The construction cost (HTTP client / token
+ * provider init) lives entirely inside the background `Future`, so commit latency is
+ * unaffected.
+ *
+ * Gated by [[DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED]]. Silent no-op when the
+ * catalog is not configured for `deltaRestApi.enabled=true`. Errors from the async
+ * dispatch are logged and swallowed; commit success is unaffected.
+ *
+ * @param catalogTable catalog metadata for UC-managed detection and identifier lookup
  */
 case class UpdateMetricsHook(catalogTable: Option[CatalogTable])
     extends PostCommitHook with DeltaLogging {
@@ -105,44 +74,49 @@ case class UpdateMetricsHook(catalogTable: Option[CatalogTable])
         !CatalogTableUtils.isUnityCatalogManagedTable(ct)) {
       return
     }
-    val tableId = ct.storage.properties(
-      UCCommitCoordinatorClient.UC_TABLE_ID_KEY)
-    sendMetricsAsync(spark, tableId, ct, txn)
+    sendMetricsAsync(spark, ct, txn)
   }
 
   private def sendMetricsAsync(
       spark: SparkSession,
-      tableId: String,
       ct: CatalogTable,
       txn: CommittedTransaction): Unit = {
-    val catalogName = ct.identifier.catalog
-    val actions = txn.committedActions
-    val version = txn.committedVersion
+    val catalogName = ct.identifier.catalog.getOrElse {
+      // CatalogTable has no V2 catalog identifier (e.g. path-based table) -- silent no-op.
+      return
+    }
+    val committedActions = txn.committedActions
+    val committedVersion = txn.committedVersion
+    // Read histogram from the CRC only -- avoids triggering state reconstruction.
+    val snapshotHistogram = txn.postCommitSnapshot.checksumOpt.flatMap(_.histogramOpt)
     val logPath = txn.deltaLog.logPath
-    // Read histogram from the CRC only - avoids triggering state reconstruction.
-    val snapshotHistogram =
-      txn.postCommitSnapshot.checksumOpt.flatMap(_.histogramOpt)
 
     implicit val ec: ExecutionContext =
       UpdateMetricsHook.getOrCreateExecutionContext(spark)
     UpdateMetricsHook.activeRequests.incrementAndGet()
     Future {
-      val request = UpdateMetricsHook.buildRequest(
-        tableId, actions, version, snapshotHistogram)
-      UpdateMetricsHook.sendMetrics(
-        spark, request, catalogName)
-      logDebug(
-        log"Successfully sent UC metrics for table " +
-        log"${MDC(DeltaLogKeys.PATH, logPath)} " +
-        log"version " +
-        log"${MDC(DeltaLogKeys.VERSION, version)}")
+      // Build the client inside the Future so its construction cost (HTTP client / token
+      // provider init) doesn't sit on the commit thread, and so the client and any
+      // SparkSession it transitively captures become GC-eligible as soon as the Future
+      // completes.
+      val opts = UpdateMetricsHook.catalogOptionsFor(spark, catalogName)
+      AbstractDeltaCatalogClient
+        .fromCatalogOptionsIfEnabled(catalogName, opts, UpdateMetricsHook.UnusedLoader)
+        .foreach { client =>
+          client.reportMetrics(ct, committedActions, committedVersion, snapshotHistogram)
+          logDebug(
+            log"Successfully sent UC metrics for table " +
+            log"${MDC(DeltaLogKeys.PATH, logPath)} " +
+            log"version " +
+            log"${MDC(DeltaLogKeys.VERSION, committedVersion)}")
+        }
     }.recover {
       case e: Exception =>
         logWarning(
           log"Failed to send UC metrics for table " +
           log"${MDC(DeltaLogKeys.PATH, logPath)} " +
           log"version " +
-          log"${MDC(DeltaLogKeys.VERSION, version)}" +
+          log"${MDC(DeltaLogKeys.VERSION, committedVersion)}" +
           log": ${MDC(DeltaLogKeys.ERROR, e.getMessage)}",
           e)
     }.onComplete { _ =>
@@ -183,180 +157,31 @@ object UpdateMetricsHook {
     activeRequests.get() == 0
   }
 
-  // -- Payload builder --
+  // -- Per-commit client construction --
 
-  private[metrics] def buildRequest(
-      tableId: String,
-      committedActions: Seq[Action],
-      committedVersion: Long,
-      snapshotHistogram: Option[FileSizeHistogram] = None
-      ): ReportDeltaMetricsRequest = {
-    val commitInfo =
-      committedActions.collectFirst { case ci: CommitInfo => ci }
-    val opMetrics =
-      commitInfo.flatMap(_.operationMetrics).getOrElse(Map.empty)
-    val addFiles =
-      committedActions.collect { case a: AddFile => a }
-    val removeFiles =
-      committedActions.collect { case r: RemoveFile => r }
-
-    val histogramPayload = snapshotHistogram.map { h =>
-      FileSizeHistogramPayload(
-        sortedBinBoundaries = h.sortedBinBoundaries,
-        fileCounts = h.fileCounts.toSeq,
-        totalBytes = h.totalBytes.toSeq,
-        commitVersion = committedVersion)
-    }
-
-    val commitReport = CommitReport(
-      numFilesAdded = addFiles.size.toLong,
-      numFilesRemoved = removeFiles.size.toLong,
-      numBytesAdded = addFiles.map(_.size).sum,
-      numBytesRemoved = removeFiles.flatMap(_.size).sum,
-      numRowsInserted =
-        extractRowsInserted(opMetrics, addFiles),
-      numRowsRemoved =
-        extractRowsRemoved(opMetrics, removeFiles),
-      numRowsUpdated = extractRowsUpdated(opMetrics),
-      fileSizeHistogram = histogramPayload
-    )
-
-    ReportDeltaMetricsRequest(
-      tableId = tableId,
-      report = CommitReportEnvelope(commitReport)
-    )
+  /**
+   * Assembles the catalog options for `catalogName` from the live `spark.conf` by walking
+   * `spark.sql.catalog.<name>.*` keys, stripping the prefix, and packing the result into a
+   * [[CaseInsensitiveStringMap]] -- the same shape `AbstractDeltaCatalog.initialize`
+   * receives. Returns an empty map if no entries exist (the resulting client lookup will
+   * silently no-op via the `deltaRestApi.enabled=false` default).
+   */
+  private[metrics] def catalogOptionsFor(
+      spark: SparkSession, catalogName: String): CaseInsensitiveStringMap = {
+    val prefix = s"spark.sql.catalog.$catalogName."
+    val opts = spark.conf.getAll.iterator.collect {
+      case (k, v) if k.startsWith(prefix) => k.substring(prefix.length) -> v
+    }.toMap
+    new CaseInsensitiveStringMap(opts.asJava)
   }
 
-  // operationMetrics keys vary by operation: MERGE writes
-  // numTargetRowsInserted, WRITE writes numOutputRows.
-  private def extractRowsInserted(
-      opMetrics: Map[String, String],
-      addFiles: Seq[AddFile]): Option[Long] = {
-    opMetrics.get("numTargetRowsInserted")
-      .orElse(opMetrics.get("numOutputRows"))
-      .flatMap(toLong)
-      .orElse {
-        val fromStats = addFiles.flatMap(_.numLogicalRecords)
-        if (fromStats.nonEmpty) Some(fromStats.sum) else None
-      }
-  }
-
-  // MERGE writes numTargetRowsDeleted, DELETE writes
-  // numDeletedRows.
-  private def extractRowsRemoved(
-      opMetrics: Map[String, String],
-      removeFiles: Seq[RemoveFile]): Option[Long] = {
-    opMetrics.get("numTargetRowsDeleted")
-      .orElse(opMetrics.get("numDeletedRows"))
-      .flatMap(toLong)
-      .orElse {
-        val fromStats =
-          removeFiles.flatMap(_.numLogicalRecords)
-        if (fromStats.nonEmpty) Some(fromStats.sum) else None
-      }
-  }
-
-  // MERGE writes numTargetRowsUpdated, UPDATE writes
-  // numUpdatedRows. No file-stats fallback: per-file stats cannot
-  // distinguish updated rows from inserted/removed rows.
-  private def extractRowsUpdated(
-      opMetrics: Map[String, String]): Option[Long] = {
-    opMetrics.get("numTargetRowsUpdated")
-      .orElse(opMetrics.get("numUpdatedRows"))
-      .flatMap(toLong)
-  }
-
-  private def toLong(s: String): Option[Long] =
-    try Some(s.toLong)
-    catch { case _: NumberFormatException => None }
-
-  // -- HTTP client --
-
-  private val CATALOG_CONF_PREFIX = "spark.sql.catalog"
-  private val CATALOG_URI_CONF_SUFFIX = "uri"
-  private val METRICS_ENDPOINT_PATH =
-    "/api/2.1/unity-catalog/delta/preview/metrics"
-  private val HTTP_TIMEOUT_MS = 5000L
-
-  private[metrics] def sendMetrics(
-      spark: SparkSession,
-      request: ReportDeltaMetricsRequest,
-      catalogName: Option[String] = None): Unit = {
-    val catalog = catalogName.getOrElse(
-      throw new IllegalArgumentException(
-        "Catalog name required for UC metrics; " +
-        "endpoint URI is read from " +
-        "spark.sql.catalog.<name>.uri"))
-    val endpointUrl = getEndpointUrl(spark, catalog)
-    val authToken = getAuthToken(spark, catalog)
-
-    val requestConfig = RequestConfig.custom()
-      .setConnectTimeout(HTTP_TIMEOUT_MS.toInt)
-      .setSocketTimeout(HTTP_TIMEOUT_MS.toInt)
-      .setConnectionRequestTimeout(HTTP_TIMEOUT_MS.toInt)
-      .build()
-
-    val httpClient: CloseableHttpClient =
-      HttpClientBuilder.create()
-        .setDefaultRequestConfig(requestConfig)
-        .build()
-
-    try {
-      val httpPost = new HttpPost(endpointUrl)
-      httpPost.setHeader(
-        HttpHeaders.AUTHORIZATION, s"Bearer $authToken")
-      val jsonPayload = JsonUtils.toJson(request)
-      httpPost.setEntity(
-        new StringEntity(
-          jsonPayload, ContentType.APPLICATION_JSON))
-
-      val response = httpClient.execute(httpPost)
-      try {
-        val statusCode = response.getStatusLine.getStatusCode
-        if (statusCode < 200 || statusCode >= 300) {
-          val responseBody = Option(response.getEntity)
-            .map(EntityUtils.toString)
-            .getOrElse("<no response body>")
-          throw new RuntimeException(
-            "UC metrics endpoint returned error " +
-            s"status $statusCode: $responseBody")
-        }
-      } finally {
-        response.close()
-      }
-    } finally {
-      httpClient.close()
-    }
-  }
-
-  private def getEndpointUrl(
-      spark: SparkSession,
-      catalogName: String): String = {
-    val uriKey = s"$CATALOG_CONF_PREFIX.$catalogName" +
-      s".$CATALOG_URI_CONF_SUFFIX"
-    spark.conf.getOption(uriKey) match {
-      case Some(uri) if uri.nonEmpty =>
-        s"${uri.stripSuffix("/")}$METRICS_ENDPOINT_PATH"
-      case _ =>
-        throw new IllegalArgumentException(
-          s"UC catalog base URI not configured. " +
-          s"Set $uriKey")
-    }
-  }
-
-  private def getAuthToken(
-      spark: SparkSession,
-      catalogName: String): String = {
-    val configMap =
-      UCCommitCoordinatorBuilder.getCatalogConfigMap(spark)
-    val config = configMap.get(catalogName).getOrElse(
-      throw new IllegalArgumentException(
-        "Unity Catalog configuration not found for " +
-        s"catalog '$catalogName'. Configure " +
-        "spark.sql.catalog.<catalog>.uri and auth " +
-        "(auth.type/auth.token or legacy .token)."))
-    val tokenProvider =
-      TokenProvider.create(config.authConfig.asJava)
-    tokenProvider.accessToken()
-  }
+  /**
+   * `fromCatalogOptionsIfEnabled` requires a `Identifier => Table` loader for the catalog
+   * client's `loadTable` fallback path. The metrics path never invokes `loadTable`, so we
+   * pass a throwing stub: it surfaces loudly if a future code change unexpectedly starts
+   * calling it from `reportMetrics`, rather than returning a misleading `null`.
+   */
+  private[metrics] val UnusedLoader: Identifier => Table =
+    _ => throw new UnsupportedOperationException(
+      "UpdateMetricsHook's per-commit client does not support loadTable")
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -899,6 +899,11 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       columns: util.List[UCClient.ColumnDef],
       properties: util.Map[String, String]): Unit =
     throw new UnsupportedOperationException
+  override def reportMetrics(
+      tableId: String,
+      tableIdentifier: StorageTableIdentifier,
+      report: UCDeltaModels.CommitReport): Unit =
+    throw new UnsupportedOperationException
   override def close(): Unit = ()
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImplMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImplMetricsSuite.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
+import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Unit tests for `UCDeltaCatalogClientImpl.buildCommitReport`, which converts per-commit
+ * Delta state (actions, version, snapshot histogram) into the `UCDeltaModels.CommitReport`
+ * shipped to UC's Delta metrics endpoint.
+ *
+ * Same-package as the function under test so the package-private helper is reachable
+ * without widening its visibility.
+ */
+class UCDeltaCatalogClientImplMetricsSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  test("buildCommitReport: file metrics from synthetic AddFile/RemoveFile actions") {
+    val add1 = AddFile("f1.parquet", Map.empty, 1024L,
+      System.currentTimeMillis(), dataChange = true)
+    val add2 = AddFile("f2.parquet", Map.empty, 2048L,
+      System.currentTimeMillis(), dataChange = true)
+    val add3 = AddFile("f3.parquet", Map.empty, 4096L,
+      System.currentTimeMillis(), dataChange = true)
+    val removed = RemoveFile("old.parquet",
+      Some(System.currentTimeMillis()),
+      dataChange = true, size = Some(512L))
+
+    val snapshotHist = FileSizeHistogramUtils.emptyHistogram
+    snapshotHist.insert(1024L)
+    snapshotHist.insert(2048L)
+    snapshotHist.insert(4096L)
+
+    val actions: Seq[Action] = Seq(add1, add2, add3, removed)
+    val report = UCDeltaCatalogClientImpl.buildCommitReport(
+      actions, committedVersion = 7L, snapshotHistogram = Some(snapshotHist))
+
+    assert(report.getNumFilesAdded == 3L, "3 AddFiles")
+    assert(report.getNumFilesRemoved == 1L, "1 RemoveFile")
+    assert(report.getNumBytesAdded == 1024L + 2048L + 4096L, "sum of add sizes")
+    assert(report.getNumBytesRemoved == 512L, "sum of remove sizes")
+
+    assert(report.getFileSizeHistogram.isPresent)
+    val hist = report.getFileSizeHistogram.get
+    assert(hist.getCommitVersion == 7L, "commit_version must be set")
+    assert(hist.getSortedBinBoundaries.get(0) == 0L, "bins must start at 0")
+    assert(hist.getFileCounts.asScala.map(_.longValue).sum == 3L,
+      "histogram covers all files")
+    assert(hist.getTotalBytes.asScala.map(_.longValue).sum == 1024L + 2048L + 4096L,
+      "histogram totalBytes")
+  }
+
+  test("buildCommitReport: row metrics prefer operationMetrics over file stats") {
+    val addFileWithStats = AddFile("f.parquet", Map.empty, 1000L,
+      System.currentTimeMillis(), dataChange = true,
+      stats = """{"numRecords": 999}""")
+    val commitInfoWithMetrics = commitInfo(
+      operation = "WRITE",
+      operationMetrics = Some(Map("numOutputRows" -> "100")))
+
+    val r1 = UCDeltaCatalogClientImpl.buildCommitReport(
+      Seq(commitInfoWithMetrics, addFileWithStats), 0L, None)
+    assert(r1.getNumRowsInserted.get == 100L,
+      "operationMetrics wins over file stats")
+
+    val commitInfoNoMetrics = commitInfo(
+      operation = "WRITE", operationMetrics = None, version = Some(1L))
+
+    val r2 = UCDeltaCatalogClientImpl.buildCommitReport(
+      Seq(commitInfoNoMetrics, addFileWithStats), 1L, None)
+    assert(r2.getNumRowsInserted.get == 999L,
+      "fallback to numLogicalRecords from file stats")
+
+    val r3 = UCDeltaCatalogClientImpl.buildCommitReport(
+      Seq(addFileWithStats), 2L, None)
+    assert(r3.getNumRowsInserted.get == 999L,
+      "fallback works with no CommitInfo in actions")
+  }
+
+  test("buildCommitReport: row metrics for MERGE operation") {
+    val ci = commitInfo(
+      operation = "MERGE",
+      operationMetrics = Some(Map(
+        "numTargetRowsInserted" -> "10",
+        "numTargetRowsDeleted" -> "5",
+        "numTargetRowsUpdated" -> "3")))
+    val r = UCDeltaCatalogClientImpl.buildCommitReport(Seq(ci), 0L, None)
+    assert(r.getNumRowsInserted.get == 10L)
+    assert(r.getNumRowsRemoved.get == 5L)
+    assert(r.getNumRowsUpdated.get == 3L)
+  }
+
+  test("buildCommitReport: row metrics for DELETE operation") {
+    val ci = commitInfo(
+      operation = "DELETE",
+      operationMetrics = Some(Map("numDeletedRows" -> "42")))
+    val r = UCDeltaCatalogClientImpl.buildCommitReport(Seq(ci), 0L, None)
+    assert(r.getNumRowsRemoved.get == 42L)
+  }
+
+  test("buildCommitReport: row metrics for UPDATE operation") {
+    val ci = commitInfo(
+      operation = "UPDATE",
+      operationMetrics = Some(Map("numUpdatedRows" -> "17")))
+    val r = UCDeltaCatalogClientImpl.buildCommitReport(Seq(ci), 0L, None)
+    assert(r.getNumRowsUpdated.get == 17L)
+  }
+
+  test("buildCommitReport: row metrics absent when neither operationMetrics nor file stats " +
+      "can supply them") {
+    // AddFile/RemoveFile without numRecords stats, and no CommitInfo => all three row
+    // counts must be absent (the falsy branch of every extractRows* helper).
+    val add = AddFile("f.parquet", Map.empty, 1024L,
+      System.currentTimeMillis(), dataChange = true)
+    val remove = RemoveFile("r.parquet", Some(System.currentTimeMillis()),
+      dataChange = true, size = Some(512L))
+    val r = UCDeltaCatalogClientImpl.buildCommitReport(Seq(add, remove), 0L, None)
+    assert(!r.getNumRowsInserted.isPresent, "no opMetrics + no AddFile stats => empty")
+    assert(!r.getNumRowsRemoved.isPresent, "no opMetrics + no RemoveFile stats => empty")
+    assert(!r.getNumRowsUpdated.isPresent, "no opMetrics => empty (no file-stats fallback)")
+    assert(r.getNumFilesAdded == 1L)
+    assert(r.getNumFilesRemoved == 1L)
+  }
+
+  test("buildCommitReport: uses snapshot histogram when provided") {
+    val snapshotHist = FileSizeHistogramUtils.emptyHistogram
+    snapshotHist.insert(1024L)
+    snapshotHist.insert(2048L)
+    snapshotHist.insert(4096L)
+
+    // AddFile with a DIFFERENT size than what's in the snapshot histogram; histogram should
+    // come from the snapshot, not from the per-commit AddFiles.
+    val add = AddFile("f.parquet", Map.empty, 8192L,
+      System.currentTimeMillis(), dataChange = true)
+
+    val r = UCDeltaCatalogClientImpl.buildCommitReport(
+      Seq(add), committedVersion = 5L, snapshotHistogram = Some(snapshotHist))
+    val hist = r.getFileSizeHistogram.get
+
+    assert(hist.getFileCounts.asScala.map(_.longValue).sum == 3L,
+      "should use snapshot histogram file counts, not per-commit AddFiles")
+    assert(hist.getTotalBytes.asScala.map(_.longValue).sum == 1024L + 2048L + 4096L,
+      "should use snapshot histogram total bytes")
+    assert(hist.getCommitVersion == 5L)
+  }
+
+  test("buildCommitReport: omits histogram when snapshot is None") {
+    val add = AddFile("f.parquet", Map.empty, 1024L,
+      System.currentTimeMillis(), dataChange = true)
+    val r = UCDeltaCatalogClientImpl.buildCommitReport(
+      Seq(add), committedVersion = 3L, snapshotHistogram = None)
+
+    assert(!r.getFileSizeHistogram.isPresent,
+      "histogram should be absent when snapshot is unavailable")
+  }
+
+  // -- Helpers --
+
+  private def commitInfo(
+      operation: String,
+      operationMetrics: Option[Map[String, String]],
+      version: Option[Long] = Some(0L)): CommitInfo = {
+    CommitInfo(
+      version = version,
+      inCommitTimestamp = None,
+      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
+      userId = None, userName = None,
+      operation = operation,
+      operationParameters = Map.empty,
+      job = None, notebook = None, clusterId = None,
+      readVersion = None, isolationLevel = None,
+      isBlindAppend = Some(false),
+      operationMetrics = operationMetrics,
+      userMetadata = None, tags = None, engineInfo = None, txnId = None)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
@@ -18,7 +18,10 @@ package org.apache.spark.sql.delta.hooks.metrics
 
 import java.io.{BufferedReader, InputStreamReader, PrintWriter}
 import java.net.{ServerSocket, Socket}
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.JavaConverters._
 
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 
@@ -26,7 +29,6 @@ import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog, DeltaOperatio
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.util.{CatalogTableUtils, JsonUtils}
 
 import org.apache.spark.sql.SaveMode
@@ -35,15 +37,19 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
 class UpdateMetricsHookSuite extends QueryTest
   with SharedSparkSession
   with DeltaSQLCommandTest {
-  private val TEST_CATALOG_NAME = "test_catalog"
-  private val TEST_UC_TABLE_ID = "uc-table-id-abc"
+  private val TEST_UC_TABLE_ID = UUID.fromString("11111111-1111-1111-1111-111111111111")
   private val CONF_KEY = DeltaSQLConf.DELTA_UC_COMMIT_METRICS_ENABLED.key
+
+  // The Spark-registered catalog class used in run() tests; extends AbstractDeltaCatalog and
+  // wires up an AbstractDeltaCatalogClient when deltaRestApi.enabled=true on the options.
+  private val DELTA_CATALOG_CLASS = "org.apache.spark.sql.delta.catalog.DeltaCatalogV1"
 
   private def makeTxn(
       deltaLog: DeltaLog,
@@ -60,7 +66,8 @@ class UpdateMetricsHookSuite extends QueryTest
       isBlindAppend = true)
   }
 
-  private def ucStorageFormat(ucTableId: String = TEST_UC_TABLE_ID): CatalogStorageFormat = {
+  private def ucStorageFormat(
+      ucTableId: UUID = TEST_UC_TABLE_ID): CatalogStorageFormat = {
     CatalogStorageFormat(
       locationUri = None,
       inputFormat = None,
@@ -68,29 +75,46 @@ class UpdateMetricsHookSuite extends QueryTest
       serde = None,
       compressed = false,
       properties = Map(
-        UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> ucTableId,
+        UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> ucTableId.toString,
         "delta.feature.catalogManaged" -> "supported"
       )
     )
   }
 
+  // Unique-per-test catalog name so each test's Spark-cached catalog instance is rebuilt and
+  // points at this test's fresh mock-server port (Spark CatalogManager caches the catalog
+  // instance by name across tests within a session).
+  private val catalogCounter = new AtomicInteger(0)
+
+  /**
+   * Sets up `spark.sql.catalog.<name>.*` confs pointing at the mock HTTP server. The hook
+   * reads these confs at commit time, builds a fresh `UCDeltaCatalogClientImpl` inside the
+   * async dispatch, and forwards to `UCDeltaTokenBasedRestClient.reportMetrics`, which
+   * posts to the mock at `/delta/v1/catalogs/<cat>/schemas/<sch>/tables/<tbl>/metrics`.
+   */
   private def withMockMetricsServer(
       responseCode: Int = 200,
       responseDelay: Int = 0,
-      enableFlag: Boolean = true)(
+      enableFlag: Boolean = true,
+      catalogName: String = null)(
       testBody: (SimpleMockServer, DeltaLog, CatalogTable) => Unit): Unit = {
+    val effectiveCatalog = Option(catalogName)
+      .getOrElse(s"mock_cat_${catalogCounter.incrementAndGet()}")
     val mockServer = new SimpleMockServer(0)
     mockServer.setResponseCode(responseCode)
     if (responseDelay > 0) { mockServer.setResponseDelay(responseDelay) }
     mockServer.start()
     try {
       spark.conf.set(CONF_KEY, enableFlag.toString)
-      spark.conf.set("spark.sql.catalog.spark_catalog",
-        "io.unitycatalog.spark.UCSingleCatalog")
-      spark.conf.set("spark.sql.catalog.spark_catalog.uri",
+      spark.conf.set(s"spark.sql.catalog.$effectiveCatalog", DELTA_CATALOG_CLASS)
+      spark.conf.set(s"spark.sql.catalog.$effectiveCatalog.uri",
         s"http://localhost:${mockServer.getPort()}")
-      spark.conf.set("spark.sql.catalog.spark_catalog.token",
-        "test-token")
+      spark.conf.set(s"spark.sql.catalog.$effectiveCatalog.deltaRestApi.enabled", "true")
+      spark.conf.set(s"spark.sql.catalog.$effectiveCatalog.auth.type", "static")
+      spark.conf.set(s"spark.sql.catalog.$effectiveCatalog.auth.token", "test-token")
+      // Eagerly resolve the catalog so initialize() runs and wires the client; otherwise the
+      // hook's first lookup races against catalog construction.
+      spark.sessionState.catalogManager.catalog(effectiveCatalog)
       withTempDir { dir =>
         spark.range(1).write.format("delta")
           .save(dir.getCanonicalPath)
@@ -98,7 +122,7 @@ class UpdateMetricsHookSuite extends QueryTest
           spark, dir.getCanonicalPath)
         val ct = CatalogTable(
           identifier = TableIdentifier(
-            "t", Some("d"), Some("spark_catalog")),
+            "t", Some("d"), Some(effectiveCatalog)),
           tableType = CatalogTableType.MANAGED,
           storage = ucStorageFormat(), schema = new StructType())
         testBody(mockServer, deltaLog, ct)
@@ -150,7 +174,7 @@ class UpdateMetricsHookSuite extends QueryTest
         serde = None,
         compressed = false,
         properties = Map(
-          UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> "some-id"
+          UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> TEST_UC_TABLE_ID.toString
         )
       ),
       schema = new StructType()
@@ -168,336 +192,10 @@ class UpdateMetricsHookSuite extends QueryTest
       "table with empty storage properties should not be detected")
   }
 
-  test("buildRequest: file metrics from synthetic AddFile/RemoveFile actions") {
-    val add1 = AddFile("f1.parquet", Map.empty, 1024L,
-      System.currentTimeMillis(), dataChange = true)
-    val add2 = AddFile("f2.parquet", Map.empty, 2048L,
-      System.currentTimeMillis(), dataChange = true)
-    val add3 = AddFile("f3.parquet", Map.empty, 4096L,
-      System.currentTimeMillis(), dataChange = true)
-    val removed = RemoveFile("old.parquet",
-      Some(System.currentTimeMillis()),
-      dataChange = true, size = Some(512L))
+  // NOTE: tests for `UCDeltaCatalogClientImpl.buildCommitReport` live in
+  // `UCDeltaCatalogClientImplMetricsSuite` (same-package as the function).
 
-    // Simulate a snapshot histogram reflecting the table state
-    val snapshotHist = FileSizeHistogramUtils.emptyHistogram
-    snapshotHist.insert(1024L)
-    snapshotHist.insert(2048L)
-    snapshotHist.insert(4096L)
-
-    val actions: Seq[Action] = Seq(add1, add2, add3, removed)
-    val request = UpdateMetricsHook.buildRequest(
-      "tbl-123", actions, committedVersion = 7L,
-      snapshotHistogram = Some(snapshotHist))
-    val report = request.report.commitReport
-
-    assert(request.tableId == "tbl-123")
-    assert(report.numFilesAdded == 3L, "3 AddFiles")
-    assert(report.numFilesRemoved == 1L, "1 RemoveFile")
-    assert(report.numBytesAdded == 1024L + 2048L + 4096L,
-      "sum of add sizes")
-    assert(report.numBytesRemoved == 512L,
-      "sum of remove sizes")
-
-    val hist = report.fileSizeHistogram.get
-    assert(hist.commitVersion == 7L, "commit_version must be set")
-    assert(hist.sortedBinBoundaries.head == 0L, "bins must start at 0")
-    assert(hist.fileCounts.sum == 3L, "histogram covers all files")
-    assert(hist.totalBytes.sum == 1024L + 2048L + 4096L, "histogram totalBytes")
-  }
-
-  test("buildRequest: row metrics prefer operationMetrics over file stats") {
-    val addFileWithStats = AddFile("f.parquet", Map.empty, 1000L,
-      System.currentTimeMillis(), dataChange = true,
-      stats = """{"numRecords": 999}""")
-    val commitInfoWithMetrics = CommitInfo(
-      version = Some(0L),
-      inCommitTimestamp = None,
-      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
-      userId = None, userName = None,
-      operation = "WRITE",
-      operationParameters = Map.empty,
-      job = None, notebook = None, clusterId = None,
-      readVersion = None, isolationLevel = None,
-      isBlindAppend = Some(true),
-      operationMetrics = Some(Map("numOutputRows" -> "100")),
-      userMetadata = None, tags = None, engineInfo = None, txnId = None)
-
-    val req1 = UpdateMetricsHook.buildRequest(
-      "t1", Seq(commitInfoWithMetrics, addFileWithStats), 0L)
-    assert(req1.report.commitReport.numRowsInserted == Some(100L),
-      "operationMetrics wins over file stats")
-
-    val commitInfoNoMetrics = CommitInfo(
-      version = Some(1L),
-      inCommitTimestamp = None,
-      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
-      userId = None, userName = None,
-      operation = "WRITE",
-      operationParameters = Map.empty,
-      job = None, notebook = None, clusterId = None,
-      readVersion = None, isolationLevel = None,
-      isBlindAppend = Some(true),
-      operationMetrics = None,
-      userMetadata = None, tags = None, engineInfo = None, txnId = None)
-
-    val req2 = UpdateMetricsHook.buildRequest(
-      "t2", Seq(commitInfoNoMetrics, addFileWithStats), 1L)
-    assert(req2.report.commitReport.numRowsInserted == Some(999L),
-      "fallback to numLogicalRecords from file stats")
-
-    val req3 = UpdateMetricsHook.buildRequest(
-      "t3", Seq(addFileWithStats), 2L)
-    assert(req3.report.commitReport.numRowsInserted == Some(999L),
-      "fallback works with no CommitInfo in actions")
-  }
-
-  test("buildRequest: row metrics for MERGE operation") {
-    val ci = CommitInfo(
-      version = Some(0L), inCommitTimestamp = None,
-      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
-      userId = None, userName = None, operation = "MERGE",
-      operationParameters = Map.empty, job = None, notebook = None,
-      clusterId = None, readVersion = None, isolationLevel = None,
-      isBlindAppend = Some(false),
-      operationMetrics = Some(Map(
-        "numTargetRowsInserted" -> "10",
-        "numTargetRowsDeleted" -> "5",
-        "numTargetRowsUpdated" -> "3")),
-      userMetadata = None, tags = None, engineInfo = None, txnId = None)
-    val req = UpdateMetricsHook.buildRequest("t", Seq(ci), 0L)
-    assert(req.report.commitReport.numRowsInserted == Some(10L))
-    assert(req.report.commitReport.numRowsRemoved == Some(5L))
-    assert(req.report.commitReport.numRowsUpdated == Some(3L))
-  }
-
-  test("buildRequest: row metrics for DELETE operation") {
-    val ci = CommitInfo(
-      version = Some(0L), inCommitTimestamp = None,
-      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
-      userId = None, userName = None, operation = "DELETE",
-      operationParameters = Map.empty, job = None, notebook = None,
-      clusterId = None, readVersion = None, isolationLevel = None,
-      isBlindAppend = Some(false),
-      operationMetrics = Some(Map("numDeletedRows" -> "42")),
-      userMetadata = None, tags = None, engineInfo = None, txnId = None)
-    val req = UpdateMetricsHook.buildRequest("t", Seq(ci), 0L)
-    assert(req.report.commitReport.numRowsRemoved == Some(42L))
-  }
-
-  test("buildRequest: row metrics for UPDATE operation") {
-    val ci = CommitInfo(
-      version = Some(0L), inCommitTimestamp = None,
-      timestamp = new java.sql.Timestamp(System.currentTimeMillis()),
-      userId = None, userName = None, operation = "UPDATE",
-      operationParameters = Map.empty, job = None, notebook = None,
-      clusterId = None, readVersion = None, isolationLevel = None,
-      isBlindAppend = Some(false),
-      operationMetrics = Some(Map("numUpdatedRows" -> "17")),
-      userMetadata = None, tags = None, engineInfo = None, txnId = None)
-    val req = UpdateMetricsHook.buildRequest("t", Seq(ci), 0L)
-    assert(req.report.commitReport.numRowsUpdated == Some(17L))
-  }
-
-  test("JSON payload validation - matches server contract (snake_case, nested)") {
-    val request = ReportDeltaMetricsRequest(
-      tableId = "test-table-id-123",
-      report = CommitReportEnvelope(CommitReport(
-        numFilesAdded = 10L,
-        numFilesRemoved = 2L,
-        numBytesAdded = 10000L,
-        numBytesRemoved = 2000L,
-        numRowsInserted = Some(1000L),
-        numRowsRemoved = Some(200L),
-        numRowsUpdated = Some(50L),
-        fileSizeHistogram = Some(FileSizeHistogramPayload(
-          sortedBinBoundaries = Seq(0L, 1024L),
-          fileCounts = Seq(5L, 5L),
-          totalBytes = Seq(2000L, 8000L),
-          commitVersion = 42L
-        ))
-      ))
-    )
-
-    val json = JsonUtils.toJson(request)
-
-    assert(json.contains(""""table_id":"test-table-id-123""""),
-      "table_id must be snake_case")
-    assert(json.contains(""""commit_report""""),
-      "must have nested commit_report key")
-    assert(json.contains(""""num_files_added":10"""),
-      "num_files_added must be snake_case")
-    assert(json.contains(""""num_rows_inserted":1000"""),
-      "must use num_rows_inserted (not num_rows_added)")
-    assert(json.contains(""""commit_version":42"""),
-      "commit_version required for server staleness check")
-
-    assert(!json.contains(""""tableId""""), "no camelCase tableId")
-    assert(!json.contains(""""numFilesAdded""""), "no camelCase numFilesAdded")
-    assert(!json.contains(""""numRowsAdded""""), "no old numRowsAdded field")
-  }
-
-  test("JSON payload: optional fields are omitted when None") {
-    val request = ReportDeltaMetricsRequest(
-      tableId = "some-id",
-      report = CommitReportEnvelope(CommitReport(
-        numFilesAdded = 1L,
-        numFilesRemoved = 0L,
-        numBytesAdded = 100L,
-        numBytesRemoved = 0L,
-        fileSizeHistogram = Some(FileSizeHistogramPayload(
-          sortedBinBoundaries = Seq(0L), fileCounts = Seq(1L),
-          totalBytes = Seq(100L), commitVersion = 0L))
-      ))
-    )
-
-    val json = JsonUtils.toJson(request)
-    assert(!json.contains(""""num_rows_inserted""""),
-      "None fields should be absent from JSON")
-    assert(!json.contains(""""num_rows_updated""""),
-      "None fields should be absent from JSON")
-  }
-
-  test("path-based table writes continue without UC metrics hook") {
-    withTempDir { dir =>
-      val tablePath = dir.getCanonicalPath
-      spark.range(10).write.format("delta").save(tablePath)
-      spark.range(10, 20).write.format("delta").mode("append").save(tablePath)
-
-      val deltaLog = DeltaLog.forTable(spark, tablePath)
-      assert(deltaLog.snapshot.version == 1, "Expected 2 commits")
-    }
-  }
-
-  test("sendMetrics: throws RuntimeException on HTTP 5xx") {
-    val mockServer = new SimpleMockServer(0)
-    try {
-      mockServer.setResponseCode(500)
-      mockServer.start()
-
-      spark.conf.set(
-        s"spark.sql.catalog.$TEST_CATALOG_NAME",
-        "io.unitycatalog.spark.UCSingleCatalog")
-      spark.conf.set(
-        s"spark.sql.catalog.$TEST_CATALOG_NAME.uri",
-        s"http://localhost:${mockServer.getPort()}")
-      spark.conf.set(
-        s"spark.sql.catalog.$TEST_CATALOG_NAME.token", "test-token")
-
-      val request = ReportDeltaMetricsRequest(
-        tableId = "test-id",
-        report = CommitReportEnvelope(CommitReport(
-          numFilesAdded = 1L, numFilesRemoved = 0L,
-          numBytesAdded = 100L, numBytesRemoved = 0L,
-          fileSizeHistogram = Some(FileSizeHistogramPayload(
-            sortedBinBoundaries = Seq(0L), fileCounts = Seq(1L),
-            totalBytes = Seq(100L), commitVersion = 0L)))))
-      intercept[RuntimeException] {
-        UpdateMetricsHook.sendMetrics(
-          spark, request, catalogName = Some(TEST_CATALOG_NAME))
-      }
-      assert(mockServer.getRequestCount() == 1,
-        "Expected 1 HTTP request even on error")
-    } finally {
-      mockServer.stop()
-    }
-  }
-
-  test("sendMetrics: sends payload with Authorization header") {
-    val mockServer = new SimpleMockServer(0)
-    try {
-      mockServer.setResponseCode(200)
-      mockServer.start()
-
-      spark.conf.set(
-        s"spark.sql.catalog.$TEST_CATALOG_NAME",
-        "io.unitycatalog.spark.UCSingleCatalog")
-      spark.conf.set(
-        s"spark.sql.catalog.$TEST_CATALOG_NAME.uri",
-        s"http://localhost:${mockServer.getPort()}")
-      spark.conf.set(
-        s"spark.sql.catalog.$TEST_CATALOG_NAME.token",
-        "test-token-123")
-
-      val request = ReportDeltaMetricsRequest(
-        tableId = "abc-123",
-        report = CommitReportEnvelope(CommitReport(
-          numFilesAdded = 5L, numFilesRemoved = 0L,
-          numBytesAdded = 5000L, numBytesRemoved = 0L,
-          numRowsInserted = Some(100L),
-          fileSizeHistogram = Some(FileSizeHistogramPayload(
-            sortedBinBoundaries = Seq(0L), fileCounts = Seq(5L),
-            totalBytes = Seq(5000L), commitVersion = 0L))))
-      )
-      UpdateMetricsHook.sendMetrics(
-        spark, request, catalogName = Some(TEST_CATALOG_NAME))
-
-      assert(mockServer.getRequestCount() == 1, "Expected 1 HTTP request")
-
-      val authHeader = mockServer.getLastHeaders().get("Authorization")
-      assert(authHeader.isDefined, "Authorization header should be present")
-      assert(authHeader.get == "Bearer test-token-123",
-        "Auth token must match")
-
-      val body = mockServer.getLastRequestBody()
-      val actualPayload =
-        JsonUtils.fromJson[Map[String, Any]](body)
-      val expectedPayload =
-        JsonUtils.fromJson[Map[String, Any]](JsonUtils.toJson(request))
-      assert(actualPayload == expectedPayload,
-        "request JSON should match expected payload")
-    } finally {
-      mockServer.stop()
-    }
-  }
-
-  test("sendMetrics: auth.type=static with auth.token") {
-    val authStaticCatalog = "auth_static_catalog"
-    val mockServer = new SimpleMockServer(0)
-    try {
-      mockServer.setResponseCode(200)
-      mockServer.start()
-
-      spark.conf.set(
-        s"spark.sql.catalog.$authStaticCatalog",
-        "io.unitycatalog.spark.UCSingleCatalog")
-      spark.conf.set(
-        s"spark.sql.catalog.$authStaticCatalog.uri",
-        s"http://localhost:${mockServer.getPort()}")
-      spark.conf.set(
-        s"spark.sql.catalog.$authStaticCatalog.auth.type",
-        "static")
-      spark.conf.set(
-        s"spark.sql.catalog.$authStaticCatalog.auth.token",
-        "auth-static-token-456")
-
-      val request = ReportDeltaMetricsRequest(
-        tableId = "auth-test-id",
-        report = CommitReportEnvelope(CommitReport(
-          numFilesAdded = 1L, numFilesRemoved = 0L,
-          numBytesAdded = 100L, numBytesRemoved = 0L,
-          fileSizeHistogram = Some(FileSizeHistogramPayload(
-            sortedBinBoundaries = Seq(0L), fileCounts = Seq(1L),
-            totalBytes = Seq(100L), commitVersion = 0L))))
-      )
-      UpdateMetricsHook.sendMetrics(
-        spark, request, catalogName = Some(authStaticCatalog))
-
-      assert(mockServer.getRequestCount() == 1, "Expected 1 HTTP request")
-      val authHeader = mockServer.getLastHeaders().get("Authorization")
-      assert(authHeader.isDefined,
-        "Authorization header should be present")
-      assert(authHeader.get == "Bearer auth-static-token-456",
-        "Auth token from auth.token must match")
-    } finally {
-      mockServer.stop()
-    }
-  }
-
-  // Async dispatch tests: verify end-to-end send with payload
-  // validation, feature-flag gating, non-blocking
-  // behavior, error resilience, and skip logic for non-UC /
-  // missing-table-ID tables.
+  // -- HTTP / wire-shape tests via mock server (end-to-end through DeltaCatalogV1) --
 
   test("run(): skips when commitMetrics.enabled is false") {
     withMockMetricsServer(enableFlag = false) {
@@ -530,15 +228,29 @@ class UpdateMetricsHookSuite extends QueryTest
         "async send should complete within timeout")
       assert(mockServer.getRequestCount() == 1,
         "Expected exactly 1 HTTP POST")
+
+      // Pin the new endpoint path (kebab-case URL template from delta.yaml). Match on
+      // suffix so we stay robust to any ApiClient base-path that future SDK changes might
+      // inject ahead of the endpoint template.
+      val path = mockServer.getLastRequestPath()
+      val cat = ct.identifier.catalog.get
+      val expectedSuffix = s"/delta/v1/catalogs/$cat/schemas/d/tables/t/metrics"
+      assert(path.endsWith(expectedSuffix),
+        s"path should end with the new reportMetrics endpoint $expectedSuffix, got: $path")
+
+      // Pin the kebab-case JSON wire shape produced by the SDK serializer.
       val body = mockServer.getLastRequestBody()
-      val expected = UpdateMetricsHook.buildRequest(
-        TEST_UC_TABLE_ID, Seq(commitInfo, addFile), 0L,
-        deltaLog.snapshot.checksumOpt.flatMap(_.histogramOpt))
-      assert(
-        JsonUtils.fromJson[Map[String, Any]](body) ==
-          JsonUtils.fromJson[Map[String, Any]](
-            JsonUtils.toJson(expected)),
-        "payload should match expected JSON")
+      val payload = JsonUtils.fromJson[Map[String, Any]](body)
+      assert(payload.contains("table-id"), "table-id (kebab) required, got keys " + payload.keys)
+      assert(payload("table-id") == TEST_UC_TABLE_ID.toString,
+        "table-id must match the UC table id")
+      val report = payload("report").asInstanceOf[Map[String, Any]]
+      assert(report.contains("commit-report"),
+        "report.commit-report (kebab) required")
+      val cr = report("commit-report").asInstanceOf[Map[String, Any]]
+      assert(cr("num-files-added").asInstanceOf[Number].longValue == 1L)
+      assert(cr("num-bytes-added").asInstanceOf[Number].longValue == 4096L)
+      assert(cr("num-rows-inserted").asInstanceOf[Number].longValue == 50L)
     }
   }
 
@@ -549,8 +261,10 @@ class UpdateMetricsHookSuite extends QueryTest
         spark, makeTxn(deltaLog, ct))
       assert(UpdateMetricsHook.awaitCompletion(10000),
         "async send should complete even on error")
-      assert(mockServer.getRequestCount() == 1,
-        "request should have been sent despite 5xx")
+      // SDK ApiClient may retry on 5xx; accept any non-zero count rather than pinning a
+      // specific retry policy.
+      assert(mockServer.getRequestCount() >= 1,
+        "at least one request should have been sent despite 5xx")
       assert(UpdateMetricsHook.activeRequests.get() == 0,
         "activeRequests must return to 0 after error")
     }
@@ -588,79 +302,6 @@ class UpdateMetricsHookSuite extends QueryTest
     }
   }
 
-  test("buildRequest: uses snapshot histogram when provided") {
-    val snapshotHist = FileSizeHistogramUtils.emptyHistogram
-    snapshotHist.insert(1024L)
-    snapshotHist.insert(2048L)
-    snapshotHist.insert(4096L)
-
-    // AddFile with a DIFFERENT size than what's in the snapshot histogram
-    val add = AddFile("f.parquet", Map.empty, 8192L,
-      System.currentTimeMillis(), dataChange = true)
-
-    val req = UpdateMetricsHook.buildRequest(
-      "tbl", Seq(add), committedVersion = 5L,
-      snapshotHistogram = Some(snapshotHist))
-    val hist = req.report.commitReport.fileSizeHistogram.get
-
-    assert(hist.fileCounts.sum == 3L,
-      "should use snapshot histogram file counts, not per-commit AddFiles")
-    assert(hist.totalBytes.sum == 1024L + 2048L + 4096L,
-      "should use snapshot histogram total bytes")
-    assert(hist.commitVersion == 5L)
-  }
-
-  test("buildRequest: omits histogram when snapshot is None") {
-    val add = AddFile("f.parquet", Map.empty, 1024L,
-      System.currentTimeMillis(), dataChange = true)
-    val req = UpdateMetricsHook.buildRequest(
-      "tbl", Seq(add), committedVersion = 3L,
-      snapshotHistogram = None)
-
-    assert(req.report.commitReport.fileSizeHistogram.isEmpty,
-      "histogram should be None when snapshot is unavailable")
-
-    val json = JsonUtils.toJson(req)
-    assert(!json.contains("file_size_histogram"),
-      "file_size_histogram should be absent from JSON when None")
-  }
-
-  test("run(): does not trigger state reconstruction") {
-    // Disable test-only CRC verification paths that would force state reconstruction.
-    // Matches the config pattern used by ChecksumSuite.
-    withSQLConf(
-      DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false",
-      DeltaSQLConf.INCREMENTAL_COMMIT_ENABLED.key -> "true",
-      DeltaSQLConf.INCREMENTAL_COMMIT_FORCE_VERIFY_IN_TESTS.key -> "false",
-      DeltaSQLConf.DELTA_ALL_FILES_IN_CRC_FORCE_VERIFICATION_MODE_FOR_NON_UTC_ENABLED.key ->
-        "false"
-    ) {
-      withMockMetricsServer() { (mockServer, deltaLog, ct) =>
-        // High-level Spark writes (DataFrame.write, INSERT) trigger state reconstruction
-        // during analysis. Use low-level commit API to get a post-commit snapshot where
-        // stateReconstructionTriggered is still false, so we can verify that the hook's
-        // async execution does not trigger it.
-        // Neither this commit nor the initial spark.range(1).write in withMockMetricsServer
-        // triggers UpdateMetricsHook because the table is path-based (no UC catalog table).
-        deltaLog
-          .startTransaction()
-          .commit(Seq.empty, DeltaOperations.Write(SaveMode.Append))
-        val postCommitSnapshot = deltaLog.snapshot
-        assert(!postCommitSnapshot.stateReconstructionTriggered,
-          "pre-condition: snapshot should not have state reconstruction before hook runs")
-
-        val txn = makeTxn(deltaLog, ct)
-        UpdateMetricsHook(Some(ct)).run(spark, txn)
-        assert(UpdateMetricsHook.awaitCompletion(10000),
-          "async hook should complete within timeout")
-        assert(mockServer.getRequestCount() == 1,
-          "hook should have sent metrics")
-        assert(!postCommitSnapshot.stateReconstructionTriggered,
-          "hook must not trigger state reconstruction")
-      }
-    }
-  }
-
   test("run(): skips metrics when table ID not in storage properties") {
     withMockMetricsServer() { (mockServer, deltaLog, _) =>
       val noIdTable = CatalogTable(
@@ -681,8 +322,160 @@ class UpdateMetricsHookSuite extends QueryTest
         "no HTTP request when table ID is missing")
     }
   }
+
+  test("run(): silent no-op when catalog opted out via deltaRestApi.enabled=false") {
+    val mockServer = new SimpleMockServer(0)
+    mockServer.start()
+    val noClientCatalog = s"no_client_catalog_${catalogCounter.incrementAndGet()}"
+    try {
+      spark.conf.set(CONF_KEY, "true")
+      spark.conf.set(s"spark.sql.catalog.$noClientCatalog.deltaRestApi.enabled", "false")
+      spark.conf.set(s"spark.sql.catalog.$noClientCatalog.uri",
+        s"http://localhost:${mockServer.getPort()}")
+      withTempDir { dir =>
+        spark.range(1).write.format("delta").save(dir.getCanonicalPath)
+        val deltaLog = DeltaLog.forTable(spark, dir.getCanonicalPath)
+        val ct = CatalogTable(
+          identifier = TableIdentifier("t", Some("d"), Some(noClientCatalog)),
+          tableType = CatalogTableType.MANAGED,
+          storage = ucStorageFormat(),
+          schema = new StructType())
+        UpdateMetricsHook(Some(ct)).run(spark, makeTxn(deltaLog, ct))
+        UpdateMetricsHook.awaitCompletion(5000)
+        assert(mockServer.getRequestCount() == 0,
+          "no HTTP request when deltaRestApi.enabled is false")
+      }
+    } finally {
+      spark.conf.set(CONF_KEY, "false")
+      mockServer.stop()
+    }
+  }
+
+  test("run(): silent no-op when catalog name has no spark.conf entries") {
+    val unknownCatalog = s"unknown_catalog_${catalogCounter.incrementAndGet()}"
+    spark.conf.set(CONF_KEY, "true")
+    try {
+      withTempDir { dir =>
+        spark.range(1).write.format("delta").save(dir.getCanonicalPath)
+        val deltaLog = DeltaLog.forTable(spark, dir.getCanonicalPath)
+        val ct = CatalogTable(
+          identifier = TableIdentifier("t", Some("d"), Some(unknownCatalog)),
+          tableType = CatalogTableType.MANAGED,
+          storage = ucStorageFormat(),
+          schema = new StructType())
+        // No spark.sql.catalog.<unknownCatalog>.* entries -> catalogOptionsFor returns an
+        // empty map -> fromCatalogOptionsIfEnabled returns None -> hook no-ops without
+        // crashing or scheduling network work.
+        UpdateMetricsHook(Some(ct)).run(spark, makeTxn(deltaLog, ct))
+        assert(UpdateMetricsHook.awaitCompletion(5000),
+          "any scheduled async work should complete promptly")
+        assert(UpdateMetricsHook.activeRequests.get() == 0,
+          "activeRequests must settle to 0")
+      }
+    } finally {
+      spark.conf.set(CONF_KEY, "false")
+    }
+  }
+
+  test("catalogOptionsFor: pulls only the named catalog's keys with the prefix stripped") {
+    val cat = s"opts_test_${catalogCounter.incrementAndGet()}"
+    val otherCat = s"opts_test_other_${catalogCounter.incrementAndGet()}"
+    try {
+      spark.conf.set(s"spark.sql.catalog.$cat.uri", "http://example/uc")
+      spark.conf.set(s"spark.sql.catalog.$cat.deltaRestApi.enabled", "true")
+      spark.conf.set(s"spark.sql.catalog.$cat.auth.type", "static")
+      // Confs on a different catalog name must not leak into the result.
+      spark.conf.set(s"spark.sql.catalog.$otherCat.uri", "http://example/other")
+
+      val opts = UpdateMetricsHook.catalogOptionsFor(spark, cat)
+      assert(opts.get("uri") == "http://example/uc")
+      assert(opts.get("deltaRestApi.enabled") == "true")
+      assert(opts.get("auth.type") == "static")
+      assert(opts.size() == 3,
+        s"only the named catalog's keys should appear, got: $opts")
+    } finally {
+      spark.conf.unset(s"spark.sql.catalog.$cat.uri")
+      spark.conf.unset(s"spark.sql.catalog.$cat.deltaRestApi.enabled")
+      spark.conf.unset(s"spark.sql.catalog.$cat.auth.type")
+      spark.conf.unset(s"spark.sql.catalog.$otherCat.uri")
+    }
+  }
+
+  test("catalogOptionsFor: returns empty map when no entries exist for the name") {
+    val opts = UpdateMetricsHook.catalogOptionsFor(
+      spark, s"definitely_unconfigured_${catalogCounter.incrementAndGet()}")
+    assert(opts.isEmpty, s"expected empty map, got: $opts")
+  }
+
+  test("run(): each commit produces its own request (no cross-commit client caching)") {
+    withMockMetricsServer() { (mockServer, deltaLog, ct) =>
+      val hook = UpdateMetricsHook(Some(ct))
+      val commits = 3
+      for (_ <- 1 to commits) {
+        hook.run(spark, makeTxn(deltaLog, ct))
+      }
+      assert(UpdateMetricsHook.awaitCompletion(10000),
+        "all async sends should complete within timeout")
+      assert(mockServer.getRequestCount() == commits,
+        s"Expected exactly $commits HTTP POSTs (one per commit), " +
+        s"got ${mockServer.getRequestCount()}")
+    }
+  }
+
+  test("UnusedLoader: throws when invoked so a future caller failure is loud, not silent") {
+    val ex = intercept[UnsupportedOperationException] {
+      UpdateMetricsHook.UnusedLoader(Identifier.of(Array("x"), "y"))
+    }
+    assert(ex.getMessage.contains("loadTable"),
+      s"error message should mention loadTable, got: ${ex.getMessage}")
+  }
+
+  test("path-based table writes continue without UC metrics hook") {
+    withTempDir { dir =>
+      val tablePath = dir.getCanonicalPath
+      spark.range(10).write.format("delta").save(tablePath)
+      spark.range(10, 20).write.format("delta").mode("append").save(tablePath)
+
+      val deltaLog = DeltaLog.forTable(spark, tablePath)
+      assert(deltaLog.snapshot.version == 1, "Expected 2 commits")
+    }
+  }
+
+  test("run(): does not trigger state reconstruction") {
+    // Disable test-only CRC verification paths that would force state reconstruction.
+    withSQLConf(
+      DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false",
+      DeltaSQLConf.INCREMENTAL_COMMIT_ENABLED.key -> "true",
+      DeltaSQLConf.INCREMENTAL_COMMIT_FORCE_VERIFY_IN_TESTS.key -> "false",
+      DeltaSQLConf.DELTA_ALL_FILES_IN_CRC_FORCE_VERIFICATION_MODE_FOR_NON_UTC_ENABLED.key ->
+        "false"
+    ) {
+      withMockMetricsServer() { (mockServer, deltaLog, ct) =>
+        deltaLog
+          .startTransaction()
+          .commit(Seq.empty, DeltaOperations.Write(SaveMode.Append))
+        val postCommitSnapshot = deltaLog.snapshot
+        assert(!postCommitSnapshot.stateReconstructionTriggered,
+          "pre-condition: snapshot should not have state reconstruction before hook runs")
+
+        val txn = makeTxn(deltaLog, ct)
+        UpdateMetricsHook(Some(ct)).run(spark, txn)
+        assert(UpdateMetricsHook.awaitCompletion(10000),
+          "async hook should complete within timeout")
+        assert(mockServer.getRequestCount() == 1,
+          "hook should have sent metrics")
+        assert(!postCommitSnapshot.stateReconstructionTriggered,
+          "hook must not trigger state reconstruction")
+      }
+    }
+  }
 }
 
+/**
+ * Minimal HTTP/1.1 server that records request line / headers / body for the last request.
+ * Sufficient to pin the request path and JSON shape produced by the SDK's
+ * `TablesApi.reportMetrics`.
+ */
 class SimpleMockServer(port: Int) {
   private var serverSocket: ServerSocket = _
   private var serverThread: Thread = _
@@ -692,6 +485,7 @@ class SimpleMockServer(port: Int) {
   private val requestCount = new AtomicInteger(0)
   @volatile private var lastRequestBody = ""
   @volatile private var lastHeaders = Map[String, String]()
+  @volatile private var lastRequestPath = ""
   private var actualPort = port
 
   def setResponseCode(code: Int): Unit = { responseCode = code }
@@ -704,6 +498,8 @@ class SimpleMockServer(port: Int) {
   def getLastRequestBody(): String = lastRequestBody
 
   def getLastHeaders(): Map[String, String] = lastHeaders
+
+  def getLastRequestPath(): String = lastRequestPath
 
   def start(): Unit = {
     serverSocket = new ServerSocket(port)
@@ -733,7 +529,12 @@ class SimpleMockServer(port: Int) {
         new InputStreamReader(clientSocket.getInputStream))
       val out = new PrintWriter(clientSocket.getOutputStream, true)
 
-      in.readLine()
+      // Request line: "POST /path HTTP/1.1"
+      val requestLine = in.readLine()
+      val requestPath = if (requestLine != null) {
+        val parts = requestLine.split(" ", 3)
+        if (parts.length >= 2) parts(1) else ""
+      } else ""
 
       val headers = scala.collection.mutable.Map[String, String]()
       var contentLength = 0
@@ -759,6 +560,7 @@ class SimpleMockServer(port: Int) {
       requestCount.incrementAndGet()
       lastRequestBody = new String(body)
       lastHeaders = headers.toMap
+      lastRequestPath = requestPath
 
       out.write(
         s"HTTP/1.1 $responseCode ${statusMessage(responseCode)}\r\n")

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -20,6 +20,7 @@ import io.delta.storage.commit.TableIdentifier;
 import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.CommitReport;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.StagingTableInfo;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo;
 import java.io.IOException;
@@ -83,4 +84,18 @@ public interface UCDeltaClient extends UCClient {
       AbstractProtocol protocol,
       List<AbstractDomainMetadata> domainMetadata,
       long lastCommitTimestampMs) throws IOException;
+
+  /**
+   * Reports post-commit telemetry for a table (file/row counts, byte counts, file-size
+   * histogram) to the catalog.
+   *
+   * @param tableId         catalog-side table id (UC's `table_uuid`)
+   * @param tableIdentifier catalog + schema namespace and table name
+   * @param report          per-commit metrics payload
+   * @throws IOException on network or API errors
+   */
+  void reportMetrics(
+      String tableId,
+      TableIdentifier tableIdentifier,
+      CommitReport report) throws IOException;
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
@@ -22,6 +22,7 @@ import io.delta.storage.commit.uniform.UniformMetadata;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -220,5 +221,71 @@ public final class UCDeltaModels {
     public Map<String, String> getStorageProperties() {
       return storageProperties == null ? Collections.emptyMap() : storageProperties;
     }
+  }
+
+  /** Per-commit metrics payload reported to Unity Catalog. */
+  public static final class CommitReport {
+
+    private final long numFilesAdded;
+    private final long numFilesRemoved;
+    private final long numBytesAdded;
+    private final long numBytesRemoved;
+    private final Optional<Long> numRowsInserted;
+    private final Optional<Long> numRowsRemoved;
+    private final Optional<Long> numRowsUpdated;
+    private final Optional<FileSizeHistogram> fileSizeHistogram;
+
+    public CommitReport(
+        long numFilesAdded,
+        long numFilesRemoved,
+        long numBytesAdded,
+        long numBytesRemoved,
+        Optional<Long> numRowsInserted,
+        Optional<Long> numRowsRemoved,
+        Optional<Long> numRowsUpdated,
+        Optional<FileSizeHistogram> fileSizeHistogram) {
+      this.numFilesAdded = numFilesAdded;
+      this.numFilesRemoved = numFilesRemoved;
+      this.numBytesAdded = numBytesAdded;
+      this.numBytesRemoved = numBytesRemoved;
+      this.numRowsInserted = numRowsInserted;
+      this.numRowsRemoved = numRowsRemoved;
+      this.numRowsUpdated = numRowsUpdated;
+      this.fileSizeHistogram = fileSizeHistogram;
+    }
+
+    public long getNumFilesAdded() { return numFilesAdded; }
+    public long getNumFilesRemoved() { return numFilesRemoved; }
+    public long getNumBytesAdded() { return numBytesAdded; }
+    public long getNumBytesRemoved() { return numBytesRemoved; }
+    public Optional<Long> getNumRowsInserted() { return numRowsInserted; }
+    public Optional<Long> getNumRowsRemoved() { return numRowsRemoved; }
+    public Optional<Long> getNumRowsUpdated() { return numRowsUpdated; }
+    public Optional<FileSizeHistogram> getFileSizeHistogram() { return fileSizeHistogram; }
+  }
+
+  /** Post-commit file-size distribution snapshot, reported alongside the commit report. */
+  public static final class FileSizeHistogram {
+
+    private final List<Long> sortedBinBoundaries;
+    private final List<Long> fileCounts;
+    private final List<Long> totalBytes;
+    private final long commitVersion;
+
+    public FileSizeHistogram(
+        List<Long> sortedBinBoundaries,
+        List<Long> fileCounts,
+        List<Long> totalBytes,
+        long commitVersion) {
+      this.sortedBinBoundaries = sortedBinBoundaries;
+      this.fileCounts = fileCounts;
+      this.totalBytes = totalBytes;
+      this.commitVersion = commitVersion;
+    }
+
+    public List<Long> getSortedBinBoundaries() { return sortedBinBoundaries; }
+    public List<Long> getFileCounts() { return fileCounts; }
+    public List<Long> getTotalBytes() { return totalBytes; }
+    public long getCommitVersion() { return commitVersion; }
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -51,6 +51,10 @@ import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
 import io.unitycatalog.client.delta.model.DeltaProtocol;
 import io.unitycatalog.client.delta.model.DeltaRemoveDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.DeltaRemovePropertiesUpdate;
+import io.unitycatalog.client.delta.model.DeltaReportMetricsRequest;
+import io.unitycatalog.client.delta.model.DeltaReportMetricsRequestReport;
+import io.unitycatalog.client.delta.model.DeltaReportMetricsRequestReportCommitReport;
+import io.unitycatalog.client.delta.model.DeltaReportMetricsRequestReportCommitReportFileSizeHistogram;
 import io.unitycatalog.client.delta.model.DeltaRowTrackingDomainMetadata;
 import io.unitycatalog.client.delta.model.DeltaSetDomainMetadataUpdate;
 import io.unitycatalog.client.delta.model.DeltaSetLatestBackfilledVersionUpdate;
@@ -538,6 +542,51 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           String.format("Failed to create table %s (HTTP %s): %s",
               name.fullName, e.getCode(), e.getResponseBody()), e);
     }
+  }
+
+  @Override
+  public void reportMetrics(
+      String tableId,
+      TableIdentifier tableIdentifier,
+      UCDeltaModels.CommitReport report) throws IOException {
+    ensureOpen();
+    Objects.requireNonNull(tableId, "tableId must not be null");
+    Objects.requireNonNull(report, "report must not be null");
+    ResolvedTableName name = requireThreePartName(tableIdentifier);
+    try {
+      DeltaReportMetricsRequest sdkRequest = new DeltaReportMetricsRequest()
+          .tableId(UUID.fromString(tableId))
+          .report(new DeltaReportMetricsRequestReport().commitReport(toSDKCommitReport(report)));
+      deltaTablesApi.reportMetrics(name.catalog, name.schema, name.table, sdkRequest);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format("Failed to report metrics for table %s (HTTP %s): %s",
+              name.fullName, e.getCode(), e.getResponseBody()), e);
+    }
+  }
+
+  private static DeltaReportMetricsRequestReportCommitReport toSDKCommitReport(
+      UCDeltaModels.CommitReport report) {
+    DeltaReportMetricsRequestReportCommitReport sdkReport =
+        new DeltaReportMetricsRequestReportCommitReport()
+            .numFilesAdded(report.getNumFilesAdded())
+            .numFilesRemoved(report.getNumFilesRemoved())
+            .numBytesAdded(report.getNumBytesAdded())
+            .numBytesRemoved(report.getNumBytesRemoved());
+    report.getNumRowsInserted().ifPresent(sdkReport::numRowsInserted);
+    report.getNumRowsRemoved().ifPresent(sdkReport::numRowsRemoved);
+    report.getNumRowsUpdated().ifPresent(sdkReport::numRowsUpdated);
+    report.getFileSizeHistogram().ifPresent(h -> sdkReport.fileSizeHistogram(toSDKHistogram(h)));
+    return sdkReport;
+  }
+
+  private static DeltaReportMetricsRequestReportCommitReportFileSizeHistogram toSDKHistogram(
+      UCDeltaModels.FileSizeHistogram h) {
+    return new DeltaReportMetricsRequestReportCommitReportFileSizeHistogram()
+        .sortedBinBoundaries(h.getSortedBinBoundaries())
+        .fileCounts(h.getFileCounts())
+        .totalBytes(h.getTotalBytes())
+        .commitVersion(h.getCommitVersion());
   }
 
   // ===========================


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6949/files) to review incremental changes.
- [**stack/metrics**](https://github.com/delta-io/delta/pull/6949) [[Files changed](https://github.com/delta-io/delta/pull/6949/files)]
  - [stack/replace_path_table_fail](https://github.com/delta-io/delta/pull/6924) [[Files changed](https://github.com/delta-io/delta/pull/6924/files/9b149f0aaebc2db97fb05ba365ef3cb185559fd3..f9e0cb458bbaa3fe080e924377014c3caac1208e)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Migrate UpdateMetricsHook to the Delta API /metrics endpoint

What:
- `UpdateMetricsHook` now posts to `/delta/v1/catalogs/{cat}/schemas/{sch}/tables/{tbl}/metrics` (defined in `delta.yaml`), replacing the hardcoded `/api/2.1/unity-catalog/delta/preview/metrics`.
- New `AbstractDeltaCatalogClient.reportMetrics` carries the payload; `UCDeltaCatalogClientImpl.buildCommitReport` builds it from the committed actions and the CRC histogram (no state reconstruction).
- `UCDeltaClient.reportMetrics` + thin `UCDeltaModels.CommitReport` / `FileSizeHistogram` POJOs handle the wire shape; `UCDeltaTokenBasedRestClient` routes through the SDK `TablesApi.reportMetrics`.

Gates:
- `DELTA_UC_COMMIT_METRICS_ENABLED` SQL conf.
- Silent no-op unless the catalog has `deltaRestApi.enabled=true`.
- Errors logged and swallowed; commit success unaffected.


## How was this patch tested?

Tests:
- `UpdateMetricsHookSuite` (15) pins the URL, kebab-case JSON, async semantics, silent-skip, and per-commit-no-caching contract.
- `UCDeltaCatalogClientImplMetricsSuite` (7) covers the report builder.

## Does this PR introduce _any_ user-facing changes?
No
