### PR TITLE
[Docs][Spark] Document schema evolution for INSERT operations

### DIFF
--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1838,6 +1838,38 @@ If the query on `source_table` returns columns that don't exist in the target ta
   `WITH SCHEMA EVOLUTION` is available in Delta Lake 4.3 and above.
 </Aside>
 
+#### INSERT with schema evolution using DataFrame API
+
+The following example demonstrates using the `mergeSchema` option with a batch write operation:
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    (spark.read
+      .table("source_table")
+      .write
+      .option("mergeSchema", "true")
+      .mode("append")
+      .saveAsTable("target_table")
+    )
+    ```
+
+  </TabItem>
+  <TabItem label="Scala">
+
+    ```scala
+    spark.read
+      .table("source_table")
+      .write
+      .option("mergeSchema", "true")
+      .mode("append")
+      .saveAsTable("target_table")
+    ```
+
+  </TabItem>
+</Tabs>
+
 #### `NullType` columns
 
 Because Parquet doesn't support `NullType`, `NullType` columns are dropped from the DataFrame when writing into Delta tables, but are still stored in the schema. When a different data type is received for that column, Delta Lake merges the schema to the new data type. If Delta Lake receives a `NullType` for an existing column, the old schema is retained and the new column is dropped during the write.

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1832,7 +1832,7 @@ Include `WITH SCHEMA EVOLUTION` in an `INSERT` statement to enable automatic sch
   </TabItem>
 </Tabs>
 
-If the query on `source_table` returns columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns. The clause is supported for `INSERT INTO` and `INSERT OVERWRITE` statements.
+If the query on `source_table` returns columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns.
 
 <Aside type="note">
   `WITH SCHEMA EVOLUTION` is available in Delta Lake 4.3 and above.

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1819,7 +1819,7 @@ When both the `mergeSchema` option and the Spark configuration are specified, th
 
 #### Schema evolution syntax for INSERT
 
-Include `WITH SCHEMA EVOLUTION` in an `INSERT` statement to enable automatic schema evolution for that operation. When enabled, the schema of the target Delta Lake table is automatically updated to accommodate additional columns or widened types of the source query. For example:
+Include `WITH SCHEMA EVOLUTION` in an `INSERT` statement to enable automatic schema evolution for that operation. When enabled, the schema of the target Delta Lake table is automatically updated to accommodate additional columns or widened types of the source query. For a list of the supported type changes, see [Supported type changes](https://docs.delta.io/delta-type-widening/). For example:
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL" active>

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1809,12 +1809,35 @@ Delta Lake can automatically update the schema of a table as part of a DML trans
 
 #### Add columns
 
-Columns that are present in the DataFrame but missing from the table are automatically added as part of a write transaction when:
+Columns that are present in the source data but missing from the table are automatically added as part of a write transaction when schema evolution is enabled. Enable schema evolution using one of the following methods:
 
-- `write` or `writeStream` have `.option("mergeSchema", "true")`
-- `spark.databricks.delta.schema.autoMerge.enabled` is `true`
+- **Use `INSERT WITH SCHEMA EVOLUTION` syntax**: Works with SQL `INSERT` statements. Include `WITH SCHEMA EVOLUTION` in the SQL syntax.
+- **Use `MERGE WITH SCHEMA EVOLUTION` syntax**: Works with `MERGE` statements. Include `WITH SCHEMA EVOLUTION` in the SQL syntax or use `.withSchemaEvolution()` in the Delta Lake API.
+- **Set the `mergeSchema` option**: Works with batch writes or streaming writes. Set `.option("mergeSchema", "true")` on individual `write` or `writeStream` operations.
+- **Set the Spark configuration (legacy)**: Sets `spark.databricks.delta.schema.autoMerge.enabled` to `true` for the entire `SparkSession`. Not recommended for production use, because session-wide configuration can lead to unintended schema changes across multiple operations.
 
-When both options are specified, the option from the `DataFrameWriter` takes precedence. The added columns are appended to the end of the struct they are present in. Case is preserved when appending a new column.
+When both the `mergeSchema` option and the Spark configuration are specified, the option from the `DataFrameWriter` takes precedence. The added columns are appended to the end of the struct they are present in. Case is preserved when appending a new column.
+
+#### Schema evolution syntax for INSERT
+
+Include `WITH SCHEMA EVOLUTION` in an `INSERT` statement to enable automatic schema evolution for that operation. When enabled, the schema of the target Delta Lake table is automatically updated to accommodate additional columns or widened types of the source query. For example:
+
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    INSERT WITH SCHEMA EVOLUTION INTO target_table
+    SELECT * FROM source_table
+    ```
+
+  </TabItem>
+</Tabs>
+
+If the query on `source_table` returns columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns. The clause is supported for `INSERT INTO`, `INSERT OVERWRITE`, and `INSERT INTO ... REPLACE` statements.
+
+<Aside type="note">
+  `WITH SCHEMA EVOLUTION` is available in Delta Lake 4.3 and above.
+</Aside>
 
 #### `NullType` columns
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1870,6 +1870,45 @@ The following example demonstrates using the `mergeSchema` option with a batch w
   </TabItem>
 </Tabs>
 
