### PR TITLE
Block UC Delta ALTER TABLE RENAME COLUMN

### DIFF
--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
@@ -111,7 +111,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
   }
 
   @Test
-  public void testAlterTableRenameColumnUpdatesUcDeltaMetadata() throws Exception {
+  public void testAlterTableRenameColumnRemainsUnsupportedForUcDeltaCatalog() throws Exception {
     withNewTable(
         "alter_rename_column_test",
         "id INT, old_name STRING",
@@ -120,12 +120,17 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         COLUMN_MAPPING_PROPERTIES,
         tableName -> {
           sql("INSERT INTO %s VALUES (1, 'before_rename')", tableName);
-          sql("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName);
+          long versionBefore = currentVersion(tableName);
 
+          assertThrowsWithCauseContaining(
+              "RENAME COLUMN is not supported for UC Delta tables",
+              () -> sql("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName));
+
+          assertEquals(versionBefore, currentVersion(tableName));
           LoadTableResponse response = loadTableViaDeltaRest(tableName);
-          assertEquals(List.of("id", "new_name"), fieldNames(response.getMetadata().getColumns()));
+          assertEquals(List.of("id", "old_name"), fieldNames(response.getMetadata().getColumns()));
           check(
-              sql("SELECT id, new_name FROM %s ORDER BY id", tableName),
+              sql("SELECT id, old_name FROM %s ORDER BY id", tableName),
               List.of(row("1", "before_rename")));
         });
   }
@@ -149,7 +154,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
   }
 
   @Test
-  public void testAlterTableNestedColumnUpdatesUcDeltaMetadata() throws Exception {
+  public void testAlterTableNestedAddColumnUpdatesUcDeltaMetadata() throws Exception {
     withNewTable(
         "alter_nested_column_test",
         "id INT, info STRUCT<first: STRING, last: STRING>",
@@ -157,12 +162,11 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         TableType.MANAGED,
         COLUMN_MAPPING_PROPERTIES,
         tableName -> {
-          sql("ALTER TABLE %s RENAME COLUMN info.first TO given", tableName);
-          sql("ALTER TABLE %s ADD COLUMNS (info.age INT AFTER given)", tableName);
+          sql("ALTER TABLE %s ADD COLUMNS (info.age INT AFTER first)", tableName);
 
           LoadTableResponse response = loadTableViaDeltaRest(tableName);
           StructType info = structField(response.getMetadata().getColumns(), "info");
-          assertEquals(List.of("given", "age", "last"), fieldNames(info));
+          assertEquals(List.of("first", "age", "last"), fieldNames(info));
         });
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -39,6 +39,7 @@ import io.unitycatalog.client.api.MetastoresApi;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.api.TablesApi;
 import io.unitycatalog.client.delta.model.AddCommitUpdate;
+import io.unitycatalog.client.delta.model.ArrayType;
 import io.unitycatalog.client.delta.model.AssertTableUUID;
 import io.unitycatalog.client.delta.model.ClusteringDomainMetadata;
 import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
@@ -46,7 +47,9 @@ import io.unitycatalog.client.delta.model.CreateTableRequest;
 import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
 import io.unitycatalog.client.delta.model.DeltaCommit;
 import io.unitycatalog.client.delta.model.DeltaProtocol;
+import io.unitycatalog.client.delta.model.DeltaType;
 import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.model.MapType;
 import io.unitycatalog.client.delta.model.RemovePropertiesUpdate;
 import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
 import io.unitycatalog.client.delta.model.SetLatestBackfilledVersionUpdate;
@@ -58,6 +61,8 @@ import io.unitycatalog.client.delta.model.SetTableCommentUpdate;
 import io.unitycatalog.client.delta.model.StagingTableResponse;
 import io.unitycatalog.client.delta.model.StagingTableResponseRequiredProtocol;
 import io.unitycatalog.client.delta.model.StagingTableResponseSuggestedProtocol;
+import io.unitycatalog.client.delta.model.StructField;
+import io.unitycatalog.client.delta.model.StructType;
 import io.unitycatalog.client.delta.model.TableMetadata;
 import io.delta.storage.commit.uniform.IcebergMetadata;
 import io.unitycatalog.client.delta.model.UniformMetadata;
@@ -99,6 +104,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private static final int HTTP_BAD_REQUEST = 400;
   private static final int HTTP_CONFLICT = 409;
   private static final int HTTP_NOT_FOUND = 404;
+  private static final String COLUMN_MAPPING_ID_KEY = "delta.columnMapping.id";
+  private static final String COLUMN_MAPPING_PHYSICAL_NAME_KEY =
+      "delta.columnMapping.physicalName";
 
   private TablesApi deltaTablesApi;
   private MetastoresApi metastoresApi;
@@ -797,6 +805,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       AbstractMetadata oldMetadata,
       AbstractMetadata newMetadata) {
     if (!Objects.equals(oldMetadata.getSchemaString(), newMetadata.getSchemaString())) {
+      rejectRenameColumnMetadataUpdate(oldMetadata.getSchemaString(), newMetadata.getSchemaString());
       request.addUpdatesItem(new SetSchemaUpdate()
           .action("set-columns")
           .columns(UCDeltaSchemaConverter.parseSchemaString(newMetadata.getSchemaString())));
@@ -842,6 +851,81 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
             .removals(toRemove));
       }
     }
+  }
+
+  /**
+   * Rejects schema updates that represent ALTER TABLE RENAME COLUMN.
+   *
+   * <p>The UC Delta API receives old/new Delta metadata, not the original SQL operation, so this
+   * detects a rename by finding the same Delta column-mapping identity at a different logical
+   * field path.
+   */
+  private static void rejectRenameColumnMetadataUpdate(
+      String oldSchemaString, String newSchemaString) {
+    Map<String, String> oldNamesByColumnId = columnNameByMappingId(oldSchemaString);
+    Map<String, String> newNamesByColumnId = columnNameByMappingId(newSchemaString);
+    for (Map.Entry<String, String> newColumn : newNamesByColumnId.entrySet()) {
+      String oldName = oldNamesByColumnId.get(newColumn.getKey());
+      if (oldName != null && !oldName.equals(newColumn.getValue())) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "RENAME COLUMN is not supported for UC Delta tables: %s -> %s",
+                oldName, newColumn.getValue()));
+      }
+    }
+  }
+
+  /** Returns mapped columns keyed by stable Delta column-mapping identity. */
+  private static Map<String, String> columnNameByMappingId(String schemaString) {
+    Map<String, String> namesById = new LinkedHashMap<>();
+    collectColumnNameByMappingId(
+        UCDeltaSchemaConverter.parseSchemaString(schemaString), "", namesById);
+    return namesById;
+  }
+
+  /** Walks nested fields because RENAME COLUMN can target nested columns. */
+  private static void collectColumnNameByMappingId(
+      DeltaType dataType, String parentPath, Map<String, String> namesById) {
+    if (dataType instanceof StructType) {
+      List<StructField> fields = ((StructType) dataType).getFields();
+      if (fields == null) {
+        return;
+      }
+      for (StructField field : fields) {
+        String fieldPath = parentPath.isEmpty()
+            ? field.getName()
+            : parentPath + "." + field.getName();
+        String identity = columnMappingIdentity(field);
+        if (identity != null) {
+          namesById.put(identity, fieldPath);
+        }
+        collectColumnNameByMappingId(field.getType(), fieldPath, namesById);
+      }
+      return;
+    }
+
+    if (dataType instanceof ArrayType) {
+      collectColumnNameByMappingId(
+          ((ArrayType) dataType).getElementType(), parentPath + ".element", namesById);
+    } else if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      collectColumnNameByMappingId(mapType.getKeyType(), parentPath + ".key", namesById);
+      collectColumnNameByMappingId(mapType.getValueType(), parentPath + ".value", namesById);
+    }
+  }
+
+  /** Returns the stable Delta column-mapping identity encoded in field metadata, if present. */
+  private static String columnMappingIdentity(StructField field) {
+    Map<String, Object> metadata = field.getMetadata();
+    if (metadata == null) {
+      return null;
+    }
+    Object id = metadata.get(COLUMN_MAPPING_ID_KEY);
+    if (id != null) {
+      return "id:" + id;
+    }
+    Object physicalName = metadata.get(COLUMN_MAPPING_PHYSICAL_NAME_KEY);
+    return physicalName == null ? null : "physicalName:" + physicalName;
   }
 
   // ===========================

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -360,6 +360,41 @@ class UCDeltaTokenBasedRestClientSuite
     assert(actions.contains("remove-properties"))
   }
 
