### PR TITLE
Add test for generated column referencing a keyword-named column

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -603,6 +603,19 @@ trait GeneratedColumnSuiteBase
     }
   }
 
+  test("validateGeneratedColumns: column named as SQL keyword") {
+    // `current_date` in a generation expression is parsed as an UnresolvedAttribute (column
+    // reference), not the CurrentDate() function. So a column literally named `current_date`
+    // can be referenced in a generated column.
+    withTableName("keyword_col_gen") { table =>
+      createTable(
+        table, None, "`current_date` INT, bar INT",
+        Map("bar" -> "`current_date` + 1"), Nil)
+      sql(s"INSERT INTO $table (`current_date`) VALUES (10)")
+      checkAnswer(spark.table(table), Row(10, 11) :: Nil)
+    }
+  }
+
   protected def testTypeMismatch(
       generatedColumnType: DataType,
       generatedColumnNullable: Boolean,


### PR DESCRIPTION
## Description

Add a test for generated column validation when a column is named after a SQL keyword (e.g. `current_date`).

The test covers default mode (`enforceReservedKeywords` off): Creates a Delta table with a column named `current_date` and a generated column referencing it, inserts data, and verifies the generated column computes correctly via `checkAnswer`.

## How was this patch tested?

New unit test in `GeneratedColumnSuite`.