+#### Enable schema evolution with Spark configuration (legacy)
+
+You can set the Spark configuration `spark.databricks.delta.schema.autoMerge.enabled` to `true` to enable schema evolution for all write operations in the current `SparkSession`:
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", True)
+    ```
+
+  </TabItem>
+  <TabItem label="Scala">
+
+    ```scala
+    spark.conf.set("spark.databricks.delta.schema.autoMerge.enabled", true)
+    ```
+
+  </TabItem>
+  <TabItem label="SQL">
+
+    ```sql
+    SET spark.databricks.delta.schema.autoMerge.enabled=true
+    ```
+
+  </TabItem>
+</Tabs>
+
+<Aside type="caution" title="Important">
+  This approach is not recommended for production use. Instead, enable schema evolution for each write operation:
+
+  - For `INSERT` and batch/streaming writes, use `.option("mergeSchema", "true")` or `INSERT WITH SCHEMA EVOLUTION`
+  - For `MERGE` statements, use `MERGE WITH SCHEMA EVOLUTION`
+
+  Setting a session-wide configuration can lead to unintended schema changes across multiple operations and makes it harder to reason about which operations evolve the schema.
+</Aside>
+
+When you use options or syntax to enable schema evolution in a write operation, this takes precedence over the Spark configuration.
+
 #### `NullType` columns
 
 Because Parquet doesn't support `NullType`, `NullType` columns are dropped from the DataFrame when writing into Delta tables, but are still stored in the schema. When a different data type is received for that column, Delta Lake merges the schema to the new data type. If Delta Lake receives a `NullType` for an existing column, the old schema is retained and the new column is dropped during the write.

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1809,17 +1809,11 @@ Delta Lake can automatically update the schema of a table as part of a DML trans
 
 #### Add columns
 
-Columns that are present in the source data but missing from the table are automatically added as part of a write transaction when schema evolution is enabled. Enable schema evolution using one of the following methods:
+Columns that are present in the source data but missing from the table are automatically added as part of a write transaction when schema evolution is enabled. The added columns are appended to the end of the struct they are present in. Case is preserved when appending a new column.
 
-- **Use `INSERT WITH SCHEMA EVOLUTION` syntax**: Works with SQL `INSERT` statements. Include `WITH SCHEMA EVOLUTION` in the SQL syntax.
-- **Set the `mergeSchema` option**: Works with batch writes or streaming writes. Set `.option("mergeSchema", "true")` on individual `write` or `writeStream` operations.
-- **Set the Spark configuration (legacy)**: Sets `spark.databricks.delta.schema.autoMerge.enabled` to `true` for the entire `SparkSession`. Not recommended, because session-wide configuration can lead to unintended schema changes across multiple operations.
+##### Enable schema evolution (Delta Lake 4.3 and above)
 
-When both the `mergeSchema` option and the Spark configuration are specified, the option from the `DataFrameWriter` takes precedence. The added columns are appended to the end of the struct they are present in. Case is preserved when appending a new column.
-
-#### Schema evolution syntax for INSERT
-
-Include `WITH SCHEMA EVOLUTION` in an `INSERT` statement to enable automatic schema evolution for that operation. When enabled, the schema of the target Delta Lake table is automatically updated to accommodate additional columns or widened types of the source query. For a list of the supported type changes, see [Supported type changes](https://docs.delta.io/delta-type-widening/). For example:
+Use `WITH SCHEMA EVOLUTION` in a SQL `INSERT` statement or `.withSchemaEvolution()` in the DataFrame API to enable automatic schema evolution for a single operation. When enabled, the schema of the target Delta Lake table is automatically updated to accommodate additional columns or widened types of the source data. For a list of the supported type changes, see [Supported type changes](https://docs.delta.io/delta-type-widening/). For example:
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL" active>
@@ -1830,17 +1824,44 @@ Include `WITH SCHEMA EVOLUTION` in an `INSERT` statement to enable automatic sch
     ```
 
   </TabItem>
