### PR TITLE
[Spark] Support Spark 4.1.2 shim split

### DIFF
--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -92,8 +92,17 @@ jobs:
           else
             uv pip install --python .venv/bin/python --require-hashes -r .github/ci-requirements/spark-python/spark4.1.lock
           fi
-          # pyspark installed with --no-deps: its only transitive dep (py4j) is in the lock file
-          uv pip install --python .venv/bin/python --no-deps pyspark==${{ steps.spark-details.outputs.spark_full_version }}
+          # pyspark is installed with --no-deps: its only transitive dep (py4j) is in the lock file.
+          if [[ "${{ matrix.spark_version }}" == "4.1.2" ]]; then
+            # Spark 4.1.2 was published after the global package cutoff, so relax the cutoff only
+            # for this single no-deps install.
+            UV_EXCLUDE_NEWER=2026-05-22T00:00:00Z \
+              uv pip install --python .venv/bin/python --no-deps \
+              pyspark==${{ steps.spark-details.outputs.spark_full_version }}
+          else
+            uv pip install --python .venv/bin/python --no-deps \
+              pyspark==${{ steps.spark-details.outputs.spark_full_version }}
+          fi
       - name: Run Python tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_test.yaml
         run: |

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -208,6 +208,9 @@ import Unidoc._
  * @param fullVersion The full Spark version (e.g., "3.5.7", "4.0.2-SNAPSHOT")
  * @param targetJvm Target JVM version (e.g., "11", "17")
  * @param additionalSourceDir Optional version-specific source directory suffix (e.g., "scala-spark-3.5")
+ * @param artifactSuffix Optional artifact suffix override. By default, artifacts use the Spark
+ *                       major/minor suffix (e.g., "_4.1"). Patch-level splits can override this
+ *                       (e.g., "_4.1.2") to avoid publishing collisions.
  * @param antlr4Version ANTLR version to use (e.g., "4.9.3", "4.13.1")
  * @param additionalJavaOptions Additional JVM options for tests (e.g., Java 17 --add-opens flags)
  */
