### PR TITLE
Implement DeltaV2Table version()/id() so STRICT cache detects drop+recreate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,6 +201,12 @@ lazy val connectClient = (project in file("spark-connect/client"))
     commonSettings,
     releaseSettings,
     CrossSparkVersions.sparkDependentSettings(sparkVersion),
+    // Shared refresh test traits compiled into both this module and the `spark`
+    // module. See io.delta.tables.shared.
+    Test / unmanagedSourceDirectories += {
+      (LocalRootProject / baseDirectory).value /
+        "spark-shared-tests" / "src" / "test" / "scala-shared"
+    },
     libraryDependencies ++= Seq(
       "com.google.protobuf" % "protobuf-java" % protoVersion % "protobuf",
       "org.apache.spark" %% "spark-connect-client-jvm" % sparkVersion.value % "provided",
@@ -217,12 +223,16 @@ lazy val connectClient = (project in file("spark-connect/client"))
 
       if (!distributionDir.exists()) {
         IO.createDirectory(jarsDir)
+        // V2/STRICT mode requires the Delta Kernel engine at runtime
+        // (io.delta.kernel.defaults.engine.DefaultEngine), so add the packaged kernel jars.
+        val kernelJars = Seq(
+          (kernelApi / Compile / packageBin).value,
+          (kernelDefaults / Compile / packageBin).value)
         // Create symlinks for all dependencies (filter to only JAR files)
-        serverClassPath.distinct.filter(_.data.isFile).foreach { entry =>
-          val jarFile = entry.data.toPath
-          val linkedJarFile = jarsDir / entry.data.getName
+        (serverClassPath.map(_.data).filter(_.isFile) ++ kernelJars).distinct.foreach { jarFile =>
+          val linkedJarFile = jarsDir / jarFile.getName
           if (!java.nio.file.Files.exists(linkedJarFile.toPath)) {
-            Files.createSymbolicLink(linkedJarFile.toPath, jarFile)
+            Files.createSymbolicLink(linkedJarFile.toPath, jarFile.toPath)
           }
         }
         // Create a symlink for the log4j properties
@@ -558,6 +568,7 @@ lazy val spark = (project in file("spark-unified"))
         sparkDir / "src" / "test" / "java",
         unifiedDir / "src" / "test" / "scala",
         unifiedDir / "src" / "test" / "java",
+        unifiedDir.getParentFile / "spark-shared-tests" / "src" / "test" / "scala-shared",
         shimDir
       )
     },

--- a/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
+++ b/spark-connect/client/src/test/scala/io/delta/connect/tables/DeltaTableRefreshConnectSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables
+
+import io.delta.tables.shared.DeltaCacheTableTests
+
+import org.apache.spark.sql.test.DeltaQueryTest
+
+/**
+ * Runs the shared refresh and cache tests over a remote Spark Connect session. In Connect the
+ * Dataset is re-analyzed on each execution, so repeated reads always see the latest data and
+ * schema.
+ */
+trait DeltaTableRefreshConnectSuiteBase
+  extends DeltaQueryTest
+  with RemoteSparkSession
+  with DeltaCacheTableTests {
+
+  // The conf key is a literal because the Spark Connect thin client does not depend on Spark
+  // Classic, which is where the Delta SQL configs live, so DeltaSQLConf.V2_ENABLE_MODE.key is
+  // not importable here.
+  override protected def serverConfigs: Map[String, String] =
+    super.serverConfigs + ("spark.databricks.delta.v2.enableMode" -> v2EnableMode)
+}
+
+/**
+ * V2_ENABLE_MODE = AUTO, the product default: the Delta Kernel V2 connector is used only where it
+ * is supported and falls back to the legacy V1 path otherwise.
+ */
+class DeltaTableRefreshConnectAutoModeSuite
+  extends DeltaTableRefreshConnectSuiteBase {
+  override protected def v2EnableMode: String = "AUTO"
+}
+
+/**
+ * V2_ENABLE_MODE = STRICT: always engages the Delta Kernel V2 connector with no V1 fallback. Unlike
+ * AUTO, this surfaces gaps in the V2 connector instead of silently routing around them.
+ *
+ * TODO: full V2 connector support is in progress; ADD COLUMN is not supported in V2 yet.
+ */
+class DeltaTableRefreshConnectStrictModeSuite
+  extends DeltaTableRefreshConnectSuiteBase {
+  override protected def v2EnableMode: String = "STRICT"
+}

--- a/spark-connect/client/src/test/scala/io/delta/connect/tables/RemoteSparkSession.scala
+++ b/spark-connect/client/src/test/scala/io/delta/connect/tables/RemoteSparkSession.scala
@@ -68,6 +68,13 @@ trait RemoteSparkSession extends BeforeAndAfterAll { self: Suite =>
   private val serverPort = 15003
   var spark: SparkSession = _
 
+  /**
+   * Extra Spark configs passed to the server process as `--conf key=value` at startup (the
+   * Connect analog of overriding Spark Classic's `sparkConf`, since the server runs in a separate
+   * JVM).
+   */
+  protected def serverConfigs: Map[String, String] = Map.empty
+
   private val javaHome = System.getProperty("java.home")
 
   private val sparkHome = System.getProperty("delta.spark.home")
@@ -110,6 +117,9 @@ trait RemoteSparkSession extends BeforeAndAfterAll { self: Suite =>
       "org.apache.spark.sql.connect.delta.DeltaRelationPlugin"
     command += "--conf" += "spark.connect.extensions.command.classes=" +
       "org.apache.spark.sql.connect.delta.DeltaCommandPlugin"
+    serverConfigs.foreach { case (confKey, confValue) =>
+      command += "--conf" += s"$confKey=$confValue"
+    }
     // Spark submit requires a jar. We pick one we know exists.
     command += s"$sparkHome/jars/unused-1.0.0.jar"
 

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaCacheTableTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaCacheTableTests.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables.shared
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.Row
+
+/**
+ * CACHE TABLE behavior across session and external mutations, mirroring the DSv2 CACHE scenarios in
+ * apache/spark. An external write (committed straight into `_delta_log`) bypasses the CacheManager.
+ * Shared across classic and Connect.
+ *
+ * The asserted behavior is version and mode dependent, so each scenario branches explicitly on
+ * `spark.version` (4.2+, 4.1, 4.0) and on [[v2EnableMode]] (STRICT vs AUTO):
+ *   - 4.1 and 4.2+: https://github.com/apache/spark/pull/52764 made cached DSv2 tables pin
+ *     their state, so the cache pins and REFRESH TABLE surfaces external changes. A STRICT
+ *     schema change additionally stays pinned out until REFRESH.
+ *   - 4.0 STRICT: there is no pinning, so external changes are visible immediately.
+ *   - 4.0 AUTO: the cache pins but REFRESH TABLE does not surface an external write (a drop and
+ *     recreate is not seen either).
+ */
+trait DeltaCacheTableTests
+  extends DeltaTableRefreshSharedBase { self: AnyFunSuite =>
+
+  /** Runs `body` against an external catalog table `t` holding `(1, 100)` that has been cached. */
+  private def withCachedTable(body: String => Unit): Unit =
+    withExternalTable { path =>
+      writerSql("CACHE TABLE t")
+      try body(path)
+      finally writerSql("UNCACHE TABLE IF EXISTS t")
+    }
+
+  /** Spark minor version bucket ("4.0", "4.1", "4.2+") that the asserted behavior keys off. */
+  private def sparkMinorVersion: String = {
+    // Parse major and minor numerically so the bucket stays correct once Spark reaches 4.10,
+    // where a lexicographic string compare would wrongly rank "4.10" below "4.2".
+    val versionParts = spark.version.split('.')
+    val major = versionParts(0).toInt
+    val minor = versionParts(1).toInt
+    if (major > 4 || (major == 4 && minor >= 2)) "4.2+"
+    else if (major == 4 && minor >= 1) "4.1"
+    else "4.0"
+  }
+
+  test("cache scenario 1: external data write while cached") {
+    withCachedTable { path =>
+      externalDataWrite(path, Seq((2, 200)))
+      (sparkMinorVersion, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") =>
+          // 4.1 and 4.2+: the cache pins, so the external write is invisible until REFRESH TABLE.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the external write is visible immediately.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+        case ("4.0", "AUTO") =>
+          // 4.0 AUTO: the cache pins and REFRESH TABLE does not surface an external write.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100)))
+      }
+    }
+  }
+
+  test("cache scenario 2: session write then external write while cached") {
+    withCachedTable { path =>
+      writerSql("INSERT INTO t VALUES (2, 200)")
+      assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+      externalDataWrite(path, Seq((3, 300)))
+      (sparkMinorVersion, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.2+", "AUTO") | ("4.1", "STRICT") | ("4.1", "AUTO") =>
+          // 4.1 and 4.2+: the external write is pinned out of the cache, surfaced by REFRESH TABLE.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200), Row(3, 300)))
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the external write is visible immediately.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200), Row(3, 300)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200), Row(3, 300)))
+        case ("4.0", "AUTO") =>
+          // 4.0 AUTO: the external write is pinned out and REFRESH does not surface it.
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+      }
+    }
+  }
+
+  test("cache scenario 3: external schema change while cached") {
+    withCachedTable { path =>
+      externalAddColumnAndWrite(path, Seq((2, 200, -1)))
+      (sparkMinorVersion, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+          // 4.1 and 4.2+ STRICT: the V2 connector pins the cached snapshot, so the change is
+          // invisible.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+        case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "STRICT") | ("4.0", "AUTO") =>
+          // Everywhere else: a schema change breaks cache pinning, so the external change is
+          // visible even before REFRESH.
+          assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+      }
+      writerSql("REFRESH TABLE t")
+      assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+    }
+  }
+
+  test("cache scenario 4: session schema change then external write while cached") {
+    withCachedTable { path =>
+      writerSql("ALTER TABLE t ADD COLUMN new_column INT")
+      externalThreeColumnDataWrite(path, Seq((2, 200, -1)))
+      // TODO: ADD COLUMN is not properly supported in the STRICT V2 connector yet. The connector
+      // caches the schema at table lookup, so the session ADD COLUMN never surfaces and rows read
+      // back as 2 columns. Once STRICT V2 supports ADD COLUMN, new_column should surface (NULL for
+      // the existing row) and these STRICT assertions should expect 3 columns. Under AUTO the
+      // schema change breaks cache pinning, so the ADD COLUMN and external row are both visible.
+      (sparkMinorVersion, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+          // 4.1 and 4.2+ STRICT: the external write is pinned out of the cache until REFRESH.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+        case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
+          assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100, null), Row(2, 200, -1)))
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the external write is visible immediately (read as 2 columns).
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100), Row(2, 200)))
+      }
+    }
+  }
+
+  test("cache scenario 5: external drop and recreate while cached") {
+    withCachedTable { path =>
+      externalDropAndRecreate(path)
+      (sparkMinorVersion, v2EnableMode) match {
+        case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+          // 4.1 and 4.2+ STRICT: the V2 connector reports a stable id(), so Spark sees the
+          // recreated table's new identity and reads the now empty table immediately, even
+          // before REFRESH.
+          assertFinalTableState("t", Seq.empty)
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq.empty)
+        case ("4.2+", "AUTO") | ("4.1", "AUTO") =>
+          // 4.1 and 4.2+ AUTO: the read falls back to the V1 file index, which does not expose
+          // Table.id(), so the cache pins and the drop and recreate is invisible until REFRESH
+          // TABLE, which then surfaces the now empty table.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq.empty)
+        case ("4.0", "STRICT") =>
+          // 4.0 STRICT: no pinning, the drop and recreate is visible immediately.
+          assertFinalTableState("t", Seq.empty)
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq.empty)
+        case ("4.0", "AUTO") =>
+          // 4.0 AUTO: the cache pins and REFRESH does not surface the drop and recreate.
+          assertFinalTableState("t", Seq(Row(1, 100)))
+          writerSql("REFRESH TABLE t")
+          assertFinalTableState("t", Seq(Row(1, 100)))
+      }
+    }
+  }
+}

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
@@ -1,0 +1,213 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables.shared
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Paths}
+import java.util.UUID
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
+
+trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
+
+  protected def spark: SparkSession
+
+  protected def v2EnableMode: String = "NONE"
+
+  protected def checkAnswer(df: => DataFrame, expectedAnswer: Seq[Row]): Unit
+  protected def withTable(tableNames: String*)(f: => Unit): Unit
+
+  /**
+   * Asserts `exception` carries `condition`, tolerating a Connect-wrapped error (the condition may
+   * appear in the message rather than as the error condition) and classic error subclasses.
+   */
+  protected def checkError(exception: SparkThrowable, condition: String): Unit = {
+    val cond = exception.getCondition
+    if (cond != condition) {
+      assert(exception.asInstanceOf[Exception].getMessage.contains(condition),
+        s"Expected error condition '$condition' but got '$cond' " +
+        s"and message does not contain it either")
+    }
+  }
+
+  protected def writerSql(sqlText: String): Unit = spark.sql(sqlText)
+
+  protected def createSimpleTable(tableRef: String): Unit =
+    spark.sql(s"CREATE TABLE $tableRef (id INT, salary INT) USING delta")
+
+  protected def insertInitialData(tableRef: String): Unit =
+    spark.sql(s"INSERT INTO $tableRef VALUES (1, 100)")
+
+  /** Inserts the initial `(1, 100)` row into `tableRef` and asserts the first read. */
+  private def seedInitialRow(tableRef: String): Unit = {
+    insertInitialData(tableRef)
+    checkAnswer(spark.sql(s"SELECT * FROM $tableRef"), Seq(Row(1, 100)))
+  }
+
+  /** Asserts the full table contents (ordered by id) match `expectedRows`. */
+  protected def assertFinalTableState(tableRef: String, expectedRows: Seq[Row]): Unit =
+    checkAnswer(spark.sql(s"SELECT * FROM $tableRef ORDER BY id"), expectedRows)
+
+  /** Runs `body` against a fresh managed catalog table `t` already holding `(1, 100)`. */
+  protected def withInitialTable(body: String => Unit): Unit =
+    withTable("t") {
+      createSimpleTable("t")
+      seedInitialRow("t")
+      body("t")
+    }
+
+  /**
+   * Runs `body` against a fresh external catalog table `t` already holding `(1, 100)`, passing the
+   * table's storage path so the body can stage external commits there before REFRESH TABLE.
+   */
+  protected def withExternalTable(body: String => Unit): Unit = {
+    val dir = Files.createTempDirectory("refresh-ext").toFile
+    try {
+      withTable("t") {
+        spark.sql(
+          s"CREATE TABLE t (id INT, salary INT) USING delta LOCATION '${dir.getAbsolutePath}'")
+        seedInitialRow("t")
+        body(dir.getAbsolutePath)
+      }
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  // External-write simulation: write commit files directly into _delta_log, editing schemas as
+  // StructType values recovered from the stored schemaString.
+
+  private val IdRegex = """"id"\s*:\s*"([^"]+)"""".r
+  private val SchemaStringRegex = """"schemaString"\s*:\s*"((?:[^"\\]|\\.)*)"""".r
+
+  private def deltaLogDir(path: String): File = new File(path, "_delta_log")
+
+  private def commitJsonFiles(path: String): Array[File] =
+    deltaLogDir(path).listFiles().filter(_.getName.endsWith(".json"))
+
+  private def currentVersion(path: String): Long =
+    commitJsonFiles(path).map(_.getName.stripSuffix(".json").toLong).max
+
+  private def latestMetaDataLine(path: String): String =
+    commitJsonFiles(path).sortBy(_.getName).flatMap { f =>
+      new String(Files.readAllBytes(f.toPath), UTF_8).split("\n")
+    }.filter(_.contains("\"metaData\"")).lastOption.getOrElse(
+      throw new RuntimeException("No metaData action found in commit files"))
+
+  /** The table's current schema, recovered from the stored schemaString. */
+  private def currentSchema(path: String): StructType = {
+    val escaped = SchemaStringRegex.findFirstMatchIn(latestMetaDataLine(path)).map(_.group(1))
+      .getOrElse(throw new RuntimeException("Could not extract schemaString from metadata"))
+    DataType.fromJson(escaped.replace("\\\"", "\"")).asInstanceOf[StructType]
+  }
+
+  /** Returns the metaData line with its schemaString replaced (id and configuration preserved). */
+  private def metadataLineWithSchema(metadataLine: String, schema: StructType): String = {
+    val escaped = schema.json.replace("\"", "\\\"")
+    SchemaStringRegex.replaceFirstIn(
+      metadataLine, java.util.regex.Matcher.quoteReplacement(s""""schemaString":"$escaped""""))
+  }
+
+  /** Returns the metaData line with a fresh table id (simulating a recreated table). */
+  private def metadataLineWithNewId(metadataLine: String): String =
+    IdRegex.replaceFirstIn(
+      metadataLine, java.util.regex.Matcher.quoteReplacement(s""""id":"${UUID.randomUUID()}""""))
+
+  private def addFileJson(name: String, size: Long): String =
+    s"""{"add":{"path":"$name","partitionValues":{},"size":$size,""" +
+    s""""modificationTime":${System.currentTimeMillis()},"dataChange":true}}"""
+
+  private def removeFileJson(name: String): String =
+    s"""{"remove":{"path":"$name","deletionTimestamp":${System.currentTimeMillis()},""" +
+    s""""dataChange":true}}"""
+
+  /** RemoveFile actions for every data file still active in the table. */
+  private def removeActiveFiles(path: String): Seq[String] = {
+    val addRegex = """"add":\{[^}]*"path"\s*:\s*"([^"]+)"""".r
+    val removeRegex = """"remove":\{[^}]*"path"\s*:\s*"([^"]+)"""".r
+    val added = scala.collection.mutable.Set[String]()
+    val removed = scala.collection.mutable.Set[String]()
+    commitJsonFiles(path).sortBy(_.getName).foreach { f =>
+      val content = new String(Files.readAllBytes(f.toPath), UTF_8)
+      addRegex.findAllMatchIn(content).foreach(m => added += m.group(1))
+      removeRegex.findAllMatchIn(content).foreach(m => removed += m.group(1))
+    }
+    (added -- removed).toSeq.map(removeFileJson)
+  }
+
+  /** Writes a parquet file from a DataFrame into the table dir; returns its AddFile action. */
+  private def writeParquetAndGetAddFileAction(path: String, df: DataFrame): String = {
+    val tempDir = Files.createTempDirectory("ext-write").toFile
+    try {
+      df.coalesce(1).write.parquet(s"${tempDir.getAbsolutePath}/out")
+      val parquetFile = new File(tempDir, "out").listFiles()
+        .filter(_.getName.endsWith(".parquet")).head
+      val targetName = s"ext-commit-v${currentVersion(path) + 1}.snappy.parquet"
+      Files.copy(parquetFile.toPath, Paths.get(path).resolve(targetName))
+      addFileJson(targetName, parquetFile.length())
+    } finally {
+      deleteRecursively(tempDir)
+    }
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    Option(file.listFiles()).foreach(_.foreach(deleteRecursively))
+    file.delete()
+  }
+
+  /** Writes a new commit (version + 1) containing the given actions. */
+  private def writeCommit(path: String, actions: Seq[String]): Unit =
+    Files.write(
+      new File(deltaLogDir(path), f"${currentVersion(path) + 1}%020d.json").toPath,
+      actions.mkString("\n").getBytes(UTF_8))
+
+  private def idSalaryRowsToDf(rows: Seq[(Int, Int)]): DataFrame = {
+    val session = spark
+    import session.implicits._
+    rows.toDF("id", "salary")
+  }
+
+  private def idSalaryNewColumnRowsToDf(rows: Seq[(Int, Int, Int)]): DataFrame = {
+    val session = spark
+    import session.implicits._
+    rows.toDF("id", "salary", "new_column")
+  }
+
+  protected def externalDataWrite(path: String, rows: Seq[(Int, Int)]): Unit =
+    writeCommit(path, Seq(writeParquetAndGetAddFileAction(path, idSalaryRowsToDf(rows))))
+
+  /** Appends three column rows externally without a schema change (table is already 3 columns). */
+  protected def externalThreeColumnDataWrite(path: String, rows: Seq[(Int, Int, Int)]): Unit =
+    writeCommit(path, Seq(writeParquetAndGetAddFileAction(path, idSalaryNewColumnRowsToDf(rows))))
+
+  protected def externalAddColumnAndWrite(path: String, rows: Seq[(Int, Int, Int)]): Unit = {
+    val newSchema = currentSchema(path).add("new_column", IntegerType, nullable = true)
+    writeCommit(path, Seq(
+      metadataLineWithSchema(latestMetaDataLine(path), newSchema),
+      writeParquetAndGetAddFileAction(path, idSalaryNewColumnRowsToDf(rows))))
+  }
+
+  protected def externalDropAndRecreate(path: String): Unit = {
+    val recreatedMeta = metadataLineWithNewId(latestMetaDataLine(path))
+    writeCommit(path, removeActiveFiles(path) :+ recreatedMeta)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableRefreshSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import io.delta.tables.shared.DeltaCacheTableTests
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/** Tests repeated table access with external changes. */
+trait DeltaTableRefreshSuiteBase
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaCacheTableTests {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(DeltaSQLConf.DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED.key, "true")
+      .set(DeltaSQLConf.V2_ENABLE_MODE.key, v2EnableMode)
+  }
+}
+
+/**
+ * V2_ENABLE_MODE = AUTO, the product default: the Delta Kernel V2 connector is used only where it
+ * is supported and falls back to the legacy V1 path otherwise.
+ */
+class DeltaTableRefreshAutoModeSuite
+  extends DeltaTableRefreshSuiteBase {
+  override protected def v2EnableMode: String = "AUTO"
+}
+
+/**
+ * V2_ENABLE_MODE = STRICT: always engages the Delta Kernel V2 connector with no V1 fallback. Unlike
+ * AUTO, this surfaces gaps in the V2 connector instead of silently routing around them.
+ *
+ * TODO: full V2 connector support is in progress; ADD COLUMN is not supported in V2 yet.
+ */
+class DeltaTableRefreshStrictModeSuite
+  extends DeltaTableRefreshSuiteBase {
+  override protected def v2EnableMode: String = "STRICT"
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -302,6 +302,28 @@ public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, Support
         .orElse("delta.`" + tablePath + "`");
   }
 
+  /**
+   * Reporting a non-null version opts this table into Spark's table-version refresh
+   * ([[org.apache.spark.sql.execution.QueryExecution]]): a DataFrame analyzed at one version is
+   * re-resolved to the latest committed version at execution, matching DSv1 refresh semantics
+   * instead of staying pinned to the snapshot captured when this table was loaded.
+   *
+   * <p>No {@code @Override}: {@code Table.version()} only exists in Spark 4.1+ (SPARK-54157); on
+   * Spark 4.0 this stays an inert extra method so the connector still cross-compiles.
+   */
+  public String version() {
+    return Long.toString(initialSnapshot.getVersion());
+  }
+
+  /**
+   * A stable table identity so Spark's refresh can detect a drop and recreate (a recreated table
+   * gets a different id) rather than silently reading a different table at the same name. Omits
+   * {@code @Override} for the same cross-Spark reason as {@link #version()}.
+   */
+  public String id() {
+    return ((SnapshotImpl) initialSnapshot).getMetadata().getId();
+  }
+
   @Override
   public StructType schema() {
     StructType base = schemaProvider.getPublicSchema();


### PR DESCRIPTION
## Summary
- Restore `version()` and `id()` on `DeltaV2Table` (removed from PR #6945 by commit `3c990285`). `version()` opts the V2 connector into Spark's table-version refresh (SPARK-54157); `id()` returns the Delta metadata UUID so Spark can detect an external drop and recreate.
- With `id()`, an external drop+recreate (new UUID) is now detected under STRICT: a cached table reads the now-empty table immediately instead of serving stale rows.
- Brings the `DeltaCacheTableTests` harness over from PR #6936 to exercise the behavior, and updates cache scenario 5:
  - **STRICT (4.1/4.2+)**: reads `Seq.empty` immediately (V2 connector reports `id()`).
  - **AUTO (4.1/4.2+)**: read falls back to the V1 file index, which does not expose `Table.id()`, so the cache pins until `REFRESH TABLE` (unchanged).
  - **4.0**: unchanged (`Table.id()`/`version()` do not exist on Spark 4.0; the methods are inert).

Both methods intentionally omit `@Override` so the connector still cross-compiles on Spark 4.0.

## Test plan
- [x] `spark/testOnly DeltaTableRefresh{Strict,Auto}ModeSuite -- -z "cache scenario"` (Spark 4.1): all 5 scenarios green in both modes.
- [x] `connectClient/testOnly DeltaTableRefreshConnect{Strict,Auto}ModeSuite -- -z "cache scenario"` (Spark 4.1): all 5 scenarios green in both modes.

Note: the cache test files are duplicated from PR #6936 until that PR merges.

This pull request and its description were written by Isaac.