+  <TabItem label="Python">
+
+    ```python
+    (spark.read
+      .table("source_table")
+      .write
+      .mode("append")
+      .withSchemaEvolution()
+      .saveAsTable("target_table")
+    )
+    ```
+
+  </TabItem>
+  <TabItem label="Scala">
+
+    ```scala
+    spark.read
+      .table("source_table")
+      .write
+      .mode("append")
+      .withSchemaEvolution()
+      .saveAsTable("target_table")
+    ```
+
+  </TabItem>
 </Tabs>
 
-If the query on `source_table` returns columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns.
+If the source data contains columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns.
 
 <Aside type="note">
-  `WITH SCHEMA EVOLUTION` is available in Delta Lake 4.3 and above.
+  `WITH SCHEMA EVOLUTION` and `.withSchemaEvolution()` are available in Delta Lake 4.3 and above.
 </Aside>
 
-#### INSERT with schema evolution using DataFrame API
+##### Enable schema evolution in earlier versions
 
-The following example demonstrates using the `mergeSchema` option with a batch write operation:
+In Delta Lake versions earlier than 4.3, enable schema evolution using one of the following alternatives. Both are also available in Delta Lake 4.3 and above.
+
+Set the `mergeSchema` option on an individual `write` or `writeStream` operation:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python" active>
@@ -1870,9 +1891,7 @@ The following example demonstrates using the `mergeSchema` option with a batch w
   </TabItem>
 </Tabs>
 
