### PR TITLE
Revert "[SPARK] Validate consistent dataChange across commit FileActions (#6937)"

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -239,31 +239,22 @@ private[delta] class ConflictChecker(
   def checkConflictsAndValidateActions(): CurrentTransactionInfo = {
     val updatedInfo = checkConflicts()
 
-    // In case the actions of the current transaction changed, re-run the invariant
-    // checks against the rebased action set.
-    checkInvariants(updatedInfo)
+    // In case the actions of the current transaction changed, we need to validate
+    // again that there are no duplicate actions.
+    checkNoDuplicateActionsIfApplicable(updatedInfo)
     updatedInfo
   }
 
   /**
-   * Returns true when conflict resolution produced a different action set than the one the
-   * transaction started with.
+   * Validates that `updatedInfo` does not contain duplicate actions, but only when conflict
+   * resolution actually changed the actions of the current transaction.
    */
-  protected def hasActionsChanged(updatedInfo: CurrentTransactionInfo): Boolean = {
-    updatedInfo.actions ne initialCurrentTransactionInfo.actions
-  }
-
-  /** Run invariants on new set of actions in case they changed. */
-  private def checkInvariants(updatedInfo: CurrentTransactionInfo): Unit = {
-    if (!hasActionsChanged(updatedInfo)) return
-    ConflictChecker.checkNoDuplicateActions(spark, updatedInfo.actions.iterator)
-      .foreach(_ => ())
-    ConflictChecker.trackConsistentDataChange(
-      spark,
-      updatedInfo.actions.iterator,
-      deltaLog,
-      updatedInfo.op,
-      callerContext = "checkConflictsAndValidateActions").foreach(_ => ())
+  protected def checkNoDuplicateActionsIfApplicable(
+      updatedInfo: CurrentTransactionInfo): Unit = {
+    if ((updatedInfo.actions ne initialCurrentTransactionInfo.actions) &&
+        spark.conf.get(DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED)) {
+      ConflictChecker.checkNoDuplicateActions(updatedInfo.actions.iterator).foreach(_ => ())
+    }
   }
 
   /**
@@ -1522,75 +1513,13 @@ private[delta] class ConflictChecker(
   }
 }
 
-private[delta] object ConflictChecker extends DeltaLogging {
-  /**
-   * Returns an iterator that validates all [[AddFile]] and [[RemoveFile]] actions in
-   * `actions` share a consistent `dataChange` value. [[AddCDCFile]] is excluded because
-   * change-data-feed files are always emitted with `dataChange = false`.
-   *
-   * Behavior is controlled by
-   * [[DeltaSQLConf.DELTA_COMMIT_VALIDATE_CONSISTENT_DATA_CHANGE_MODE]]:
-   *  - `off`:   skip the check entirely.
-   *  - `log`:   record a Delta event on violation but do not throw.
-   *  - `fatal`: record a Delta event and then throw an [[IllegalStateException]].
-   *
-   * Single pass, no materialization; the throw fires on the first detected inconsistency.
-   */
-  def trackConsistentDataChange(
-      spark: SparkSession,
-      actions: Iterator[Action],
-      deltaLog: DeltaLog,
-      op: DeltaOperations.Operation,
-      callerContext: String): Iterator[Action] = {
-    val mode =
-      DeltaSQLConf.ConsistentDataChangeValidationMode.fromConf(spark.sessionState.conf)
-    if (mode == DeltaSQLConf.ConsistentDataChangeValidationMode.OFF) return actions
-    var firstDataChangeAction: Option[FileAction] = None
-    var firstNoDataChangeAction: Option[FileAction] = None
-    var violationReported = false
-    actions.map { action =>
-      action match {
-        case f: FileAction if !f.isInstanceOf[AddCDCFile] =>
-          if (f.dataChange) {
-            if (firstDataChangeAction.isEmpty) firstDataChangeAction = Some(f)
-          } else {
-            if (firstNoDataChangeAction.isEmpty) firstNoDataChangeAction = Some(f)
-          }
-          if (!violationReported &&
-              firstDataChangeAction.isDefined && firstNoDataChangeAction.isDefined) {
-            violationReported = true
-            val message = "All FileActions in a single commit must share a consistent " +
-              "dataChange value, but this commit mixes dataChange = true and " +
-              "dataChange = false actions."
-            recordDeltaEvent(
-              deltaLog,
-              "delta.commit.inconsistentDataChange",
-              data = Map(
-                "callerContext" -> callerContext,
-                "operation" -> op.name,
-                "operationParameters" -> op.jsonEncodedValues,
-                "firstDataChangeAction" -> firstDataChangeAction,
-                "firstNoDataChangeAction" -> firstNoDataChangeAction))
-            if (mode == DeltaSQLConf.ConsistentDataChangeValidationMode.FATAL) {
-              throw new IllegalStateException(message)
-            }
-          }
-        case _ =>
-      }
-      action
-    }
-  }
-
+private[delta] object ConflictChecker {
   /**
    * Returns an iterator that validates no duplicate file actions exist as it
    * streams. Checks: duplicate adds, duplicate removes, and same path+DV both
-   * added and removed. Single pass, no materialization. Returns `actions`
-   * unchanged when [[DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED]] is off.
+   * added and removed. Single pass, no materialization.
    */
-  def checkNoDuplicateActions(
-      spark: SparkSession,
-      actions: Iterator[Action]): Iterator[Action] = {
-    if (!spark.conf.get(DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED)) return actions
+  def checkNoDuplicateActions(actions: Iterator[Action]): Iterator[Action] = {
     val addPaths = mutable.Map.empty[String, Option[String]]
     val removePaths = mutable.Map.empty[String, Option[String]]
     def pathAndDVString(path: String, dvIdOpt: Option[String]): String = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1514,7 +1514,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   /** Ensure that actions do not contain duplicates for the same path. */
   protected def checkNoDuplicateActions(actions: Seq[Action]): Unit = {
-    ConflictChecker.checkNoDuplicateActions(spark, actions.iterator).foreach(_ => ())
+    ConflictChecker.checkNoDuplicateActions(actions.iterator).foreach(_ => ())
   }
 
   /**
@@ -1798,10 +1798,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
       validateActionsAddFileInvariants(preparedActions, metadata)
 
-      checkNoDuplicateActions(preparedActions)
-      ConflictChecker.trackConsistentDataChange(
-        spark, preparedActions.iterator, deltaLog, op, callerContext = "commit")
-        .foreach(_ => ())
+      if (spark.conf.get(DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED)) {
+        checkNoDuplicateActions(preparedActions)
+      }
 
       // Find the isolation level to use for this commit
       val isolationLevelToUse = getIsolationLevelToUse(preparedActions, op)
@@ -2094,8 +2093,6 @@ trait OptimisticTransactionImpl extends TransactionHelper
         }
         action
       }
-      allActions = ConflictChecker.trackConsistentDataChange(
-        spark, allActions, deltaLog, op, callerContext = "commitLarge")
       val (allActions2, acStatsCollector) = collectAutoOptimizeStats(allActions)
       allActions = allActions2
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2094,40 +2094,6 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .checkValues(GeneratedColumnValidateOnWriteMode.values.map(_.toString))
       .createWithDefault(GeneratedColumnValidateOnWriteMode.LOG_ONLY.toString)
 
-  sealed abstract class ConsistentDataChangeValidationMode(val name: String) {
-    override def toString: String = name
-  }
-  object ConsistentDataChangeValidationMode {
-    /** Skip the validation entirely. */
-    case object OFF extends ConsistentDataChangeValidationMode("off")
-    /** Record a Delta event on violation but do not throw. */
-    case object LOG extends ConsistentDataChangeValidationMode("log")
-    /** Throw an exception on violation. */
-    case object FATAL extends ConsistentDataChangeValidationMode("fatal")
-
-    val values: Seq[ConsistentDataChangeValidationMode] = Seq(OFF, LOG, FATAL)
-    private val byName: Map[String, ConsistentDataChangeValidationMode] =
-      values.map(m => m.name -> m).toMap
-
-    def fromConf(conf: SQLConf): ConsistentDataChangeValidationMode =
-      byName(conf.getConf(DELTA_COMMIT_VALIDATE_CONSISTENT_DATA_CHANGE_MODE))
-  }
-
-  val DELTA_COMMIT_VALIDATE_CONSISTENT_DATA_CHANGE_MODE =
-    buildConf("commitValidation.consistentDataChange.mode")
-      .internal()
-      .doc("""
-             |Controls validation that all FileActions in a single commit share a consistent
-             |dataChange value (either all true or all false).
-             | - off:   Skip the validation entirely.
-             | - log:   Record a Delta event on violation but do not throw.
-             | - fatal: Throw an exception on violation.
-             |""".stripMargin)
-      .stringConf
-      .transform(_.toLowerCase(Locale.ROOT))
-      .checkValues(ConsistentDataChangeValidationMode.values.map(_.name).toSet)
-      .createWithDefault(ConsistentDataChangeValidationMode.LOG.name)
-
   object ValidateCheckConstraintsMode extends Enumeration {
     val OFF, LOG_ONLY, ASSERT = Value
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -20,10 +20,10 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.nio.file.FileAlreadyExistsException
 
-import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
-import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, Metadata, Protocol, RemoveFile, SetTransaction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, Metadata, Protocol, RemoveFile, SetTransaction}
 import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorBuilder, CommitCoordinatorProvider, InMemoryCommitCoordinator, InMemoryCommitCoordinatorBuilder, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -1655,133 +1655,4 @@ class OptimisticTransactionSuite
       assertPartitionColumns(new TableIdentifier(pathOrTable), expected)
     }
   }
-
-  /* ************************
-   * Consistent dataChange validation
-   * ************************ */
-
-  /**
-   * Commits a mixed batch (one dataChange=true AddFile and one dataChange=false AddFile)
-   * against a fresh table under `mode` using either `commit` or `commitLarge`. Returns the
-   * captured `delta.commit.inconsistentDataChange` records along with the thrown exception
-   * (if any).
-   */
-  private def commitMixedDataChangeBatch(
-      tempDir: File,
-      mode: DeltaSQLConf.ConsistentDataChangeValidationMode,
-      useCommitLarge: Boolean)
-      : (Seq[UsageRecord], Option[Throwable]) = {
-    withSQLConf(
-      DeltaSQLConf.DELTA_COMMIT_VALIDATE_CONSISTENT_DATA_CHANGE_MODE.key -> mode.toString) {
-      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
-      val seedTxn = log.startTransaction()
-      seedTxn.updateMetadataForNewTable(Metadata())
-      seedTxn.commit(Seq.empty, ManualUpdate)
-
-      val mixedActions = Seq(
-        createTestAddFile(encodedPath = "data-change", dataChange = true),
-        createTestAddFile(encodedPath = "no-data-change", dataChange = false))
-      var thrown: Option[Throwable] = None
-      val allRecords = Log4jUsageLogger.track {
-        try {
-          if (useCommitLarge) {
-            log.startTransaction().commitLarge(
-              spark,
-              nonProtocolMetadataActions = mixedActions.iterator,
-              newProtocolOpt = None,
-              op = DeltaOperations.ManualUpdate,
-              context = Map.empty,
-              metrics = Map.empty)
-          } else {
-            log.startTransaction().commit(mixedActions, ManualUpdate)
-          }
-        } catch {
-          case t: Throwable => thrown = Some(t)
-        }
-      }
-      val records = filterUsageRecords(allRecords, "delta.commit.inconsistentDataChange")
-      (records, thrown)
-    }
-  }
-
-  for (useCommitLarge <- BOOLEAN_DOMAIN) {
-    val callerContext = if (useCommitLarge) "commitLarge" else "commit"
-
-    test(s"consistent dataChange validation: FATAL mode throws and logs payload" +
-        s" ($callerContext)") {
-      withTempDir { tempDir =>
-        val (records, thrown) = commitMixedDataChangeBatch(
-          tempDir, DeltaSQLConf.ConsistentDataChangeValidationMode.FATAL, useCommitLarge)
-        assert(thrown.exists(_.isInstanceOf[IllegalStateException]))
-        assert(records.size == 1)
-        val payload = JsonUtils.fromJson[Map[String, Any]](records.head.blob)
-        assert(payload("callerContext") == callerContext)
-        assert(payload("operation") == ManualUpdate.name)
-        assert(payload.contains("operationParameters"))
-        val firstDataChange = payload("firstDataChangeAction").asInstanceOf[Map[String, Any]]
-        val firstNoDataChange = payload("firstNoDataChangeAction").asInstanceOf[Map[String, Any]]
-        assert(firstDataChange("path") == "data-change")
-        assert(firstNoDataChange("path") == "no-data-change")
-      }
-    }
-
-    test(s"consistent dataChange validation: LOG mode logs but does not throw" +
-        s" ($callerContext)") {
-      withTempDir { tempDir =>
-        val (records, thrown) = commitMixedDataChangeBatch(
-          tempDir, DeltaSQLConf.ConsistentDataChangeValidationMode.LOG, useCommitLarge)
-        assert(thrown.isEmpty)
-        assert(records.size == 1)
-      }
-    }
-
-    test(s"consistent dataChange validation: OFF mode neither logs nor throws" +
-        s" ($callerContext)") {
-      withTempDir { tempDir =>
-        val (records, thrown) = commitMixedDataChangeBatch(
-          tempDir, DeltaSQLConf.ConsistentDataChangeValidationMode.OFF, useCommitLarge)
-        assert(thrown.isEmpty)
-        assert(records.isEmpty)
-      }
-    }
-  }
-
-  test("consistent dataChange validation: uniform commit passes in FATAL mode") {
-    withTempDir { tempDir =>
-      withSQLConf(DeltaSQLConf.DELTA_COMMIT_VALIDATE_CONSISTENT_DATA_CHANGE_MODE.key ->
-          DeltaSQLConf.ConsistentDataChangeValidationMode.FATAL.toString) {
-        val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
-        val seedTxn = log.startTransaction()
-        seedTxn.updateMetadataForNewTable(Metadata())
-        seedTxn.commit(Seq.empty, ManualUpdate)
-        // All true.
-        log.startTransaction().commit(
-          Seq(createTestAddFile(encodedPath = "a", dataChange = true)), ManualUpdate)
-        // All false.
-        log.startTransaction().commit(
-          Seq(createTestAddFile(encodedPath = "b", dataChange = false)), ManualUpdate)
-      }
-    }
-  }
-
-  test("consistent dataChange validation: AddCDCFile is excluded from the check") {
-    withTempDir { tempDir =>
-      withSQLConf(DeltaSQLConf.DELTA_COMMIT_VALIDATE_CONSISTENT_DATA_CHANGE_MODE.key ->
-          DeltaSQLConf.ConsistentDataChangeValidationMode.FATAL.toString) {
-        val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
-        val seedTxn = log.startTransaction()
-        seedTxn.updateMetadataForNewTable(Metadata())
-        seedTxn.commit(Seq.empty, ManualUpdate)
-        // AddCDCFile has dataChange = false hardcoded; co-committing it with a
-        // dataChange = true AddFile is the normal CDF write shape and must not trip
-        // the validation.
-        log.startTransaction().commit(
-          Seq(
-            createTestAddFile(encodedPath = "data", dataChange = true),
-            AddCDCFile(path = "_change_data/cdc-file", partitionValues = Map.empty, size = 1)),
-          ManualUpdate)
-      }
-    }
-  }
-
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -298,7 +298,7 @@ trait OptimisticTransactionSuiteBase
     withTempPath { tempPath =>
       val path = tempPath.getPath
       val deltaLog = DeltaLog.forTable(spark, path)
-      val firstFile = writeDuplicateActionsData(path).head.copy(dataChange = true)
+      val firstFile = writeDuplicateActionsData(path).head
       enableDeletionVectorsInTable(deltaLog)
       val (addFileWithDV, _) = addDVToFileInTable(path, firstFile)
       testDuplicateActions(Seq(firstFile, addFileWithDV), deltaLog)
@@ -322,7 +322,7 @@ trait OptimisticTransactionSuiteBase
     withTempPath { tempPath =>
       val path = tempPath.getPath
       val deltaLog = DeltaLog.forTable(spark, path)
-      val addFile = writeDuplicateActionsData(path).head.copy(dataChange = true)
+      val addFile = writeDuplicateActionsData(path).head
       testDuplicateActions(Seq(addFile, addFile.remove), deltaLog)
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
@@ -124,7 +124,7 @@ class ConflictCheckerRowIdSuite extends QueryTest
       // in the table before.
       def txnA(): Array[Row] = {
         val file1 = createTestAddFile()
-        val oldFile = filesBefore.last.copy(dataChange = true)
+        val oldFile = filesBefore.last
         log.startTransaction().commit(Seq(oldFile, file1), ManualUpdate)
         Array.empty
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This reverts commit 16a7e9fbfd6a11b374683707e12fd14449900ccb (#6937), which added validation that all `FileAction`s within a single commit share a consistent `dataChange` value (gated by `<prefix>.commitValidation.consistentDataChange.mode` with `off` / `log` / `fatal` modes).

The revert restores `ConflictChecker`, `OptimisticTransaction`, and `DeltaSQLConf` to their prior state and removes the tests added in #6937. It is a clean, complete inverse of the original commit (the resulting tree is identical to #6937's parent).

## How was this patch tested?

This is a straight revert of #6937; existing tests cover the restored behavior.

## Does this PR introduce _any_ user-facing changes?

No.

This pull request and its description were written by Isaac.
