### PR TITLE
[Protocol] Specify VOID column behavior

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2732,9 +2732,11 @@ See Parquet [timestamp type](https://github.com/apache/parquet-format/blob/maste
 
 #### Void Type
 
-On write, `void` columns are omitted from data files: they do not appear in the data file's schema. On read, they are reconstructed as all-`null` columns, following the [rule](#consistency-between-table-metadata-and-data-files) that columns present in the table schema but missing from a data file are read as `null`.
+_Note: `void` was never deliberately designed as a Delta feature; the Spark connector has produced such columns for a long time without it being specified here. This section documents that pre-existing behavior post-facto, rather than introducing it through the usual RFC process. Because such columns already exist in tables written by earlier clients, `void` is not gated by any table feature and applies to all tables._
 
-Because `void` is never written to data files, writers must reject **writing data** to a table whose schema contains any of the following shapes:
+On write, writers MUST omit `void` columns from data files; they do not appear in the data file's schema. On read, readers MUST reconstruct them as all-`null` columns, consistent with the [rule](#consistency-between-table-metadata-and-data-files) that columns present in the table schema but missing from a data file are read as `null`.
+
+Because `void` is never written to data files, writers MUST reject **writing data** to a table whose schema contains any of the following shapes:
 - a `void` type inside an `array` or `map` at any nesting level;
 - a `struct` (at any nesting level) whose fields are all `void`; or
 - a table whose columns are all `void`.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -123,6 +123,7 @@
   - [Partition Value Serialization](#partition-value-serialization)
   - [Schema Serialization Format](#schema-serialization-format)
     - [Primitive Types](#primitive-types)
+      - [Void Type](#void-type)
     - [Struct Type](#struct-type)
     - [Struct Field](#struct-field)
     - [Array Type](#array-type)
@@ -2006,6 +2007,8 @@ The supported type changes are:
   - `Byte`, `Short` or `Int` -> `Decimal(10 + k1, k2)` where `k1 >= k2 >= 0`.
   - `Long` -> `Decimal(20 + k1, k2)` where `k1 >= k2 >= 0`.
 
+Note: changing a `void` column to another type does not require the Type Widening feature; see [Void Type](#void-type).
+
 To support this feature:
 - The table must be on Reader version 3 and Writer Version 7.
 - The feature `typeWidening` must exist in the table `protocol`'s `readerFeatures` and `writerFeatures`, either during its creation or at a later stage.
@@ -2729,14 +2732,14 @@ See Parquet [timestamp type](https://github.com/apache/parquet-format/blob/maste
 
 #### Void Type
 
-On write, `void` columns are stripped from the physical Parquet schema; on read, they are reconstructed as all-`null` columns, following the [rule](#consistency-between-table-metadata-and-data-files) that columns present in the table schema but missing from a data file are read as `null`.
+On write, `void` columns are omitted from data files: they do not appear in the data file's schema. On read, they are reconstructed as all-`null` columns, following the [rule](#consistency-between-table-metadata-and-data-files) that columns present in the table schema but missing from a data file are read as `null`.
 
-Because `void` is never written to data files, writers must reject any attempt to **write data** in the following cases:
-- a `void` type nested anywhere inside an `array` or `map`;
-- a `struct` all of whose fields are of `void` type (a struct that would have no physical columns); or
-- a table all of whose columns are of `void` type (a table that would have no physical columns).
+Because `void` is never written to data files, writers must reject **writing data** to a table whose schema contains any of the following shapes:
+- a `void` type inside an `array` or `map` at any nesting level;
+- a `struct` (at any nesting level) whose fields are all `void`; or
+- a table whose columns are all `void`.
 
-These restrictions apply only to writing data; reads and metadata-only operations on such tables remain allowed. For example, a table consisting only of `void` columns can be created and read from, and then made writable by adding a non-`void` column or by changing a `void` column to another type.
+These restrictions are stated in terms of the **table schema**, not the schema of any individual data file. A table with such a schema can still be created, altered through metadata-only operations, and read. In particular, a table covered by these restrictions can be made writable by evolving its schema - for example, by changing a `void` column to another type.
 
 A `void` column may be changed to any other data type through supported schema-evolution operations; this does not require the [Type Widening](#type-widening) table feature.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2723,10 +2723,22 @@ binary| A sequence of binary data.
 date| A calendar date, represented as a year-month-day triple without a timezone.
 timestamp| Microsecond precision timestamp elapsed since the Unix epoch, 1970-01-01 00:00:00 UTC. When this is stored in a parquet file, its `isAdjustedToUTC` must be set to `true`.
 timestamp without time zone | Microsecond precision timestamp in a local timezone elapsed since the Unix epoch, 1970-01-01 00:00:00. It doesn't have the timezone information, and a value of this type can map to multiple physical time instants. It should always be displayed in the same way, regardless of the local time zone in effect. When this is stored in a parquet file, its `isAdjustedToUTC` must be set to `false`. To use this type, a table must support a feature `timestampNtz`. See section [Timestamp without timezone (TimestampNtz)](#timestamp-without-timezone-timestampNtz) for more information.
+void| A column that contains only `null` values and is never materialized in data files. See section [Void Type](#void-type) for more information.
 
 See Parquet [timestamp type](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp) for more details about timestamp and `isAdjustedToUTC`.
 
-Note: Existing tables may have `void` data type columns. Behavior is undefined for `void` data type columns but it is recommended to drop any `void` data type columns on reads (as is implemented by the Spark connector).
+#### Void Type
+
+On write, `void` columns are stripped from the physical Parquet schema; on read, they are reconstructed as all-`null` columns, following the [rule](#consistency-between-table-metadata-and-data-files) that columns present in the table schema but missing from a data file are read as `null`.
+
+Because `void` is never written to data files, writers must reject any attempt to **write data** in the following cases:
+- a `void` type nested anywhere inside an `array` or `map`;
+- a `struct` all of whose fields are of `void` type (a struct that would have no physical columns); or
+- a table all of whose columns are of `void` type (a table that would have no physical columns).
+
+These restrictions apply only to writing data; reads and metadata-only operations on such tables remain allowed. For example, a table consisting only of `void` columns can be created and read from, and then made writable by adding a non-`void` column or by changing a `void` column to another type.
+
+A `void` column may be changed to any other data type through supported schema-evolution operations; this does not require the [Type Widening](#type-widening) table feature.
 
 ### Struct Type
 
@@ -3088,3 +3100,5 @@ binary| `binary` |
 array| either as `2-level` or `3-level` representation. Refer to [Parquet documentation](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists) for further details | `LIST`
 map| either as `2-level` or `3-level` representation. Refer to [Parquet documentation](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps) for further details | `MAP`
 struct| `group` |
+
+Note that `void` columns are not stored in Parquet files. See section [Void Type](#void-type).

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2734,9 +2734,11 @@ See Parquet [timestamp type](https://github.com/apache/parquet-format/blob/maste
 
 _Note: `void` was never deliberately designed as a Delta feature; the Spark connector has produced such columns for a long time without it being specified here. This section documents that pre-existing behavior post-facto, rather than introducing it through the usual RFC process. Because such columns already exist in tables written by earlier clients, `void` is not gated by any table feature and applies to all tables._
 
+`void` is a primitive type and can appear both as a top-level column and nested inside complex types.
+
 On write, writers MUST omit `void` columns from data files; they do not appear in the data file's schema. On read, readers MUST reconstruct them as all-`null` columns, consistent with the [rule](#consistency-between-table-metadata-and-data-files) that columns present in the table schema but missing from a data file are read as `null`.
 
-Because `void` is never written to data files, writers MUST reject **writing data** to a table whose schema contains any of the following shapes:
+Because `void` is never written to data files, writers MUST reject operations that **would write new data files** when the table's schema contains any of the following shapes:
 - a `void` type inside an `array` or `map` at any nesting level;
 - a `struct` (at any nesting level) whose fields are all `void`; or
 - a table whose columns are all `void`.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol)

## Description

Define how VOID columns need to be handled in Delta tables in the Protocol, and add it to the list of supported types.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

Yes, the Protocol is changing.