-#### Enable schema evolution with Spark configuration (legacy)
-
-You can set the Spark configuration `spark.databricks.delta.schema.autoMerge.enabled` to `true` to enable schema evolution for all write operations in the current `SparkSession`:
+Alternatively, set the Spark configuration `spark.databricks.delta.schema.autoMerge.enabled` to `true` to enable schema evolution for all write operations in the current `SparkSession`:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python" active>
@@ -1899,15 +1918,10 @@ You can set the Spark configuration `spark.databricks.delta.schema.autoMerge.ena
 </Tabs>
 
 <Aside type="caution" title="Important">
-  This approach is not recommended. Instead, enable schema evolution for each write operation:
-
-  - For `INSERT` and batch/streaming writes, use `.option("mergeSchema", "true")` or `INSERT WITH SCHEMA EVOLUTION`
-  - For `MERGE` statements, use `MERGE WITH SCHEMA EVOLUTION`
-
-  Setting a session-wide configuration can lead to unintended schema changes across multiple operations and makes it harder to reason about which operations evolve the schema.
+  Enabling schema evolution session-wide is not recommended, because it can lead to unintended schema changes across multiple operations and makes it harder to reason about which operations evolve the schema. Instead, enable schema evolution for each individual operation using `WITH SCHEMA EVOLUTION`, `.withSchemaEvolution()`, or the `mergeSchema` option.
 </Aside>
 
-When you use options or syntax to enable schema evolution in a write operation, this takes precedence over the Spark configuration.
+When both an operation-level setting (the `mergeSchema` option or `WITH SCHEMA EVOLUTION` / `.withSchemaEvolution()`) and the session-wide Spark configuration are specified, the operation-level setting takes precedence.
 
 #### `NullType` columns
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1809,11 +1809,11 @@ Delta Lake can automatically update the schema of a table as part of a DML trans
 
 #### Add columns
 
-Columns that are present in the source data but missing from the table are automatically added as part of a write transaction when schema evolution is enabled. The added columns are appended to the end of the struct they are present in. Case is preserved when appending a new column.
+Columns present in the source data but missing from the table are automatically added during a write transaction when schema evolution is enabled. The added columns are appended to the end of the struct they are present in. The case is preserved when a new column is appended.
 
 ##### Enable schema evolution (Delta Lake 4.3 and above)
 
-Use `WITH SCHEMA EVOLUTION` in a SQL `INSERT` statement or `.withSchemaEvolution()` in the DataFrame API to enable automatic schema evolution for a single operation. When enabled, the schema of the target Delta Lake table is automatically updated to accommodate additional columns or widened types of the source data. For a list of the supported type changes, see [Supported type changes](https://docs.delta.io/delta-type-widening/). For example:
+On Delta Lake 4.3 and above, use `WITH SCHEMA EVOLUTION` in a SQL `INSERT` statement or `.withSchemaEvolution()` in the DataFrame API to enable automatic schema evolution for a single operation. When enabled, the schema of the target Delta Lake table is automatically updated to accommodate additional columns or widened types of the source data. For a list of the supported type changes, see [Supported type changes](https://docs.delta.io/delta-type-widening/). For example:
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL" active>
@@ -1852,10 +1852,6 @@ Use `WITH SCHEMA EVOLUTION` in a SQL `INSERT` statement or `.withSchemaEvolution
 </Tabs>
 
 If the source data contains columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns.
-
-<Aside type="note">
-  `WITH SCHEMA EVOLUTION` and `.withSchemaEvolution()` are available in Delta Lake 4.3 and above.
-</Aside>
 
 ##### Enable schema evolution in earlier versions
 
@@ -1918,7 +1914,7 @@ Alternatively, set the Spark configuration `spark.databricks.delta.schema.autoMe
 </Tabs>
 
 <Aside type="caution" title="Important">
-  Enabling schema evolution session-wide is not recommended, because it can lead to unintended schema changes across multiple operations and makes it harder to reason about which operations evolve the schema. Instead, enable schema evolution for each individual operation using `WITH SCHEMA EVOLUTION`, `.withSchemaEvolution()`, or the `mergeSchema` option.
+  Enabling schema evolution session-wide is not recommended because it can lead to unintended schema changes across multiple operations and makes it harder to reason about which operations evolve the schema. Instead, enable schema evolution for each individual operation using `WITH SCHEMA EVOLUTION`, `.withSchemaEvolution()`, or the `mergeSchema` option.
 </Aside>
 
 When both an operation-level setting (the `mergeSchema` option or `WITH SCHEMA EVOLUTION` / `.withSchemaEvolution()`) and the session-wide Spark configuration are specified, the operation-level setting takes precedence.

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1813,7 +1813,7 @@ Columns that are present in the source data but missing from the table are autom
 
 - **Use `INSERT WITH SCHEMA EVOLUTION` syntax**: Works with SQL `INSERT` statements. Include `WITH SCHEMA EVOLUTION` in the SQL syntax.
 - **Set the `mergeSchema` option**: Works with batch writes or streaming writes. Set `.option("mergeSchema", "true")` on individual `write` or `writeStream` operations.
-- **Set the Spark configuration (legacy)**: Sets `spark.databricks.delta.schema.autoMerge.enabled` to `true` for the entire `SparkSession`. Not recommended for production use, because session-wide configuration can lead to unintended schema changes across multiple operations.
+- **Set the Spark configuration (legacy)**: Sets `spark.databricks.delta.schema.autoMerge.enabled` to `true` for the entire `SparkSession`. Not recommended, because session-wide configuration can lead to unintended schema changes across multiple operations.
 
 When both the `mergeSchema` option and the Spark configuration are specified, the option from the `DataFrameWriter` takes precedence. The added columns are appended to the end of the struct they are present in. Case is preserved when appending a new column.
 
@@ -1899,7 +1899,7 @@ You can set the Spark configuration `spark.databricks.delta.schema.autoMerge.ena
 </Tabs>
 
 <Aside type="caution" title="Important">
