### PR TITLE
[Spark] Fix NoClassDefFoundError on Spark 4.1.2 (empty IgnoreCachedData marker)

### DIFF
--- a/spark/src/main/scala-shims/spark-4.1/IgnoreCachedDataShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1/IgnoreCachedDataShim.scala
@@ -16,10 +16,10 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 /**
- * Shim for Spark's `IgnoreCachedData` trait. On Spark 4.1 this aliases the real
- * trait so `CacheManager` continues to skip these plans during cache replacement.
- * On Spark 4.2 (SPARK-54812) the trait was removed because `CacheManager` now
- * automatically skips any `Command`-derived plan, so the 4.2 variant of this
- * shim is an empty marker.
+ * Shim for Spark's `IgnoreCachedData` trait. Spark 4.1.2 (SPARK-54812) removed the trait and
+ * changed `CacheManager` to automatically skip any `Command`-derived plan during cache
+ * replacement, the same change that shipped in Spark 4.2. This is an empty marker so the
+ * compiled jar carries no reference to the removed trait and loads on Spark 4.1.2. It still
+ * works on 4.1.0/4.1.1, where the marker was a no-op for these (Command-derived) Delta commands.
  */
-trait IgnoreCachedDataShim extends IgnoreCachedData
+trait IgnoreCachedDataShim


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`delta-spark_4.1` is built against Spark 4.1.0, where the `spark-4.1` shim does
`trait IgnoreCachedDataShim extends IgnoreCachedData`. Spark 4.1.2 backported
SPARK-54812, which deleted the `IgnoreCachedData` trait. The removed trait is baked
into the compiled jar as a superinterface, so on Spark 4.1.2 loading any Delta command
that mixes the shim in (`ALTER TABLE`, `TRUNCATE`, `REORG`/`OPTIMIZE`) fails with
`NoClassDefFoundError`.

We need this fix because users cannot run these commands on Spark 4.1.2 today.

This makes the shim an empty marker, so the jar no longer references the removed trait
and loads on Spark 4.1.2. The build still targets Spark 4.1.0, so 4.1.0/4.1.1 stay
covered by CI.

Dropping the marker is safe for these commands. Every one of them is `Command`-derived,
which Spark 4.1.2's `CacheManager` skips automatically. On the older 4.1 `CacheManager`
the marker was a no-op for them anyway: the `ALTER`/`REORG` commands are leaf commands
with no child plan for the cache rewrite to touch, and `TruncateTableSuite` (the one
command with a child) caches a table then truncates it and still passes on 4.1.1
without the marker.

## How was this patch tested?

- `build/sbt "sparkV1 / Compile / compile"` against Spark 4.1.0 (the build target) -> success.
- Verified the empty-marker shim compiles against Spark 4.1.2 (`sparkV1` and the unified
  `spark` module) -> success.
- Ran `TruncateTableSuite` against Spark 4.1.1 with the empty marker -> 7/7 pass,
  including `truncate should refresh DF cache - table` and `- path` (the cache + TRUNCATE
  cases).

## Does this PR introduce _any_ user-facing changes?

Yes. `ALTER TABLE`, `TRUNCATE`, and `REORG` on Delta tables now work on Spark 4.1.2,
where they previously failed with `NoClassDefFoundError`. No behavior change on Spark
4.1.0/4.1.1.
