### PR TITLE
[Spark] Make deltaRestApi.enabled default to true

### DIFF
--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -45,6 +45,10 @@ jobs:
         scala: [2.13.17]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
+      # The setup-unitycatalog action's script reads SPARK_VERSION (cut to major-minor) to
+      # decide which `unitycatalog-spark_<major.minor>_2.13` artifact to publish. Matches
+      # spark_test.yaml's convention.
+      SPARK_VERSION: ${{ matrix.spark_version }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Get Spark version details

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -162,6 +162,18 @@ def resolveSparkVersion(deltaVersion: String): String = {
   else lookupSparkVersion.apply(getMajorMinor(deltaVersion))
 }
 
+// The OSS Unity Catalog project publishes one Spark connector artifact per Spark major.minor
+// (e.g. unitycatalog-spark_4.1_2.13) and, unlike delta-spark, has no unsuffixed backward-compat
+// variant. So its suffix must track the resolved Spark version -- matching what
+// setup_unitycatalog_main.sh publishes -- rather than `getSparkPackageSuffix`, which is empty for
+// the default Spark version (since `delta-spark_2.13` resolves unsuffixed).
+val getUnityCatalogSparkArtifact = settingKey[String](
+  "Unity Catalog Spark connector artifact base name, suffixed with the resolved Spark major.minor.")
+getUnityCatalogSparkArtifact := {
+  val (sparkMajor, sparkMinor) = getMajorMinor(resolveSparkVersion(getDeltaVersion.value))
+  s"unitycatalog-spark_${sparkMajor}.${sparkMinor}"
+}
+
 def getLibraryDependencies(
     deltaVersion: String,
     deltaArtifactName: String,
@@ -216,7 +228,7 @@ lazy val root = (project in file("."))
       scalaBinaryVersion.value,
       getSupportIceberg.value),
     libraryDependencies ++= Seq(
-      "io.unitycatalog" %% s"unitycatalog-spark${getSparkPackageSuffix.value}" % unityCatalogVersion excludeAll(
+      "io.unitycatalog" %% getUnityCatalogSparkArtifact.value % unityCatalogVersion excludeAll(
         ExclusionRule(organization = "com.fasterxml.jackson.core"),
         ExclusionRule(organization = "com.fasterxml.jackson.module"),
         ExclusionRule(organization = "com.fasterxml.jackson.datatype"),

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -20,7 +20,10 @@ organizationName := "example"
 
 val scala213 = "2.13.17"
 val icebergVersion = "1.4.1"
-val unityCatalogVersion = "0.4.1"
+val unityCatalogVersion: String = sys.props.getOrElse("unityCatalogVersion", {
+  import scala.sys.process._
+  Process(Seq("bash", "../../project/scripts/setup_unitycatalog_main.sh", "--print-version")).!!.trim
+})
 val jacksonVersion = "2.15.4"
 
 val defaultDeltaVersion = {
@@ -213,7 +216,7 @@ lazy val root = (project in file("."))
       scalaBinaryVersion.value,
       getSupportIceberg.value),
     libraryDependencies ++= Seq(
-      "io.unitycatalog" %% "unitycatalog-spark" % unityCatalogVersion excludeAll(
+      "io.unitycatalog" %% s"unitycatalog-spark${getSparkPackageSuffix.value}" % unityCatalogVersion excludeAll(
         ExclusionRule(organization = "com.fasterxml.jackson.core"),
         ExclusionRule(organization = "com.fasterxml.jackson.module"),
         ExclusionRule(organization = "com.fasterxml.jackson.datatype"),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -86,6 +86,12 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
 
   val spark = SparkSession.active
 
+  // Captured from `initialize` so `deltaCatalogClient` can be built lazily (see its docs). Using
+  // the `initialize` name directly rather than `name()`, which delegates to the (possibly unset)
+  // delegate catalog.
+  private var catalogName: String = _
+  private var catalogOptions: CaseInsensitiveStringMap = _
+
   /**
    * When defined, table operations are routed through this client instead of through the
    * [[org.apache.spark.sql.connector.catalog.DelegatingCatalogExtension]] delegate that
@@ -93,13 +99,25 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
    * interactions (e.g. talking to a REST endpoint, catalog-specific property handling,
    * storage-credential vending) rather than going through the Spark
    * [[org.apache.spark.sql.connector.catalog.TableCatalog]] API.
+   *
+   * Evaluated lazily rather than in `initialize` because the decision depends on
+   * [[isUnityCatalog]], which reads the [[DelegatingCatalogExtension]] delegate. Spark's
+   * `CatalogManager` calls `initialize` *before* `setDelegateCatalog` for the session catalog,
+   * so the delegate isn't available yet during `initialize`; it is by the time any table
+   * operation (the only reader of this client) runs.
    */
-  private[catalog] var deltaCatalogClient: Option[AbstractDeltaCatalogClient] = None
+  private[catalog] lazy val deltaCatalogClient: Option[AbstractDeltaCatalogClient] =
+    if (isUnityCatalog) {
+      AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
+        catalogName, catalogOptions, super.loadTable)
+    } else {
+      None
+    }
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     super.initialize(name, options)
-    deltaCatalogClient =
-      AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(name, options, super.loadTable)
+    catalogName = name
+    catalogOptions = options
   }
 
   private lazy val isUnityCatalog: Boolean = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -136,17 +136,19 @@ private[catalog] object AbstractDeltaCatalogClient extends Logging {
     "org.apache.spark.sql.delta.catalog.UCDeltaCatalogClientImpl"
 
   /**
-   * Returns a [[AbstractDeltaCatalogClient]] wrapped in [[Some]] when the catalog opted in via
-   * `deltaRestApi.enabled`, else [[None]]. The concrete impl is loaded reflectively so
-   * [[AbstractDeltaCatalog]] doesn't compile-depend on it. If opt-in is explicit but reflective
-   * loading fails, throws [[IllegalStateException]] rather than silently degrading.
+   * Returns a [[AbstractDeltaCatalogClient]] wrapped in [[Some]] unless the catalog has
+   * opted out via `deltaRestApi.enabled=false`, in which case returns [[None]]. The flag
+   * defaults to `true` when absent, so any UC catalog goes through the UC Delta API path
+   * unless the operator explicitly disables it. The concrete impl is loaded reflectively so
+   * [[AbstractDeltaCatalog]] doesn't compile-depend on it; if loading fails, throws
+   * [[IllegalStateException]] rather than silently degrading.
    */
   def fromCatalogOptionsIfEnabled(
       catalogName: String,
       options: CaseInsensitiveStringMap,
       fallbackLoadTableFunc: Identifier => Table): Option[AbstractDeltaCatalogClient] = {
     val key = UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY
-    if (!options.getBoolean(key, false)) {
+    if (!options.getBoolean(key, true)) {
       return None
     }
     val factory = try {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -637,7 +637,6 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
     // case-insensitive so defaults don't create duplicate keys.
     val merged = new java.util.HashMap[String, String](options.asCaseSensitiveMap())
     Seq(
-      UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY -> "true",
       UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY -> "true",
       UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false"
     ).foreach { case (k, v) => if (!options.containsKey(k)) merged.put(k, v) }
@@ -665,8 +664,8 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
     val hasLegacyToken = options.get(LegacyTokenKey) != null
     if (!hasAuthPrefix && !hasLegacyToken) {
       throw new IllegalArgumentException(
-        s"auth configuration is required when 'deltaRestApi.enabled' is true " +
-          s"(catalog '$catalogName'). Set either '${AuthPrefix}type' (with the corresponding " +
+        s"auth configuration is required (catalog '$catalogName'). " +
+          s"Set either '${AuthPrefix}type' (with the corresponding " +
           s"$AuthPrefix* keys) or the legacy '$LegacyTokenKey' option.")
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -280,8 +280,8 @@ trait UCClientFactory {
  * Recognised ucConfig keys:
  *  - `uri` (required) -- the UC server endpoint.
  *  - `auth.*` / `token` (legacy) -- authentication parameters for [[TokenProvider]].
- *  - `deltaRestApi.enabled` -- if `"true"`, uses [[UCDeltaTokenBasedRestClient]];
- *    otherwise uses [[UCTokenBasedRestClient]].
+ *  - `deltaRestApi.enabled` -- defaults to `"true"`; uses [[UCDeltaTokenBasedRestClient]]
+ *    unless explicitly set to `"false"`, in which case [[UCTokenBasedRestClient]] is used.
  *  - `appVersions.*` -- caller-supplied version entries merged with defaults; e.g.
  *    `appVersions.Kernel -> "0.7.0"` adds a `"Kernel"` entry to the version map.
  */
@@ -309,7 +309,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
     val tokenProvider = TokenProvider.create(authConfig.asJava)
 
     val className =
-      if (Option(ucConfig.get(DELTA_REST_API_ENABLED_KEY)).exists(_.equalsIgnoreCase("true"))) {
+      if (ucConfig.getOrDefault(DELTA_REST_API_ENABLED_KEY, "true").toBoolean) {
         DELTA_UC_CLIENT_CLASS
       } else {
         DEFAULT_UC_CLIENT_CLASS

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -50,55 +50,55 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     new CaseInsensitiveStringMap(m)
   }
 
-  test("deltaRestApi.enabled=false leaves deltaCatalogClient empty") {
-    val catalog = new AbstractDeltaCatalog
-    catalog.initialize("test_cat", options("deltaRestApi.enabled" -> "false"))
-    assert(catalog.deltaCatalogClient.isEmpty,
-      "UC Delta API client should not be constructed when the catalog opts out")
-  }
+  // Catalog-wiring behavior (opt-out / opt-in / validation) is exercised through the
+  // factory below; `AbstractDeltaCatalog.deltaCatalogClient` gates lazily on `isUnityCatalog`,
+  // which reads the delegate field, and unit tests never wire a delegate.
 
   test("deltaRestApi.enabled defaults to true: requires uri when flag absent") {
-    val catalog = new AbstractDeltaCatalog
     val e = intercept[IllegalArgumentException] {
-      catalog.initialize("test_cat", options())
+      AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled("test_cat", options(), noFallback)
     }
     assert(e.getMessage.contains("'uri' is required"))
   }
 
   test("deltaRestApi.enabled=true requires uri") {
-    val catalog = new AbstractDeltaCatalog
     val e = intercept[IllegalArgumentException] {
-      catalog.initialize("test_cat", options("deltaRestApi.enabled" -> "true"))
+      AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
+        "test_cat", options("deltaRestApi.enabled" -> "true"), noFallback)
     }
     assert(e.getMessage.contains("'uri' is required"))
   }
 
   test("deltaRestApi.enabled=true requires an auth configuration") {
-    val catalog = new AbstractDeltaCatalog
     val e = intercept[IllegalArgumentException] {
-      catalog.initialize("test_cat",
-        options("deltaRestApi.enabled" -> "true", "uri" -> "http://uc"))
+      AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
+        "test_cat",
+        options("deltaRestApi.enabled" -> "true", "uri" -> "http://uc"),
+        noFallback)
     }
     assert(e.getMessage.contains("auth configuration is required"))
   }
 
   test("auth.* options are passed through to TokenProvider (new format)") {
-    val catalog = new AbstractDeltaCatalog
-    catalog.initialize("test_cat",
+    // Exercised at the factory level since `AbstractDeltaCatalog.deltaCatalogClient` gates the
+    // candidate on `isUnityCatalog`, which requires a delegate that unit tests don't wire in.
+    val result = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
+      "test_cat",
       options(
         "deltaRestApi.enabled" -> "true",
         "uri" -> "http://uc",
         "auth.type" -> "static",
-        "auth.token" -> "tok"))
-    assert(catalog.deltaCatalogClient.isDefined)
+        "auth.token" -> "tok"),
+      noFallback)
+    assert(result.isDefined)
   }
 
   test("deltaRestApi.enabled=true with uri+token constructs the UC Delta API client") {
-    val catalog = new AbstractDeltaCatalog
-    catalog.initialize("test_cat",
-      options("deltaRestApi.enabled" -> "true", "uri" -> "http://uc", "token" -> "tok"))
-    val client = catalog.deltaCatalogClient.getOrElse(
-      fail("UC Delta API client should be constructed when the catalog opts in"))
+    val client = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
+      "test_cat",
+      options("deltaRestApi.enabled" -> "true", "uri" -> "http://uc", "token" -> "tok"),
+      noFallback).getOrElse(
+        fail("UC Delta API client should be constructed when the catalog opts in"))
     assert(client.isInstanceOf[UCDeltaCatalogClientImpl],
       s"UC Delta API client should be UCDeltaCatalogClientImpl, was ${client.getClass}")
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -52,9 +52,17 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
 
   test("deltaRestApi.enabled=false leaves deltaCatalogClient empty") {
     val catalog = new AbstractDeltaCatalog
-    catalog.initialize("test_cat", options())
+    catalog.initialize("test_cat", options("deltaRestApi.enabled" -> "false"))
     assert(catalog.deltaCatalogClient.isEmpty,
       "UC Delta API client should not be constructed when the catalog opts out")
+  }
+
+  test("deltaRestApi.enabled defaults to true: requires uri when flag absent") {
+    val catalog = new AbstractDeltaCatalog
+    val e = intercept[IllegalArgumentException] {
+      catalog.initialize("test_cat", options())
+    }
+    assert(e.getMessage.contains("'uri' is required"))
   }
 
   test("deltaRestApi.enabled=true requires uri") {
@@ -97,7 +105,7 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
 
   test("AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled returns None when flag is off") {
     val result = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
-      "test_cat", options(), noFallback)
+      "test_cat", options("deltaRestApi.enabled" -> "false"), noFallback)
     assert(result.isEmpty)
   }
 
@@ -107,6 +115,16 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       options("deltaRestApi.enabled" -> "true", "uri" -> "http://uc", "token" -> "tok"),
       noFallback)
     assert(result.isDefined)
+  }
+
+  test("AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled returns Some when flag absent " +
+      "(default is on)") {
+    val result = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
+      "test_cat",
+      options("uri" -> "http://uc", "token" -> "tok"),
+      noFallback)
+    assert(result.isDefined,
+      "absent deltaRestApi.enabled should default to true and construct the client")
   }
 
   private val noFallback: Identifier => Table =

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -168,18 +168,17 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     conf =
         conf.set("spark.sql.catalog." + catalogName, "io.unitycatalog.spark.UCSingleCatalog")
             .set("spark.sql.catalog." + catalogName + ".uri", uc.serverUri())
-            .set("spark.sql.catalog." + catalogName + ".token", uc.serverToken())
-            // Both Delta's AbstractDeltaCatalog and UC's UCSingleCatalog read this same option
-            // key to decide whether to take the UC Delta API path. UC pinned at the current SHA
-            // defaults this to true, so a test that wants the legacy staging path must opt out
-            // explicitly -- otherwise UC skips `createStagingTable` and the later
-            // `tablesApi.createTable` call 404s for lack of a staging entry.
-            .set(
+            .set("spark.sql.catalog." + catalogName + ".token", uc.serverToken());
+    if (!useDeltaRestApiForTests()) {
+      // Default is true. Tests can opt out.
+      conf =
+          conf.set(
                 "spark.sql.catalog."
                     + catalogName
                     + "."
                     + UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY(),
-                Boolean.toString(useDeltaRestApiForTests()));
+              "false");
+    }
     return conf;
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -173,10 +173,10 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
       // Default is true. Tests can opt out.
       conf =
           conf.set(
-                "spark.sql.catalog."
-                    + catalogName
-                    + "."
-                    + UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY(),
+              "spark.sql.catalog."
+                  + catalogName
+                  + "."
+                  + UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY(),
               "false");
     }
     return conf;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6951/files) to review incremental changes.
- [**stack/delta_api_default**](https://github.com/delta-io/delta/pull/6951) [[Files changed](https://github.com/delta-io/delta/pull/6951/files)]
  - [stack/bump_uc_sha](https://github.com/delta-io/delta/pull/6866) [[Files changed](https://github.com/delta-io/delta/pull/6866/files/b10907d26b19259e04e49351c9ba2e829b750c34..d6ef81b19a91a3ee0fccb700bb23fd00d10b16b1)]

---------
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Make deltaRestApi.enabled default to true

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
No
