### PR TITLE
[Spark] Fix NoClassDefFoundError on Spark 4.1.2 -- IgnoreCachedData

### DIFF
--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -92,8 +92,12 @@ jobs:
           else
             uv pip install --python .venv/bin/python --require-hashes -r .github/ci-requirements/spark-python/spark4.1.lock
           fi
-          # pyspark installed with --no-deps: its only transitive dep (py4j) is in the lock file
-          uv pip install --python .venv/bin/python --no-deps pyspark==${{ steps.spark-details.outputs.spark_full_version }}
+          # pyspark is installed with --no-deps: its only transitive dep (py4j) is in the lock file.
+          # Spark 4.1.2 was published after the global package cutoff, so relax the cutoff only
+          # for this single no-deps install.
+          UV_EXCLUDE_NEWER=2026-05-22T00:00:00Z \
+            uv pip install --python .venv/bin/python --no-deps \
+            pyspark==${{ steps.spark-details.outputs.spark_full_version }}
       - name: Run Python tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_test.yaml
         run: |

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -276,7 +276,11 @@ object SparkVersionSpec {
   )
 
   private val spark41 = SparkVersionSpec(
-    fullVersion = "4.1.0",
+    // Build the 4.1 line against the latest 4.1 patch. SPARK-54812 was backported to
+    // 4.1.2, which removed the `IgnoreCachedData` trait that 4.1.0/4.1.1 still ship.
+    // Compiling against 4.1.0 produced a `delta-spark_4.1` jar that threw
+    // NoClassDefFoundError on 4.1.2 (see the spark-4.1 IgnoreCachedDataShim).
+    fullVersion = "4.1.2",
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.1"),
     supportIceberg = true,

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -276,10 +276,6 @@ object SparkVersionSpec {
   )
 
   private val spark41 = SparkVersionSpec(
-    // Build the 4.1 line against the latest 4.1 patch. SPARK-54812 was backported to
-    // 4.1.2, which removed the `IgnoreCachedData` trait that 4.1.0/4.1.1 still ship.
-    // Compiling against 4.1.0 produced a `delta-spark_4.1` jar that threw
-    // NoClassDefFoundError on 4.1.2 (see the spark-4.1 IgnoreCachedDataShim).
     fullVersion = "4.1.2",
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.1"),

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -107,13 +107,13 @@ class SparkVersionSpec:
 # These should mirror CrossSparkVersions.scala
 SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
     "4.0.1": SparkVersionSpec(suffix="_4.0", support_iceberg=True, support_hudi=True),
-    "4.1.0": SparkVersionSpec(suffix="_4.1", support_iceberg=True, support_hudi=False),
+    "4.1.2": SparkVersionSpec(suffix="_4.1", support_iceberg=True, support_hudi=False),
     "4.2.0-preview5": SparkVersionSpec(suffix="_4.2", support_iceberg=False, support_hudi=False)
 }
 
 # The default Spark version
 # This is intentionally hardcoded here to explicitly test the default version.
-DEFAULT_SPARK = "4.1.0"
+DEFAULT_SPARK = "4.1.2"
 
 
 def substitute_xversion(jar_templates: List[str], delta_version: str) -> Set[str]:

--- a/spark/src/main/scala-shims/spark-4.1/IgnoreCachedDataShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1/IgnoreCachedDataShim.scala
@@ -16,10 +16,11 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 /**
- * Shim for Spark's `IgnoreCachedData` trait. On Spark 4.1 this aliases the real
- * trait so `CacheManager` continues to skip these plans during cache replacement.
- * On Spark 4.2 (SPARK-54812) the trait was removed because `CacheManager` now
- * automatically skips any `Command`-derived plan, so the 4.2 variant of this
- * shim is an empty marker.
+ * Shim for Spark's `IgnoreCachedData` trait. SPARK-54812 removed the trait and changed
+ * `CacheManager` to automatically skip any `Command`-derived plan during cache replacement.
+ * That change shipped in Spark 4.2 and was backported to Spark 4.1.2, so the 4.1 line now
+ * targets 4.1.2 (see CrossSparkVersions) and this is an empty marker, same as the 4.2 variant.
+ * All Delta commands that mix this in already extend `RunnableCommand`/`Command`, so they are
+ * covered by the new automatic path.
  */
-trait IgnoreCachedDataShim extends IgnoreCachedData
+trait IgnoreCachedDataShim


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`delta-spark_4.1` is built against Spark 4.1.0. Spark 4.1.2 backported [SPARK-54812](https://github.com/apache/spark/pull/53572), which removed the `IgnoreCachedData` trait. Our `spark-4.1` shim still does `extends IgnoreCachedData`, so the missing trait is baked into the jar. On Spark 4.1.2, loading any Delta command that uses this shim (`ALTER TABLE`, `TRUNCATE`, `REORG`/`OPTIMIZE`) fails with `NoClassDefFoundError`.

We need this fix because users cannot run these commands on Spark 4.1.2 today.

This PR builds the 4.1 line against the latest patch (4.1.2) and turns the `spark-4.1` shim into an empty marker, like the existing `spark-4.2` shim. 4.1.2 changed only this one API that Delta shims (confirmed by looking at all the changes between 4.1.1 and 4.1.2 with the help of Claude), and all of these commands extend `Command`, which the new `CacheManager` skips on its own. The artifact name stays `delta-spark_4.1`, and CI now builds against 4.1.2.

Also needed to temporarily bump up `UV_EXCLUDE_NEWER` because PySpark 4.1.2 is released after the existing `UV_EXCLUDE_NEWER`

## How was this patch tested?

Compiled against Spark 4.1.2:
- `build/sbt -DsparkVersion=4.1.2 "sparkV1 / Compile / compile"` -> success
- `build/sbt -DsparkVersion=4.1.2 "spark / Compile / compile"` -> success
- `python3 project/scripts/get_spark_version_info.py --get-field 4.1 fullVersion` -> `4.1.2`

The Spark 4.1 CI matrix now runs on 4.1.2.

## Does this PR introduce _any_ user-facing changes?
Yes. The Spark 4.1 build now targets Spark 4.1.2. `ALTER TABLE`, `TRUNCATE`, and `REORG` on Delta tables work again on Spark 4.1.2, where they failed before with `NoClassDefFoundError`.
