### PR TITLE
[kernel-spark] Re-enable checkpoint-missing V2 source test and fix #6232 TODO comment

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -99,6 +99,7 @@ object DeltaV2SourceSuite {
     "incremental: commit file gap between versions, fails",
     "incremental: first commit file missing, failOnDataLoss=false succeeds",
     "initial snapshot: commit file missing but checkpoint intact, succeeds",
+    "initial snapshot: checkpoint missing but all commit files intact, succeeds",
     "initial snapshot: both checkpoint and commit file missing, fails",
     "initial snapshot: log retention deletes old checkpoint and commit files mid-stream," +
       " restart fails",
@@ -165,9 +166,9 @@ object DeltaV2SourceSuite {
     "streaming delta source should drop null columns without feature flag",
 
     // === Schema Evolution ===
-    // TODO(#6232): enable the two tests after spark streaming engine supports leaf node projection
-    //  for datasource v2 such that we can adopt the two schema changes without refreshing the
-    //  dataframe
+    // TODO(#6232): DSv2 pins the table schema when the DataFrame is loaded, so restarting from a
+    //  stale DataFrame can't adopt the schema change. Enable once the V2 relation refreshes its
+    //  schema without rebuilding the DataFrame.
     "relax nullability: restarting with stale DataFrame should recover",
     "type widening: restarting with stale DataFrame should recover",
 
@@ -175,9 +176,6 @@ object DeltaV2SourceSuite {
     // V2 only tolerates missing start versions with failOnDataLoss=false; mid-log gaps still
     // throw InvalidTableException because non-contiguous versions are not a log-retention scenario.
     "incremental: commit file gap between versions, failOnDataLoss=false succeeds",
-    // Kernel cannot reconstruct snapshot without checkpoint file (_last_checkpoint still
-    // points to deleted checkpoint). V1 falls back to delta files; Kernel does not.
-    "initial snapshot: checkpoint missing but all commit files intact, succeeds",
 
     // === Misc ===
     // TODO(#5900): fix exception mismatch


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Two test-classification cleanups in `DeltaV2SourceSuite`:

- Move `initial snapshot: checkpoint missing but all commit files intact, succeeds` from `FailingTests` to `PassingTests`. Kernel now replays delta files when `_last_checkpoint` points to a deleted checkpoint (#6495), so the V2 connector recovers like DSv1. The old comment claiming "Kernel does not fall back" is stale.
- Rewrite the `#6232` schema-evolution TODO. The blocker is that DSv2 pins the table schema when the DataFrame is loaded, so restarting from a stale DataFrame can't adopt the change — not a missing "leaf node projection" engine feature.

## How was this patch tested?

Existing tests; the re-enabled test now runs (and passes) under `DeltaV2SourceSuite`. The TODO change is comment-only.

## Does this PR introduce _any_ user-facing changes?

No.