### PR TITLE
Add numDeltaFiles/totalDeltaFilesByteSize to SnapshotDescriptor

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -67,6 +67,12 @@ trait SnapshotDescriptor extends DeltaLoggingProvider {
 
   def schema: StructType = metadata.schema
 
+  def numDeltaFiles: Long =
+    throw new UnsupportedOperationException("numDeltaFiles is not implemented for this descriptor")
+  def totalDeltaFilesByteSize: Long =
+    throw new UnsupportedOperationException(
+      "totalDeltaFilesByteSize is not implemented for this descriptor")
+
   def dataPath: Path
 
   protected[delta] def numOfFilesIfKnown: Option[Long]
@@ -124,6 +130,8 @@ class Snapshot(
   import org.apache.spark.sql.delta.implicits._
 
   override def dataPath: Path = deltaLog.dataPath
+  override def numDeltaFiles: Long = logSegment.numDeltaFiles
+  override def totalDeltaFilesByteSize: Long = logSegment.totalDeltaFilesByteSize
 
   protected def spark = SparkSession.active
 


### PR DESCRIPTION
## Description

Adds `numDeltaFiles` and `totalDeltaFilesByteSize` to the `SnapshotDescriptor` trait, with default implementations that throw `UnsupportedOperationException` (mirroring the existing `dataPath` pattern). `Snapshot` overrides them to delegate to its `logSegment`.

This lets callers read these file statistics through the `SnapshotDescriptor` abstraction instead of reaching into the snapshot's `logSegment` directly.

## How was this patch tested?

Existing tests. This is a small refactor that surfaces values already computed on `logSegment` through the trait; there is no behavior change.

## Does this PR introduce _any_ user-facing changes?

No.
