### PR TITLE
[Flink][Upsert Step 6] Implement MoRUpsert and default to merge-on-read

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
@@ -17,7 +17,8 @@
 package io.delta.flink.sink;
 
 import io.delta.flink.sink.mergestrategy.AppendOnly;
-import io.delta.flink.sink.mergestrategy.CoWUpsert;
+import io.delta.flink.sink.mergestrategy.MoRUpsert;
+import io.delta.flink.sink.mergestrategy.Upsert;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -296,10 +297,10 @@ public class DeltaSinkConf implements Serializable {
    * <p>Returns a new instance on every call — merge strategies hold per-checkpoint state and must
    * not be shared across {@link DeltaSinkWriter} instances.
    *
-   * @return {@link CoWUpsert} when in upsert mode; {@link AppendOnly} otherwise
+   * @return {@link Upsert} when in upsert mode; {@link AppendOnly} otherwise
    */
   public MergeStrategy createMergeStrategy() {
-    return isUpsert() ? new CoWUpsert() : new AppendOnly();
+    return isUpsert() ? new MoRUpsert() : new AppendOnly();
   }
 
   /**

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/MoRUpsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/MoRUpsert.java
@@ -16,34 +16,179 @@
 
 package io.delta.flink.sink.mergestrategy;
 
+import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
+
+import io.delta.flink.kernel.dv.BinDVAccess;
+import io.delta.flink.kernel.dv.DVAccess;
+import io.delta.flink.kernel.dv.RoaringBitmapArray;
+import io.delta.flink.table.AbstractKernelTable;
 import io.delta.flink.table.DeltaTable;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.engine.FileReadResult;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.internal.data.GenericRow;
+import io.delta.kernel.statistics.DataFileStatistics;
+import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiPredicate;
 
 /**
- * Merge-on-read {@link Upsert} (stub). Logically deletes rows by writing deletion vectors over the
- * existing data files; readers combine each base file with its DV at scan time.
+ * Merge-on-read {@link Upsert}: for each candidate file, walk its row positions and add every
+ * filter-matched row index into a {@link RoaringBitmapArray}, merged with the file's existing
+ * deletion vector (if any). Write the resulting bitmap to a new {@code deletion_vector_<UUID>.bin}
+ * under the table root and emit a {@link AddFile}/{@code RemoveFile} pair that points at the same
+ * data file but carries the new {@link DeletionVectorDescriptor}. The Parquet itself is untouched.
  *
- * <p><b>Status:</b> not implemented. {@link #deleteRecords} throws; needs DV writing, the {@code
- * deletionVectors} table feature, and concurrent-commit retry handling before it can ship.
+ * <p>Compatible with Spark's {@code DeletionVectorStore} on-disk layout (see {@link BinDVAccess}).
  */
 public class MoRUpsert extends Upsert {
 
+  private final DVAccess dvAccess;
+
   public MoRUpsert() {
     super(new ScanLocator());
+    this.dvAccess = new BinDVAccess();
   }
 
   @Override
   protected CloseableIterator<Row> deleteRecords(
       Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
-    throw new UnsupportedOperationException("MoRUpsert not implemented");
+    final Engine engine = table.getEngine();
+    final StructType schema = table.getSchema();
+    final FileStatus source = InternalScanFileUtils.getAddFileStatus(addFile);
+    final AddFile sourceAddFile =
+        new AddFile(addFile.getStruct(InternalScanFileUtils.ADD_FILE_ORDINAL));
+
+    // 1. Start from the file's existing DV (if any) so this is an additive update, not a
+    //    replacement.
+    final RoaringBitmapArray bitmap = loadExistingDv(engine, sourceAddFile.getDeletionVector());
+    final long existingCardinality = bitmap.cardinality();
+
+    // 2. Walk the source Parquet and mark every filter-matched row position.
+    try (CloseableIterator<ColumnarBatch> data =
+        engine
+            .getParquetHandler()
+            .readParquetFiles(singletonCloseableIterator(source), schema, Optional.empty())
+            .map(FileReadResult::getData)) {
+      long rowIdx = 0L;
+      while (data.hasNext()) {
+        ColumnarBatch batch = data.next();
+        int batchSize = batch.getSize();
+        for (int i = 0; i < batchSize; i++) {
+          if (filter.test(batch, i)) {
+            bitmap.add(rowIdx + i);
+          }
+        }
+        rowIdx += batchSize;
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read source file " + source.getPath(), e);
+    }
+
+    final long newCardinality = bitmap.cardinality();
+    if (newCardinality == existingCardinality) {
+      // No new rows matched; the existing DV (if any) is still authoritative -- leave the file
+      // alone. We can hit this when the locator over-reports candidate files (e.g. a stats-pruned
+      // scan that surfaces a file containing no actual PK match).
+      return toCloseableIterator(Collections.emptyIterator());
+    }
+
+    // 3. Hand the bitmap to DVAccess; it picks the file name, in-file offset and encoding for us.
+    final DeletionVectorDescriptor newDv =
+        dvAccess.store(engine, table.getTablePath().toString(), bitmap);
+
+    // 4. Emit RemoveFile(source) + AddFile(same data file path, new DV). The data file is reused
+    //    as-is; only the DV pointer changes.
+    final Row removeAction =
+        SingleAction.createRemoveFileSingleAction(
+            sourceAddFile.toRemoveFileRow(true /* dataChange */, Optional.empty()));
+    final Row addAction =
+        SingleAction.createAddFileSingleAction(addFileRowWithNewDv(schema, sourceAddFile, newDv));
+    return toCloseableIterator(Arrays.asList(removeAction, addAction).iterator());
   }
 
   @Override
   public Row markRemovesOnStaged(DeltaTable table, Row stagedAddFile, Set<Integer> positions) {
-    throw new UnsupportedOperationException("MoRUpsert not implemented");
+    AbstractKernelTable kernelTable = (AbstractKernelTable) table;
+    StructType schema = kernelTable.getSchema();
+    String tableRoot = kernelTable.getTablePath().toString();
+    RoaringBitmapArray bitmap = new RoaringBitmapArray();
+    bitmap.addAll(positions);
+    DeletionVectorDescriptor dvDesc = dvAccess.store(kernelTable.getEngine(), tableRoot, bitmap);
+    AddFile oldAddFile = new AddFile(stagedAddFile.getStruct(SingleAction.ADD_FILE_ORDINAL));
+    Row newAddFileRow = addFileRowWithNewDv(schema, oldAddFile, dvDesc);
+    return SingleAction.createAddFileSingleAction(newAddFileRow);
+  }
+
+  /**
+   * Load the existing deletion vector attached to {@code dvOpt}, or return an empty bitmap if the
+   * file has no DV. Both UUID ({@code "u"}) and path ({@code "p"}) storage are supported; inline
+   * DVs ({@code "i"}) are intentionally rejected -- new writes go through {@link DVAccess#store},
+   * which produces path-based descriptors, and we don't generate inline DVs anywhere.
+   */
+  private RoaringBitmapArray loadExistingDv(
+      Engine engine, Optional<DeletionVectorDescriptor> dvOpt) {
+    if (!dvOpt.isPresent()) {
+      return new RoaringBitmapArray();
+    }
+    DeletionVectorDescriptor dv = dvOpt.get();
+    if (dv.isInline()) {
+      throw new UnsupportedOperationException(
+          "Inline deletion vectors are not supported by Flink upserts (DV "
+              + dv.getUniqueId()
+              + ")");
+    }
+    return dvAccess.read(engine, dv.getAbsolutePath(table.getTablePath().toString()));
+  }
+
+  /**
+   * Build a fresh {@link AddFile#FULL_SCHEMA} row from {@code source}'s fields, replacing only the
+   * {@code deletionVector}. Mirrors {@link AddFile#toRemoveFileRow}'s field-by-field copy so the
+   * resulting row is independent of the source's runtime schema (which may or may not include
+   * stats).
+   *
+   * <p>Exposed for {@link io.delta.flink.sink.DeltaUpsertWriterTask}, which needs the same
+   * AddFile-with-new-DV splice when decorating the writer task's outputs.
+   */
+  public static Row addFileRowWithNewDv(
+      StructType physicalSchema, AddFile source, DeletionVectorDescriptor newDv) {
+    Map<Integer, Object> fieldMap = new HashMap<>();
+    fieldMap.put(AddFile.FULL_SCHEMA.indexOf("path"), source.getPath());
+    fieldMap.put(AddFile.FULL_SCHEMA.indexOf("partitionValues"), source.getPartitionValues());
+    fieldMap.put(AddFile.FULL_SCHEMA.indexOf("size"), source.getSize());
+    fieldMap.put(AddFile.FULL_SCHEMA.indexOf("modificationTime"), source.getModificationTime());
+    fieldMap.put(AddFile.FULL_SCHEMA.indexOf("dataChange"), true);
+    fieldMap.put(AddFile.FULL_SCHEMA.indexOf("deletionVector"), newDv.toRow());
+    source.getTags().ifPresent(t -> fieldMap.put(AddFile.FULL_SCHEMA.indexOf("tags"), t));
+    source
+        .getBaseRowId()
+        .ifPresent(id -> fieldMap.put(AddFile.FULL_SCHEMA.indexOf("baseRowId"), id));
+    source
+        .getDefaultRowCommitVersion()
+        .ifPresent(v -> fieldMap.put(AddFile.FULL_SCHEMA.indexOf("defaultRowCommitVersion"), v));
+    source
+        .getStatsJson()
+        .flatMap(
+            s ->
+                DataFileStatistics.deserializeFromJson(s, physicalSchema)
+                    .map(DataFileStatistics::withoutTightBounds)
+                    .map(st -> st.serializeAsJson(physicalSchema)))
+        .ifPresent(cleared -> fieldMap.put(AddFile.FULL_SCHEMA.indexOf("stats"), cleared));
+    return new GenericRow(AddFile.FULL_SCHEMA, fieldMap);
   }
 }

--- a/flink/src/test/java/io/delta/flink/sink/mergestrategy/MoRUpsertTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/mergestrategy/MoRUpsertTest.java
@@ -1,0 +1,407 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink.mergestrategy;
+
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.flink.TestHelper;
+import io.delta.flink.kernel.dv.BinDVAccess;
+import io.delta.flink.sink.DeltaSinkConf;
+import io.delta.flink.sink.DeltaWriterResult;
+import io.delta.flink.sink.DeltaWriterTask;
+import io.delta.flink.sink.TestSinkWriterContext;
+import io.delta.flink.table.AbstractKernelTable;
+import io.delta.flink.table.HadoopTable;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.AlwaysTrue;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.internal.util.PartitionUtils;
+import io.delta.kernel.statistics.DataFileStatistics;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Per-file tests for {@link MoRUpsert#deleteRecords}. Mirrors the structure of {@link
+ * CoWUpsertTest}: supply a scan-file row and a row-level filter directly, bypassing {@link
+ * Upsert#merge} / {@link RowLocator}.
+ */
+class MoRUpsertTest extends TestHelper {
+
+  private static final StructType SCHEMA =
+      new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+
+  /** Column ordinal of {@code id} in {@link #SCHEMA}. */
+  private static final int ID_ORDINAL = 0;
+
+  @Test
+  void testAddsDvForFreshFile() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          // 10 rows with ids 0..9, no pre-existing DV.
+          Row scanFileRow = writeAndScan(table, 10);
+
+          // Drop every other row -- expect 5 row positions in the DV.
+          BiPredicate<ColumnarBatch, Integer> dropEvens = idMatches(i -> i % 2 == 0);
+          List<Row> actions = runDeleteRecords(table, scanFileRow, dropEvens).toInMemoryList();
+
+          assertEquals(2, actions.size(), "expected RemoveFile + AddFile");
+          assertTrue(isRemoveAction(actions.get(0)));
+          assertTrue(isAddAction(actions.get(1)));
+
+          AddFile addFile = addFileOf(actions.get(1));
+          AddFile sourceAddFile = sourceAddFile(scanFileRow);
+          // MoR reuses the data file -- only the DV pointer changes.
+          assertEquals(sourceAddFile.getPath(), addFile.getPath());
+          assertEquals(sourceAddFile.getSize(), addFile.getSize());
+
+          // The AddFile now carries a path-based on-disk DV with cardinality 5.
+          DeletionVectorDescriptor dv =
+              addFile.getDeletionVector().orElseThrow(() -> new AssertionError("expected a DV"));
+          assertEquals(DeletionVectorDescriptor.PATH_DV_MARKER, dv.getStorageType());
+          assertEquals(5L, dv.getCardinality());
+          // pathOrInlineDv is the absolute URI of the .bin file.
+          assertTrue(dv.getPathOrInlineDv().startsWith("file:"));
+          assertTrue(dv.getPathOrInlineDv().endsWith(".bin"));
+          assertTrue(dv.getOffset().isPresent());
+
+          // DV file exists on disk and round-trips to the expected positions. We use the
+          // table's URI-form path so getAbsolutePath produces a fully-qualified file:// URI.
+          String dvPath = dv.getAbsolutePath(table.getTablePath().toString());
+          assertTrue(new File(URI.create(dvPath)).exists(), "DV file missing at " + dvPath);
+          assertArrayEquals(
+              new long[] {0L, 2L, 4L, 6L, 8L},
+              new BinDVAccess().read(table.getEngine(), dvPath).toArray());
+        });
+  }
+
+  @Test
+  void testNoMatchReturnsNoActions() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          Row scanFileRow = writeAndScan(table, 5);
+
+          // Locator over-reports: this candidate file actually has no matching rows.
+          List<Row> actions =
+              runDeleteRecords(table, scanFileRow, (batch, rowId) -> false).toInMemoryList();
+
+          assertEquals(0, actions.size(), "no actions when nothing in the file matched");
+        });
+  }
+
+  @Test
+  void testDeletesEveryRow() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          Row scanFileRow = writeAndScan(table, 6);
+
+          List<Row> actions =
+              runDeleteRecords(table, scanFileRow, (batch, rowId) -> true).toInMemoryList();
+
+          assertEquals(2, actions.size());
+          assertTrue(isRemoveAction(actions.get(0)));
+          assertTrue(isAddAction(actions.get(1)));
+
+          AddFile addFile = addFileOf(actions.get(1));
+          DeletionVectorDescriptor dv =
+              addFile.getDeletionVector().orElseThrow(() -> new AssertionError("expected a DV"));
+          assertEquals(6L, dv.getCardinality());
+
+          String dvPath = dv.getAbsolutePath(table.getTablePath().toString());
+          assertArrayEquals(
+              new long[] {0L, 1L, 2L, 3L, 4L, 5L},
+              new BinDVAccess().read(table.getEngine(), dvPath).toArray());
+        });
+  }
+
+  @Test
+  void testTwoSequentialRunsMergeDvs() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          Row scanFileRow = writeAndScan(table, 10);
+
+          // First run: delete rows 0, 4 (id % 4 == 0).
+          List<Row> firstActions =
+              runDeleteRecords(table, scanFileRow, idMatches(i -> i % 4 == 0)).toInMemoryList();
+          AddFile firstAdd = addFileOf(firstActions.get(1));
+          DeletionVectorDescriptor firstDv = firstAdd.getDeletionVector().get();
+
+          // Splice the new DV onto the scan-file row so the second run sees it as the "existing".
+          Row scanRowWithDv = scanFileRowWithDv(scanFileRow, firstDv);
+
+          // Second run: delete rows where id % 2 == 0 (i.e. 0, 2, 4, 6, 8). The union with the
+          // existing DV {0, 4} is the same set, so the new bitmap is {0, 2, 4, 6, 8}, cardinality
+          // 5.
+          List<Row> secondActions =
+              runDeleteRecords(table, scanRowWithDv, idMatches(i -> i % 2 == 0)).toInMemoryList();
+          assertEquals(2, secondActions.size());
+
+          AddFile secondAdd = addFileOf(secondActions.get(1));
+          DeletionVectorDescriptor secondDv = secondAdd.getDeletionVector().get();
+          assertEquals(5L, secondDv.getCardinality());
+          // Distinct DV file from the first run -- DVs are immutable.
+          assertFalse(
+              firstDv.getPathOrInlineDv().equals(secondDv.getPathOrInlineDv()),
+              "expected a fresh DV file on the second run");
+
+          String dvPath = secondDv.getAbsolutePath(table.getTablePath().toString());
+          assertArrayEquals(
+              new long[] {0L, 2L, 4L, 6L, 8L},
+              new BinDVAccess().read(table.getEngine(), dvPath).toArray());
+        });
+  }
+
+  @Test
+  void testNoNewMatchesOverExistingDvReturnsNoActions() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          Row scanFileRow = writeAndScan(table, 10);
+
+          // Establish an existing DV by running MoR once.
+          List<Row> firstActions =
+              runDeleteRecords(table, scanFileRow, idMatches(i -> i % 2 == 0)).toInMemoryList();
+          DeletionVectorDescriptor firstDv =
+              addFileOf(firstActions.get(1)).getDeletionVector().get();
+          Row scanRowWithDv = scanFileRowWithDv(scanFileRow, firstDv);
+
+          // Second run drops exactly the same rows -- bitmap is unchanged, so MoR should emit
+          // nothing rather than churn a redundant DV file.
+          List<Row> secondActions =
+              runDeleteRecords(table, scanRowWithDv, idMatches(i -> i % 2 == 0)).toInMemoryList();
+          assertTrue(secondActions.isEmpty(), "no actions when DV is unchanged");
+        });
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Test-only subclass of {@link MoRUpsert} that exposes the protected {@code deleteRecords} and
+   * the inherited {@code table} field, the same way {@code ExposedCoWUpsert} does for the CoW
+   * tests.
+   */
+  private static final class ExposedMoRUpsert extends MoRUpsert {
+    ExposedMoRUpsert(AbstractKernelTable backingTable) {
+      this.table = backingTable;
+    }
+
+    CloseableIterator<Row> deleteRecordsForTest(
+        Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
+      return deleteRecords(addFile, filter);
+    }
+  }
+
+  private CloseableIterator<Row> runDeleteRecords(
+      HadoopTable table, Row scanFileRow, BiPredicate<ColumnarBatch, Integer> filter) {
+    return new ExposedMoRUpsert(table).deleteRecordsForTest(scanFileRow, filter);
+  }
+
+  /** Build a "matches if {@code id} satisfies {@code idTest}" filter on column 0. */
+  private static BiPredicate<ColumnarBatch, Integer> idMatches(
+      java.util.function.IntPredicate idTest) {
+    return (batch, rowId) -> idTest.test(batch.getColumnVector(ID_ORDINAL).getInt(rowId));
+  }
+
+  private HadoopTable openTable(File dir) {
+    HadoopTable table =
+        new HadoopTable(
+            URI.create(dir.getAbsolutePath()),
+            Collections.emptyMap(),
+            SCHEMA,
+            Collections.emptyList());
+    table.open();
+    return table;
+  }
+
+  /**
+   * Write {@code numRows} rows {@code (i, "row-i")} via a {@link DeltaWriterTask}, commit the
+   * resulting AddFile, and return the (single) scan-file row.
+   */
+  private Row writeAndScan(HadoopTable table, int numRows) {
+    DeltaSinkConf conf = new DeltaSinkConf(SCHEMA, Collections.emptyMap());
+    DeltaWriterTask task =
+        new DeltaWriterTask(
+            "test-job",
+            /* subtaskId= */ 0,
+            /* attemptNumber= */ 0,
+            table,
+            conf,
+            Collections.emptyMap());
+    try {
+      for (int i = 0; i < numRows; i++) {
+        task.write(
+            GenericRowData.of(Integer.valueOf(i), StringData.fromString("row-" + i)),
+            new TestSinkWriterContext(0, 0));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    List<DeltaWriterResult> results;
+    try {
+      results = task.complete();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    List<Row> actions = new ArrayList<>();
+    for (DeltaWriterResult r : results) {
+      actions.addAll(r.getDeltaActions());
+    }
+    table.commit(
+        CloseableIterable.inMemoryIterable(toCloseableIterator(actions.iterator())),
+        "test-app",
+        /* txnId= */ 0L,
+        Collections.emptyMap());
+    List<Row> all = table.scan(AlwaysTrue.ALWAYS_TRUE).toInMemoryList();
+    assertEquals(1, all.size(), "expected exactly one scan file after commit");
+    return all.get(0);
+  }
+
+  @Test
+  public void addFileRowWithNewDv_clearsTightBounds_andKeepsPhysicalNameStats() {
+    // Column-mapping style: stats are keyed by physical names, so the DV-splice must round-trip
+    // the stats through the physical schema and clear tightBounds (min/max may no longer be exact).
+    StructType physicalSchema =
+        new StructType().add("col-aaaa", IntegerType.INTEGER).add("col-bbbb", StringType.STRING);
+
+    String statsJson =
+        "{\"numRecords\":10,"
+            + "\"minValues\":{\"col-aaaa\":1},"
+            + "\"maxValues\":{\"col-aaaa\":100},"
+            + "\"nullCount\":{\"col-aaaa\":0,\"col-bbbb\":3},"
+            + "\"tightBounds\":true}";
+    DataFileStatistics stats =
+        DataFileStatistics.deserializeFromJson(statsJson, physicalSchema).get();
+
+    AddFile source =
+        new AddFile(
+            AddFile.createAddFileRow(
+                physicalSchema,
+                "part-0.parquet",
+                PartitionUtils.serializePartitionMap(Collections.emptyMap()),
+                100L, /* size */
+                1L, /* modificationTime */
+                true, /* dataChange */
+                Optional.empty(), /* deletionVector */
+                Optional.empty(), /* tags */
+                Optional.empty(), /* baseRowId */
+                Optional.empty(), /* defaultRowCommitVersion */
+                Optional.of(stats)));
+
+    DeletionVectorDescriptor newDv =
+        new DeletionVectorDescriptor("p", "/tmp/deletion_vector_test.bin", Optional.of(0), 42, 5L);
+
+    Row result = MoRUpsert.addFileRowWithNewDv(physicalSchema, source, newDv);
+
+    String newStatsJson = result.getString(AddFile.FULL_SCHEMA.indexOf("stats"));
+    DataFileStatistics cleared =
+        DataFileStatistics.deserializeFromJson(newStatsJson, physicalSchema).get();
+
+    // tightBounds cleared to false once a DV is attached.
+    assertFalse(cleared.getTightBounds().orElse(true));
+
+    // Physical-name-keyed stats are preserved across the round-trip.
+    assertEquals(10L, cleared.getNumRecords());
+    Column colA = new Column("col-aaaa");
+    Column colB = new Column("col-bbbb");
+    assertEquals(1, ((Number) cleared.getMinValues().get(colA).getValue()).intValue());
+    assertEquals(100, ((Number) cleared.getMaxValues().get(colA).getValue()).intValue());
+    assertEquals(0L, cleared.getNullCount().get(colA).longValue());
+    assertEquals(3L, cleared.getNullCount().get(colB).longValue());
+
+    // The new DV pointer is spliced onto the AddFile.
+    assertEquals(
+        "/tmp/deletion_vector_test.bin",
+        new AddFile(result).getDeletionVector().get().getPathOrInlineDv());
+  }
+
+  /**
+   * Wrap a fresh scan-file row whose {@code add} struct carries the given {@link
+   * DeletionVectorDescriptor}, so we can feed a "file with an existing DV" into MoR without going
+   * through a second commit cycle.
+   */
+  private static Row scanFileRowWithDv(Row originalScanRow, DeletionVectorDescriptor dv) {
+    AddFile source = sourceAddFile(originalScanRow);
+    Row newAddRow =
+        AddFile.createAddFileRow(
+            SCHEMA,
+            source.getPath(),
+            source.getPartitionValues(),
+            source.getSize(),
+            source.getModificationTime(),
+            source.getDataChange(),
+            java.util.Optional.of(dv),
+            source.getTags(),
+            source.getBaseRowId(),
+            source.getDefaultRowCommitVersion(),
+            /* stats= */ java.util.Optional.empty());
+
+    // Re-pack into a scan-file row. SCAN_FILE_SCHEMA has just "add" + "tableRoot" (StringType);
+    // copy tableRoot verbatim, replace add.
+    java.util.Map<Integer, Object> fields = new java.util.HashMap<>();
+    fields.put(InternalScanFileUtils.ADD_FILE_ORDINAL, newAddRow);
+    int tableRootOrdinal = InternalScanFileUtils.SCAN_FILE_SCHEMA.indexOf("tableRoot");
+    if (tableRootOrdinal >= 0 && !originalScanRow.isNullAt(tableRootOrdinal)) {
+      fields.put(tableRootOrdinal, originalScanRow.getString(tableRootOrdinal));
+    }
+    return new io.delta.kernel.internal.data.GenericRow(
+        InternalScanFileUtils.SCAN_FILE_SCHEMA, fields);
+  }
+
+  private static AddFile sourceAddFile(Row scanFileRow) {
+    return new AddFile(scanFileRow.getStruct(InternalScanFileUtils.ADD_FILE_ORDINAL));
+  }
+
+  private static AddFile addFileOf(Row singleAction) {
+    return new AddFile(singleAction.getStruct(SingleAction.ADD_FILE_ORDINAL));
+  }
+
+  private static boolean isAddAction(Row action) {
+    return !action.isNullAt(SingleAction.ADD_FILE_ORDINAL);
+  }
+
+  private static boolean isRemoveAction(Row action) {
+    return !action.isNullAt(SingleAction.REMOVE_FILE_ORDINAL);
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

Step 7 of the Flink upsert sink stack. Introduces the Merge-on-Read upsert algorithm and switches it to be the default the rest of the stack picks up.

`MoRUpsert`:
- `Upsert` implementation that, for every candidate file matched by the row locator, walks the source Parquet, collects matched row positions into a `RoaringBitmapArray`, merges with the file's existing DV (UUID-form or path-form, inline DVs intentionally rejected), and writes a fresh `deletion_vector_<UUID>.bin` via `BinDVAccess.store`. Emits a `RemoveFile`/`AddFile` pair against the same data file with the new path-based `DeletionVectorDescriptor` — the data file is never rewritten.
- Idempotent: when the new bitmap cardinality matches the existing cardinality (locator over-reporting, etc.), emits zero actions instead of churning a redundant DV file.

`DeltaSinkConf.createMergeStrategy()` is flipped so the default upsert strategy is `MoRUpsert` instead of `CoWUpsert`. `CoWUpsert` remains available as an alternative implementation (not deprecated).

Tests in `MoRUpsertTest` cover fresh-file DV creation, no-match short-circuit, every-row deletion, two-run DV merging, and unchanged-DV early return.

Stack:
- Built on the SQL DDL PR (#6935) and the DV-support PR (#6964) — both must merge before this one. The branch contains the DV commits inline for local testability; once #6964 merges, those commits drop on rebase and the PR diff narrows to just the MoR work.

Part of #5901.

## How was this patch tested?

- `build/sbt "flink/testOnly io.delta.flink.sink.mergestrategy.MoRUpsertTest io.delta.flink.kernel.dv.BinDVAccessTest io.delta.flink.kernel.dv.RoaringBitmapArrayTest"`.

## Does this PR introduce _any_ user-facing changes?

Indirectly via the rest of the stack: when `write.mode='upsert'` is selected, the sink now uses merge-on-read (DV-based) to materialize deletes/updates against previously-committed files. No new public API surface lands in this PR alone.