+  test("commit rejects rename column metadata updates") {
+    var postedUpdate = false
+    deltaHandler = (exchange, body) => {
+      if (exchange.getRequestMethod == "POST") {
+        postedUpdate = true
+      }
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    val oldSchema =
+      """{"type":"struct","fields":[""" +
+      """{"name":"id","type":"integer","nullable":true,"metadata":{}},""" +
+      """{"name":"old_name","type":"string","nullable":true,""" +
+      """"metadata":{"delta.columnMapping.id":2,""" +
+      """"delta.columnMapping.physicalName":"col-old"}}]}"""
+    val renamedSchema =
+      """{"type":"struct","fields":[""" +
+      """{"name":"id","type":"integer","nullable":true,"metadata":{}},""" +
+      """{"name":"new_name","type":"string","nullable":true,""" +
+      """"metadata":{"delta.columnMapping.id":2,""" +
+      """"delta.columnMapping.physicalName":"col-old"}}]}"""
+
+    val e = intercept[UnsupportedOperationException] {
+      withClient { c =>
+        c.commit(testTableId.toString, new URI("s3://b/t"), testIdentifier,
+          Optional.of(createCommit(1L)), Optional.empty(),
+          Optional.of(metadata(schema = oldSchema)), Optional.of(metadata(schema = renamedSchema)),
+          Optional.empty(), Optional.empty(), Optional.empty())
+      }
+    }
+
+    assert(e.getMessage.contains("RENAME COLUMN is not supported for UC Delta tables"))
+    assert(!postedUpdate)
+  }
+
   test("commit sends SET_PROTOCOL when protocol changes") {
     var captured: String = null
     deltaHandler = (exchange, body) => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR blocks ALTER TABLE RENAME COLUMN for UC Delta tables in UCDeltaTokenBasedRestClient.

At this layer the original SQL RenameColumn operation has already become a generic schema metadata update. The client detects rename-shaped updates by comparing old/new schema JSON: if the same Delta column-mapping identity appears at a different logical path, it rejects before sending updateTable.

This keeps ADD, DROP, and MODIFY on the existing metadata update path while blocking RENAME COLUMN.

## How was this patch tested?
- ./build/sbt "javafmtAll" "scalafmtAll"
- ./build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClientSuite"
- ./build/sbt "sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableAlterTest"

## Does this PR introduce _any_ user-facing changes?
Yes. ALTER TABLE RENAME COLUMN is now blocked for UC Delta tables that use the UC Delta REST client path.
