### PR TITLE
Block UC Delta ALTER TABLE RENAME COLUMN

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -1167,6 +1167,10 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
               newColumn = spec.newColumn.copy(nullable = nullability.nullable()))
 
           case rename: RenameColumn =>
+            if (deltaCatalogClient.nonEmpty) {
+              throw new UnsupportedOperationException(
+                "RENAME COLUMN is not supported for UC Delta tables")
+            }
             val field = rename.fieldNames()
             val spec = getColumn(field)
             columnUpdates(field) = spec.copy(

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
@@ -111,7 +111,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
   }
 
   @Test
-  public void testAlterTableRenameColumnUpdatesUcDeltaMetadata() throws Exception {
+  public void testAlterTableRenameColumnRemainsUnsupportedForUcDeltaCatalog() throws Exception {
     withNewTable(
         "alter_rename_column_test",
         "id INT, old_name STRING",
@@ -120,12 +120,17 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         COLUMN_MAPPING_PROPERTIES,
         tableName -> {
           sql("INSERT INTO %s VALUES (1, 'before_rename')", tableName);
-          sql("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName);
+          long versionBefore = currentVersion(tableName);
 
+          assertThrowsWithCauseContaining(
+              "RENAME COLUMN is not supported for UC Delta tables",
+              () -> sql("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName));
+
+          assertEquals(versionBefore, currentVersion(tableName));
           LoadTableResponse response = loadTableViaDeltaRest(tableName);
-          assertEquals(List.of("id", "new_name"), fieldNames(response.getMetadata().getColumns()));
+          assertEquals(List.of("id", "old_name"), fieldNames(response.getMetadata().getColumns()));
           check(
-              sql("SELECT id, new_name FROM %s ORDER BY id", tableName),
+              sql("SELECT id, old_name FROM %s ORDER BY id", tableName),
               List.of(row("1", "before_rename")));
         });
   }
@@ -149,7 +154,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
   }
 
   @Test
-  public void testAlterTableNestedColumnUpdatesUcDeltaMetadata() throws Exception {
+  public void testAlterTableNestedAddColumnUpdatesUcDeltaMetadata() throws Exception {
     withNewTable(
         "alter_nested_column_test",
         "id INT, info STRUCT<first: STRING, last: STRING>",
@@ -157,12 +162,11 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         TableType.MANAGED,
         COLUMN_MAPPING_PROPERTIES,
         tableName -> {
-          sql("ALTER TABLE %s RENAME COLUMN info.first TO given", tableName);
-          sql("ALTER TABLE %s ADD COLUMNS (info.age INT AFTER given)", tableName);
+          sql("ALTER TABLE %s ADD COLUMNS (info.age INT AFTER first)", tableName);
 
           LoadTableResponse response = loadTableViaDeltaRest(tableName);
           StructType info = structField(response.getMetadata().getColumns(), "info");
-          assertEquals(List.of("given", "age", "last"), fieldNames(info));
+          assertEquals(List.of("first", "age", "last"), fieldNames(info));
         });
   }
 


### PR DESCRIPTION
## Description

This PR blocks ALTER TABLE RENAME COLUMN for UC Delta tables that use the Delta REST catalog path. The guard is placed at the parsed RenameColumn ALTER TABLE handling point, before Delta creates the metadata update, so the table is left unchanged.

It also updates the UC Delta ALTER TABLE integration coverage to assert that RENAME COLUMN fails, the table version does not advance, and the original column remains visible through both UC Delta REST metadata and SQL reads. The nested column coverage is kept focused on nested ADD COLUMN now that rename is unsupported.

## How was this patch tested?

- ./build/sbt "javafmtAll" "scalafmtAll"
- ./build/sbt "sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableAlterTest"