### PR TITLE
[Flink] Add deletion-vector read/write/merge support

### DIFF
--- a/flink/src/main/java/io/delta/flink/kernel/dv/BinDVAccess.java
+++ b/flink/src/main/java/io/delta/flink/kernel/dv/BinDVAccess.java
@@ -32,9 +32,9 @@ import java.util.UUID;
 
 /**
  * Ported from {@code org.apache.spark.sql.delta.storage.dv.DeletionVectorStore}; layout {@code
- * [version][length BE][payload][crc32 BE]}. Supports a single DV per bin file: {@link #write}/{@link
- * #store} emit one DV at offset 1 and {@link #read} rejects any larger file rather than mis-reading
- * it.
+ * [version][length BE][payload][crc32 BE]}. Supports a single DV per bin file: {@link
+ * #write}/{@link #store} emit one DV at offset 1 and {@link #read} rejects any larger file rather
+ * than mis-reading it.
  *
  * <p>Multi-DV-per-file support (needed to modify DVs in place) is future work.
  */
@@ -91,10 +91,10 @@ public class BinDVAccess extends DVAccess {
   /**
    * Reads the single deletion vector from {@code filePath}, starting at the beginning of the file.
    *
-   * <p>Only single-DV files are supported: the file must consist of exactly {@code
-   * [version][length BE][payload][crc32 BE]} and nothing more. If the file is longer than one DV
-   * (e.g. a delta-spark bin-packed file holding multiple DVs), this throws rather than returning a
-   * truncated or wrong result. See the class Javadoc for the multi-DV limitation.
+   * <p>Only single-DV files are supported: the file must consist of exactly {@code [version][length
+   * BE][payload][crc32 BE]} and nothing more. If the file is longer than one DV (e.g. a delta-spark
+   * bin-packed file holding multiple DVs), this throws rather than returning a truncated or wrong
+   * result. See the class Javadoc for the multi-DV limitation.
    */
   @Override
   public RoaringBitmapArray read(Engine engine, String filePath) {

--- a/flink/src/main/java/io/delta/flink/kernel/dv/BinDVAccess.java
+++ b/flink/src/main/java/io/delta/flink/kernel/dv/BinDVAccess.java
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.kernel.dv;
+
+import io.delta.kernel.defaults.engine.fileio.FileIO;
+import io.delta.kernel.defaults.engine.fileio.InputFile;
+import io.delta.kernel.defaults.engine.fileio.OutputFile;
+import io.delta.kernel.defaults.engine.fileio.SeekableInputStream;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Ported from {@code org.apache.spark.sql.delta.storage.dv.DeletionVectorStore}; layout {@code
+ * [version][length BE][payload][crc32 BE]}. Supports a single DV per bin file: {@link #write}/{@link
+ * #store} emit one DV at offset 1 and {@link #read} rejects any larger file rather than mis-reading
+ * it.
+ *
+ * <p>Multi-DV-per-file support (needed to modify DVs in place) is future work.
+ */
+public class BinDVAccess extends DVAccess {
+
+  static final byte DV_FILE_FORMAT_VERSION_ID_V1 = 1;
+
+  /**
+   * Offset of the DV payload's length-prefix within the {@code .bin} file -- 1 byte past the file
+   * header. {@link DeletionVectorDescriptor#getOffset()} stores this value so readers know where to
+   * start.
+   */
+  static final int DV_PAYLOAD_OFFSET_IN_FILE = 1;
+
+  /** Filename pattern for UUID-keyed DV files; distinct from Spark. */
+  private static final String DV_FILE_NAME_TEMPLATE = "dv_flink_%s.bin";
+
+  @Override
+  public void write(Engine engine, String filePath, RoaringBitmapArray bitmap) {
+    Objects.requireNonNull(filePath, "filePath is null");
+    Objects.requireNonNull(bitmap, "bitmap is null");
+    writePayload(engine, filePath, bitmap.serializeAsByteArray());
+  }
+
+  /**
+   * Writes the bitmap to a fresh UUID-named {@code .bin} file under {@code tableRootPath} and emits
+   * a <b>path-based</b> ({@code "p"}) descriptor whose {@code pathOrInlineDv} is the absolute URI
+   * of the file. We avoid the UUID ({@code "u"}) variant for new writes -- path descriptors
+   * round-trip without any UUID encoding/prefix handling on the reader side -- but {@link #read}
+   * still accepts UUID descriptors via {@link DeletionVectorDescriptor#getAbsolutePath} for interop
+   * with files written by other engines.
+   */
+  @Override
+  public DeletionVectorDescriptor store(
+      Engine engine, String tableRootPath, RoaringBitmapArray bitmap) {
+    Objects.requireNonNull(tableRootPath, "tableRootPath is null");
+    Objects.requireNonNull(bitmap, "bitmap is null");
+
+    String filePath =
+        joinPath(tableRootPath, String.format(DV_FILE_NAME_TEMPLATE, UUID.randomUUID()));
+    // Serialize exactly once -- both the file write and the descriptor's sizeInBytes need the
+    // payload, and we want them guaranteed-consistent.
+    byte[] payload = bitmap.serializeAsByteArray();
+    writePayload(engine, filePath, payload);
+
+    return new DeletionVectorDescriptor(
+        DeletionVectorDescriptor.PATH_DV_MARKER,
+        filePath,
+        Optional.of(DV_PAYLOAD_OFFSET_IN_FILE),
+        payload.length,
+        bitmap.cardinality());
+  }
+
+  /**
+   * Reads the single deletion vector from {@code filePath}, starting at the beginning of the file.
+   *
+   * <p>Only single-DV files are supported: the file must consist of exactly {@code
+   * [version][length BE][payload][crc32 BE]} and nothing more. If the file is longer than one DV
+   * (e.g. a delta-spark bin-packed file holding multiple DVs), this throws rather than returning a
+   * truncated or wrong result. See the class Javadoc for the multi-DV limitation.
+   */
+  @Override
+  public RoaringBitmapArray read(Engine engine, String filePath) {
+    Objects.requireNonNull(filePath, "filePath is null");
+    FileIO fileIO = fileIOFromEngine(engine);
+    try {
+      long size = fileIO.getFileStatus(filePath).getSize();
+      InputFile inputFile = fileIO.newInputFile(filePath, size);
+      try (SeekableInputStream rawIn = inputFile.newStream();
+          DataInputStream in = new DataInputStream(rawIn)) {
+        byte version = in.readByte();
+        if (version != DV_FILE_FORMAT_VERSION_ID_V1) {
+          throw new IOException(
+              "Unexpected DV file format version "
+                  + version
+                  + " (expected "
+                  + DV_FILE_FORMAT_VERSION_ID_V1
+                  + ") in "
+                  + filePath);
+        }
+        int length = in.readInt();
+        if (length < 0) {
+          throw new IOException("Negative DV payload length " + length + " in " + filePath);
+        }
+        // Enforce the single-DV-per-file contract: a lone DV occupies exactly
+        // [1 version][4 length][length payload][4 crc] bytes. A larger file means it holds more
+        // than one DV (e.g. a delta-spark bin-packed file), which this reader does not support --
+        // fail loudly instead of silently returning only the first DV.
+        long expectedSize = 1L /* version */ + 4L /* length */ + (long) length + 4L /* crc */;
+        if (size != expectedSize) {
+          throw new IOException(
+              "BinDVAccess supports only single-DV files, but "
+                  + filePath
+                  + " has size "
+                  + size
+                  + " (expected "
+                  + expectedSize
+                  + " for a single DV with payload length "
+                  + length
+                  + "); bin-packed multi-DV files are not supported");
+        }
+        byte[] data = new byte[length];
+        in.readFully(data);
+        int storedChecksum = in.readInt();
+        int computedChecksum = crc32(data);
+        if (storedChecksum != computedChecksum) {
+          throw new IOException(
+              "DV checksum mismatch in "
+                  + filePath
+                  + " (stored="
+                  + storedChecksum
+                  + ", computed="
+                  + computedChecksum
+                  + ")");
+        }
+        return RoaringBitmapArray.readFrom(data);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read DV file: " + filePath, e);
+    }
+  }
+
+  /**
+   * Write {@code payload} (a pre-serialized {@link RoaringBitmapArray}) to {@code filePath} wrapped
+   * in the BIN framing. Shared by {@link #write} and {@link #store} so the file layout lives in
+   * exactly one place.
+   */
+  private static void writePayload(Engine engine, String filePath, byte[] payload) {
+    int checksum = crc32(payload);
+    FileIO fileIO = fileIOFromEngine(engine);
+    OutputFile outputFile = fileIO.newOutputFile(filePath);
+    // Only the DataOutputStream goes in try-with-resources. Hadoop's putIfAbsent OutputFile wraps
+    // a temp-write + rename-on-close pattern that is NOT idempotent -- closing the
+    // PositionOutputStream a second time would re-attempt the rename and fail.
+    try (DataOutputStream out = new DataOutputStream(outputFile.create(/* putIfAbsent */ true))) {
+      out.writeByte(DV_FILE_FORMAT_VERSION_ID_V1);
+      out.writeInt(payload.length);
+      out.write(payload);
+      out.writeInt(checksum);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to write DV file: " + filePath, e);
+    }
+  }
+
+  private static String joinPath(String base, String name) {
+    return base.endsWith("/") ? base + name : base + "/" + name;
+  }
+}

--- a/flink/src/main/java/io/delta/flink/kernel/dv/DVAccess.java
+++ b/flink/src/main/java/io/delta/flink/kernel/dv/DVAccess.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.kernel.dv;
+
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.defaults.engine.fileio.FileIO;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import java.lang.reflect.Field;
+import java.util.zip.CRC32;
+
+/** Base for deletion-vector file-format implementations. */
+public abstract class DVAccess {
+
+  public abstract void write(Engine engine, String filePath, RoaringBitmapArray bitmap);
+
+  public abstract RoaringBitmapArray read(Engine engine, String filePath);
+
+  /**
+   * Write {@code bitmap} to a freshly-named DV file under {@code tableRootPath} and return a {@link
+   * DeletionVectorDescriptor} suitable for attaching to an {@code AddFile}. Encapsulates everything
+   * format-specific -- file naming, in-file offset, base85 encoding -- so callers don't have to
+   * track those details when the DV layout changes.
+   *
+   * @param engine Kernel engine providing file-system access.
+   * @param tableRootPath the table data path (e.g. {@code file:///...}); the DV file is placed
+   *     directly under this path with an implementation-chosen name.
+   * @param bitmap deletion vector to write.
+   * @return a descriptor whose {@link DeletionVectorDescriptor#getAbsolutePath(String) absolute
+   *     path} (passed the same {@code tableRootPath}) resolves to the file just written.
+   */
+  public abstract DeletionVectorDescriptor store(
+      Engine engine, String tableRootPath, RoaringBitmapArray bitmap);
+
+  /** Reflective handle on the private {@code DefaultEngine.fileIO}; resolved once at class load. */
+  private static final Field DEFAULT_ENGINE_FILE_IO_FIELD;
+
+  static {
+    try {
+      DEFAULT_ENGINE_FILE_IO_FIELD = DefaultEngine.class.getDeclaredField("fileIO");
+      DEFAULT_ENGINE_FILE_IO_FIELD.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      throw new ExceptionInInitializerError(
+          "DefaultEngine.fileIO field not found; Kernel API drift?");
+    }
+  }
+
+  protected static FileIO fileIOFromEngine(Engine engine) {
+    if (!(engine instanceof DefaultEngine)) {
+      throw new IllegalArgumentException(
+          "DVAccess currently requires a DefaultEngine instance; got "
+              + (engine == null ? "null" : engine.getClass().getName()));
+    }
+    try {
+      return (FileIO) DEFAULT_ENGINE_FILE_IO_FIELD.get(engine);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Failed to read DefaultEngine.fileIO via reflection", e);
+    }
+  }
+
+  protected static int crc32(byte[] data) {
+    CRC32 crc = new CRC32();
+    crc.update(data);
+    return (int) crc.getValue();
+  }
+}

--- a/flink/src/main/java/io/delta/flink/kernel/dv/RoaringBitmapArray.java
+++ b/flink/src/main/java/io/delta/flink/kernel/dv/RoaringBitmapArray.java
@@ -19,9 +19,9 @@ package io.delta.flink.kernel.dv;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Collection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import org.roaringbitmap.RoaringBitmap;
 
 /** Ported from {@code org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray}. */

--- a/flink/src/main/java/io/delta/flink/kernel/dv/RoaringBitmapArray.java
+++ b/flink/src/main/java/io/delta/flink/kernel/dv/RoaringBitmapArray.java
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.kernel.dv;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.roaringbitmap.RoaringBitmap;
+
+/** Ported from {@code org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray}. */
+public final class RoaringBitmapArray {
+
+  /** Magic number for the Portable serialization format (the only format we read/write). */
+  static final int PORTABLE_MAGIC_NUMBER = 1681511377;
+
+  /** The largest value a {@link RoaringBitmapArray} can possibly represent. */
+  public static final long MAX_REPRESENTABLE_VALUE =
+      composeFromHighLowBytes(Integer.MAX_VALUE - 1, Integer.MIN_VALUE);
+
+  private RoaringBitmap[] bitmaps = new RoaringBitmap[0];
+
+  public static RoaringBitmapArray create(long... values) {
+    RoaringBitmapArray bitmap = new RoaringBitmapArray();
+    bitmap.addAll(values);
+    return bitmap;
+  }
+
+  public static RoaringBitmapArray readFrom(byte[] bytes) throws IOException {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+    RoaringBitmapArray bitmap = new RoaringBitmapArray();
+    bitmap.deserialize(buffer);
+    return bitmap;
+  }
+
+  public void add(long value) {
+    requireRepresentable(value);
+    int high = highBytes(value);
+    int low = lowBytes(value);
+    if (high >= bitmaps.length) {
+      extendBitmaps(high + 1);
+    }
+    bitmaps[high].add(low);
+  }
+
+  public void addAll(long... values) {
+    for (long v : values) {
+      add(v);
+    }
+  }
+
+  /** Convenience overload for {@link Integer} collections (callers using {@code Set<Integer>}). */
+  public void addAll(Collection<Integer> values) {
+    for (Integer v : values) {
+      add(v.longValue());
+    }
+  }
+
+  public boolean contains(long value) {
+    requireRepresentable(value);
+    int high = highBytes(value);
+    if (high >= bitmaps.length) {
+      return false;
+    }
+    return bitmaps[high].contains(lowBytes(value));
+  }
+
+  public long cardinality() {
+    long total = 0L;
+    for (RoaringBitmap bitmap : bitmaps) {
+      total += bitmap.getLongCardinality();
+    }
+    return total;
+  }
+
+  public boolean isEmpty() {
+    for (RoaringBitmap bitmap : bitmaps) {
+      if (!bitmap.isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** In-place union: {@code this |= other}. */
+  public void merge(RoaringBitmapArray other) {
+    if (this.bitmaps.length < other.bitmaps.length) {
+      extendBitmaps(other.bitmaps.length);
+    }
+    for (int i = 0; i < other.bitmaps.length; i++) {
+      this.bitmaps[i].or(other.bitmaps[i]);
+    }
+  }
+
+  /** Materialize the set as a sorted {@code long[]}. */
+  public long[] toArray() {
+    long cardinality = cardinality();
+    if (cardinality > Integer.MAX_VALUE) {
+      throw new IllegalStateException(
+          "Cardinality " + cardinality + " exceeds Integer.MAX_VALUE; cannot materialize toArray");
+    }
+    long[] values = new long[(int) cardinality];
+    int[] cursor = new int[] {0};
+    for (int high = 0; high < bitmaps.length; high++) {
+      final long composed = ((long) high) << 32;
+      bitmaps[high].forEach(
+          (org.roaringbitmap.IntConsumer)
+              low -> values[cursor[0]++] = composed | toUnsignedLong(low));
+    }
+    return values;
+  }
+
+  /**
+   * Serialize this bitmap to a freshly-allocated byte array using the Portable format. Layout:
+   *
+   * <pre>
+   *   [4 LE]  magic = PORTABLE_MAGIC_NUMBER
+   *   [8 LE]  number of inner bitmaps
+   *   for each inner bitmap (index = high 32-bit key):
+   *     [4 LE] key
+   *     [..]   RoaringBitmap.serialize output
+   * </pre>
+   */
+  public byte[] serializeAsByteArray() {
+    long size = 4L /* magic */ + 8L /* count */;
+    for (RoaringBitmap b : bitmaps) {
+      size += 4L /* key */ + b.serializedSizeInBytes();
+    }
+    if (size > Integer.MAX_VALUE) {
+      throw new IllegalStateException(
+          "Bitmap too big to serialize into a single byte[] (" + size + " bytes)");
+    }
+    ByteBuffer buffer = ByteBuffer.allocate((int) size).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putInt(PORTABLE_MAGIC_NUMBER);
+    buffer.putLong((long) bitmaps.length);
+    for (int i = 0; i < bitmaps.length; i++) {
+      buffer.putInt(i);
+      bitmaps[i].serialize(buffer);
+    }
+    return buffer.array();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof RoaringBitmapArray)) {
+      return false;
+    }
+    return Arrays.deepEquals(this.bitmaps, ((RoaringBitmapArray) other).bitmaps);
+  }
+
+  @Override
+  public int hashCode() {
+    return 131 * Arrays.deepHashCode(bitmaps);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Internal: Portable-format deserialization. Native is intentionally not supported -- Spark
+  // emits Portable for every DV write, so any file we read came through that path.
+  // ---------------------------------------------------------------------------------------------
+
+  private void deserialize(ByteBuffer buffer) throws IOException {
+    if (buffer.order() != ByteOrder.LITTLE_ENDIAN) {
+      throw new IllegalArgumentException(
+          "RoaringBitmapArray must be deserialized using a little-endian buffer");
+    }
+    int magic = buffer.getInt();
+    if (magic != PORTABLE_MAGIC_NUMBER) {
+      throw new IOException(
+          "Unsupported RoaringBitmapArray magic number "
+              + magic
+              + " (expected "
+              + PORTABLE_MAGIC_NUMBER
+              + "); only the Portable format is supported");
+    }
+    long numberOfBitmaps = buffer.getLong();
+    if (numberOfBitmaps < 0L || numberOfBitmaps > Integer.MAX_VALUE) {
+      throw new IOException("Invalid RoaringBitmapArray length: " + numberOfBitmaps);
+    }
+    // Portable allows sparse keys; numberOfBitmaps is only a lower bound on the array size.
+    ArrayList<RoaringBitmap> out = new ArrayList<>((int) numberOfBitmaps);
+    int lastIndex = 0;
+    for (long i = 0; i < numberOfBitmaps; i++) {
+      int key = buffer.getInt();
+      if (key < 0) {
+        throw new IOException("Invalid unsigned entry in RoaringBitmapArray: " + key);
+      }
+      if (key < lastIndex) {
+        throw new IOException(
+            "RoaringBitmapArray keys must be ascending; got " + key + " after " + lastIndex);
+      }
+      while (lastIndex < key) {
+        out.add(new RoaringBitmap());
+        lastIndex++;
+      }
+      RoaringBitmap bitmap = new RoaringBitmap();
+      bitmap.deserialize(buffer);
+      out.add(bitmap);
+      lastIndex++;
+      // RoaringBitmap.deserialize does not advance the buffer's position.
+      buffer.position(buffer.position() + bitmap.serializedSizeInBytes());
+    }
+    bitmaps = out.toArray(new RoaringBitmap[0]);
+  }
+
+  private void extendBitmaps(int newLength) {
+    if (bitmaps.length == 0 && newLength == 1) {
+      bitmaps = new RoaringBitmap[] {new RoaringBitmap()};
+      return;
+    }
+    RoaringBitmap[] newBitmaps = new RoaringBitmap[newLength];
+    System.arraycopy(bitmaps, 0, newBitmaps, 0, bitmaps.length);
+    for (int i = bitmaps.length; i < newLength; i++) {
+      newBitmaps[i] = new RoaringBitmap();
+    }
+    bitmaps = newBitmaps;
+  }
+
+  private static int highBytes(long value) {
+    return (int) (value >> 32);
+  }
+
+  private static int lowBytes(long value) {
+    return (int) value;
+  }
+
+  private static long composeFromHighLowBytes(int high, int low) {
+    return (((long) high) << 32) | toUnsignedLong(low);
+  }
+
+  private static long toUnsignedLong(int v) {
+    return ((long) v) & 0xFFFFFFFFL;
+  }
+
+  private static void requireRepresentable(long value) {
+    if (value < 0 || value > MAX_REPRESENTABLE_VALUE) {
+      throw new IllegalArgumentException(
+          "Value out of range: "
+              + value
+              + " (must be 0 <= v <= MAX_REPRESENTABLE_VALUE="
+              + MAX_REPRESENTABLE_VALUE
+              + ")");
+    }
+  }
+}

--- a/flink/src/test/java/io/delta/flink/kernel/dv/BinDVAccessTest.java
+++ b/flink/src/test/java/io/delta/flink/kernel/dv/BinDVAccessTest.java
@@ -1,0 +1,211 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.kernel.dv;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.delta.flink.TestHelper;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.file.NoSuchFileException;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trip + edge-case tests for {@link BinDVAccess}.
+ *
+ * <p>{@link BinDVAccess} no longer carries its own Hadoop {@code Configuration}; the {@link Engine}
+ * we pass in wires up the Hadoop-backed {@code FileIO} for both write and read paths.
+ */
+class BinDVAccessTest extends TestHelper {
+
+  @Test
+  void testRoundTripEmptyBitmap() {
+    withTempDir(
+        dir -> {
+          BinDVAccess store = new BinDVAccess();
+          Engine engine = DefaultEngine.create(new Configuration());
+          String filePath = pathIn(dir, "empty.bin");
+
+          RoaringBitmapArray original = new RoaringBitmapArray();
+          store.write(engine, filePath, original);
+
+          RoaringBitmapArray restored = store.read(engine, filePath);
+          assertArrayEquals(original.toArray(), restored.toArray());
+        });
+  }
+
+  @Test
+  void testRoundTripDenseLowKeyBitmap() {
+    withTempDir(
+        dir -> {
+          BinDVAccess store = new BinDVAccess();
+          Engine engine = DefaultEngine.create(new Configuration());
+          String filePath = pathIn(dir, "dense.bin");
+
+          // Single high-32-bit key (= 0); covers the dominant DV case where row ordinals fit in a
+          // single 32-bit RoaringBitmap.
+          RoaringBitmapArray original = new RoaringBitmapArray();
+          for (long v = 0; v < 100_000; v += 7) {
+            original.add(v);
+          }
+          store.write(engine, filePath, original);
+
+          RoaringBitmapArray restored = store.read(engine, filePath);
+          assertArrayEquals(original.toArray(), restored.toArray());
+        });
+  }
+
+  @Test
+  void testRoundTripSparseAcrossHighKeys() {
+    withTempDir(
+        dir -> {
+          BinDVAccess store = new BinDVAccess();
+          Engine engine = DefaultEngine.create(new Configuration());
+          String filePath = pathIn(dir, "sparse.bin");
+
+          // Values across several distinct high-32-bit keys; exercises the per-key encoding loop.
+          RoaringBitmapArray original =
+              RoaringBitmapArray.create(
+                  0L, 7L, (1L << 32) + 13L, (5L << 32), (5L << 32) + 1L, (100L << 32) + 999_999L);
+          store.write(engine, filePath, original);
+
+          RoaringBitmapArray restored = store.read(engine, filePath);
+          assertArrayEquals(original.toArray(), restored.toArray());
+        });
+  }
+
+  @Test
+  void testReadMissingFileThrows() {
+    withTempDir(
+        dir -> {
+          BinDVAccess store = new BinDVAccess();
+          Engine engine = DefaultEngine.create(new Configuration());
+          String filePath = pathIn(dir, "does-not-exist.bin");
+
+          // FileIO.getFileStatus raises FileNotFoundException; HadoopFileIO's underlying
+          // FileSystem may surface it as java.nio.file.NoSuchFileException OR
+          // java.io.FileNotFoundException depending on the FS impl, so we walk the cause chain
+          // for either marker.
+          RuntimeException ex =
+              assertThrows(RuntimeException.class, () -> store.read(engine, filePath));
+          assertCauseMatches(
+              ex,
+              t -> t instanceof NoSuchFileException || t instanceof java.io.FileNotFoundException);
+        });
+  }
+
+  @Test
+  void testReadDetectsCorruptedChecksum() {
+    withTempDir(
+        dir -> {
+          BinDVAccess store = new BinDVAccess();
+          Engine engine = DefaultEngine.create(new Configuration());
+          String filePath = pathIn(dir, "corrupt.bin");
+
+          RoaringBitmapArray bitmap = RoaringBitmapArray.create(10L, 20L, 30L);
+          store.write(engine, filePath, bitmap);
+
+          // Flip the last byte (part of the CRC32 trailer); the reader must reject the file.
+          File diskFile = new File(dir, "corrupt.bin");
+          try (RandomAccessFile raf = new RandomAccessFile(diskFile, "rw")) {
+            long size = raf.length();
+            raf.seek(size - 1);
+            int b = raf.read();
+            raf.seek(size - 1);
+            raf.write(b ^ 0x01);
+          }
+
+          RuntimeException ex =
+              assertThrows(RuntimeException.class, () -> store.read(engine, filePath));
+          assertContainsIgnoringWrappers(ex, "checksum");
+        });
+  }
+
+  @Test
+  void testReadDetectsBadVersionByte() {
+    withTempDir(
+        dir -> {
+          BinDVAccess store = new BinDVAccess();
+          Engine engine = DefaultEngine.create(new Configuration());
+          String filePath = pathIn(dir, "badversion.bin");
+
+          store.write(engine, filePath, RoaringBitmapArray.create(1L));
+
+          File diskFile = new File(dir, "badversion.bin");
+          try (RandomAccessFile raf = new RandomAccessFile(diskFile, "rw")) {
+            raf.seek(0);
+            raf.write(0x09);
+          }
+
+          RuntimeException ex =
+              assertThrows(RuntimeException.class, () -> store.read(engine, filePath));
+          assertContainsIgnoringWrappers(ex, "version");
+        });
+  }
+
+  @Test
+  void testWriteUsesPortableMagic() {
+    // The serialized payload must start with the Portable magic number, so we catch accidental
+    // format drift away from Spark/Kernel interop.
+    byte[] payload = RoaringBitmapArray.create(1L, 2L, 3L).serializeAsByteArray();
+    int magic =
+        (payload[0] & 0xFF)
+            | ((payload[1] & 0xFF) << 8)
+            | ((payload[2] & 0xFF) << 16)
+            | ((payload[3] & 0xFF) << 24);
+    assertEquals(RoaringBitmapArray.PORTABLE_MAGIC_NUMBER, magic);
+  }
+
+  // ----------------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------------
+
+  private static String pathIn(File dir, String name) {
+    return new File(dir, name).toURI().toString();
+  }
+
+  /** Walk an exception's cause chain looking for one that matches {@code predicate}. */
+  private static void assertCauseMatches(
+      Throwable actual, java.util.function.Predicate<Throwable> predicate) {
+    Throwable cur = actual;
+    while (cur != null) {
+      if (predicate.test(cur)) {
+        return;
+      }
+      cur = cur.getCause();
+    }
+    throw new AssertionError("No matching cause in chain", actual);
+  }
+
+  private static void assertContainsIgnoringWrappers(Throwable actual, String needle) {
+    Throwable cur = actual;
+    while (cur != null) {
+      String msg = cur.getMessage();
+      if (msg != null && msg.toLowerCase().contains(needle.toLowerCase())) {
+        return;
+      }
+      cur = cur.getCause();
+    }
+    throw new AssertionError(
+        "Expected exception message containing '" + needle + "' but got chain: " + actual);
+  }
+}

--- a/flink/src/test/java/io/delta/flink/kernel/dv/BinDVAccessTest.java
+++ b/flink/src/test/java/io/delta/flink/kernel/dv/BinDVAccessTest.java
@@ -19,13 +19,16 @@ package io.delta.flink.kernel.dv;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.flink.TestHelper;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.file.NoSuchFileException;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
@@ -159,6 +162,32 @@ class BinDVAccessTest extends TestHelper {
           RuntimeException ex =
               assertThrows(RuntimeException.class, () -> store.read(engine, filePath));
           assertContainsIgnoringWrappers(ex, "version");
+        });
+  }
+
+  @Test
+  void testStoreDescriptorContract() {
+    withTempDir(
+        dir -> {
+          BinDVAccess store = new BinDVAccess();
+          Engine engine = DefaultEngine.create(new Configuration());
+          String tableRootPath = dir.toURI().toString();
+
+          RoaringBitmapArray bitmap = RoaringBitmapArray.create(1L, 2L, 100L, (1L << 32) + 7L);
+          byte[] expectedPayload = bitmap.serializeAsByteArray();
+
+          DeletionVectorDescriptor desc = store.store(engine, tableRootPath, bitmap);
+
+          assertEquals(DeletionVectorDescriptor.PATH_DV_MARKER, desc.getStorageType());
+          assertTrue(desc.getPathOrInlineDv().contains("dv_flink_"));
+          assertTrue(desc.getPathOrInlineDv().endsWith(".bin"));
+          assertEquals(Optional.of(BinDVAccess.DV_PAYLOAD_OFFSET_IN_FILE), desc.getOffset());
+          assertEquals(expectedPayload.length, desc.getSizeInBytes());
+          assertEquals(bitmap.cardinality(), desc.getCardinality());
+
+          // File written by store() is readable via the descriptor's path.
+          RoaringBitmapArray restored = store.read(engine, desc.getPathOrInlineDv());
+          assertArrayEquals(bitmap.toArray(), restored.toArray());
         });
   }
 

--- a/flink/src/test/java/io/delta/flink/kernel/dv/RoaringBitmapArrayTest.java
+++ b/flink/src/test/java/io/delta/flink/kernel/dv/RoaringBitmapArrayTest.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.kernel.dv;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link RoaringBitmapArray}. */
+class RoaringBitmapArrayTest {
+
+  @Test
+  void testEmptyBitmap() {
+    RoaringBitmapArray rb = new RoaringBitmapArray();
+    assertTrue(rb.isEmpty());
+    assertEquals(0L, rb.cardinality());
+    assertArrayEquals(new long[0], rb.toArray());
+    assertFalse(rb.contains(0L));
+  }
+
+  @Test
+  void testAddAndContains() {
+    RoaringBitmapArray rb = RoaringBitmapArray.create(1L, 5L, 100L, (1L << 32) + 7L);
+    assertTrue(rb.contains(1L));
+    assertTrue(rb.contains(5L));
+    assertTrue(rb.contains(100L));
+    assertTrue(rb.contains((1L << 32) + 7L));
+    assertFalse(rb.contains(0L));
+    assertFalse(rb.contains((1L << 32))); // adjacent but absent
+    assertEquals(4L, rb.cardinality());
+    assertFalse(rb.isEmpty());
+  }
+
+  @Test
+  void testAddRejectsNegative() {
+    RoaringBitmapArray rb = new RoaringBitmapArray();
+    assertThrows(IllegalArgumentException.class, () -> rb.add(-1L));
+  }
+
+  @Test
+  void testToArrayIsSortedAscending() {
+    RoaringBitmapArray rb =
+        RoaringBitmapArray.create(
+            (5L << 32) + 1L, 0L, (1L << 32) + 13L, 7L, (100L << 32) + 999_999L, (5L << 32));
+    assertArrayEquals(
+        new long[] {0L, 7L, (1L << 32) + 13L, (5L << 32), (5L << 32) + 1L, (100L << 32) + 999_999L},
+        rb.toArray());
+  }
+
+  @Test
+  void testMergeIsUnion() {
+    RoaringBitmapArray a = RoaringBitmapArray.create(1L, 2L, 3L);
+    RoaringBitmapArray b = RoaringBitmapArray.create(2L, 3L, 4L);
+    a.merge(b);
+    assertArrayEquals(new long[] {1L, 2L, 3L, 4L}, a.toArray());
+  }
+
+  @Test
+  void testMergeExtendsHighKeys() {
+    RoaringBitmapArray a = RoaringBitmapArray.create(1L);
+    RoaringBitmapArray b = RoaringBitmapArray.create((3L << 32) + 5L);
+    a.merge(b);
+    assertArrayEquals(new long[] {1L, (3L << 32) + 5L}, a.toArray());
+  }
+
+  @Test
+  void testEquality() {
+    RoaringBitmapArray a = RoaringBitmapArray.create(1L, 5L, 100L);
+    RoaringBitmapArray b = RoaringBitmapArray.create(100L, 1L, 5L);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+
+    RoaringBitmapArray c = RoaringBitmapArray.create(1L, 5L, 101L);
+    assertNotEquals(a, c);
+  }
+
+  @Test
+  void testSerializationRoundTrip() throws Exception {
+    RoaringBitmapArray original =
+        RoaringBitmapArray.create(
+            0L, 7L, (1L << 32) + 13L, (5L << 32), (5L << 32) + 1L, (100L << 32) + 999_999L);
+    byte[] payload = original.serializeAsByteArray();
+    RoaringBitmapArray restored = RoaringBitmapArray.readFrom(payload);
+    assertArrayEquals(original.toArray(), restored.toArray());
+    assertEquals(original, restored);
+  }
+
+  @Test
+  void testEmptyBitmapRoundTrip() throws Exception {
+    RoaringBitmapArray original = new RoaringBitmapArray();
+    RoaringBitmapArray restored = RoaringBitmapArray.readFrom(original.serializeAsByteArray());
+    assertEquals(original, restored);
+    assertTrue(restored.isEmpty());
+  }
+
+  @Test
+  void testPortableMagicNumberMatchesSpec() {
+    // Locked in against accidental drift -- delta-spark and delta-kernel both hard-code this.
+    assertEquals(1681511377, RoaringBitmapArray.PORTABLE_MAGIC_NUMBER);
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

First step toward deletion-vector (DV) support in the Flink connector. Adds the read/write/merge primitives under `io.delta.flink.kernel.dv`:

- `DVAccess` (abstract): two-method contract (`write(Engine, path, RoaringBitmapArray)`, `read(Engine, path) -> RoaringBitmapArray`) plus a shared CRC32 helper and a reflective `FileIO` accessor (Kernel's public `Engine` interface does not expose `FileIO`; we hand-roll a one-shot `DefaultEngine.fileIO` field lookup, cached once at class load).
- `BinDVAccess`: implements the contract for Delta's plain `.bin` framing (`[version][length BE][payload][crc32 BE]`). Ported from `org.apache.spark.sql.delta.storage.dv.DeletionVectorStore`.
- `PuffinDVAccess`: stub for the Puffin-wrapped DV format; throws today, slated for a follow-up.
- `RoaringBitmapArray`: minimal Java port of `org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray`, trimmed to the surface this connector actually needs (`add`/`addAll`, `contains`, `cardinality`, `isEmpty`, `merge`, `toArray`, `serializeAsByteArray`, static `readFrom`, plus `equals`/`hashCode`). Only the Portable serialization format is supported -- delta-spark writes Portable in all 8 production+test call sites we checked, so the Native format would be dead code here.

Part of #5901.

## How was this patch tested?

- `BinDVAccessTest` -- round-trip + edge cases (empty bitmap, dense/sparse keys, `putIfAbsent` rejection, missing file, corrupted checksum, bad version byte, Portable magic byte assertion).
- `RoaringBitmapArrayTest` -- add/contains, sorted `toArray`, merge as union, equality, serialization round-trip, magic-number constant lock.
- `build/sbt \"flink/Test/compile\"` and `build/sbt \"flink/Compile/doc\"` to be validated on CI.

## Does this PR introduce _any_ user-facing changes?

No new public API surface for the connector yet -- everything lands in the `io.delta.flink.kernel.dv` package. Future PRs will wire these primitives into the writer's merge path.