### PR TITLE
Cap Delta v2 test parallelism at local[2]

### DIFF
--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/DeltaV2TestBase.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/DeltaV2TestBase.java
@@ -30,7 +30,9 @@ public abstract class DeltaV2TestBase {
   public static void setUpSparkAndEngine() {
     spark =
         SparkSession.builder()
-            .master("local[*]")
+            // local[2] caps task parallelism so concurrent test tasks fit within the
+            // off-heap test buffer pool; local[*] OOMs on high-core CI hosts.
+            .master("local[2]")
             .appName("SparkKernelDsv2Tests")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtensionV1")
             .config(


### PR DESCRIPTION
## Description
Caps the Delta v2 test SparkSession master at local[2] so test task parallelism stays within the off-heap buffer pool on high-core CI hosts.

## How was this tested?
Existing tests. This is a test-only configuration change.