### PR TITLE
[Spark][Docs] Document selective overwrite with replaceOn and replaceUsing

### DIFF
--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1109,7 +1109,7 @@ Dynamic partition overwrites (the legacy [`partitionOverwriteMode`](#dynamic-par
 
 ##### replaceUsing
 
-`replaceUsing` atomically deletes the rows in the target table that match a row in the DataFrame on the specified columns, then inserts the DataFrame rows. Matching is based on equality comparison of the specified column values. Provide a comma-separated list of columns. Each column must exist in both the table and the DataFrame, at the same ordinal position. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
+`replaceUsing` atomically deletes the rows in the target table that match a row in the incoming DataFrame on the specified columns, then inserts the incoming DataFrame rows. Matching is based on equality comparison of the specified column values. Provide a comma-separated list of columns. Each column must exist in both the table and the DataFrame, at the same ordinal position. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python" active>

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1105,7 +1105,7 @@ In Delta Lake 1.1.0 and above, if you want to fall back to the old behavior, you
 
 Dynamic data overwrites selectively replace the data that matches the specified key columns or Boolean expression, leaving all other data unchanged. The `replaceUsing` option matches on key columns, while `replaceOn` matches on a Boolean expression. Partitioned tables, unpartitioned tables, and tables with liquid clustering are all supported. Both options are available with DataFrames in Delta Lake 4.3.0 and above.
 
-Dynamic partition overwrites (the legacy [`partitionOverwriteMode`](#dynamic-partition-overwrites-with-partitionoverwritemode-legacy) option) are a subset of dynamic data overwrite behavior. Dynamic partition overwrites replace all the existing data in each partition for which the write will commit new data, and leave all other partitions unchanged. Only partitioned tables are supported in dynamic partition overwrite mode.
+Dynamic partition overwrites (the legacy [`partitionOverwriteMode`](#dynamic-partition-overwrites-with-partitionoverwritemode-legacy-since-delta-lake-430) option) are a subset of dynamic data overwrite behavior. Dynamic partition overwrites replace all the existing data in each partition for which the write will commit new data, and leave all other partitions unchanged. Only partitioned tables are supported in dynamic partition overwrite mode.
 
 ##### replaceUsing
 
@@ -1296,7 +1296,7 @@ The `replaceOn` and `replaceUsing` options can't be combined with `replaceWhere`
 
 </Aside>
 
-#### Dynamic Partition Overwrites with `partitionOverwriteMode` (legacy)
+#### Dynamic Partition Overwrites with `partitionOverwriteMode` (legacy since Delta Lake 4.3.0)
 
 Delta Lake 2.0 and above supports _dynamic_ partition overwrite mode for partitioned tables.
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -976,6 +976,17 @@ To atomically replace all the data in a table, use `overwrite` mode:
   </TabItem>
 </Tabs>
 
+Delta Lake provides several options to selectively overwrite only part of a table. The following table summarizes them. For most use cases, we recommend using `replaceUsing` or `replaceWhere`. Use `replaceOn` only when your use case requires complex or null-safe matching conditions. `partitionOverwriteMode` is a legacy option and is not recommended.
+
+| Option | Use case | Available since |
+| --- | --- | --- |
+| `replaceWhere` | Atomically overwrite rows that match a predicate, for example `colA = 5`. | Delta Lake 1.1.0 (DataFrames); 2.4.0 (SQL) |
+| `replaceUsing` | Dynamic data overwrite by column equality. | Delta Lake 4.3.0 |
+| `replaceOn` | Dynamic data overwrite by Boolean expression, including null-safe conditions. | Delta Lake 4.3.0 |
+| `partitionOverwriteMode` | Legacy dynamic partition overwrite (not recommended). | Delta Lake 2.0 |
+
+#### Overwrite rows matching a predicate with `replaceWhere`
+
 You can selectively overwrite only the data that matches an arbitrary expression. This feature is available with DataFrames in Delta Lake 1.1.0 and above and supported in SQL in Delta Lake 2.4.0 and above.
 
 The following command atomically replaces events in January in the target table, which is partitioned by `start_date`, with the data in `replace_data`:
@@ -1090,7 +1101,87 @@ In Delta Lake 1.1.0 and above, if you want to fall back to the old behavior, you
   </TabItem>
 </Tabs>
 
-#### Dynamic Partition Overwrites
+#### Dynamically overwrite data with `replaceUsing` and `replaceOn`
+
+The `replaceUsing` and `replaceOn` options selectively replace the rows that match the incoming DataFrame while leaving all other rows unchanged. They work on partitioned tables, unpartitioned tables, and clustered tables, and are available with DataFrames in Delta Lake 4.3.0 and above.
+
+##### replaceUsing
+
+`replaceUsing` replaces rows when the specified columns compare equal under equality. Provide a comma-separated list of columns. Each column must exist in both the table and the DataFrame, at the same ordinal position. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    source_data.write \
+      .format("delta") \
+      .mode("overwrite") \
+      .option("replaceUsing", "event_id, start_date") \
+      .saveAsTable("events")
+    ```
+
+  </TabItem>
+  <TabItem label="Scala">
+
+    ```scala
+    source_data.write
+      .format("delta")
+      .mode("overwrite")
+      .option("replaceUsing", "event_id, start_date")
+      .saveAsTable("events")
+    ```
+
+  </TabItem>
+</Tabs>
+
+If the source query is empty, no data is deleted. For matching logic that equality cannot express, use `replaceOn` instead.
+
+##### replaceOn
+
+`replaceOn` replaces rows when they match a user-defined condition, including null-safe comparisons using the `<=>` operator. Use the `targetAlias` option to reference the target table, and alias the DataFrame to reference the source, in the condition. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    source_data.alias("s").write \
+      .format("delta") \
+      .mode("overwrite") \
+      .option("targetAlias", "t") \
+      .option("replaceOn", "s.event_id <=> t.event_id AND s.start_date <=> t.start_date") \
+      .saveAsTable("events")
+    ```
+
+  </TabItem>
+  <TabItem label="Scala">
+
+    ```scala
+    source_data.as("s").write
+      .format("delta")
+      .mode("overwrite")
+      .option("targetAlias", "t")
+      .option("replaceOn", "s.event_id <=> t.event_id AND s.start_date <=> t.start_date")
+      .saveAsTable("events")
+    ```
+
+  </TabItem>
+</Tabs>
+
+If the source query is empty, no data is deleted.
+
+<Aside type="note">
+
+The `replaceOn` and `replaceUsing` options can't be combined with `replaceWhere` or dynamic partition overwrite (`partitionOverwriteMode`) in the same write.
+
+</Aside>
+
+#### Dynamic Partition Overwrites with `partitionOverwriteMode` (legacy)
+
+<Aside type="caution" title="Legacy">
+
+Dynamic partition overwrite mode (the `partitionOverwriteMode` option) is a legacy approach. When possible, use [`replaceUsing` and `replaceOn`](#dynamically-overwrite-data-with-replaceusing-and-replaceon) or `replaceWhere` instead. These options let you specify exactly which rows to replace and avoid accidentally overwriting entire partitions.
+
+</Aside>
 
 Delta Lake 2.0 and above supports _dynamic_ partition overwrite mode for partitioned tables.
 
@@ -1145,7 +1236,7 @@ Dynamic partition overwrite conflicts with the option `replaceWhere` for partiti
 
 <Aside type="caution" title="Important">
 
-Validate that the data written with dynamic partition overwrite touches only the expected partitions. A single row in the incorrect partition can lead to unintentionally overwriting an entire partition. We recommend using `replaceWhere` to specify which data to overwrite.
+Validate that the data written with dynamic partition overwrite touches only the expected partitions. A single row in the incorrect partition can lead to unintentionally overwriting an entire partition. We recommend using `replaceOn`, `replaceUsing`, or `replaceWhere` to specify which data to overwrite.
 
 If a partition has been accidentally overwritten, you can use [Restore a Delta table to an earlier state](/delta-utility/#restore-a-delta-table-to-an-earlier-state) to undo the change.
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -976,7 +976,7 @@ To atomically replace all the data in a table, use `overwrite` mode:
   </TabItem>
 </Tabs>
 
-Delta Lake provides several options to selectively overwrite only part of a table. The following table summarizes them. For most use cases, we recommend using `replaceUsing` or `replaceWhere`. Use `replaceOn` only when your use case requires complex or null-safe matching conditions. `partitionOverwriteMode` is a legacy option and is not recommended.
+Delta Lake provides several options to selectively overwrite only part of a table. The following table summarizes them. For most use cases, we recommend using `replaceUsing` or `replaceWhere`. Use `replaceOn` only when your use case requires complex or null-safe matching conditions.
 
 | Option | Use case | Available since |
 | --- | --- | --- |

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1109,7 +1109,7 @@ Dynamic partition overwrites (the legacy [`partitionOverwriteMode`](#dynamic-par
 
 ##### replaceUsing
 
-`replaceUsing` atomically deletes the rows in the target table that match a row in the incoming DataFrame on the specified columns, then inserts the incoming DataFrame rows. Matching is based on equality comparison of the specified column values. Provide a comma-separated list of columns. Each column must exist in both the table and the DataFrame, at the same ordinal position. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
+`replaceUsing` atomically deletes the rows in the target table that match a row in the incoming DataFrame on the specified columns, then inserts the incoming DataFrame rows. Matching is based on equality comparison of the specified column values. Provide a comma-separated list of columns. Each column must exist in both the table and the incoming DataFrame, at the same ordinal position. The following command replaces rows whose `event_id` and `start_date` match between the incoming DataFrame and the target table:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python" active>
@@ -1195,11 +1195,15 @@ After the write, `students` contains:
 | Adam | `NULL` |
 | Eva | `NULL` |
 
-Doug is removed because `UK` matches a row in the DataFrame. Adam keeps his row because his `NULL` country never matches, and Eva's `NULL` row is appended for the same reason.
+Doug is removed because `UK` matches a row in the incoming DataFrame. Adam keeps his row because his `NULL` country never matches, and Eva's `NULL` row is appended for the same reason.
 
 ##### replaceOn
 
-`replaceOn` atomically deletes the rows in the target table that match the DataFrame rows under a user-defined condition, then inserts the DataFrame rows. Unlike `replaceWhere`, whose predicate references only the target table, the `replaceOn` condition can reference columns from both the target table and the DataFrame, and it supports null-safe comparisons using the `<=>` operator. Use the `targetAlias` option to reference the target table, and alias the DataFrame to reference the source, in the condition. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
+`replaceOn` replaces rows when they match a user-defined condition, unlike `replaceUsing`, which replaces rows when the specified columns compare equal under equality. Use `replaceOn` when you need matching logic that `replaceUsing` does not support, such as treating `NULL` values as equal with the `<=>` operator.
+
+Optionally, use the `targetAlias` option to specify an alias for the target table and the `.as()` or `.alias()` APIs to specify an alias for the source data.
+
+The following command replaces rows whose `event_id` and `start_date` match between the incoming DataFrame and the target table:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python" active>
@@ -1284,7 +1288,7 @@ After the write, `students` contains:
 | Bob | table |
 | Delta | query |
 
-Because `<=>` is null-safe, the `NULL` row matches and is replaced. Bob has no match in the DataFrame, so his row is kept, and Delta is appended.
+Because `<=>` is null-safe, the `NULL` row matches and is replaced. Bob has no match in the incoming DataFrame, so his row is kept, and Delta is appended.
 
 <Aside type="note">
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1140,7 +1140,7 @@ If the source query is empty, no data is deleted.
 
 Like a `JOIN USING`, `replaceUsing` matches rows with regular equality, where `NULL` is not equal to anything. Rows with `NULL` values in the specified columns don't match and aren't removed from the target table. For null-safe matching, or other logic that equality cannot express, use `replaceOn` instead.
 
-For example, suppose the `students` table is partitioned by `country`:
+For example, suppose the `students` table is clustered by `country`:
 
 | name | country |
 | --- | --- |

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1105,7 +1105,7 @@ In Delta Lake 1.1.0 and above, if you want to fall back to the old behavior, you
 
 Dynamic data overwrites selectively replace the data that matches the specified key columns or Boolean expression, leaving all other data unchanged. The `replaceUsing` option matches on key columns, while `replaceOn` matches on a Boolean expression. Partitioned tables, unpartitioned tables, and tables with liquid clustering are all supported. Both options are available with DataFrames in Delta Lake 4.3.0 and above.
 
-Dynamic partition overwrites (the legacy [`partitionOverwriteMode`](#dynamic-partition-overwrites-with-partitionoverwritemode-legacy) option) are a subset of dynamic data overwrite behavior. Dynamic partition overwrites replace all the existing data in each partition for which the write will commit new data, and leave all other partitions unchanged. Only partitioned tables are supported.
+Dynamic partition overwrites (the legacy [`partitionOverwriteMode`](#dynamic-partition-overwrites-with-partitionoverwritemode-legacy) option) are a subset of dynamic data overwrite behavior. Dynamic partition overwrites replace all the existing data in each partition for which the write will commit new data, and leave all other partitions unchanged. Only partitioned tables are supported in dynamic partition overwrite mode.
 
 ##### replaceUsing
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -983,7 +983,7 @@ Delta Lake provides several options to selectively overwrite only part of a tabl
 | `replaceWhere` | Atomically overwrite rows that match a predicate. Use for replacements with a fixed matching condition, such as `colA = 5` or `int_col IN (1, 2, 3)`. | Delta Lake 1.1.0 (DataFrames); 2.4.0 (SQL) |
 | `replaceUsing` | Dynamic data overwrite by column equality. Replaces all rows that match the specified columns, based on equality comparison of the column values, in the provided data set. | Delta Lake 4.3.0 |
 | `replaceOn` | Dynamic data overwrite by Boolean expression. Use for replacements with a complex or null-safe matching condition, such as `s.colA <=> t.colA AND s.colB <=> t.colB`. | Delta Lake 4.3.0 |
-| `partitionOverwriteMode` | Legacy dynamic partition overwrite, which overwrites all the existing data in each partition for which the write will commit new data. Not recommended for new workloads. | Delta Lake 2.0 |
+| `partitionOverwriteMode` | Dynamic partition overwrite, which overwrites all the existing data in each partition for which the write will commit new data. Legacy since Delta Lake 4.3.0; not recommended for new workloads. | Delta Lake 2.0 |
 
 #### Overwrite rows matching a predicate with `replaceWhere`
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1351,7 +1351,7 @@ Dynamic partition overwrite conflicts with the option `replaceWhere` for partiti
 
 <Aside type="caution" title="Important">
 
-Validate that the data written with dynamic partition overwrite touches only the expected partitions. A single row in the incorrect partition can lead to unintentionally overwriting an entire partition. Partition overwrite may also use stale data when the partitioning changes. We recommend using `replaceOn`, `replaceUsing`, or `replaceWhere` to specify which data to overwrite.
+Validate that the data written with dynamic partition overwrite touches only the expected partitions. A single row in the incorrect partition can lead to unintentionally overwriting an entire partition.
 
 If a partition has been accidentally overwritten, you can use [Restore a Delta table to an earlier state](/delta-utility/#restore-a-delta-table-to-an-earlier-state) to undo the change.
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1161,6 +1161,7 @@ and the `new_students` DataFrame holds the replacement rows:
   <TabItem label="Python" active>
 
     ```python
+    # Replace rows in students whose country matches a row in new_students.
     new_students.write \
       .format("delta") \
       .mode("overwrite") \
@@ -1172,6 +1173,7 @@ and the `new_students` DataFrame holds the replacement rows:
   <TabItem label="Scala">
 
     ```scala
+    // Replace rows in students whose country matches a row in new_students.
     new_students.write
       .format("delta")
       .mode("overwrite")
@@ -1248,6 +1250,7 @@ and the `people` DataFrame holds the replacement rows:
   <TabItem label="Python" active>
 
     ```python
+    # Replace rows in students whose name matches a row in people, using a null-safe comparison.
     people.alias("s").write \
       .format("delta") \
       .mode("overwrite") \
@@ -1260,6 +1263,7 @@ and the `people` DataFrame holds the replacement rows:
   <TabItem label="Scala">
 
     ```scala
+    // Replace rows in students whose name matches a row in people, using a null-safe comparison.
     people.as("s").write
       .format("delta")
       .mode("overwrite")

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -980,14 +980,14 @@ Delta Lake provides several options to selectively overwrite only part of a tabl
 
 | Option | Use case | Available since |
 | --- | --- | --- |
-| `replaceWhere` | Atomically overwrite rows that match a predicate, for example `colA = 5`. | Delta Lake 1.1.0 (DataFrames); 2.4.0 (SQL) |
-| `replaceUsing` | Dynamic data overwrite by column equality. | Delta Lake 4.3.0 |
-| `replaceOn` | Dynamic data overwrite by Boolean expression, including null-safe conditions. | Delta Lake 4.3.0 |
-| `partitionOverwriteMode` | Legacy dynamic partition overwrite (not recommended). | Delta Lake 2.0 |
+| `replaceWhere` | Atomically overwrite rows that match a predicate. Use for replacements with a fixed matching condition, such as `colA = 5` or `int_col IN (1, 2, 3)`. | Delta Lake 1.1.0 (DataFrames); 2.4.0 (SQL) |
+| `replaceUsing` | Dynamic data overwrite by column equality. Replaces all rows that match the specified columns, based on equality comparison of the column values, in the provided data set. | Delta Lake 4.3.0 |
+| `replaceOn` | Dynamic data overwrite by Boolean expression. Use for replacements with a complex or null-safe matching condition, such as `s.colA <=> t.colA AND s.colB <=> t.colB`. | Delta Lake 4.3.0 |
+| `partitionOverwriteMode` | Legacy dynamic partition overwrite, which overwrites all the existing data in each partition for which the write will commit new data. Not recommended for new workloads. | Delta Lake 2.0 |
 
 #### Overwrite rows matching a predicate with `replaceWhere`
 
-You can selectively overwrite only the data that matches an arbitrary expression. This feature is available with DataFrames in Delta Lake 1.1.0 and above and supported in SQL in Delta Lake 2.4.0 and above.
+`replaceWhere` atomically overwrites the rows that match a predicate, leaving all other rows unchanged. Use it for replacements with a fixed matching condition, such as `colA = 5` or `int_col IN (1, 2, 3)`. This feature is available with DataFrames in Delta Lake 1.1.0 and above and supported in SQL in Delta Lake 2.4.0 and above.
 
 The following command atomically replaces events in January in the target table, which is partitioned by `start_date`, with the data in `replace_data`:
 
@@ -1103,11 +1103,13 @@ In Delta Lake 1.1.0 and above, if you want to fall back to the old behavior, you
 
 #### Dynamically overwrite data with `replaceUsing` and `replaceOn`
 
-The `replaceUsing` and `replaceOn` options selectively replace the rows that match the incoming DataFrame while leaving all other rows unchanged. They work on partitioned tables, unpartitioned tables, and clustered tables, and are available with DataFrames in Delta Lake 4.3.0 and above.
+Dynamic data overwrites selectively replace the data that matches the specified key columns or Boolean expression, leaving all other data unchanged. The `replaceUsing` option matches on key columns, while `replaceOn` matches on a Boolean expression. Partitioned tables, unpartitioned tables, and tables with liquid clustering are all supported. Both options are available with DataFrames in Delta Lake 4.3.0 and above.
+
+Dynamic partition overwrites (the legacy [`partitionOverwriteMode`](#dynamic-partition-overwrites-with-partitionoverwritemode-legacy) option) are a subset of dynamic data overwrite behavior. Dynamic partition overwrites replace all the existing data in each partition for which the write will commit new data, and leave all other partitions unchanged. Only partitioned tables are supported.
 
 ##### replaceUsing
 
-`replaceUsing` replaces rows when the specified columns compare equal under equality. Provide a comma-separated list of columns. Each column must exist in both the table and the DataFrame, at the same ordinal position. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
+`replaceUsing` atomically deletes the rows in the target table that match a row in the DataFrame on the specified columns, then inserts the DataFrame rows. Matching is based on equality comparison of the specified column values. Provide a comma-separated list of columns. Each column must exist in both the table and the DataFrame, at the same ordinal position. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python" active>
@@ -1134,11 +1136,68 @@ The `replaceUsing` and `replaceOn` options selectively replace the rows that mat
   </TabItem>
 </Tabs>
 
-If the source query is empty, no data is deleted. For matching logic that equality cannot express, use `replaceOn` instead.
+If the source query is empty, no data is deleted.
+
+Like a `JOIN USING`, `replaceUsing` matches rows with regular equality, where `NULL` is not equal to anything. Rows with `NULL` values in the specified columns don't match and aren't removed from the target table. For null-safe matching, or other logic that equality cannot express, use `replaceOn` instead.
+
+For example, suppose the `students` table is partitioned by `country`:
+
+| name | country |
+| --- | --- |
+| Dylan | US |
+| Doug | UK |
+| Julia | IT |
+| Adam | `NULL` |
+
+and the `new_students` DataFrame holds the replacement rows:
+
+| name | country |
+| --- | --- |
+| Peter | FR |
+| Jennie | UK |
+| Eva | `NULL` |
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    new_students.write \
+      .format("delta") \
+      .mode("overwrite") \
+      .option("replaceUsing", "country") \
+      .saveAsTable("students")
+    ```
+
+  </TabItem>
+  <TabItem label="Scala">
+
+    ```scala
+    new_students.write
+      .format("delta")
+      .mode("overwrite")
+      .option("replaceUsing", "country")
+      .saveAsTable("students")
+    ```
+
+  </TabItem>
+</Tabs>
+
+After the write, `students` contains:
+
+| name | country |
+| --- | --- |
+| Dylan | US |
+| Julia | IT |
+| Jennie | UK |
+| Peter | FR |
+| Adam | `NULL` |
+| Eva | `NULL` |
+
+Doug is removed because `UK` matches a row in the DataFrame. Adam keeps his row because his `NULL` country never matches, and Eva's `NULL` row is appended for the same reason.
 
 ##### replaceOn
 
-`replaceOn` replaces rows when they match a user-defined condition, including null-safe comparisons using the `<=>` operator. Use the `targetAlias` option to reference the target table, and alias the DataFrame to reference the source, in the condition. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
+`replaceOn` atomically deletes the rows in the target table that match the DataFrame rows under a user-defined condition, then inserts the DataFrame rows. Unlike `replaceWhere`, whose predicate references only the target table, the `replaceOn` condition can reference columns from both the target table and the DataFrame, and it supports null-safe comparisons using the `<=>` operator. Use the `targetAlias` option to reference the target table, and alias the DataFrame to reference the source, in the condition. The following command replaces rows whose `event_id` and `start_date` match between the DataFrame and the target table:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python" active>
@@ -1169,6 +1228,60 @@ If the source query is empty, no data is deleted. For matching logic that equali
 
 If the source query is empty, no data is deleted.
 
+For example, suppose the `students` table contains:
+
+| name | row_origin |
+| --- | --- |
+| Alice | table |
+| `NULL` | table |
+| Bob | table |
+
+and the `people` DataFrame holds the replacement rows:
+
+| name | row_origin |
+| --- | --- |
+| Alice | query |
+| `NULL` | query |
+| Delta | query |
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    people.alias("s").write \
+      .format("delta") \
+      .mode("overwrite") \
+      .option("targetAlias", "t") \
+      .option("replaceOn", "t.name <=> s.name") \
+      .saveAsTable("students")
+    ```
+
+  </TabItem>
+  <TabItem label="Scala">
+
+    ```scala
+    people.as("s").write
+      .format("delta")
+      .mode("overwrite")
+      .option("targetAlias", "t")
+      .option("replaceOn", "t.name <=> s.name")
+      .saveAsTable("students")
+    ```
+
+  </TabItem>
+</Tabs>
+
+After the write, `students` contains:
+
+| name | row_origin |
+| --- | --- |
+| Alice | query |
+| `NULL` | query |
+| Bob | table |
+| Delta | query |
+
+Because `<=>` is null-safe, the `NULL` row matches and is replaced. Bob has no match in the DataFrame, so his row is kept, and Delta is appended.
+
 <Aside type="note">
 
 The `replaceOn` and `replaceUsing` options can't be combined with `replaceWhere` or dynamic partition overwrite (`partitionOverwriteMode`) in the same write.
@@ -1176,12 +1289,6 @@ The `replaceOn` and `replaceUsing` options can't be combined with `replaceWhere`
 </Aside>
 
 #### Dynamic Partition Overwrites with `partitionOverwriteMode` (legacy)
-
-<Aside type="caution" title="Legacy">
-
-Dynamic partition overwrite mode (the `partitionOverwriteMode` option) is a legacy approach. When possible, use [`replaceUsing` and `replaceOn`](#dynamically-overwrite-data-with-replaceusing-and-replaceon) or `replaceWhere` instead. These options let you specify exactly which rows to replace and avoid accidentally overwriting entire partitions.
-
-</Aside>
 
 Delta Lake 2.0 and above supports _dynamic_ partition overwrite mode for partitioned tables.
 
@@ -1236,7 +1343,7 @@ Dynamic partition overwrite conflicts with the option `replaceWhere` for partiti
 
 <Aside type="caution" title="Important">
 
-Validate that the data written with dynamic partition overwrite touches only the expected partitions. A single row in the incorrect partition can lead to unintentionally overwriting an entire partition. We recommend using `replaceOn`, `replaceUsing`, or `replaceWhere` to specify which data to overwrite.
+Validate that the data written with dynamic partition overwrite touches only the expected partitions. A single row in the incorrect partition can lead to unintentionally overwriting an entire partition. Partition overwrite may also use stale data when the partitioning changes. We recommend using `replaceOn`, `replaceUsing`, or `replaceWhere` to specify which data to overwrite.
 
 If a partition has been accidentally overwritten, you can use [Restore a Delta table to an earlier state](/delta-utility/#restore-a-delta-table-to-an-earlier-state) to undo the change.
 

--- a/docs/src/content/docs/delta-batch.mdx
+++ b/docs/src/content/docs/delta-batch.mdx
@@ -1195,7 +1195,7 @@ After the write, `students` contains:
 | Adam | `NULL` |
 | Eva | `NULL` |
 
-Doug is removed because `UK` matches a row in the incoming DataFrame. Adam keeps his row because his `NULL` country never matches, and Eva's `NULL` row is appended for the same reason.
+`Doug` is removed because `UK` matches a row in the incoming DataFrame. `Adam` keeps his row because his `NULL` country never matches, and `Eva`'s `NULL` row is appended for the same reason.
 
 ##### replaceOn
 
@@ -1288,7 +1288,7 @@ After the write, `students` contains:
 | Bob | table |
 | Delta | query |
 
-Because `<=>` is null-safe, the `NULL` row matches and is replaced. Bob has no match in the incoming DataFrame, so his row is kept, and Delta is appended.
+Because `<=>` is null-safe, the `NULL` row matches and is replaced. `Bob` has no match in the incoming DataFrame, so his row is kept, and `Delta` is appended.
 
 <Aside type="note">
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Docs)

## Description
Add a comparison table of the selective-overwrite options to the batch docs, document the new `replaceUsing` and `replaceOn` DataFrame write options in Delta 4.3, and note that the dynamic `partitionOverwriteMode` option is legacy.

The `replaceOn`/`replaceUsing` DataFrameWriter support being documented here is implemented by:

- #6445 — Add `replaceOn`/`replaceUsing` DataFrame writer option definitions and validation (foundation)
- #6569 — Support `replaceUsing`/`replaceOn` for DataFrameWriterV1 `save()` overwrite mode
- #6579 — Support `replaceUsing`/`replaceOn` for DataFrameWriterV1 `insertInto()` overwrite mode
- #6580 — Support `replaceUsing`/`replaceOn` for DataFrameWriterV1 `saveAsTable()` overwrite mode

Co-authored-by: Isaac

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
N/A
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
User-facing docs change.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