-  This approach is not recommended for production use. Instead, enable schema evolution for each write operation:
+  This approach is not recommended. Instead, enable schema evolution for each write operation:
 
   - For `INSERT` and batch/streaming writes, use `.option("mergeSchema", "true")` or `INSERT WITH SCHEMA EVOLUTION`
   - For `MERGE` statements, use `MERGE WITH SCHEMA EVOLUTION`

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1812,7 +1812,6 @@ Delta Lake can automatically update the schema of a table as part of a DML trans
 Columns that are present in the source data but missing from the table are automatically added as part of a write transaction when schema evolution is enabled. Enable schema evolution using one of the following methods:
 
 - **Use `INSERT WITH SCHEMA EVOLUTION` syntax**: Works with SQL `INSERT` statements. Include `WITH SCHEMA EVOLUTION` in the SQL syntax.
-- **Use `MERGE WITH SCHEMA EVOLUTION` syntax**: Works with `MERGE` statements. Include `WITH SCHEMA EVOLUTION` in the SQL syntax or use `.withSchemaEvolution()` in the Delta Lake API.
 - **Set the `mergeSchema` option**: Works with batch writes or streaming writes. Set `.option("mergeSchema", "true")` on individual `write` or `writeStream` operations.
 - **Set the Spark configuration (legacy)**: Sets `spark.databricks.delta.schema.autoMerge.enabled` to `true` for the entire `SparkSession`. Not recommended for production use, because session-wide configuration can lead to unintended schema changes across multiple operations.
 
@@ -1833,7 +1832,7 @@ Include `WITH SCHEMA EVOLUTION` in an `INSERT` statement to enable automatic sch
   </TabItem>
 </Tabs>
 
-If the query on `source_table` returns columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns. The clause is supported for `INSERT INTO`, `INSERT OVERWRITE`, and `INSERT INTO ... REPLACE` statements.
+If the query on `source_table` returns columns that don't exist in the target table, those columns are automatically added to the `target_table` schema. Existing rows receive `NULL` values for the new columns. The clause is supported for `INSERT INTO` and `INSERT OVERWRITE` statements.
 
 <Aside type="note">
   `WITH SCHEMA EVOLUTION` is available in Delta Lake 4.3 and above.


### PR DESCRIPTION
Restructure the "Add columns" section of the Automatic schema update docs to list the ways to enable schema evolution for `INSERT`, presenting the per-operation `WITH SCHEMA EVOLUTION` / `.withSchemaEvolution()` (Delta Lake 4.3+) as the recommended approach and marking the session-wide `spark.databricks.delta.schema.autoMerge.enabled` config as a not-recommended alternative.

Documentation for `MERGE WITH SCHEMA EVOLUTION` will be added in a separate follow-up PR.

Co-authored-by: Isaac

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Docs)

## Description

This PR documents how to enable automatic schema evolution for `INSERT` operations:
- **Delta Lake 4.3 and above (recommended, per-operation):** the `INSERT WITH SCHEMA EVOLUTION` SQL syntax and the `.withSchemaEvolution()` DataFrame API (Python and Scala examples), including a link to the supported type changes.
- **Earlier versions (also available in 4.3+):** the `mergeSchema` write option, and the session-wide `spark.databricks.delta.schema.autoMerge.enabled` Spark configuration (flagged as not recommended, with guidance to prefer per-operation enablement).
- Clarifies that when both an operation-level setting and the session-wide config are specified, the operation-level setting takes precedence.

Documentation for `MERGE WITH SCHEMA EVOLUTION` will be added in a separate follow-up PR.

## How was this patch tested?

Docs-only change.

## Does this PR introduce _any_ user-facing changes?

No (documentation only).
