### PR TITLE
[Spark] Fix CDF streaming reads on UC-managed tables in AUTO mode

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -124,8 +124,11 @@ class DeltaDataSource
     val deltaV2Mode = new DeltaV2Mode(sqlContext.sparkSession.sessionState.conf)
     if (schema.isDefined &&
         deltaV2Mode.shouldBypassSchemaValidationForStreaming(parameters.asJava)) {
-      require(!CDCReader.isCDCRead(options), "CDC read is not supported for schema bypass.")
-      return (shortName(), schema.get)
+      // For a CDF read, surface the change-data columns so this relation is a valid CDF
+      // source on its own, independent of the later ApplyV2Streaming rewrite to V2.
+      val schemaToUse =
+        if (CDCReader.isCDCRead(options)) CDCReader.cdcReadSchema(schema.get) else schema.get
+      return (shortName(), schemaToUse)
     }
     val path = parameters.getOrElse("path", {
       throw DeltaErrors.pathNotSpecifiedException

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -240,10 +240,11 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
   }
 
   /**
-   * CDF streaming reads work for EXTERNAL tables but fail for MANAGED tables.
+   * CDF streaming reads work for both EXTERNAL and MANAGED tables.
    *
-   * <p>For EXTERNAL: verifies that inserts and a delete produce the expected typed change events.
-   * For MANAGED: verifies the stream fails with an error containing "not supported" and "CDC".
+   * <p>Verifies that inserts and a delete produce the expected typed change events. Under the
+   * default AUTO mode, MANAGED (catalogManaged) reads are served by the DSv2 connector while
+   * EXTERNAL reads stay on the V1 connector.
    */
   @TestAllTableTypes
   public void testStreamingCDFRead(TableType tableType) throws Exception {
@@ -258,36 +259,28 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
           long insertVersion = currentVersion(tableName);
           sql("DELETE FROM %s WHERE id = 1", tableName);
 
-          if (tableType == TableType.EXTERNAL) {
-            List<Row> changes = new ArrayList<>();
-            spark()
-                .readStream()
-                .format("delta")
-                .option("readChangeFeed", "true")
-                .option("startingVersion", insertVersion)
-                .table(tableName)
-                .writeStream()
-                .trigger(Trigger.AvailableNow())
-                .option("checkpointLocation", checkpoint())
-                .foreachBatch(
-                    (VoidFunction2<Dataset<Row>, Long>)
-                        (df, id) -> changes.addAll(df.select("id", "_change_type").collectAsList()))
-                .start()
-                .awaitTermination();
-            assertThat(changes)
-                .extracting(r -> r.getString(1))
-                .containsExactlyInAnyOrder("insert", "insert", "insert", "delete");
-            assertThat(changes)
-                .filteredOn(r -> "delete".equals(r.getString(1)))
-                .extracting(r -> r.getInt(0))
-                .containsExactly(1);
-          } else {
-            assertInvalidStreamOption(
-                tableName,
-                r -> r.option("readChangeFeed", "true").option("startingVersion", insertVersion),
-                "not supported",
-                "CDC");
-          }
+          List<Row> changes = new ArrayList<>();
+          spark()
+              .readStream()
+              .format("delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", insertVersion)
+              .table(tableName)
+              .writeStream()
+              .trigger(Trigger.AvailableNow())
+              .option("checkpointLocation", checkpoint())
+              .foreachBatch(
+                  (VoidFunction2<Dataset<Row>, Long>)
+                      (df, id) -> changes.addAll(df.select("id", "_change_type").collectAsList()))
+              .start()
+              .awaitTermination();
+          assertThat(changes)
+              .extracting(r -> r.getString(1))
+              .containsExactlyInAnyOrder("insert", "insert", "insert", "delete");
+          assertThat(changes)
+              .filteredOn(r -> "delete".equals(r.getString(1)))
+              .extracting(r -> r.getInt(0))
+              .containsExactly(1);
         });
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

CDF streaming reads (`readChangeFeed`) on Unity-Catalog–managed tables failed under the
default `AUTO` mode with `requirement failed: CDC read is not supported for schema bypass`,
even though the same read worked in `STRICT` mode and on external tables.

In `AUTO`, a managed streaming read passes through the V1 `DeltaDataSource` before
`ApplyV2Streaming` rewrites it to the V2 connector. Constructing that intermediate V1
relation calls `DeltaDataSource.sourceSchema`, which for managed tables takes a schema-bypass
shortcut: it trusts the catalog-provided schema instead of loading it from the DeltaLog, since
the client may not have direct storage access to the managed location. That shortcut hard-rejected
CDF reads — a guard left over from when there was no V2 CDF path to hand off to — and the
rejection threw during planning, before the V2 rewrite could happen.

This change replaces the rejection with the CDF schema (`CDCReader.cdcReadSchema(schema.get)`),
the same decoration the normal (non-bypass) path already applies. Planning then proceeds,
`ApplyV2Streaming` swaps in the V2 connector, and the read runs end to end as it does in `STRICT`.

Why it's safe:
- `cdcReadSchema` is a pure schema transform (appends `_change_type`, `_commit_version`,
  `_commit_timestamp`); it does not touch the DeltaLog, so the bypass's no-storage-access
  guarantee is preserved.
- The branch is only reached for UC-managed tables (`AUTO`/`STRICT`), which `ApplyV2Streaming`
  rewrites to V2, so the returned schema is normally discarded. We still return the correct CDF
  schema so the V1 relation is valid on its own, independent of the rewrite firing.
- Non-CDF reads are unchanged.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
- `UCDeltaTableDataFrameStreamingTest#testStreamingCDFRead` — updated so MANAGED now asserts the
  expected change events instead of the previous "not supported" failure.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes (within the unreleased master branch). Previously, a `readChangeFeed` streaming read on a UC-managed table in the default `AUTO` mode failed with `CDC read is not supported for schema bypass`. It now succeeds and is served by the DSv2 connector, matching the behavior of external tables and of `STRICT` mode.