### PR TITLE
[Storage][Spark] Adapt UC managed table code to the Delta-prefixed UC SDK

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -57,7 +57,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=af8212e9d2d96feabbb2dd3f686175dd1b5cc466
+UC_PIN_SHA=5a3b69dd79366e2e48ccff7a22fc735e0317ea8b
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -57,7 +57,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=ae0a40caa8b2b0627e88b93cb84fe6be255575db
+UC_PIN_SHA=af8212e9d2d96feabbb2dd3f686175dd1b5cc466
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaStreamingTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiException;
-import io.unitycatalog.client.delta.api.TablesApi;
-import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -193,13 +193,13 @@ public class UCDeltaStreamingTest extends UCDeltaTableIntegrationBaseTest {
   private void assertUCManagedTableVersion(
       long expectedVersion, String fullTableName, ApiClient client) throws ApiException {
     // The UC Delta API's `loadTable` returns the table metadata and the latest committed
-    // version in a single response, replacing the previous two-step lookup (TablesApi.getTable
+    // version in a single response, replacing the previous two-step lookup (DeltaTablesApi.getTable
     // followed by DeltaCommitsApi.getCommits).
     String[] parts = fullTableName.split("\\.");
     assertEquals(3, parts.length, "Full table name must be catalog.schema.table");
-    TablesApi deltaTablesApi = new TablesApi(client);
-    LoadTableResponse resp = deltaTablesApi.loadTable(parts[0], parts[1], parts[2]);
-    assertNotNull(resp, "LoadTableResponse should not be null");
+    DeltaTablesApi deltaTablesApi = new DeltaTablesApi(client);
+    DeltaLoadTableResponse resp = deltaTablesApi.loadTable(parts[0], parts[1], parts[2]);
+    assertNotNull(resp, "DeltaLoadTableResponse should not be null");
     assertNotNull(resp.getLatestTableVersion(), "Latest table version should not be null");
     assertEquals(expectedVersion, resp.getLatestTableVersion());
   }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
@@ -19,6 +19,8 @@ package io.sparkuctest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.unitycatalog.client.delta.api.DeltaTablesApi;
 import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
@@ -72,7 +74,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
           assertEquals("true", tableProperty(tableName, "delta.autoOptimize.optimizeWrite"));
           assertEquals("true", tableProperty(tableName, "delta.autoOptimize.autoCompact"));
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           Map<String, String> properties = response.getMetadata().getProperties();
           assertEquals("true", properties.get("delta.autoOptimize.optimizeWrite"));
           assertEquals("true", properties.get("delta.autoOptimize.autoCompact"));
@@ -134,7 +136,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
                   + "created_at TIMESTAMP)",
               tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           assertEquals(
               List.of("id", "name", "price", "active", "created_at"),
               fieldNames(response.getMetadata().getColumns()));
@@ -191,7 +193,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
               "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')",
               tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           assertEquals(
               "true", response.getMetadata().getProperties().get("delta.enableChangeDataFeed"));
         });