@@ -215,6 +218,7 @@ case class SparkVersionSpec(
   fullVersion: String,
   targetJvm: String,
   additionalSourceDir: Option[String] = None,
+  artifactSuffix: Option[String] = None,
   supportIceberg: Boolean,
   supportHudi: Boolean = true,
   antlr4Version: String,
@@ -246,6 +250,9 @@ case class SparkVersionSpec(
 
   /** Whether to generate Javadoc/Scaladoc for this version */
   def generateDocs: Boolean = isDefault
+
+  /** Maven artifact suffix for Spark-dependent modules (e.g., "_4.1" or "_4.1.2"). */
+  def packageSuffix: String = artifactSuffix.getOrElse(s"_$shortVersion")
 }
 
 object SparkVersionSpec {
@@ -286,6 +293,18 @@ object SparkVersionSpec {
     jacksonVersion = "2.18.2"
   )
 
+  private val spark412 = SparkVersionSpec(
+    fullVersion = "4.1.2",
+    targetJvm = "17",
+    additionalSourceDir = Some("scala-shims/spark-4.1.2"),
+    artifactSuffix = Some("_4.1.2"),
+    supportIceberg = true,
+    supportHudi = false,
+    antlr4Version = "4.13.1",
+    additionalJavaOptions = java17TestSettings,
+    jacksonVersion = "2.18.2"
+  )
+
   private val spark42Preview = SparkVersionSpec(
     fullVersion = "4.2.0-preview5",
     targetJvm = "17",
@@ -304,7 +323,7 @@ object SparkVersionSpec {
   val MASTER: Option[SparkVersionSpec] = None
 
   /** All supported Spark versions - internal use only */
-  val ALL_SPECS = Seq(spark40, spark41, spark42Preview)
+  val ALL_SPECS = Seq(spark40, spark41, spark412, spark42Preview)
 }
 
 /** See docs on top of this file */
@@ -331,13 +350,16 @@ object CrossSparkVersions extends AutoPlugin {
       case other => other
     }
 
-    // Find spec by full version or short version
+    // Find spec by full version, short version, or package suffix without the leading underscore.
+    // When multiple specs share a short version, the older patch remains the short-version default.
     SparkVersionSpec.ALL_SPECS.find { spec =>
-      spec.fullVersion == resolvedInput || spec.shortVersion == resolvedInput
+      spec.fullVersion == resolvedInput ||
+        spec.shortVersion == resolvedInput ||
+        spec.packageSuffix.stripPrefix("_") == resolvedInput
     }.getOrElse {
       val aliases = Seq("default") ++ SparkVersionSpec.MASTER.map(_ => "master").toSeq
       val validInputs = SparkVersionSpec.ALL_SPECS.flatMap { spec =>
-        Seq(spec.fullVersion, spec.shortVersion)
+        Seq(spec.fullVersion, spec.shortVersion, spec.packageSuffix.stripPrefix("_"))
       } ++ aliases
       throw new IllegalArgumentException(
         s"Invalid sparkVersion: $input. Valid values: ${validInputs.mkString(", ")}"
@@ -369,7 +391,7 @@ object CrossSparkVersions extends AutoPlugin {
     if (skipSparkSuffix) {
       baseName
     } else {
-      s"${baseName}_${spec.shortVersion}"
+      s"$baseName${spec.packageSuffix}"
     }
   }
 
@@ -594,8 +616,8 @@ object CrossSparkVersions extends AutoPlugin {
           val comma = if (idx < SparkVersionSpec.ALL_SPECS.size - 1) "," else ""
           val isMaster = SparkVersionSpec.MASTER.contains(spec)
           val isDefault = spec == SparkVersionSpec.DEFAULT
-          // Package suffix always includes Spark version (e.g., "_4.0", "_4.1")
-          val packageSuffix = s"_${spec.shortVersion}"
+          // Package suffix always includes Spark version (e.g., "_4.0", "_4.1", "_4.1.2")
+          val packageSuffix = spec.packageSuffix
           writer.println(s"""  {""")
           writer.println(s"""    "fullVersion": "${spec.fullVersion}",""")
           writer.println(s"""    "shortVersion": "${spec.shortVersion}",""")

--- a/project/scripts/get_spark_version_info.py
+++ b/project/scripts/get_spark_version_info.py
@@ -10,11 +10,11 @@ The script automatically generates the JSON file if it doesn't exist.
 Usage:
     # Get all Spark versions as JSON array
     python project/scripts/get_spark_version_info.py --all-spark-versions
-    # Output: ["4.0", "4.1"] or ["master", "4.0"] if master is present
+    # Output: ["4.0", "4.1", "4.1.2"] or ["master", "4.0"] if master is present
 
     # Get only released Spark versions (no snapshots)
     python project/scripts/get_spark_version_info.py --released-spark-versions
-    # Output: ["4.0", "4.1"] (excludes versions with -SNAPSHOT)
+    # Output: ["4.0", "4.1", "4.1.2"] (excludes versions with -SNAPSHOT)
 
     # Get a specific field for a Spark version (using short version or "master")
     python project/scripts/get_spark_version_info.py --get-field 4.0 targetJvm
@@ -69,6 +69,17 @@ def load_spark_versions(json_path: Path, repo_root: Path):
         return json.load(f)
 
 
+def matrix_version(version_entry):
+    """Return the CI matrix key for a Spark version entry."""
+    if version_entry.get("isMaster", False):
+        return "master"
+
+    package_suffix = version_entry.get("packageSuffix", "")
+    if package_suffix.startswith("_"):
+        return package_suffix[1:]
+    return version_entry["shortVersion"]
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate Spark version information from CrossSparkVersions.scala"
@@ -101,14 +112,7 @@ def main():
         versions = load_spark_versions(json_path, repo_root)
 
         if args.all_spark_versions:
-            # For master version, use "master"; for others, use short version
-            matrix_versions = []
-            for v in versions:
-                if v.get("isMaster", False):
-                    matrix_versions.append("master")
-                else:
-                    matrix_versions.append(v["shortVersion"])
-            print(json.dumps(matrix_versions))
+            print(json.dumps([matrix_version(v) for v in versions]))
 
         elif args.released_spark_versions:
             # Only include released versions; explicitly exclude pre-release markers
@@ -117,7 +121,7 @@ def main():
             matrix_versions = []
             for v in versions:
                 if not any(m in v["fullVersion"] for m in pre_release_markers):
-                    matrix_versions.append(v["shortVersion"])
+                    matrix_versions.append(matrix_version(v))
             print(json.dumps(matrix_versions))
 
         elif args.get_field:
@@ -126,6 +130,7 @@ def main():
             # Find the version entry by matching:
             # - "default" matches isDefault=true
             # - "master" matches isMaster=true
+            # - matrix version like "4.1.2" matches packageSuffix without the leading underscore
             # - short version like "4.0" matches shortVersion
             # - full version like "4.0.1" matches fullVersion
             version_entry = None
@@ -134,6 +139,9 @@ def main():
                     version_entry = v
                     break
                 elif spark_version == "master" and v.get("isMaster", False):
+                    version_entry = v
+                    break
+                elif spark_version == matrix_version(v):
                     version_entry = v
                     break
                 elif spark_version == v["shortVersion"] or spark_version == v["fullVersion"]:

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -108,6 +108,7 @@ class SparkVersionSpec:
 SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
     "4.0.1": SparkVersionSpec(suffix="_4.0", support_iceberg=True, support_hudi=True),
     "4.1.0": SparkVersionSpec(suffix="_4.1", support_iceberg=True, support_hudi=False),
+    "4.1.2": SparkVersionSpec(suffix="_4.1.2", support_iceberg=True, support_hudi=False),
     "4.2.0-preview5": SparkVersionSpec(suffix="_4.2", support_iceberg=False, support_hudi=False)
 }
 
@@ -121,6 +122,17 @@ def substitute_xversion(jar_templates: List[str], delta_version: str) -> Set[str
     Substitutes {version} placeholder in JAR templates with actual Delta version.
     """
     return {jar.format(version=delta_version) for jar in jar_templates}
+
+
+def matrix_version(entry: Dict[str, object]) -> str:
+    """Return the CI matrix key for a Spark version JSON entry."""
+    if entry.get("isMaster"):
+        return "master"
+
+    package_suffix = entry["packageSuffix"]
+    if isinstance(package_suffix, str) and package_suffix.startswith("_"):
+        return package_suffix[1:]
+    return str(entry["shortVersion"])
 
 
 class CrossSparkPublishTest:
@@ -417,7 +429,7 @@ class SparkVersionsScriptTest:
                     print(f"  ✗ Entry {idx}: Invalid field types")
                     return False
 
-            versions_str = ", ".join([entry.get("isMaster") and "master" or entry["shortVersion"] for entry in data])
+            versions_str = ", ".join([matrix_version(entry) for entry in data])
             print(f"  ✓ JSON format valid: {len(data)} version(s) [{versions_str}]")
             return True
 
@@ -459,6 +471,11 @@ class SparkVersionsScriptTest:
 
             if len(matrix_versions) != len(data):
                 print(f"  ✗ Matrix has {len(matrix_versions)} versions, JSON has {len(data)}")
+                return False
+
+            expected_versions = [matrix_version(entry) for entry in data]
+            if matrix_versions != expected_versions:
+                print(f"  ✗ Expected matrix versions {expected_versions}, got {matrix_versions}")
                 return False
 
             print(f"  ✓ --all-spark-versions: {matrix_versions}")
@@ -508,10 +525,17 @@ class SparkVersionsScriptTest:
                 print(f"  ✗ Expected {expected_count} released versions, got {len(released_versions)}")
                 return False
 
-            # Verify no pre-release versions included (rough check via shortVersion lookup)
-            full_versions_by_short = {entry["shortVersion"]: entry["fullVersion"] for entry in data}
+            expected_versions = [
+                matrix_version(entry) for entry in data if not is_pre_release(entry["fullVersion"])
+            ]
+            if released_versions != expected_versions:
+                print(f"  ✗ Expected released versions {expected_versions}, got {released_versions}")
+                return False
+
+            # Verify no pre-release versions included.
+            full_versions_by_matrix_version = {matrix_version(entry): entry["fullVersion"] for entry in data}
             for version in released_versions:
-                full = full_versions_by_short.get(version, "")
+                full = full_versions_by_matrix_version.get(version, "")
                 if is_pre_release(full):
                     print(f"  ✗ Released versions should not include pre-releases: {version} ({full})")
                     return False
@@ -535,8 +559,9 @@ class SparkVersionsScriptTest:
 
             test_cases = []
             for entry in data:
-                # Test short version and full version
-                test_cases.append((entry["shortVersion"], "targetJvm", entry["targetJvm"]))
+                # Test matrix version and full version. Do not use shortVersion as a unique key:
+                # Spark 4.1.0 and 4.1.2 intentionally share shortVersion "4.1".
+                test_cases.append((matrix_version(entry), "targetJvm", entry["targetJvm"]))
                 test_cases.append((entry["fullVersion"], "fullVersion", entry["fullVersion"]))
                 
                 # Test "master" if applicable

--- a/sharing/src/test/scala-shims/spark-4.1.2/SharingStreamingTestShims.scala
+++ b/sharing/src/test/scala-shims/spark-4.1.2/SharingStreamingTestShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sharing/src/test/scala-shims/spark-4.1.2/SharingStreamingTestShims.scala
+++ b/sharing/src/test/scala-shims/spark-4.1.2/SharingStreamingTestShims.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark.test.shims
+
+import org.apache.spark.sql.execution.streaming.checkpointing.{
+  CheckpointFileManager => CheckpointFileManagerShim,
+  CommitMetadata => CommitMetadataShim,
+  OffsetSeqLog => OffsetSeqLogShim
+}
+import org.apache.spark.sql.execution.streaming.runtime.{
+  SerializedOffset => SerializedOffsetShim,
+  StreamingCheckpointConstants => StreamingCheckpointConstantsShim,
+  StreamMetadata => StreamMetadataShim
+}
+
+/**
+ * Test shims for streaming classes that were relocated in Spark 4.1.
+ * In Spark 4.1, these classes moved to checkpointing and runtime sub-packages.
+ */
+object SharingStreamingTestShims {
+  type CheckpointFileManager = CheckpointFileManagerShim
+  val CheckpointFileManager: CheckpointFileManagerShim.type =
+    CheckpointFileManagerShim
+  val CommitMetadata: CommitMetadataShim.type = CommitMetadataShim
+  type OffsetSeqLog = OffsetSeqLogShim
+  val SerializedOffset: SerializedOffsetShim.type = SerializedOffsetShim
+  val StreamMetadata: StreamMetadataShim.type = StreamMetadataShim
+  val StreamingCheckpointConstants: StreamingCheckpointConstantsShim.type =
+    StreamingCheckpointConstantsShim
+}

--- a/spark-connect/client/src/main/scala-shims/spark-4.1.2/SparkStringUtilsShims.scala
+++ b/spark-connect/client/src/main/scala-shims/spark-4.1.2/SparkStringUtilsShims.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.util.SparkStringUtils
+
+/**
+ * Shim for SparkStringUtils to handle package relocation between Spark versions.
+ * In Spark 4.1+, SparkStringUtils was moved from org.apache.spark.sql.catalyst.util
+ * to org.apache.spark.util.
+ */
+object SparkStringUtilsShims {
+  def sideBySide(left: Seq[String], right: Seq[String]): Seq[String] = {
+    SparkStringUtils.sideBySide(left, right)
+  }
+}
+

--- a/spark-unified/src/main/scala-shims/spark-4.1.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.1.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import org.apache.spark.sql.connector.catalog.TableCatalog
+
+/**
+ * No-op shim of `ChangelogSupport` for Spark 4.1.
+ *
+ * <p>The catalog-driven `TableCatalog.loadChangelog` entrypoint and its supporting types
+ * (`Changelog`, `ChangelogInfo`, `ChangelogRange`) were introduced in Spark 4.2 via
+ * SPARK-56685. They do not exist in Spark 4.0/4.1, so the Auto-CDF wiring is compiled in only
+ * when building against Spark 4.2 (see `scala-shims/spark-4.2/...ChangelogSupport.scala`).
+ *
+ * <p>In 4.0/4.1 builds, mixing this empty trait into `DeltaCatalog` is a no-op: there is no
+ * `loadChangelog` to override, and downstream Auto-CDF classes (`DeltaChangelog`, etc.) live in
+ * version-specific `java-shims/spark-4.2/` dirs and are not present here either.
+ */
+trait ChangelogSupport extends TableCatalog

--- a/spark/src/main/java-shims/spark-4.1.2/org/apache/spark/sql/delta/shims/VariantStatsShims.java
+++ b/spark/src/main/java-shims/spark-4.1.2/org/apache/spark/sql/delta/shims/VariantStatsShims.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.shims;
+
+import org.apache.spark.QueryContext;
+import org.apache.spark.SparkRuntimeException;
+import org.apache.spark.types.variant.VariantUtil;
+import scala.collection.immutable.Map$;
+
+/**
+ * Shim for variant stats functionality in Spark 4.1+.
+ * In Spark 4.1, VariantUtil.readUnsigned is public, so we can use it directly.
+ */
+public class VariantStatsShims {
+
+  static SparkRuntimeException malformedVariant() {
+    return new SparkRuntimeException("MALFORMED_VARIANT",
+        Map$.MODULE$.<String, String>empty(), null, new QueryContext[]{}, "");
+  }
+
+  // Check the validity of an array index `pos`. Throw `MALFORMED_VARIANT` if it is out of bound,
+  // meaning that the variant is malformed.
+  private static void checkIndex(int pos, int length) {
+    if (pos < 0 || pos >= length) throw malformedVariant();
+  }
+
+  // Get the length of metadata in the provided array. It is used to split metadata and value in
+  // situations where they are serialized as a concatenated pair (e.g. Delta stats).
+  public static int metadataSize(byte[] metadata) {
+    checkIndex(0, metadata.length);
+    // Similar to the logic from getMetadataKey where "id" is equal to "dictSize".
+    int offsetSize = ((metadata[0] >> 6) & 0x3) + 1;
+    int dictSize = VariantUtil.readUnsigned(metadata, 1, offsetSize);
+    int lastOffset = VariantUtil.readUnsigned(metadata, 1 + (dictSize + 1) * offsetSize, offsetSize);
+    int size = 1 + (dictSize + 2) * offsetSize + lastOffset;
+    if (size > metadata.length) {
+      throw malformedVariant();
+    }
+    return size;
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/AbstractDeltaCatalogShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/AbstractDeltaCatalogShims.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+/**
+ * Spark 4.1 does not expose a V2 CREATE TABLE LIKE hook on TableCatalog.
+ */
+trait AbstractDeltaCatalogShims

--- a/spark/src/main/scala-shims/spark-4.1.2/CharVarcharShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/CharVarcharShims.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.types
+
+/**
+ * Pattern extractors for `CharType` / `VarcharType` that stay source-compatible
+ * across Spark versions. In Spark 4.2 the case classes gained a `collation:
+ * Option[Int]` parameter, which breaks single-arg extractor patterns like
+ * `CharType(_)`. These extractors expose only the length; Delta's callsites
+ * do not care about collation.
+ */
+object CharTypeShim {
+  def unapply(t: CharType): Option[Int] = Some(t.length)
+}
+
+object VarcharTypeShim {
+  def unapply(t: VarcharType): Option[Int] = Some(t.length)
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/CreateDeltaTableLikeShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/CreateDeltaTableLikeShims.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.delta.DeltaOptions
+
+object CreateDeltaTableLikeShims {
+
+  /**
+   * Differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   *
+   * In Spark 4.1, DataFrameWriter provides the option "__v1_save_as_table_overwrite", because
+   * the stack trace does not indicate the calling API anymore in connect mode - planning and
+   * execution has been separated.
+   *
+   * TODO: Shim no longer needed once spark-4.0 is removed.
+   */
+  def isV1WriterSaveAsTableOverwrite(options: DeltaOptions, mode: SaveMode): Boolean = {
+    // Note: Spark is setting this only for SaveMode.Overwrite anyway, but we double check.
+    // The 4.0 shim relies on stack trace analysis instead, so it has to check.
+    // After 4.0 is dropped, we can simplify.
+    options.isDataFrameWriterV1SaveAsTableOverwrite && mode == SaveMode.Overwrite
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/DataSourceV2RelationShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/DataSourceV2RelationShims.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Shim for DataSourceV2Relation to handle API changes between Spark versions.
+ * In Spark 4.1, DataSourceV2Relation has 6 constructor parameters (added an extra parameter).
+ */
+object DataSourceV2RelationShim {
+
+  /**
+   * Main extractor for DataSourceV2Relation that works across Spark versions.
+   * Returns the common fields that exist in all versions.
+   */
+  def unapply(plan: LogicalPlan): Option[(
+    Table, Seq[AttributeReference],
+      Option[CatalogPlugin],
+      Option[Identifier],
+      CaseInsensitiveStringMap)] = {
+    plan match {
+      case r: DataSourceV2Relation =>
+        Some((r.table, r.output, r.catalog, r.identifier, r.options))
+      case _ => None
+    }
+  }
+}
+
+/**
+ * Simplified extractor when only table and options are needed.
+ */
+object DataSourceV2RelationSimple {
+  def unapply(plan: LogicalPlan): Option[(Table, CaseInsensitiveStringMap)] = {
+    plan match {
+      case r: DataSourceV2Relation =>
+        Some((r.table, r.options))
+      case _ => None
+    }
+  }
+}
+
+/**
+ * Extractor for cases that only need the table.
+ */
+object DataSourceV2RelationTable {
+  def unapply(plan: LogicalPlan): Option[Table] = {
+    plan match {
+      case r: DataSourceV2Relation => Some(r.table)
+      case _ => None
+    }
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/DateTimeExpressionShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/DateTimeExpressionShims.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+/**
+ * Shim for date/time expressions in Spark 4.1
+ * Note: TimeAdd is removed in Spark 4.1
+ */
+object DateTimeExpressionShims {
+  /**
+   * Check if the given expression is a date/time arithmetic expression
+   */
+  def isDateTimeArithmeticExpression(expr: Expression): Boolean = {
+    expr match {
+      case _: AddMonthsBase | _: DateAdd | _: DateAddInterval | _: DateDiff | _: DateSub |
+           _: DatetimeSub | _: LastDay | _: MonthsBetween | _: NextDay | _: SubtractDates |
+           _: SubtractTimestamps | _: TimestampAdd | _: TimestampAddYMInterval |
+           _: TimestampDiff | _: TruncInstant => true
+      case _ => false
+    }
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/GeoTypesShim.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.shims
+
+import org.apache.spark.sql.catalyst.expressions.st.{
+  ST_AsBinary, ST_GeogFromWKB, ST_GeomFromWKB, ST_SetSrid, ST_Srid}
+
+import org.apache.spark.sql.types.{DataType, GeographyType, GeometryType}
+
+/**
+ * Shim for the Spark GeometryType / GeographyType catalyst types, which were introduced
+ * in Spark 4.1 (SPARK-53760). This is the real implementation for Spark 4.1.
+ */
+object GeoTypesShim {
+  /** Returns true if `dt` is `GeometryType` or `GeographyType`. */
+  def isGeoSpatialType(dt: DataType): Boolean = dt match {
+    case _: GeometryType | _: GeographyType => true
+    case _ => false
+  }
+
+  /**
+   * If `dt` is a geospatial type with an unsupported SRID, returns `Some(srid)`. Returns
+   * `None` for non-geospatial types or geospatial types with supported SRIDs.
+   */
+  def unsupportedSrid(dt: DataType): Option[Int] = dt match {
+    case g: GeometryType if !GeometryType.isSridSupported(g.srid) => Some(g.srid)
+    case g: GeographyType if !GeographyType.isSridSupported(g.srid) => Some(g.srid)
+    case _ => None
+  }
+
+  /**
+   * Geospatial Catalyst expression classes whitelisted for user-provided expressions
+   * (e.g. generated columns, check constraints).
+   */
+  val geoExpressions: Set[Class[_]] = Set(
+    classOf[ST_AsBinary],
+    classOf[ST_GeogFromWKB],
+    classOf[ST_GeomFromWKB],
+    classOf[ST_SetSrid],
+    classOf[ST_Srid])
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/IgnoreCachedDataShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/IgnoreCachedDataShim.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+/**
+ * Shim for Spark's `IgnoreCachedData` trait. SPARK-54812 removed the trait and changed
+ * `CacheManager` to automatically skip any `Command`-derived plan during cache replacement.
+ * That change was backported to Spark 4.1.2, so this post-backport shim is an empty marker.
+ * All Delta commands that mix this in already extend `RunnableCommand`/`Command`, so they are
+ * covered by the new automatic path.
+ */
+trait IgnoreCachedDataShim

--- a/spark/src/main/scala-shims/spark-4.1.2/LogKeyShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/LogKeyShims.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.logging
+
+import java.util.Locale
+
+import org.apache.spark.internal.LogKey
+
+/**
+ * Shim for LogKey to handle API changes between Spark versions.
+ * In Spark 4.1, LogKey is a Java interface requiring explicit implementation of `name()`.
+ *
+ * DeltaLogKey provides the implementation of name() that case objects can inherit.
+ */
+abstract class DeltaLogKey extends LogKey {
+  override def name(): String = getClass.getSimpleName.stripSuffix("$").toLowerCase(Locale.ROOT)
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/ParquetFooterReaderShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/ParquetFooterReaderShims.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.parquet
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.hadoop.fs.FileStatus
+import org.apache.parquet.hadoop.metadata.ParquetMetadata
+import org.apache.parquet.hadoop.util.HadoopInputFile
+
+
+object ParquetFooterReaderShims {
+  def readParquetFooter(
+    conf: Configuration,
+    status: FileStatus,
+    filter: ParquetMetadataConverter.MetadataFilter) : ParquetMetadata = {
+    val inputFile = HadoopInputFile.fromStatus(status, conf)
+    ParquetFooterReader.readFooter(inputFile, filter)
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/ParseExceptionShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/ParseExceptionShims.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser
+
+import org.antlr.v4.runtime.ParserRuleContext
+
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserUtils}
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.delta.DeltaThrowable
+
+/**
+ * DeltaParseException for Spark 4.1.
+ * In this version, ParseException only takes a single origin parameter (stop was removed).
+ */
+class DeltaParseException(
+    ctx: ParserRuleContext,
+    errorClass: String,
+    messageParameters: Map[String, String] = Map.empty)
+  extends ParseException(
+      Option(ParserUtils.command(ctx)),
+      ParserUtils.position(ctx.getStart),  // In Spark 4.1, only start position is used
+      // No stop parameter in Spark 4.1
+      errorClass,
+      messageParameters
+    ) with DeltaThrowable {
+  override def getErrorClass: String = errorClass
+}
+
+/**
+ * Shim for ParseException to handle API changes between Spark versions.
+ * In Spark 4.1, ParseException only has a single origin parameter (stop was removed).
+ */
+object ParseExceptionShims {
+
+  /**
+   * Create a ParseException with the appropriate constructor for this Spark version.
+   * In Spark 4.1, we only use the start Origin (stop parameter was removed).
+   */
+  def createParseException(
+      command: Option[String],
+      start: Origin,
+      stop: Origin,  // This parameter is ignored in Spark 4.1
+      errorClass: String,
+      messageParameters: Map[String, String]): ParseException = {
+    // In Spark 4.1, ParseException only takes a single origin parameter
+    new ParseException(command, start, errorClass, messageParameters)
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/PropagateSchemaEvolutionWriteOptionShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/PropagateSchemaEvolutionWriteOptionShims.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+ * Rule to maintain backward compatibility for enabling schema evolution in Delta.
+ * Spark introduced `withSchemaEvolution` on insert plan nodes, but Delta checks writer option
+ * `mergeSchema`. This rules sets that writer option whenever schema evolution is enabled on
+ * an insert plan node.
+ */
+object PropagateSchemaEvolutionWriteOptionShims extends Rule[LogicalPlan] {
+  // Do nothing, Spark 4.1 and below doesn't support WITH SCHEMA EVOLUTION in inserts.
+  override def apply(plan: LogicalPlan): LogicalPlan = plan
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/QualifiedColTypeShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/QualifiedColTypeShims.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.connector.catalog.TableChange.AddColumn
+
+/**
+ * In Spark 4.1 QualifiedColType stores `default` as a DefaultValueExpression
+ */
+object QualifiedColTypeShims {
+
+  def getDefaultValueArgFromAddColumn(col: AddColumn): Option[DefaultValueExpression] = {
+    Option(col.defaultValue).map(v =>
+    DefaultValueExpression(
+      org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parseExpression(
+        v.getSql()),
+      v.getSql()))
+  }
+
+  def getDefaultValueStr(col: QualifiedColType): Option[String] = {
+    col.default.map { value =>
+      value match {
+        case DefaultValueExpression(_, originalSQL, _) => originalSQL
+        case _ => value.toString
+      }
+    }
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/RelocatedStreamingClassesShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/RelocatedStreamingClassesShims.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import java.util.UUID
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.streaming.runtime.WatermarkPropagator
+import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.types.StructType
+
+import org.apache.spark.sql.execution.streaming.checkpointing.{
+  CheckpointFileManager => CheckpointFileManagerShim,
+  MetadataVersionUtil => MetadataVersionUtilShim,
+  OffsetSeqMetadata
+}
+import org.apache.spark.sql.execution.streaming.runtime.{
+  IncrementalExecution => IncrementalExecutionShim,
+  MetadataLogFileIndex => MetadataLogFileIndexShim,
+  StreamExecution => StreamExecutionShim,
+  StreamingRelation => StreamingRelationShim
+}
+import org.apache.spark.sql.execution.streaming.sinks.{FileStreamSink => FileStreamSinkShim}
+
+object Relocated {
+  type CheckpointFileManager = CheckpointFileManagerShim
+  val CheckpointFileManager: CheckpointFileManagerShim.type = CheckpointFileManagerShim
+
+  type IncrementalExecution = IncrementalExecutionShim
+  // scalastyle:off argcount
+  def createIncrementalExecution(
+      sparkSession: org.apache.spark.sql.classic.SparkSession,
+      logicalPlan: LogicalPlan,
+      outputMode: OutputMode,
+      checkpointLocation: String,
+      queryId: UUID,
+      runId: UUID,
+      currentBatchId: Long,
+      prevOffsetSeqMetadata: Option[OffsetSeqMetadata],
+      offsetSeqMetadata: OffsetSeqMetadata,
+      watermarkPropagator: WatermarkPropagator,
+      isFirstBatch: Boolean): IncrementalExecution = {
+    // scalastyle:on argcount
+    new IncrementalExecutionShim(
+      sparkSession,
+      logicalPlan,
+      outputMode,
+      checkpointLocation,
+      queryId,
+      runId,
+      currentBatchId,
+      prevOffsetSeqMetadata,
+      offsetSeqMetadata,
+      watermarkPropagator,
+      isFirstBatch)
+  }
+
+  type StreamingRelation = StreamingRelationShim
+  val StreamingRelation: StreamingRelationShim.type = StreamingRelationShim
+
+  type MetadataLogFileIndex = MetadataLogFileIndexShim
+  def createMetadataLogFileIndex(
+      sparkSession: org.apache.spark.sql.SparkSession,
+      path: Path,
+      options: Map[String, String],
+      userSpecifiedSchema: Option[StructType]): MetadataLogFileIndex = {
+    new MetadataLogFileIndexShim(sparkSession, path, options, userSpecifiedSchema)
+  }
+
+  type FileStreamSink = FileStreamSinkShim
+  val FileStreamSink: FileStreamSinkShim.type = FileStreamSinkShim
+
+  type StreamExecution = StreamExecutionShim
+  val StreamExecution: StreamExecutionShim.type = StreamExecutionShim
+
+  val MetadataVersionUtil: MetadataVersionUtilShim.type = MetadataVersionUtilShim
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/SetDSv2SchemaEvolutionShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/SetDSv2SchemaEvolutionShims.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+ * No-op for Spark 4.1 - `withSchemaEvolution` is not available on plan nodes, except
+ * MergeIntoTable but Spark doesn't support schema evolution for MERGE until Spark 4.2.
+ */
+class SetDSv2SchemaEvolutionShims(session: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/SparkTableShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/SparkTableShims.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.connector.catalog.TableCapability
+
+/** Shim to build [[DeltaV2Table]] against different Spark versions. */
+object SparkTableShims {
+  // Capability [[TableCapability.AUTOMATIC_SCHEMA_EVOLUTION]] is available in Spark 4.1, but
+  // schema evolution isn't properly supported yet in MERGE/INSERT there so ignore it.
+  val schemaEvolutionCapability: Option[TableCapability] = None
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/StreamingRelationV2Shim.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/StreamingRelationV2Shim.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta.shims
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableProvider}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Pattern extractor for `StreamingRelationV2` that stays source-compatible
+ * across Spark versions. In Spark 4.2 the case class gained a 9th parameter
+ * `sourceIdentifyingName` (SPARK-54910), which breaks 8-arg extractor
+ * patterns. This extractor exposes the 8 fields that exist in all supported
+ * versions.
+ */
+object StreamingRelationV2Shim {
+  def apply(
+      source: Option[TableProvider],
+      sourceName: String,
+      table: Table,
+      extraOptions: CaseInsensitiveStringMap,
+      output: Seq[AttributeReference],
+      catalog: Option[CatalogPlugin],
+      identifier: Option[Identifier],
+      v1Relation: Option[LogicalPlan]): StreamingRelationV2 =
+    StreamingRelationV2(source, sourceName, table, extraOptions, output,
+          catalog, identifier, v1Relation)
+
+  def unapply(r: StreamingRelationV2): Option[(
+      Option[TableProvider],
+      String,
+      Table,
+      CaseInsensitiveStringMap,
+      Seq[AttributeReference],
+      Option[CatalogPlugin],
+      Option[Identifier],
+      Option[LogicalPlan])] =
+    Some((r.source, r.sourceName, r.table, r.extraOptions, r.output,
+          r.catalog, r.identifier, r.v1Relation))
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/VariantShreddingShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/VariantShreddingShims.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.shims
+
+import scala.util.control.NonFatal
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.hadoop.util.HadoopInputFile
+
+import org.apache.spark.sql.delta.stats.{DeltaTaskStatisticsTracker, VariantStatsData}
+import org.apache.spark.sql.execution.datasources.{DataSourceUtils, OutputWriter, WriteTaskStatsTracker}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFooterReader
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Shim for variant shredding configs to handle API changes between Spark versions.
+ * Spark 4.1 supports shredded writes, and by extension the collection of variant stats.
+ */
+object VariantShreddingShims {
+  def getVariantInferShreddingSchemaOptions(enableVariantShredding: Boolean)
+    : Map[String, String] = {
+    Map(SQLConf.VARIANT_INFER_SHREDDING_SCHEMA.key -> enableVariantShredding.toString)
+  }
+
+  // Extract variant stats from the parquet footer of a written file and inject data into the
+  // variant stats collection expressions.
+  def extractAndInjectVariantStats(
+      writer: OutputWriter,
+      trackers: Seq[WriteTaskStatsTracker],
+      parquetRebaseModeInRead: String,
+      hadoopConf: Configuration): Unit = {
+    val hasVariantTrackers = trackers.exists {
+      case t: DeltaTaskStatisticsTracker =>
+        t.minVariantStatsExpressions.nonEmpty || t.maxVariantStatsExpressions.nonEmpty
+      case _ => false
+    }
+    if (!hasVariantTrackers) return
+    val footer = try {
+      ParquetFooterReader.readFooter(
+        HadoopInputFile.fromPath(new Path(writer.path()), hadoopConf),
+        ParquetMetadataConverter.NO_FILTER)
+    } catch {
+      case NonFatal(_) => return
+    }
+    val keyValueMetadata = footer.getFileMetaData.getKeyValueMetaData
+    val rebaseSpec = DataSourceUtils.datetimeRebaseSpec(
+      k => keyValueMetadata.get(k),
+      parquetRebaseModeInRead)
+    val dateRebaseFunc =
+      DataSourceUtils.createDateRebaseFuncInRead(rebaseSpec.mode, "Parquet")
+    val timestampRebaseFunc =
+      DataSourceUtils.createTimestampRebaseFuncInRead(rebaseSpec, "Parquet")
+    val variantStatsData = VariantStatsData(footer, dateRebaseFunc, timestampRebaseFunc)
+    trackers.foreach {
+      case tracker: DeltaTaskStatisticsTracker =>
+        tracker.minVariantStatsExpressions.foreach(
+          _.addVariantStatsData(variantStatsData))
+        tracker.maxVariantStatsExpressions.foreach(
+          _.addVariantStatsData(variantStatsData))
+      case _ =>
+    }
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1.2/ViewShims.scala
+++ b/spark/src/main/scala-shims/spark-4.1.2/ViewShims.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * Shim for View to handle API changes between Spark versions.
+ * In Spark 4.1, View has an additional constructor parameter.
+ */
+object ViewShims {
+
+  /**
+   * Extractor that matches View(desc, true, child) pattern.
+   * Used in DeltaViewHelper for matching temp views with a specific structure.
+   * In Spark 4.1, View has an additional parameter, so we use a wildcard to ignore it.
+   */
+  object TempViewWithChild {
+    def unapply(plan: LogicalPlan): Option[(CatalogTable, LogicalPlan)] = plan match {
+      // In Spark 4.1, View has an additional parameter, we use _ to match it
+      case View(desc, isTempView, child, _) if isTempView => Some((desc, child))
+      case _ => None
+    }
+  }
+}

--- a/spark/src/test/scala-shims/spark-4.1.2/GridTestShim.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/GridTestShim.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test.shims
+
+import org.apache.spark.SparkFunSuite
+
+/**
+ * Shim for SparkFunSuite as gridTest doesn't exist in Spark 4.0 but we rely on it
+ * in tests. In Spark 4.1 it exists so we don't need to do anything.
+ */
+trait GridTestShim { self: SparkFunSuite =>
+}
+

--- a/spark/src/test/scala-shims/spark-4.1.2/InMemorySparkTableShims.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/InMemorySparkTableShims.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import org.apache.spark.sql.connector.catalog.BufferedRows
+import org.apache.spark.sql.types.StructType
+
+/** Shim for [[InMemorySparkTable]] - exposes APIs that differ between Spark versions. */
+object InMemorySparkTableShims {
+  // [[InMemoryBaseTable.alterTableWithData]] is available in Spark 4.1, but schema evolution is
+  // not properly supported in that version anyway, so fail.
+  def migrateData(
+      table: InMemorySparkTable,
+      data: Array[BufferedRows],
+      newSchema: StructType): Unit = {
+    throw new UnsupportedOperationException(
+      "Schema evolution on InMemorySparkTable is not supported on Spark 4.1")
+  }
+}

--- a/spark/src/test/scala-shims/spark-4.1.2/InMemoryTestTableMixinShims.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/InMemoryTestTableMixinShims.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+trait InMemoryTestTableMixinShims {
+  /** Delta DML schema evolution on DSv2 is only supported with Spark 4.2. */
+  protected def v2DmlSchemaEvolutionSupported: Boolean = false
+}

--- a/spark/src/test/scala-shims/spark-4.1.2/InvalidDefaultValueErrorShims.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/InvalidDefaultValueErrorShims.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test.shims
+
+/**
+ * Test shim for INVALID_DEFAULT_VALUE error codes that changed between Spark versions.
+ * In Spark 4.1, the error code is INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION
+ */
+object InvalidDefaultValueErrorShims {
+  val INVALID_DEFAULT_VALUE_ERROR_CODE: String = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION"
+}
+

--- a/spark/src/test/scala-shims/spark-4.1.2/StreamingRelationV2Shim.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/StreamingRelationV2Shim.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta.test.shims
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableProvider}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Pattern extractor for `StreamingRelationV2` that stays source-compatible
+ * across Spark versions. In Spark 4.2 the case class gained a 9th parameter
+ * `sourceIdentifyingName`, which breaks 8-arg extractor patterns used in
+ * Delta tests. This extractor exposes the 8 fields that exist in all
+ * supported versions.
+ */
+object StreamingRelationV2Shim {
+  def unapply(r: StreamingRelationV2): Option[(
+      Option[TableProvider],
+      String,
+      Table,
+      CaseInsensitiveStringMap,
+      Seq[AttributeReference],
+      Option[CatalogPlugin],
+      Option[Identifier],
+      Option[LogicalPlan])] =
+    Some((r.source, r.sourceName, r.table, r.extraOptions, r.output,
+          r.catalog, r.identifier, r.v1Relation))
+}

--- a/spark/src/test/scala-shims/spark-4.1.2/StreamingTestShims.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/StreamingTestShims.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test.shims
+
+/**
+ * Test shims for streaming classes that were relocated in Spark 4.1.
+ * In Spark 4.1, these classes moved to new package locations.
+ */
+object StreamingTestShims {
+  // MemoryStream - moved to runtime package
+  type MemoryStream[T] = org.apache.spark.sql.execution.streaming.runtime.MemoryStream[T]
+  val MemoryStream: org.apache.spark.sql.execution.streaming.runtime.MemoryStream.type =
+    org.apache.spark.sql.execution.streaming.runtime.MemoryStream
+
+  // MicroBatchExecution - moved to runtime package (class only, no companion object)
+  type MicroBatchExecution = org.apache.spark.sql.execution.streaming.runtime.MicroBatchExecution
+
+  // StreamingQueryWrapper - moved to runtime package (class only, no companion object)
+  type StreamingQueryWrapper =
+    org.apache.spark.sql.execution.streaming.runtime.StreamingQueryWrapper
+
+  // StreamingExecutionRelation - moved to runtime package (class only, no companion object)
+  type StreamingExecutionRelation =
+    org.apache.spark.sql.execution.streaming.runtime.StreamingExecutionRelation
+
+  // OffsetSeqLog - moved to checkpointing package (class only, no companion object)
+  type OffsetSeqLog = org.apache.spark.sql.execution.streaming.checkpointing.OffsetSeqLog
+}
+

--- a/spark/src/test/scala-shims/spark-4.1.2/UnsupportedTableOperationErrorShims.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/UnsupportedTableOperationErrorShims.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test.shims
+
+/**
+ * Test shim for UNSUPPORTED_FEATURE.TABLE_OPERATION error codes that changed between
+ * Spark versions. In Spark 4.1, the error code is UNSUPPORTED_FEATURE.TABLE_OPERATION
+ */
+object UnsupportedTableOperationErrorShims {
+  val UNSUPPORTED_TABLE_OPERATION_ERROR_CODE: String = "UNSUPPORTED_FEATURE.TABLE_OPERATION"
+
+  /**
+   * Returns the parameters map for UPDATE TABLE error in Spark 4.1
+   * @param tableSQLIdentifier The table identifier (e.g., "test_delta_table")
+   */
+  def updateTableErrorParameters(tableSQLIdentifier: String): Map[String, String] = {
+    // Construct the full table name with catalog prefix
+    val fullTableName = s"`spark_catalog`.`default`.`$tableSQLIdentifier`"
+    Map(
+      "tableName" -> fullTableName,
+      "operation" -> "UPDATE TABLE")
+  }
+}
+

--- a/spark/src/test/scala-shims/spark-4.1.2/VariantShreddingTestShims.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/VariantShreddingTestShims.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test.shims
+
+import java.math.{BigDecimal => JBigDecimal}
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.types.variant.Variant
+
+/**
+ * Test shim for variant shredding to handle differences between Spark versions.
+ * In Spark 4.1, VARIANT_INFER_SHREDDING_SCHEMA exists.
+ */
+object VariantShreddingTestShims {
+  /**
+   * Returns true if VARIANT_INFER_SHREDDING_SCHEMA config is supported in this Spark version.
+   * In Spark 4.1, this returns true.
+   */
+  val variantInferShreddingSchemaSupported: Boolean = true
+
+  /**
+   * Returns the config key for VARIANT_INFER_SHREDDING_SCHEMA.
+   * In Spark 4.1, this returns the actual SQLConf key.
+   */
+  val variantInferShreddingSchemaKey: String = SQLConf.VARIANT_INFER_SHREDDING_SCHEMA.key
+
+  def getDecimalWithOriginalScale(v: Variant): JBigDecimal = v.getDecimalWithOriginalScale()
+}

--- a/spark/src/test/scala-shims/spark-4.1.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.1.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -1,0 +1,588 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.schema.SchemaMergingUtils
+import org.apache.spark.sql.delta.shims.GeoTypesShim
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.st.{
+  ST_AsBinary, ST_GeogFromWKB, ST_GeomFromWKB, ST_SetSrid, ST_Srid}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+/**
+ * Tests for the GeoSpatial table feature in the Delta Spark connector. Verifies:
+ *  - Auto-enablement of the [[GeoSpatialTableFeature]] when a geospatial column is present.
+ *  - Required protocol versions (3, 7).
+ *  - SRID validation at commit time.
+ *  - Removability contract (drop is rejected while geospatial columns still exist).
+ *
+ * Note: this suite lives under the spark-4.1 test shim directory because Spark's
+ * `GeometryType` / `GeographyType` catalyst types were only added in Spark 4.1
+ * (SPARK-53760). The GeoSpatial table feature is therefore a no-op on Spark 4.0.
+ */
+class DeltaGeoSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaSQLTestUtils {
+
+  // Default SRID used in Parquet/Iceberg/Delta specs (OGC:CRS84).
+  private val DefaultSrid = 4326
+
+  private def metadataWithSchema(schema: StructType): Metadata = {
+    Metadata(schemaString = schema.json)
+  }
+
+  test("containsGeoColumns detects top-level geometry and geography columns") {
+    val schemaGeom = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val schemaGeog = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val schemaPlain = new StructType()
+      .add("id", IntegerType)
+      .add("s", StringType)
+
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeom))
+    assert(DeltaGeoSpatial.containsGeoColumns(schemaGeog))
+    assert(!DeltaGeoSpatial.containsGeoColumns(schemaPlain))
+  }
+
+  test("containsGeoColumns detects nested geospatial columns") {
+    val nested = new StructType()
+      .add("outer", new StructType().add("inner", GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(nested))
+
+    val arr = new StructType().add("xs", ArrayType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(arr))
+
+    val map = new StructType().add("m", MapType(StringType, GeographyType(DefaultSrid)))
+    assert(DeltaGeoSpatial.containsGeoColumns(map))
+  }
+
+  test("findGeoColumnsRecursively returns the first matching type") {
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val result = DeltaGeoSpatial.findGeoColumnsRecursively(schema)
+    assert(result.isDefined)
+    assert(result.get.isInstanceOf[GeographyType])
+  }
+
+  test("assertSridSupported passes for default fixed SRIDs") {
+    val schema = new StructType()
+      .add("g1", GeometryType(DefaultSrid))
+      .add("g2", GeographyType(DefaultSrid))
+    DeltaGeoSpatial.assertSridSupported(schema)
+  }
+
+  test("isGeoSpatialType returns true for geometry and geography") {
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeometryType(DefaultSrid)))
+    assert(DeltaGeoSpatial.isGeoSpatialType(GeographyType(DefaultSrid)))
+    assert(!DeltaGeoSpatial.isGeoSpatialType(StringType))
+  }
+
+  test("DeltaDataSource accepts GeoSpatial types via supportsDataType") {
+    val ds = new sources.DeltaDataSource
+    assert(ds.supportsDataType(GeometryType(DefaultSrid)))
+    assert(ds.supportsDataType(GeographyType(DefaultSrid)))
+  }
+
+  test("isSupported checks both preview and stable features") {
+    val protoNone = Protocol(3, 7)
+    val protoStable = Protocol(3, 7).withFeature(GeoSpatialTableFeature)
+    val protoPreview = Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!DeltaGeoSpatial.isSupported(protoNone))
+    assert(DeltaGeoSpatial.isSupported(protoStable))
+    assert(DeltaGeoSpatial.isSupported(protoPreview))
+  }
+
+  test("GeoSpatialTableFeature is a reader+writer feature with min protocol (3, 7)") {
+    assert(GeoSpatialTableFeature.isReaderWriterFeature)
+    assert(GeoSpatialTableFeature.minReaderVersion == 3)
+    assert(GeoSpatialTableFeature.minWriterVersion == 7)
+    assert(GeoSpatialTableFeature.name == "geospatial")
+    assert(GeoSpatialPreviewTableFeature.name == "geospatial-dev")
+  }
+
+  test("Both GeoSpatial features are registered in allSupportedFeaturesMap") {
+    assert(TableFeature.featureNameToFeature("geospatial").contains(GeoSpatialTableFeature))
+    assert(TableFeature.featureNameToFeature("geospatial-dev")
+      .contains(GeoSpatialPreviewTableFeature))
+  }
+
+  test("metadataRequiresFeatureToBeEnabled is true iff schema has geospatial columns") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val withoutGeo = metadataWithSchema(new StructType().add("s", StringType))
+    assert(GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withGeo, spark))
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      Protocol(1, 2), withoutGeo, spark))
+  }
+
+  test("stable feature does not auto-enable when preview feature is already supported") {
+    val withGeo = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val protocolWithPreview =
+      Protocol(3, 7).withFeature(GeoSpatialPreviewTableFeature)
+    assert(!GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled(
+      protocolWithPreview, withGeo, spark))
+  }
+
+  test("automaticallyUpdateProtocolOfExistingTables returns true") {
+    assert(GeoSpatialTableFeature.automaticallyUpdateProtocolOfExistingTables)
+  }
+
+  test("creating a table with a geometry column auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(protocol.isFeatureSupported(GeoSpatialTableFeature),
+        s"Expected GeoSpatialTableFeature in protocol but got: $protocol")
+      assert(protocol.minReaderVersion >= GeoSpatialTableFeature.minReaderVersion)
+      assert(protocol.minWriterVersion >= GeoSpatialTableFeature.minWriterVersion)
+    }
+  }
+
+  test("creating a table without geospatial columns does not enable GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT, s STRING) USING delta")
+      val protocol = getProtocolForTable("tbl")
+      assert(!protocol.isFeatureSupported(GeoSpatialTableFeature))
+      assert(!protocol.isFeatureSupported(GeoSpatialPreviewTableFeature))
+    }
+  }
+
+  test("ALTER TABLE ADD COLUMN with geography auto-enables GeoSpatial feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      assert(!getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+      sql(s"ALTER TABLE tbl ADD COLUMN g GEOGRAPHY($DefaultSrid)")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+    }
+  }
+
+  test("PartitionUtils rejects GeoSpatial type as a partition column") {
+    // Geometry / Geography are not orderable and thus cannot be partition columns. Delta's
+    // `util/PartitionUtils.validatePartitionColumn` is the write-path backstop; the catalog
+    // (DDL) path goes through Spark's own `PartitioningUtils` which is out of Delta's hands.
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val ex = intercept[DeltaAnalysisException] {
+      util.PartitionUtils.validatePartitionColumn(schema, Seq("g"), caseSensitive = false)
+    }
+    assert(ex.getErrorClass == "DELTA_INVALID_PARTITION_COLUMN_TYPE",
+      s"Unexpected error class: ${ex.getErrorClass}")
+  }
+
+  test("commit fails when geo column is added and preview conf is disabled") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val ex = intercept[SparkThrowable] {
+          sql(s"ALTER TABLE tbl ADD COLUMN g GEOMETRY($DefaultSrid)")
+        }
+        assert(ex.getErrorClass == "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("read fails when table has geo column and preview conf is disabled") {
+    // Covers the read-path guard wired through [[ProtocolMetadataAdapterV1.assertTableReadable]]:
+    // a `SELECT *` against a table with a geo column triggers DeltaParquetFileFormat
+    // construction, which invokes [[DeltaGeoSpatial.assertTableReadable]] and throws when the
+    // preview config is off.
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val ex = intercept[SparkThrowable] {
+          sql("SELECT * FROM tbl").collect()
+        }
+        assert(ex.getErrorClass == "DELTA_GEOSPATIAL_NOT_SUPPORTED",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("assertMetadata refuses a geo column in a committed Metadata action when preview is off") {
+    // Covers the inline guard in [[OptimisticTransactionImpl.assertMetadata]].
+    // The standard DDL path hits [[GeoSpatialTableFeature.metadataRequiresFeatureToBeEnabled]]
+    // first - see the test above - so we exercise the inline guard by committing a Metadata
+    // action directly, which routes through `prepareCommit -> updateMetadataAndProtocolWith-
+    // RequiredFeatures -> assertMetadata` before the table-feature gate runs.
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT) USING delta")
+      withSQLConf(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key -> "false") {
+        val log = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+        val txn = log.startTransaction()
+        val geoSchema = new StructType()
+          .add("id", IntegerType)
+          .add("g", GeometryType(DefaultSrid))
+        val geoMetadata = txn.snapshot.metadata.copy(schemaString = geoSchema.json)
+
+        val ex = intercept[SparkThrowable] {
+          txn.commit(Seq(geoMetadata), DeltaOperations.ManualUpdate)
+        }
+        assert(ex.getErrorClass == "UNSUPPORTED_DATATYPE",
+          s"Unexpected error class: ${ex.getErrorClass}")
+      }
+    }
+  }
+
+  test("DROP FEATURE is rejected while geospatial columns remain in the schema") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      assert(getProtocolForTable("tbl").isFeatureSupported(GeoSpatialTableFeature))
+
+      val ex = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE tbl DROP FEATURE ${GeoSpatialTableFeature.name}")
+      }
+      assert(ex.getErrorClass == "DELTA_CANNOT_DROP_GEOSPATIAL_FEATURE",
+        s"Unexpected error class: ${ex.getErrorClass}")
+      assert(ex.getMessage.contains("g"))
+    }
+  }
+
+  test("validateDropInvariants returns true after geospatial columns are dropped") {
+    withTable("tbl") {
+      sql(
+        s"""CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta
+           |TBLPROPERTIES('delta.columnMapping.mode' = 'name')""".stripMargin)
+      val tableBefore = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(!GeoSpatialTableFeature.validateDropInvariants(
+        tableBefore, tableBefore.initialSnapshot))
+
+      sql("ALTER TABLE tbl DROP COLUMN g")
+      val tableAfter = DeltaTableV2(spark, TableIdentifier("tbl"))
+      assert(GeoSpatialTableFeature.validateDropInvariants(
+        tableAfter, tableAfter.initialSnapshot))
+    }
+  }
+
+  test("actionUsesFeature returns false for all actions (history protection disabled)") {
+    val geoMeta = metadataWithSchema(new StructType().add("g", GeometryType(DefaultSrid)))
+    val plainMeta = metadataWithSchema(new StructType().add("s", StringType))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(geoMeta))
+    assert(!GeoSpatialTableFeature.actionUsesFeature(plainMeta))
+    assert(!GeoSpatialPreviewTableFeature.actionUsesFeature(geoMeta))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Geo schema type handling (Delta log JSON ser/de support)
+  // ---------------------------------------------------------------------------
+
+  test("Schema JSON round-trips a top-level geometry column") {
+    val original = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val roundtripped = DataType.fromJson(original.json).asInstanceOf[StructType]
+    assert(roundtripped === original)
+    assert(roundtripped("g").dataType.isInstanceOf[GeometryType])
+    assert(roundtripped("g").dataType.asInstanceOf[GeometryType].srid == DefaultSrid)
+  }
+
+  test("Schema JSON round-trips a top-level geography column") {
+    val original = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val roundtripped = DataType.fromJson(original.json).asInstanceOf[StructType]
+    assert(roundtripped === original)
+    assert(roundtripped("g").dataType.isInstanceOf[GeographyType])
+    assert(roundtripped("g").dataType.asInstanceOf[GeographyType].srid == DefaultSrid)
+  }
+
+  test("Schema JSON round-trips nested geo columns inside structs, arrays, and maps") {
+    val nested = new StructType()
+      .add("outer", new StructType().add("inner", GeometryType(DefaultSrid)))
+      .add("arr", ArrayType(GeographyType(DefaultSrid)))
+      .add("map", MapType(StringType, GeometryType(DefaultSrid)))
+    val roundtripped = DataType.fromJson(nested.json).asInstanceOf[StructType]
+    assert(roundtripped === nested)
+  }
+
+  test("assertSridSupported throws AnalysisException for unsupported SRID on Geometry") {
+    // `GeometryType("ANY")` produces a type whose `srid == MIXED_SRID (-1)`. Spark accepts that
+    // type at construction, but `GeometryType.isSridSupported(-1)` is false, so it's exactly the
+    // gap that `DeltaGeoSpatial.assertSridSupported` is meant to catch. (Direct `GeometryType(-1)`
+    // would now throw `ST_INVALID_SRID_VALUE` from the int constructor and never reach Delta.)
+    val schema = new StructType().add("g", GeometryType("ANY"))
+    val ex = intercept[AnalysisException] {
+      DeltaGeoSpatial.assertSridSupported(schema)
+    }
+    assert(ex.getCondition == "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED")
+  }
+
+  test("assertSridSupported throws AnalysisException for unsupported SRID on Geography") {
+    val schema = new StructType().add("g", GeographyType("ANY"))
+    val ex = intercept[AnalysisException] {
+      DeltaGeoSpatial.assertSridSupported(schema)
+    }
+    assert(ex.getCondition == "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED")
+  }
+
+  test("assertSridSupported is a no-op for the default supported SRID") {
+    val schema = new StructType()
+      .add("a", GeometryType(DefaultSrid))
+      .add("b", GeographyType(DefaultSrid))
+    // Should not throw.
+    DeltaGeoSpatial.assertSridSupported(schema)
+  }
+
+  test("validateCommitActions rejects unsupported-SRID metadata even when preview is enabled") {
+    val schema = new StructType().add("g", GeometryType("ANY"))
+    val metadata = metadataWithSchema(schema)
+    val protocol = Protocol(
+      GeoSpatialTableFeature.minReaderVersion,
+      GeoSpatialTableFeature.minWriterVersion)
+      .merge(Protocol.forTableFeature(GeoSpatialTableFeature))
+    val ex = intercept[AnalysisException] {
+      DeltaGeoSpatial.validateCommitActions(spark, protocol, Seq(metadata))
+    }
+    assert(ex.getCondition == "DELTA_GEOSPATIAL_SRID_NOT_SUPPORTED")
+  }
+
+  // ---------------------------------------------------------------------------
+  // DML command support and validation for geospatial columns
+  // ---------------------------------------------------------------------------
+
+  test("GeoTypesShim.geoExpressions contains the expected ST_ catalyst classes") {
+    val expected = Set[Class[_]](
+      classOf[ST_AsBinary],
+      classOf[ST_GeogFromWKB],
+      classOf[ST_GeomFromWKB],
+      classOf[ST_SetSrid],
+      classOf[ST_Srid])
+    assert(GeoTypesShim.geoExpressions == expected)
+  }
+
+  test("AllowedUserProvidedExpressions whitelists the ST_ classes via the shim") {
+    // The geo ST_* classes are appended to `checkConstraintExpressions` (not `expressions`),
+    // so they are usable in CHECK constraints only and not in generated columns. The shim
+    // contributes the five classes on top of the static `checkConstraintExpressions` Set.
+    val whitelist = AllowedUserProvidedExpressions.checkConstraintExpressions
+    assert(whitelist.contains(classOf[ST_AsBinary]))
+    assert(whitelist.contains(classOf[ST_GeogFromWKB]))
+    assert(whitelist.contains(classOf[ST_GeomFromWKB]))
+    assert(whitelist.contains(classOf[ST_SetSrid]))
+    assert(whitelist.contains(classOf[ST_Srid]))
+  }
+
+  test("failIfSchemaHasGeoColumn rejects schemas containing geometry") {
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeometryType(DefaultSrid))
+    val ex = intercept[Throwable] {
+      DeltaGeoSpatial.failIfSchemaHasGeoColumn(schema, "TEST OP")
+    }
+    assert(ex.getMessage.contains("TEST OP"))
+  }
+
+  test("failIfSchemaHasGeoColumn rejects nested geography columns") {
+    val schema = new StructType()
+      .add("outer", new StructType().add("inner", GeographyType(DefaultSrid)))
+    val ex = intercept[Throwable] {
+      DeltaGeoSpatial.failIfSchemaHasGeoColumn(schema, "TEST NESTED")
+    }
+    assert(ex.getMessage.contains("TEST NESTED"))
+  }
+
+  test("failIfSchemaHasGeoColumn is a no-op for non-geo schemas") {
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("s", StringType)
+      .add("xs", ArrayType(IntegerType))
+    // Should not throw.
+    DeltaGeoSpatial.failIfSchemaHasGeoColumn(schema, "TEST")
+  }
+
+  test("ZORDER BY a geometry column is rejected with DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta")
+      // No INSERT - `validateZorderByColumns` runs against the snapshot schema before any data
+      // is touched. Inserting geo values would fail in OSS Spark's Parquet writer, which doesn't
+      // (yet) know how to write GeometryType.
+      val ex = intercept[AnalysisException] {
+        sql("OPTIMIZE tbl ZORDER BY (g)")
+      }
+      assert(ex.getCondition == "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES",
+        s"Expected DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES, got: ${ex.getCondition}")
+    }
+  }
+
+  test("Column default values are rejected on geometry columns at CREATE TABLE") {
+    // `CREATE TABLE ... DEFAULT ...` goes through `CreateTable`, which is one of the ops
+    // `OptimisticTransactionImpl.checkColumnDefaults` matches on. (Note: `ALTER TABLE ADD COLUMN
+    // ... DEFAULT ...` is always rejected by Spark with
+    // `WRONG_COLUMN_DEFAULTS_FOR_DELTA_ALTER_TABLE_ADD_COLUMN_NOT_SUPPORTED` regardless of type
+    // and never reaches the Delta-side check.)
+    //
+    // Use a unique table name + explicit LOCATION inside a temp dir: the CREATE TABLE is
+    // expected to throw, but the catalog/Hadoop FS will already have created the table
+    // directory by the time `checkColumnDefaults` fires, and the default `withTable` cleanup
+    // (just `DROP TABLE IF EXISTS`) would leave that directory behind because the table was
+    // never actually registered. Pointing LOCATION at a `withTempDir` path ensures it is
+    // cleaned up regardless, so subsequent tests can re-create their own `tbl`.
+    withTempDir { tempDir =>
+      withTable("tbl_geo_default_create") {
+        val ex = intercept[AnalysisException] {
+          sql(s"CREATE TABLE tbl_geo_default_create(g GEOMETRY($DefaultSrid) DEFAULT NULL) " +
+            s"USING delta LOCATION '${tempDir.getAbsolutePath}/t' " +
+            "TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported')")
+        }
+        assert(ex.getCondition == "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES",
+          s"Expected DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES, got: ${ex.getCondition}")
+      }
+    }
+  }
+
+  test("Column default values are rejected on geometry columns via ALTER COLUMN SET DEFAULT") {
+    // `ALTER TABLE ... ALTER COLUMN ... SET DEFAULT ...` goes through `ChangeColumn`, which is
+    // also matched by `checkColumnDefaults`.
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(g GEOMETRY($DefaultSrid)) USING delta " +
+        "TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported')")
+      val ex = intercept[AnalysisException] {
+        sql("ALTER TABLE tbl ALTER COLUMN g SET DEFAULT NULL")
+      }
+      assert(ex.getCondition == "DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES",
+        s"Expected DELTA_OPERATION_NOT_SUPPORTED_FOR_DATATYPES, got: ${ex.getCondition}")
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Schema evolution for geospatial columns through MERGE
+  // ---------------------------------------------------------------------------
+
+  test("Adding a new geo column via ALTER TABLE writes a Metadata action with the geo schema") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(id INT, s STRING) USING delta")
+      sql(s"ALTER TABLE tbl ADD COLUMN g GEOGRAPHY($DefaultSrid)")
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      val schema = deltaLog.update().metadata.schema
+      assert(schema("g").dataType.isInstanceOf[GeographyType])
+    }
+  }
+
+  test("SchemaMergingUtils.mergeSchemas rejects geo columns with different SRIDs " +
+    "(blocks SRID change / MERGE schema evolution with mismatched SRIDs)") {
+    // Two schemas that agree on column name and broad type (geometry) but differ in SRID. The
+    // geo guard in `SchemaMergingUtils.typeForImplicitCast` returns None for any geo-to-geo
+    // mismatch, so the merge falls through and the field-merge wrapper rethrows as
+    // `DELTA_FAILED_TO_MERGE_FIELDS` (whose cause is `DELTA_MERGE_INCOMPATIBLE_DATATYPE`). This
+    // is the same path that fires on `ALTER TABLE ... ALTER COLUMN g TYPE GEOMETRY(<other srid>)`
+    // and on `MERGE WITH SCHEMA EVOLUTION` when source/target SRIDs differ.
+    val tableSchema = new StructType().add("g", GeometryType(DefaultSrid))
+    val dataSchema = new StructType().add("g", GeometryType(0))
+    val ex = intercept[DeltaAnalysisException] {
+      SchemaMergingUtils.mergeSchemas(
+        tableSchema,
+        dataSchema,
+        allowImplicitConversions = true)
+    }
+    assert(ex.getErrorClass == "DELTA_FAILED_TO_MERGE_FIELDS",
+      s"Expected DELTA_FAILED_TO_MERGE_FIELDS, got: ${ex.getErrorClass}")
+  }
+
+  test("SchemaMergingUtils.mergeSchemas rejects geo->non-geo and non-geo->geo merges") {
+    // The geo guard short-circuits whenever EITHER side is geo, so swapping a non-geo column
+    // for a geo one (or vice versa) also fails to merge with `DELTA_FAILED_TO_MERGE_FIELDS`.
+    val geoToString = new StructType().add("g", GeometryType(DefaultSrid))
+    val stringToGeo = new StructType().add("g", StringType)
+    val ex1 = intercept[DeltaAnalysisException] {
+      SchemaMergingUtils.mergeSchemas(geoToString, stringToGeo, allowImplicitConversions = true)
+    }
+    assert(ex1.getErrorClass == "DELTA_FAILED_TO_MERGE_FIELDS")
+    val ex2 = intercept[DeltaAnalysisException] {
+      SchemaMergingUtils.mergeSchemas(stringToGeo, geoToString, allowImplicitConversions = true)
+    }
+    assert(ex2.getErrorClass == "DELTA_FAILED_TO_MERGE_FIELDS")
+  }
+
+  test("ALTER TABLE ALTER COLUMN ... TYPE between geo SRIDs is rejected") {
+    // `ALTER TABLE ... ALTER COLUMN g TYPE GEOMETRY(<other srid>)` routes through
+    // `AlterTableChangeColumnDeltaCommand`, which goes through schema merge. The geo guard
+    // above blocks the change. No data needs to be written, so this works even on OSS Spark
+    // 4.1 (whose Parquet writer cannot encode geo values).
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(g GEOMETRY($DefaultSrid)) USING delta")
+      val ex = intercept[AnalysisException] {
+        sql("ALTER TABLE tbl ALTER COLUMN g TYPE GEOMETRY(0)")
+      }
+      assert(ex.getMessage.toUpperCase(java.util.Locale.ROOT).contains("GEOMETRY"),
+        s"Expected the rejection message to mention GEOMETRY, got: ${ex.getMessage}")
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Convert to Delta with geospatial compatibility
+  // ---------------------------------------------------------------------------
+
+  test("CONVERT TO DELTA fails when the schema contains geo types " +
+    "(failIfSchemaHasGeoColumn unit check)") {
+    // This is the unit-level check that `ConvertToDeltaCommandBase.validateConvert` runs on
+    // the parquet table's schema (see `ConvertToDeltaCommand.scala`). The end-to-end SQL
+    // version (CREATE TABLE USING parquet AS SELECT ... ST_GeomFromWKB; CONVERT TO DELTA)
+    // lives only in the Spark 4.2 shim because OSS Spark 4.1's Parquet writer cannot encode
+    // `GeometryType`/`GeographyType` (`UnsupportedDataType GeometryType(...)` from
+    // `ParquetWriteSupport.makeWriter`). On 4.1 we test the validation hook directly so the
+    // check stays deterministic across Spark versions.
+    val schema = new StructType()
+      .add("id", IntegerType)
+      .add("g", GeographyType(DefaultSrid))
+    val ex = intercept[Throwable] {
+      DeltaGeoSpatial.failIfSchemaHasGeoColumn(schema, "CONVERT TO DELTA")
+    }
+    assert(ex.getMessage.contains("CONVERT TO DELTA"),
+      s"Expected message to mention CONVERT TO DELTA, got: ${ex.getMessage}")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Change Data Feed support for geospatial columns
+  // ---------------------------------------------------------------------------
+
+  test("Enabling CDF on a table with a geo column does not throw at table creation") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta " +
+        "TBLPROPERTIES('delta.enableChangeDataFeed' = 'true')")
+      val protocol = getProtocolForTable("tbl")
+      // GeoSpatial feature must be supported alongside CDF.
+      assert(protocol.isFeatureSupported(GeoSpatialTableFeature))
+    }
+  }
+
+  test("CDF schema contains the geo column with original type and SRID") {
+    withTable("tbl") {
+      sql(s"CREATE TABLE tbl(id INT, g GEOMETRY($DefaultSrid)) USING delta " +
+        "TBLPROPERTIES('delta.enableChangeDataFeed' = 'true')")
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      val schema = deltaLog.update().metadata.schema
+      val geoField = schema("g")
+      assert(geoField.dataType.isInstanceOf[GeometryType])
+      assert(geoField.dataType.asInstanceOf[GeometryType].srid == DefaultSrid)
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark 4.1.2 backported the Spark 4.2 cache-manager change from SPARK-54812. As part of that change, Spark removed `org.apache.spark.sql.catalyst.plans.logical.IgnoreCachedData`; `CacheManager` now skips `Command` plans directly.

Delta still needs to support Spark 4.1.0, where `IgnoreCachedData` exists and the existing `spark-4.1` shim should keep extending it. Reusing the same `spark-4.1` shim for Spark 4.1.2 would either fail on 4.1.2 with `NoClassDefFoundError`, or preserve 4.1.2 by breaking 4.1.0 behavior. This PR keeps those paths separate:

- Spark 4.1.0 keeps using `spark-4.1` and artifact suffix `_4.1`.
- Spark 4.1.2 uses new `spark-4.1.2` shim directories and artifact suffix `_4.1.2`.
- `spark-4.1.2/IgnoreCachedDataShim.scala` is an empty marker, matching the post-SPARK-54812 behavior.

Most of the diff is copied shim files. This is intentional: the cross-Spark build chooses one version-specific shim directory per module, and those directories are self-contained. Once `SparkVersionSpec` points Spark 4.1.2 at `scala-shims/spark-4.1.2`, each module-local `spark-4.1` shim tree needs a `spark-4.1.2` counterpart so existing shims do not disappear from that module's compile classpath. The only semantic shim difference in this PR is `IgnoreCachedDataShim`; the rest preserves the Spark 4.1.0 shim behavior for the new patch-version bucket.

This PR also updates the CI matrix helper to use the package suffix as the matrix key, so Spark 4.1.0 and 4.1.2 do not both collapse to `4.1`. The Python workflow relaxes `UV_EXCLUDE_NEWER` only for the no-deps `pyspark==4.1.2` install because that package was published after the global cutoff.

## How was this patch tested?

- `build/sbt showSparkVersions exportSparkVersionsJson`
- `python3 project/scripts/get_spark_version_info.py --all-spark-versions`
- `python3 project/scripts/get_spark_version_info.py --released-spark-versions`
- `python3 project/scripts/get_spark_version_info.py --get-field 4.1 fullVersion`
- `python3 project/scripts/get_spark_version_info.py --get-field 4.1.2 fullVersion`
- `python3.10 -m py_compile project/scripts/get_spark_version_info.py project/tests/test_cross_spark_publish.py`
- `build/sbt -DsparkVersion=4.1.0 "sparkV1 / Compile / compile"`
- `build/sbt -DsparkVersion=4.1.2 "sparkV1 / Compile / compile"`
- `build/sbt -DsparkVersion=4.1.2 "connectClient / Test / compile"`
- `build/sbt -DsparkVersion=4.1.2 "spark / Compile / compile"`
- `git diff --check`

## Does this PR introduce _any_ user-facing changes?

No. This is a build/shim compatibility change so Delta can build and test against Spark 4.1.2 while preserving Spark 4.1.0 behavior.
