### PR TITLE
[Spark] Disable GeoSpatial by default

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3187,7 +3187,7 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .internal()
       .doc("Enable GeoSpatial features that are part of the preview scope.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   ///////////
   // VARIANT

--- a/spark/src/test/scala-shims/spark-4.1/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.1/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
-import org.apache.spark.SparkThrowable
+import org.apache.spark.{SparkConf, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.st.{
@@ -48,11 +48,19 @@ class DeltaGeoSuite extends QueryTest
   with DeltaSQLCommandTest
   with DeltaSQLTestUtils {
 
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key, "true")
+
   // Default SRID used in Parquet/Iceberg/Delta specs (OGC:CRS84).
   private val DefaultSrid = 4326
 
   private def metadataWithSchema(schema: StructType): Metadata = {
     Metadata(schemaString = schema.json)
+  }
+
+  test("geo preview is disabled by default") {
+    assert(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.defaultValue.contains(false),
+      "DELTA_GEO_PREVIEW_ENABLED must default to false while geospatial is in private preview")
   }
 
   test("containsGeoColumns detects top-level geometry and geography columns") {

--- a/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
-import org.apache.spark.SparkThrowable
+import org.apache.spark.{SparkConf, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.st.{
@@ -48,6 +48,9 @@ class DeltaGeoSuite extends QueryTest
   with DeltaSQLCommandTest
   with DeltaSQLTestUtils {
 
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.key, "true")
+
   // Default SRID used in Parquet/Iceberg/Delta specs (OGC:CRS84).
   private val DefaultSrid = 4326
 
@@ -68,6 +71,11 @@ class DeltaGeoSuite extends QueryTest
 
   private def metadataWithSchema(schema: StructType): Metadata = {
     Metadata(schemaString = schema.json)
+  }
+
+  test("geo preview is disabled by default") {
+    assert(DeltaSQLConf.DELTA_GEO_PREVIEW_ENABLED.defaultValue.contains(false),
+      "DELTA_GEO_PREVIEW_ENABLED must default to false while geospatial is in private preview")
   }
 
   test("containsGeoColumns detects top-level geometry and geography columns") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

Part of https://github.com/delta-io/delta/issues/6622.

## Description

Gates `GeoSpatial` support (create/write/read paths) - disabling by default, while it's still under development and not part of public protocol.

## How was this patch tested?

Added appropriate tests under `DeltaGeoSuite`.

## Does this PR introduce _any_ user-facing changes?

Yes. Tables with geospatial columns cannot be created, written, or read (by default, with config disabled).