@@ -206,7 +208,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         tableName -> {
           sql("ALTER TABLE %s CLUSTER BY (id)", tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           Map<String, String> properties = response.getMetadata().getProperties();
           assertEquals("supported", properties.get("delta.feature.clustering"));
           assertEquals("[[\"id\"]]", tableProperty(tableName, "clusteringColumns"));
@@ -234,7 +236,9 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
   }
 
   @Test
-  public void testAlterTableRenameColumnUpdatesUcDeltaMetadata() throws Exception {
+  public void testAlterTableRenameColumnIsRejectedForUcManagedTable() throws Exception {
+    // UCSingleCatalog rejects ALTER TABLE RENAME COLUMN ahead of any Delta routing. Pin
+    // this contract so we notice if UC ever re-enables it.
     withNewTable(
         "alter_rename_column_test",
         "id INT, old_name STRING",
@@ -243,13 +247,13 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         COLUMN_MAPPING_PROPERTIES,
         tableName -> {
           sql("INSERT INTO %s VALUES (1, 'before_rename')", tableName);
-          sql("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName);
-
-          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
-          assertEquals(List.of("id", "new_name"), fieldNames(response.getMetadata().getColumns()));
-          check(
-              sql("SELECT id, new_name FROM %s ORDER BY id", tableName),
-              List.of(row("1", "before_rename")));
+          UnsupportedOperationException ex =
+              assertThrows(
+                  UnsupportedOperationException.class,
+                  () -> sql("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName));
+          assertTrue(
+              ex.getMessage().contains("RENAME COLUMN is not supported for Unity Catalog"),
+              "Unexpected error message: " + ex.getMessage());
         });
   }
 
@@ -273,6 +277,9 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
 
   @Test
   public void testAlterTableNestedColumnUpdatesUcDeltaMetadata() throws Exception {
+    // RENAME COLUMN is rejected upstream by UCSingleCatalog (see
+    // testAlterTableRenameColumnIsRejectedForUcManagedTable); this test covers nested-column
+    // ADD COLUMNS, the other nested-schema mutation that still propagates to UC.
     withNewTable(
         "alter_nested_column_test",
         "id INT, info STRUCT<first: STRING, last: STRING>",
@@ -280,12 +287,11 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         TableType.MANAGED,
         COLUMN_MAPPING_PROPERTIES,
         tableName -> {
-          sql("ALTER TABLE %s RENAME COLUMN info.first TO given", tableName);
-          sql("ALTER TABLE %s ADD COLUMNS (info.age INT AFTER given)", tableName);
+          sql("ALTER TABLE %s ADD COLUMNS (info.age INT AFTER first)", tableName);
 
           DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           DeltaStructType info = structField(response.getMetadata().getColumns(), "info");
-          assertEquals(List.of("given", "age", "last"), fieldNames(info));
+          assertEquals(List.of("first", "age", "last"), fieldNames(info));
         });
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.unitycatalog.client.delta.api.TablesApi;
-import io.unitycatalog.client.delta.model.LoadTableResponse;
-import io.unitycatalog.client.delta.model.StructField;
-import io.unitycatalog.client.delta.model.StructType;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
+import io.unitycatalog.client.delta.model.DeltaStructField;
+import io.unitycatalog.client.delta.model.DeltaStructType;
 import io.unitycatalog.client.model.TableInfo;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +46,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         tableName -> {
           sql("ALTER TABLE %s SET TBLPROPERTIES ('custom.key' = 'custom.value')", tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           assertEquals("custom.value", response.getMetadata().getProperties().get("custom.key"));
 
           sql("ALTER TABLE %s UNSET TBLPROPERTIES ('custom.key')", tableName);
@@ -150,7 +150,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         tableName -> {
           sql("ALTER TABLE %s CHANGE COLUMN name COMMENT 'display name'", tableName);
 
-          StructField name =
+          DeltaStructField name =
               field(loadTableViaDeltaRest(tableName).getMetadata().getColumns(), "name");
           assertEquals("display name", name.getMetadata().get("comment"));
 
@@ -220,13 +220,13 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         "id INT, code VARCHAR(5)",
         TableType.MANAGED,
         tableName -> {
-          StructField codeBefore =
+          DeltaStructField codeBefore =
               field(loadTableViaDeltaRest(tableName).getMetadata().getColumns(), "code");
           assertEquals("varchar(5)", codeBefore.getMetadata().get(CHAR_VARCHAR_TYPE_METADATA_KEY));
 
           sql("ALTER TABLE %s CHANGE COLUMN code TYPE STRING", tableName);
 
-          StructField codeAfter =
+          DeltaStructField codeAfter =
               field(loadTableViaDeltaRest(tableName).getMetadata().getColumns(), "code");
           assertEquals("string", codeAfter.getType().getType());
           assertFalse(codeAfter.getMetadata().containsKey(CHAR_VARCHAR_TYPE_METADATA_KEY));
@@ -245,7 +245,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
           sql("INSERT INTO %s VALUES (1, 'before_rename')", tableName);
           sql("ALTER TABLE %s RENAME COLUMN old_name TO new_name", tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           assertEquals(List.of("id", "new_name"), fieldNames(response.getMetadata().getColumns()));
           check(
               sql("SELECT id, new_name FROM %s ORDER BY id", tableName),
@@ -265,7 +265,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
           sql("INSERT INTO %s VALUES (1, 'kept', 'dropped')", tableName);
           sql("ALTER TABLE %s DROP COLUMN (extra)", tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
           assertEquals(List.of("id", "name"), fieldNames(response.getMetadata().getColumns()));
           check(sql("SELECT id, name FROM %s ORDER BY id", tableName), List.of(row("1", "kept")));
         });
@@ -283,8 +283,8 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
           sql("ALTER TABLE %s RENAME COLUMN info.first TO given", tableName);
           sql("ALTER TABLE %s ADD COLUMNS (info.age INT AFTER given)", tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
-          StructType info = structField(response.getMetadata().getColumns(), "info");
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaStructType info = structField(response.getMetadata().getColumns(), "info");
           assertEquals(List.of("given", "age", "last"), fieldNames(info));
         });
   }
@@ -301,8 +301,8 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
               "ALTER TABLE %s CHANGE COLUMN name name STRING COMMENT 'display name' AFTER note",
               tableName);
 
-          LoadTableResponse response = loadTableViaDeltaRest(tableName);
-          StructType columns = response.getMetadata().getColumns();
+          DeltaLoadTableResponse response = loadTableViaDeltaRest(tableName);
+          DeltaStructType columns = response.getMetadata().getColumns();
           assertEquals(List.of("id", "note", "name"), fieldNames(columns));
           assertEquals("display name", field(columns, "name").getMetadata().get("comment"));
         });
@@ -318,7 +318,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
           sql("INSERT INTO %s VALUES (1, 'valid')", tableName);
           sql("ALTER TABLE %s ADD CONSTRAINT positive_id CHECK (id > 0)", tableName);
 
-          LoadTableResponse withConstraint = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse withConstraint = loadTableViaDeltaRest(tableName);
           assertEquals(
               "id > 0",
               withConstraint.getMetadata().getProperties().get("delta.constraints.positive_id"));
@@ -327,7 +327,7 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
 
           sql("ALTER TABLE %s DROP CONSTRAINT positive_id", tableName);
 
-          LoadTableResponse withoutConstraint = loadTableViaDeltaRest(tableName);
+          DeltaLoadTableResponse withoutConstraint = loadTableViaDeltaRest(tableName);
           assertFalse(
               withoutConstraint
                   .getMetadata()
@@ -486,9 +486,9 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         });
   }
 
-  private LoadTableResponse loadTableViaDeltaRest(String tableName) throws Exception {
+  private DeltaLoadTableResponse loadTableViaDeltaRest(String tableName) throws Exception {
     String[] parts = tableName.split("\\.", 3);
-    return new TablesApi(unityCatalogInfo().createApiClient())
+    return new DeltaTablesApi(unityCatalogInfo().createApiClient())
         .loadTable(parts[0], parts[1], parts[2]);
   }
 
@@ -512,18 +512,20 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
     assertEquals(expectedOperation, history.get(0).get(4));
   }
 
-  private static List<String> fieldNames(StructType structType) {
-    return structType.getFields().stream().map(StructField::getName).collect(Collectors.toList());
+  private static List<String> fieldNames(DeltaStructType structType) {
+    return structType.getFields().stream()
+        .map(DeltaStructField::getName)
+        .collect(Collectors.toList());
   }
 
-  private static StructField field(StructType structType, String name) {
+  private static DeltaStructField field(DeltaStructType structType, String name) {
     return structType.getFields().stream()
         .filter(f -> name.equals(f.getName()))
         .findFirst()
         .orElseThrow(() -> new AssertionError("Missing field: " + name));
   }
 
-  private static StructType structField(StructType structType, String name) {
-    return (StructType) field(structType, name).getType();
+  private static DeltaStructType structField(DeltaStructType structType, String name) {
+    return (DeltaStructType) field(structType, name).getType();
   }
 }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -168,16 +168,18 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     conf =
         conf.set("spark.sql.catalog." + catalogName, "io.unitycatalog.spark.UCSingleCatalog")
             .set("spark.sql.catalog." + catalogName + ".uri", uc.serverUri())
-            .set("spark.sql.catalog." + catalogName + ".token", uc.serverToken());
-    if (useDeltaRestApiForTests()) {
-      conf =
-          conf.set(
-              "spark.sql.catalog."
-                  + catalogName
-                  + "."
-                  + UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY(),
-              "true");
-    }
+            .set("spark.sql.catalog." + catalogName + ".token", uc.serverToken())
+            // Both Delta's AbstractDeltaCatalog and UC's UCSingleCatalog read this same option
+            // key to decide whether to take the UC Delta API path. UC pinned at the current SHA
+            // defaults this to true, so a test that wants the legacy staging path must opt out
+            // explicitly -- otherwise UC skips `createStagingTable` and the later
+            // `tablesApi.createTable` call 404s for lack of a staging entry.
+            .set(
+                "spark.sql.catalog."
+                    + catalogName
+                    + "."
+                    + UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY(),
+                Boolean.toString(useDeltaRestApiForTests()));
     return conf;
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableMetadataUpdateTest.java
@@ -18,8 +18,8 @@ package io.sparkuctest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.unitycatalog.client.delta.api.TablesApi;
-import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -118,7 +118,7 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
 
           sql("ALTER TABLE %s CLUSTER BY (id)", tableName);
 
-          LoadTableResponse response = loadTable(tableName);
+          DeltaLoadTableResponse response = loadTable(tableName);
           assertThat(response.getMetadata().getProperties())
               .containsEntry("delta.feature.clustering", "supported");
           // Column mapping rewrites the logical `id` to a physical `col-<UUID>` reference. The UC
@@ -256,9 +256,9 @@ public class UCDeltaTableMetadataUpdateTest extends UCDeltaTableIntegrationBaseT
         });
   }
 
-  private LoadTableResponse loadTable(String tableName) throws Exception {
+  private DeltaLoadTableResponse loadTable(String tableName) throws Exception {
     String[] parts = tableName.split("\\.", 3);
-    return new TablesApi(unityCatalogInfo().createApiClient())
+    return new DeltaTablesApi(unityCatalogInfo().createApiClient())
         .loadTable(parts[0], parts[1], parts[2]);
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableUniformIcebergTest.java
@@ -16,8 +16,8 @@
 
 package io.sparkuctest;
 
-import io.unitycatalog.client.delta.api.TablesApi;
-import io.unitycatalog.client.delta.model.LoadTableResponse;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -52,13 +52,13 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
   /**
    * Asserts that none of the in-memory-only {@code deltaUniformIceberg.*} keys are present in the
    * table's server-side properties. These keys are populated transiently in {@code
-   * catalogTable.storage.properties} from the {@code LoadTableResponse.uniform} field and must
+   * catalogTable.storage.properties} from the {@code DeltaLoadTableResponse.uniform} field and must
    * never be written back to the UC catalog.
    */
   private void assertNoUniformPropsOnServer(String fullTableName) throws Exception {
     String[] parts = fullTableName.split("\\.");
-    TablesApi deltaApi = new TablesApi(unityCatalogInfo().createApiClient());
-    LoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
+    DeltaTablesApi deltaApi = new DeltaTablesApi(unityCatalogInfo().createApiClient());
+    DeltaLoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
     for (String key : resp.getMetadata().getProperties().keySet()) {
       Assertions.assertFalse(
           key.startsWith("deltaUniformIceberg."),
@@ -75,8 +75,8 @@ public class UCDeltaTableUniformIcebergTest extends UCDeltaTableIntegrationBaseT
   private String verifyUCMetadataAndFetchIcebergPath(
       String fullTableName, long expectedConvertedDeltaVersion) throws Exception {
     String[] parts = fullTableName.split("\\.");
-    TablesApi deltaApi = new TablesApi(unityCatalogInfo().createApiClient());
-    LoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
+    DeltaTablesApi deltaApi = new DeltaTablesApi(unityCatalogInfo().createApiClient());
+    DeltaLoadTableResponse resp = deltaApi.loadTable(parts[0], parts[1], parts[2]);
     if (resp.getUniform() == null || resp.getUniform().getIceberg() == null) {
       throw new IllegalStateException("No Iceberg metadata found for table: " + fullTableName);
     }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverter.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverter.java
@@ -27,7 +27,7 @@ import io.unitycatalog.client.delta.model.DeltaMapType;
 import io.unitycatalog.client.delta.model.DeltaPrimitiveType;
 import io.unitycatalog.client.delta.model.DeltaStructField;
 import io.unitycatalog.client.delta.model.DeltaStructType;
-import io.unitycatalog.client.delta.serde.DeltaTypeModule;
+import io.unitycatalog.client.delta.serde.DeltaDataTypeModule;
 
 import java.util.List;
 import java.util.Objects;
@@ -40,7 +40,7 @@ import java.util.Objects;
  * Delta's wire format on its own:
  * <ul>
  *   <li>{@link DeltaPrimitiveType} serializes as {@code {"type":"integer"}} by default, but Delta
- *       expects a bare string ({@code "integer"}). {@link DeltaTypeModule} provides custom
+ *       expects a bare string ({@code "integer"}). {@link DeltaDataTypeModule} provides custom
  *       serializers/deserializers that flatten primitives (and decimal) to bare strings.</li>
  *   <li>The SDK uses kebab-case JSON keys for nested types ({@code element-type},
  *       {@code contains-null}, {@code key-type}, etc.). Delta's wire format uses camelCase
@@ -146,8 +146,8 @@ final class UCDeltaSchemaConverter {
     // Copy the SDK's default mapper so we inherit its base config (visibility, naming, etc.)
     // without mutating the shared instance.
     ObjectMapper m = JSON.getDefault().getMapper().copy();
-    // DeltaTypeModule flattens DeltaPrimitiveType/DeltaDecimalType into bare type-name strings.
-    m.registerModule(new DeltaTypeModule());
+    // DeltaDataTypeModule flattens DeltaPrimitiveType/DeltaDecimalType into bare type-name strings.
+    m.registerModule(new DeltaDataTypeModule());
     // The SDK ships DeltaArrayType/DeltaMapType with kebab-case JSON keys; Delta's wire format uses
     // camelCase. Mixins rewrite the property names without modifying the generated SDK
     // classes themselves.

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverter.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverter.java
@@ -21,25 +21,25 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.unitycatalog.client.JSON;
-import io.unitycatalog.client.delta.model.ArrayType;
-import io.unitycatalog.client.delta.model.DeltaType;
-import io.unitycatalog.client.delta.model.MapType;
-import io.unitycatalog.client.delta.model.PrimitiveType;
-import io.unitycatalog.client.delta.model.StructField;
-import io.unitycatalog.client.delta.model.StructType;
+import io.unitycatalog.client.delta.model.DeltaArrayType;
+import io.unitycatalog.client.delta.model.DeltaDataType;
+import io.unitycatalog.client.delta.model.DeltaMapType;
+import io.unitycatalog.client.delta.model.DeltaPrimitiveType;
+import io.unitycatalog.client.delta.model.DeltaStructField;
+import io.unitycatalog.client.delta.model.DeltaStructType;
 import io.unitycatalog.client.delta.serde.DeltaTypeModule;
 
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Bidirectional conversion between the UC SDK's Delta schema model ({@link StructType},
- * {@link DeltaType}, {@link PrimitiveType}) and Delta's JSON schema wire format.
+ * Bidirectional conversion between the UC SDK's Delta schema model ({@link DeltaStructType},
+ * {@link DeltaDataType}, {@link DeltaPrimitiveType}) and Delta's JSON schema wire format.
  *
  * <p>The SDK's default {@link ObjectMapper} (from {@link JSON#getDefault()}) does not emit
  * Delta's wire format on its own:
  * <ul>
- *   <li>{@link PrimitiveType} serializes as {@code {"type":"integer"}} by default, but Delta
+ *   <li>{@link DeltaPrimitiveType} serializes as {@code {"type":"integer"}} by default, but Delta
  *       expects a bare string ({@code "integer"}). {@link DeltaTypeModule} provides custom
  *       serializers/deserializers that flatten primitives (and decimal) to bare strings.</li>
  *   <li>The SDK uses kebab-case JSON keys for nested types ({@code element-type},
@@ -61,13 +61,13 @@ final class UCDeltaSchemaConverter {
   private UCDeltaSchemaConverter() {}
 
   /**
-   * Serializes the SDK's {@link StructType} to Delta's JSON schema wire format. The resulting
+   * Serializes the SDK's {@link DeltaStructType} to Delta's JSON schema wire format. The resulting
    * string is parseable by Delta's schema readers (e.g. {@code DataType.fromJson}).
    *
    * @return JSON string, or {@code null} if {@code columns} is {@code null}.
    * @throws IllegalStateException if Jackson fails to serialize.
    */
-  static String serializeSchema(StructType columns) {
+  static String serializeSchema(DeltaStructType columns) {
     if (columns == null) {
       return null;
     }
@@ -80,17 +80,17 @@ final class UCDeltaSchemaConverter {
 
   /**
    * Parses a Delta JSON schema string (e.g. {@code AbstractMetadata#getSchemaString()}) into
-   * the UC SDK's {@link StructType}. Complex types (struct/array/map) and bare-string
+   * the UC SDK's {@link DeltaStructType}. Complex types (struct/array/map) and bare-string
    * primitives are dispatched by the SDK's {@code DeltaTypeDeserializer} +
-   * {@code @JsonSubTypes} on {@link DeltaType}.
+   * {@code @JsonSubTypes} on {@link DeltaDataType}.
    *
    * @throws NullPointerException if {@code schemaString} is {@code null}.
    * @throws IllegalStateException if the string is not a valid Delta JSON schema.
    */
-  static StructType parseSchemaString(String schemaString) {
+  static DeltaStructType parseSchemaString(String schemaString) {
     Objects.requireNonNull(schemaString, "schemaString must not be null");
     try {
-      return DELTA_SCHEMA_MAPPER.readValue(schemaString, StructType.class);
+      return DELTA_SCHEMA_MAPPER.readValue(schemaString, DeltaStructType.class);
     } catch (JsonProcessingException e) {
       throw new IllegalStateException(
           "Failed to parse Delta JSON schema string: " + schemaString, e);
@@ -98,8 +98,8 @@ final class UCDeltaSchemaConverter {
   }
 
   /**
-   * Converts a {@link UCClient.ColumnDef} list into the UC SDK's {@link StructType}. Each
-   * column's {@code typeJson} is parsed as a full {@link StructField}, preserving
+   * Converts a {@link UCClient.ColumnDef} list into the UC SDK's {@link DeltaStructType}. Each
+   * column's {@code typeJson} is parsed as a full {@link DeltaStructField}, preserving
    * name/nullable/type/metadata. {@code typeText} / {@code typeName} are not consulted
    * because they carry the catalog's engine-side DDL textual form (e.g. {@code "int"}),
    * which diverges from the Delta wire form (e.g. {@code "integer"}) that {@code typeJson}
@@ -110,25 +110,25 @@ final class UCDeltaSchemaConverter {
    * @throws IllegalStateException if a column's {@code typeJson} fails to parse or is missing
    *         the {@code "type"} field.
    */
-  static StructType toUCStructType(List<UCClient.ColumnDef> columns) {
+  static DeltaStructType toUCStructType(List<UCClient.ColumnDef> columns) {
     Objects.requireNonNull(columns, "columns must not be null");
-    StructType structType = new StructType();
+    DeltaStructType structType = new DeltaStructType();
     for (UCClient.ColumnDef col : columns) {
       structType.addFieldsItem(toUCStructField(col));
     }
     return structType;
   }
 
-  private static StructField toUCStructField(UCClient.ColumnDef col) {
+  private static DeltaStructField toUCStructField(UCClient.ColumnDef col) {
     String typeJson = col.getTypeJson();
     if (typeJson == null || typeJson.isEmpty()) {
       throw new IllegalArgumentException(
           "Cannot resolve type for column '" + col.getName() +
               "': typeJson is empty (typeName='" + col.getTypeName() + "').");
     }
-    StructField sdkField;
+    DeltaStructField sdkField;
     try {
-      sdkField = DELTA_SCHEMA_MAPPER.readValue(typeJson, StructField.class);
+      sdkField = DELTA_SCHEMA_MAPPER.readValue(typeJson, DeltaStructField.class);
     } catch (JsonProcessingException e) {
       throw new IllegalStateException(
           "Failed to parse typeJson for column '" + col.getName() +
@@ -146,18 +146,18 @@ final class UCDeltaSchemaConverter {
     // Copy the SDK's default mapper so we inherit its base config (visibility, naming, etc.)
     // without mutating the shared instance.
     ObjectMapper m = JSON.getDefault().getMapper().copy();
-    // DeltaTypeModule flattens PrimitiveType/DecimalType into bare type-name strings.
+    // DeltaTypeModule flattens DeltaPrimitiveType/DeltaDecimalType into bare type-name strings.
     m.registerModule(new DeltaTypeModule());
-    // The SDK ships ArrayType/MapType with kebab-case JSON keys; Delta's wire format uses
+    // The SDK ships DeltaArrayType/DeltaMapType with kebab-case JSON keys; Delta's wire format uses
     // camelCase. Mixins rewrite the property names without modifying the generated SDK
     // classes themselves.
-    m.addMixIn(ArrayType.class, CamelCaseArrayMixin.class);
-    m.addMixIn(MapType.class, CamelCaseMapMixin.class);
+    m.addMixIn(DeltaArrayType.class, CamelCaseArrayMixin.class);
+    m.addMixIn(DeltaMapType.class, CamelCaseMapMixin.class);
     return m;
   }
 
   /**
-   * Jackson mixin that renames {@link ArrayType}'s JSON keys from kebab-case to camelCase
+   * Jackson mixin that renames {@link DeltaArrayType}'s JSON keys from kebab-case to camelCase
    * (matching Delta's wire format).
    *
    * <p>The class is {@code abstract} and the methods abstract because Jackson never
@@ -167,9 +167,9 @@ final class UCDeltaSchemaConverter {
    */
   private abstract static class CamelCaseArrayMixin {
     @JsonProperty("elementType")
-    abstract DeltaType getElementType();
+    abstract DeltaDataType getElementType();
     @JsonSetter("elementType")
-    abstract void setElementType(DeltaType v);
+    abstract void setElementType(DeltaDataType v);
     @JsonProperty("containsNull")
     abstract Boolean getContainsNull();
     @JsonSetter("containsNull")
@@ -177,18 +177,18 @@ final class UCDeltaSchemaConverter {
   }
 
   /**
-   * Jackson mixin that renames {@link MapType}'s JSON keys from kebab-case to camelCase
+   * Jackson mixin that renames {@link DeltaMapType}'s JSON keys from kebab-case to camelCase
    * (matching Delta's wire format). See {@link CamelCaseArrayMixin} for the mixin pattern.
    */
   private abstract static class CamelCaseMapMixin {
     @JsonProperty("keyType")
-    abstract DeltaType getKeyType();
+    abstract DeltaDataType getKeyType();
     @JsonSetter("keyType")
-    abstract void setKeyType(DeltaType v);
+    abstract void setKeyType(DeltaDataType v);
     @JsonProperty("valueType")
-    abstract DeltaType getValueType();
+    abstract DeltaDataType getValueType();
     @JsonSetter("valueType")
-    abstract void setValueType(DeltaType v);
+    abstract void setValueType(DeltaDataType v);
     @JsonProperty("valueContainsNull")
     abstract Boolean getValueContainsNull();
     @JsonSetter("valueContainsNull")

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.storage.commit.Commit;
 import io.delta.storage.commit.CommitFailedException;
 import io.delta.storage.commit.CoordinatedCommitsUtils;
-import io.delta.storage.commit.UCDeltaGetCommitsResponse;
 import io.delta.storage.commit.GetCommitsResponse;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.UCDeltaGetCommitsResponse;
 import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
@@ -32,39 +32,41 @@ import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo;
 import io.delta.storage.commit.uccommitcoordinator.exceptions.CredentialFetchFailedException;
 import io.delta.storage.commit.uccommitcoordinator.exceptions.NoSuchTableException;
 import io.delta.storage.commit.uccommitcoordinator.exceptions.UnsupportedTableFormatException;
+import io.delta.storage.commit.uniform.IcebergMetadata;
+import io.delta.storage.commit.uniform.UniformMetadata;
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.MetastoresApi;
 import io.unitycatalog.client.auth.TokenProvider;
-import io.unitycatalog.client.delta.api.TablesApi;
-import io.unitycatalog.client.delta.model.AddCommitUpdate;
-import io.unitycatalog.client.delta.model.AssertTableUUID;
-import io.unitycatalog.client.delta.model.ClusteringDomainMetadata;
-import io.unitycatalog.client.delta.model.CreateStagingTableRequest;
-import io.unitycatalog.client.delta.model.CreateTableRequest;
-import io.unitycatalog.client.delta.model.DomainMetadataUpdates;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaAddCommitUpdate;
+import io.unitycatalog.client.delta.model.DeltaAssertTableUUID;
+import io.unitycatalog.client.delta.model.DeltaClusteringDomainMetadata;
 import io.unitycatalog.client.delta.model.DeltaCommit;
+import io.unitycatalog.client.delta.model.DeltaCreateStagingTableRequest;
+import io.unitycatalog.client.delta.model.DeltaCreateTableRequest;
+import io.unitycatalog.client.delta.model.DeltaDomainMetadataUpdates;
+import io.unitycatalog.client.delta.model.DeltaLoadTableResponse;
 import io.unitycatalog.client.delta.model.DeltaProtocol;
-import io.unitycatalog.client.delta.model.LoadTableResponse;
-import io.unitycatalog.client.delta.model.RemoveDomainMetadataUpdate;
-import io.unitycatalog.client.delta.model.RemovePropertiesUpdate;
-import io.unitycatalog.client.delta.model.RowTrackingDomainMetadata;
-import io.unitycatalog.client.delta.model.SetDomainMetadataUpdate;
-import io.unitycatalog.client.delta.model.SetLatestBackfilledVersionUpdate;
-import io.unitycatalog.client.delta.model.SetPartitionColumnsUpdate;
-import io.unitycatalog.client.delta.model.SetPropertiesUpdate;
-import io.unitycatalog.client.delta.model.SetProtocolUpdate;
-import io.unitycatalog.client.delta.model.SetSchemaUpdate;
-import io.unitycatalog.client.delta.model.SetTableCommentUpdate;
-import io.unitycatalog.client.delta.model.StagingTableResponse;
-import io.unitycatalog.client.delta.model.StagingTableResponseRequiredProtocol;
-import io.unitycatalog.client.delta.model.StagingTableResponseSuggestedProtocol;
-import io.unitycatalog.client.delta.model.TableMetadata;
-import io.delta.storage.commit.uniform.IcebergMetadata;
-import io.unitycatalog.client.delta.model.UniformMetadata;
-import io.unitycatalog.client.delta.model.UniformMetadataIceberg;
-import io.unitycatalog.client.delta.model.UpdateTableRequest;
+import io.unitycatalog.client.delta.model.DeltaRemoveDomainMetadataUpdate;
+import io.unitycatalog.client.delta.model.DeltaRemovePropertiesUpdate;
+import io.unitycatalog.client.delta.model.DeltaRowTrackingDomainMetadata;
+import io.unitycatalog.client.delta.model.DeltaSetDomainMetadataUpdate;
+import io.unitycatalog.client.delta.model.DeltaSetLatestBackfilledVersionUpdate;
+import io.unitycatalog.client.delta.model.DeltaSetPartitionColumnsUpdate;
+import io.unitycatalog.client.delta.model.DeltaSetPropertiesUpdate;
+import io.unitycatalog.client.delta.model.DeltaSetProtocolUpdate;
+import io.unitycatalog.client.delta.model.DeltaSetSchemaUpdate;
+import io.unitycatalog.client.delta.model.DeltaSetTableCommentUpdate;
+import io.unitycatalog.client.delta.model.DeltaStagingTableResponse;
+import io.unitycatalog.client.delta.model.DeltaStagingTableResponseRequiredProtocol;
+import io.unitycatalog.client.delta.model.DeltaStagingTableResponseSuggestedProtocol;
+import io.unitycatalog.client.delta.model.DeltaTableMetadata;
+import io.unitycatalog.client.delta.model.DeltaTableType;
+import io.unitycatalog.client.delta.model.DeltaUniformMetadata;
+import io.unitycatalog.client.delta.model.DeltaUniformMetadataIceberg;
+import io.unitycatalog.client.delta.model.DeltaUpdateTableRequest;
 import io.unitycatalog.client.model.GetMetastoreSummaryResponse;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs;
 import io.unitycatalog.hadoop.UCCredentialHadoopConfs.TableOperation;
@@ -91,7 +93,7 @@ import org.apache.hadoop.fs.Path;
  * A REST client implementation of {@link UCDeltaClient} that uses the UC Delta API for
  * all table lifecycle and commit coordination operations.
  *
- * <p>This client uses {@code io.unitycatalog.client.delta.api.TablesApi} for Delta-specific
+ * <p>This client uses {@code io.unitycatalog.client.delta.api.DeltaTablesApi} for Delta-specific
  * table operations (load, create, update) and {@link MetastoresApi} for metastore queries.
  *
  * @see UCDeltaClient
@@ -102,7 +104,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private static final int HTTP_CONFLICT = 409;
   private static final int HTTP_NOT_FOUND = 404;
 
-  private TablesApi deltaTablesApi;
+  private DeltaTablesApi deltaTablesApi;
   private MetastoresApi metastoresApi;
   private final ApiClient apiClient;
   private final String baseUri;
@@ -145,7 +147,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     });
 
     this.apiClient = builder.build();
-    this.deltaTablesApi = new TablesApi(this.apiClient);
+    this.deltaTablesApi = new DeltaTablesApi(this.apiClient);
     this.metastoresApi = new MetastoresApi(this.apiClient);
     this.baseUri = baseUri;
     this.tokenProvider = tokenProvider;
@@ -263,20 +265,20 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       Optional<AbstractProtocol> oldProtocol,
       Optional<AbstractProtocol> newProtocol,
       List<AbstractDomainMetadata> transactionDomainMetadata,
-      Optional<io.delta.storage.commit.uniform.UniformMetadata> uniform)
+      Optional<UniformMetadata> uniform)
       throws IOException, CommitFailedException, UCCommitCoordinatorException {
     ensureOpen();
     Objects.requireNonNull(tableId, "tableId must not be null");
     Objects.requireNonNull(transactionDomainMetadata, "transactionDomainMetadata must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
 
-    UpdateTableRequest request = new UpdateTableRequest();
-    request.addRequirementsItem(new AssertTableUUID()
+    DeltaUpdateTableRequest request = new DeltaUpdateTableRequest();
+    request.addRequirementsItem(new DeltaAssertTableUUID()
         .type("assert-table-uuid")
         .uuid(UUID.fromString(tableId)));
 
     commit.ifPresent(c -> {
-      AddCommitUpdate addCommit = new AddCommitUpdate()
+      DeltaAddCommitUpdate addCommit = new DeltaAddCommitUpdate()
           .action("add-commit")
           .commit(toSDKDeltaCommit(c));
       uniform.ifPresent(u -> addCommit.uniform(toSDKUniformMetadata(u)));
@@ -284,7 +286,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     });
 
     lastKnownBackfilledVersion.ifPresent(v ->
-        request.addUpdatesItem(new SetLatestBackfilledVersionUpdate()
+        request.addUpdatesItem(new DeltaSetLatestBackfilledVersionUpdate()
             .action("set-latest-backfilled-version")
             .latestPublishedVersion(v)));
 
@@ -296,7 +298,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     if (oldProtocol.isPresent()
         && newProtocol.isPresent()
         && !Objects.equals(oldProtocol.get(), newProtocol.get())) {
-      request.addUpdatesItem(new SetProtocolUpdate()
+      request.addUpdatesItem(new DeltaSetProtocolUpdate()
           .action("set-protocol")
           .protocol(toSDKDeltaProtocol(newProtocol.get())));
     }
@@ -327,7 +329,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     // The UC loadTable endpoint does not support server-side filtering by version range, so
     // we fetch the full unbackfilled commit window and filter client-side below. The server
     // bounds the window size, so this list is not unbounded in practice.
-    LoadTableResponse response;
+    DeltaLoadTableResponse response;
     try {
       response = deltaTablesApi.loadTable(name.catalog, name.schema, name.table);
     } catch (ApiException e) {
@@ -341,7 +343,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           e);
     }
 
-    TableMetadata metadata = response.getMetadata();
+    DeltaTableMetadata metadata = response.getMetadata();
     String actualTableId = metadata != null && metadata.getTableUuid() != null
         ? metadata.getTableUuid().toString()
         : null;
@@ -372,8 +374,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
     long latestTableVersion = response.getLatestTableVersion() != null
         ? response.getLatestTableVersion() : -1L;
-    Optional<io.delta.storage.commit.uniform.UniformMetadata> storageUniform =
-        toStorageUniformMetadata(response.getUniform());
+    Optional<UniformMetadata> storageUniform = toStorageUniformMetadata(response.getUniform());
     return new UCDeltaGetCommitsResponse(commits, latestTableVersion, storageUniform);
   }
 
@@ -405,7 +406,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(columns, "columns must not be null");
     Objects.requireNonNull(properties, "properties must not be null");
 
-    CreateTableRequest sdkRequest = new CreateTableRequest()
+    DeltaCreateTableRequest sdkRequest = new DeltaCreateTableRequest()
         .name(tableName)
         .location(storageLocation)
         .properties(properties);
@@ -472,8 +473,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     ensureOpen();
     ResolvedTableName name = requireThreePartName(tableIdentifier);
     try {
-      CreateStagingTableRequest request = new CreateStagingTableRequest().name(name.table);
-      StagingTableResponse response =
+      DeltaCreateStagingTableRequest request =
+          new DeltaCreateStagingTableRequest().name(name.table);
+      DeltaStagingTableResponse response =
           deltaTablesApi.createStagingTable(name.catalog, name.schema, request);
       return toStagingTableInfo(response);
     } catch (ApiException e) {
@@ -503,11 +505,10 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(schemaJson, "metadata.schemaString must not be null");
 
     try {
-      CreateTableRequest sdkRequest = new CreateTableRequest()
+      DeltaCreateTableRequest sdkRequest = new DeltaCreateTableRequest()
           .name(name.table)
           .location(tableUri.toString())
-          .tableType(io.unitycatalog.client.delta.model.TableType.fromValue(tableType.name()))
-          .dataSourceFormat(io.unitycatalog.client.delta.model.DataSourceFormat.DELTA)
+          .tableType(DeltaTableType.fromValue(tableType.name()))
           .columns(UCDeltaSchemaConverter.parseSchemaString(schemaJson))
           .protocol(toSDKDeltaProtocol(protocol))
           .lastCommitTimestampMs(lastCommitTimestampMs);
@@ -522,7 +523,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       if (configuration != null && !configuration.isEmpty()) {
         sdkRequest.properties(configuration);
       }
-      DomainMetadataUpdates updates = toSDKDomainMetadataUpdates(domainMetadata);
+      DeltaDomainMetadataUpdates updates = toSDKDomainMetadataUpdates(domainMetadata);
       if (updates != null) {
         sdkRequest.domainMetadata(updates);
       }
@@ -544,8 +545,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   // ===========================
 
   private TableInfo toTableInfo(
-      LoadTableResponse response, String catalog, String schema, String name) throws IOException {
-    TableMetadata m = response.getMetadata();
+      DeltaLoadTableResponse response, String catalog, String schema, String name)
+      throws IOException {
+    DeltaTableMetadata m = response.getMetadata();
     String location = m.getLocation();
     if (location == null) {
       throw new IOException("UC returned null location for table " + name);
@@ -559,8 +561,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     }
     UCDeltaModels.TableType tableType =
         UCDeltaModels.TableType.valueOf(m.getTableType().getValue());
-    DeltaTableMetadata adapted = new DeltaTableMetadata(name, m);
-    Optional<io.delta.storage.commit.uniform.UniformMetadata> uniformMetadata =
+    AdaptedTableMetadata adapted = new AdaptedTableMetadata(name, m);
+    Optional<UniformMetadata> uniformMetadata =
         toStorageUniformMetadata(response.getUniform());
     Map<String, String> storageProps;
     try {
@@ -579,21 +581,21 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return new TableInfo(ucTableId, tableType, location, adapted, storageProps, uniformMetadata);
   }
 
-  private static Optional<io.delta.storage.commit.uniform.UniformMetadata>
-      toStorageUniformMetadata(UniformMetadata sdkUniform) {
+  private static Optional<UniformMetadata> toStorageUniformMetadata(
+      DeltaUniformMetadata sdkUniform) {
     if (sdkUniform == null) {
       return Optional.empty();
     }
-    UniformMetadataIceberg sdkIceberg = sdkUniform.getIceberg();
+    DeltaUniformMetadataIceberg sdkIceberg = sdkUniform.getIceberg();
     if (sdkIceberg == null) {
-      return Optional.of(new io.delta.storage.commit.uniform.UniformMetadata(null));
+      return Optional.of(new UniformMetadata(null));
     }
     String metadataLocation = sdkIceberg.getMetadataLocation();
     Long rawVersion = sdkIceberg.getConvertedDeltaVersion();
     Long rawTimestamp = sdkIceberg.getConvertedDeltaTimestamp();
     if (metadataLocation == null || rawVersion == null || rawTimestamp == null) {
       throw new IllegalStateException(
-          "UC returned a non-null UniformMetadataIceberg with missing required fields: "
+          "UC returned a non-null DeltaUniformMetadataIceberg with missing required fields: "
               + "metadataLocation="
               + metadataLocation
               + ", convertedDeltaVersion="
@@ -604,10 +606,10 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     String convertedDeltaTimestamp = Instant.ofEpochMilli(rawTimestamp).toString();
     IcebergMetadata icebergMetadata =
         new IcebergMetadata(metadataLocation, rawVersion, convertedDeltaTimestamp);
-    return Optional.of(new io.delta.storage.commit.uniform.UniformMetadata(icebergMetadata));
+    return Optional.of(new UniformMetadata(icebergMetadata));
   }
 
-  private UCDeltaModels.StagingTableInfo toStagingTableInfo(StagingTableResponse r)
+  private UCDeltaModels.StagingTableInfo toStagingTableInfo(DeltaStagingTableResponse r)
       throws IOException, ApiException {
     if (r.getTableId() == null) {
       throw new IOException("UC returned null tableId for staging table");
@@ -634,7 +636,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
         storageProps);
   }
 
-  private UCDeltaModels.DeltaProtocol toDeltaProtocol(StagingTableResponseRequiredProtocol p) {
+  private UCDeltaModels.DeltaProtocol toDeltaProtocol(DeltaStagingTableResponseRequiredProtocol p) {
     if (p == null) {
       return null;
     }
@@ -650,7 +652,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return protocol;
   }
 
-  private UCDeltaModels.DeltaProtocol toDeltaProtocol(StagingTableResponseSuggestedProtocol p) {
+  private UCDeltaModels.DeltaProtocol toDeltaProtocol(
+      DeltaStagingTableResponseSuggestedProtocol p) {
     if (p == null) {
       return null;
     }
@@ -693,7 +696,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   }
 
   private static void addDomainMetadataUpdateActions(
-      UpdateTableRequest request,
+      DeltaUpdateTableRequest request,
       List<AbstractDomainMetadata> transactionDomainMetadata) throws IOException {
     List<AbstractDomainMetadata> setDomainMetadata = new ArrayList<>();
     List<String> removeDomains = new ArrayList<>();
@@ -705,14 +708,14 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       }
     }
 
-    DomainMetadataUpdates setUpdates = toSDKDomainMetadataUpdates(setDomainMetadata);
+    DeltaDomainMetadataUpdates setUpdates = toSDKDomainMetadataUpdates(setDomainMetadata);
     if (setUpdates != null) {
-      request.addUpdatesItem(new SetDomainMetadataUpdate()
+      request.addUpdatesItem(new DeltaSetDomainMetadataUpdate()
           .action("set-domain-metadata")
           .updates(setUpdates));
     }
     if (!removeDomains.isEmpty()) {
-      request.addUpdatesItem(new RemoveDomainMetadataUpdate()
+      request.addUpdatesItem(new DeltaRemoveDomainMetadataUpdate()
           .action("remove-domain-metadata")
           .domains(removeDomains));
     }
@@ -720,7 +723,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
   /**
    * Maps Delta {@link AbstractDomainMetadata} entries onto the UC SDK's typed {@link
-   * DomainMetadataUpdates}. UC models only {@code delta.clustering} and {@code
+   * DeltaDomainMetadataUpdates}. UC models only {@code delta.clustering} and {@code
    * delta.rowTracking}; entries for unknown domains fail fast. Returns {@code null} when no
    * known-domain entries were produced.
    *
@@ -729,9 +732,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
    *
    * <p>Package-private for unit testing.
    */
-  static DomainMetadataUpdates toSDKDomainMetadataUpdates(
+  static DeltaDomainMetadataUpdates toSDKDomainMetadataUpdates(
       List<AbstractDomainMetadata> entries) throws IOException {
-    DomainMetadataUpdates updates = new DomainMetadataUpdates();
+    DeltaDomainMetadataUpdates updates = new DeltaDomainMetadataUpdates();
     boolean any = false;
     for (AbstractDomainMetadata dm : entries) {
       // Remove intents are carried separately by remove-domain-metadata commit updates.
@@ -740,22 +743,22 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       }
       String domain = dm.getDomain();
       switch (domain) {
-        case DomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING: {
+        case DeltaDomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING: {
           ClusteringDomainConfig config = DOMAIN_METADATA_MAPPER.readValue(
               dm.getConfiguration(), ClusteringDomainConfig.class);
           if (config.clusteringColumns != null) {
             updates.setDeltaClustering(
-                new ClusteringDomainMetadata().clusteringColumns(config.clusteringColumns));
+                new DeltaClusteringDomainMetadata().clusteringColumns(config.clusteringColumns));
             any = true;
           }
           break;
         }
-        case DomainMetadataUpdates.JSON_PROPERTY_DELTA_ROW_TRACKING: {
+        case DeltaDomainMetadataUpdates.JSON_PROPERTY_DELTA_ROW_TRACKING: {
           RowTrackingDomainConfig config = DOMAIN_METADATA_MAPPER.readValue(
               dm.getConfiguration(), RowTrackingDomainConfig.class);
           if (config.rowIdHighWaterMark != null) {
             updates.setDeltaRowTracking(
-                new RowTrackingDomainMetadata().rowIdHighWaterMark(config.rowIdHighWaterMark));
+                new DeltaRowTrackingDomainMetadata().rowIdHighWaterMark(config.rowIdHighWaterMark));
             any = true;
           }
           break;
@@ -763,8 +766,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
         default:
           throw new IOException(
               "Unsupported Delta domain metadata domain '" + domain + "': UC SDK only models "
-                  + DomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING + " and "
-                  + DomainMetadataUpdates.JSON_PROPERTY_DELTA_ROW_TRACKING + ". Add SDK "
+                  + DeltaDomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING + " and "
+                  + DeltaDomainMetadataUpdates.JSON_PROPERTY_DELTA_ROW_TRACKING + ". Add SDK "
                   + "support before issuing writes that produce this domain.");
       }
     }
@@ -788,11 +791,10 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     public Long rowIdHighWaterMark;
   }
 
-  private UniformMetadata toSDKUniformMetadata(
-      io.delta.storage.commit.uniform.UniformMetadata uniform) {
-    UniformMetadata ucUniform = new UniformMetadata();
+  private DeltaUniformMetadata toSDKUniformMetadata(UniformMetadata uniform) {
+    DeltaUniformMetadata ucUniform = new DeltaUniformMetadata();
     uniform.getIcebergMetadata().ifPresent(iceberg -> {
-      UniformMetadataIceberg ucIceberg = new UniformMetadataIceberg()
+      DeltaUniformMetadataIceberg ucIceberg = new DeltaUniformMetadataIceberg()
           .metadataLocation(iceberg.getMetadataLocation())
           .convertedDeltaVersion(iceberg.getConvertedDeltaVersion())
           .convertedDeltaTimestamp(parseTimestampToEpochMs(
@@ -824,21 +826,21 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
    * any fields that changed.
    */
   private void addMetadataUpdates(
-      UpdateTableRequest request,
+      DeltaUpdateTableRequest request,
       AbstractMetadata oldMetadata,
       AbstractMetadata newMetadata) {
     if (!Objects.equals(oldMetadata.getSchemaString(), newMetadata.getSchemaString())) {
-      request.addUpdatesItem(new SetSchemaUpdate()
+      request.addUpdatesItem(new DeltaSetSchemaUpdate()
           .action("set-columns")
           .columns(UCDeltaSchemaConverter.parseSchemaString(newMetadata.getSchemaString())));
     }
     if (!Objects.equals(oldMetadata.getPartitionColumns(), newMetadata.getPartitionColumns())) {
-      request.addUpdatesItem(new SetPartitionColumnsUpdate()
+      request.addUpdatesItem(new DeltaSetPartitionColumnsUpdate()
           .action("set-partition-columns")
           .partitionColumns(newMetadata.getPartitionColumns()));
     }
     if (!Objects.equals(oldMetadata.getDescription(), newMetadata.getDescription())) {
-      request.addUpdatesItem(new SetTableCommentUpdate()
+      request.addUpdatesItem(new DeltaSetTableCommentUpdate()
           .action("set-table-comment")
           .comment(newMetadata.getDescription()));
     }
@@ -856,7 +858,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
         }
       }
       if (!toSet.isEmpty()) {
-        request.addUpdatesItem(new SetPropertiesUpdate()
+        request.addUpdatesItem(new DeltaSetPropertiesUpdate()
             .action("set-properties")
             .updates(toSet));
       }
@@ -868,7 +870,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
         }
       }
       if (!toRemove.isEmpty()) {
-        request.addUpdatesItem(new RemovePropertiesUpdate()
+        request.addUpdatesItem(new DeltaRemovePropertiesUpdate()
             .action("remove-properties")
             .removals(toRemove));
       }
@@ -950,14 +952,14 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   }
 
   /**
-   * Adapts a UC SDK {@link TableMetadata} to {@link AbstractMetadata}.
+   * Adapts a UC SDK {@link DeltaTableMetadata} to {@link AbstractMetadata}.
    */
-  private static final class DeltaTableMetadata implements AbstractMetadata {
+  private static final class AdaptedTableMetadata implements AbstractMetadata {
 
     private final String name;
-    private final TableMetadata m;
+    private final DeltaTableMetadata m;
 
-    DeltaTableMetadata(String name, TableMetadata m) {
+    AdaptedTableMetadata(String name, DeltaTableMetadata m) {
       this.name = name;
       this.m = m;
     }
@@ -982,7 +984,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
     @Override
     public String getProvider() {
-      return m.getDataSourceFormat() != null ? m.getDataSourceFormat().getValue() : "DELTA";
+      // The UC Delta API only serves Delta tables; the data source format is implicit and is not
+      // carried on the SDK's table metadata, so the provider is always "DELTA".
+      return "DELTA";
     }
 
     @Override
@@ -1014,8 +1018,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof DeltaTableMetadata)) return false;
-      DeltaTableMetadata that = (DeltaTableMetadata) o;
+      if (!(o instanceof AdaptedTableMetadata)) return false;
+      AdaptedTableMetadata that = (AdaptedTableMetadata) o;
       return Objects.equals(getId(), that.getId())
           && Objects.equals(getName(), that.getName())
           && Objects.equals(getProvider(), that.getProvider())

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverterSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaSchemaConverterSuite.scala
@@ -19,8 +19,14 @@ package io.delta.storage.commit.uccommitcoordinator
 import java.util.{Arrays, Collections}
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.unitycatalog.client.delta.model.{ArrayType, DecimalType, DeltaType, MapType}
-import io.unitycatalog.client.delta.model.{PrimitiveType, StructField, StructFieldMetadata, StructType}
+import io.unitycatalog.client.delta.model.DeltaArrayType
+import io.unitycatalog.client.delta.model.DeltaDataType
+import io.unitycatalog.client.delta.model.DeltaDecimalType
+import io.unitycatalog.client.delta.model.DeltaMapType
+import io.unitycatalog.client.delta.model.DeltaPrimitiveType
+import io.unitycatalog.client.delta.model.DeltaStructField
+import io.unitycatalog.client.delta.model.DeltaStructFieldMetadata
+import io.unitycatalog.client.delta.model.DeltaStructType
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -28,13 +34,13 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
 
   private val objectMapper = new ObjectMapper()
 
-  private def prim(t: String): PrimitiveType = new PrimitiveType().`type`(t)
+  private def prim(t: String): DeltaPrimitiveType = new DeltaPrimitiveType().`type`(t)
   // Delta's wire format requires `metadata` to always be present (even if empty); a real
   // schema parsed from the wire never has a null metadata, so the helper mirrors that
-  // shape with an empty StructFieldMetadata by default.
-  private def field(name: String, t: DeltaType, nullable: Boolean = true): StructField =
-    new StructField()
-      .name(name).nullable(nullable).`type`(t).metadata(new StructFieldMetadata())
+  // shape with an empty DeltaStructFieldMetadata by default.
+  private def field(name: String, t: DeltaDataType, nullable: Boolean = true): DeltaStructField =
+    new DeltaStructField()
+      .name(name).nullable(nullable).`type`(t).metadata(new DeltaStructFieldMetadata())
 
   /**
    * One example per primitive: (UC `ColumnTypeName`, catalog-side DDL form, Delta wire form).
@@ -57,7 +63,7 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
     ("BINARY", "binary", "binary"),
     ("DECIMAL", "decimal(10,2)", "decimal(10,2)"))
 
-  /** Build the StructField JSON that UC's `toStructFieldJson` produces. */
+  /** Build the DeltaStructField JSON that UC's `toStructFieldJson` produces. */
   private def fieldJson(name: String, deltaWireType: String, nullable: Boolean): String =
     s"""{"name":"$name","type":"$deltaWireType","nullable":$nullable,"metadata":{}}"""
 
@@ -70,7 +76,8 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
   }
 
   test("serializeSchema: empty struct produces an empty fields array") {
-    val parsed = objectMapper.readTree(UCDeltaSchemaConverter.serializeSchema(new StructType()))
+    val parsed =
+      objectMapper.readTree(UCDeltaSchemaConverter.serializeSchema(new DeltaStructType()))
     assert(parsed.get("type").asText() === "struct")
     assert(parsed.get("fields").isArray)
     assert(parsed.get("fields").size() === 0)
@@ -78,13 +85,13 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
 
   test("serializeSchema: every primitive serializes as bare-string wire form " +
       "inside Array and Map containers") {
-    // Covers (a) bare-string emission (PrimitiveType serializes flat, not {"type":"integer"}),
+    // Covers (a) bare-string emission (DeltaPrimitiveType serializes flat, not {"type":"integer"}),
     // (b) decimal parameter preservation, and (c) wire fidelity for every primitive type at
     // both Array.elementType and Map.valueType (the two camelCase mixin paths).
     primitiveExamples.foreach { case (_, _, p) =>
-      val arr = new ArrayType().elementType(prim(p)).containsNull(true)
-      val m = new MapType().keyType(prim("string")).valueType(prim(p)).valueContainsNull(true)
-      val s = new StructType().addFieldsItem(field("a", arr)).addFieldsItem(field("m", m))
+      val arr = new DeltaArrayType().elementType(prim(p)).containsNull(true)
+      val m = new DeltaMapType().keyType(prim("string")).valueType(prim(p)).valueContainsNull(true)
+      val s = new DeltaStructType().addFieldsItem(field("a", arr)).addFieldsItem(field("m", m))
       val parsed = objectMapper.readTree(UCDeltaSchemaConverter.serializeSchema(s))
       val arrType = parsed.get("fields").get(0).get("type")
       assert(arrType.get("type").asText() === "array", s"primitive=$p")
@@ -99,21 +106,21 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
       "camelCase (never kebab-case) at every level") {
     // Kitchen-sink schema exercising the mixins (array, map, nested struct, array-of-map,
     // map-of-struct, array-of-struct) and nullability in every direction.
-    val innerStruct = new StructType()
+    val innerStruct = new DeltaStructType()
       .addFieldsItem(field("k", prim("string")))
       .addFieldsItem(field("v", prim("long"), nullable = false))
-    val arrOfStruct = new ArrayType().elementType(innerStruct).containsNull(false)
-    val mapOfStruct = new MapType()
+    val arrOfStruct = new DeltaArrayType().elementType(innerStruct).containsNull(false)
+    val mapOfStruct = new DeltaMapType()
       .keyType(prim("string"))
       .valueType(innerStruct)
       .valueContainsNull(true)
-    val innerMap = new MapType()
+    val innerMap = new DeltaMapType()
       .keyType(prim("string"))
       .valueType(prim("date"))
       .valueContainsNull(true)
-    val arrOfMap = new ArrayType().elementType(innerMap).containsNull(true)
+    val arrOfMap = new DeltaArrayType().elementType(innerMap).containsNull(true)
 
-    val s = new StructType()
+    val s = new DeltaStructType()
       .addFieldsItem(field("z_int", prim("integer"), nullable = false))
       .addFieldsItem(field("a_str", prim("string")))
       .addFieldsItem(field("arr_of_struct", arrOfStruct))
@@ -163,13 +170,13 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
   }
 
   test("serializeSchema: per-field metadata round-trips; empty metadata emits {} (not omitted)") {
-    val metadata = new StructFieldMetadata()
+    val metadata = new DeltaStructFieldMetadata()
     metadata.put("comment", "user-facing column doc")
     metadata.put("delta.columnMapping.id", java.lang.Long.valueOf(42L))
-    val annotated = new StructField()
+    val annotated = new DeltaStructField()
       .name("annotated").nullable(true).`type`(prim("integer")).metadata(metadata)
     val plain = field("plain", prim("integer"))
-    val s = new StructType().addFieldsItem(annotated).addFieldsItem(plain)
+    val s = new DeltaStructType().addFieldsItem(annotated).addFieldsItem(plain)
 
     val parsed = objectMapper.readTree(UCDeltaSchemaConverter.serializeSchema(s))
     val annotatedMeta = parsed.get("fields").get(0).get("metadata")
@@ -193,7 +200,7 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
 
   test("parseSchemaString: empty struct round-trips") {
     val parsed = UCDeltaSchemaConverter.parseSchemaString("""{"type":"struct","fields":[]}""")
-    assert(parsed.isInstanceOf[StructType])
+    assert(parsed.isInstanceOf[DeltaStructType])
     assert(parsed.getFields == null || parsed.getFields.isEmpty)
   }
 
@@ -218,25 +225,25 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
 
     val i = parsed.getFields.get(0)
     assert(i.getNullable === false)
-    assert(i.getType.asInstanceOf[PrimitiveType].getType === "integer")
+    assert(i.getType.asInstanceOf[DeltaPrimitiveType].getType === "integer")
 
-    val d = parsed.getFields.get(1).getType.asInstanceOf[DecimalType]
+    val d = parsed.getFields.get(1).getType.asInstanceOf[DeltaDecimalType]
     assert(d.getPrecision === 10 && d.getScale === 2)
 
-    val arr = parsed.getFields.get(2).getType.asInstanceOf[ArrayType]
+    val arr = parsed.getFields.get(2).getType.asInstanceOf[DeltaArrayType]
     assert(arr.getContainsNull === true)
-    assert(arr.getElementType.asInstanceOf[PrimitiveType].getType === "string")
+    assert(arr.getElementType.asInstanceOf[DeltaPrimitiveType].getType === "string")
 
-    val m = parsed.getFields.get(3).getType.asInstanceOf[MapType]
+    val m = parsed.getFields.get(3).getType.asInstanceOf[DeltaMapType]
     assert(m.getValueContainsNull === false)
-    assert(m.getKeyType.asInstanceOf[PrimitiveType].getType === "string")
-    assert(m.getValueType.asInstanceOf[PrimitiveType].getType === "long")
+    assert(m.getKeyType.asInstanceOf[DeltaPrimitiveType].getType === "string")
+    assert(m.getValueType.asInstanceOf[DeltaPrimitiveType].getType === "long")
 
     val outer = parsed.getFields.get(4)
     assert(outer.getMetadata.get("comment") === "outer-doc")
     assert(outer.getMetadata.get("delta.columnMapping.id")
       .asInstanceOf[Number].longValue === 5L)
-    val inner = outer.getType.asInstanceOf[StructType].getFields.get(0)
+    val inner = outer.getType.asInstanceOf[DeltaStructType].getFields.get(0)
     assert(inner.getMetadata.get("comment") === "inner-doc")
     assert(inner.getMetadata.get("delta.columnMapping.id")
       .asInstanceOf[Number].longValue === 7L)
@@ -251,15 +258,15 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
 
   test("serializeSchema -> parseSchemaString round-trip: complex schema is idempotent on the " +
       "wire") {
-    val arr = new ArrayType().elementType(prim("double")).containsNull(false)
-    val map = new MapType()
+    val arr = new DeltaArrayType().elementType(prim("double")).containsNull(false)
+    val map = new DeltaMapType()
       .keyType(prim("string"))
       .valueType(prim("date"))
       .valueContainsNull(true)
-    val inner = new StructType()
+    val inner = new DeltaStructType()
       .addFieldsItem(field("inner_i", prim("integer"), nullable = false))
       .addFieldsItem(field("inner_s", prim("string")))
-    val original = new StructType()
+    val original = new DeltaStructType()
       .addFieldsItem(field("a", prim("integer"), nullable = false))
       .addFieldsItem(field("arr", arr))
       .addFieldsItem(field("m", map))
@@ -309,10 +316,11 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
       val s = UCDeltaSchemaConverter.toUCStructType(Collections.singletonList(column))
       val t = s.getFields.get(0).getType
       if (typeName == "DECIMAL") {
-        assert(t.isInstanceOf[DecimalType], s"typeName=$typeName: expected DecimalType")
+        assert(t.isInstanceOf[DeltaDecimalType], s"typeName=$typeName: expected DeltaDecimalType")
       } else {
-        assert(t.isInstanceOf[PrimitiveType], s"typeName=$typeName: expected PrimitiveType")
-        val got = t.asInstanceOf[PrimitiveType].getType
+        assert(
+          t.isInstanceOf[DeltaPrimitiveType], s"typeName=$typeName: expected DeltaPrimitiveType")
+        val got = t.asInstanceOf[DeltaPrimitiveType].getType
         assert(got === wire, s"typeName=$typeName: expected wire '$wire' got '$got'")
         if (ddl != wire) {
           assert(got !== ddl, s"typeName=$typeName: DDL form '$ddl' leaked into the output")
@@ -342,7 +350,7 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
   }
 
   test("toUCStructType: typeJson without a 'type' field throws IllegalStateException") {
-    // E.g. a bare type JSON or an empty object -- neither is StructField-shaped.
+    // E.g. a bare type JSON or an empty object -- neither is DeltaStructField-shaped.
     val cols = Arrays.asList(
       new UCClient.ColumnDef("a", "INT", "int", "{}", true, 0))
     val e = intercept[IllegalStateException] {
@@ -378,20 +386,20 @@ class UCDeltaSchemaConverterSuite extends AnyFunSuite {
     assert(outer.getName === "deep")
     assert(outer.getMetadata.get("delta.columnMapping.id").asInstanceOf[Number].longValue === 3L)
 
-    val outerArr = outer.getType.asInstanceOf[ArrayType]
+    val outerArr = outer.getType.asInstanceOf[DeltaArrayType]
     assert(outerArr.getContainsNull === true)
-    val innerStruct = outerArr.getElementType.asInstanceOf[StructType]
+    val innerStruct = outerArr.getElementType.asInstanceOf[DeltaStructType]
     val innerFields = innerStruct.getFields
     assert(innerFields.size() === 2)
-    assert(innerFields.get(0).getType.asInstanceOf[PrimitiveType].getType === "integer")
+    assert(innerFields.get(0).getType.asInstanceOf[DeltaPrimitiveType].getType === "integer")
     assert(innerFields.get(0).getMetadata.get("comment") === "x-doc")
-    val yMap = innerFields.get(1).getType.asInstanceOf[MapType]
+    val yMap = innerFields.get(1).getType.asInstanceOf[DeltaMapType]
     assert(yMap.getValueContainsNull === false)
-    val yArr = yMap.getValueType.asInstanceOf[ArrayType]
+    val yArr = yMap.getValueType.asInstanceOf[DeltaArrayType]
     assert(yArr.getContainsNull === true)
-    assert(yArr.getElementType.asInstanceOf[PrimitiveType].getType === "long")
+    assert(yArr.getElementType.asInstanceOf[DeltaPrimitiveType].getType === "long")
 
-    // Round-trip: parsed StructField re-serializes to the same JSON tree (order-insensitive).
+    // Round-trip: parsed DeltaStructField re-serializes to the same JSON tree (order-insensitive).
     val reserialized = UCDeltaSchemaConverter.serializeSchema(s)
     val expectedTree = objectMapper.readTree(s"""{"type":"struct","fields":[$fieldJson]}""")
     val actualTree = objectMapper.readTree(reserialized)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/6963/files) to review incremental changes.
- [**stack/uc_sdk_delta_prefix**](https://github.com/delta-io/delta/pull/6963) [[Files changed](https://github.com/delta-io/delta/pull/6963/files)]
  - [stack/metrics](https://github.com/delta-io/delta/pull/6949) [[Files changed](https://github.com/delta-io/delta/pull/6949/files/49804a7feaee3459009ab93fb13c7263402745b1..8a6e06d6a2f9737e1a200e5100b9d0d55497042b)]
  - [stack/replace_path_table_fail](https://github.com/delta-io/delta/pull/6924) [[Files changed](https://github.com/delta-io/delta/pull/6924/files/49804a7feaee3459009ab93fb13c7263402745b1..dcdd3108572a543545b94064c7b97b1546b591b6)]

---------
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (storage)

## Description
[Storage][Spark] Adapt UC managed table code to the Delta-prefixed UC SDK

The UC SDK renamed every class in `io.unitycatalog.client.delta.{model,api}` to carry a `Delta` prefix.

- Bump UC pin SHA to af8212e.
- Add `Delta` prefix to all referenced SDK types (e.g. `TablesApi` -> `DeltaTablesApi`); special case `DeltaType` -> `DeltaDataType`; serde `DeltaTypeModule` unchanged.
- Rename inner adapter `DeltaTableMetadata` -> `AdaptedTableMetadata` to avoid colliding with the SDK type.
- Drop SDK members removed at this SHA (`CreateTableRequest.dataSourceFormat`, `TableMetadata.getDataSourceFormat`); the Delta-only API implies provider "DELTA".

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
No
