### PR TITLE
[spark] Use exact checkpoint when loading versioned snapshots

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1538,7 +1538,7 @@ trait SnapshotManagement { self: DeltaLog =>
       case _ =>
         val lastCheckpointInfoForListing = lastCheckpointHint
             .filter(_.version <= version)
-            .orElse(findLastCompleteCheckpointBefore(version))
+            .orElse(findLastCompleteCheckpointBefore(version + 1))
             .map(manuallyLoadCheckpoint)
         lastCheckpointInfoForListing -> None
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -664,6 +664,27 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       assert(updatedLogSegment === snapshot.logSegment)
     }
   }
+
+  test("getSnapshotAt uses checkpoint at requested version as listing hint") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      spark.range(10).write.format("delta").save(path)
+      spark.range(10).write.format("delta").mode("append").save(path)
+      spark.range(10).write.format("delta").mode("append").save(path)
+      var (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, path)
+      deltaLog.checkpoint(snapshot)
+      spark.range(10).write.format("delta").mode("append").save(path)
+
+      DeltaLog.clearCache()
+      deltaLog = DeltaLog.forTable(spark, path)
+
+      val usageRecords = DeltaTestUtils.collectUsageLogs("delta.findLastCompleteCheckpointBefore") {
+        assert(deltaLog.getSnapshotAt(2).version == 2)
+      }
+      val checkpointSearchEvent = JsonUtils.fromJson[Map[String, String]](usageRecords.head.blob)
+      assert(checkpointSearchEvent("resultantCheckpointVersion") == "2")
+    }
+  }
 }
 
 class SnapshotManagementWithCatalogManagedBatch1Suite extends SnapshotManagementSuite {


### PR DESCRIPTION
## Summary

This PR updates Delta snapshot loading so `DeltaLog.getSnapshotAt(version)` can use a complete checkpoint at the requested version as its checkpoint listing hint.

When looking for the last complete checkpoint before a given version, the search boundary was off by one: passing `version` instead of `version + 1` caused the checkpoint at exactly the requested version to be excluded from consideration. This fix ensures that an available checkpoint at the exact requested version is used as the listing hint, reducing unnecessary log replay work.

## How was this patch tested?

Added a unit test to cover the new code path