### PR TITLE
[Spark][DSv2] All streaming options now supported: add passthrough tests for batch-only read options; remove V2 unsupported-option block

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -104,6 +104,9 @@ object DeltaV2SourceSuite {
       " restart fails",
     "streaming processes 100 sequential single-value commits and contains all values 0 to 99",
 
+    // ========== Passthrough options ==========
+    "batch-only options are ignored in streaming",
+
     // ========== startingVersion option tests ==========
     "startingVersion",
     "startingVersion latest",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1692,6 +1692,45 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
+  test("batch-only options are ignored in streaming") {
+    // endingVersion and endingTimestamp are batch CDC options that DeltaSource does not enforce.
+    // Each is accepted without error and the stream continues past the specified bound.
+    // Note: versionAsOf and timestampAsOf are NOT passthrough - they throw
+    // DELTA_UNSUPPORTED_TIME_TRAVEL_VIEWS at analysis time and are intentionally excluded here.
+    val fmt = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    val ts2000 = fmt.format(new java.util.Date(2000))
+
+    val passthroughOptions = Seq(
+      "endingVersion" -> "1",
+      "endingTimestamp" -> ts2000
+    )
+
+    passthroughOptions.foreach { case (optKey, optVal) =>
+      withTempDir { inputDir =>
+        val deltaLog = DeltaLog.forTable(spark, inputDir.getAbsolutePath)
+        // version 0
+        Seq(1, 2, 3).toDF("id").write.format("delta").save(inputDir.toString)
+        modifyCommitTimestamp(deltaLog, 0, 1000)
+        // version 1
+        Seq(4, 5).toDF("id").write.mode("append").format("delta").save(inputDir.toString)
+        modifyCommitTimestamp(deltaLog, 1, 2000)
+
+        val df = loadStreamWithOptions(inputDir.toString, Map(
+          "startingVersion" -> "0",
+          optKey -> optVal
+        ))
+
+        testStream(df)(
+          ProcessAllAvailable(),
+          CheckAnswer(1, 2, 3, 4, 5),
+          AddToReservoir(inputDir, Seq(6).toDF("id")), // version 2 - past any ending bound
+          ProcessAllAvailable(),
+          CheckAnswer(1, 2, 3, 4, 5, 6)
+        )
+      }
+    }
+  }
+
   test("startingVersion: user defined start works with mergeSchema") {
     withTempDir { inputDir =>
       withTempView("startingVersionTest") {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -62,36 +62,6 @@ import scala.Option;
 /** Spark DSV2 Scan implementation backed by Delta Kernel. */
 public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
 
-  /** Supported streaming options for the V2 connector. */
-  private static final List<String> SUPPORTED_STREAMING_OPTIONS =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              DeltaOptions.STARTING_VERSION_OPTION(),
-              DeltaOptions.STARTING_TIMESTAMP_OPTION(),
-              DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION(),
-              DeltaOptions.MAX_BYTES_PER_TRIGGER_OPTION(),
-              DeltaOptions.IGNORE_FILE_DELETION_OPTION(),
-              DeltaOptions.IGNORE_CHANGES_OPTION(),
-              DeltaOptions.IGNORE_DELETES_OPTION(),
-              DeltaOptions.SKIP_CHANGE_COMMITS_OPTION(),
-              DeltaOptions.EXCLUDE_REGEX_OPTION(),
-              DeltaOptions.FAIL_ON_DATA_LOSS_OPTION(),
-              DeltaOptions.CDC_READ_OPTION(),
-              DeltaOptions.CDC_READ_OPTION_LEGACY(),
-              DeltaOptions.SCHEMA_TRACKING_LOCATION(),
-              DeltaOptions.SCHEMA_TRACKING_LOCATION_ALIAS(),
-              DeltaOptions.STREAMING_SOURCE_TRACKING_ID(),
-              DeltaOptions.ALLOW_SOURCE_COLUMN_DROP(),
-              DeltaOptions.ALLOW_SOURCE_COLUMN_RENAME(),
-              DeltaOptions.ALLOW_SOURCE_COLUMN_TYPE_CHANGE()));
-
-  private static final Set<String> UNSUPPORTED_STREAMING_OPTIONS =
-      Collections.unmodifiableSet(
-          new HashSet<>(
-              Arrays.asList(
-                  DeltaOptions.CDC_END_VERSION().toLowerCase(),
-                  DeltaOptions.CDC_END_TIMESTAMP().toLowerCase())));
-
   private final DeltaSnapshotManager snapshotManager;
   private final Snapshot initialSnapshot;
   private final StructType readDataSchema;
@@ -246,8 +216,6 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
-    validateStreamingOptions(deltaOptions);
-
     // Loads a fresh snapshot as the baseline for schema change detection and table identity
     // checks. SparkScan's initialSnapshot is from analysis time and may be stale by stream
     // start/restart.
@@ -653,39 +621,6 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
    */
   private boolean arePlanStatsEnabled() {
     return sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
-  }
-
-  /**
-   * Validates that unsupported streaming options are not used. Uses a block list approach - only
-   * blocks known DeltaOptions that are unsupported, allowing user-defined custom options to pass
-   * through.
-   *
-   * <p>Note: DeltaOptions internally uses CaseInsensitiveMap, which preserves the original key
-   * casing but performs case-insensitive lookups.
-   *
-   * @param deltaOptions the DeltaOptions to validate
-   * @throws UnsupportedOperationException if unsupported options are found
-   */
-  static void validateStreamingOptions(DeltaOptions deltaOptions) {
-    List<String> unsupportedOptions = new ArrayList<>();
-    scala.collection.Iterator<String> keysIterator = deltaOptions.options().keysIterator();
-
-    while (keysIterator.hasNext()) {
-      String key = keysIterator.next();
-      // DeltaOptions uses CaseInsensitiveMap with keys already lowercased.
-      if (UNSUPPORTED_STREAMING_OPTIONS.contains(key)) {
-        unsupportedOptions.add(key);
-      }
-    }
-
-    if (!unsupportedOptions.isEmpty()) {
-      throw new UnsupportedOperationException(
-          String.format(
-              "The following streaming options are not supported: [%s]. "
-                  + "Supported options are: [%s].",
-              String.join(", ", unsupportedOptions),
-              String.join(", ", SUPPORTED_STREAMING_OPTIONS)));
-    }
   }
 
   @Override

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -29,7 +29,6 @@ import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
-import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -700,65 +699,6 @@ public class SparkScanTest extends DeltaV2TestBase {
       spark.sql("DROP TABLE IF EXISTS " + tblName);
     }
   }
-
-  // ================================================================================================
-  // Tests for streaming options validation
-  // ================================================================================================
-
-  @Test
-  public void testValidateStreamingOptions_SupportedOptions() {
-    // Test with supported options (case insensitive) and custom user options
-    Map<String, String> javaOptions = new HashMap<>();
-    javaOptions.put("startingVersion", "0");
-    javaOptions.put("MaxFilesPerTrigger", "100");
-    javaOptions.put("MAXBYTESPERTRIGGER", "1g");
-    javaOptions.put("readChangeFeed", "true");
-    javaOptions.put("myCustomOption", "value");
-    scala.collection.immutable.Map<String, String> supportedOptions =
-        ScalaUtils.toScalaMap(javaOptions);
-    DeltaOptions deltaOptions = new DeltaOptions(supportedOptions, spark.sessionState().conf());
-
-    // Verify DeltaOptions can recognize the options (case insensitive)
-    assertEquals(true, deltaOptions.maxFilesPerTrigger().isDefined());
-    assertEquals(100, deltaOptions.maxFilesPerTrigger().get());
-    assertEquals(true, deltaOptions.maxBytesPerTrigger().isDefined());
-    assertEquals(true, deltaOptions.readChangeFeed());
-
-    // Should not throw - supported and custom options are allowed
-    SparkScan.validateStreamingOptions(deltaOptions);
-  }
-
-  @Test
-  public void testValidateStreamingOptions_UnsupportedOptions() {
-    // Test with blocked DeltaOptions, supported options, and custom user options
-    Map<String, String> javaOptions = new HashMap<>();
-    javaOptions.put("startingVersion", "0");
-    javaOptions.put("endingTimestamp", "2024-01-01");
-    javaOptions.put("myCustomOption", "value");
-    scala.collection.immutable.Map<String, String> mixedOptions =
-        ScalaUtils.toScalaMap(javaOptions);
-    DeltaOptions deltaOptions = new DeltaOptions(mixedOptions, spark.sessionState().conf());
-
-    UnsupportedOperationException exception =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> SparkScan.validateStreamingOptions(deltaOptions));
-
-    // Verify exact error message - only the blocked option should appear
-    // Note: DeltaOptions uses CaseInsensitiveMap which lowercases keys during iteration
-    assertEquals(
-        "The following streaming options are not supported: [endingtimestamp]. "
-            + "Supported options are: [startingVersion, startingTimestamp, maxFilesPerTrigger, "
-            + "maxBytesPerTrigger, ignoreFileDeletion, ignoreChanges, ignoreDeletes, "
-            + "skipChangeCommits, excludeRegex, failOnDataLoss, readChangeFeed, readChangeData, "
-            + "schemaTrackingLocation, schemaLocation, streamingSourceTrackingId, "
-            + "allowSourceColumnDrop, allowSourceColumnRename, allowSourceColumnTypeChange].",
-        exception.getMessage());
-  }
-
-  // ================================================================================================
-  // Tests for CDC readSchema
-  // ================================================================================================
 
   @Test
   public void testReadSchema_cdcRead_returnsTableSchemaWithCDCColumns() {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark

## Description

`endingVersion` and `endingTimestamp` are batch CDC options that `DeltaSource` silently ignores in streaming. The V2 connector was actively throwing `UnsupportedOperationException` for these options, diverging from V1's passthrough behavior.

This PR adds a test documenting the passthrough behavior and removes the V2 unsupported-option block.

Note: `versionAsOf` and `timestampAsOf` are correctly rejected in streaming at analysis time (`DELTA_UNSUPPORTED_TIME_TRAVEL_VIEWS`) — they are intentionally excluded from this change.

## How was this patch tested?

New test `"batch-only options are ignored in streaming"` in `DeltaSourceSuite`, run under both V1 and V2 via `DeltaV2SourceSuite`.

## Does this PR introduce _any_ user-facing changes?

Yes. In the V2 connector, passing `endingVersion` or `endingTimestamp` to a CDC streaming query previously threw `UnsupportedOperationException`. After this PR it silently passes through, matching V1.